### PR TITLE
Handle missing Accept header when _format is provided

### DIFF
--- a/src/Microsoft.Health.Fhir.Api.UnitTests/Features/Filters/ValidateContentTypeFilterAttributeTests.cs
+++ b/src/Microsoft.Health.Fhir.Api.UnitTests/Features/Filters/ValidateContentTypeFilterAttributeTests.cs
@@ -78,6 +78,33 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
             await filter.OnActionExecutionAsync(context, actionExecutedDelegate);
         }
 
+        [Fact]
+        public async Task GivenARequestWithAValidFormatQueryStringAndNoAcceptHeader_WhenValidatingTheContentType_ThenNoExceptionShouldBeThrown()
+        {
+            var filter = CreateFilter();
+
+            var context = CreateContext(Guid.NewGuid().ToString());
+            var actionExecutedDelegate = CreateActionExecutedDelegate(context);
+
+            context.HttpContext.Request.QueryString = new QueryString($"?_format=json");
+
+            await filter.OnActionExecutionAsync(context, actionExecutedDelegate);
+        }
+
+        [Fact]
+        public async Task GivenARequestWithAValidFormatQueryStringAndEmptyAcceptHeader_WhenValidatingTheContentType_ThenNoExceptionShouldBeThrown()
+        {
+            var filter = CreateFilter();
+
+            var context = CreateContext(Guid.NewGuid().ToString());
+            var actionExecutedDelegate = CreateActionExecutedDelegate(context);
+
+            context.HttpContext.Request.QueryString = new QueryString($"?_format=json");
+            context.HttpContext.Request.Headers.Add("Accept", string.Empty);
+
+            await filter.OnActionExecutionAsync(context, actionExecutedDelegate);
+        }
+
         [Theory]
         [InlineData("application/blah")]
         [InlineData("application/xml")]

--- a/src/Microsoft.Health.Fhir.Api/Features/ContentTypes/ContentTypeService.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/ContentTypes/ContentTypeService.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Health.Fhir.Api.Features.ContentTypes
                     throw new UnsupportedMediaTypeException(Resources.UnsupportedFormatParameter);
                 }
 
-                string closestClientMediaType = _outputFormatters.GetClosestClientMediaType(resourceFormat, acceptHeaders.Select(x => x.MediaType.Value));
+                string closestClientMediaType = _outputFormatters.GetClosestClientMediaType(resourceFormat, acceptHeaders?.Select(x => x.MediaType.Value));
 
                 // Overrides output format type
                 httpContext.Response.ContentType = closestClientMediaType;

--- a/src/Microsoft.Health.Fhir.Api/Features/Formatters/FormatterExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Formatters/FormatterExtensions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Formatters
             string closestClientMediaType = null;
             string preferred = resourceFormat.ToContentType();
 
-            if (outputFormatters != null)
+            if (outputFormatters != null && acceptHeaders != null)
             {
                 // Gets formatters that can write the desired format
                 var validFormatters = outputFormatters


### PR DESCRIPTION
## Description
Fixed the format/content-type resolution code to handle the case where _format is specified in the query string but the Accept header is not provided.

## Related issues
Addresses #370 

## Testing
Added unit tests