### PR TITLE
Make scripts more robust for keyvault and resource group.

### DIFF
--- a/release/scripts/PowerShell/FhirServerRelease/Private/SharedModuleFunctions.ps1
+++ b/release/scripts/PowerShell/FhirServerRelease/Private/SharedModuleFunctions.ps1
@@ -50,10 +50,14 @@ function Get-ServiceAudience {
     param (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [string]$EnvironmentName
+        [string]$EnvironmentName,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$WebAppSuffix
     )
  
-    return "https://$EnvironmentName.azurewebsites.net/"
+    return "https://$EnvironmentName.$WebAppSuffix/"
 }
 
 function Get-UserId { 

--- a/release/scripts/PowerShell/FhirServerRelease/Public/Add-AadTestAuthEnvironment.ps1
+++ b/release/scripts/PowerShell/FhirServerRelease/Public/Add-AadTestAuthEnvironment.ps1
@@ -31,10 +31,10 @@ function Add-AadTestAuthEnvironment {
         [String]$WebAppSuffix = "azurewebsites.net",
 
         [Parameter(Mandatory = $false)]
-        [string]$ResourceGroupName,
+        [string]$ResourceGroupName = $EnvironmentName,
 
         [parameter(Mandatory = $false)]
-        [string]$KeyVaultName
+        [string]$KeyVaultName = "$EnvironmentName-ts"
     )
     
     Set-StrictMode -Version Latest
@@ -58,15 +58,6 @@ function Add-AadTestAuthEnvironment {
     Write-Host "Setting up Test Authorization Environment for AAD"
 
     $testAuthEnvironment = Get-Content -Raw -Path $TestAuthEnvironmentPath | ConvertFrom-Json
-
-    if(!$ResourceGroupName) {
-        $ResourceGroupName = $EnvironmentName
-    }
-    
-    if(!$KeyVaultName){
-        $KeyVaultName = "$EnvironmentName-ts"
-    }
-
 
     $keyVault = Get-AzureRmKeyVault -VaultName $KeyVaultName
 

--- a/release/scripts/PowerShell/FhirServerRelease/Public/Add-AadTestAuthEnvironment.ps1
+++ b/release/scripts/PowerShell/FhirServerRelease/Public/Add-AadTestAuthEnvironment.ps1
@@ -25,7 +25,16 @@ function Add-AadTestAuthEnvironment {
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNull()]
-        [pscredential]$TenantAdminCredential
+        [pscredential]$TenantAdminCredential,
+        
+        [Parameter(Mandatory = $false )]
+        [String]$WebAppSuffix = "azurewebsites.net",
+
+        [Parameter(Mandatory = $false)]
+        [string]$ResourceGroupName,
+
+        [parameter(Mandatory = $false)]
+        [string]$KeyVaultName
     )
     
     Set-StrictMode -Version Latest
@@ -50,22 +59,29 @@ function Add-AadTestAuthEnvironment {
 
     $testAuthEnvironment = Get-Content -Raw -Path $TestAuthEnvironmentPath | ConvertFrom-Json
 
-    $keyVaultName = "$EnvironmentName-ts"
+    if(!$ResourceGroupName) {
+        $ResourceGroupName = $EnvironmentName
+    }
+    
+    if(!$KeyVaultName){
+        $KeyVaultName = "$EnvironmentName-ts"
+    }
 
-    $keyVault = Get-AzureRmKeyVault -VaultName $keyVaultName
+
+    $keyVault = Get-AzureRmKeyVault -VaultName $KeyVaultName
 
     if (!$keyVault) {
-        Write-Host "Creating keyvault with the name $keyVaultName"
-        New-AzureRmKeyVault -VaultName $keyVaultName -ResourceGroupName $EnvironmentName -Location $EnvironmentLocation | Out-Null
+        Write-Host "Creating keyvault with the name $KeyVaultName"
+        New-AzureRmKeyVault -VaultName $KeyVaultName -ResourceGroupName $ResourceGroupName -Location $EnvironmentLocation | Out-Null
     }
 
     $retryCount = 0
     # Make sure key vault exists and is ready
-    while (!(Get-AzureRmKeyVault -VaultName $keyVaultName )) {
+    while (!(Get-AzureRmKeyVault -VaultName $KeyVaultName )) {
         $retryCount += 1
 
         if ($retryCount -gt 7) {
-            throw "Could not connect to the vault $keyVaultName"
+            throw "Could not connect to the vault $KeyVaultName"
         }
 
         sleep 10
@@ -86,12 +102,12 @@ function Add-AadTestAuthEnvironment {
 
     if ($currentObjectId) {
         Write-Host "Adding permission to keyvault for $currentObjectId"
-        Set-AzureRmKeyVaultAccessPolicy -VaultName $keyVaultName -ObjectId $currentObjectId -PermissionsToSecrets Get, Set
+        Set-AzureRmKeyVaultAccessPolicy -VaultName $KeyVaultName -ObjectId $currentObjectId -PermissionsToSecrets Get, Set
     }
 
     Write-Host "Ensuring API application exists"
 
-    $fhirServiceAudience = Get-ServiceAudience $EnvironmentName
+    $fhirServiceAudience = Get-ServiceAudience -EnvironmentName $EnvironmentName -WebAppSuffix $WebAppSuffix
 
     $application = Get-AzureAdApplicationByIdentifierUri $fhirServiceAudience
 
@@ -107,7 +123,7 @@ function Add-AadTestAuthEnvironment {
     Set-FhirServerApiApplicationRoles -ApiAppId $application.AppId -AppRoles $appRoles | Out-Null
 
     Write-Host "Ensuring users and role assignments for API Application exist"
-    $environmentUsers = Set-FhirServerApiUsers -UserNamePrefix $EnvironmentName -TenantDomain $tenantInfo.TenantDomain -ApiAppId $application.AppId -UserConfiguration $testAuthEnvironment.Users -KeyVaultName $keyVaultName
+    $environmentUsers = Set-FhirServerApiUsers -UserNamePrefix $EnvironmentName -TenantDomain $tenantInfo.TenantDomain -ApiAppId $application.AppId -UserConfiguration $testAuthEnvironment.Users -KeyVaultName $KeyVaultName
 
     $environmentClientApplications = @()
 
@@ -142,13 +158,13 @@ function Add-AadTestAuthEnvironment {
             appId       = $aadClientApplication.AppId
         }
         
-        Set-AzureKeyVaultSecret -VaultName $keyVaultName -Name "$displayName-secret" -SecretValue $secretSecureString | Out-Null
+        Set-AzureKeyVaultSecret -VaultName $KeyVaultName -Name "$displayName-secret" -SecretValue $secretSecureString | Out-Null
 
         Set-FhirServerClientAppRoleAssignments -ApiAppId $application.AppId -AppId $aadClientApplication.AppId -AppRoles $clientApp.roles | Out-Null
     }
 
     @{
-        keyVaultName                  = $keyVaultName
+        keyVaultName                  = $KeyVaultName
         environmentUsers              = $environmentUsers
         environmentClientApplications = $environmentClientApplications
     }

--- a/release/scripts/PowerShell/FhirServerRelease/Public/Remove-AadTestAuthEnvironment.ps1
+++ b/release/scripts/PowerShell/FhirServerRelease/Public/Remove-AadTestAuthEnvironment.ps1
@@ -16,7 +16,10 @@ function Remove-AadTestAuthEnvironment {
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [string]$EnvironmentName
+        [string]$EnvironmentName,
+        
+        [Parameter(Mandatory = $false )]
+        [String]$WebAppSuffix = "azurewebsites.net"
     )
 
     Set-StrictMode -Version Latest
@@ -33,7 +36,7 @@ function Remove-AadTestAuthEnvironment {
 
     $testAuthEnvironment = Get-Content -Raw -Path $TestAuthEnvironmentPath | ConvertFrom-Json
 
-    $fhirServiceAudience = Get-ServiceAudience $EnvironmentName
+    $fhirServiceAudience = Get-ServiceAudience -EnvironmentName $EnvironmentName -WebAppSuffix $WebAppSuffix
 
     $application = Get-AzureAdApplicationByIdentifierUri $fhirServiceAudience
 


### PR DESCRIPTION
This PR updates the release scripts to allow you to optionally pass in the following parameters as opposed to relying on convention:
* WebAppSuffix
* KeyVaultName
* ResourceGroupName 