### PR TITLE
Fix broken local audit test.

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/ActionResults/BaseActionResult.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/ActionResults/BaseActionResult.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Health.Fhir.Api.Features.ActionResults
 {
-    public abstract class BaseActionResult<TResult> : ActionResult
+    public abstract class BaseActionResult<TResult> : ActionResult, IBaseActionResult
     {
         protected BaseActionResult()
         {
@@ -72,6 +72,11 @@ namespace Microsoft.Health.Fhir.Api.Features.ActionResults
             }
 
             return result.ExecuteResultAsync(context);
+        }
+
+        public string GetResultTypeName()
+        {
+            return Result?.GetType().Name;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Features/ActionResults/IBaseActionResult.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/ActionResults/IBaseActionResult.cs
@@ -1,0 +1,12 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Fhir.Api.Features.ActionResults
+{
+    public interface IBaseActionResult
+    {
+        string GetResultTypeName();
+    }
+}

--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditHelper.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditHelper.cs
@@ -72,9 +72,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
         }
 
         /// <inheritdoc />
-        public void LogExecuted(string controllerName, string actionName, HttpStatusCode statusCode, string resourceType)
+        public void LogExecuted(string controllerName, string actionName, HttpStatusCode statusCode, string responseResultType)
         {
-            Log(AuditAction.Executed, controllerName, actionName, statusCode, resourceType);
+            Log(AuditAction.Executed, controllerName, actionName, statusCode, responseResultType);
         }
 
         void IStartable.Start()

--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditLoggingFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditLoggingFilterAttribute.cs
@@ -50,24 +50,13 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
             Debug.Assert(actionDescriptor != null, "The ActionDescriptor must be ControllerActionDescriptor.");
 
             // The result can either be a FhirResult or an OperationOutcomeResult which both extend BaseActionResult.
-
-            string typeName = null;
-
-            switch (context.Result)
-            {
-                case FhirResult fhirResult:
-                    typeName = fhirResult?.Result?.TypeName;
-                    break;
-                case OperationOutcomeResult operationOutcomeResult:
-                    typeName = operationOutcomeResult?.Result?.TypeName;
-                    break;
-            }
+            var result = context.Result as IBaseActionResult;
 
             _auditHelper.LogExecuted(
                 actionDescriptor.ControllerName,
                 actionDescriptor.ActionName,
                 (HttpStatusCode)context.HttpContext.Response.StatusCode,
-                typeName);
+                result?.GetResultTypeName());
 
             base.OnResultExecuted(context);
         }

--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditLoggingFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditLoggingFilterAttribute.cs
@@ -49,13 +49,25 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
 
             Debug.Assert(actionDescriptor != null, "The ActionDescriptor must be ControllerActionDescriptor.");
 
-            var fhirResult = context.Result as FhirResult;
+            // The result can either be a FhirResult or an OperationOutcomeResult which both extend BaseActionResult.
+
+            string typeName = null;
+
+            switch (context.Result)
+            {
+                case FhirResult fhirResult:
+                    typeName = fhirResult?.Result?.TypeName;
+                    break;
+                case OperationOutcomeResult operationOutcomeResult:
+                    typeName = operationOutcomeResult?.Result?.TypeName;
+                    break;
+            }
 
             _auditHelper.LogExecuted(
                 actionDescriptor.ControllerName,
                 actionDescriptor.ActionName,
                 (HttpStatusCode)context.HttpContext.Response.StatusCode,
-                fhirResult?.Result?.TypeName);
+                typeName);
 
             base.OnResultExecuted(context);
         }

--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/IAuditHelper.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/IAuditHelper.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
         /// <param name="controllerName">The controller name.</param>
         /// <param name="actionName">The action name.</param>
         /// <param name="statusCode">The HTTP status code.</param>
-        /// <param name="resourceType">The optional resource type.</param>
-        void LogExecuted(string controllerName, string actionName, HttpStatusCode statusCode, string resourceType);
+        /// <param name="responseResultType">The optional response result type.</param>
+        void LogExecuted(string controllerName, string actionName, HttpStatusCode statusCode, string responseResultType);
     }
 }

--- a/test/Microsoft.Health.Fhir.Tests.E2E/SmartProxy/SmartProxyTests.cs
+++ b/test/Microsoft.Health.Fhir.Tests.E2E/SmartProxy/SmartProxyTests.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.SmartProxy
                 // Consent, should only be done if we can find the button
                 try
                 {
-                    // Sleep in case a lightbox is shown. 
+                    // Sleep in case a light box is shown.
                     Thread.Sleep(TimeSpan.FromMilliseconds(1000));
                     var button = driver.FindElementById("idSIButton9");
                     Advance();

--- a/test/Microsoft.Health.Fhir.Tests.E2E/SmartProxy/SmartProxyTests.cs
+++ b/test/Microsoft.Health.Fhir.Tests.E2E/SmartProxy/SmartProxyTests.cs
@@ -121,6 +121,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.SmartProxy
                 // Consent, should only be done if we can find the button
                 try
                 {
+                    // Sleep in case a lightbox is shown. 
+                    Thread.Sleep(TimeSpan.FromMilliseconds(1000));
                     var button = driver.FindElementById("idSIButton9");
                     Advance();
                 }


### PR DESCRIPTION
## Description
This updates the audit log filter to check for both FhirResults and OperationOutcomeResults to get the resource type.

## Related issues
Addresses #447.

## Testing
The failing local test no longer fails.


--------
[AB#69049](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/69049)