### PR TITLE
Fixed the concurrency issue.

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Search/SearchIndexEntryConverter.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Search/SearchIndexEntryConverter.cs
@@ -42,15 +42,15 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Search
             try
             {
                 generatedObjects = generator.Generate(searchIndexEntry);
+
+                foreach (JObject generatedObj in generatedObjects)
+                {
+                    generatedObj.WriteTo(writer);
+                }
             }
             finally
             {
                 CachedGenerators.Enqueue(generator);
-            }
-
-            foreach (JObject generatedObj in generatedObjects)
-            {
-                generatedObj.WriteTo(writer);
             }
         }
     }


### PR DESCRIPTION
This is a regression from #173. When multiple requests are processed simultaneously, the collection could be updated while the enumeration is happening, which results in error.

Addresses #192 