### PR TITLE
Fix for SmartProxy E2E test failure

### DIFF
--- a/test/Microsoft.Health.Fhir.Tests.E2E/SmartProxy/SmartProxyTests.cs
+++ b/test/Microsoft.Health.Fhir.Tests.E2E/SmartProxy/SmartProxyTests.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.SmartProxy
 
         private static IWebElement WaitForAndReturnElement(IWebDriver driver, string elementName, TimeSpan timeout, bool findElementById)
         {
-            // We poll every 100ms to check whether the requested element is available or not.
+            // We poll every 100ms to check whether the requested element is available and enabled.
             // If the element is still not available after "timeout" seconds, we throw a TimeoutException
             var driverWait = new WebDriverWait(driver, timeout)
             {
@@ -162,11 +162,13 @@ namespace Microsoft.Health.Fhir.Tests.E2E.SmartProxy
             IWebElement element;
             if (findElementById)
             {
-                element = driverWait.Until(d => d.FindElement(By.Id(elementName)));
+                driverWait.Until(d => d.FindElement(By.Id(elementName)).Enabled);
+                element = driver.FindElement(By.Id(elementName));
             }
             else
             {
-                element = driverWait.Until(d => d.FindElement(By.Name(elementName)));
+                driverWait.Until(d => d.FindElement(By.Name(elementName)).Enabled);
+                element = driver.FindElement(By.Name(elementName));
             }
 
             return element;

--- a/test/Microsoft.Health.Fhir.Tests.E2E/SmartProxy/SmartProxyTests.cs
+++ b/test/Microsoft.Health.Fhir.Tests.E2E/SmartProxy/SmartProxyTests.cs
@@ -113,7 +113,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.SmartProxy
 
                 // We need to add some delay before we enter the password to avoid
                 // clicking the button before the whole text is entered.
-                Thread.Sleep(TimeSpan.FromMilliseconds(1000));
+              WebDriverWait wait = new WebDriverWait(driver, 5);
+              wait.until(ExpectedConditions.visibilityOfElementLocated(By.Name("passwd")));
 
                 driver.FindElementByName("passwd").SendKeys(testUserPassword);
                 Advance();

--- a/test/Microsoft.Health.Fhir.Tests.E2E/SmartProxy/SmartProxyTests.cs
+++ b/test/Microsoft.Health.Fhir.Tests.E2E/SmartProxy/SmartProxyTests.cs
@@ -109,14 +109,13 @@ namespace Microsoft.Health.Fhir.Tests.E2E.SmartProxy
                     Assert.InRange(waitCount++, 0, 10);
                 }
 
-                driver.FindElementByName("loginfmt").SendKeys(testUserName);
+                IWebElement loginElement = WaitForAndReturnElement(driver, "loginfmt", TimeSpan.FromSeconds(5), false);
+                loginElement.SendKeys(testUserName);
                 Advance();
 
                 // We want to make sure the passwd element is available before we try to access it.
-                var wait = new WebDriverWait(driver, TimeSpan.FromSeconds(5));
-                IWebElement passwdElement = wait.Until(d => d.FindElement(By.Name("passwd")));
-
-                passwdElement.SendKeys(testUserPassword);
+                IWebElement passwordElement = WaitForAndReturnElement(driver, "passwd", TimeSpan.FromSeconds(5), false);
+                passwordElement.SendKeys(testUserPassword);
                 Advance();
 
                 // Consent, should only be done if we can find the button
@@ -130,17 +129,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.SmartProxy
                     // Nothing to do, we are assuming that we are at the SMART App screen.
                 }
 
-                var tokenResponseElement = driver.FindElement(By.Id("tokenresponsefield"));
+                IWebElement tokenResponseElement = WaitForAndReturnElement(driver, "tokenresponsefield", TimeSpan.FromSeconds(10), true);
                 var tokenResponseText = tokenResponseElement.GetAttribute("value");
-
-                // It can take some time for the token to appear, we will wait
-                waitCount = 0;
-                while (string.IsNullOrWhiteSpace(tokenResponseText))
-                {
-                    Thread.Sleep(TimeSpan.FromMilliseconds(1000));
-                    tokenResponseText = tokenResponseElement.GetAttribute("value");
-                    Assert.InRange(waitCount++, 0, 10);
-                }
 
                 // Check the token response, should have right audience
                 var tokenResponse = JObject.Parse(tokenResponseElement.GetAttribute("value"));
@@ -157,6 +147,29 @@ namespace Microsoft.Health.Fhir.Tests.E2E.SmartProxy
                 var patientResource = JObject.Parse(patientResponseElement.GetAttribute("value"));
                 Assert.Equal(patient.Id, patientResource["id"].ToString());
             }
+        }
+
+        private static IWebElement WaitForAndReturnElement(IWebDriver driver, string elementName, TimeSpan timeout, bool findElementById)
+        {
+            // We poll every 100ms to check whether the requested element is available or not.
+            // If the element is still not available after "timeout" seconds, we throw a TimeoutException
+            var driverWait = new WebDriverWait(driver, timeout)
+            {
+                PollingInterval = TimeSpan.FromMilliseconds(100),
+            };
+
+            // findElementById determines whether we search by Id or by Name.
+            IWebElement element;
+            if (findElementById)
+            {
+                element = driverWait.Until(d => d.FindElement(By.Id(elementName)));
+            }
+            else
+            {
+                element = driverWait.Until(d => d.FindElement(By.Name(elementName)));
+            }
+
+            return element;
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Tests.E2E/SmartProxy/SmartProxyTests.cs
+++ b/test/Microsoft.Health.Fhir.Tests.E2E/SmartProxy/SmartProxyTests.cs
@@ -16,6 +16,7 @@ using Microsoft.Health.Fhir.Tests.E2E.Common;
 using Newtonsoft.Json.Linq;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chrome;
+using OpenQA.Selenium.Support.UI;
 using Xunit;
 using Task = System.Threading.Tasks.Task;
 
@@ -111,12 +112,11 @@ namespace Microsoft.Health.Fhir.Tests.E2E.SmartProxy
                 driver.FindElementByName("loginfmt").SendKeys(testUserName);
                 Advance();
 
-                // We need to add some delay before we enter the password to avoid
-                // clicking the button before the whole text is entered.
-              WebDriverWait wait = new WebDriverWait(driver, 5);
-              wait.until(ExpectedConditions.visibilityOfElementLocated(By.Name("passwd")));
+                // We want to make sure the passwd element is available before we try to access it.
+                var wait = new WebDriverWait(driver, TimeSpan.FromSeconds(5));
+                IWebElement passwdElement = wait.Until(d => d.FindElement(By.Name("passwd")));
 
-                driver.FindElementByName("passwd").SendKeys(testUserPassword);
+                passwdElement.SendKeys(testUserPassword);
                 Advance();
 
                 // Consent, should only be done if we can find the button

--- a/test/Microsoft.Health.Fhir.Tests.E2E/SmartProxy/SmartProxyTests.cs
+++ b/test/Microsoft.Health.Fhir.Tests.E2E/SmartProxy/SmartProxyTests.cs
@@ -111,6 +111,10 @@ namespace Microsoft.Health.Fhir.Tests.E2E.SmartProxy
                 driver.FindElementByName("loginfmt").SendKeys(testUserName);
                 Advance();
 
+                // We need to add some delay before we enter the password to avoid
+                // clicking the button before the whole text is entered.
+                Thread.Sleep(TimeSpan.FromMilliseconds(1000));
+
                 driver.FindElementByName("passwd").SendKeys(testUserPassword);
                 Advance();
 


### PR DESCRIPTION
## Description
Fixed the SmartProxy E2E test. The failure was caused because we were advancing to the next action before the previous action completed. Added delay to prevent this.

## Related issues
Addresses [issue #409 ].

## Testing
Existing tests passed.
