### PR TITLE
Make the E2E tests packable.

### DIFF
--- a/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
+++ b/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <IsPackable>true</IsPackable>
     <CodeAnalysisRuleSet>..\..\CustomAnalysisRules.Test.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />

--- a/test/Microsoft.Health.Fhir.Tests.E2E/Microsoft.Health.Fhir.Tests.E2E.csproj
+++ b/test/Microsoft.Health.Fhir.Tests.E2E/Microsoft.Health.Fhir.Tests.E2E.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <IsPackable>true</IsPackable>
     <CodeAnalysisRuleSet>..\..\CustomAnalysisRules.Test.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />


### PR DESCRIPTION
Make the E2E tests packable so that NuGet packages can be created.

I don't know what condition causes other project to be packable but not these test ones but explicitly set these two projects to be packable.