### PR TITLE
Changing to Range Index in Cosmos DB

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Versioning/CollectionSettingsUpdater.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Versioning/CollectionSettingsUpdater.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Versioning
         private readonly CosmosDataStoreConfiguration _configuration;
         private static readonly RangeIndex DefaultStringRangeIndex = new RangeIndex(DataType.String, -1);
 
-        private const int CollectionSettingsVersion = 1;
+        private const int CollectionSettingsVersion = 2;
 
         public CollectionSettingsUpdater(ILogger<CollectionSettingsUpdater> logger, CosmosDataStoreConfiguration configuration)
         {
@@ -59,7 +59,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Versioning
                         Indexes = new Collection<Index>
                         {
                             new RangeIndex(DataType.Number, -1),
-                            new HashIndex(DataType.String, 3),
+                            new RangeIndex(DataType.String, -1),
                         },
                     },
                     new IncludedPath

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Versioning/CollectionSettingsUpdater.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Versioning/CollectionSettingsUpdater.cs
@@ -62,14 +62,6 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Versioning
                             new RangeIndex(DataType.String, -1),
                         },
                     },
-                    new IncludedPath
-                    {
-                        Path = $"/{KnownResourceWrapperProperties.LastModified}/?",
-                        Indexes = new Collection<Index>
-                        {
-                            DefaultStringRangeIndex,
-                        },
-                    },
                     GenerateIncludedPathForSearchIndexEntryField(SearchValueConstants.DateTimeStartName, DefaultStringRangeIndex),
                     GenerateIncludedPathForSearchIndexEntryField(SearchValueConstants.DateTimeEndName, DefaultStringRangeIndex),
                 },

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Versioning/CollectionSettingsUpdater.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Versioning/CollectionSettingsUpdater.cs
@@ -14,7 +14,6 @@ using Microsoft.Azure.Documents.Linq;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.CosmosDb.Configs;
-using Microsoft.Health.Fhir.CosmosDb.Features.Search;
 
 namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Versioning
 {
@@ -25,7 +24,6 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Versioning
     {
         private readonly ILogger<CollectionSettingsUpdater> _logger;
         private readonly CosmosDataStoreConfiguration _configuration;
-        private static readonly RangeIndex DefaultStringRangeIndex = new RangeIndex(DataType.String, -1);
 
         private const int CollectionSettingsVersion = 2;
 
@@ -62,8 +60,6 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Versioning
                             new RangeIndex(DataType.String, -1),
                         },
                     },
-                    GenerateIncludedPathForSearchIndexEntryField(SearchValueConstants.DateTimeStartName, DefaultStringRangeIndex),
-                    GenerateIncludedPathForSearchIndexEntryField(SearchValueConstants.DateTimeEndName, DefaultStringRangeIndex),
                 },
                     ExcludedPaths = new Collection<ExcludedPath>
                 {

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Versioning/CollectionSettingsUpdater.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Versioning/CollectionSettingsUpdater.cs
@@ -50,24 +50,24 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Versioning
                 collection.IndexingPolicy = new IndexingPolicy
                 {
                     IncludedPaths = new Collection<IncludedPath>
-                {
-                    new IncludedPath
                     {
-                        Path = "/*",
-                        Indexes = new Collection<Index>
+                        new IncludedPath
                         {
-                            new RangeIndex(DataType.Number, -1),
-                            new RangeIndex(DataType.String, -1),
+                            Path = "/*",
+                            Indexes = new Collection<Index>
+                            {
+                                new RangeIndex(DataType.Number, -1),
+                                new RangeIndex(DataType.String, -1),
+                            },
                         },
                     },
-                },
                     ExcludedPaths = new Collection<ExcludedPath>
-                {
-                    new ExcludedPath
                     {
-                        Path = $"/{KnownResourceWrapperProperties.RawResource}/*",
+                        new ExcludedPath
+                        {
+                            Path = $"/{KnownResourceWrapperProperties.RawResource}/*",
+                        },
                     },
-                },
                 };
 
                 // Setting the DefaultTTL to -1 means that by default all documents in the collection will live forever

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Versioning/CollectionUpgradeManager.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Versioning/CollectionUpgradeManager.cs
@@ -20,8 +20,8 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Versioning
         private readonly CosmosDataStoreConfiguration _configuration;
 
         /// <summary>
-        /// This integer should be incremented when changing any value in the
-        /// UpdateIndexAsync function
+        /// This integer should be incremented when changing any configuration in the
+        /// CollectionSettingsUpdater.
         /// </summary>
         internal const int CollectionSettingsVersion = 2;
 

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Versioning/CollectionUpgradeManager.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Versioning/CollectionUpgradeManager.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Versioning
         /// This integer should be incremented when changing any value in the
         /// UpdateIndexAsync function
         /// </summary>
-        internal const int CollectionSettingsVersion = 1;
+        internal const int CollectionSettingsVersion = 2;
 
         private readonly ICosmosDbDistributedLockFactory _lockFactory;
         private readonly ILogger<CollectionUpgradeManager> _logger;


### PR DESCRIPTION
## Description
This change will change the index type to range index for strings.

## Related issues
Addresses [issue 235]: https://github.com/Microsoft/fhir-server/issues/235.

## Testing
We need to do manual testing to verify the performance  that will be achieved after this change in search.
