### PR TITLE
Use Polly instead of EnterpriseLibrary #169

### DIFF
--- a/src/Microsoft.Health.CosmosDb/Configs/CosmosDataStoreRetryOptions.cs
+++ b/src/Microsoft.Health.CosmosDb/Configs/CosmosDataStoreRetryOptions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Health.CosmosDb.Configs
         /// <summary>
         /// Gets the minimum number of seconds to wait while the retries are happening.
         /// </summary>
-        public int MinWaitTimeInSeconds { get; set; } = 5;
+        public int MinWaitTimeInSeconds { get; set; } = 1;
 
         /// <summary>
         /// Gets the maximum number of seconds to wait while the retries are happening.

--- a/src/Microsoft.Health.CosmosDb/Configs/CosmosDataStoreRetryOptions.cs
+++ b/src/Microsoft.Health.CosmosDb/Configs/CosmosDataStoreRetryOptions.cs
@@ -13,6 +13,11 @@ namespace Microsoft.Health.CosmosDb.Configs
         public int MaxNumberOfRetries { get; set; } = 3;
 
         /// <summary>
+        /// Gets the minimum number of seconds to wait while the retries are happening.
+        /// </summary>
+        public int MinWaitTimeInSeconds { get; set; } = 5;
+
+        /// <summary>
         /// Gets the maximum number of seconds to wait while the retries are happening.
         /// </summary>
         public int MaxWaitTimeInSeconds { get; set; } = 5;

--- a/src/Microsoft.Health.CosmosDb/Features/Storage/RetryExceptionPolicy.cs
+++ b/src/Microsoft.Health.CosmosDb/Features/Storage/RetryExceptionPolicy.cs
@@ -6,11 +6,10 @@
 using System;
 using System.Net;
 using Microsoft.Azure.Documents;
-using Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling;
 
 namespace Microsoft.Health.CosmosDb.Features.Storage
 {
-    internal class RetryExceptionPolicy : ITransientErrorDetectionStrategy
+    internal class RetryExceptionPolicy
     {
         /// <summary>
         /// Determines whether the specified exception represents a transient failure that can be compensated by a retry.
@@ -19,7 +18,7 @@ namespace Microsoft.Health.CosmosDb.Features.Storage
         /// <returns>
         /// true if the specified exception is considered as transient; otherwise, false.
         /// </returns>
-        public bool IsTransient(Exception ex)
+        public static bool IsTransient(Exception ex)
         {
             // Detects "449 Retry With" - The operation encountered a transient error. This only occurs on write operations. It is safe to retry the operation.
             // Detects "429 Too Many Request" - The collection has exceeded the provisioned throughput limit. Retry the request after the server specified retry after duration.

--- a/src/Microsoft.Health.CosmosDb/Features/Storage/RetryExceptionPolicyFactory.cs
+++ b/src/Microsoft.Health.CosmosDb/Features/Storage/RetryExceptionPolicyFactory.cs
@@ -6,7 +6,8 @@
 using System;
 using EnsureThat;
 using Microsoft.Health.CosmosDb.Configs;
-using Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling;
+using Polly;
+using Polly.Retry;
 
 namespace Microsoft.Health.CosmosDb.Features.Storage
 {
@@ -21,19 +22,20 @@ namespace Microsoft.Health.CosmosDb.Features.Storage
             EnsureArg.IsNotNull(configuration, nameof(configuration));
 
             _maxNumberOfRetries = configuration.RetryOptions.MaxNumberOfRetries;
-            _minWaitTime = TimeSpan.FromSeconds(Math.Min(RetryStrategy.DefaultMinBackoff.TotalSeconds, configuration.RetryOptions.MaxWaitTimeInSeconds));
+            _minWaitTime = TimeSpan.FromSeconds(configuration.RetryOptions.MinWaitTimeInSeconds);
             _maxWaitTime = TimeSpan.FromSeconds(configuration.RetryOptions.MaxWaitTimeInSeconds);
         }
 
         public RetryPolicy CreateRetryPolicy()
         {
-            var strategy = new ExponentialBackoff(
-                _maxNumberOfRetries,
-                _minWaitTime,
-                _maxWaitTime,
-                RetryStrategy.DefaultClientBackoff);
+            var policy = Policy
+                .Handle<Exception>(RetryExceptionPolicy.IsTransient)
+                .WaitAndRetryAsync(
+                    _maxNumberOfRetries,
+                    retryAttempt =>
+                        TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)));
 
-            return new RetryPolicy<RetryExceptionPolicy>(strategy);
+            return policy;
         }
     }
 }

--- a/src/Microsoft.Health.CosmosDb/Microsoft.Health.CosmosDb.csproj
+++ b/src/Microsoft.Health.CosmosDb/Microsoft.Health.CosmosDb.csproj
@@ -11,12 +11,12 @@
 
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="8.1.0" />
-    <PackageReference Include="EnterpriseLibrary.TransientFaultHandling.Core" Version="1.2.0" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.1.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.1.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" />
+    <PackageReference Include="Polly" Version="6.1.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61" />
   </ItemGroup>
 

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/FhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/FhirDataStore.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
                 _logger.LogDebug($"Upserting {resource.ResourceTypeName}/{resource.ResourceId}, ETag: \"{weakETag?.VersionId}\", AllowCreate: {allowCreate}, KeepHistory: {keepHistory}");
 
                 UpsertWithHistoryModel response = await _retryExceptionPolicyFactory.CreateRetryPolicy().ExecuteAsync(
-                    async () => await _upsertWithHistoryProc.Execute(
+                    async (ct) => await _upsertWithHistoryProc.Execute(
                         _documentClient,
                         _collectionUri,
                         cosmosWrapper,
@@ -187,7 +187,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
                 _logger.LogDebug($"Obliterating {key.ResourceType}/{key.Id}");
 
                 StoredProcedureResponse<IList<string>> response = await _retryExceptionPolicyFactory.CreateRetryPolicy().ExecuteAsync(
-                    async () => await _hardDelete.Execute(
+                    async (ct) => await _hardDelete.Execute(
                         _documentClient,
                         _collectionUri,
                         key),


### PR DESCRIPTION
## Description
Changed out EnterpriseLibrary transient error retry for Polly

## Related issues
Addresses [issue #169].

## Testing
All the unit tests pass.  Per Polly documentation, there is not way to individual unit test Polly.
