### PR TITLE
Defer creation of the cartesian product for composite search values.

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/SearchValues/CompositeSearchValueTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/SearchValues/CompositeSearchValueTests.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
 using Xunit;
 
@@ -22,21 +23,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.SearchValues
         [Fact]
         public void GivenAnEmptyComponents_WhenInitializing_ThenExceptionShouldBeThrown()
         {
-            Assert.Throws<ArgumentException>(ParamNameComponents, () => new CompositeSearchValue(new StringSearchValue[0]));
-        }
-
-        [Fact]
-        public void GivenComponents_WhenInitialized_ThenCorrectComponentsShouldBeAssigned()
-        {
-            var components = new ISearchValue[]
-            {
-                new StringSearchValue("abc"),
-                new NumberSearchValue(123),
-            };
-
-            var value = new CompositeSearchValue(components);
-
-            Assert.Same(components, value.Components);
+            Assert.Throws<ArgumentException>(ParamNameComponents, () => new CompositeSearchValue(new IReadOnlyList<ISearchValue>[] { }));
         }
 
         [Fact]
@@ -47,7 +34,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.SearchValues
                 new StringSearchValue("abc"),
             };
 
-            var value = new CompositeSearchValue(components);
+            var value = new CompositeSearchValue(new[] { components });
 
             Assert.False(value.IsValidAsCompositeComponent);
         }
@@ -55,15 +42,23 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.SearchValues
         [Fact]
         public void GivenASearchValue_WhenToStringIsCalled_ThenCorrectStringShouldBeReturned()
         {
-            var components = new ISearchValue[]
+            var components = new ISearchValue[][]
             {
-                new TokenSearchValue("system", "code", "text"),
-                new NumberSearchValue(123),
+                new ISearchValue[]
+                {
+                    new TokenSearchValue("system1", "code1", "text1"),
+                    new TokenSearchValue("system2", "code2", "text2"),
+                },
+                new ISearchValue[]
+                {
+                    new NumberSearchValue(123),
+                    new NumberSearchValue(789),
+                },
             };
 
             var value = new CompositeSearchValue(components);
 
-            Assert.Equal("system|code$123", value.ToString());
+            Assert.Equal("(system1|code1), (system2|code2) $ (123), (789)", value.ToString());
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchIndexer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchIndexer.cs
@@ -12,7 +12,6 @@ using EnsureThat;
 using Hl7.Fhir.FhirPath;
 using Hl7.Fhir.Model;
 using Microsoft.Extensions.Logging;
-using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Search.Converters;
 using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
@@ -132,13 +131,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                     continue;
                 }
 
-                // Create the list of searchable values.
-                foreach (IEnumerable<ISearchValue> compositeSearchValues in componentValues.CartesianProduct())
-                {
-                    yield return new SearchIndexEntry(
-                        searchParameter.Name,
-                        new CompositeSearchValue(compositeSearchValues.ToArray()));
-                }
+                yield return new SearchIndexEntry(searchParameter.Name, new CompositeSearchValue(componentValues));
             }
         }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/CompositeSearchValue.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/CompositeSearchValue.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Linq;
 using EnsureThat;
 
 namespace Microsoft.Health.Fhir.Core.Features.Search.SearchValues
@@ -17,7 +18,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.SearchValues
         /// Initializes a new instance of the <see cref="CompositeSearchValue"/> class.
         /// </summary>
         /// <param name="components">The composite component values.</param>
-        public CompositeSearchValue(IReadOnlyList<ISearchValue> components)
+        public CompositeSearchValue(IReadOnlyList<IReadOnlyList<ISearchValue>> components)
         {
             EnsureArg.IsNotNull(components, nameof(components));
             EnsureArg.HasItems(components, nameof(components));
@@ -28,7 +29,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.SearchValues
         /// <summary>
         /// Gets the composite component values.
         /// </summary>
-        public IReadOnlyList<ISearchValue> Components { get; }
+        public IReadOnlyList<IReadOnlyList<ISearchValue>> Components { get; }
 
         /// <inheritdoc />
         public bool IsValidAsCompositeComponent => false;
@@ -44,7 +45,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.SearchValues
         /// <inheritdoc />
         public override string ToString()
         {
-            return string.Join("$", Components);
+            return string.Join(" $ ", Components.Select(component => string.Join(", ", component.Select(v => $"({v})"))));
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/Search/SearchIndexEntryJObjectGeneratorTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/Search/SearchIndexEntryJObjectGeneratorTests.cs
@@ -38,12 +38,13 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Storage.Search
             const string system3 = "s3";
             const string code3 = "c3";
 
-            var value = new CompositeSearchValue(new ISearchValue[]
-            {
-                new TokenSearchValue(system1, code1, text1),
-                new TokenSearchValue(system2, code2, text2),
-                new QuantitySearchValue(system3, code3, quantity),
-            });
+            var value = new CompositeSearchValue(
+                new[]
+                {
+                    new ISearchValue[] { new TokenSearchValue(system1, code1, text1) },
+                    new ISearchValue[] { new TokenSearchValue(system2, code2, text2) },
+                    new ISearchValue[] { new QuantitySearchValue(system3, code3, quantity) },
+                });
 
             TestAndValidateOutput(
                 value,

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Search/SearchIndexEntryConverter.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Search/SearchIndexEntryConverter.cs
@@ -5,7 +5,11 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Search;
+using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
 using Microsoft.Health.Fhir.CosmosDb.Features.Search;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -37,11 +41,27 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Search
                 generator = new SearchIndexEntryJObjectGenerator();
             }
 
+            if (searchIndexEntry.Value is CompositeSearchValue compositeValue)
+            {
+                // From the cartesian product, produce CompositeSearchValues where each component has exactly one value.
+                foreach (IEnumerable<ISearchValue> compositeSearchValues in compositeValue.Components.CartesianProduct())
+                {
+                    WriteJsonImpl(writer, generator, searchIndexEntry.ParamName, new CompositeSearchValue(compositeSearchValues.Select(v => new[] { v }).ToArray()));
+                }
+            }
+            else
+            {
+                WriteJsonImpl(writer, generator, searchIndexEntry.ParamName, searchIndexEntry.Value);
+            }
+        }
+
+        private static void WriteJsonImpl(JsonWriter writer, SearchIndexEntryJObjectGenerator generator, string paramName, ISearchValue searchValue)
+        {
             JObject generatedObj;
 
             try
             {
-                searchIndexEntry.Value.AcceptVisitor(generator);
+                searchValue.AcceptVisitor(generator);
 
                 generatedObj = generator.Output;
             }
@@ -53,7 +73,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Search
             }
 
             generatedObj.AddFirst(
-                new JProperty(SearchValueConstants.ParamName, searchIndexEntry.ParamName));
+                new JProperty(SearchValueConstants.ParamName, paramName));
 
             generatedObj.WriteTo(writer);
         }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Search/SearchIndexEntryJObjectGenerator.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Search/SearchIndexEntryJObjectGenerator.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
 using Microsoft.Health.Fhir.CosmosDb.Features.Search;
@@ -37,7 +39,9 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Search
                     Index = i;
                     ExcludeTokenText = true;
 
-                    composite.Components[i].AcceptVisitor(this);
+                    IReadOnlyList<ISearchValue> components = composite.Components[i];
+                    Debug.Assert(components.Count == 1, "There should be only a single value in each component");
+                    components[0].AcceptVisitor(this);
                 }
             }
             finally


### PR DESCRIPTION
For search indexes for composite search params stored in Cosmos DB, we compute the cartesian product of all possible values for each component. This is not desirable for the SQL provider, so we defer the computing the product to the Cosmos DB provider.

Separately, we can look at optimizing the storage to avoid the cartesian product altogether.