### PR TITLE
Setting CosmosDb:ContinuationTokenSizeLimitInKb to 1 in app service

### DIFF
--- a/samples/templates/default-azuredeploy.json
+++ b/samples/templates/default-azuredeploy.json
@@ -143,7 +143,8 @@
             "FhirServer:Security:Enabled": "[variables('securityAuthenticationEnabled')]",
             "FhirServer:Security:EnableAadSmartOnFhirProxy": "[parameters('enableAadSmartOnFhirProxy')]",
             "FhirServer:Security:Authentication:Authority": "[parameters('securityAuthenticationAuthority')]",
-            "FhirServer:Security:Authentication:Audience": "[parameters('securityAuthenticationAudience')]"
+            "FhirServer:Security:Authentication:Audience": "[parameters('securityAuthenticationAudience')]",
+            "CosmosDb:ContinuationTokenSizeLimitInKb": "1"
         },
         "combinedFhirServerConfigProperties": "[union(variables('staticFhirServerConfigProperties'), parameters('additionalFhirServerConfigProperties'))]"
     },


### PR DESCRIPTION
## Description
This PR sets `CosmosDb:ContinuationTokenSizeLimitInKb` to `1` when deploying in App Service to prevent too long continuation URLs. 

## Related issues
Addresses #442 

## Testing
Checked that with this setting, continuation tokens appear OK in App Service. 