### PR TITLE
Application Insights in code

### DIFF
--- a/samples/templates/default-azuredeploy.json
+++ b/samples/templates/default-azuredeploy.json
@@ -207,7 +207,7 @@
                         "[concat('Microsoft.Web/Sites/', variables('serviceName'))]",
                         "[if(variables('deployAppInsights'),concat('Microsoft.Insights/components/', variables('appInsightsName')),resourceId('Microsoft.KeyVault/vaults', variables('serviceName')))]"
                     ],
-                    "properties": "[if(variables('deployAppInsights'), union(variables('combinedFhirServerConfigProperties'), json(concat('{\"APPINSIGHTS_INSTRUMENTATIONKEY\": \"', reference(concat('Microsoft.Insights/components/', variables('appInsightsName'))).InstrumentationKey, '\"}'))), variables('combinedFhirServerConfigProperties'))]"
+                    "properties": "[if(variables('deployAppInsights'), union(variables('combinedFhirServerConfigProperties'), json(concat('{\"ApplicationInsights:InstrumentationKey\": \"', reference(concat('Microsoft.Insights/components/', variables('appInsightsName'))).InstrumentationKey, '\"}'))), variables('combinedFhirServerConfigProperties'))]"
                 },
                 {
                     "apiVersion": "2015-08-01",

--- a/samples/templates/default-azuredeploy.json
+++ b/samples/templates/default-azuredeploy.json
@@ -223,18 +223,6 @@
                         "branch": "[parameters('repositoryBranch')]",
                         "IsManualIntegration": true
                     }
-                },
-                {
-                    "apiVersion": "2015-08-01",
-                    "name": "Microsoft.ApplicationInsights.AzureWebSites",
-                    "type": "siteextensions",
-                    "condition": "[variables('deployAppInsights')]",
-                    "dependsOn": [
-                        "[resourceId('Microsoft.Web/Sites', variables('serviceName'))]",
-                        "[resourceId('Microsoft.Web/Sites/config', variables('serviceName'), 'appsettings')]",
-                        "[resourceId('Microsoft.Web/sites/sourcecontrols', variables('serviceName'), 'web')]"
-                    ],
-                    "properties": {}
                 }
             ]
         },

--- a/src/Microsoft.Health.Fhir.Web/Microsoft.Health.Fhir.Web.csproj
+++ b/src/Microsoft.Health.Fhir.Web/Microsoft.Health.Fhir.Web.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="IdentityServer4" Version="2.3.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.6.1" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.2.0-preview2" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" />

--- a/src/Microsoft.Health.Fhir.Web/Microsoft.Health.Fhir.Web.csproj
+++ b/src/Microsoft.Health.Fhir.Web/Microsoft.Health.Fhir.Web.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.2.0-preview2" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.9.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61" />
   </ItemGroup>

--- a/src/Microsoft.Health.Fhir.Web/Program.cs
+++ b/src/Microsoft.Health.Fhir.Web/Program.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Health.Fhir.Web
         public static void Main(string[] args)
         {
             var host = WebHost.CreateDefaultBuilder(args)
+                .UseApplicationInsights()
                 .ConfigureAppConfiguration((hostContext, builder) =>
                 {
                     var builtConfig = builder.Build();

--- a/src/Microsoft.Health.Fhir.Web/Program.cs
+++ b/src/Microsoft.Health.Fhir.Web/Program.cs
@@ -17,7 +17,6 @@ namespace Microsoft.Health.Fhir.Web
         public static void Main(string[] args)
         {
             var host = WebHost.CreateDefaultBuilder(args)
-                .UseApplicationInsights()
                 .ConfigureAppConfiguration((hostContext, builder) =>
                 {
                     var builtConfig = builder.Build();

--- a/src/Microsoft.Health.Fhir.Web/Startup.cs
+++ b/src/Microsoft.Health.Fhir.Web/Startup.cs
@@ -21,6 +21,8 @@ namespace Microsoft.Health.Fhir.Web
         // This method gets called by the runtime. Use this method to add services to the container.
         public virtual void ConfigureServices(IServiceCollection services)
         {
+            services.AddApplicationInsightsTelemetry(Configuration);
+
             services.AddControlPlaneCosmosDb(Configuration).AddDevelopmentIdentityProvider(Configuration);
 
             services.AddFhirServer(Configuration).AddFhirServerCosmosDb(Configuration);

--- a/src/Microsoft.Health.Fhir.Web/Startup.cs
+++ b/src/Microsoft.Health.Fhir.Web/Startup.cs
@@ -6,6 +6,8 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.ApplicationInsights;
 
 namespace Microsoft.Health.Fhir.Web
 {
@@ -21,11 +23,13 @@ namespace Microsoft.Health.Fhir.Web
         // This method gets called by the runtime. Use this method to add services to the container.
         public virtual void ConfigureServices(IServiceCollection services)
         {
-            services.AddApplicationInsightsTelemetry(Configuration);
+            services.AddDevelopmentIdentityProvider(Configuration);
 
-            services.AddControlPlaneCosmosDb(Configuration).AddDevelopmentIdentityProvider(Configuration);
+            services.AddControlPlaneCosmosDb(Configuration);
 
             services.AddFhirServer(Configuration).AddFhirServerCosmosDb(Configuration);
+
+            AddApplicationInsightsTelemetry(services);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -34,6 +38,27 @@ namespace Microsoft.Health.Fhir.Web
             app.UseFhirServer();
 
             app.UseDevelopmentIdentityProvider();
+        }
+
+        /// <summary>
+        /// Adds ApplicationInsights for telemetry and logging.
+        /// </summary>
+        private void AddApplicationInsightsTelemetry(IServiceCollection services)
+        {
+            string instrumentationKey = Configuration["ApplicationInsights:InstrumentationKey"];
+
+            if (!string.IsNullOrWhiteSpace(instrumentationKey))
+            {
+                services.AddApplicationInsightsTelemetry(instrumentationKey);
+                services.AddLogging(loggingBuilder =>
+                {
+                    loggingBuilder.AddApplicationInsights(instrumentationKey);
+
+                    // Filter out messages by category and level
+                    loggingBuilder.AddFilter<ApplicationInsightsLoggerProvider>(string.Empty, LogLevel.Information);
+                    loggingBuilder.AddFilter<ApplicationInsightsLoggerProvider>("Microsoft.AspNetCore", LogLevel.Warning);
+                });
+            }
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Web/Startup.cs
+++ b/src/Microsoft.Health.Fhir.Web/Startup.cs
@@ -50,14 +50,7 @@ namespace Microsoft.Health.Fhir.Web
             if (!string.IsNullOrWhiteSpace(instrumentationKey))
             {
                 services.AddApplicationInsightsTelemetry(instrumentationKey);
-                services.AddLogging(loggingBuilder =>
-                {
-                    loggingBuilder.AddApplicationInsights(instrumentationKey);
-
-                    // Filter out messages by category and level
-                    loggingBuilder.AddFilter<ApplicationInsightsLoggerProvider>(string.Empty, LogLevel.Information);
-                    loggingBuilder.AddFilter<ApplicationInsightsLoggerProvider>("Microsoft.AspNetCore", LogLevel.Warning);
-                });
+                services.AddLogging(loggingBuilder => loggingBuilder.AddApplicationInsights(instrumentationKey));
             }
         }
     }

--- a/src/Microsoft.Health.Fhir.Web/appsettings.Development.json
+++ b/src/Microsoft.Health.Fhir.Web/appsettings.Development.json
@@ -1,10 +1,11 @@
 ﻿{
-  "Logging": {
-    "IncludeScopes": false,
-    "LogLevel": {
-      "Default": "Debug",
-      "System": "Information",
-      "Microsoft": "Information"
+    "Logging": {
+        "IncludeScopes": false,
+        "LogLevel": {
+            "Default": "Debug",
+            "Microsoft.Health": "Debug",
+            "Microsoft": "Information",
+            "System": "Information"
+        }
     }
-  }
 }

--- a/src/Microsoft.Health.Fhir.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Web/appsettings.json
@@ -1,69 +1,77 @@
 ﻿{
-    "FhirServer": {
-        "Conformance": {
-            "UseStrictConformance": true
-        },
-        "Security": {
-            "Enabled": true,
-            "EnableAadSmartOnFhirProxy": true,
-            "Authentication": {
-                "Audience": null,
-                "Authority": "https://localhost:44348"
-            },
-            "LastModifiedClaims": [
-                "client_id"
-            ],
-            "Authorization": {
-                "Enabled": true
-            }
-        },
-        "Features": {
-            "SupportsUI": false,
-            "SupportsXml": true
-        },
-        "CosmosDb": {
-            "CollectionId": "fhir",
-            "InitialCollectionThroughput": null
-        },
-        "Cors": {
-            "Origins": [],
-            "Methods": [],
-            "Headers": [],
-            "MaxAge": null,
-            "AllowCredentials": false
-        } 
+  "FhirServer": {
+    "Conformance": {
+      "UseStrictConformance": true
     },
-    "ControlPlane": {
-        "CosmosDb": {
-            "CollectionId": "controlPlane",
-            "InitialCollectionThroughPut":  null 
-        } 
+    "Security": {
+      "Enabled": true,
+      "EnableAadSmartOnFhirProxy": true,
+      "Authentication": {
+        "Audience": null,
+        "Authority": "https://localhost:44348"
+      },
+      "LastModifiedClaims": [
+        "client_id"
+      ],
+      "Authorization": {
+        "Enabled": true
+      }
+    },
+    "Features": {
+      "SupportsUI": false,
+      "SupportsXml": true
     },
     "CosmosDb": {
-        "Host": null,
-        "Key": null,
-        "DatabaseId": "health",
-        "InitialDatabaseThroughput": null,  
-        "ConnectionMode": "Direct",
-        "ConnectionProtocol": "Tcp",
-        "ContinuationTokenSizeLimitInKb": 2,
-        "DefaultConsistencyLevel": "Session",
-        "PreferredLocations": [],
-        "RetryOptions": {
-            "MaxNumberOfRetries": 3,
-            "MaxWaitTimeInSeconds": 5
-        }
+      "CollectionId": "fhir",
+      "InitialCollectionThroughput": null
     },
-    "KeyVault": {
-        "Endpoint": null
-    },
-    "Logging": {
-        "IncludeScopes": false,
-        "LogLevel": {
-            "Default": "Warning"
-        }
+    "Cors": {
+      "Origins": [],
+      "Methods": [],
+      "Headers": [],
+      "MaxAge": null,
+      "AllowCredentials": false
+    }
+  },
+  "ControlPlane": {
+    "CosmosDb": {
+      "CollectionId": "controlPlane",
+      "InitialCollectionThroughPut": null
+    }
+  },
+  "CosmosDb": {
+    "Host": null,
+    "Key": null,
+    "DatabaseId": "health",
+    "InitialDatabaseThroughput": null,
+    "ConnectionMode": "Direct",
+    "ConnectionProtocol": "Tcp",
+    "ContinuationTokenSizeLimitInKb": 2,
+    "DefaultConsistencyLevel": "Session",
+    "PreferredLocations": [],
+    "RetryOptions": {
+      "MaxNumberOfRetries": 3,
+      "MaxWaitTimeInSeconds": 5
+    }
+  },
+  "KeyVault": {
+    "Endpoint": null
+  },
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Warning"
     },
     "ApplicationInsights": {
-      "InstrumentationKey": ""
+      "LogLevel": {
+        "Default": "Information",
+        "Microsoft.Health": "Information",
+        "Microsoft": "Warning",
+        "System": "Warning"
+      }
     }
+  },
+  "ApplicationInsights": {
+    "InstrumentationKey": ""
+  }
 }

--- a/src/Microsoft.Health.Fhir.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Web/appsettings.json
@@ -62,5 +62,8 @@
         "LogLevel": {
             "Default": "Warning"
         }
+    },
+    "ApplicationInsights": {
+      "InstrumentationKey": ""
     }
 }


### PR DESCRIPTION
## Description
Rather than relying on App Service's Application Insights support (which does not yet support asp.net core 2.2), we App Insights directly from code, passing in the instrumentation key as a config setting.

## Related issues
Addresses #368 

## Testing
Verified telemetry is flowing.
