### PR TITLE
Add audit for smart.

### DIFF
--- a/src/Microsoft.Health.Fhir.Api.UnitTests/Features/Audit/SmartOnFhirAuditLoggingFilterAttributeTests.cs
+++ b/src/Microsoft.Health.Fhir.Api.UnitTests/Features/Audit/SmartOnFhirAuditLoggingFilterAttributeTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
         {
             SetupExecutingAction(_queryCollection, null);
 
-            VerifyAuditLoggerReceivedLogAudit(AuditAction.Executing);
+            VerifyAuditLoggerReceivedLogAudit(AuditAction.Executing, null);
             VerifyClaims();
         }
 
@@ -70,7 +70,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
         {
             SetupExecutingAction(null, _formCollection);
 
-            VerifyAuditLoggerReceivedLogAudit(AuditAction.Executing);
+            VerifyAuditLoggerReceivedLogAudit(AuditAction.Executing, null);
             VerifyClaims();
         }
 
@@ -79,7 +79,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
         {
             SetupExecutingAction(null, null);
 
-            VerifyAuditLoggerReceivedLogAudit(AuditAction.Executing);
+            VerifyAuditLoggerReceivedLogAudit(AuditAction.Executing, null);
             Assert.Empty(_loggedClaims);
         }
 
@@ -89,7 +89,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
             const HttpStatusCode expectedStatusCode = HttpStatusCode.InternalServerError;
             SetupExecutedAction(expectedStatusCode, new OkResult(), _queryCollection, null);
 
-            VerifyAuditLoggerReceivedLogAudit(AuditAction.Executed);
+            VerifyAuditLoggerReceivedLogAudit(AuditAction.Executed, expectedStatusCode);
             VerifyClaims();
         }
 
@@ -99,7 +99,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
             const HttpStatusCode expectedStatusCode = HttpStatusCode.InternalServerError;
             SetupExecutedAction(expectedStatusCode, new OkResult(), null, _formCollection);
 
-            VerifyAuditLoggerReceivedLogAudit(AuditAction.Executed);
+            VerifyAuditLoggerReceivedLogAudit(AuditAction.Executed, expectedStatusCode);
             VerifyClaims();
         }
 
@@ -109,7 +109,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
             const HttpStatusCode expectedStatusCode = HttpStatusCode.InternalServerError;
             SetupExecutedAction(expectedStatusCode, new OkResult(), null, null);
 
-            VerifyAuditLoggerReceivedLogAudit(AuditAction.Executed);
+            VerifyAuditLoggerReceivedLogAudit(AuditAction.Executed, expectedStatusCode);
             Assert.Empty(_loggedClaims);
         }
 
@@ -155,14 +155,14 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
             _filter.OnResultExecuted(resultExecutedContext);
         }
 
-        private void VerifyAuditLoggerReceivedLogAudit(AuditAction auditAction)
+        private void VerifyAuditLoggerReceivedLogAudit(AuditAction auditAction, HttpStatusCode? httpStatusCode)
         {
             _auditLogger.Received(1).LogAudit(
                 Arg.Is(auditAction),
                 Arg.Is(Action),
                 Arg.Is<string>(x => x == null),
                 Arg.Any<Uri>(),
-                Arg.Any<HttpStatusCode?>(),
+                Arg.Is(httpStatusCode),
                 Arg.Is(_correlationId),
                 Arg.Any<IReadOnlyCollection<KeyValuePair<string, string>>>());
         }

--- a/src/Microsoft.Health.Fhir.Api.UnitTests/Features/Audit/SmartOnFhirAuditLoggingFilterAttributeTests.cs
+++ b/src/Microsoft.Health.Fhir.Api.UnitTests/Features/Audit/SmartOnFhirAuditLoggingFilterAttributeTests.cs
@@ -1,0 +1,182 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Internal;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Primitives;
+using Microsoft.Health.Fhir.Api.Features.Audit;
+using Microsoft.Health.Fhir.Core.Features.Context;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
+{
+    public class SmartOnFhirAuditLoggingFilterAttributeTests
+    {
+        private const string ControllerName = "controller";
+        private const string ActionName = "action";
+        private const string Action = "smart-on-fhir-action";
+
+        private readonly IAuditLogger _auditLogger = Substitute.For<IAuditLogger>();
+        private readonly IFhirRequestContextAccessor _fhirRequestContextAccessor = Substitute.For<IFhirRequestContextAccessor>();
+        private readonly SmartOnFhirAuditLoggingFilterAttribute _filter;
+        private IReadOnlyCollection<KeyValuePair<string, string>> _loggedClaims;
+        private readonly QueryCollection _queryCollection;
+        private readonly FormCollection _formCollection;
+        private readonly string _correlationId;
+
+        public SmartOnFhirAuditLoggingFilterAttributeTests()
+        {
+            _correlationId = Guid.NewGuid().ToString();
+            _fhirRequestContextAccessor.FhirRequestContext.CorrelationId.Returns(_correlationId);
+
+            _filter = new SmartOnFhirAuditLoggingFilterAttribute(Action, _auditLogger, _fhirRequestContextAccessor);
+            _auditLogger.LogAudit(Arg.Any<AuditAction>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Uri>(), Arg.Any<HttpStatusCode?>(), Arg.Any<string>(), Arg.Do<IReadOnlyCollection<KeyValuePair<string, string>>>(c => _loggedClaims = c));
+
+            var passedValues = new Dictionary<string, StringValues>
+            {
+                { "client_id", new StringValues("1234") },
+                { "secret", new StringValues("secret") },
+            };
+
+            _queryCollection = new QueryCollection(
+                passedValues);
+
+            _formCollection = new FormCollection(
+                passedValues);
+        }
+
+        [Fact]
+        public void GivenAController_WhenExecutingAction_ThenAuditLogShouldBeLogged()
+        {
+            SetupExecutingAction(_queryCollection, null);
+
+            VerifyAuditLoggerReceivedLogAudit(AuditAction.Executing);
+            VerifyClaims();
+        }
+
+        [Fact]
+        public void GivenAController_WhenExecutingActionWithFormCollection_ThenAuditLogShouldBeLogged()
+        {
+            SetupExecutingAction(null, _formCollection);
+
+            VerifyAuditLoggerReceivedLogAudit(AuditAction.Executing);
+            VerifyClaims();
+        }
+
+        [Fact]
+        public void GivenAController_WhenExecutingActionWithEmptyQueryCollectionAndEmptyFormCollection_ThenAuditLogShouldBeLogged()
+        {
+            SetupExecutingAction(null, null);
+
+            VerifyAuditLoggerReceivedLogAudit(AuditAction.Executing);
+            Assert.Empty(_loggedClaims);
+        }
+
+        [Fact]
+        public void GivenAController_WhenExecutedAction_ThenAuditLogShouldBeLogged()
+        {
+            const HttpStatusCode expectedStatusCode = HttpStatusCode.InternalServerError;
+            SetupExecutedAction(expectedStatusCode, new OkResult(), _queryCollection, null);
+
+            VerifyAuditLoggerReceivedLogAudit(AuditAction.Executed);
+            VerifyClaims();
+        }
+
+        [Fact]
+        public void GivenAController_WhenExecutedActionWithFormCollection_ThenAuditLogShouldBeLogged()
+        {
+            const HttpStatusCode expectedStatusCode = HttpStatusCode.InternalServerError;
+            SetupExecutedAction(expectedStatusCode, new OkResult(), null, _formCollection);
+
+            VerifyAuditLoggerReceivedLogAudit(AuditAction.Executed);
+            VerifyClaims();
+        }
+
+        [Fact]
+        public void GivenAController_WhenExecutedActionWithEmptyQueryCollectionAndEmptyFormCollection_ThenAuditLogShouldBeLogged()
+        {
+            const HttpStatusCode expectedStatusCode = HttpStatusCode.InternalServerError;
+            SetupExecutedAction(expectedStatusCode, new OkResult(), null, null);
+
+            VerifyAuditLoggerReceivedLogAudit(AuditAction.Executed);
+            Assert.Empty(_loggedClaims);
+        }
+
+        private void SetupExecutingAction(IQueryCollection queryCollection, IFormCollection formCollection)
+        {
+            var actionExecutingContext = new ActionExecutingContext(
+                new ActionContext(new DefaultHttpContext(), new RouteData(), new ControllerActionDescriptor() { DisplayName = "Executing Context Test Descriptor" }),
+                new List<IFilterMetadata>(),
+                new Dictionary<string, object>(),
+                new MockController());
+
+            actionExecutingContext.HttpContext.Request.Query = queryCollection;
+            actionExecutingContext.HttpContext.Request.Form = formCollection;
+
+            actionExecutingContext.ActionDescriptor = new ControllerActionDescriptor()
+            {
+                ControllerName = ControllerName,
+                ActionName = ActionName,
+            };
+
+            _filter.OnActionExecuting(actionExecutingContext);
+        }
+
+        private void SetupExecutedAction(HttpStatusCode expectedStatusCode, IActionResult result, IQueryCollection queryCollection, IFormCollection formCollection)
+        {
+            var resultExecutedContext = new ResultExecutedContext(
+                new ActionContext(new DefaultHttpContext(), new RouteData(), new ControllerActionDescriptor() { DisplayName = "Executed Context Test Descriptor" }),
+                new List<IFilterMetadata>(),
+                result,
+                new MockController());
+
+            resultExecutedContext.HttpContext.Request.Query = queryCollection;
+            resultExecutedContext.HttpContext.Request.Form = formCollection;
+
+            resultExecutedContext.HttpContext.Response.StatusCode = (int)expectedStatusCode;
+
+            resultExecutedContext.ActionDescriptor = new ControllerActionDescriptor()
+            {
+                ControllerName = ControllerName,
+                ActionName = ActionName,
+            };
+
+            _filter.OnResultExecuted(resultExecutedContext);
+        }
+
+        private void VerifyAuditLoggerReceivedLogAudit(AuditAction auditAction)
+        {
+            _auditLogger.Received(1).LogAudit(
+                Arg.Is(auditAction),
+                Arg.Is(Action),
+                Arg.Is<string>(x => x == null),
+                Arg.Any<Uri>(),
+                Arg.Any<HttpStatusCode?>(),
+                Arg.Is(_correlationId),
+                Arg.Any<IReadOnlyCollection<KeyValuePair<string, string>>>());
+        }
+
+        private void VerifyClaims()
+        {
+            Assert.Equal(1, _loggedClaims.Count);
+            (string key, string value) = _loggedClaims.First();
+            Assert.Equal("client_id", key);
+            Assert.Equal("1234", value);
+        }
+
+        private class MockController : Controller
+        {
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Api/Controllers/AadSmartOnFhirProxyController.cs
+++ b/src/Microsoft.Health.Fhir.Api/Controllers/AadSmartOnFhirProxyController.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using System.Web;
 using EnsureThat;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
@@ -128,14 +129,14 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                 { "l", launch },
             };
 
-            string newState = Base64UrlEncoder.Encode(newStateObj.ToString(Newtonsoft.Json.Formatting.None));
+            string newState = Base64UrlEncoder.Encode(newStateObj.ToString());
 
             var callbackUrl = UriHelper.BuildAbsolute(Request.Scheme, Request.Host, "/AadSmartOnFhirProxy/callback/", Base64UrlEncoder.Encode(redirectUri.ToString()));
 
-            var queryStringBuilder = new StringBuilder($"response_type={responseType}&redirect_uri={callbackUrl}&client_id={clientId}");
+            var queryStringBuilder = new StringBuilder($"response_type={HttpUtility.UrlEncode(responseType)}&redirect_uri={callbackUrl}&client_id={HttpUtility.UrlEncode(clientId)}");
             if (!_isAadV2)
             {
-                queryStringBuilder.Append($"&resource={aud}");
+                queryStringBuilder.Append($"&resource={HttpUtility.UrlEncode(aud)}");
             }
             else
             {
@@ -191,7 +192,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
 
             if (!string.IsNullOrEmpty(error))
             {
-                return Redirect($"{redirectUrl}?error={error}&error_description={errorDescription}");
+                return Redirect($"{redirectUrl}?error={HttpUtility.UrlEncode(error)}&error_description={HttpUtility.UrlEncode(errorDescription)}");
             }
 
             string compoundCode;
@@ -210,7 +211,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                 return BadRequest("Invalid launch context parameters");
             }
 
-            return Redirect($"{redirectUrl}?code={compoundCode}&state={newState}&session_state={sessionState}");
+            return Redirect($"{redirectUrl}?code={compoundCode}&state={newState}&session_state={HttpUtility.UrlEncode(sessionState)}");
         }
 
         /// <summary>

--- a/src/Microsoft.Health.Fhir.Api/Controllers/AadSmartOnFhirProxyController.cs
+++ b/src/Microsoft.Health.Fhir.Api/Controllers/AadSmartOnFhirProxyController.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
 
             string newState = Base64UrlEncoder.Encode(newStateObj.ToString());
 
-            var callbackUrl = UriHelper.BuildAbsolute(Request.Scheme, Request.Host, "/AadSmartOnFhirProxy/callback/", Base64UrlEncoder.Encode(redirectUri.ToString()));
+            var callbackUrl = UriHelper.BuildAbsolute(Request.Scheme, Request.Host, "/AadSmartOnFhirProxy/callback", $"/{Base64UrlEncoder.Encode(redirectUri.ToString())}");
 
             var queryStringBuilder = new StringBuilder($"response_type={HttpUtility.UrlEncode(responseType)}&redirect_uri={callbackUrl}&client_id={HttpUtility.UrlEncode(clientId)}");
             if (!_isAadV2)

--- a/src/Microsoft.Health.Fhir.Api/Controllers/AadSmartOnFhirProxyController.cs
+++ b/src/Microsoft.Health.Fhir.Api/Controllers/AadSmartOnFhirProxyController.cs
@@ -17,6 +17,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Api.Features.ActionResults;
 using Microsoft.Health.Fhir.Api.Features.Audit;
+using Microsoft.Health.Fhir.Api.Features.Routing;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.ValueSets;
@@ -102,8 +103,9 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         /// <param name="scope">scope URL parameter.</param>
         /// <param name="state">state URL parameter.</param>
         /// <param name="aud">aud (audience) URL parameter.</param>
-        [HttpGet("authorize")]
+        [HttpGet]
         [TypeFilter(typeof(SmartOnFhirAuditLoggingFilterAttribute), Arguments = new object[] { AuditEventSubType.SmartOnFhirAuthorize })]
+        [Route("authorize", Name = RouteNames.AadSmartOnFhirProxyAuthorize)]
         public ActionResult Authorize(
             [FromQuery(Name = "response_type")] string responseType,
             [FromQuery(Name = "client_id")] string clientId,
@@ -222,8 +224,9 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         /// <param name="redirectUri">redirect_uri request parameter.</param>
         /// <param name="clientId">client_id request parameter.</param>
         /// <param name="clientSecret">client_secret request parameter.</param>
-        [HttpPost("token")]
+        [HttpPost]
         [TypeFilter(typeof(SmartOnFhirAuditLoggingFilterAttribute), Arguments = new object[] { AuditEventSubType.SmartOnFhirToken })]
+        [Route("token", Name = RouteNames.AadSmartOnFhirProxyToken)]
         public async Task<ActionResult> Token(
             [FromForm(Name = "grant_type")] string grantType,
             [FromForm(Name = "code")] string compoundCode,

--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/SmartOnFhirAuditLoggingFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/SmartOnFhirAuditLoggingFilterAttribute.cs
@@ -1,0 +1,76 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Net;
+using EnsureThat;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Primitives;
+using Microsoft.Health.Fhir.Core.Features.Context;
+
+namespace Microsoft.Health.Fhir.Api.Features.Audit
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    internal class SmartOnFhirAuditLoggingFilterAttribute : ActionFilterAttribute
+    {
+        private readonly IAuditLogger _auditLogger;
+        private readonly IFhirRequestContextAccessor _fhirRequestContextAccessor;
+        private readonly string _action;
+
+        public SmartOnFhirAuditLoggingFilterAttribute(string action, IAuditLogger auditLogger, IFhirRequestContextAccessor fhirRequestContextAccessor)
+        {
+            EnsureArg.IsNotNullOrWhiteSpace(action, nameof(action));
+            EnsureArg.IsNotNull(auditLogger, nameof(auditLogger));
+            EnsureArg.IsNotNull(fhirRequestContextAccessor, nameof(fhirRequestContextAccessor));
+
+            _action = action;
+            _auditLogger = auditLogger;
+            _fhirRequestContextAccessor = fhirRequestContextAccessor;
+        }
+
+        public override void OnActionExecuting(ActionExecutingContext context)
+        {
+            EnsureArg.IsNotNull(context, nameof(context));
+
+            _auditLogger.LogAudit(
+                AuditAction.Executing,
+                _action,
+                null,
+                _fhirRequestContextAccessor.FhirRequestContext.Uri,
+                null,
+                _fhirRequestContextAccessor.FhirRequestContext.CorrelationId,
+                GetClientIdFromQueryStringOrForm(context));
+
+            base.OnActionExecuting(context);
+        }
+
+        public override void OnResultExecuted(ResultExecutedContext context)
+        {
+            EnsureArg.IsNotNull(context, nameof(context));
+
+            _auditLogger.LogAudit(
+                AuditAction.Executed,
+                _action,
+                null,
+                _fhirRequestContextAccessor.FhirRequestContext.Uri,
+                (HttpStatusCode)context.HttpContext.Response.StatusCode,
+                _fhirRequestContextAccessor.FhirRequestContext.CorrelationId,
+                GetClientIdFromQueryStringOrForm(context));
+
+            base.OnResultExecuted(context);
+        }
+
+        private static ReadOnlyCollection<KeyValuePair<string, string>> GetClientIdFromQueryStringOrForm(FilterContext context)
+        {
+            StringValues clientId = context.HttpContext.Request.HasFormContentType ? context.HttpContext.Request.Form["client_id"] : context.HttpContext.Request.Query["client_id"];
+
+            ReadOnlyCollection<KeyValuePair<string, string>> claims = clientId.Select(x => new KeyValuePair<string, string>("client_id", x)).ToList().AsReadOnly();
+            return claims;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/SmartOnFhirAuditLoggingFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/SmartOnFhirAuditLoggingFilterAttribute.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
     [AttributeUsage(AttributeTargets.Method)]
     internal class SmartOnFhirAuditLoggingFilterAttribute : ActionFilterAttribute
     {
+        private const string ClientId = "client_id";
         private readonly IAuditLogger _auditLogger;
         private readonly IFhirRequestContextAccessor _fhirRequestContextAccessor;
         private readonly string _action;
@@ -67,9 +68,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
 
         private static ReadOnlyCollection<KeyValuePair<string, string>> GetClientIdFromQueryStringOrForm(FilterContext context)
         {
-            StringValues clientId = context.HttpContext.Request.HasFormContentType ? context.HttpContext.Request.Form["client_id"] : context.HttpContext.Request.Query["client_id"];
+            StringValues clientId = context.HttpContext.Request.HasFormContentType ? context.HttpContext.Request.Form[ClientId] : context.HttpContext.Request.Query[ClientId];
 
-            ReadOnlyCollection<KeyValuePair<string, string>> claims = clientId.Select(x => new KeyValuePair<string, string>("client_id", x)).ToList().AsReadOnly();
+            ReadOnlyCollection<KeyValuePair<string, string>> claims = clientId.Select(x => new KeyValuePair<string, string>(ClientId, x)).ToList().AsReadOnly();
             return claims;
         }
     }

--- a/src/Microsoft.Health.Fhir.Api/Features/Routing/RouteNames.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Routing/RouteNames.cs
@@ -28,5 +28,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
         internal const string SearchAllResourcesPost = "SearchAllResourcesPost";
 
         internal const string SearchCompartmentByResourceType = "SearchCompartmentByResourceType";
+
+        internal const string AadSmartOnFhirProxyAuthorize = "AadSmartOnFhirProxyAuthorize";
+
+        internal const string AadSmartOnFhirProxyToken = "AadSmartOnFhirProxyToken";
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Features/Routing/RouteNames.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Routing/RouteNames.cs
@@ -31,6 +31,8 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
 
         internal const string AadSmartOnFhirProxyAuthorize = "AadSmartOnFhirProxyAuthorize";
 
+        internal const string AadSmartOnFhirProxyCallback = "AadSmartOnFhirProxyCallback";
+
         internal const string AadSmartOnFhirProxyToken = "AadSmartOnFhirProxyToken";
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Features/Routing/UrlResolver.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Routing/UrlResolver.cs
@@ -161,5 +161,16 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
 
             return new Uri(uriString);
         }
+
+        public Uri ResolveRouteNameUrl(string routeName)
+        {
+            var uriString = UrlHelper.RouteUrl(
+                routeName,
+                null,
+                Request.Scheme,
+                Request.Host.Value);
+
+            return new Uri(uriString);
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Features/Routing/UrlResolver.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Routing/UrlResolver.cs
@@ -162,11 +162,13 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
             return new Uri(uriString);
         }
 
-        public Uri ResolveRouteNameUrl(string routeName)
+        public Uri ResolveRouteNameUrl(string routeName, IDictionary<string, object> routeValues)
         {
+            var routeValueDictionary = new RouteValueDictionary(routeValues);
+
             var uriString = UrlHelper.RouteUrl(
                 routeName,
-                null,
+                routeValueDictionary,
                 Request.Scheme,
                 Request.Host.Value);
 

--- a/src/Microsoft.Health.Fhir.Api/Features/Security/SecurityProvider.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Security/SecurityProvider.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 using EnsureThat;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Health.Fhir.Api.Features.Routing;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features.Conformance;
 using Microsoft.Health.Fhir.Core.Features.Routing;
@@ -38,7 +39,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Security
             {
                 if (_securityConfiguration.EnableAadSmartOnFhirProxy)
                 {
-                    statement.AddProxyOAuthSecurityService(_urlResolver.ResolveMetadataUrl(false));
+                    statement.AddProxyOAuthSecurityService(_urlResolver, RouteNames.AadSmartOnFhirProxyAuthorize, RouteNames.AadSmartOnFhirProxyToken);
                 }
                 else
                 {

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementExtensions.cs
@@ -97,8 +97,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
             var security = restComponent.Security ?? new CapabilityStatement.SecurityComponent();
 
             security.Service.Add(Constants.RestfulSecurityServiceOAuth);
-            var tokenEndpoint = urlResolver.ResolveRouteNameUrl(tokenRouteName);
-            var authorizationEndpoint = urlResolver.ResolveRouteNameUrl(authorizeRouteName);
+            var tokenEndpoint = urlResolver.ResolveRouteNameUrl(tokenRouteName, null);
+            var authorizationEndpoint = urlResolver.ResolveRouteNameUrl(authorizeRouteName, null);
 
             var smartExtension = new Extension()
             {

--- a/src/Microsoft.Health.Fhir.Core/Features/Routing/IUrlResolver.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Routing/IUrlResolver.cs
@@ -10,7 +10,7 @@ using Hl7.Fhir.Model;
 namespace Microsoft.Health.Fhir.Core.Features.Routing
 {
     /// <summary>
-    /// Provides functionalities to resolve URLs.
+    /// Provides functionality to resolve URLs.
     /// </summary>
     public interface IUrlResolver
     {
@@ -41,7 +41,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Routing
         /// Resolves the URL for the specified routeName.
         /// </summary>
         /// <param name="routeName">The route name to resolve.</param>
+        /// <param name="routeValues">Any route values to use in the route.</param>
         /// <returns>The URL.</returns>
-        Uri ResolveRouteNameUrl(string routeName);
+        Uri ResolveRouteNameUrl(string routeName, IDictionary<string, object> routeValues);
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Routing/IUrlResolver.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Routing/IUrlResolver.cs
@@ -36,5 +36,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Routing
         /// <param name="continuationToken">The continuation token.</param>
         /// <returns>The URL.</returns>
         Uri ResolveRouteUrl(IEnumerable<Tuple<string, string>> unsupportedSearchParams = null, string continuationToken = null);
+
+        /// <summary>
+        /// Resolves the URL for the specified routeName.
+        /// </summary>
+        /// <param name="routeName">The route name to resolve.</param>
+        /// <returns>The URL.</returns>
+        Uri ResolveRouteNameUrl(string routeName);
     }
 }

--- a/src/Microsoft.Health.Fhir.ValueSets/AuditEventSubType.cs
+++ b/src/Microsoft.Health.Fhir.ValueSets/AuditEventSubType.cs
@@ -37,5 +37,11 @@ namespace Microsoft.Health.Fhir.ValueSets
         public const string SearchSystem = "search-system";
 
         public const string Capabilities = "capabilities";
+
+        public const string SmartOnFhirAuthorize = "smart-on-fhir-authorize";
+
+        public const string SmartOnFhirCallback = "smart-on-fhir-callback";
+
+        public const string SmartOnFhirToken = "smart-on-fhir-token";
     }
 }

--- a/src/Microsoft.Health.Fhir.Web/Startup.cs
+++ b/src/Microsoft.Health.Fhir.Web/Startup.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.ApplicationInsights;
 
 namespace Microsoft.Health.Fhir.Web
 {


### PR DESCRIPTION
## Description
This PR add audit logging to the smart on fhir proxy controller. It logs the `client_id` that comes in either on the query string or the form collection.

## Related issues
Addresses #379.

## Testing
- Unit test was created for the filter
- Manual E2E verification was performed by adding application insights to the local machine and completing the smart on fhir process
