### PR TITLE
Compartment Lookup work.

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Modules/CompartmentModule.cs
+++ b/src/Microsoft.Health.Fhir.Api/Modules/CompartmentModule.cs
@@ -1,0 +1,28 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using EnsureThat;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Health.Fhir.Core.Features.Definition;
+
+namespace Microsoft.Health.Fhir.Api.Modules
+{
+    public class CompartmentModule : IStartupModule
+    {
+        public void Load(IServiceCollection services)
+        {
+            EnsureArg.IsNotNull(services, nameof(services));
+
+            services.Add<CompartmentDefinitionManager>()
+                .Singleton()
+                .AsSelf()
+                .AsService<IStartable>()
+
+                // TODO Add the capability once fuly implemented.
+                .AsService<ICompartmentDefinitionManager>();
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Api/Modules/FhirModule.cs
+++ b/src/Microsoft.Health.Fhir.Api/Modules/FhirModule.cs
@@ -15,9 +15,11 @@ using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Api.Features.Context;
 using Microsoft.Health.Fhir.Api.Features.Filters;
 using Microsoft.Health.Fhir.Api.Features.Formatters;
+using Microsoft.Health.Fhir.Api.Features.Routing;
 using Microsoft.Health.Fhir.Api.Features.Security;
 using Microsoft.Health.Fhir.Core.Features.Conformance;
 using Microsoft.Health.Fhir.Core.Features.Context;
+using Microsoft.Health.Fhir.Core.Features.Routing;
 using Microsoft.Health.Fhir.Core.Features.Validation.Narratives;
 
 namespace Microsoft.Health.Fhir.Api.Modules
@@ -64,6 +66,7 @@ namespace Microsoft.Health.Fhir.Api.Modules
 
             services.AddSingleton<IFhirContextAccessor, FhirContextAccessor>();
             services.AddSingleton<CorrelationIdProvider>(provider => () => Guid.NewGuid().ToString());
+            services.AddSingleton<IUrlResolver, UrlResolver>();
 
             // Add conformance provider for implementation metadata.
             services.AddSingleton<IConfiguredConformanceProvider, DefaultConformanceProvider>();

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Definition/CompartmentDefinitionBuilderTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Definition/CompartmentDefinitionBuilderTests.cs
@@ -1,0 +1,57 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Linq;
+using Hl7.Fhir.Model;
+using Microsoft.Health.Fhir.Core.Exceptions;
+using Microsoft.Health.Fhir.Core.Features.Definition;
+using Microsoft.Health.Fhir.Tests.Common;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Definition
+{
+    public class CompartmentDefinitionBuilderTests
+    {
+        private CompartmentDefinitionBuilder _validBuiltCompartment;
+
+        public CompartmentDefinitionBuilderTests()
+        {
+            var validCompartmentBundle = Samples.GetJsonSample<Bundle>("ValidCompartmentDefinition");
+            _validBuiltCompartment = new CompartmentDefinitionBuilder(validCompartmentBundle);
+            _validBuiltCompartment.Build();
+        }
+
+        [Fact]
+        public void GivenAValidCompartDefinitionBundle_NoIssues_And_ValidCounts()
+        {
+            Assert.Equal(5, _validBuiltCompartment.CompartmentSearchParams.Count);
+            Assert.Equal(2, _validBuiltCompartment.CompartmentLookup.Count);
+        }
+
+        [Fact]
+        public void GivenAValidCompartDefinitionBundle_NoIssues_And_ValidSearchParams()
+        {
+            var conditionDict = _validBuiltCompartment.CompartmentSearchParams[ResourceType.Condition];
+            Assert.Equal(2, conditionDict.Count);
+            Assert.True(conditionDict.ContainsKey(CompartmentType.Patient));
+            Assert.True(conditionDict.ContainsKey(CompartmentType.Encounter));
+            var communicationDict = _validBuiltCompartment.CompartmentSearchParams[ResourceType.Communication];
+            Assert.Equal(1, communicationDict.Count);
+            Assert.True(communicationDict.ContainsKey(CompartmentType.Patient));
+        }
+
+        [Fact]
+        public void GivenAnInvalidCompartmentDefinitionBundle_Issues_MustBeReturned()
+        {
+            var invalidCompartmentBundle = Samples.GetJsonSample<Bundle>("InvalidCompartmentDefinition");
+            var invalidBuiltCompartment = new CompartmentDefinitionBuilder(invalidCompartmentBundle);
+            var exception = Assert.Throws<InvalidDefinitionException>(() => invalidBuiltCompartment.Build());
+            Assert.Contains("invalid entries", exception.Message);
+            Assert.Equal(2, exception.Issues.Count);
+            Assert.NotNull(exception.Issues.SingleOrDefault(ic => ic.Severity == OperationOutcome.IssueSeverity.Fatal && ic.Code == OperationOutcome.IssueType.Invalid && ic.Diagnostics.Contains("not a CompartmentDefinition")));
+            Assert.NotNull(exception.Issues.SingleOrDefault(ic => ic.Severity == OperationOutcome.IssueSeverity.Fatal && ic.Code == OperationOutcome.IssueType.Invalid && ic.Diagnostics.Contains("url is invalid")));
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/CompartmentDefinitionBuilder.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/CompartmentDefinitionBuilder.cs
@@ -1,0 +1,155 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using EnsureThat;
+using Hl7.Fhir.Model;
+using Microsoft.Health.Fhir.Core.Exceptions;
+using static Hl7.Fhir.Model.Bundle;
+using static Hl7.Fhir.Model.CompartmentDefinition;
+using static Hl7.Fhir.Model.OperationOutcome;
+
+namespace Microsoft.Health.Fhir.Core.Features.Definition
+{
+    internal class CompartmentDefinitionBuilder
+    {
+        private readonly Bundle _bundle;
+
+        private Dictionary<CompartmentType, CompartmentDefinition> _compartmentTypeDictionary = new Dictionary<CompartmentType, CompartmentDefinition>();
+
+        // Given a fhir resource type, you can get the search params by compartment type.
+        // Example (Appointment (FhirResource), { Patient (CompartmentType), actor (searchparam) })
+        private Dictionary<ResourceType, IDictionary<CompartmentType, IList<string>>> _resourceTypeParamsByCompartmentDictionary = new Dictionary<ResourceType, IDictionary<CompartmentType, IList<string>>>();
+
+        private bool _initialized;
+
+        internal CompartmentDefinitionBuilder(Bundle bundle)
+        {
+            EnsureArg.IsNotNull(bundle, nameof(bundle));
+            _bundle = bundle;
+        }
+
+        internal IDictionary<ResourceType, IDictionary<CompartmentType, IList<string>>> CompartmentSearchParams
+        {
+            get
+            {
+                if (!_initialized)
+                {
+                    Build();
+                }
+
+                return _resourceTypeParamsByCompartmentDictionary;
+            }
+        }
+
+        internal IDictionary<CompartmentType, CompartmentDefinition> CompartmentLookup
+        {
+            get
+            {
+                if (!_initialized)
+                {
+                    Build();
+                }
+
+                return _compartmentTypeDictionary;
+            }
+        }
+
+        internal void Build()
+        {
+            _compartmentTypeDictionary = ValidateAndGetCompartmentDict();
+
+            // Build the lookup for the compartment by resource type.
+            foreach (var entry in _compartmentTypeDictionary)
+            {
+                BuildResourceTypeLookup(entry.Value);
+            }
+
+            _initialized = true;
+        }
+
+        private Dictionary<CompartmentType, CompartmentDefinition> ValidateAndGetCompartmentDict()
+        {
+            var issues = new List<IssueComponent>();
+            var validatedCompartments = new Dictionary<CompartmentType, CompartmentDefinition>();
+
+            for (int entryIndex = 0; entryIndex < _bundle.Entry.Count; entryIndex++)
+            {
+                // Make sure resources are not null and they are Compartment.
+                EntryComponent entry = _bundle.Entry[entryIndex];
+
+                var compartment = entry.Resource as CompartmentDefinition;
+
+                if (compartment == null)
+                {
+                    AddIssue(Core.Resources.CompartmentDefinitionInvalidResource, entryIndex);
+                    continue;
+                }
+
+                if (compartment.Code == null)
+                {
+                    AddIssue(Core.Resources.CompartmentDefinitionInvalidCompartmentType, entryIndex);
+                    continue;
+                }
+
+                if (string.IsNullOrWhiteSpace(compartment.Url) || !Uri.IsWellFormedUriString(compartment.Url, UriKind.Absolute))
+                {
+                    AddIssue(Core.Resources.CompartmentDefinitionInvalidUrl, entryIndex);
+                    continue;
+                }
+
+                validatedCompartments.Add(compartment.Code.Value, compartment);
+            }
+
+            EnsureNoIssues();
+            return validatedCompartments;
+
+            void AddIssue(string format, params object[] args)
+            {
+                issues.Add(new IssueComponent()
+                {
+                    Severity = IssueSeverity.Fatal,
+                    Code = IssueType.Invalid,
+                    Diagnostics = string.Format(CultureInfo.InvariantCulture, format, args),
+                });
+            }
+
+            void EnsureNoIssues()
+            {
+                if (issues.Count != 0)
+                {
+                    throw new InvalidDefinitionException(
+                        Core.Resources.CompartmentDefinitionContainsInvalidEntry,
+                        issues.ToArray());
+                }
+            }
+        }
+
+        private void BuildResourceTypeLookup(CompartmentDefinition compartment)
+        {
+            foreach (ResourceComponent resource in compartment.Resource)
+            {
+                if (!_resourceTypeParamsByCompartmentDictionary.TryGetValue(resource.Code.Value, out var resourceTypeDict))
+                {
+                    resourceTypeDict = new Dictionary<CompartmentType, IList<string>>();
+                    _resourceTypeParamsByCompartmentDictionary.Add(resource.Code.Value, resourceTypeDict);
+                }
+
+                // Already populated
+                if (resourceTypeDict.ContainsKey(compartment.Code.Value))
+                {
+                    continue;
+                }
+
+                resourceTypeDict[compartment.Code.Value] = resource.Param.ToList();
+            }
+
+            return;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/CompartmentDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/CompartmentDefinitionManager.cs
@@ -1,0 +1,77 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using EnsureThat;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
+using Microsoft.Health.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+
+namespace Microsoft.Health.Fhir.Core.Features.Definition
+{
+    /// <summary>
+    /// Manager to access compartment definitions.
+    /// </summary>
+    public class CompartmentDefinitionManager : IStartable, ICompartmentDefinitionManager
+    {
+        private readonly FhirJsonParser _fhirJsonParser;
+        private IDictionary<CompartmentType, CompartmentDefinition> _compartmentlLookup;
+        private IDictionary<ResourceType, IDictionary<CompartmentType, IList<string>>> _compartmentSearchParams;
+
+        public CompartmentDefinitionManager(FhirJsonParser fhirJsonParser)
+        {
+            EnsureArg.IsNotNull(fhirJsonParser, nameof(fhirJsonParser));
+            _fhirJsonParser = fhirJsonParser;
+        }
+
+        public void Start()
+        {
+            Type type = GetType();
+
+            // The json file is a bundle compiled from the compartment definitions currently defined by HL7.
+            // The definitions are available at https://www.hl7.org/fhir/compartmentdefinition.html.
+            using (Stream stream = type.Assembly.GetManifestResourceStream($"{type.Namespace}.compartment.json"))
+            using (TextReader reader = new StreamReader(stream))
+            using (JsonReader jsonReader = new JsonTextReader(reader))
+            {
+                var bundle = _fhirJsonParser.Parse<Bundle>(jsonReader);
+
+                var builder = new CompartmentDefinitionBuilder(bundle);
+
+                builder.Build();
+                _compartmentSearchParams = builder.CompartmentSearchParams;
+                _compartmentlLookup = builder.CompartmentLookup;
+            }
+        }
+
+        public CompartmentDefinition GetCompartmentDefinition(CompartmentType compartmentType)
+        {
+            if (_compartmentlLookup.TryGetValue(compartmentType, out var compartmentDefinition))
+            {
+                return compartmentDefinition;
+            }
+
+            throw new NotSupportedException(compartmentType.ToString());
+        }
+
+        public IDictionary<CompartmentType, IList<string>> GetCompartmentSearchParams(ResourceType resourceType)
+        {
+            if (_compartmentSearchParams.TryGetValue(resourceType, out var compartmentSearchParams))
+            {
+                return compartmentSearchParams;
+            }
+
+            throw new ResourceNotSupportedException(resourceType.ToString());
+        }
+
+        public bool TryGetCompartmentSearchParams(ResourceType resourceType, out IDictionary<CompartmentType, IList<string>> compartmentSearchParams)
+        {
+            return _compartmentSearchParams.TryGetValue(resourceType, out compartmentSearchParams);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/ICompartmentDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/ICompartmentDefinitionManager.cs
@@ -1,0 +1,39 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Hl7.Fhir.Model;
+
+namespace Microsoft.Health.Fhir.Core.Features.Definition
+{
+    /// <summary>
+    /// Methods to access compartment definitions
+    /// </summary>
+    public interface ICompartmentDefinitionManager
+    {
+        /// <summary>
+        /// Get the compartment Definition for the given <paramref name="compartmentType"/>.
+        /// </summary>
+        /// <param name="compartmentType">The compartment type.</param>
+        /// <returns>The compartment definition.</returns>
+        CompartmentDefinition GetCompartmentDefinition(CompartmentType compartmentType);
+
+        /// <summary>
+        /// Get the compartment index for the given <paramref name="resourceType"/>.
+        /// </summary>
+        /// <param name="resourceType">The fhir resource type for which to get the index.</param>
+        /// <returns>The index of compartment type to fieldnames that represent the <paramref name="resourceType"/> in a compartment.</returns>
+        IDictionary<CompartmentType, IList<string>> GetCompartmentSearchParams(ResourceType resourceType);
+
+        /// <summary>
+        /// Get the compartment index for the given <paramref name="resourceType"/>.
+        /// </summary>
+        /// <param name="resourceType">The fhir resource type for which to get the index.</param>
+        /// <param name="compartmentSearchParams">On return, the index of compartment type to the fieldnames that represent the <paramref name="resourceType"/> in a compartment if it exists. Otherwise the default value.</param>
+        /// <returns><c>true</c> if the compartmentSearchParams exists; otherwise, <c>false</c>.</returns>
+        bool TryGetCompartmentSearchParams(ResourceType resourceType, out IDictionary<CompartmentType, IList<string>> compartmentSearchParams);
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/compartment.json
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/compartment.json
@@ -1,0 +1,2022 @@
+{
+    "resourceType": "Bundle",
+    "id": "compartments",
+    "meta": {
+        "lastUpdated": "2017-04-19T07:44:43.294+10:00"
+    },
+    "type": "collection",
+    "entry": [{
+        "fullUrl": "http://hl7.org/fhir/CompartmentDefinition/patient",
+        "resource": {
+            "resourceType": "CompartmentDefinition",
+            "id": "patient",
+            "text": {
+                "status": "generated",
+                "div": "<div>!-- Snipped for Brevity --></div>"
+            },
+            "url": "http://hl7.org/fhir/CompartmentDefinition/patient",
+            "name": "Base FHIR compartment definition for Patient",
+            "status": "draft",
+            "experimental": true,
+            "date": "2017-04-19T07:44:43+10:00",
+            "publisher": "FHIR Project Team",
+            "contact": [{
+                "telecom": [{
+                    "system": "url",
+                    "value": "http://hl7.org/fhir"
+                }]
+            }],
+            "description": "There is an instance of the patient compartment for each patient resource, and the identity of the compartment is the same as the patient. When a patient is linked to another patient, all the records associated with the linked patient are in the compartment associated with the target of the link.. The set of resources associated with a particular patient",
+            "code": "Patient",
+            "search": true,
+            "resource": [{
+                "code": "Account",
+                "param": [
+                    "subject"
+                ]
+            }, {
+                "code": "ActivityDefinition"
+            }, {
+                "code": "AdverseEvent",
+                "param": [
+                    "subject"
+                ]
+            }, {
+                "code": "AllergyIntolerance",
+                "param": [
+                    "patient",
+                    "recorder",
+                    "asserter"
+                ]
+            }, {
+                "code": "Appointment",
+                "param": [
+                    "actor"
+                ]
+            }, {
+                "code": "AppointmentResponse",
+                "param": [
+                    "actor"
+                ]
+            }, {
+                "code": "AuditEvent",
+                "param": [
+                    "patient",
+                    "agent.patient",
+                    "entity.patient"
+                ]
+            }, {
+                "code": "Basic",
+                "param": [
+                    "patient",
+                    "author"
+                ]
+            }, {
+                "code": "Binary"
+            }, {
+                "code": "BodySite",
+                "param": [
+                    "patient"
+                ]
+            }, {
+                "code": "Bundle"
+            }, {
+                "code": "CapabilityStatement"
+            }, {
+                "code": "CarePlan",
+                "param": [
+                    "patient",
+                    "performer"
+                ]
+            }, {
+                "code": "CareTeam",
+                "param": [
+                    "patient",
+                    "participant"
+                ]
+            }, {
+                "code": "ChargeItem",
+                "param": [
+                    "subject"
+                ]
+            }, {
+                "code": "Claim",
+                "param": [
+                    "patient",
+                    "payee"
+                ]
+            }, {
+                "code": "ClaimResponse",
+                "param": [
+                    "patient"
+                ]
+            }, {
+                "code": "ClinicalImpression",
+                "param": [
+                    "subject"
+                ]
+            }, {
+                "code": "CodeSystem"
+            }, {
+                "code": "Communication",
+                "param": [
+                    "subject",
+                    "sender",
+                    "recipient"
+                ]
+            }, {
+                "code": "CommunicationRequest",
+                "param": [
+                    "subject",
+                    "sender",
+                    "recipient",
+                    "requester"
+                ]
+            }, {
+                "code": "CompartmentDefinition"
+            }, {
+                "code": "Composition",
+                "param": [
+                    "subject",
+                    "author",
+                    "attester"
+                ]
+            }, {
+                "code": "ConceptMap"
+            }, {
+                "code": "Condition",
+                "param": [
+                    "patient",
+                    "asserter"
+                ]
+            }, {
+                "code": "Consent",
+                "param": [
+                    "patient"
+                ]
+            }, {
+                "code": "Contract"
+            }, {
+                "code": "Coverage",
+                "param": [
+                    "policy-holder",
+                    "subscriber",
+                    "beneficiary",
+                    "payor"
+                ]
+            }, {
+                "code": "DataElement"
+            }, {
+                "code": "DetectedIssue",
+                "param": [
+                    "patient"
+                ]
+            }, {
+                "code": "Device"
+            }, {
+                "code": "DeviceComponent"
+            }, {
+                "code": "DeviceMetric"
+            }, {
+                "code": "DeviceRequest",
+                "param": [
+                    "subject",
+                    "requester",
+                    "performer"
+                ]
+            }, {
+                "code": "DeviceUseStatement",
+                "param": [
+                    "subject"
+                ]
+            }, {
+                "code": "DiagnosticReport",
+                "param": [
+                    "subject"
+                ]
+            }, {
+                "code": "DocumentManifest",
+                "param": [
+                    "subject",
+                    "author",
+                    "recipient"
+                ]
+            }, {
+                "code": "DocumentReference",
+                "param": [
+                    "subject",
+                    "author"
+                ]
+            }, {
+                "code": "EligibilityRequest",
+                "param": [
+                    "patient"
+                ]
+            }, {
+                "code": "EligibilityResponse"
+            }, {
+                "code": "Encounter",
+                "param": [
+                    "patient"
+                ]
+            }, {
+                "code": "Endpoint"
+            }, {
+                "code": "EnrollmentRequest",
+                "param": [
+                    "subject"
+                ]
+            }, {
+                "code": "EnrollmentResponse"
+            }, {
+                "code": "EpisodeOfCare",
+                "param": [
+                    "patient"
+                ]
+            }, {
+                "code": "ExpansionProfile"
+            }, {
+                "code": "ExplanationOfBenefit",
+                "param": [
+                    "patient",
+                    "payee"
+                ]
+            }, {
+                "code": "FamilyMemberHistory",
+                "param": [
+                    "patient"
+                ]
+            }, {
+                "code": "Flag",
+                "param": [
+                    "patient"
+                ]
+            }, {
+                "code": "Goal",
+                "param": [
+                    "patient"
+                ]
+            }, {
+                "code": "GraphDefinition"
+            }, {
+                "code": "Group",
+                "param": [
+                    "member"
+                ]
+            }, {
+                "code": "GuidanceResponse"
+            }, {
+                "code": "HealthcareService"
+            }, {
+                "code": "ImagingManifest",
+                "param": [
+                    "patient",
+                    "author"
+                ]
+            }, {
+                "code": "ImagingStudy",
+                "param": [
+                    "patient"
+                ]
+            }, {
+                "code": "Immunization",
+                "param": [
+                    "patient"
+                ]
+            }, {
+                "code": "ImmunizationRecommendation",
+                "param": [
+                    "patient"
+                ]
+            }, {
+                "code": "ImplementationGuide"
+            }, {
+                "code": "Library"
+            }, {
+                "code": "Linkage"
+            }, {
+                "code": "List",
+                "param": [
+                    "subject",
+                    "source"
+                ]
+            }, {
+                "code": "Location"
+            }, {
+                "code": "Measure"
+            }, {
+                "code": "MeasureReport",
+                "param": [
+                    "patient"
+                ]
+            }, {
+                "code": "Media",
+                "param": [
+                    "subject"
+                ]
+            }, {
+                "code": "Medication"
+            }, {
+                "code": "MedicationAdministration",
+                "param": [
+                    "patient",
+                    "performer",
+                    "subject"
+                ]
+            }, {
+                "code": "MedicationDispense",
+                "param": [
+                    "subject",
+                    "patient",
+                    "receiver"
+                ]
+            }, {
+                "code": "MedicationRequest",
+                "param": [
+                    "subject"
+                ]
+            }, {
+                "code": "MedicationStatement",
+                "param": [
+                    "subject"
+                ]
+            }, {
+                "code": "MessageDefinition"
+            }, {
+                "code": "MessageHeader"
+            }, {
+                "code": "NamingSystem"
+            }, {
+                "code": "NutritionOrder",
+                "param": [
+                    "patient"
+                ]
+            }, {
+                "code": "Observation",
+                "param": [
+                    "subject",
+                    "performer"
+                ]
+            }, {
+                "code": "OperationDefinition"
+            }, {
+                "code": "OperationOutcome"
+            }, {
+                "code": "Organization"
+            }, {
+                "code": "Patient",
+                "param": [
+                    "link"
+                ]
+            }, {
+                "code": "PaymentNotice"
+            }, {
+                "code": "PaymentReconciliation"
+            }, {
+                "code": "Person",
+                "param": [
+                    "patient"
+                ]
+            }, {
+                "code": "PlanDefinition"
+            }, {
+                "code": "Practitioner"
+            }, {
+                "code": "PractitionerRole"
+            }, {
+                "code": "Procedure",
+                "param": [
+                    "patient",
+                    "performer"
+                ]
+            }, {
+                "code": "ProcedureRequest",
+                "param": [
+                    "subject",
+                    "performer"
+                ]
+            }, {
+                "code": "ProcessRequest"
+            }, {
+                "code": "ProcessResponse"
+            }, {
+                "code": "Provenance",
+                "param": [
+                    "target.subject",
+                    "target.patient",
+                    "patient"
+                ]
+            }, {
+                "code": "Questionnaire"
+            }, {
+                "code": "QuestionnaireResponse",
+                "param": [
+                    "subject",
+                    "author"
+                ]
+            }, {
+                "code": "ReferralRequest",
+                "param": [
+                    "patient",
+                    "requester"
+                ]
+            }, {
+                "code": "RelatedPerson",
+                "param": [
+                    "patient"
+                ]
+            }, {
+                "code": "RequestGroup",
+                "param": [
+                    "subject",
+                    "participant"
+                ]
+            }, {
+                "code": "ResearchStudy"
+            }, {
+                "code": "ResearchSubject",
+                "param": [
+                    "individual"
+                ]
+            }, {
+                "code": "RiskAssessment",
+                "param": [
+                    "subject"
+                ]
+            }, {
+                "code": "Schedule",
+                "param": [
+                    "actor"
+                ]
+            }, {
+                "code": "SearchParameter"
+            }, {
+                "code": "Sequence"
+            }, {
+                "code": "ServiceDefinition"
+            }, {
+                "code": "Slot"
+            }, {
+                "code": "Specimen",
+                "param": [
+                    "subject"
+                ]
+            }, {
+                "code": "StructureDefinition"
+            }, {
+                "code": "StructureMap"
+            }, {
+                "code": "Subscription"
+            }, {
+                "code": "Substance"
+            }, {
+                "code": "SupplyDelivery",
+                "param": [
+                    "patient"
+                ]
+            }, {
+                "code": "SupplyRequest",
+                "param": [
+                    "requester"
+                ]
+            }, {
+                "code": "Task"
+            }, {
+                "code": "TestReport"
+            }, {
+                "code": "TestScript"
+            }, {
+                "code": "ValueSet"
+            }, {
+                "code": "VisionPrescription",
+                "param": [
+                    "patient"
+                ]
+            }]
+        }
+    }, {
+        "fullUrl": "http://hl7.org/fhir/CompartmentDefinition/encounter",
+        "resource": {
+            "resourceType": "CompartmentDefinition",
+            "id": "encounter",
+            "text": {
+                "status": "generated",
+                "div": "<div>!-- Snipped for Brevity --></div>"
+            },
+            "url": "http://hl7.org/fhir/CompartmentDefinition/encounter",
+            "name": "Base FHIR compartment definition for Encounter",
+            "status": "draft",
+            "experimental": true,
+            "date": "2017-04-19T07:44:43+10:00",
+            "publisher": "FHIR Project Team",
+            "contact": [{
+                "telecom": [{
+                    "system": "url",
+                    "value": "http://hl7.org/fhir"
+                }]
+            }],
+            "description": "There is an instance of the encounter compartment for each encounter resource, and the identity of the compartment is the same as the encounter. The set of resources associated with a particular encounter",
+            "code": "Encounter",
+            "search": true,
+            "resource": [{
+                "code": "Account"
+            }, {
+                "code": "ActivityDefinition"
+            }, {
+                "code": "AdverseEvent"
+            }, {
+                "code": "AllergyIntolerance"
+            }, {
+                "code": "Appointment"
+            }, {
+                "code": "AppointmentResponse"
+            }, {
+                "code": "AuditEvent"
+            }, {
+                "code": "Basic"
+            }, {
+                "code": "Binary"
+            }, {
+                "code": "BodySite"
+            }, {
+                "code": "Bundle"
+            }, {
+                "code": "CapabilityStatement"
+            }, {
+                "code": "CarePlan"
+            }, {
+                "code": "CareTeam"
+            }, {
+                "code": "ChargeItem",
+                "param": [
+                    "context"
+                ]
+            }, {
+                "code": "Claim",
+                "param": [
+                    "encounter"
+                ]
+            }, {
+                "code": "ClaimResponse"
+            }, {
+                "code": "ClinicalImpression",
+                "param": [
+                    "context"
+                ]
+            }, {
+                "code": "CodeSystem"
+            }, {
+                "code": "Communication",
+                "param": [
+                    "context"
+                ]
+            }, {
+                "code": "CommunicationRequest",
+                "param": [
+                    "context"
+                ]
+            }, {
+                "code": "CompartmentDefinition"
+            }, {
+                "code": "Composition",
+                "param": [
+                    "encounter"
+                ]
+            }, {
+                "code": "ConceptMap"
+            }, {
+                "code": "Condition",
+                "param": [
+                    "context"
+                ]
+            }, {
+                "code": "Consent"
+            }, {
+                "code": "Contract"
+            }, {
+                "code": "Coverage"
+            }, {
+                "code": "DataElement"
+            }, {
+                "code": "DetectedIssue"
+            }, {
+                "code": "Device"
+            }, {
+                "code": "DeviceComponent"
+            }, {
+                "code": "DeviceMetric"
+            }, {
+                "code": "DeviceRequest",
+                "param": [
+                    "encounter"
+                ]
+            }, {
+                "code": "DeviceUseStatement"
+            }, {
+                "code": "DiagnosticReport",
+                "param": [
+                    "encounter"
+                ]
+            }, {
+                "code": "DocumentManifest"
+            }, {
+                "code": "DocumentReference",
+                "param": [
+                    "encounter"
+                ]
+            }, {
+                "code": "EligibilityRequest"
+            }, {
+                "code": "EligibilityResponse"
+            }, {
+                "code": "Encounter",
+                "param": [
+                    "{def}"
+                ]
+            }, {
+                "code": "Endpoint"
+            }, {
+                "code": "EnrollmentRequest"
+            }, {
+                "code": "EnrollmentResponse"
+            }, {
+                "code": "EpisodeOfCare"
+            }, {
+                "code": "ExpansionProfile"
+            }, {
+                "code": "ExplanationOfBenefit",
+                "param": [
+                    "encounter"
+                ]
+            }, {
+                "code": "FamilyMemberHistory"
+            }, {
+                "code": "Flag"
+            }, {
+                "code": "Goal"
+            }, {
+                "code": "GraphDefinition"
+            }, {
+                "code": "Group"
+            }, {
+                "code": "GuidanceResponse"
+            }, {
+                "code": "HealthcareService"
+            }, {
+                "code": "ImagingManifest"
+            }, {
+                "code": "ImagingStudy"
+            }, {
+                "code": "Immunization"
+            }, {
+                "code": "ImmunizationRecommendation"
+            }, {
+                "code": "ImplementationGuide"
+            }, {
+                "code": "Library"
+            }, {
+                "code": "Linkage"
+            }, {
+                "code": "List"
+            }, {
+                "code": "Location"
+            }, {
+                "code": "Measure"
+            }, {
+                "code": "MeasureReport"
+            }, {
+                "code": "Media"
+            }, {
+                "code": "Medication"
+            }, {
+                "code": "MedicationAdministration",
+                "param": [
+                    "context"
+                ]
+            }, {
+                "code": "MedicationDispense"
+            }, {
+                "code": "MedicationRequest",
+                "param": [
+                    "context"
+                ]
+            }, {
+                "code": "MedicationStatement"
+            }, {
+                "code": "MessageDefinition"
+            }, {
+                "code": "MessageHeader"
+            }, {
+                "code": "NamingSystem"
+            }, {
+                "code": "NutritionOrder",
+                "param": [
+                    "encounter"
+                ]
+            }, {
+                "code": "Observation",
+                "param": [
+                    "encounter"
+                ]
+            }, {
+                "code": "OperationDefinition"
+            }, {
+                "code": "OperationOutcome"
+            }, {
+                "code": "Organization"
+            }, {
+                "code": "Patient"
+            }, {
+                "code": "PaymentNotice"
+            }, {
+                "code": "PaymentReconciliation"
+            }, {
+                "code": "Person"
+            }, {
+                "code": "PlanDefinition"
+            }, {
+                "code": "Practitioner"
+            }, {
+                "code": "PractitionerRole"
+            }, {
+                "code": "Procedure",
+                "param": [
+                    "encounter"
+                ]
+            }, {
+                "code": "ProcedureRequest",
+                "param": [
+                    "context"
+                ]
+            }, {
+                "code": "ProcessRequest"
+            }, {
+                "code": "ProcessResponse"
+            }, {
+                "code": "Provenance"
+            }, {
+                "code": "Questionnaire"
+            }, {
+                "code": "QuestionnaireResponse",
+                "param": [
+                    "context"
+                ]
+            }, {
+                "code": "ReferralRequest"
+            }, {
+                "code": "RelatedPerson"
+            }, {
+                "code": "RequestGroup",
+                "param": [
+                    "encounter"
+                ]
+            }, {
+                "code": "ResearchStudy"
+            }, {
+                "code": "ResearchSubject"
+            }, {
+                "code": "RiskAssessment"
+            }, {
+                "code": "Schedule"
+            }, {
+                "code": "SearchParameter"
+            }, {
+                "code": "Sequence"
+            }, {
+                "code": "ServiceDefinition"
+            }, {
+                "code": "Slot"
+            }, {
+                "code": "Specimen"
+            }, {
+                "code": "StructureDefinition"
+            }, {
+                "code": "StructureMap"
+            }, {
+                "code": "Subscription"
+            }, {
+                "code": "Substance"
+            }, {
+                "code": "SupplyDelivery"
+            }, {
+                "code": "SupplyRequest"
+            }, {
+                "code": "Task"
+            }, {
+                "code": "TestReport"
+            }, {
+                "code": "TestScript"
+            }, {
+                "code": "ValueSet"
+            }, {
+                "code": "VisionPrescription",
+                "param": [
+                    "encounter"
+                ]
+            }]
+        }
+    }, {
+        "fullUrl": "http://hl7.org/fhir/CompartmentDefinition/relatedPerson",
+        "resource": {
+            "resourceType": "CompartmentDefinition",
+            "id": "relatedPerson",
+            "text": {
+                "status": "generated",
+                "div": "<div>!-- Snipped for Brevity --></div>"
+            },
+            "url": "http://hl7.org/fhir/CompartmentDefinition/relatedPerson",
+            "name": "Base FHIR compartment definition for RelatedPerson",
+            "status": "draft",
+            "experimental": true,
+            "date": "2017-04-19T07:44:43+10:00",
+            "publisher": "FHIR Project Team",
+            "contact": [{
+                "telecom": [{
+                    "system": "url",
+                    "value": "http://hl7.org/fhir"
+                }]
+            }],
+            "description": "There is an instance of the relatedPerson compartment for each relatedPerson resource, and the identity of the compartment is the same as the relatedPerson. The set of resources associated with a particular 'related person'",
+            "code": "RelatedPerson",
+            "search": true,
+            "resource": [{
+                "code": "Account"
+            }, {
+                "code": "ActivityDefinition"
+            }, {
+                "code": "AdverseEvent",
+                "param": [
+                    "recorder"
+                ]
+            }, {
+                "code": "AllergyIntolerance",
+                "param": [
+                    "asserter"
+                ]
+            }, {
+                "code": "Appointment",
+                "param": [
+                    "actor"
+                ]
+            }, {
+                "code": "AppointmentResponse",
+                "param": [
+                    "actor"
+                ]
+            }, {
+                "code": "AuditEvent"
+            }, {
+                "code": "Basic",
+                "param": [
+                    "author"
+                ]
+            }, {
+                "code": "Binary"
+            }, {
+                "code": "BodySite"
+            }, {
+                "code": "Bundle"
+            }, {
+                "code": "CapabilityStatement"
+            }, {
+                "code": "CarePlan",
+                "param": [
+                    "performer"
+                ]
+            }, {
+                "code": "CareTeam",
+                "param": [
+                    "participant"
+                ]
+            }, {
+                "code": "ChargeItem",
+                "param": [
+                    "enterer",
+                    "participant-actor"
+                ]
+            }, {
+                "code": "Claim",
+                "param": [
+                    "payee"
+                ]
+            }, {
+                "code": "ClaimResponse"
+            }, {
+                "code": "ClinicalImpression"
+            }, {
+                "code": "CodeSystem"
+            }, {
+                "code": "Communication",
+                "param": [
+                    "sender",
+                    "recipient"
+                ]
+            }, {
+                "code": "CommunicationRequest",
+                "param": [
+                    "sender",
+                    "recipient",
+                    "requester"
+                ]
+            }, {
+                "code": "CompartmentDefinition"
+            }, {
+                "code": "Composition",
+                "param": [
+                    "author"
+                ]
+            }, {
+                "code": "ConceptMap"
+            }, {
+                "code": "Condition",
+                "param": [
+                    "asserter"
+                ]
+            }, {
+                "code": "Consent"
+            }, {
+                "code": "Contract"
+            }, {
+                "code": "Coverage",
+                "param": [
+                    "policy-holder",
+                    "subscriber",
+                    "payor"
+                ]
+            }, {
+                "code": "DataElement"
+            }, {
+                "code": "DetectedIssue"
+            }, {
+                "code": "Device"
+            }, {
+                "code": "DeviceComponent"
+            }, {
+                "code": "DeviceMetric"
+            }, {
+                "code": "DeviceRequest"
+            }, {
+                "code": "DeviceUseStatement"
+            }, {
+                "code": "DiagnosticReport"
+            }, {
+                "code": "DocumentManifest",
+                "param": [
+                    "author"
+                ]
+            }, {
+                "code": "DocumentReference",
+                "param": [
+                    "author"
+                ]
+            }, {
+                "code": "EligibilityRequest"
+            }, {
+                "code": "EligibilityResponse"
+            }, {
+                "code": "Encounter",
+                "param": [
+                    "participant"
+                ]
+            }, {
+                "code": "Endpoint"
+            }, {
+                "code": "EnrollmentRequest"
+            }, {
+                "code": "EnrollmentResponse"
+            }, {
+                "code": "EpisodeOfCare"
+            }, {
+                "code": "ExpansionProfile"
+            }, {
+                "code": "ExplanationOfBenefit",
+                "param": [
+                    "payee"
+                ]
+            }, {
+                "code": "FamilyMemberHistory"
+            }, {
+                "code": "Flag"
+            }, {
+                "code": "Goal"
+            }, {
+                "code": "GraphDefinition"
+            }, {
+                "code": "Group"
+            }, {
+                "code": "GuidanceResponse"
+            }, {
+                "code": "HealthcareService"
+            }, {
+                "code": "ImagingManifest",
+                "param": [
+                    "author"
+                ]
+            }, {
+                "code": "ImagingStudy"
+            }, {
+                "code": "Immunization"
+            }, {
+                "code": "ImmunizationRecommendation"
+            }, {
+                "code": "ImplementationGuide"
+            }, {
+                "code": "Library"
+            }, {
+                "code": "Linkage"
+            }, {
+                "code": "List"
+            }, {
+                "code": "Location"
+            }, {
+                "code": "Measure"
+            }, {
+                "code": "MeasureReport"
+            }, {
+                "code": "Media"
+            }, {
+                "code": "Medication"
+            }, {
+                "code": "MedicationAdministration",
+                "param": [
+                    "performer"
+                ]
+            }, {
+                "code": "MedicationDispense"
+            }, {
+                "code": "MedicationRequest"
+            }, {
+                "code": "MedicationStatement",
+                "param": [
+                    "source"
+                ]
+            }, {
+                "code": "MessageDefinition"
+            }, {
+                "code": "MessageHeader"
+            }, {
+                "code": "NamingSystem"
+            }, {
+                "code": "NutritionOrder"
+            }, {
+                "code": "Observation",
+                "param": [
+                    "performer"
+                ]
+            }, {
+                "code": "OperationDefinition"
+            }, {
+                "code": "OperationOutcome"
+            }, {
+                "code": "Organization"
+            }, {
+                "code": "Patient",
+                "param": [
+                    "link"
+                ]
+            }, {
+                "code": "PaymentNotice"
+            }, {
+                "code": "PaymentReconciliation"
+            }, {
+                "code": "Person",
+                "param": [
+                    "link"
+                ]
+            }, {
+                "code": "PlanDefinition"
+            }, {
+                "code": "Practitioner"
+            }, {
+                "code": "PractitionerRole"
+            }, {
+                "code": "Procedure",
+                "param": [
+                    "performer"
+                ]
+            }, {
+                "code": "ProcedureRequest",
+                "param": [
+                    "performer"
+                ]
+            }, {
+                "code": "ProcessRequest"
+            }, {
+                "code": "ProcessResponse"
+            }, {
+                "code": "Provenance",
+                "param": [
+                    "agent"
+                ]
+            }, {
+                "code": "Questionnaire"
+            }, {
+                "code": "QuestionnaireResponse",
+                "param": [
+                    "author",
+                    "source"
+                ]
+            }, {
+                "code": "ReferralRequest"
+            }, {
+                "code": "RelatedPerson",
+                "param": [
+                    "{def}"
+                ]
+            }, {
+                "code": "RequestGroup",
+                "param": [
+                    "participant"
+                ]
+            }, {
+                "code": "ResearchStudy"
+            }, {
+                "code": "ResearchSubject"
+            }, {
+                "code": "RiskAssessment"
+            }, {
+                "code": "Schedule",
+                "param": [
+                    "actor"
+                ]
+            }, {
+                "code": "SearchParameter"
+            }, {
+                "code": "Sequence"
+            }, {
+                "code": "ServiceDefinition"
+            }, {
+                "code": "Slot"
+            }, {
+                "code": "Specimen"
+            }, {
+                "code": "StructureDefinition"
+            }, {
+                "code": "StructureMap"
+            }, {
+                "code": "Subscription"
+            }, {
+                "code": "Substance"
+            }, {
+                "code": "SupplyDelivery"
+            }, {
+                "code": "SupplyRequest",
+                "param": [
+                    "requester"
+                ]
+            }, {
+                "code": "Task"
+            }, {
+                "code": "TestReport"
+            }, {
+                "code": "TestScript"
+            }, {
+                "code": "ValueSet"
+            }, {
+                "code": "VisionPrescription"
+            }]
+        }
+    }, {
+        "fullUrl": "http://hl7.org/fhir/CompartmentDefinition/practitioner",
+        "resource": {
+            "resourceType": "CompartmentDefinition",
+            "id": "practitioner",
+            "text": {
+                "status": "generated",
+                "div": "<div>!-- Snipped for Brevity --></div>"
+            },
+            "url": "http://hl7.org/fhir/CompartmentDefinition/practitioner",
+            "name": "Base FHIR compartment definition for Practitioner",
+            "status": "draft",
+            "experimental": true,
+            "date": "2017-04-19T07:44:43+10:00",
+            "publisher": "FHIR Project Team",
+            "contact": [{
+                "telecom": [{
+                    "system": "url",
+                    "value": "http://hl7.org/fhir"
+                }]
+            }],
+            "description": "There is an instance of the practitioner compartment for each Practitioner resource, and the identity of the compartment is the same as the Practitioner. The set of resources associated with a particular practitioner",
+            "code": "Practitioner",
+            "search": true,
+            "resource": [{
+                "code": "Account",
+                "param": [
+                    "subject"
+                ]
+            }, {
+                "code": "ActivityDefinition"
+            }, {
+                "code": "AdverseEvent",
+                "param": [
+                    "recorder"
+                ]
+            }, {
+                "code": "AllergyIntolerance",
+                "param": [
+                    "recorder",
+                    "asserter"
+                ]
+            }, {
+                "code": "Appointment",
+                "param": [
+                    "actor"
+                ]
+            }, {
+                "code": "AppointmentResponse",
+                "param": [
+                    "actor"
+                ]
+            }, {
+                "code": "AuditEvent",
+                "param": [
+                    "agent"
+                ]
+            }, {
+                "code": "Basic",
+                "param": [
+                    "author"
+                ]
+            }, {
+                "code": "Binary"
+            }, {
+                "code": "BodySite"
+            }, {
+                "code": "Bundle"
+            }, {
+                "code": "CapabilityStatement"
+            }, {
+                "code": "CarePlan",
+                "param": [
+                    "performer"
+                ]
+            }, {
+                "code": "CareTeam",
+                "param": [
+                    "participant"
+                ]
+            }, {
+                "code": "ChargeItem",
+                "param": [
+                    "enterer",
+                    "participant-actor"
+                ]
+            }, {
+                "code": "Claim",
+                "param": [
+                    "enterer",
+                    "provider",
+                    "payee",
+                    "care-team"
+                ]
+            }, {
+                "code": "ClaimResponse",
+                "param": [
+                    "request-provider"
+                ]
+            }, {
+                "code": "ClinicalImpression",
+                "param": [
+                    "assessor"
+                ]
+            }, {
+                "code": "CodeSystem"
+            }, {
+                "code": "Communication",
+                "param": [
+                    "sender",
+                    "recipient"
+                ]
+            }, {
+                "code": "CommunicationRequest",
+                "param": [
+                    "sender",
+                    "recipient",
+                    "requester"
+                ]
+            }, {
+                "code": "CompartmentDefinition"
+            }, {
+                "code": "Composition",
+                "param": [
+                    "subject",
+                    "author",
+                    "attester"
+                ]
+            }, {
+                "code": "ConceptMap"
+            }, {
+                "code": "Condition",
+                "param": [
+                    "asserter"
+                ]
+            }, {
+                "code": "Consent"
+            }, {
+                "code": "Contract"
+            }, {
+                "code": "Coverage"
+            }, {
+                "code": "DataElement"
+            }, {
+                "code": "DetectedIssue",
+                "param": [
+                    "author"
+                ]
+            }, {
+                "code": "Device"
+            }, {
+                "code": "DeviceComponent"
+            }, {
+                "code": "DeviceMetric"
+            }, {
+                "code": "DeviceRequest",
+                "param": [
+                    "requester",
+                    "performer"
+                ]
+            }, {
+                "code": "DeviceUseStatement"
+            }, {
+                "code": "DiagnosticReport",
+                "param": [
+                    "performer"
+                ]
+            }, {
+                "code": "DocumentManifest",
+                "param": [
+                    "subject",
+                    "author",
+                    "recipient"
+                ]
+            }, {
+                "code": "DocumentReference",
+                "param": [
+                    "subject",
+                    "author",
+                    "authenticator"
+                ]
+            }, {
+                "code": "EligibilityRequest",
+                "param": [
+                    "enterer",
+                    "provider"
+                ]
+            }, {
+                "code": "EligibilityResponse",
+                "param": [
+                    "request-provider"
+                ]
+            }, {
+                "code": "Encounter",
+                "param": [
+                    "practitioner",
+                    "participant"
+                ]
+            }, {
+                "code": "Endpoint"
+            }, {
+                "code": "EnrollmentRequest"
+            }, {
+                "code": "EnrollmentResponse"
+            }, {
+                "code": "EpisodeOfCare",
+                "param": [
+                    "care-manager"
+                ]
+            }, {
+                "code": "ExpansionProfile"
+            }, {
+                "code": "ExplanationOfBenefit",
+                "param": [
+                    "enterer",
+                    "provider",
+                    "payee",
+                    "care-team"
+                ]
+            }, {
+                "code": "FamilyMemberHistory"
+            }, {
+                "code": "Flag",
+                "param": [
+                    "author"
+                ]
+            }, {
+                "code": "Goal"
+            }, {
+                "code": "GraphDefinition"
+            }, {
+                "code": "Group",
+                "param": [
+                    "member"
+                ]
+            }, {
+                "code": "GuidanceResponse"
+            }, {
+                "code": "HealthcareService"
+            }, {
+                "code": "ImagingManifest",
+                "param": [
+                    "author"
+                ]
+            }, {
+                "code": "ImagingStudy"
+            }, {
+                "code": "Immunization",
+                "param": [
+                    "practitioner"
+                ]
+            }, {
+                "code": "ImmunizationRecommendation"
+            }, {
+                "code": "ImplementationGuide"
+            }, {
+                "code": "Library"
+            }, {
+                "code": "Linkage",
+                "param": [
+                    "author"
+                ]
+            }, {
+                "code": "List",
+                "param": [
+                    "source"
+                ]
+            }, {
+                "code": "Location"
+            }, {
+                "code": "Measure"
+            }, {
+                "code": "MeasureReport"
+            }, {
+                "code": "Media",
+                "param": [
+                    "subject",
+                    "operator"
+                ]
+            }, {
+                "code": "Medication"
+            }, {
+                "code": "MedicationAdministration",
+                "param": [
+                    "performer"
+                ]
+            }, {
+                "code": "MedicationDispense",
+                "param": [
+                    "performer",
+                    "receiver"
+                ]
+            }, {
+                "code": "MedicationRequest",
+                "param": [
+                    "requester"
+                ]
+            }, {
+                "code": "MedicationStatement",
+                "param": [
+                    "source"
+                ]
+            }, {
+                "code": "MessageDefinition"
+            }, {
+                "code": "MessageHeader",
+                "param": [
+                    "receiver",
+                    "author",
+                    "responsible",
+                    "enterer"
+                ]
+            }, {
+                "code": "NamingSystem"
+            }, {
+                "code": "NutritionOrder",
+                "param": [
+                    "provider"
+                ]
+            }, {
+                "code": "Observation",
+                "param": [
+                    "performer"
+                ]
+            }, {
+                "code": "OperationDefinition"
+            }, {
+                "code": "OperationOutcome"
+            }, {
+                "code": "Organization"
+            }, {
+                "code": "Patient",
+                "param": [
+                    "general-practitioner"
+                ]
+            }, {
+                "code": "PaymentNotice",
+                "param": [
+                    "provider"
+                ]
+            }, {
+                "code": "PaymentReconciliation",
+                "param": [
+                    "request-provider"
+                ]
+            }, {
+                "code": "Person",
+                "param": [
+                    "practitioner"
+                ]
+            }, {
+                "code": "PlanDefinition"
+            }, {
+                "code": "Practitioner",
+                "param": [
+                    "{def}"
+                ]
+            }, {
+                "code": "PractitionerRole",
+                "param": [
+                    "practitioner"
+                ]
+            }, {
+                "code": "Procedure",
+                "param": [
+                    "performer"
+                ]
+            }, {
+                "code": "ProcedureRequest",
+                "param": [
+                    "performer",
+                    "requester"
+                ]
+            }, {
+                "code": "ProcessRequest",
+                "param": [
+                    "provider"
+                ]
+            }, {
+                "code": "ProcessResponse",
+                "param": [
+                    "request-provider"
+                ]
+            }, {
+                "code": "Provenance",
+                "param": [
+                    "agent"
+                ]
+            }, {
+                "code": "Questionnaire"
+            }, {
+                "code": "QuestionnaireResponse",
+                "param": [
+                    "author",
+                    "source"
+                ]
+            }, {
+                "code": "ReferralRequest",
+                "param": [
+                    "requester",
+                    "recipient"
+                ]
+            }, {
+                "code": "RelatedPerson"
+            }, {
+                "code": "RequestGroup",
+                "param": [
+                    "participant",
+                    "author"
+                ]
+            }, {
+                "code": "ResearchStudy",
+                "param": [
+                    "principalinvestigator"
+                ]
+            }, {
+                "code": "ResearchSubject"
+            }, {
+                "code": "RiskAssessment",
+                "param": [
+                    "performer"
+                ]
+            }, {
+                "code": "Schedule",
+                "param": [
+                    "actor"
+                ]
+            }, {
+                "code": "SearchParameter"
+            }, {
+                "code": "Sequence"
+            }, {
+                "code": "ServiceDefinition"
+            }, {
+                "code": "Slot"
+            }, {
+                "code": "Specimen",
+                "param": [
+                    "collector"
+                ]
+            }, {
+                "code": "StructureDefinition"
+            }, {
+                "code": "StructureMap"
+            }, {
+                "code": "Subscription"
+            }, {
+                "code": "Substance"
+            }, {
+                "code": "SupplyDelivery",
+                "param": [
+                    "supplier",
+                    "receiver"
+                ]
+            }, {
+                "code": "SupplyRequest",
+                "param": [
+                    "requester"
+                ]
+            }, {
+                "code": "Task"
+            }, {
+                "code": "TestReport"
+            }, {
+                "code": "TestScript"
+            }, {
+                "code": "ValueSet"
+            }, {
+                "code": "VisionPrescription",
+                "param": [
+                    "prescriber"
+                ]
+            }]
+        }
+    }, {
+        "fullUrl": "http://hl7.org/fhir/CompartmentDefinition/device",
+        "resource": {
+            "resourceType": "CompartmentDefinition",
+            "id": "device",
+            "text": {
+                "status": "generated",
+                "div": "<div>!-- Snipped for Brevity --></div>"
+            },
+            "url": "http://hl7.org/fhir/CompartmentDefinition/device",
+            "name": "Base FHIR compartment definition for Device",
+            "status": "draft",
+            "experimental": true,
+            "date": "2017-04-19T07:44:43+10:00",
+            "publisher": "FHIR Project Team",
+            "contact": [{
+                "telecom": [{
+                    "system": "url",
+                    "value": "http://hl7.org/fhir"
+                }]
+            }],
+            "description": "There is an instance of the practitioner compartment for each Device resource, and the identity of the compartment is the same as the Device. The set of resources associated with a particular device",
+            "code": "Device",
+            "search": true,
+            "resource": [{
+                "code": "Account",
+                "param": [
+                    "subject"
+                ]
+            }, {
+                "code": "ActivityDefinition"
+            }, {
+                "code": "AdverseEvent"
+            }, {
+                "code": "AllergyIntolerance"
+            }, {
+                "code": "Appointment",
+                "param": [
+                    "actor"
+                ]
+            }, {
+                "code": "AppointmentResponse",
+                "param": [
+                    "actor"
+                ]
+            }, {
+                "code": "AuditEvent",
+                "param": [
+                    "agent"
+                ]
+            }, {
+                "code": "Basic"
+            }, {
+                "code": "Binary"
+            }, {
+                "code": "BodySite"
+            }, {
+                "code": "Bundle"
+            }, {
+                "code": "CapabilityStatement"
+            }, {
+                "code": "CarePlan"
+            }, {
+                "code": "CareTeam"
+            }, {
+                "code": "ChargeItem",
+                "param": [
+                    "enterer",
+                    "participant-actor"
+                ]
+            }, {
+                "code": "Claim"
+            }, {
+                "code": "ClaimResponse"
+            }, {
+                "code": "ClinicalImpression"
+            }, {
+                "code": "CodeSystem"
+            }, {
+                "code": "Communication",
+                "param": [
+                    "sender",
+                    "recipient"
+                ]
+            }, {
+                "code": "CommunicationRequest",
+                "param": [
+                    "sender",
+                    "recipient"
+                ]
+            }, {
+                "code": "CompartmentDefinition"
+            }, {
+                "code": "Composition",
+                "param": [
+                    "author"
+                ]
+            }, {
+                "code": "ConceptMap"
+            }, {
+                "code": "Condition"
+            }, {
+                "code": "Consent"
+            }, {
+                "code": "Contract"
+            }, {
+                "code": "Coverage"
+            }, {
+                "code": "DataElement"
+            }, {
+                "code": "DetectedIssue",
+                "param": [
+                    "author"
+                ]
+            }, {
+                "code": "Device",
+                "param": [
+                    "{def}"
+                ]
+            }, {
+                "code": "DeviceComponent",
+                "param": [
+                    "source"
+                ]
+            }, {
+                "code": "DeviceMetric",
+                "param": [
+                    "source"
+                ]
+            }, {
+                "code": "DeviceRequest",
+                "param": [
+                    "device",
+                    "subject",
+                    "requester",
+                    "performer"
+                ]
+            }, {
+                "code": "DeviceUseStatement",
+                "param": [
+                    "device"
+                ]
+            }, {
+                "code": "DiagnosticReport",
+                "param": [
+                    "subject"
+                ]
+            }, {
+                "code": "DocumentManifest",
+                "param": [
+                    "subject",
+                    "author"
+                ]
+            }, {
+                "code": "DocumentReference",
+                "param": [
+                    "subject",
+                    "author"
+                ]
+            }, {
+                "code": "EligibilityRequest"
+            }, {
+                "code": "EligibilityResponse"
+            }, {
+                "code": "Encounter"
+            }, {
+                "code": "Endpoint"
+            }, {
+                "code": "EnrollmentRequest"
+            }, {
+                "code": "EnrollmentResponse"
+            }, {
+                "code": "EpisodeOfCare"
+            }, {
+                "code": "ExpansionProfile"
+            }, {
+                "code": "ExplanationOfBenefit"
+            }, {
+                "code": "FamilyMemberHistory"
+            }, {
+                "code": "Flag",
+                "param": [
+                    "author"
+                ]
+            }, {
+                "code": "Goal"
+            }, {
+                "code": "GraphDefinition"
+            }, {
+                "code": "Group",
+                "param": [
+                    "member"
+                ]
+            }, {
+                "code": "GuidanceResponse"
+            }, {
+                "code": "HealthcareService"
+            }, {
+                "code": "ImagingManifest",
+                "param": [
+                    "author"
+                ]
+            }, {
+                "code": "ImagingStudy"
+            }, {
+                "code": "Immunization"
+            }, {
+                "code": "ImmunizationRecommendation"
+            }, {
+                "code": "ImplementationGuide"
+            }, {
+                "code": "Library"
+            }, {
+                "code": "Linkage"
+            }, {
+                "code": "List",
+                "param": [
+                    "subject",
+                    "source"
+                ]
+            }, {
+                "code": "Location"
+            }, {
+                "code": "Measure"
+            }, {
+                "code": "MeasureReport"
+            }, {
+                "code": "Media",
+                "param": [
+                    "subject"
+                ]
+            }, {
+                "code": "Medication"
+            }, {
+                "code": "MedicationAdministration",
+                "param": [
+                    "device"
+                ]
+            }, {
+                "code": "MedicationDispense"
+            }, {
+                "code": "MedicationRequest"
+            }, {
+                "code": "MedicationStatement"
+            }, {
+                "code": "MessageDefinition"
+            }, {
+                "code": "MessageHeader",
+                "param": [
+                    "target"
+                ]
+            }, {
+                "code": "NamingSystem"
+            }, {
+                "code": "NutritionOrder"
+            }, {
+                "code": "Observation",
+                "param": [
+                    "subject",
+                    "device"
+                ]
+            }, {
+                "code": "OperationDefinition"
+            }, {
+                "code": "OperationOutcome"
+            }, {
+                "code": "Organization"
+            }, {
+                "code": "Patient"
+            }, {
+                "code": "PaymentNotice"
+            }, {
+                "code": "PaymentReconciliation"
+            }, {
+                "code": "Person"
+            }, {
+                "code": "PlanDefinition"
+            }, {
+                "code": "Practitioner"
+            }, {
+                "code": "PractitionerRole"
+            }, {
+                "code": "Procedure"
+            }, {
+                "code": "ProcedureRequest",
+                "param": [
+                    "performer",
+                    "requester"
+                ]
+            }, {
+                "code": "ProcessRequest"
+            }, {
+                "code": "ProcessResponse"
+            }, {
+                "code": "Provenance",
+                "param": [
+                    "agent"
+                ]
+            }, {
+                "code": "Questionnaire"
+            }, {
+                "code": "QuestionnaireResponse",
+                "param": [
+                    "author"
+                ]
+            }, {
+                "code": "ReferralRequest"
+            }, {
+                "code": "RelatedPerson"
+            }, {
+                "code": "RequestGroup",
+                "param": [
+                    "author"
+                ]
+            }, {
+                "code": "ResearchStudy"
+            }, {
+                "code": "ResearchSubject"
+            }, {
+                "code": "RiskAssessment",
+                "param": [
+                    "performer"
+                ]
+            }, {
+                "code": "Schedule",
+                "param": [
+                    "actor"
+                ]
+            }, {
+                "code": "SearchParameter"
+            }, {
+                "code": "Sequence"
+            }, {
+                "code": "ServiceDefinition"
+            }, {
+                "code": "Slot"
+            }, {
+                "code": "Specimen",
+                "param": [
+                    "subject"
+                ]
+            }, {
+                "code": "StructureDefinition"
+            }, {
+                "code": "StructureMap"
+            }, {
+                "code": "Subscription"
+            }, {
+                "code": "Substance"
+            }, {
+                "code": "SupplyDelivery"
+            }, {
+                "code": "SupplyRequest",
+                "param": [
+                    "requester"
+                ]
+            }, {
+                "code": "Task"
+            }, {
+                "code": "TestReport"
+            }, {
+                "code": "TestScript"
+            }, {
+                "code": "ValueSet"
+            }, {
+                "code": "VisionPrescription"
+            }]
+        }
+    }]
+}

--- a/src/Microsoft.Health.Fhir.Core/Microsoft.Health.Fhir.Core.csproj
+++ b/src/Microsoft.Health.Fhir.Core/Microsoft.Health.Fhir.Core.csproj
@@ -21,6 +21,7 @@
     <EmbeddedResource Include="Features\Conformance\BaseCapabilities.json" />
     <EmbeddedResource Include="Features\Conformance\LegacyDefaultCapabilities.json" />
     <EmbeddedResource Include="Features\Definition\search-parameters.json" />
+    <EmbeddedResource Include="Features\Definition\compartment.json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -106,6 +106,60 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The compartment definition contains one or more invalid entries..
+        /// </summary>
+        internal static string CompartmentDefinitionContainsInvalidEntry {
+            get {
+                return ResourceManager.GetString("CompartmentDefinitionContainsInvalidEntry", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to bundle.entry[{0}] is null..
+        /// </summary>
+        internal static string CompartmentDefinitionInvalidBundle {
+            get {
+                return ResourceManager.GetString("CompartmentDefinitionInvalidBundle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to bundle.entry[{0}].resource.code is null. Not a valid compartment type..
+        /// </summary>
+        internal static string CompartmentDefinitionInvalidCompartmentType {
+            get {
+                return ResourceManager.GetString("CompartmentDefinitionInvalidCompartmentType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to bundle.entry[{0}].resource is null or is not a CompartmentDefinition resource.
+        /// </summary>
+        internal static string CompartmentDefinitionInvalidResource {
+            get {
+                return ResourceManager.GetString("CompartmentDefinitionInvalidResource", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to bundle.entry[{0}].url is invalid..
+        /// </summary>
+        internal static string CompartmentDefinitionInvalidUrl {
+            get {
+                return ResourceManager.GetString("CompartmentDefinitionInvalidUrl", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The composite separator character cannot be found..
+        /// </summary>
+        internal static string CompositeSeparatorNotFound {
+            get {
+                return ResourceManager.GetString("CompositeSeparatorNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Deleting a specific record version is not supported..
         /// </summary>
         internal static string DeleteVersionNotAllowed {

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -132,6 +132,25 @@
   <data name="ComparatorNotSupported" xml:space="preserve">
     <value>The comparator '{0}' is not supported for search parameter '{1}'.</value>
   </data>
+  <data name="CompartmentDefinitionContainsInvalidEntry" xml:space="preserve">
+    <value>The compartment definition contains one or more invalid entries.</value>
+  </data>
+  <data name="CompartmentDefinitionInvalidBundle" xml:space="preserve">
+    <value>bundle.entry[{0}] is null.</value>
+    <comment>{0}: The bundle entry id.</comment>
+  </data>
+  <data name="CompartmentDefinitionInvalidCompartmentType" xml:space="preserve">
+    <value>bundle.entry[{0}].resource.code is null. Not a valid compartment type.</value>
+  </data>
+  <data name="CompartmentDefinitionInvalidResource" xml:space="preserve">
+    <value>bundle.entry[{0}].resource is null or is not a CompartmentDefinition resource</value>
+  </data>
+  <data name="CompartmentDefinitionInvalidUrl" xml:space="preserve">
+    <value>bundle.entry[{0}].url is invalid.</value>
+  </data>
+  <data name="CompositeSeparatorNotFound" xml:space="preserve">
+    <value>The composite separator character cannot be found.</value>
+  </data>
   <data name="DeleteVersionNotAllowed" xml:space="preserve">
     <value>Deleting a specific record version is not supported.</value>
   </data>

--- a/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
+++ b/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
@@ -24,6 +24,7 @@
     <None Remove="TestFiles\BloodPressure.json" />
     <None Remove="TestFiles\ObservationWith20MinuteApgarScore.json" />
     <None Remove="TestFiles\ObservationWithEyeColor.json" />
+    <None Remove="TestFiles\InvalidCompartmentDefinition.json" />
     <None Remove="TestFiles\ObservationWithInvalidStatus.json" />
     <None Remove="TestFiles\ObservationWithInvalidStatus.xml" />
     <None Remove="TestFiles\ObservationWithNoCode.json" />
@@ -35,6 +36,7 @@
     <None Remove="TestFiles\Patient.json" />
     <None Remove="TestFiles\Patient.xml" />
     <None Remove="TestFiles\ResourceWrapperNoVersion.json" />
+    <None Remove="TestFiles\ValidCompartmentDefinition.json" />
     <None Remove="TestFiles\Weight.json" />
     <None Remove="TestFiles\WeightInGrams.json" />
     <None Remove="TestFiles\WeightInPounds.json" />
@@ -60,6 +62,7 @@
     <EmbeddedResource Include="TestFiles\ObservationWithTemperature.json" />
     <EmbeddedResource Include="TestFiles\ObservationWithTPMTDiplotype.json" />
     <EmbeddedResource Include="TestFiles\ObservationWithTPMTHaplotypeOne.json" />
+    <EmbeddedResource Include="TestFiles\InvalidCompartmentDefinition.json" />
     <EmbeddedResource Include="TestFiles\ObservationWithInvalidStatus.xml" />
     <EmbeddedResource Include="TestFiles\ObservationWithInvalidStatus.json" />
     <EmbeddedResource Include="TestFiles\ObservationWithNoCode.xml" />
@@ -68,6 +71,9 @@
     <EmbeddedResource Include="TestFiles\Patient.json" />
     <EmbeddedResource Include="TestFiles\Patient.xml" />
     <EmbeddedResource Include="TestFiles\ResourceWrapperNoVersion.json" />
+    <EmbeddedResource Include="TestFiles\ValidCompartmentDefinition.json">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </EmbeddedResource>
     <EmbeddedResource Include="TestFiles\Weight.json" />
     <EmbeddedResource Include="TestFiles\WeightInGrams.json" />
     <EmbeddedResource Include="TestFiles\WeightInPounds.json" />

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/InvalidCompartmentDefinition.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/InvalidCompartmentDefinition.json
@@ -1,0 +1,789 @@
+﻿{
+    "resourceType": "Bundle",
+    "id": "compartments",
+    "meta": {
+        "lastUpdated": "2017-04-19T07:44:43.294+10:00"
+    },
+    "type": "collection",
+    "entry": [
+        {
+            "fullUrl": "http://hl7.org/fhir/CompartmentDefinition/patient",
+            "resource": {
+                "resourceType": "CompartmentDefinition",
+                "id": "patient",
+                "text": {
+                    "status": "generated",
+                    "div": "<div>!-- Snipped for Brevity --></div>"
+                },
+                "url": "patient",
+                "name": "Base FHIR compartment definition for Patient",
+                "status": "draft",
+                "experimental": true,
+                "date": "2017-04-19T07:44:43+10:00",
+                "publisher": "FHIR Project Team",
+                "contact": [
+                    {
+                        "telecom": [
+                            {
+                                "system": "url",
+                                "value": "http://hl7.org/fhir"
+                            }
+                        ]
+                    }
+                ],
+                "description": "There is an instance of the patient compartment for each patient resource, and the identity of the compartment is the same as the patient. When a patient is linked to another patient, all the records associated with the linked patient are in the compartment associated with the target of the link.. The set of resources associated with a particular patient",
+                "code": "Patient",
+                "search": true,
+                "resource": [
+                    {
+                        "code": "Account",
+                        "param": [
+                            "subject"
+                        ]
+                    },
+                    {
+                        "code": "ActivityDefinition"
+                    },
+                    {
+                        "code": "AdverseEvent",
+                        "param": [
+                            "subject"
+                        ]
+                    },
+                    {
+                        "code": "AllergyIntolerance",
+                        "param": [
+                            "patient",
+                            "recorder",
+                            "asserter"
+                        ]
+                    },
+                    {
+                        "code": "Appointment",
+                        "param": [
+                            "actor"
+                        ]
+                    },
+                    {
+                        "code": "AppointmentResponse",
+                        "param": [
+                            "actor"
+                        ]
+                    },
+                    {
+                        "code": "AuditEvent",
+                        "param": [
+                            "patient",
+                            "agent.patient",
+                            "entity.patient"
+                        ]
+                    },
+                    {
+                        "code": "Basic",
+                        "param": [
+                            "patient",
+                            "author"
+                        ]
+                    },
+                    {
+                        "code": "Binary"
+                    },
+                    {
+                        "code": "BodySite",
+                        "param": [
+                            "patient"
+                        ]
+                    },
+                    {
+                        "code": "Bundle"
+                    },
+                    {
+                        "code": "CapabilityStatement"
+                    },
+                    {
+                        "code": "CarePlan",
+                        "param": [
+                            "patient",
+                            "performer"
+                        ]
+                    },
+                    {
+                        "code": "CareTeam",
+                        "param": [
+                            "patient",
+                            "participant"
+                        ]
+                    },
+                    {
+                        "code": "ChargeItem",
+                        "param": [
+                            "subject"
+                        ]
+                    },
+                    {
+                        "code": "Claim",
+                        "param": [
+                            "patient",
+                            "payee"
+                        ]
+                    },
+                    {
+                        "code": "ClaimResponse",
+                        "param": [
+                            "patient"
+                        ]
+                    },
+                    {
+                        "code": "ClinicalImpression",
+                        "param": [
+                            "subject"
+                        ]
+                    },
+                    {
+                        "code": "CodeSystem"
+                    },
+                    {
+                        "code": "Communication",
+                        "param": [
+                            "subject",
+                            "sender",
+                            "recipient"
+                        ]
+                    },
+                    {
+                        "code": "CommunicationRequest",
+                        "param": [
+                            "subject",
+                            "sender",
+                            "recipient",
+                            "requester"
+                        ]
+                    },
+                    {
+                        "code": "CompartmentDefinition"
+                    },
+                    {
+                        "code": "Composition",
+                        "param": [
+                            "subject",
+                            "author",
+                            "attester"
+                        ]
+                    },
+                    {
+                        "code": "ConceptMap"
+                    },
+                    {
+                        "code": "Condition",
+                        "param": [
+                            "patient",
+                            "asserter"
+                        ]
+                    },
+                    {
+                        "code": "Consent",
+                        "param": [
+                            "patient"
+                        ]
+                    },
+                    {
+                        "code": "Contract"
+                    },
+                    {
+                        "code": "Coverage",
+                        "param": [
+                            "policy-holder",
+                            "subscriber",
+                            "beneficiary",
+                            "payor"
+                        ]
+                    },
+                    {
+                        "code": "DataElement"
+                    },
+                    {
+                        "code": "DetectedIssue",
+                        "param": [
+                            "patient"
+                        ]
+                    },
+                    {
+                        "code": "Device"
+                    },
+                    {
+                        "code": "DeviceComponent"
+                    },
+                    {
+                        "code": "DeviceMetric"
+                    },
+                    {
+                        "code": "DeviceRequest",
+                        "param": [
+                            "subject",
+                            "requester",
+                            "performer"
+                        ]
+                    },
+                    {
+                        "code": "DeviceUseStatement",
+                        "param": [
+                            "subject"
+                        ]
+                    },
+                    {
+                        "code": "DiagnosticReport",
+                        "param": [
+                            "subject"
+                        ]
+                    },
+                    {
+                        "code": "DocumentManifest",
+                        "param": [
+                            "subject",
+                            "author",
+                            "recipient"
+                        ]
+                    },
+                    {
+                        "code": "DocumentReference",
+                        "param": [
+                            "subject",
+                            "author"
+                        ]
+                    },
+                    {
+                        "code": "EligibilityRequest",
+                        "param": [
+                            "patient"
+                        ]
+                    },
+                    {
+                        "code": "EligibilityResponse"
+                    },
+                    {
+                        "code": "Encounter",
+                        "param": [
+                            "patient"
+                        ]
+                    },
+                    {
+                        "code": "Endpoint"
+                    },
+                    {
+                        "code": "EnrollmentRequest",
+                        "param": [
+                            "subject"
+                        ]
+                    },
+                    {
+                        "code": "EnrollmentResponse"
+                    },
+                    {
+                        "code": "EpisodeOfCare",
+                        "param": [
+                            "patient"
+                        ]
+                    },
+                    {
+                        "code": "ExpansionProfile"
+                    },
+                    {
+                        "code": "ExplanationOfBenefit",
+                        "param": [
+                            "patient",
+                            "payee"
+                        ]
+                    },
+                    {
+                        "code": "FamilyMemberHistory",
+                        "param": [
+                            "patient"
+                        ]
+                    },
+                    {
+                        "code": "Flag",
+                        "param": [
+                            "patient"
+                        ]
+                    },
+                    {
+                        "code": "Goal",
+                        "param": [
+                            "patient"
+                        ]
+                    },
+                    {
+                        "code": "GraphDefinition"
+                    },
+                    {
+                        "code": "Group",
+                        "param": [
+                            "member"
+                        ]
+                    },
+                    {
+                        "code": "GuidanceResponse"
+                    },
+                    {
+                        "code": "HealthcareService"
+                    },
+                    {
+                        "code": "ImagingManifest",
+                        "param": [
+                            "patient",
+                            "author"
+                        ]
+                    },
+                    {
+                        "code": "ImagingStudy",
+                        "param": [
+                            "patient"
+                        ]
+                    },
+                    {
+                        "code": "Immunization",
+                        "param": [
+                            "patient"
+                        ]
+                    },
+                    {
+                        "code": "ImmunizationRecommendation",
+                        "param": [
+                            "patient"
+                        ]
+                    },
+                    {
+                        "code": "ImplementationGuide"
+                    },
+                    {
+                        "code": "Library"
+                    },
+                    {
+                        "code": "Linkage"
+                    },
+                    {
+                        "code": "List",
+                        "param": [
+                            "subject",
+                            "source"
+                        ]
+                    },
+                    {
+                        "code": "Location"
+                    },
+                    {
+                        "code": "Measure"
+                    },
+                    {
+                        "code": "MeasureReport",
+                        "param": [
+                            "patient"
+                        ]
+                    },
+                    {
+                        "code": "Media",
+                        "param": [
+                            "subject"
+                        ]
+                    },
+                    {
+                        "code": "Medication"
+                    },
+                    {
+                        "code": "MedicationAdministration",
+                        "param": [
+                            "patient",
+                            "performer",
+                            "subject"
+                        ]
+                    },
+                    {
+                        "code": "MedicationDispense",
+                        "param": [
+                            "subject",
+                            "patient",
+                            "receiver"
+                        ]
+                    },
+                    {
+                        "code": "MedicationRequest",
+                        "param": [
+                            "subject"
+                        ]
+                    },
+                    {
+                        "code": "MedicationStatement",
+                        "param": [
+                            "subject"
+                        ]
+                    },
+                    {
+                        "code": "MessageDefinition"
+                    },
+                    {
+                        "code": "MessageHeader"
+                    },
+                    {
+                        "code": "NamingSystem"
+                    },
+                    {
+                        "code": "NutritionOrder",
+                        "param": [
+                            "patient"
+                        ]
+                    },
+                    {
+                        "code": "Observation",
+                        "param": [
+                            "subject",
+                            "performer"
+                        ]
+                    },
+                    {
+                        "code": "OperationDefinition"
+                    },
+                    {
+                        "code": "OperationOutcome"
+                    },
+                    {
+                        "code": "Organization"
+                    },
+                    {
+                        "code": "Patient",
+                        "param": [
+                            "link"
+                        ]
+                    },
+                    {
+                        "code": "PaymentNotice"
+                    },
+                    {
+                        "code": "PaymentReconciliation"
+                    },
+                    {
+                        "code": "Person",
+                        "param": [
+                            "patient"
+                        ]
+                    },
+                    {
+                        "code": "PlanDefinition"
+                    },
+                    {
+                        "code": "Practitioner"
+                    },
+                    {
+                        "code": "PractitionerRole"
+                    },
+                    {
+                        "code": "Procedure",
+                        "param": [
+                            "patient",
+                            "performer"
+                        ]
+                    },
+                    {
+                        "code": "ProcedureRequest",
+                        "param": [
+                            "subject",
+                            "performer"
+                        ]
+                    },
+                    {
+                        "code": "ProcessRequest"
+                    },
+                    {
+                        "code": "ProcessResponse"
+                    },
+                    {
+                        "code": "Provenance",
+                        "param": [
+                            "target.subject",
+                            "target.patient",
+                            "patient"
+                        ]
+                    },
+                    {
+                        "code": "Questionnaire"
+                    },
+                    {
+                        "code": "QuestionnaireResponse",
+                        "param": [
+                            "subject",
+                            "author"
+                        ]
+                    },
+                    {
+                        "code": "ReferralRequest",
+                        "param": [
+                            "patient",
+                            "requester"
+                        ]
+                    },
+                    {
+                        "code": "RelatedPerson",
+                        "param": [
+                            "patient"
+                        ]
+                    },
+                    {
+                        "code": "RequestGroup",
+                        "param": [
+                            "subject",
+                            "participant"
+                        ]
+                    },
+                    {
+                        "code": "ResearchStudy"
+                    },
+                    {
+                        "code": "ResearchSubject",
+                        "param": [
+                            "individual"
+                        ]
+                    },
+                    {
+                        "code": "RiskAssessment",
+                        "param": [
+                            "subject"
+                        ]
+                    },
+                    {
+                        "code": "Schedule",
+                        "param": [
+                            "actor"
+                        ]
+                    },
+                    {
+                        "code": "SearchParameter"
+                    },
+                    {
+                        "code": "Sequence"
+                    },
+                    {
+                        "code": "ServiceDefinition"
+                    },
+                    {
+                        "code": "Slot"
+                    },
+                    {
+                        "code": "Specimen",
+                        "param": [
+                            "subject"
+                        ]
+                    },
+                    {
+                        "code": "StructureDefinition"
+                    },
+                    {
+                        "code": "StructureMap"
+                    },
+                    {
+                        "code": "Subscription"
+                    },
+                    {
+                        "code": "Substance"
+                    },
+                    {
+                        "code": "SupplyDelivery",
+                        "param": [
+                            "patient"
+                        ]
+                    },
+                    {
+                        "code": "SupplyRequest",
+                        "param": [
+                            "requester"
+                        ]
+                    },
+                    {
+                        "code": "Task"
+                    },
+                    {
+                        "code": "TestReport"
+                    },
+                    {
+                        "code": "TestScript"
+                    },
+                    {
+                        "code": "ValueSet"
+                    },
+                    {
+                        "code": "VisionPrescription",
+                        "param": [
+                            "patient"
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "fullUrl": "http://hl7.org/fhir/ResourceDefinition/patient",
+            "resource": {
+                "resourceType": "Patient",
+                "id": "example",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n\t\t\t<table>\n\t\t\t\t<tbody>\n\t\t\t\t\t<tr>\n\t\t\t\t\t\t<td>Name</td>\n\t\t\t\t\t\t<td>Peter James \n              <b>Chalmers</b> (&quot;Jim&quot;)\n            </td>\n\t\t\t\t\t</tr>\n\t\t\t\t\t<tr>\n\t\t\t\t\t\t<td>Address</td>\n\t\t\t\t\t\t<td>534 Erewhon, Pleasantville, Vic, 3999</td>\n\t\t\t\t\t</tr>\n\t\t\t\t\t<tr>\n\t\t\t\t\t\t<td>Contacts</td>\n\t\t\t\t\t\t<td>Home: unknown. Work: (03) 5555 6473</td>\n\t\t\t\t\t</tr>\n\t\t\t\t\t<tr>\n\t\t\t\t\t\t<td>Id</td>\n\t\t\t\t\t\t<td>MRN: 12345 (Acme Healthcare)</td>\n\t\t\t\t\t</tr>\n\t\t\t\t</tbody>\n\t\t\t</table>\n\t\t</div>"
+                },
+                "identifier": [
+                    {
+                        "use": "usual",
+                        "type": {
+                            "coding": [
+                                {
+                                    "system": "http://hl7.org/fhir/v2/0203",
+                                    "code": "MR"
+                                }
+                            ]
+                        },
+                        "system": "urn:oid:1.2.36.146.595.217.0.1",
+                        "value": "12345",
+                        "period": {
+                            "start": "2001-05-06"
+                        },
+                        "assigner": {
+                            "display": "Acme Healthcare"
+                        }
+                    }
+                ],
+                "active": true,
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "Chalmers",
+                        "given": [
+                            "Peter",
+                            "James"
+                        ]
+                    },
+                    {
+                        "use": "usual",
+                        "given": [
+                            "Jim"
+                        ]
+                    },
+                    {
+                        "use": "maiden",
+                        "family": "Windsor",
+                        "given": [
+                            "Peter",
+                            "James"
+                        ],
+                        "period": {
+                            "end": "2002"
+                        }
+                    }
+                ],
+                "telecom": [
+                    {
+                        "use": "home"
+                    },
+                    {
+                        "system": "phone",
+                        "value": "(03) 5555 6473",
+                        "use": "work",
+                        "rank": 1
+                    },
+                    {
+                        "system": "phone",
+                        "value": "(03) 3410 5613",
+                        "use": "mobile",
+                        "rank": 2
+                    },
+                    {
+                        "system": "phone",
+                        "value": "(03) 5555 8834",
+                        "use": "old",
+                        "period": {
+                            "end": "2014"
+                        }
+                    }
+                ],
+                "gender": "male",
+                "birthDate": "1974-12-25",
+                "_birthDate": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/patient-birthTime",
+                            "valueDateTime": "1974-12-25T14:35:45-05:00"
+                        }
+                    ]
+                },
+                "deceasedBoolean": false,
+                "address": [
+                    {
+                        "use": "home",
+                        "type": "both",
+                        "text": "534 Erewhon St PeasantVille, Rainbow, Vic  3999",
+                        "line": [
+                            "534 Erewhon St"
+                        ],
+                        "city": "PleasantVille",
+                        "district": "Rainbow",
+                        "state": "Vic",
+                        "postalCode": "3999",
+                        "period": {
+                            "start": "1974-12-25"
+                        }
+                    }
+                ],
+                "contact": [
+                    {
+                        "relationship": [
+                            {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/v2/0131",
+                                        "code": "N"
+                                    }
+                                ]
+                            }
+                        ],
+                        "name": {
+                            "family": "du Marché",
+                            "_family": {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                                        "valueString": "VV"
+                                    }
+                                ]
+                            },
+                            "given": [
+                                "Bénédicte"
+                            ]
+                        },
+                        "telecom": [
+                            {
+                                "system": "phone",
+                                "value": "+33 (237) 998327"
+                            }
+                        ],
+                        "address": {
+                            "use": "home",
+                            "type": "both",
+                            "line": [
+                                "534 Erewhon St"
+                            ],
+                            "city": "PleasantVille",
+                            "district": "Rainbow",
+                            "state": "Vic",
+                            "postalCode": "3999",
+                            "period": {
+                                "start": "1974-12-25"
+                            }
+                        },
+                        "gender": "female",
+                        "period": {
+                            "start": "2012"
+                        }
+                    }
+                ],
+                "managingOrganization": {
+                    "reference": "Organization/1"
+                }
+            }
+        }
+    ]
+}

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/ValidCompartmentDefinition.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/ValidCompartmentDefinition.json
@@ -1,0 +1,117 @@
+﻿{
+    "resourceType": "Bundle",
+    "id": "compartments",
+    "meta": {
+        "lastUpdated": "2017-04-19T07:44:43.294+10:00"
+    },
+    "type": "collection",
+    "entry": [
+        {
+            "fullUrl": "http://hl7.org/fhir/CompartmentDefinition/patient",
+            "resource": {
+                "resourceType": "CompartmentDefinition",
+                "id": "patient",
+                "text": {
+                    "status": "generated",
+                    "div": "<div>!-- Snipped for Brevity --></div>"
+                },
+                "url": "http://hl7.org/fhir/CompartmentDefinition/patient",
+                "name": "Base FHIR compartment definition for Patient",
+                "status": "draft",
+                "experimental": true,
+                "date": "2017-04-19T07:44:43+10:00",
+                "publisher": "FHIR Project Team",
+                "contact": [
+                    {
+                        "telecom": [
+                            {
+                                "system": "url",
+                                "value": "http://hl7.org/fhir"
+                            }
+                        ]
+                    }
+                ],
+                "description": "There is an instance of the patient compartment for each patient resource, and the identity of the compartment is the same as the patient. When a patient is linked to another patient, all the records associated with the linked patient are in the compartment associated with the target of the link.. The set of resources associated with a particular patient",
+                "code": "Patient",
+                "search": true,
+                "resource": [
+                    {
+                        "code": "Communication",
+                        "param": [
+                            "subject",
+                            "sender",
+                            "recipient"
+                        ]
+                    },
+                    {
+                        "code": "Condition",
+                        "param": [
+                            "patient",
+                            "asserter"
+                        ]
+                    },
+                    {
+                        "code": "Encounter",
+                        "param": [
+                            "patient"
+                        ]
+                    },
+                    {
+                        "code": "Observation",
+                        "param": [
+                            "subject",
+                            "performer"
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "fullUrl": "http://hl7.org/fhir/CompartmentDefinition/encounter",
+            "resource": {
+                "resourceType": "CompartmentDefinition",
+                "id": "encounter",
+                "text": {
+                    "status": "generated",
+                    "div": "<div>!-- Snipped for Brevity --></div>"
+                },
+                "url": "http://hl7.org/fhir/CompartmentDefinition/encounter",
+                "name": "Base FHIR compartment definition for Encounter",
+                "status": "draft",
+                "experimental": true,
+                "date": "2017-04-19T07:44:43+10:00",
+                "publisher": "FHIR Project Team",
+                "contact": [
+                    {
+                        "telecom": [
+                            {
+                                "system": "url",
+                                "value": "http://hl7.org/fhir"
+                            }
+                        ]
+                    }
+                ],
+                "description": "There is an instance of the encounter compartment for each encounter resource, and the identity of the compartment is the same as the encounter. The set of resources associated with a particular encounter",
+                "code": "Encounter",
+                "search": true,
+                "resource": [
+                    {
+                        "code": "Account"
+                    },
+                    {
+                        "code": "Condition",
+                        "param": [
+                            "context"
+                        ]
+                    },
+                    {
+                        "code": "Observation",
+                        "param": [
+                            "encounter"
+                        ]
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
As a first step towards supporting compartment based searches (also needed for Authorization), we need to lookup individual resources for Compartments.
HL7 currently defines Patient, Encounter, RelatedPerson, Practitioner and Device compartments. The PR contains
a) A bundle definition of all the currently available Compartment definitions. This is compiled from the definition available from https://www.hl7.org/fhir/compartmentdefinition.html.
b) A builder, manager to load the definitions and cache them in dictionary by ResourceType for fast lookup during search. The loading happen during startup.
c) Tests
Compartment based searches will use the same underlying infrastructure as search. The compartment search parameters that are part of the definition will already be available in the search index of the resource, so we don't need to add a separate index for compartment. During compartment search, we will lookup the parameters to search on the target resource that will have the compartment id from the index and initiate a search.

Next Step: Index individual resources with compartment indexes so that * based searches are efficient and possible.