### PR TITLE
Avoid duplicate Token.text index entries

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Compartment/CompartmentIndexerTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Compartment/CompartmentIndexerTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Compartment
                     x[2] = new HashSet<string> { "testParam" };
                     return true;
                 });
-            var searchIndexEntries = new List<SearchIndexEntry> { new SearchIndexEntry("testParam", new ReferenceSearchValue(ReferenceKind.Internal, new Uri("http://localhost"), CompartmentDefinitionManager.CompartmentTypeToResourceType(compartmentType), resourceId)) };
+            var searchIndexEntries = new List<SearchIndexEntry> { new SearchIndexEntry(new SearchParameter { Name = "testParam" }, new ReferenceSearchValue(ReferenceKind.Internal, new Uri("http://localhost"), CompartmentDefinitionManager.CompartmentTypeToResourceType(compartmentType), resourceId)) };
             CompartmentIndices compartmentIndices = compartmentIndexer.Extract(resourceType, searchIndexEntries);
 
             IReadOnlyCollection<string> resourceIds = null;

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/Converters/CodeableConceptToSearchValueTypeConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/Converters/CodeableConceptToSearchValueTypeConverterTests.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
 
         [Theory]
         [MemberData(nameof(GetMultipleCodingDataSource))]
-        public void GivenACodeableConceptWithCodings_WhenConverted_ThenOneOrMultipleTokenSearchValuesShouldBetCreated(params Token[] tokens)
+        public void GivenACodeableConceptWithCodings_WhenConverted_ThenOneOrMultipleTokenSearchValuesShouldBeCreated(params Token[] tokens)
         {
             Test(
                 cc => cc.Coding.AddRange(tokens.Select(token => new Coding(token.System, token.Code, token.Text))),

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/Converters/CodeableConceptToSearchValueTypeConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/Converters/CodeableConceptToSearchValueTypeConverterTests.cs
@@ -33,6 +33,40 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
         }
 
         [Fact]
+        public void GivenACodeableConceptWithTextThatIsTheSameAsTheDisplayOfACoding_WhenConverted_ThenATokenSearchValueShouldNotBeCreatedForTheConceptText()
+        {
+            const string system = "system";
+            const string text = "text";
+
+            Test(
+                cc =>
+                {
+                    cc.Text = text;
+                    cc.Coding.Add(new Coding(system, null, text));
+                },
+                ValidateToken,
+                new Token(system: system, text: text));
+        }
+
+        [Fact]
+        public void GivenACodeableConceptWithTextThatIsDifferentThanTheDisplayOfACoding_WhenConverted_ThenATokenSearchValueShouldBeCreatedForTheConceptText()
+        {
+            const string system = "system";
+            const string conceptText = "conceptText";
+            const string codingDisplayText = "codingDisplay";
+
+            Test(
+                cc =>
+                {
+                    cc.Text = conceptText;
+                    cc.Coding.Add(new Coding(system, null, codingDisplayText));
+                },
+                ValidateToken,
+                new Token(system: system, text: codingDisplayText),
+                new Token(text: conceptText));
+        }
+
+        [Fact]
         public void GivenACodeableConceptWithNullCoding_WhenConverted_ThenNoSearchValueShouldBeCreated()
         {
             Test(cc => cc.Coding = null);
@@ -40,7 +74,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
 
         [Theory]
         [MemberData(nameof(GetMultipleCodingDataSource))]
-        public void GivenACodeableConceptWithCodings_WhenConverted_ThenOneOrMultipleTokenSearchValuesShouldBeCreated(params Token[] tokens)
+        public void GivenACodeableConceptWithCodings_WhenConverted_ThenOneOrMultipleTokenSearchValuesShouldBetCreated(params Token[] tokens)
         {
             Test(
                 cc => cc.Coding.AddRange(tokens.Select(token => new Coding(token.System, token.Code, token.Text))),

--- a/src/Microsoft.Health.Fhir.Core/Features/Compartment/CompartmentIndexer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Compartment/CompartmentIndexer.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Compartment
 
                 if (_compartmentDefinitionManager.TryGetSearchParams(resourceType, compartmentType, out HashSet<string> searchParams) && searchIndicesByCompartmentType.TryGetValue(compartmentType, out List<SearchIndexEntry> searchIndicesForCompartment))
                 {
-                    var searchEntries = searchIndicesForCompartment.Where(si => searchParams.Contains(si.ParamName));
+                    var searchEntries = searchIndicesForCompartment.Where(si => searchParams.Contains(si.SearchParameter.Name));
 
                     var resourceIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                     ResourceType compartmentResourceType = CompartmentDefinitionManager.CompartmentTypeToResourceType(compartmentType);

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Converters/CodeableConceptToSearchValueTypeConverter.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Converters/CodeableConceptToSearchValueTypeConverter.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
@@ -17,30 +18,37 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Converters
         protected override IEnumerable<ISearchValue> ConvertTo(CodeableConcept value)
         {
             // Based on spec: http://hl7.org/fhir/STU3/search.html#token,
-            // CodeableConcept.text is searchable.
-            if (!string.IsNullOrWhiteSpace(value.Text))
+            // CodeableConcept.text is searchable, but we will only create a dedicated entry for it
+            // if it is different from the display text of one of its codings
+
+            bool conceptTextNeedsToBeAdded = !string.IsNullOrWhiteSpace(value.Text);
+
+            if (value.Coding != null)
+            {
+                foreach (Coding coding in value.Coding)
+                {
+                    if (coding == null)
+                    {
+                        continue;
+                    }
+
+                    TokenSearchValue searchValue = coding.ToTokenSearchValue();
+
+                    if (searchValue != null)
+                    {
+                        if (conceptTextNeedsToBeAdded)
+                        {
+                            conceptTextNeedsToBeAdded = !value.Text.Equals(searchValue.Text, StringComparison.OrdinalIgnoreCase);
+                        }
+
+                        yield return searchValue;
+                    }
+                }
+            }
+
+            if (conceptTextNeedsToBeAdded)
             {
                 yield return new TokenSearchValue(null, null, value.Text);
-            }
-
-            if (value.Coding?.Count == 0)
-            {
-                yield break;
-            }
-
-            foreach (Coding coding in value.Coding)
-            {
-                if (coding == null)
-                {
-                    continue;
-                }
-
-                TokenSearchValue searchValue = coding.ToTokenSearchValue();
-
-                if (searchValue != null)
-                {
-                    yield return searchValue;
-                }
             }
         }
     }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchIndexEntry.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchIndexEntry.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using EnsureThat;
+using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
 
 namespace Microsoft.Health.Fhir.Core.Features.Search
@@ -16,21 +17,21 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
         /// <summary>
         /// Initializes a new instance of the <see cref="SearchIndexEntry"/> class.
         /// </summary>
-        /// <param name="paramName">The search parameter name.</param>
+        /// <param name="searchParameter">The search parameter</param>
         /// <param name="value">The searchable value.</param>
-        public SearchIndexEntry(string paramName, ISearchValue value)
+        public SearchIndexEntry(SearchParameter searchParameter, ISearchValue value)
         {
-            EnsureArg.IsNotNullOrWhiteSpace(paramName, nameof(paramName));
+            EnsureArg.IsNotNull(searchParameter, nameof(searchParameter));
             EnsureArg.IsNotNull(value, nameof(value));
 
-            ParamName = paramName;
+            SearchParameter = searchParameter;
             Value = value;
         }
 
         /// <summary>
-        /// Gets the parameter name.
+        /// Gets the search parameter
         /// </summary>
-        public string ParamName { get; }
+        public SearchParameter SearchParameter { get; }
 
         /// <summary>
         /// Gets the searchable value.

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchIndexer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchIndexer.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                     continue;
                 }
 
-                yield return new SearchIndexEntry(searchParameter.Name, new CompositeSearchValue(componentValues));
+                yield return new SearchIndexEntry(searchParameter, new CompositeSearchValue(componentValues));
             }
         }
 
@@ -147,7 +147,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                 searchParameter.Expression,
                 context))
             {
-                yield return new SearchIndexEntry(searchParameter.Name, searchValue);
+                yield return new SearchIndexEntry(searchParameter, searchValue);
             }
         }
 

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/Search/SearchIndexEntryJObjectGeneratorTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/Search/SearchIndexEntryJObjectGeneratorTests.cs
@@ -361,7 +361,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Storage.Search
 
         private void TestAndValidateOutput(string parameterName, ISearchValue value, params (string Name, object Value)[][] expectedValues)
         {
-            SearchIndexEntry entry = new SearchIndexEntry(parameterName, value);
+            SearchIndexEntry entry = new SearchIndexEntry(new SearchParameter { Name = parameterName }, value);
 
             IReadOnlyList<JObject> generatedObjects = _generator.Generate(entry);
 

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Search/SearchIndexEntryJObjectGenerator.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Search/SearchIndexEntryJObjectGenerator.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Search
         {
             CurrentEntry = new JObject
             {
-                new JProperty(SearchValueConstants.ParamName, Entry.ParamName),
+                new JProperty(SearchValueConstants.ParamName, Entry.SearchParameter.Name),
             };
 
             _generatedObjects.Add(CurrentEntry);


### PR DESCRIPTION
## Description
Avoid creating Token search parameter entries for codeableconcept.text where one of the codings has the same display text.

Also changing SearchIndexEntry's constructor to take a SearchParameter instead of just the search parameter's name.

## Related issues
Addresses #426
