### PR TITLE
Improves read and vread performance

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Modules/ValidationModule.cs
+++ b/src/Microsoft.Health.Fhir.Api/Modules/ValidationModule.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Health.Fhir.Api.Modules
 
             services.TypesInSameAssemblyAs<ResourceNotValidException>()
                 .AssignableTo<IValidator>()
-                .Scoped()
+                .Singleton()
                 .AsSelf()
                 .AsImplementedInterfaces();
         }


### PR DESCRIPTION
Addresses some low-hanging fruit in read (e.g. `GET /Observation/id`) and vread (e.g. `GET Observation/id/_history/1`) performance.


Average times in ms for one-box, measured from the client:

|       | Before | After |
|-------|--------|-------|
| __Read__  | 8.1    | 3.1   |
| __VRead__ | 11.5   | 5.5   |