### PR TITLE
Update FHIR context after authentication so claims are logged in audits

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Context/FhirRequestContextAfterAuthenticationMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Context/FhirRequestContextAfterAuthenticationMiddleware.cs
@@ -1,0 +1,36 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Threading.Tasks;
+using EnsureThat;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Health.Fhir.Core.Features.Context;
+
+namespace Microsoft.Health.Fhir.Api.Features.Context
+{
+    public class FhirRequestContextAfterAuthenticationMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public FhirRequestContextAfterAuthenticationMiddleware(RequestDelegate next)
+        {
+            EnsureArg.IsNotNull(next, nameof(next));
+
+            _next = next;
+        }
+
+        public Task Invoke(HttpContext context, IFhirRequestContextAccessor fhirRequestContextAccessor)
+        {
+            // Set the user again to pick up anything that was set during authentication, e.g. claims.
+            if (context.User != null)
+            {
+                fhirRequestContextAccessor.FhirRequestContext.Principal = context.User;
+            }
+
+            // Call the next delegate/middleware in the pipeline
+            return _next(context);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Api/Features/Context/FhirRequestContextAfterAuthenticationMiddlewareExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Context/FhirRequestContextAfterAuthenticationMiddlewareExtensions.cs
@@ -1,0 +1,21 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using EnsureThat;
+using Microsoft.AspNetCore.Builder;
+
+namespace Microsoft.Health.Fhir.Api.Features.Context
+{
+    public static class FhirRequestContextAfterAuthenticationMiddlewareExtensions
+    {
+        public static IApplicationBuilder UseFhirRequestContextAfterAuthentication(
+            this IApplicationBuilder builder)
+        {
+            EnsureArg.IsNotNull(builder, nameof(builder));
+
+            return builder.UseMiddleware<FhirRequestContextAfterAuthenticationMiddleware>();
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Api/Features/Context/FhirRequestContextMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Context/FhirRequestContextMiddleware.cs
@@ -53,6 +53,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Context
 
             context.Response.Headers[RequestIdHeaderName] = correlationId;
 
+            // Note that if this is executed before authentication occurs, the user will not contain any claims.
             if (context.User != null)
             {
                 fhirRequestContext.Principal = context.User;

--- a/src/Microsoft.Health.Fhir.Api/Registration/FhirServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Api/Registration/FhirServerServiceCollectionExtensions.cs
@@ -117,6 +117,9 @@ namespace Microsoft.Extensions.DependencyInjection
 
                     app.UseAuthentication();
 
+                    // Now that we've authenticated the user, update the context with any post-authentication info.
+                    app.UseFhirRequestContextAfterAuthentication();
+
                     next(app);
                 };
             }

--- a/test/Microsoft.Health.Fhir.Tests.E2E/Rest/Audit/StartupWithTraceAuditLogger.cs
+++ b/test/Microsoft.Health.Fhir.Tests.E2E/Rest/Audit/StartupWithTraceAuditLogger.cs
@@ -6,7 +6,9 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Api.Features.Audit;
+using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Web;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit
@@ -23,6 +25,12 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit
             base.ConfigureServices(services);
 
             services.Replace(new ServiceDescriptor(typeof(IAuditLogger), typeof(TraceAuditLogger), ServiceLifetime.Singleton));
+
+            // Configure the test server to log a claim that is used in both local and integration environments.
+            ServiceProvider serviceProvider = services.BuildServiceProvider();
+            var securityConfigurationOptions = serviceProvider.GetService<IOptions<SecurityConfiguration>>();
+            securityConfigurationOptions.Value.LastModifiedClaims.Clear();
+            securityConfigurationOptions.Value.LastModifiedClaims.Add("appid");
         }
     }
 }


### PR DESCRIPTION
## Description
Added a new middleware after authentication that updates the user in the FHIR context.  This picks up properties that are set during authentication, like claims.

## Related issues
Addresses #371 .

## Testing
Updated existing E2E tests to validate that claims are included in the audit logs.