### PR TITLE
Removes _lastUpdated and _id from search param tables

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/1.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/1.sql
@@ -210,6 +210,11 @@ INCLUDE -- We want the query in UpsertResource, which is done with UPDLOCK AND H
 )
 WHERE IsHistory = 0
 
+CREATE NONCLUSTERED INDEX IX_Resource_LastUpdated ON dbo.Resource
+(
+    LastUpdated
+)
+
 /*************************************************************
     Capture claims on write
 **************************************************************/

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/1.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/1.sql
@@ -267,6 +267,7 @@ CREATE TYPE dbo.CompartmentAssignmentTableType_1 AS TABLE
 
 CREATE TABLE dbo.CompartmentAssignment
 (
+    ResourceTypeId smallint NOT NULL,
     ResourceSurrogateId bigint NOT NULL,
     CompartmentTypeId tinyint NOT NULL,
     ReferenceResourceId varchar(64) NOT NULL,
@@ -286,6 +287,10 @@ ON dbo.CompartmentAssignment
 (
     CompartmentTypeId,
     ReferenceResourceId
+)
+INCLUDE
+(
+    ResourceTypeId
 )
 WHERE IsHistory = 0
 WITH (DATA_COMPRESSION = PAGE)
@@ -307,6 +312,7 @@ CREATE TYPE dbo.ReferenceSearchParamTableType_1 AS TABLE
 
 CREATE TABLE dbo.ReferenceSearchParam
 (
+    ResourceTypeId smallint NOT NULL,
     ResourceSurrogateId bigint NOT NULL,
     SearchParamId smallint NOT NULL,
     BaseUri varchar(128) NULL,
@@ -336,6 +342,10 @@ ON dbo.ReferenceSearchParam
     BaseUri,
     ReferenceResourceVersion
 )
+INCLUDE
+(
+    ResourceTypeId
+)
 WHERE IsHistory = 0
 WITH (DATA_COMPRESSION = PAGE)
 
@@ -354,6 +364,7 @@ CREATE TYPE dbo.TokenSearchParamTableType_1 AS TABLE
 
 CREATE TABLE dbo.TokenSearchParam
 (
+    ResourceTypeId smallint NOT NULL,
     ResourceSurrogateId bigint NOT NULL,
     SearchParamId smallint NOT NULL,
     SystemId int NULL,
@@ -377,6 +388,10 @@ ON dbo.TokenSearchParam
     Code,
     SystemId
 )
+INCLUDE
+(
+    ResourceTypeId
+)
 WHERE IsHistory = 0
 WITH (DATA_COMPRESSION = PAGE)
 
@@ -394,6 +409,7 @@ CREATE TYPE dbo.TokenTextTableType_1 AS TABLE
 
 CREATE TABLE dbo.TokenText
 (
+    ResourceTypeId smallint NOT NULL,
     ResourceSurrogateId bigint NOT NULL,
     SearchParamId smallint NOT NULL,
     Text nvarchar(400) COLLATE Latin1_General_CI_AI NOT NULL,
@@ -414,6 +430,10 @@ ON dbo.TokenText
     SearchParamId,
     Text
 )
+INCLUDE
+(
+    ResourceTypeId
+)
 WHERE IsHistory = 0
 WITH (DATA_COMPRESSION = PAGE)
 
@@ -432,6 +452,7 @@ CREATE TYPE dbo.StringSearchParamTableType_1 AS TABLE
 
 CREATE TABLE dbo.StringSearchParam
 (
+    ResourceTypeId smallint NOT NULL,
     ResourceSurrogateId bigint NOT NULL,
     SearchParamId smallint NOT NULL,
     Text nvarchar(256) COLLATE Latin1_General_100_CI_AI_SC NOT NULL,
@@ -454,6 +475,7 @@ ON dbo.StringSearchParam
 )
 INCLUDE
 (
+    ResourceTypeId,
     TextOverflow -- workaround for https://support.microsoft.com/en-gb/help/3051225/a-filtered-index-that-you-create-together-with-the-is-null-predicate-i
 )
 WHERE IsHistory = 0 AND TextOverflow IS NULL
@@ -464,6 +486,10 @@ ON dbo.StringSearchParam
 (
     SearchParamId,
     Text
+)
+INCLUDE
+(
+    ResourceTypeId
 )
 WHERE IsHistory = 0 AND TextOverflow IS NOT NULL
 WITH (DATA_COMPRESSION = PAGE)
@@ -482,6 +508,7 @@ CREATE TYPE dbo.UriSearchParamTableType_1 AS TABLE
 
 CREATE TABLE dbo.UriSearchParam
 (
+    ResourceTypeId smallint NOT NULL,
     ResourceSurrogateId bigint NOT NULL,
     SearchParamId smallint NOT NULL,
     Uri varchar(256) COLLATE Latin1_General_100_CS_AS NOT NULL,
@@ -501,6 +528,10 @@ ON dbo.UriSearchParam
 (
     SearchParamId,
     Uri
+)
+INCLUDE
+(
+    ResourceTypeId
 )
 WHERE IsHistory = 0
 WITH (DATA_COMPRESSION = PAGE)
@@ -528,6 +559,7 @@ CREATE TYPE dbo.NumberSearchParamTableType_1 AS TABLE
 
 CREATE TABLE dbo.NumberSearchParam
 (
+    ResourceTypeId smallint NOT NULL,
     ResourceSurrogateId bigint NOT NULL,
     SearchParamId smallint NOT NULL,
     SingleValue decimal(18,6) NULL,
@@ -550,6 +582,10 @@ ON dbo.NumberSearchParam
     SearchParamId,
     SingleValue
 )
+INCLUDE
+(
+    ResourceTypeId
+)
 WHERE IsHistory = 0 AND SingleValue IS NOT NULL
 
 CREATE NONCLUSTERED INDEX IX_NumberSearchParam_SearchParamId_LowValue_HighValue
@@ -559,6 +595,10 @@ ON dbo.NumberSearchParam
     LowValue,
     HighValue
 )
+INCLUDE
+(
+    ResourceTypeId
+)
 WHERE IsHistory = 0 AND LowValue IS NOT NULL
 
 CREATE NONCLUSTERED INDEX IX_NumberSearchParam_SearchParamId_HighValue_LowValue
@@ -567,6 +607,10 @@ ON dbo.NumberSearchParam
     SearchParamId,
     HighValue,
     LowValue
+)
+INCLUDE
+(
+    ResourceTypeId
 )
 WHERE IsHistory = 0 AND LowValue IS NOT NULL
 
@@ -590,6 +634,7 @@ CREATE TYPE dbo.QuantitySearchParamTableType_1 AS TABLE
 
 CREATE TABLE dbo.QuantitySearchParam
 (
+    ResourceTypeId smallint NOT NULL,
     ResourceSurrogateId bigint NOT NULL,
     SearchParamId smallint NOT NULL,
     SystemId int NULL,
@@ -618,6 +663,7 @@ ON dbo.QuantitySearchParam
 )
 INCLUDE
 (
+    ResourceTypeId,
     SystemId
 )
 WHERE IsHistory = 0 AND SingleValue IS NOT NULL
@@ -632,6 +678,7 @@ ON dbo.QuantitySearchParam
 )
 INCLUDE
 (
+    ResourceTypeId,
     SystemId
 )
 WHERE IsHistory = 0 AND LowValue IS NOT NULL
@@ -646,6 +693,7 @@ ON dbo.QuantitySearchParam
 )
 INCLUDE
 (
+    ResourceTypeId,
     SystemId
 )
 WHERE IsHistory = 0 AND LowValue IS NOT NULL
@@ -665,6 +713,7 @@ CREATE TYPE dbo.DateTimeSearchParamTableType_1 AS TABLE
 
 CREATE TABLE dbo.DateTimeSearchParam
 (
+    ResourceTypeId smallint NOT NULL,
     ResourceSurrogateId bigint NOT NULL,
     SearchParamId smallint NOT NULL,
     StartDateTime datetime2(7) NOT NULL,
@@ -688,6 +737,10 @@ ON dbo.DateTimeSearchParam
     StartDateTime,
     EndDateTime
 )
+INCLUDE
+(
+    ResourceTypeId
+)
 WHERE IsHistory = 0
 
 CREATE NONCLUSTERED INDEX IX_DateTimeSearchParam_SearchParamId_EndDateTime_StartDateTime
@@ -696,6 +749,10 @@ ON dbo.DateTimeSearchParam
     SearchParamId,
     EndDateTime,
     StartDateTime
+)
+INCLUDE
+(
+    ResourceTypeId
 )
 WHERE IsHistory = 0
 
@@ -718,6 +775,7 @@ CREATE TYPE dbo.ReferenceTokenCompositeSearchParamTableType_1 AS TABLE
 
 CREATE TABLE dbo.ReferenceTokenCompositeSearchParam
 (
+    ResourceTypeId smallint NOT NULL,
     ResourceSurrogateId bigint NOT NULL,
     SearchParamId smallint NOT NULL,
     BaseUri1 varchar(128) NULL,
@@ -747,6 +805,7 @@ ON dbo.ReferenceTokenCompositeSearchParam
 )
 INCLUDE
 (
+    ResourceTypeId,
     ReferenceResourceTypeId1,
     BaseUri1,
     SystemId2
@@ -771,6 +830,7 @@ CREATE TYPE dbo.TokenTokenCompositeSearchParamTableType_1 AS TABLE
 
 CREATE TABLE dbo.TokenTokenCompositeSearchParam
 (
+    ResourceTypeId smallint NOT NULL,
     ResourceSurrogateId bigint NOT NULL,
     SearchParamId smallint NOT NULL,
     SystemId1 int NULL,
@@ -798,6 +858,7 @@ ON dbo.TokenTokenCompositeSearchParam
 )
 INCLUDE
 (
+    ResourceTypeId,
     SystemId1,
     SystemId2
 )
@@ -821,6 +882,7 @@ CREATE TYPE dbo.TokenDateTimeCompositeSearchParamTableType_1 AS TABLE
 
 CREATE TABLE dbo.TokenDateTimeCompositeSearchParam
 (
+    ResourceTypeId smallint NOT NULL,
     ResourceSurrogateId bigint NOT NULL,
     SearchParamId smallint NOT NULL,
     SystemId1 int NULL,
@@ -850,6 +912,7 @@ ON dbo.TokenDateTimeCompositeSearchParam
 )
 INCLUDE
 (
+    ResourceTypeId,
     SystemId1
 )
 
@@ -866,6 +929,7 @@ ON dbo.TokenDateTimeCompositeSearchParam
 )
 INCLUDE
 (
+    ResourceTypeId,
     SystemId1
 )
 WHERE IsHistory = 0
@@ -891,6 +955,7 @@ CREATE TYPE dbo.TokenQuantityCompositeSearchParamTableType_1 AS TABLE
 
 CREATE TABLE dbo.TokenQuantityCompositeSearchParam
 (
+    ResourceTypeId smallint NOT NULL,
     ResourceSurrogateId bigint NOT NULL,
     SearchParamId smallint NOT NULL,
     SystemId1 int NULL,
@@ -921,6 +986,7 @@ ON dbo.TokenQuantityCompositeSearchParam
 )
 INCLUDE
 (
+    ResourceTypeId,
     QuantityCodeId2,
     SystemId1,
     SystemId2
@@ -938,6 +1004,7 @@ ON dbo.TokenQuantityCompositeSearchParam
 )
 INCLUDE
 (
+    ResourceTypeId,
     QuantityCodeId2,
     SystemId1,
     SystemId2
@@ -955,6 +1022,7 @@ ON dbo.TokenQuantityCompositeSearchParam
 )
 INCLUDE
 (
+    ResourceTypeId,
     QuantityCodeId2,
     SystemId1,
     SystemId2
@@ -979,6 +1047,7 @@ CREATE TYPE dbo.TokenStringCompositeSearchParamTableType_1 AS TABLE
 
 CREATE TABLE dbo.TokenStringCompositeSearchParam
 (
+    ResourceTypeId smallint NOT NULL,
     ResourceSurrogateId bigint NOT NULL,
     SearchParamId smallint NOT NULL,
     SystemId1 int NULL,
@@ -1006,6 +1075,7 @@ ON dbo.TokenStringCompositeSearchParam
 )
 INCLUDE
 (
+    ResourceTypeId,
     SystemId1,
     TextOverflow2 -- workaround for https://support.microsoft.com/en-gb/help/3051225/a-filtered-index-that-you-create-together-with-the-is-null-predicate-i
 )
@@ -1021,6 +1091,7 @@ ON dbo.TokenStringCompositeSearchParam
 )
 INCLUDE
 (
+    ResourceTypeId,
     SystemId1
 )
 WHERE IsHistory = 0 AND TextOverflow2 IS  NULL
@@ -1055,6 +1126,7 @@ CREATE TYPE dbo.TokenNumberNumberCompositeSearchParamTableType_1 AS TABLE
 
 CREATE TABLE dbo.TokenNumberNumberCompositeSearchParam
 (
+    ResourceTypeId smallint NOT NULL,
     ResourceSurrogateId bigint NOT NULL,
     SearchParamId smallint NOT NULL,
     SystemId1 int NULL,
@@ -1088,6 +1160,7 @@ ON dbo.TokenNumberNumberCompositeSearchParam
 )
 INCLUDE
 (
+    ResourceTypeId,
     SystemId1
 )
 WHERE IsHistory = 0 AND HasRange = 0
@@ -1105,6 +1178,7 @@ ON dbo.TokenNumberNumberCompositeSearchParam
 )
 INCLUDE
 (
+    ResourceTypeId,
     SystemId1
 )
 WHERE IsHistory = 0 AND HasRange = 1
@@ -1405,78 +1479,78 @@ AS
     FROM @resourceWriteClaims
 
     INSERT INTO dbo.CompartmentAssignment
-        (ResourceSurrogateId, CompartmentTypeId, ReferenceResourceId, IsHistory)
-    SELECT DISTINCT @resourceSurrogateId, CompartmentTypeId, ReferenceResourceId, 0
+        (ResourceTypeId, ResourceSurrogateId, CompartmentTypeId, ReferenceResourceId, IsHistory)
+    SELECT DISTINCT @resourceTypeId, @resourceSurrogateId, CompartmentTypeId, ReferenceResourceId, 0
     FROM @compartmentAssignments
 
     INSERT INTO dbo.ReferenceSearchParam
-        (ResourceSurrogateId, SearchParamId, BaseUri, ReferenceResourceTypeId, ReferenceResourceId, ReferenceResourceVersion, IsHistory)
-    SELECT DISTINCT @resourceSurrogateId, SearchParamId, BaseUri, ReferenceResourceTypeId, ReferenceResourceId, ReferenceResourceVersion, 0
+        (ResourceTypeId, ResourceSurrogateId, SearchParamId, BaseUri, ReferenceResourceTypeId, ReferenceResourceId, ReferenceResourceVersion, IsHistory)
+    SELECT DISTINCT @resourceTypeId, @resourceSurrogateId, SearchParamId, BaseUri, ReferenceResourceTypeId, ReferenceResourceId, ReferenceResourceVersion, 0
     FROM @referenceSearchParams
 
     INSERT INTO dbo.TokenSearchParam
-        (ResourceSurrogateId, SearchParamId, SystemId, Code, IsHistory)
-    SELECT DISTINCT @resourceSurrogateId, SearchParamId, SystemId, Code, 0
+        (ResourceTypeId, ResourceSurrogateId, SearchParamId, SystemId, Code, IsHistory)
+    SELECT DISTINCT @resourceTypeId, @resourceSurrogateId, SearchParamId, SystemId, Code, 0
     FROM @tokenSearchParams
 
     INSERT INTO dbo.TokenText
-        (ResourceSurrogateId, SearchParamId, Text, IsHistory)
-    SELECT DISTINCT @resourceSurrogateId, SearchParamId, Text, 0
+        (ResourceTypeId, ResourceSurrogateId, SearchParamId, Text, IsHistory)
+    SELECT DISTINCT @resourceTypeId, @resourceSurrogateId, SearchParamId, Text, 0
     FROM @tokenTextSearchParams
 
     INSERT INTO dbo.StringSearchParam
-        (ResourceSurrogateId, SearchParamId, Text, TextOverflow, IsHistory)
-    SELECT DISTINCT @resourceSurrogateId, SearchParamId, Text, TextOverflow, 0
+        (ResourceTypeId, ResourceSurrogateId, SearchParamId, Text, TextOverflow, IsHistory)
+    SELECT DISTINCT @resourceTypeId, @resourceSurrogateId, SearchParamId, Text, TextOverflow, 0
     FROM @stringSearchParams
 
     INSERT INTO dbo.UriSearchParam
-        (ResourceSurrogateId, SearchParamId, Uri, IsHistory)
-    SELECT DISTINCT @resourceSurrogateId, SearchParamId, Uri, 0
+        (ResourceTypeId, ResourceSurrogateId, SearchParamId, Uri, IsHistory)
+    SELECT DISTINCT @resourceTypeId, @resourceSurrogateId, SearchParamId, Uri, 0
     FROM @uriSearchParams
 
     INSERT INTO dbo.NumberSearchParam
-        (ResourceSurrogateId, SearchParamId, SingleValue, LowValue, HighValue, IsHistory)
-    SELECT DISTINCT @resourceSurrogateId, SearchParamId, SingleValue, LowValue, HighValue, 0
+        (ResourceTypeId, ResourceSurrogateId, SearchParamId, SingleValue, LowValue, HighValue, IsHistory)
+    SELECT DISTINCT @resourceTypeId, @resourceSurrogateId, SearchParamId, SingleValue, LowValue, HighValue, 0
     FROM @numberSearchParams
 
     INSERT INTO dbo.QuantitySearchParam
-        (ResourceSurrogateId, SearchParamId, SystemId, QuantityCodeId, SingleValue, LowValue, HighValue, IsHistory)
-    SELECT DISTINCT @resourceSurrogateId, SearchParamId, SystemId, QuantityCodeId, SingleValue, LowValue, HighValue, 0
+        (ResourceTypeId, ResourceSurrogateId, SearchParamId, SystemId, QuantityCodeId, SingleValue, LowValue, HighValue, IsHistory)
+    SELECT DISTINCT @resourceTypeId, @resourceSurrogateId, SearchParamId, SystemId, QuantityCodeId, SingleValue, LowValue, HighValue, 0
     FROM @quantitySearchParams
 
     INSERT INTO dbo.DateTimeSearchParam
-        (ResourceSurrogateId, SearchParamId, StartDateTime, EndDateTime, IsHistory)
-    SELECT DISTINCT @resourceSurrogateId, SearchParamId, StartDateTime, EndDateTime, 0
+        (ResourceTypeId, ResourceSurrogateId, SearchParamId, StartDateTime, EndDateTime, IsHistory)
+    SELECT DISTINCT @resourceTypeId, @resourceSurrogateId, SearchParamId, StartDateTime, EndDateTime, 0
     FROM @dateTimeSearchParms
 
     INSERT INTO dbo.ReferenceTokenCompositeSearchParam
-        (ResourceSurrogateId, SearchParamId, BaseUri1, ReferenceResourceTypeId1, ReferenceResourceId1, ReferenceResourceVersion1, SystemId2, Code2, IsHistory)
-    SELECT DISTINCT @resourceSurrogateId, SearchParamId, BaseUri1, ReferenceResourceTypeId1, ReferenceResourceId1, ReferenceResourceVersion1, SystemId2, Code2, 0
+        (ResourceTypeId, ResourceSurrogateId, SearchParamId, BaseUri1, ReferenceResourceTypeId1, ReferenceResourceId1, ReferenceResourceVersion1, SystemId2, Code2, IsHistory)
+    SELECT DISTINCT @resourceTypeId, @resourceSurrogateId, SearchParamId, BaseUri1, ReferenceResourceTypeId1, ReferenceResourceId1, ReferenceResourceVersion1, SystemId2, Code2, 0
     FROM @referenceTokenCompositeSearchParams
 
     INSERT INTO dbo.TokenTokenCompositeSearchParam
-        (ResourceSurrogateId, SearchParamId, SystemId1, Code1, SystemId2, Code2, IsHistory)
-    SELECT DISTINCT @resourceSurrogateId, SearchParamId, SystemId1, Code1, SystemId2, Code2, 0
+        (ResourceTypeId, ResourceSurrogateId, SearchParamId, SystemId1, Code1, SystemId2, Code2, IsHistory)
+    SELECT DISTINCT @resourceTypeId, @resourceSurrogateId, SearchParamId, SystemId1, Code1, SystemId2, Code2, 0
     FROM @tokenTokenCompositeSearchParams
 
     INSERT INTO dbo.TokenDateTimeCompositeSearchParam
-        (ResourceSurrogateId, SearchParamId, SystemId1, Code1, StartDateTime2, EndDateTime2, IsHistory)
-    SELECT DISTINCT @resourceSurrogateId, SearchParamId, SystemId1, Code1, StartDateTime2, EndDateTime2, 0
+        (ResourceTypeId, ResourceSurrogateId, SearchParamId, SystemId1, Code1, StartDateTime2, EndDateTime2, IsHistory)
+    SELECT DISTINCT @resourceTypeId, @resourceSurrogateId, SearchParamId, SystemId1, Code1, StartDateTime2, EndDateTime2, 0
     FROM @tokenDateTimeCompositeSearchParams
 
     INSERT INTO dbo.TokenQuantityCompositeSearchParam
-        (ResourceSurrogateId, SearchParamId, SystemId1, Code1, SingleValue2, SystemId2, QuantityCodeId2, LowValue2, HighValue2, IsHistory)
-    SELECT DISTINCT @resourceSurrogateId, SearchParamId, SystemId1, Code1, SingleValue2, SystemId2, QuantityCodeId2, LowValue2, HighValue2, 0
+        (ResourceTypeId, ResourceSurrogateId, SearchParamId, SystemId1, Code1, SingleValue2, SystemId2, QuantityCodeId2, LowValue2, HighValue2, IsHistory)
+    SELECT DISTINCT @resourceTypeId, @resourceSurrogateId, SearchParamId, SystemId1, Code1, SingleValue2, SystemId2, QuantityCodeId2, LowValue2, HighValue2, 0
     FROM @tokenQuantityCompositeSearchParams
 
     INSERT INTO dbo.TokenStringCompositeSearchParam
-        (ResourceSurrogateId, SearchParamId, SystemId1, Code1, Text2, TextOverflow2, IsHistory)
-    SELECT DISTINCT @resourceSurrogateId, SearchParamId, SystemId1, Code1, Text2, TextOverflow2, 0
+        (ResourceTypeId, ResourceSurrogateId, SearchParamId, SystemId1, Code1, Text2, TextOverflow2, IsHistory)
+    SELECT DISTINCT @resourceTypeId, @resourceSurrogateId, SearchParamId, SystemId1, Code1, Text2, TextOverflow2, 0
     FROM @tokenStringCompositeSearchParams
 
     INSERT INTO dbo.TokenNumberNumberCompositeSearchParam
-        (ResourceSurrogateId, SearchParamId, SystemId1, Code1, SingleValue2, LowValue2, HighValue2, SingleValue3, LowValue3, HighValue3, HasRange, IsHistory)
-    SELECT DISTINCT @resourceSurrogateId, SearchParamId, SystemId1, Code1, SingleValue2, LowValue2, HighValue2, SingleValue3, LowValue3, HighValue3, HasRange, 0
+        (ResourceTypeId, ResourceSurrogateId, SearchParamId, SystemId1, Code1, SingleValue2, LowValue2, HighValue2, SingleValue3, LowValue3, HighValue3, HasRange, IsHistory)
+    SELECT DISTINCT @resourceTypeId, @resourceSurrogateId, SearchParamId, SystemId1, Code1, SingleValue2, LowValue2, HighValue2, SingleValue3, LowValue3, HighValue3, HasRange, 0
     FROM @tokenNumberNumberCompositeSearchParams
 
     SELECT @version

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/V1.Generated.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/V1.Generated.cs
@@ -55,6 +55,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             {
             }
 
+            internal readonly SmallIntColumn ResourceTypeId = new SmallIntColumn("ResourceTypeId");
             internal readonly BigIntColumn ResourceSurrogateId = new BigIntColumn("ResourceSurrogateId");
             internal readonly TinyIntColumn CompartmentTypeId = new TinyIntColumn("CompartmentTypeId");
             internal readonly VarCharColumn ReferenceResourceId = new VarCharColumn("ReferenceResourceId", 64);
@@ -77,6 +78,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             {
             }
 
+            internal readonly SmallIntColumn ResourceTypeId = new SmallIntColumn("ResourceTypeId");
             internal readonly BigIntColumn ResourceSurrogateId = new BigIntColumn("ResourceSurrogateId");
             internal readonly SmallIntColumn SearchParamId = new SmallIntColumn("SearchParamId");
             internal readonly DateTime2Column StartDateTime = new DateTime2Column("StartDateTime", 7);
@@ -90,6 +92,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             {
             }
 
+            internal readonly SmallIntColumn ResourceTypeId = new SmallIntColumn("ResourceTypeId");
             internal readonly BigIntColumn ResourceSurrogateId = new BigIntColumn("ResourceSurrogateId");
             internal readonly SmallIntColumn SearchParamId = new SmallIntColumn("SearchParamId");
             internal readonly NullableDecimalColumn SingleValue = new NullableDecimalColumn("SingleValue", 18, 6);
@@ -114,6 +117,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             {
             }
 
+            internal readonly SmallIntColumn ResourceTypeId = new SmallIntColumn("ResourceTypeId");
             internal readonly BigIntColumn ResourceSurrogateId = new BigIntColumn("ResourceSurrogateId");
             internal readonly SmallIntColumn SearchParamId = new SmallIntColumn("SearchParamId");
             internal readonly NullableIntColumn SystemId = new NullableIntColumn("SystemId");
@@ -130,6 +134,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             {
             }
 
+            internal readonly SmallIntColumn ResourceTypeId = new SmallIntColumn("ResourceTypeId");
             internal readonly BigIntColumn ResourceSurrogateId = new BigIntColumn("ResourceSurrogateId");
             internal readonly SmallIntColumn SearchParamId = new SmallIntColumn("SearchParamId");
             internal readonly NullableVarCharColumn BaseUri = new NullableVarCharColumn("BaseUri", 128);
@@ -145,6 +150,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             {
             }
 
+            internal readonly SmallIntColumn ResourceTypeId = new SmallIntColumn("ResourceTypeId");
             internal readonly BigIntColumn ResourceSurrogateId = new BigIntColumn("ResourceSurrogateId");
             internal readonly SmallIntColumn SearchParamId = new SmallIntColumn("SearchParamId");
             internal readonly NullableVarCharColumn BaseUri1 = new NullableVarCharColumn("BaseUri1", 128);
@@ -220,6 +226,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             {
             }
 
+            internal readonly SmallIntColumn ResourceTypeId = new SmallIntColumn("ResourceTypeId");
             internal readonly BigIntColumn ResourceSurrogateId = new BigIntColumn("ResourceSurrogateId");
             internal readonly SmallIntColumn SearchParamId = new SmallIntColumn("SearchParamId");
             internal readonly NVarCharColumn Text = new NVarCharColumn("Text", 256);
@@ -243,6 +250,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             {
             }
 
+            internal readonly SmallIntColumn ResourceTypeId = new SmallIntColumn("ResourceTypeId");
             internal readonly BigIntColumn ResourceSurrogateId = new BigIntColumn("ResourceSurrogateId");
             internal readonly SmallIntColumn SearchParamId = new SmallIntColumn("SearchParamId");
             internal readonly NullableIntColumn SystemId1 = new NullableIntColumn("SystemId1");
@@ -258,6 +266,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             {
             }
 
+            internal readonly SmallIntColumn ResourceTypeId = new SmallIntColumn("ResourceTypeId");
             internal readonly BigIntColumn ResourceSurrogateId = new BigIntColumn("ResourceSurrogateId");
             internal readonly SmallIntColumn SearchParamId = new SmallIntColumn("SearchParamId");
             internal readonly NullableIntColumn SystemId1 = new NullableIntColumn("SystemId1");
@@ -278,6 +287,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             {
             }
 
+            internal readonly SmallIntColumn ResourceTypeId = new SmallIntColumn("ResourceTypeId");
             internal readonly BigIntColumn ResourceSurrogateId = new BigIntColumn("ResourceSurrogateId");
             internal readonly SmallIntColumn SearchParamId = new SmallIntColumn("SearchParamId");
             internal readonly NullableIntColumn SystemId1 = new NullableIntColumn("SystemId1");
@@ -296,6 +306,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             {
             }
 
+            internal readonly SmallIntColumn ResourceTypeId = new SmallIntColumn("ResourceTypeId");
             internal readonly BigIntColumn ResourceSurrogateId = new BigIntColumn("ResourceSurrogateId");
             internal readonly SmallIntColumn SearchParamId = new SmallIntColumn("SearchParamId");
             internal readonly NullableIntColumn SystemId = new NullableIntColumn("SystemId");
@@ -309,6 +320,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             {
             }
 
+            internal readonly SmallIntColumn ResourceTypeId = new SmallIntColumn("ResourceTypeId");
             internal readonly BigIntColumn ResourceSurrogateId = new BigIntColumn("ResourceSurrogateId");
             internal readonly SmallIntColumn SearchParamId = new SmallIntColumn("SearchParamId");
             internal readonly NullableIntColumn SystemId1 = new NullableIntColumn("SystemId1");
@@ -324,6 +336,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             {
             }
 
+            internal readonly SmallIntColumn ResourceTypeId = new SmallIntColumn("ResourceTypeId");
             internal readonly BigIntColumn ResourceSurrogateId = new BigIntColumn("ResourceSurrogateId");
             internal readonly SmallIntColumn SearchParamId = new SmallIntColumn("SearchParamId");
             internal readonly NVarCharColumn Text = new NVarCharColumn("Text", 400);
@@ -336,6 +349,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             {
             }
 
+            internal readonly SmallIntColumn ResourceTypeId = new SmallIntColumn("ResourceTypeId");
             internal readonly BigIntColumn ResourceSurrogateId = new BigIntColumn("ResourceSurrogateId");
             internal readonly SmallIntColumn SearchParamId = new SmallIntColumn("SearchParamId");
             internal readonly NullableIntColumn SystemId1 = new NullableIntColumn("SystemId1");
@@ -351,6 +365,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             {
             }
 
+            internal readonly SmallIntColumn ResourceTypeId = new SmallIntColumn("ResourceTypeId");
             internal readonly BigIntColumn ResourceSurrogateId = new BigIntColumn("ResourceSurrogateId");
             internal readonly SmallIntColumn SearchParamId = new SmallIntColumn("SearchParamId");
             internal readonly VarCharColumn Uri = new VarCharColumn("Uri", 256);

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/TvpRowGeneration/DateTimeSearchParameterRowGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/TvpRowGeneration/DateTimeSearchParameterRowGenerator.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
 using Microsoft.Health.Fhir.SqlServer.Features.Schema.Model;
 
@@ -10,6 +11,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.TvpRowGeneration
 {
     internal class DateTimeSearchParameterRowGenerator : SearchParameterRowGenerator<DateTimeSearchValue, V1.DateTimeSearchParamTableTypeRow>
     {
+        private short _lastUpdatedSearchParamId;
+
         public DateTimeSearchParameterRowGenerator(SqlServerFhirModel model)
             : base(model)
         {
@@ -17,12 +20,24 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.TvpRowGeneration
 
         internal override bool TryGenerateRow(short searchParamId, DateTimeSearchValue searchValue, out V1.DateTimeSearchParamTableTypeRow row)
         {
+            if (searchParamId == _lastUpdatedSearchParamId)
+            {
+                // this value is already stored on the Resource table.
+                row = default;
+                return false;
+            }
+
             row = new V1.DateTimeSearchParamTableTypeRow(
                 searchParamId,
                 searchValue.Start,
                 searchValue.End);
 
             return true;
+        }
+
+        protected override void Initialize()
+        {
+            _lastUpdatedSearchParamId = Model.GetSearchParamId(SearchParameterNames.LastUpdatedUri);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/TvpRowGeneration/SearchParameterRowGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/TvpRowGeneration/SearchParameterRowGenerator.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.TvpRowGeneration
         where TRow : struct
     {
         private readonly bool _isConvertSearchValueOverridden;
-        private readonly bool _isInitializeOverridden;
         private bool _isInitialized;
 
         protected SearchParameterRowGenerator(SqlServerFhirModel model)
@@ -24,8 +23,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.TvpRowGeneration
             EnsureArg.IsNotNull(model, nameof(model));
             Model = model;
             _isConvertSearchValueOverridden = GetType().GetMethod(nameof(ConvertSearchValue), BindingFlags.Instance | BindingFlags.NonPublic).DeclaringType != typeof(SearchParameterRowGenerator<TSearchValue, TRow>);
-            _isInitializeOverridden = GetType().GetMethod(nameof(Initialize), BindingFlags.Instance | BindingFlags.NonPublic).DeclaringType != typeof(SearchParameterRowGenerator<TSearchValue, TRow>);
-            _isInitialized = !_isInitializeOverridden;
         }
 
         protected SqlServerFhirModel Model { get; }
@@ -61,7 +58,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.TvpRowGeneration
 
         private void EnsureInitialized()
         {
-            if (!_isInitializeOverridden || Volatile.Read(ref _isInitialized))
+            if (Volatile.Read(ref _isInitialized))
             {
                 return;
             }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/TvpRowGeneration/TokenSearchParameterRowGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/TvpRowGeneration/TokenSearchParameterRowGenerator.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
 using Microsoft.Health.Fhir.SqlServer.Features.Schema.Model;
 
@@ -10,6 +11,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.TvpRowGeneration
 {
     internal class TokenSearchParameterRowGenerator : SearchParameterRowGenerator<TokenSearchValue, V1.TokenSearchParamTableTypeRow>
     {
+        private short _resourceIdSearchParamId;
+
         public TokenSearchParameterRowGenerator(SqlServerFhirModel model)
             : base(model)
         {
@@ -17,7 +20,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.TvpRowGeneration
 
         internal override bool TryGenerateRow(short searchParamId, TokenSearchValue searchValue, out V1.TokenSearchParamTableTypeRow row)
         {
-            if (string.IsNullOrWhiteSpace(searchValue.Code))
+            // don't store if the code is empty or if this the Resource _id parameter. The id is already maintained on the Resource table.
+            if (string.IsNullOrWhiteSpace(searchValue.Code) ||
+                searchParamId == _resourceIdSearchParamId)
             {
                 row = default;
                 return false;
@@ -30,5 +35,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.TvpRowGeneration
 
             return true;
         }
+
+        protected override void Initialize() => _resourceIdSearchParamId = Model.GetSearchParamId(SearchParameterNames.IdUri);
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/TvpRowGeneration/TokenSearchParameterRowGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/TvpRowGeneration/TokenSearchParameterRowGenerator.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.TvpRowGeneration
 
         internal override bool TryGenerateRow(short searchParamId, TokenSearchValue searchValue, out V1.TokenSearchParamTableTypeRow row)
         {
-            // don't store if the code is empty or if this the Resource _id parameter. The id is already maintained on the Resource table.
+            // don't store if the code is empty or if this is the Resource _id parameter. The id is already maintained on the Resource table.
             if (string.IsNullOrWhiteSpace(searchValue.Code) ||
                 searchParamId == _resourceIdSearchParamId)
             {

--- a/src/Microsoft.Health.Fhir.Stu3.Core/Features/Search/SearchParameterNames.cs
+++ b/src/Microsoft.Health.Fhir.Stu3.Core/Features/Search/SearchParameterNames.cs
@@ -3,11 +3,14 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
+
 namespace Microsoft.Health.Fhir.Core.Features.Search
 {
     public static class SearchParameterNames
     {
         public static readonly string Id = "_id";
+        public static readonly Uri IdUri = new Uri("http://hl7.org/fhir/SearchParameter/Resource-id");
         public static readonly string LastUpdated = "_lastUpdated";
         public static readonly string ResourceType = "_type";
     }

--- a/src/Microsoft.Health.Fhir.Stu3.Core/Features/Search/SearchParameterNames.cs
+++ b/src/Microsoft.Health.Fhir.Stu3.Core/Features/Search/SearchParameterNames.cs
@@ -10,8 +10,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
     public static class SearchParameterNames
     {
         public static readonly string Id = "_id";
+
         public static readonly Uri IdUri = new Uri("http://hl7.org/fhir/SearchParameter/Resource-id");
+
         public static readonly string LastUpdated = "_lastUpdated";
+
+        public static readonly Uri LastUpdatedUri = new Uri("http://hl7.org/fhir/SearchParameter/Resource-lastUpdated");
+
         public static readonly string ResourceType = "_type";
     }
 }


### PR DESCRIPTION
## Description

1. Store the resource type ID in all search param and compartment assignment table. It will not be an index column, but it is available for filtering on. 
2. Do not store the resource id as in the TokenSearchParam table as the `_id` search param. It is already on the Resource table. The same for `_lastUpdated` in the DateTimeSearchParam. 

## Related issues
Addresses [AB#69044](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/69044)

