### PR TITLE
Update Cosmos DB query generation to make lastModified query simplified

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/FieldName.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/FieldName.cs
@@ -26,6 +26,5 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         TokenSystem,
         TokenText,
         Uri,
-        LastModified,
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/FieldName.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/FieldName.cs
@@ -26,5 +26,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         TokenSystem,
         TokenText,
         Uri,
+        LastModified,
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/ExpressionQueryBuilder.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/ExpressionQueryBuilder.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries
             else if (expression.Parameter.Name == SearchParameterNames.LastUpdated)
             {
                 // For LastUpdate queries, the LastModified property on the root is
-                // mnore performant than the searchIndices _lastUpdated.st and _lastUpdate.et
+                // more performant than the searchIndices _lastUpdated.st and _lastUpdate.et
                 // we will override the mapping for that
                 OverrideFieldName(expression, SearchValueConstants.LastModified);
             }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/ExpressionQueryBuilder.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/ExpressionQueryBuilder.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries
             { FieldName.TokenSystem, SearchValueConstants.SystemName },
             { FieldName.TokenText, SearchValueConstants.TextName },
             { FieldName.Uri, SearchValueConstants.UriName },
+            { FieldName.LastModified, SearchValueConstants.LastModified },
         };
 
         private static readonly Dictionary<StringOperator, string> StringOperatorMapping = new Dictionary<StringOperator, string>()
@@ -88,18 +89,17 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries
         {
             if (expression.Parameter.Name == SearchParameterNames.ResourceType)
             {
-                try
-                {
-                    // We do not currently support specifying the system for the _type parameter value.
-                    // We would need to add it to the document, but for now it seems pretty unlikely that it will
-                    // be specified when searching.
-                    _fieldNameOverride = SearchValueConstants.RootResourceTypeName;
-                    expression.Expression.AcceptVisitor(this);
-                }
-                finally
-                {
-                    _fieldNameOverride = null;
-                }
+                // We do not currently support specifying the system for the _type parameter value.
+                // We would need to add it to the document, but for now it seems pretty unlikely that it will
+                // be specified when searching.
+                OverrideFieldName(expression, SearchValueConstants.RootResourceTypeName);
+            }
+            else if (expression.Parameter.Name == SearchParameterNames.LastUpdated)
+            {
+                // For LastUpdate queries, the LastModified property on the root is
+                // mnore performant than the searchIndices _lastUpdated.st and _lastUpdate.et
+                // we will override the mapping for that
+                OverrideFieldName(expression, SearchValueConstants.LastModified);
             }
             else
             {
@@ -353,6 +353,19 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries
                 .Append(", ")
                 .Append(_queryParameterManager.AddOrGetParameterMapping(value))
                 .AppendLine(")");
+        }
+
+        private void OverrideFieldName(SearchParameterExpression expression, string overrideValue)
+        {
+            try
+            {
+                _fieldNameOverride = overrideValue;
+                expression.Expression.AcceptVisitor(this);
+            }
+            finally
+            {
+                _fieldNameOverride = null;
+            }
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/ExpressionQueryBuilder.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/ExpressionQueryBuilder.cs
@@ -46,7 +46,6 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries
             { FieldName.TokenSystem, SearchValueConstants.SystemName },
             { FieldName.TokenText, SearchValueConstants.TextName },
             { FieldName.Uri, SearchValueConstants.UriName },
-            { FieldName.LastModified, SearchValueConstants.LastModified },
         };
 
         private static readonly Dictionary<StringOperator, string> StringOperatorMapping = new Dictionary<StringOperator, string>()

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/SearchValueConstants.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/SearchValueConstants.cs
@@ -52,5 +52,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
         public const string TextName = "t";
 
         public const string UriName = "u";
+
+        public const string LastModified = "lastModified";
     }
 }


### PR DESCRIPTION
Update Cosmos DB query generation to make lastModified query simplified and more performant, changest to History tests to make them more stable by removing some Thread.Sleeps

## Description
Updated the Cosmos DB query builder with a special case for _lastUpdated param.  It now uses lastModified property

## Related issues
Addresses [issue [AB#69164](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/69164)].

## Testing
E2E History tests used to verify the change.  These were also updated to run more reliably.
