### PR TITLE
Makes delete operation atomic

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Persistence/ResourceHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Persistence/ResourceHandlerTests.cs
@@ -219,44 +219,14 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Persistence
         [Fact]
         public async Task GivenAFhirMediator_WhenDeletingAResourceThatIsAlreadyDeleted_ThenDoNothing()
         {
-            var observation = Samples.GetDefaultObservation();
-            observation.Id = "id1";
-            observation.Meta = new Meta
-            {
-                VersionId = "version1",
-            };
+            _fhirDataStore.UpsertAsync(Arg.Any<ResourceWrapper>(), null, true, true, Arg.Any<CancellationToken>()).Returns(default(UpsertOutcome));
 
-            _fhirDataStore.GetAsync(Arg.Is<ResourceKey>(x => x.Id == "id1"), Arg.Any<CancellationToken>())
-                .Returns(CreateResourceWrapper(observation, true));
+            var resourceKey = new ResourceKey<Observation>("id1");
+            ResourceKey resultKey = (await _mediator.DeleteResourceAsync(resourceKey, false)).ResourceKey;
 
-            ResourceKey resultKey = (await _mediator.DeleteResourceAsync(new ResourceKey<Observation>("id1"), false)).ResourceKey;
-
-            await _fhirDataStore.DidNotReceive().UpsertAsync(Arg.Any<ResourceWrapper>(), Arg.Any<WeakETag>(), true, true, Arg.Any<CancellationToken>());
-
-            Assert.Equal(observation.Id, resultKey.Id);
-            Assert.Equal(observation.Meta.VersionId, resultKey.VersionId);
+            Assert.Equal(resourceKey.Id, resultKey.Id);
             Assert.Equal("Observation", resultKey.ResourceType);
-        }
-
-        [Fact]
-        public async Task GivenAFhirMediator_WhenDeletingAResourceThatDoesNotExist_ThenDoNothing()
-        {
-            var observation = Samples.GetDefaultObservation();
-            observation.Id = "id1";
-            observation.Meta = new Meta
-            {
-                VersionId = "version1",
-            };
-
-            _fhirDataStore.GetAsync(Arg.Is<ResourceKey>(x => x.Id == "id1"), Arg.Any<CancellationToken>()).Returns((ResourceWrapper)null);
-
-            ResourceKey resultKey = (await _mediator.DeleteResourceAsync(new ResourceKey<Observation>("id1"), false)).ResourceKey;
-
-            await _fhirDataStore.DidNotReceive().UpsertAsync(Arg.Any<ResourceWrapper>(), Arg.Any<WeakETag>(), true, true, Arg.Any<CancellationToken>());
-
-            Assert.Equal(observation.Id, resultKey.Id);
             Assert.Null(resultKey.VersionId);
-            Assert.Equal("Observation", resultKey.ResourceType);
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -125,6 +125,11 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
                 }
                 else if (dce.Error?.Message?.Contains(GetValue(HttpStatusCode.NotFound), StringComparison.Ordinal) == true)
                 {
+                    if (cosmosWrapper.IsDeleted)
+                    {
+                        return null;
+                    }
+
                     if (weakETag != null)
                     {
                         throw new ResourceConflictException(weakETag);

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/StoredProcedures/Upsert/upsertWithHistory.js
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/StoredProcedures/Upsert/upsertWithHistory.js
@@ -36,7 +36,7 @@ function upsertWithHistory(doc, matchVersionId, allowCreate, keepHistory) {
         throw new Error(errorMessages.InputWasArray);
     }
 
-    if (!stringIsNullOrEmpty(matchVersionId) || !allowCreate) {
+    if (!stringIsNullOrEmpty(matchVersionId) || !allowCreate || doc.isDeleted) {
         tryReplace(doc, replacePrimaryCallback, matchVersionId);
     } else {
         tryCreate(doc, createPrimaryCallback);
@@ -91,6 +91,11 @@ function upsertWithHistory(doc, matchVersionId, allowCreate, keepHistory) {
                 }
 
                 let document = documents[0];
+
+                if (doc.isDeleted && document.isDeleted) {
+                    // don't create another version if already deleted
+                    throw new Error(errorMessages.DocumentNotFound);
+                }
 
                 let documentVersion = document.version;
 

--- a/test/Microsoft.Health.Fhir.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -340,9 +340,11 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         {
             var saveResult = await Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight"));
 
-            await Mediator.DeleteResourceAsync(new ResourceKey("Observation", saveResult.Resource.Id), false);
+            var resourceKey = new ResourceKey("Observation", saveResult.Resource.Id);
 
-            var deletedResourceKey2 = await Mediator.DeleteResourceAsync(new ResourceKey("Observation", saveResult.Resource.Id), false);
+            await Mediator.DeleteResourceAsync(resourceKey, false);
+
+            var deletedResourceKey2 = await Mediator.DeleteResourceAsync(resourceKey, false);
 
             Assert.Null(deletedResourceKey2.ResourceKey.VersionId);
 


### PR DESCRIPTION
## Description
The delete operation is currently done as a read and then, conditionally a write. This change does that in a transaction.

## Related issues
Addresses #440 

## Testing
Ran and updated integration and unit tests.