### PR TITLE
Enable SQL integration tests.

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Configs/SqlServerDataStoreConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Configs/SqlServerDataStoreConfiguration.cs
@@ -13,5 +13,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Configs
         /// Allows the experimental schema initializer to attempt to bring the schema to the minimum supported version.
         /// </summary>
         public bool Initialize { get; set; }
+
+        /// <summary>
+        /// WARNING: THIS RESETS ALL DATA IN THE DATABASE
+        /// If set, this applies schema 1 which resets all the data in the database. This is temporary until the schema migration tool is complete. 
+        /// </summary>
+        public bool DeleteAllDataOnStartup { get; set; }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Configs/SqlServerDataStoreConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Configs/SqlServerDataStoreConfiguration.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Configs
 
         /// <summary>
         /// WARNING: THIS RESETS ALL DATA IN THE DATABASE
-        /// If set, this applies schema 1 which resets all the data in the database. This is temporary until the schema migration tool is complete. 
+        /// If set, this applies schema 1 which resets all the data in the database. This is temporary until the schema migration tool is complete.
         /// </summary>
         public bool DeleteAllDataOnStartup { get; set; }
     }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaInitializer.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaInitializer.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema
             GetCurrentSchemaVersion();
 
             // GetCurrentVersion doesn't exist, so run version 1.
-            if (_schemaInformation.Current == null)
+            if (_schemaInformation.Current == null || _sqlServerDataStoreConfiguration.DeleteAllDataOnStartup)
             {
                 _schemaUpgradeRunner.ApplySchema(1);
                 GetCurrentSchemaVersion();

--- a/test/Microsoft.Health.Fhir.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -34,7 +34,7 @@ using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 {
-    [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb)]
+    [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb | DataStore.SqlServer)]
     public class FhirStorageTests : IClassFixture<FhirStorageTestsFixture>
     {
         private readonly FhirStorageTestsFixture _fixture;

--- a/test/Microsoft.Health.Fhir.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         {
             var initialConnectionString = Environment.GetEnvironmentVariable("SqlServer:ConnectionString") ?? LocalDatabase.DefaultConnectionString;
             _databaseName = $"FHIRINTEGRATIONTEST_{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}_{BigInteger.Abs(new BigInteger(Guid.NewGuid().ToByteArray()))}";
-            _masterConnectionString = new SqlConnectionStringBuilder(initialConnectionString) { InitialCatalog = "Master", ConnectTimeout = 600 }.ToString();
+            _masterConnectionString = new SqlConnectionStringBuilder(initialConnectionString) { InitialCatalog = "master" }.ToString();
             TestConnectionString = new SqlConnectionStringBuilder(initialConnectionString) { InitialCatalog = _databaseName }.ToString();
 
             using (var connection = new SqlConnection(_masterConnectionString))
@@ -41,6 +41,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
                 using (SqlCommand command = connection.CreateCommand())
                 {
+                    command.CommandTimeout = 600;
                     command.CommandText = $"CREATE DATABASE {_databaseName}";
                     command.ExecuteNonQuery();
                 }
@@ -85,6 +86,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
                 using (SqlCommand command = connection.CreateCommand())
                 {
+                    command.CommandTimeout = 600;
                     command.CommandText = $"DROP DATABASE IF EXISTS {_databaseName}";
                     command.ExecuteNonQuery();
                 }

--- a/test/Microsoft.Health.Fhir.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -23,18 +23,19 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 {
     public class SqlServerFhirStorageTestsFixture : IServiceProvider, IDisposable
     {
-        private readonly string _initialConnectionString;
+        private readonly string _masterConnectionString;
         private readonly string _databaseName;
         private readonly IFhirDataStore _fhirDataStore;
         private readonly SqlServerFhirStorageTestHelper _testHelper;
 
         public SqlServerFhirStorageTestsFixture()
         {
-            _initialConnectionString = Environment.GetEnvironmentVariable("SqlServer:ConnectionString") ?? LocalDatabase.DefaultConnectionString;
+            var initialConnectionString = Environment.GetEnvironmentVariable("SqlServer:ConnectionString") ?? LocalDatabase.DefaultConnectionString;
             _databaseName = $"FHIRINTEGRATIONTEST_{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}_{BigInteger.Abs(new BigInteger(Guid.NewGuid().ToByteArray()))}";
-            TestConnectionString = new SqlConnectionStringBuilder(_initialConnectionString) { InitialCatalog = _databaseName }.ToString();
+            _masterConnectionString = new SqlConnectionStringBuilder(initialConnectionString) { InitialCatalog = "Master" }.ToString();
+            TestConnectionString = new SqlConnectionStringBuilder(initialConnectionString) { InitialCatalog = _databaseName }.ToString();
 
-            using (var connection = new SqlConnection(_initialConnectionString))
+            using (var connection = new SqlConnection(_masterConnectionString))
             {
                 connection.Open();
 
@@ -77,7 +78,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
         public void Dispose()
         {
-            using (var connection = new SqlConnection(_initialConnectionString))
+            using (var connection = new SqlConnection(_masterConnectionString))
             {
                 connection.Open();
                 SqlConnection.ClearAllPools();

--- a/test/Microsoft.Health.Fhir.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         {
             var initialConnectionString = Environment.GetEnvironmentVariable("SqlServer:ConnectionString") ?? LocalDatabase.DefaultConnectionString;
             _databaseName = $"FHIRINTEGRATIONTEST_{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}_{BigInteger.Abs(new BigInteger(Guid.NewGuid().ToByteArray()))}";
-            _masterConnectionString = new SqlConnectionStringBuilder(initialConnectionString) { InitialCatalog = "Master" }.ToString();
+            _masterConnectionString = new SqlConnectionStringBuilder(initialConnectionString) { InitialCatalog = "Master", ConnectTimeout = 600 }.ToString();
             TestConnectionString = new SqlConnectionStringBuilder(initialConnectionString) { InitialCatalog = _databaseName }.ToString();
 
             using (var connection = new SqlConnection(_masterConnectionString))


### PR DESCRIPTION
## Description
Enables the integration tests for SQL server. Makes use of the existing connection string to create a database for the tests. 

Additionally, adds a setting for deleting the data from the sql data store and re-applying versions of the schema. This should be temporary and is mainly needed when iterating on version 1. 

## Related issues
Addresses [AB#69212](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/69212).

## Testing
Existing tests were updated to include SQL integration tests locally and in the cloud. 
