### PR TITLE
Removed Azure Government Deploy button

### DIFF
--- a/docs/DefaultDeployment.md
+++ b/docs/DefaultDeployment.md
@@ -58,10 +58,6 @@ To deploy the backend Cosmos DB, Azure Web App, and FHIR server code, use the bu
     <img src="https://azuredeploy.net/deploybutton.png"/>
 </a>
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FMicrosoft%2Ffhir-server%2Fmaster%2Fsamples%2Ftemplates%2Fdefault-azuredeploy.json" target="_blank">
-    <img src="https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.png">
-</a>
-
 The template can also be deployed using PowerShell. Here is an example of how the authorization details from above can be provided:
 
 ```PowerShell


### PR DESCRIPTION
Currently Azure gov does not have ASP.NET Core 2.1.5 and the automated one-click deploy will fail.