### PR TITLE
Added permission support for export operation.

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Controllers/ExportController.cs
+++ b/src/Microsoft.Health.Fhir.Api/Controllers/ExportController.cs
@@ -76,6 +76,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         [Route(KnownRoutes.Export)]
         [ValidateExportHeadersFilter]
         [AuditEventType(AuditEventSubType.Export)]
+        [Authorize(PolicyNames.ExportPolicy)]
         public async Task<IActionResult> Export()
         {
             if (!_exportConfig.Enabled)
@@ -95,6 +96,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         [Route(KnownRoutes.ExportResourceType)]
         [ValidateExportHeadersFilter]
         [AuditEventType(AuditEventSubType.Export)]
+        [Authorize(PolicyNames.ExportPolicy)]
         public IActionResult ExportResourceType(string type)
         {
             // Export by ResourceType is supported only for Patient resource type.
@@ -110,6 +112,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         [Route(KnownRoutes.ExportResourceTypeById)]
         [ValidateExportHeadersFilter]
         [AuditEventType(AuditEventSubType.Export)]
+        [Authorize(PolicyNames.ExportPolicy)]
         public IActionResult ExportResourceTypeById(string type, string id)
         {
             // Export by ResourceTypeId is supported only for Group resource type.
@@ -124,6 +127,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         [HttpGet]
         [Route(KnownRoutes.ExportStatusById, Name = RouteNames.GetExportStatusById)]
         [AuditEventType(AuditEventSubType.Export)]
+        [Authorize(PolicyNames.ExportPolicy)]
         public async Task<IActionResult> GetExportStatusById(string id)
         {
             var getExportResult = await _mediator.GetExportStatusAsync(_fhirRequestContextAccessor.FhirRequestContext.Uri, id);

--- a/src/Microsoft.Health.Fhir.Api/Controllers/ExportController.cs
+++ b/src/Microsoft.Health.Fhir.Api/Controllers/ExportController.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
 {
     [ServiceFilter(typeof(AuditLoggingFilterAttribute), Order = -1)]
     [ServiceFilter(typeof(OperationOutcomeExceptionFilterAttribute))]
-    [Authorize(PolicyNames.FhirPolicy)]
+    [Authorize(PolicyNames.ExportPolicy)]
     public class ExportController : Controller
     {
         /*
@@ -76,7 +76,6 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         [Route(KnownRoutes.Export)]
         [ValidateExportHeadersFilter]
         [AuditEventType(AuditEventSubType.Export)]
-        [Authorize(PolicyNames.ExportPolicy)]
         public async Task<IActionResult> Export()
         {
             if (!_exportConfig.Enabled)
@@ -96,7 +95,6 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         [Route(KnownRoutes.ExportResourceType)]
         [ValidateExportHeadersFilter]
         [AuditEventType(AuditEventSubType.Export)]
-        [Authorize(PolicyNames.ExportPolicy)]
         public IActionResult ExportResourceType(string type)
         {
             // Export by ResourceType is supported only for Patient resource type.
@@ -112,7 +110,6 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         [Route(KnownRoutes.ExportResourceTypeById)]
         [ValidateExportHeadersFilter]
         [AuditEventType(AuditEventSubType.Export)]
-        [Authorize(PolicyNames.ExportPolicy)]
         public IActionResult ExportResourceTypeById(string type, string id)
         {
             // Export by ResourceTypeId is supported only for Group resource type.
@@ -127,7 +124,6 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         [HttpGet]
         [Route(KnownRoutes.ExportStatusById, Name = RouteNames.GetExportStatusById)]
         [AuditEventType(AuditEventSubType.Export)]
-        [Authorize(PolicyNames.ExportPolicy)]
         public async Task<IActionResult> GetExportStatusById(string id)
         {
             var getExportResult = await _mediator.GetExportStatusAsync(_fhirRequestContextAccessor.FhirRequestContext.Uri, id);

--- a/src/Microsoft.Health.Fhir.Api/Features/Security/PolicyNames.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Security/PolicyNames.cs
@@ -14,5 +14,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Security
         public const string WritePolicy = "Write";
 
         public const string HardDeletePolicy = "HardDelete";
+
+        public const string ExportPolicy = "Export";
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Modules/SecurityModule.cs
+++ b/src/Microsoft.Health.Fhir.Api/Modules/SecurityModule.cs
@@ -37,6 +37,8 @@ namespace Microsoft.Health.Fhir.Api.Modules
             // Set the token handler to not do auto inbound mapping. (e.g. "roles" -> "http://schemas.microsoft.com/ws/2008/06/identity/claims/role")
             JwtSecurityTokenHandler.DefaultInboundClaimTypeMap.Clear();
 
+            bool configureDefaultPolicy = true;
+
             if (_securityConfiguration.Enabled)
             {
                 services.AddAuthentication(options =>
@@ -66,15 +68,14 @@ namespace Microsoft.Health.Fhir.Api.Modules
                     services.AddSingleton(_securityConfiguration.Authorization);
                     services.AddSingleton<IAuthorizationPolicy, RoleBasedAuthorizationPolicy>();
                     services.AddSingleton<IAuthorizationHandler, ResourceActionHandler>();
-                }
-                else
-                {
-                    services.AddAuthorization(options => ConfigureDefaultPolicy(options, PolicyNames.HardDeletePolicy, PolicyNames.ReadPolicy, PolicyNames.WritePolicy));
+
+                    configureDefaultPolicy = false;
                 }
             }
-            else
+
+            if (configureDefaultPolicy)
             {
-                services.AddAuthorization(options => ConfigureDefaultPolicy(options, PolicyNames.FhirPolicy, PolicyNames.HardDeletePolicy, PolicyNames.ReadPolicy, PolicyNames.WritePolicy));
+                services.AddAuthorization(options => ConfigureDefaultPolicy(options, PolicyNames.FhirPolicy, PolicyNames.HardDeletePolicy, PolicyNames.ReadPolicy, PolicyNames.WritePolicy, PolicyNames.ExportPolicy));
             }
         }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Security/ResourceAction.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Security/ResourceAction.cs
@@ -29,5 +29,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Security
         /// </summary>
         [EnumMember(Value = "hardDelete")]
         HardDelete,
+
+        /// <summary>
+        /// Export
+        /// </summary>
+        [EnumMember(Value = "export")]
+        Export,
     }
 }

--- a/test/Microsoft.Health.Fhir.Tests.E2E/Common/FhirClient.cs
+++ b/test/Microsoft.Health.Fhir.Tests.E2E/Common/FhirClient.cs
@@ -254,7 +254,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Common
 
             await EnsureSuccessStatusCodeAsync(response);
 
-            IEnumerable<string> contentLocation = response.Content.Headers.GetValues("Content-Location");
+            IEnumerable<string> contentLocation = response.Content.Headers.GetValues(HeaderNames.ContentLocation);
 
             return contentLocation.First();
         }

--- a/test/Microsoft.Health.Fhir.Tests.E2E/Common/FhirClient.cs
+++ b/test/Microsoft.Health.Fhir.Tests.E2E/Common/FhirClient.cs
@@ -243,6 +243,22 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Common
             return await CreateResponseAsync<Bundle>(response);
         }
 
+        public async Task<string> ExportAsync()
+        {
+            var message = new HttpRequestMessage(HttpMethod.Get, "$export");
+
+            message.Headers.Add("Accept", "application/fhir+json");
+            message.Headers.Add("Prefer", "respond-async");
+
+            HttpResponseMessage response = await HttpClient.SendAsync(message);
+
+            await EnsureSuccessStatusCodeAsync(response);
+
+            IEnumerable<string> contentLocation = response.Content.Headers.GetValues("Content-Location");
+
+            return contentLocation.First();
+        }
+
         private StringContent CreateStringContent(Resource resource)
         {
             return new StringContent(_serialize(resource, SummaryType.False), Encoding.UTF8, _contentType);

--- a/test/Microsoft.Health.Fhir.Tests.E2E/Common/TestUsers.cs
+++ b/test/Microsoft.Health.Fhir.Tests.E2E/Common/TestUsers.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Common
 
         public static TestUser HardDeleteUser { get; } = new TestUser("doug");
 
+        public static TestUser ExportUser { get; } = new TestUser("steve");
+
         public static TestUser AdminUser { get; } = new TestUser("itguy");
     }
 }

--- a/test/Microsoft.Health.Fhir.Tests.E2E/Rest/BasicAuthTests.cs
+++ b/test/Microsoft.Health.Fhir.Tests.E2E/Rest/BasicAuthTests.cs
@@ -177,5 +177,25 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.Equal(createdResource.Meta.VersionId, readResource.Meta.VersionId);
             Assert.Equal(createdResource.Meta.LastUpdated, readResource.Meta.LastUpdated);
         }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task WhenExportResources_GivenAUserWithNoExportPermissions_TheServerShouldReturnForbidden()
+        {
+            await Client.RunAsUser(TestUsers.ReadOnlyUser, TestApplications.NativeClient);
+
+            FhirException fhirException = await Assert.ThrowsAsync<FhirException>(async () => await Client.ExportAsync());
+            Assert.Equal(ForbiddenMessage, fhirException.Message);
+            Assert.Equal(HttpStatusCode.Forbidden, fhirException.StatusCode);
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task WhenExportResources_GivenAUserWithExportPermissions_TheServerShouldReturnSuccess()
+        {
+            await Client.RunAsUser(TestUsers.ExportUser, TestApplications.NativeClient);
+
+            await Client.ExportAsync();
+        }
     }
 }

--- a/testauthenvironment.json
+++ b/testauthenvironment.json
@@ -32,6 +32,16 @@
             ]
         },
         {
+            "name": "mlresearcher",
+            "resourcePermissions": [
+                {
+                    "actions": [
+                        "Export"
+                    ]
+                }
+            ]
+        },
+        {
             "name": "director",
             "resourcePermissions": [
                 {
@@ -48,7 +58,8 @@
                     "actions": [
                         "Read",
                         "Write",
-                        "HardDelete"
+                        "HardDelete",
+                        "Export"
                     ]
                 }
             ]
@@ -71,6 +82,12 @@
             "id": "frank",
             "roles": [
                 "clinician"
+            ]
+        },
+        {
+            "id": "steve",
+            "roles": [
+                "mlresearcher"
             ]
         },
         {


### PR DESCRIPTION
## Description
Added permission support for the export operation. Created a new policy specifically for export.

_Note_:
This permission model is based on the existing pattern used for controller. Once we move the code to support operations more generally, it's likely that we will have to rethink how the permission would work.

## Related issues
Addresses #346. Work item: [AB#68902](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/68902).

## Testing
Added E2E tests to validate the permission.
