### PR TITLE
Fix TestEnvironmentFilePath to resolve across platforms. Fixes #266.

### DIFF
--- a/src/Microsoft.Health.Fhir.Web/DevelopmentIdentityProviderRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Web/DevelopmentIdentityProviderRegistrationExtensions.cs
@@ -122,6 +122,7 @@ namespace Microsoft.Health.Fhir.Web
             }
 
             string normalizedPath = testEnvironmentFilePath.Replace('\\', Path.DirectorySeparatorChar);
+            testEnvironmentFilePath = Path.GetFullPath(normalizedPath);
             if (!File.Exists(testEnvironmentFilePath))
             {
                 return configurationBuilder;

--- a/src/Microsoft.Health.Fhir.Web/DevelopmentIdentityProviderRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Web/DevelopmentIdentityProviderRegistrationExtensions.cs
@@ -121,7 +121,8 @@ namespace Microsoft.Health.Fhir.Web
                 return configurationBuilder;
             }
 
-            string normalizedPath = testEnvironmentFilePath.Replace('\\', Path.DirectorySeparatorChar);
+            testEnvironmentFilePath = testEnvironmentFilePath.Replace('\\', Path.DirectorySeparatorChar);
+            testEnvironmentFilePath = Path.GetFullPath(testEnvironmentFilePath);
             testEnvironmentFilePath = Path.GetFullPath(normalizedPath);
             if (!File.Exists(testEnvironmentFilePath))
             {

--- a/src/Microsoft.Health.Fhir.Web/DevelopmentIdentityProviderRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Web/DevelopmentIdentityProviderRegistrationExtensions.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Health.Fhir.Web
                 return configurationBuilder;
             }
 
-            testEnvironmentFilePath = Path.GetFullPath(testEnvironmentFilePath.Replace('\\', Path.DirectorySeparatorChar));
+            testEnvironmentFilePath = Path.GetFullPath(testEnvironmentFilePath);
             if (!File.Exists(testEnvironmentFilePath))
             {
                 return configurationBuilder;

--- a/src/Microsoft.Health.Fhir.Web/DevelopmentIdentityProviderRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Web/DevelopmentIdentityProviderRegistrationExtensions.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Health.Fhir.Web
                 return configurationBuilder;
             }
 
-            testEnvironmentFilePath = Path.GetFullPath(testEnvironmentFilePath);
+            string normalizedPath = testEnvironmentFilePath.Replace('\\', Path.DirectorySeparatorChar);
             if (!File.Exists(testEnvironmentFilePath))
             {
                 return configurationBuilder;

--- a/src/Microsoft.Health.Fhir.Web/DevelopmentIdentityProviderRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Web/DevelopmentIdentityProviderRegistrationExtensions.cs
@@ -121,9 +121,7 @@ namespace Microsoft.Health.Fhir.Web
                 return configurationBuilder;
             }
 
-            testEnvironmentFilePath = testEnvironmentFilePath.Replace('\\', Path.DirectorySeparatorChar);
-            testEnvironmentFilePath = Path.GetFullPath(testEnvironmentFilePath);
-            testEnvironmentFilePath = Path.GetFullPath(normalizedPath);
+            testEnvironmentFilePath = Path.GetFullPath(testEnvironmentFilePath.Replace('\\', Path.DirectorySeparatorChar));
             if (!File.Exists(testEnvironmentFilePath))
             {
                 return configurationBuilder;

--- a/src/Microsoft.Health.Fhir.Web/Properties/launchSettings.json
+++ b/src/Microsoft.Health.Fhir.Web/Properties/launchSettings.json
@@ -13,7 +13,7 @@
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "development",
-        "TestAuthEnvironment:FilePath": "..\\..\\testauthenvironment.json"
+        "TestAuthEnvironment:FilePath": "..//..//testauthenvironment.json"
       }
     },
     "Microsoft.Health.Fhir.Web": {
@@ -21,7 +21,7 @@
       "launchBrowser": true,
         "environmentVariables": {
             "ASPNETCORE_ENVIRONMENT": "development",
-            "TestAuthEnvironment:FilePath": "..\\..\\testauthenvironment.json"
+            "TestAuthEnvironment:FilePath": "..//..//testauthenvironment.json"
         },
       "applicationUrl": "https://localhost:44348/"
     }


### PR DESCRIPTION
## Description
Updates paths in `launchSettings.json` to ensure file resolves on both windows and macosx.

## Related issues
Addresses #266.

## Testing
Tested by navigating to `/connect/token` on both a windows computer and a macbook. Both returned correct responses.
