### PR TITLE
Audit log valid claims by default for AAD vs. IdentityServer

### DIFF
--- a/src/Microsoft.Health.Fhir.Web/DevelopmentIdentityProviderConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Web/DevelopmentIdentityProviderConfiguration.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Health.Fhir.Web
     public class DevelopmentIdentityProviderConfiguration
     {
         public const string Audience = "fhir-api";
+        public const string LastModifiedClaim = "appid";
 
         public bool Enabled { get; set; }
 

--- a/src/Microsoft.Health.Fhir.Web/DevelopmentIdentityProviderRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Web/DevelopmentIdentityProviderRegistrationExtensions.cs
@@ -187,6 +187,7 @@ namespace Microsoft.Health.Fhir.Web
                     // add properties related to the development identity provider.
                     Data["DevelopmentIdentityProvider:Enabled"] = bool.TrueString;
                     Data["FhirServer:Security:Authentication:Audience"] = DevelopmentIdentityProviderConfiguration.Audience;
+                    Data["FhirServer:Security:LastModifiedClaims:0"] = DevelopmentIdentityProviderConfiguration.LastModifiedClaim;
                 }
             }
         }

--- a/src/Microsoft.Health.Fhir.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Web/appsettings.json
@@ -11,7 +11,7 @@
         "Authority": "https://localhost:44348"
       },
       "LastModifiedClaims": [
-        "client_id"
+        "oid"
       ],
       "Authorization": {
         "Enabled": true

--- a/test/Microsoft.Health.Fhir.Tests.E2E/Rest/Audit/StartupWithTraceAuditLogger.cs
+++ b/test/Microsoft.Health.Fhir.Tests.E2E/Rest/Audit/StartupWithTraceAuditLogger.cs
@@ -6,9 +6,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Api.Features.Audit;
-using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Web;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit
@@ -25,12 +23,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit
             base.ConfigureServices(services);
 
             services.Replace(new ServiceDescriptor(typeof(IAuditLogger), typeof(TraceAuditLogger), ServiceLifetime.Singleton));
-
-            // Configure the test server to log a claim that is used in both local and integration environments.
-            ServiceProvider serviceProvider = services.BuildServiceProvider();
-            var securityConfigurationOptions = serviceProvider.GetService<IOptions<SecurityConfiguration>>();
-            securityConfigurationOptions.Value.LastModifiedClaims.Clear();
-            securityConfigurationOptions.Value.LastModifiedClaims.Add("appid");
         }
     }
 }


### PR DESCRIPTION
## Description
Updated the default LastModifiedClaims setting to oid for AAD, and updated test/local deployments to appid for IdentityServer.

## Related issues
Addresses #387 .

## Testing
Manually verified local deployments have LastModifiedClaims = appid.
Manually verified in App Insights that audit logs from the PR deployment contain oid.