### PR TITLE
Return authorization URL response on authorize call, return BadReques…

### DIFF
--- a/src/Microsoft.Health.Fhir.Api.UnitTests/Controllers/AadSmartOnFhirProxyControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Api.UnitTests/Controllers/AadSmartOnFhirProxyControllerTests.cs
@@ -1,0 +1,118 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Reflection;
+using System.Web;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Fhir.Api.Configs;
+using Microsoft.Health.Fhir.Api.Controllers;
+using Microsoft.Health.Fhir.Core.Configs;
+using Microsoft.Health.Fhir.Core.Features.Routing;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
+{
+    public class AadSmartOnFhirProxyControllerTests
+    {
+        private readonly SecurityConfiguration _securityConfiguration = new SecurityConfiguration();
+        private readonly IHttpClientFactory _httpClientFactory = Substitute.For<IHttpClientFactory>();
+        private readonly ILogger<Core.Configs.SecurityConfiguration> _logger = NullLogger<Core.Configs.SecurityConfiguration>.Instance;
+        private readonly IUrlResolver _urlResolver = Substitute.For<IUrlResolver>();
+        private readonly FeatureConfiguration _featureConfiguration = new FeatureConfiguration();
+        private readonly AadSmartOnFhirProxyController _controller;
+
+        public AadSmartOnFhirProxyControllerTests()
+        {
+            _securityConfiguration.EnableAadSmartOnFhirProxy = true;
+            _securityConfiguration.Enabled = true;
+            _securityConfiguration.Authorization = new AuthorizationConfiguration
+            {
+                Enabled = true,
+            };
+            _securityConfiguration.Authentication = new AuthenticationConfiguration
+            {
+                Audience = "testaudience",
+                Authority = "http://testauthority.com/v2.0",
+            };
+
+            string openIdConfiguration;
+            using (StreamReader r = new StreamReader(Assembly.GetExecutingAssembly().
+                GetManifestResourceStream("Microsoft.Health.Fhir.Api.UnitTests.Controllers.openid-configuration.json")))
+            {
+                    openIdConfiguration = r.ReadToEnd();
+            }
+
+            var httpMessageHandler = new TestHttpMessageHandler(new HttpResponseMessage()
+            {
+                StatusCode = System.Net.HttpStatusCode.OK,
+                Content = new StringContent(openIdConfiguration),
+            });
+
+            var httpClient = new HttpClient(httpMessageHandler);
+
+            _httpClientFactory.CreateClient().Returns(httpClient);
+
+            _controller = new AadSmartOnFhirProxyController(
+                Options.Create(_securityConfiguration),
+                _httpClientFactory,
+                _urlResolver,
+                _logger);
+        }
+
+        [Theory]
+        [InlineData(null, null, null, null, null, null, null)]
+        [InlineData("code", null, null, null, null, null, null)]
+        [InlineData("code", "clientId", null, null, null, null, null)]
+        [InlineData("code", "clientId", "https://testurl.com", null, null, null, null)]
+        [InlineData("code", "clientId", "https://testurl.com", "launch", null, null, null)]
+        [InlineData("code", "clientId", "https://testurl.com", "launch", "scope", null, null)]
+        [InlineData("code", "clientId", "https://testurl.com", "launch", "scope", "state", null)]
+
+        public void GivenIncompleteQueryPamas_WhenAuthorizeRequestAction_ThenRedirectResultReturned(
+            string responseType, string clientId, string redirectUri, string launch, string scope, string state, string aud)
+        {
+            Uri redirect = null;
+            if (!string.IsNullOrEmpty(redirectUri))
+            {
+                redirect = new Uri(redirectUri);
+            }
+
+            _urlResolver.ResolveRouteNameUrl(Arg.Any<string>(), Arg.Any<IDictionary<string, object>>()).Returns(redirect);
+
+            var result = _controller.Authorize(responseType, clientId, redirect, launch, scope, state, aud);
+
+            Assert.IsType<RedirectResult>(result);
+
+            var uri = new Uri(((RedirectResult)result).Url);
+            var queryParams = HttpUtility.ParseQueryString(uri.Query);
+
+            Assert.Equal(responseType, queryParams["response_type"]);
+            Assert.Equal(clientId, queryParams["client_id"]);
+
+            if (!string.IsNullOrEmpty(redirectUri))
+            {
+                Assert.Contains(redirect.Host, uri.AbsoluteUri);
+            }
+
+            if (!string.IsNullOrEmpty(scope))
+            {
+                Assert.NotNull(queryParams["scope"]);
+            }
+
+            if (!string.IsNullOrEmpty(state))
+            {
+                Assert.NotNull(queryParams["state"]);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Api.UnitTests/Controllers/AadSmartOnFhirProxyControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Api.UnitTests/Controllers/AadSmartOnFhirProxyControllerTests.cs
@@ -73,6 +73,9 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
 
         [Theory]
         [InlineData(null, null, null, null, null, null, null)]
+        [InlineData(null, null, null, "launch", null, null, null)]
+        [InlineData("code", null, null, "launch", null, null, null)]
+        [InlineData("code", "clientId", null, "launch", null, null, null)]
         [InlineData("code", null, null, null, null, null, null)]
         [InlineData("code", "clientId", null, null, null, null, null)]
         [InlineData("code", "clientId", "https://testurl.com", null, null, null, null)]

--- a/src/Microsoft.Health.Fhir.Api.UnitTests/Controllers/TestHttpMessageHandler.cs
+++ b/src/Microsoft.Health.Fhir.Api.UnitTests/Controllers/TestHttpMessageHandler.cs
@@ -11,16 +11,16 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
 {
     public class TestHttpMessageHandler : DelegatingHandler
     {
-        private HttpResponseMessage _response;
-
         public TestHttpMessageHandler(HttpResponseMessage message)
         {
-            _response = message;
+            Response = message;
         }
+
+        public HttpResponseMessage Response { get; set; }
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            return await Task.FromResult(_response);
+            return await Task.FromResult(Response);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Api.UnitTests/Controllers/TestHttpMessageHandler.cs
+++ b/src/Microsoft.Health.Fhir.Api.UnitTests/Controllers/TestHttpMessageHandler.cs
@@ -1,0 +1,26 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
+{
+    public class TestHttpMessageHandler : DelegatingHandler
+    {
+        private HttpResponseMessage _response;
+
+        public TestHttpMessageHandler(HttpResponseMessage message)
+        {
+            _response = message;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return await Task.FromResult(_response);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Api.UnitTests/Controllers/openid-configuration.json
+++ b/src/Microsoft.Health.Fhir.Api.UnitTests/Controllers/openid-configuration.json
@@ -1,0 +1,65 @@
+{
+    "authorization_endpoint": "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+    "token_endpoint": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+    "token_endpoint_auth_methods_supported": [
+        "client_secret_post",
+        "private_key_jwt",
+        "client_secret_basic"
+    ],
+    "jwks_uri": "https://login.microsoftonline.com/common/discovery/v2.0/keys",
+    "response_modes_supported": [
+        "query",
+        "fragment",
+        "form_post"
+    ],
+    "subject_types_supported": [
+        "pairwise"
+    ],
+    "id_token_signing_alg_values_supported": [
+        "RS256"
+    ],
+    "http_logout_supported": true,
+    "frontchannel_logout_supported": true,
+    "end_session_endpoint": "https://login.microsoftonline.com/common/oauth2/v2.0/logout",
+    "response_types_supported": [
+        "code",
+        "id_token",
+        "code id_token",
+        "id_token token"
+    ],
+    "scopes_supported": [
+        "openid",
+        "profile",
+        "email",
+        "offline_access"
+    ],
+    "issuer": "https://login.microsoftonline.com/{tenantid}/v2.0",
+    "claims_supported": [
+        "sub",
+        "iss",
+        "cloud_instance_name",
+        "cloud_instance_host_name",
+        "cloud_graph_host_name",
+        "msgraph_host",
+        "aud",
+        "exp",
+        "iat",
+        "auth_time",
+        "acr",
+        "nonce",
+        "preferred_username",
+        "name",
+        "tid",
+        "ver",
+        "at_hash",
+        "c_hash",
+        "email"
+    ],
+    "request_uri_parameter_supported": false,
+    "userinfo_endpoint": "https://graph.microsoft.com/oidc/userinfo",
+    "tenant_region_scope": null,
+    "cloud_instance_name": "microsoftonline.com",
+    "cloud_graph_host_name": "graph.windows.net",
+    "msgraph_host": "graph.microsoft.com",
+    "rbac_url": "https://pas.windows.net"
+}

--- a/src/Microsoft.Health.Fhir.Api.UnitTests/Microsoft.Health.Fhir.Api.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.Api.UnitTests/Microsoft.Health.Fhir.Api.UnitTests.csproj
@@ -5,10 +5,20 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="Controllers\openid-configuration.json" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="NSubstitute" Version="4.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Controllers\openid-configuration.json">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Health.Fhir.Api/Controllers/AadSmartOnFhirProxyController.cs
+++ b/src/Microsoft.Health.Fhir.Api/Controllers/AadSmartOnFhirProxyController.cs
@@ -293,7 +293,6 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             {
                 EnsureArg.IsNotNull(grantType, nameof(grantType));
                 EnsureArg.IsNotNull(clientId, nameof(clientId));
-                EnsureArg.IsNotNull(clientSecret, nameof(clientSecret));
             }
             catch (ArgumentNullException ex)
             {

--- a/src/Microsoft.Health.Fhir.Api/Controllers/AadSmartOnFhirProxyController.cs
+++ b/src/Microsoft.Health.Fhir.Api/Controllers/AadSmartOnFhirProxyController.cs
@@ -215,7 +215,16 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             [FromQuery(Name = "error")] string error,
             [FromQuery(Name = "error_description")] string errorDescription)
         {
-            var redirectUrl = new Uri(Base64UrlEncoder.Decode(encodedRedirect));
+            Uri redirectUrl = null;
+
+            try
+            {
+                redirectUrl = new Uri(Base64UrlEncoder.Decode(encodedRedirect));
+            }
+            catch (FormatException ex)
+            {
+                throw new AadSmartOnFhirProxyBadRequestException(string.Format(Resources.InvalidRedirectUri, redirectUrl), ex);
+            }
 
             if (!string.IsNullOrEmpty(error))
             {
@@ -245,7 +254,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             catch (Exception ex)
             {
                 _logger.LogError($"Error parsing launch parameters: {ex.Message}");
-                throw new AadSmartOnFhirProxyBadRequestException("Invalid launch context parameters", ex);
+                throw new AadSmartOnFhirProxyBadRequestException(Resources.InvalidLaunchContext, ex);
             }
 
             var queryBuilder = new QueryBuilder
@@ -288,7 +297,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             }
             catch (ArgumentNullException ex)
             {
-                throw new AadSmartOnFhirProxyBadRequestException(ex.Message, ex);
+                throw new AadSmartOnFhirProxyBadRequestException(string.Format(Resources.ValueCannotBeNull, ex.ParamName), ex);
             }
 
             var client = _httpClientFactory.CreateClient();
@@ -327,7 +336,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             }
             catch (ArgumentNullException ex)
             {
-                throw new AadSmartOnFhirProxyBadRequestException(ex.Message, ex);
+                throw new AadSmartOnFhirProxyBadRequestException(string.Format(Resources.ValueCannotBeNull, ex.ParamName), ex);
             }
 
             JObject decodedCompoundCode;
@@ -340,7 +349,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             catch (Exception ex)
             {
                 _logger.LogError($"Error decoding compound code: {ex.Message}");
-                throw new AadSmartOnFhirProxyBadRequestException("Invalid compound authorization code", ex);
+                throw new AadSmartOnFhirProxyBadRequestException(Resources.InvalidCompoundCode, ex);
             }
 
             Uri callbackUrl = _urlResolver.ResolveRouteNameUrl(RouteNames.AadSmartOnFhirProxyCallback, new RouteValueDictionary { { "encodedRedirect", Base64UrlEncoder.Encode(redirectUri.ToString()) } });

--- a/src/Microsoft.Health.Fhir.Api/Controllers/AadSmartOnFhirProxyController.cs
+++ b/src/Microsoft.Health.Fhir.Api/Controllers/AadSmartOnFhirProxyController.cs
@@ -151,9 +151,9 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                 var callbackUrl = _urlResolver.ResolveRouteNameUrl(RouteNames.AadSmartOnFhirProxyCallback, new RouteValueDictionary { { "encodedRedirect", Base64UrlEncoder.Encode(redirectUri.ToString()) } });
                 queryBuilder.Add("redirect_uri", callbackUrl.AbsoluteUri);
             }
-            catch
+            catch (Exception ex)
             {
-                // ignore the error and continue.  We will redirect to AAD and the proper error will be returned to the caller
+                _logger.LogWarning(ex, "Redirect URL passed to Authorize failed to resolve.");
             }
 
             if (!_isAadV2 && !string.IsNullOrEmpty(aud))

--- a/src/Microsoft.Health.Fhir.Api/Features/Exceptions/AadSmartOnFhirProxyBadRequestException.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Exceptions/AadSmartOnFhirProxyBadRequestException.cs
@@ -1,0 +1,23 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.Health.Fhir.Api.Features.Exceptions
+{
+    public class AadSmartOnFhirProxyBadRequestException : Exception
+    {
+        public AadSmartOnFhirProxyBadRequestException(string message, ArgumentNullException innerException)
+            : base(message, innerException)
+        {
+            message = string.Format(Resources.ValueCannotBeNull, innerException.ParamName);
+        }
+
+        public AadSmartOnFhirProxyBadRequestException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Api/Features/Exceptions/AadSmartOnFhirProxyBadRequestException.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Exceptions/AadSmartOnFhirProxyBadRequestException.cs
@@ -9,12 +9,6 @@ namespace Microsoft.Health.Fhir.Api.Features.Exceptions
 {
     public class AadSmartOnFhirProxyBadRequestException : Exception
     {
-        public AadSmartOnFhirProxyBadRequestException(string message, ArgumentNullException innerException)
-            : base(message, innerException)
-        {
-            message = string.Format(Resources.ValueCannotBeNull, innerException.ParamName);
-        }
-
         public AadSmartOnFhirProxyBadRequestException(string message, Exception innerException)
             : base(message, innerException)
         {

--- a/src/Microsoft.Health.Fhir.Api/Features/Filters/AadSmartOnFhirProxyExceptionFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Filters/AadSmartOnFhirProxyExceptionFilterAttribute.cs
@@ -1,0 +1,33 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using EnsureThat;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Health.Fhir.Api.Features.Exceptions;
+
+namespace Microsoft.Health.Fhir.Api.Features.Filters
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    internal class AadSmartOnFhirProxyExceptionFilterAttribute : ActionFilterAttribute
+    {
+        public override void OnActionExecuted(ActionExecutedContext context)
+        {
+            EnsureArg.IsNotNull(context, nameof(context));
+
+            if (context?.Exception == null)
+            {
+                return;
+            }
+
+            if (context.Exception is AadSmartOnFhirProxyBadRequestException && !context.ExceptionHandled)
+            {
+                context.Result = new BadRequestObjectResult(context.Exception.Message);
+                context.ExceptionHandled = true;
+            }
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Health.Fhir.Api {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -255,6 +255,15 @@ namespace Microsoft.Health.Fhir.Api {
         public static string UrlResourceIdMismatch {
             get {
                 return ResourceManager.GetString("UrlResourceIdMismatch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Value cannot be null.  Parameter name: {0}..
+        /// </summary>
+        public static string ValueCannotBeNull {
+            get {
+                return ResourceManager.GetString("ValueCannotBeNull", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
@@ -97,6 +97,33 @@ namespace Microsoft.Health.Fhir.Api {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid compound authorization code..
+        /// </summary>
+        public static string InvalidCompoundCode {
+            get {
+                return ResourceManager.GetString("InvalidCompoundCode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid launch context parameters..
+        /// </summary>
+        public static string InvalidLaunchContext {
+            get {
+                return ResourceManager.GetString("InvalidLaunchContext", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Provided value for redirect Uri: {0} is not a valid Uri..
+        /// </summary>
+        public static string InvalidRedirectUri {
+            get {
+                return ResourceManager.GetString("InvalidRedirectUri", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to API.
         /// </summary>
         public static string MenuAPI {

--- a/src/Microsoft.Health.Fhir.Api/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Api/Resources.resx
@@ -129,6 +129,16 @@
   <data name="GeneralInternalError" xml:space="preserve">
     <value>There was an error processing your request.</value>
   </data>
+  <data name="InvalidCompoundCode" xml:space="preserve">
+    <value>Invalid compound authorization code.</value>
+  </data>
+  <data name="InvalidLaunchContext" xml:space="preserve">
+    <value>Invalid launch context parameters.</value>
+  </data>
+  <data name="InvalidRedirectUri" xml:space="preserve">
+    <value>Provided value for redirect Uri: {0} is not a valid Uri.</value>
+    <comment>{0} is a parameter passed in for redirection.</comment>
+  </data>
   <data name="MenuAPI" xml:space="preserve">
     <value>API</value>
   </data>
@@ -191,6 +201,7 @@
   </data>
   <data name="ValueCannotBeNull" xml:space="preserve">
     <value>Value cannot be null.  Parameter name: {0}.</value>
+    <comment>Error message for missing query parameter, {0} is the parameter name</comment>
   </data>
   <data name="ViewNotFound" xml:space="preserve">
     <value>View was not found.</value>

--- a/src/Microsoft.Health.Fhir.Api/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Api/Resources.resx
@@ -189,6 +189,9 @@
   <data name="UrlResourceIdMismatch" xml:space="preserve">
     <value>Id in the URL must match id in the resource.</value>
   </data>
+  <data name="ValueCannotBeNull" xml:space="preserve">
+    <value>Value cannot be null.  Parameter name: {0}.</value>
+  </data>
   <data name="ViewNotFound" xml:space="preserve">
     <value>View was not found.</value>
   </data>

--- a/test/Microsoft.Health.Fhir.Tests.E2E/SmartProxy/SmartProxyBadRequestTests.cs
+++ b/test/Microsoft.Health.Fhir.Tests.E2E/SmartProxy/SmartProxyBadRequestTests.cs
@@ -6,6 +6,7 @@
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.E2E.Common;
 using Microsoft.Health.Fhir.Tests.E2E.Rest;
 using Microsoft.Health.Fhir.Web;
@@ -13,6 +14,7 @@ using Xunit;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.SmartProxy
 {
+    [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb, Format.Json | Format.Xml)]
     public class SmartProxyBadRequestTests : IClassFixture<HttpIntegrationTestFixture<Startup>>
     {
         private readonly FhirClient _client;

--- a/test/Microsoft.Health.Fhir.Tests.E2E/SmartProxy/SmartProxyBadRequestTests.cs
+++ b/test/Microsoft.Health.Fhir.Tests.E2E/SmartProxy/SmartProxyBadRequestTests.cs
@@ -1,0 +1,36 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Health.Fhir.Tests.E2E.Common;
+using Microsoft.Health.Fhir.Tests.E2E.Rest;
+using Microsoft.Health.Fhir.Web;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Tests.E2E.SmartProxy
+{
+    public class SmartProxyBadRequestTests : IClassFixture<HttpIntegrationTestFixture<Startup>>
+    {
+        private readonly FhirClient _client;
+
+        public SmartProxyBadRequestTests(HttpIntegrationTestFixture<Startup> fixture)
+        {
+            _client = fixture.FhirClient;
+        }
+
+        [Fact]
+        public async Task WhenRequestingAToken_GivenMissingParams_ThenBadRequestResonseReturned()
+        {
+            var content = new StringContent(string.Empty);
+            HttpResponseMessage response = await _client.HttpClient.PostAsync(_client.SecuritySettings.TokenUrl, content);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var responseContent = await response.Content.ReadAsStringAsync();
+            Assert.Contains("Value cannot be null", responseContent.ToString());
+        }
+    }
+}


### PR DESCRIPTION
Forward errors from authorization URL to caller, and return BadRequest error on missing params

## Description
Updated authorize route in proxy to return the result from the redirect.  For other errors with missing params, return a BadRequest result.

## Related issues
Addresses [issue [AB#68689](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/68689)].

## Testing
Unit test created and run
