### PR TITLE
Add quotes to exec command in BuildTimeCodeGenerator.targets

### DIFF
--- a/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/BuildTimeCodeGenerator.targets
+++ b/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/BuildTimeCodeGenerator.targets
@@ -26,6 +26,6 @@
         <ItemGroup>
             <Compile Include="@(Generated)" Condition="!Exists('@(Generated)')" />
         </ItemGroup>
-        <Exec Command="dotnet @(GeneratorPath) --generator-name %(Generated.Generator) --output-file %(Generated.FullPath) --namespace %(Generated.Namespace) %(Generated.Args)" />
+        <Exec Command='dotnet "@(GeneratorPath)" --generator-name "%(Generated.Generator)" --output-file "%(Generated.FullPath)" --namespace "%(Generated.Namespace)" "%(Generated.Args)"' />
     </Target>
 </Project>


### PR DESCRIPTION
## Description
Add quotes to the `Command` attribute on `Exec` in BuildTimeCodeGenerator.targets.

## Related issues
Doesn't address GitHub issue but I was unable to successfully build the project until I did this. I was getting error messages that `dotnet-C:\..` couldn't be found.

## Testing
I was able to build the project successfully after adding these.
