### PR TITLE
Fix SQL integration tests

### DIFF
--- a/src/Microsoft.Health.Fhir.Tests.Common/FixtureParameters/DataStore.cs
+++ b/src/Microsoft.Health.Fhir.Tests.Common/FixtureParameters/DataStore.cs
@@ -13,5 +13,7 @@ namespace Microsoft.Health.Fhir.Tests.Common.FixtureParameters
         CosmosDb = 1,
 
         SqlServer = 2,
+
+        All = CosmosDb | SqlServer,
     }
 }

--- a/src/Microsoft.Health.Fhir.Tests.Common/FixtureParameters/Format.cs
+++ b/src/Microsoft.Health.Fhir.Tests.Common/FixtureParameters/Format.cs
@@ -13,5 +13,7 @@ namespace Microsoft.Health.Fhir.Tests.Common.FixtureParameters
         Json = 1,
 
         Xml = 2,
+
+        All = Json | Xml,
     }
 }

--- a/test/Microsoft.Health.Fhir.Tests.E2E/Rest/CorsTests.cs
+++ b/test/Microsoft.Health.Fhir.Tests.E2E/Rest/CorsTests.cs
@@ -19,7 +19,7 @@ using HttpMethod = System.Net.Http.HttpMethod;
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
     [Trait(Traits.Category, Categories.Cors)]
-    [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb | DataStore.SqlServer, Format.Json)]
+    [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.Json)]
     public class CorsTests : IClassFixture<HttpIntegrationTestFixture<Startup>>
     {
         private readonly FhirClient _client;

--- a/test/Microsoft.Health.Fhir.Tests.E2E/Rest/CreateTests.cs
+++ b/test/Microsoft.Health.Fhir.Tests.E2E/Rest/CreateTests.cs
@@ -22,7 +22,7 @@ using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
-    [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb | DataStore.SqlServer, Format.Json | Format.Xml)]
+    [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.All)]
     public class CreateTests : IClassFixture<HttpIntegrationTestFixture<Startup>>
     {
         public CreateTests(HttpIntegrationTestFixture<Startup> fixture)

--- a/test/Microsoft.Health.Fhir.Tests.E2E/Rest/DeleteTests.cs
+++ b/test/Microsoft.Health.Fhir.Tests.E2E/Rest/DeleteTests.cs
@@ -20,7 +20,7 @@ using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
-    [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb, Format.Json | Format.Xml)]
+    [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb, Format.All)]
     public class DeleteTests : IClassFixture<HttpIntegrationTestFixture<Startup>>
     {
         public DeleteTests(HttpIntegrationTestFixture<Startup> fixture)

--- a/test/Microsoft.Health.Fhir.Tests.E2E/Rest/ExceptionTests.cs
+++ b/test/Microsoft.Health.Fhir.Tests.E2E/Rest/ExceptionTests.cs
@@ -19,7 +19,7 @@ using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
-    [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb | DataStore.SqlServer, Format.Json | Format.Xml)]
+    [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.All)]
     public class ExceptionTests : IClassFixture<HttpIntegrationTestFixture<ExceptionTests.StartupWithThrowingMiddleware>>
     {
         private readonly HttpIntegrationTestFixture<StartupWithThrowingMiddleware> _fixture;

--- a/test/Microsoft.Health.Fhir.Tests.E2E/Rest/HealthTests.cs
+++ b/test/Microsoft.Health.Fhir.Tests.E2E/Rest/HealthTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
-    [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb | DataStore.SqlServer, Format.Json)]
+    [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.Json)]
     public class HealthTests : IClassFixture<HttpIntegrationTestFixture<Startup>>
     {
         private readonly HttpClient _client;

--- a/test/Microsoft.Health.Fhir.Tests.E2E/Rest/HistoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Tests.E2E/Rest/HistoryTests.cs
@@ -20,7 +20,7 @@ using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
-    [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb, Format.Json | Format.Xml)]
+    [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb, Format.All)]
     [CollectionDefinition("History", DisableParallelization=true)]
     [Collection("History")]
     public class HistoryTests : IClassFixture<HttpIntegrationTestFixture<Startup>>, IDisposable

--- a/test/Microsoft.Health.Fhir.Tests.E2E/Rest/ReadTests.cs
+++ b/test/Microsoft.Health.Fhir.Tests.E2E/Rest/ReadTests.cs
@@ -16,7 +16,7 @@ using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
-    [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb | DataStore.SqlServer, Format.Json | Format.Xml)]
+    [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.All)]
     public class ReadTests : IClassFixture<HttpIntegrationTestFixture<Startup>>
     {
         public ReadTests(HttpIntegrationTestFixture<Startup> fixture)

--- a/test/Microsoft.Health.Fhir.Tests.E2E/Rest/UpdateTests.cs
+++ b/test/Microsoft.Health.Fhir.Tests.E2E/Rest/UpdateTests.cs
@@ -16,7 +16,7 @@ using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
-    [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb | DataStore.SqlServer, Format.Json | Format.Xml)]
+    [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.All)]
     public class UpdateTests : IClassFixture<HttpIntegrationTestFixture<Startup>>
     {
         public UpdateTests(HttpIntegrationTestFixture<Startup> fixture)

--- a/test/Microsoft.Health.Fhir.Tests.E2E/Rest/VReadTests.cs
+++ b/test/Microsoft.Health.Fhir.Tests.E2E/Rest/VReadTests.cs
@@ -17,7 +17,7 @@ using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
-    [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb | DataStore.SqlServer, Format.Json | Format.Xml)]
+    [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.All)]
     public class VReadTests : IClassFixture<HttpIntegrationTestFixture<Startup>>
     {
         public VReadTests(HttpIntegrationTestFixture<Startup> fixture)

--- a/test/Microsoft.Health.Fhir.Tests.E2E/SmartProxy/SmartProxyBadRequestTests.cs
+++ b/test/Microsoft.Health.Fhir.Tests.E2E/SmartProxy/SmartProxyBadRequestTests.cs
@@ -14,7 +14,7 @@ using Xunit;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.SmartProxy
 {
-    [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb, Format.Json | Format.Xml)]
+    [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb, Format.All)]
     public class SmartProxyBadRequestTests : IClassFixture<HttpIntegrationTestFixture<Startup>>
     {
         private readonly FhirClient _client;

--- a/test/Microsoft.Health.Fhir.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -36,7 +36,7 @@ using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 {
-    [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb | DataStore.SqlServer)]
+    [FhirStorageTestsFixtureArgumentSets(DataStore.All)]
     public class FhirStorageTests : IClassFixture<FhirStorageTestsFixture>
     {
         private readonly FhirStorageTestsFixture _fixture;

--- a/test/Microsoft.Health.Fhir.Tests.Integration/Persistence/SqlDataReaderExtensionsTests.cs
+++ b/test/Microsoft.Health.Fhir.Tests.Integration/Persistence/SqlDataReaderExtensionsTests.cs
@@ -93,8 +93,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             }
         }
 
+#if DEBUG // checks are only enabled on debug builds.
         [Fact]
-        [Conditional("DEBUG")] // checks are only enabled on debug builds.
         public void GivenASqlDataReader_WhenReadingFieldsWithIncorrectCorrectNamesAndOrdinals_Throws()
         {
             using (var connection = new SqlConnection(_connectionString))
@@ -111,5 +111,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 Assert.Throws<InvalidOperationException>(() => sqlDataReader.GetInt64("int", 0));
             }
         }
+#endif
     }
 }

--- a/test/Microsoft.Health.Fhir.Tests.Integration/Persistence/SqlDataReaderExtensionsTests.cs
+++ b/test/Microsoft.Health.Fhir.Tests.Integration/Persistence/SqlDataReaderExtensionsTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             _connectionString = fixture.TestConnectionString;
         }
 
-        [Fact(Skip = "test infrastructure missing")]
+        [Fact]
         public void GivenASqlDataReader_WhenReadingFieldsWithCorrectNamesAndOrdinals_ReturnsCorrectData()
         {
             using (var connection = new SqlConnection(_connectionString))
@@ -93,7 +93,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             }
         }
 
-        [Fact(Skip = "test infrastructure missing")]
+        [Fact]
         [Conditional("DEBUG")] // checks are only enabled on debug builds.
         public void GivenASqlDataReader_WhenReadingFieldsWithIncorrectCorrectNamesAndOrdinals_Throws()
         {

--- a/test/Microsoft.Health.Fhir.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.SqlServer.Configs;
 using Microsoft.Health.Fhir.SqlServer.Features.Schema;
 using Microsoft.Health.Fhir.SqlServer.Features.Schema.Model;
@@ -57,7 +58,11 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             schemaInitializer.Start();
 
             var searchParameterDefinitionManager = Substitute.For<ISearchParameterDefinitionManager>();
-            searchParameterDefinitionManager.AllSearchParameters.Returns(new SearchParameter[0]);
+            searchParameterDefinitionManager.AllSearchParameters.Returns(new[]
+            {
+                new SearchParameter { Id = SearchParameterNames.Id, Url = SearchParameterNames.IdUri.ToString() },
+                new SearchParameter { Id = SearchParameterNames.LastUpdated, Url = SearchParameterNames.LastUpdatedUri.ToString() },
+            });
 
             var securityConfiguration = new SecurityConfiguration { PrincipalClaims = { "oid" } };
 


### PR DESCRIPTION
1. Fix failure in SQL integration tests
1. Introduce `DataStore.All` and `Format.All` to make it easier to find tests that are not datastore-agnostic
1. Remove skip from `SqlDataReaderExtensionsTests`