### PR TITLE
Fixed the regression bug where the total count was not being set.

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/BundleFactory.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/BundleFactory.cs
@@ -67,6 +67,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
 
             bundle.Id = _fhirRequestContextAccessor.FhirRequestContext.CorrelationId;
             bundle.Type = Bundle.BundleType.Searchset;
+            bundle.Total = result?.TotalCount;
             bundle.Meta = new Meta
             {
                 LastUpdated = Clock.UtcNow,
@@ -119,6 +120,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
 
             bundle.Id = _fhirRequestContextAccessor.FhirRequestContext.CorrelationId;
             bundle.Type = Bundle.BundleType.History;
+            bundle.Total = result?.TotalCount;
             bundle.Meta = new Meta
             {
                 LastUpdated = Clock.UtcNow,

--- a/test/Microsoft.Health.Fhir.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -219,10 +219,10 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
             var tag = new Coding(string.Empty, Guid.NewGuid().ToString());
 
+            Patient patient = Samples.GetDefaultPatient();
+
             for (int i = 0; i < numberOfResources; i++)
             {
-                Patient patient = Samples.GetDefaultPatient();
-
                 patient.Meta = new Meta();
                 patient.Meta.Tag.Add(tag);
 

--- a/test/Microsoft.Health.Fhir.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -210,5 +210,30 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             // Search for the given coding. The only thing returned should be the updated resource
             await ExecuteAndValidateBundle($"Observation?code={testCoding.System}|{testCoding.Code}", updatedResource);
         }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenListOfResources_WhenSearchedWithCountSummary_ThenTotalCountShouldBeReturned()
+        {
+            const int numberOfResources = 5;
+
+            var tag = new Coding(string.Empty, Guid.NewGuid().ToString());
+
+            for (int i = 0; i < numberOfResources; i++)
+            {
+                Patient patient = Samples.GetDefaultPatient();
+
+                patient.Meta = new Meta();
+                patient.Meta.Tag.Add(tag);
+
+                await Client.CreateAsync(patient);
+            }
+
+            Bundle bundle = await Client.SearchAsync($"Patient?_summary=count");
+
+            Assert.NotNull(bundle);
+            Assert.Equal(numberOfResources, bundle.Total);
+            Assert.Empty(bundle.Entry);
+        }
     }
 }

--- a/test/Microsoft.Health.Fhir.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -229,7 +229,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 await Client.CreateAsync(patient);
             }
 
-            Bundle bundle = await Client.SearchAsync($"Patient?_summary=count");
+            Bundle bundle = await Client.SearchAsync($"Patient?_tag={tag.Code}&_summary=count");
 
             Assert.NotNull(bundle);
             Assert.Equal(numberOfResources, bundle.Total);


### PR DESCRIPTION
## Description
Fix the issue where the total count was not returned when _summary=count is specified.

## Related issues
Addresses #319.

## Testing
Added E2E test.
