### PR TITLE
Personal/jaerwin/history fix

### DIFF
--- a/test/Microsoft.Health.Fhir.Tests.E2E/Rest/HistoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Tests.E2E/Rest/HistoryTests.cs
@@ -40,26 +40,26 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Trait(Traits.Priority, Priority.One)]
         public async Task WhenGettingResourceHistory_GivenAType_TheServerShouldReturnTheAppropriateBundleSuccessfully()
         {
-                FhirResponse<Bundle> readResponse = await Client.SearchAsync("Observation/_history");
-                Assert.NotEmpty(readResponse.Resource.Entry);
+            FhirResponse<Bundle> readResponse = await Client.SearchAsync("Observation/_history");
+            Assert.NotEmpty(readResponse.Resource.Entry);
         }
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
         public async Task WhenGettingResourceHistory_GivenATypeAndId_TheServerShouldReturnTheAppropriateBundleSuccessfully()
         {
-                FhirResponse<Bundle> readResponse = await Client.SearchAsync($"Observation/{_createdResource.Resource.Id}/_history");
+            FhirResponse<Bundle> readResponse = await Client.SearchAsync($"Observation/{_createdResource.Resource.Id}/_history");
 
-                Assert.NotEmpty(readResponse.Resource.Entry);
+            Assert.NotEmpty(readResponse.Resource.Entry);
         }
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
         public async Task WhenGettingSystemHistory_GivenNoType_TheServerShouldReturnTheAppropriateBundleSuccessfully()
         {
-                FhirResponse<Bundle> readResponse = await Client.SearchAsync("_history");
+            FhirResponse<Bundle> readResponse = await Client.SearchAsync("_history");
 
-                Assert.NotEmpty(readResponse.Resource.Entry);
+            Assert.NotEmpty(readResponse.Resource.Entry);
         }
 
         [Fact]
@@ -67,7 +67,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         {
             var since = GetStartTimeForHistoryTest();
             var sinceUriString = HttpUtility.UrlEncode(since.ToString("o"));
-            Thread.Sleep(1000);
+
+            Thread.Sleep(500);  // put a small gap between since and the first edits
             _createdResource.Resource.Comment = "Changed by E2E test";
 
             var updatedResource = Client.UpdateAsync<Observation>(_createdResource).GetAwaiter().GetResult();
@@ -91,17 +92,19 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.Contains("Changed by E2E test", obsHistory.Comment);
         }
 
-        [Fact]
+        [Fact(Skip ="History tests are unstable at the moment due to Cosmos DB issue with continuation tokens")]
         public void WhenGettingSystemHistory_GivenAValueForSinceAndBeforeWithModifications_TheServerShouldOnlyCorrectResources()
         {
             var since = GetStartTimeForHistoryTest();
+
+            Thread.Sleep(500);  // put a small gap between since and the first edits
 
             _createdResource.Resource.Comment = "Changed by E2E test";
             Client.UpdateAsync<Observation>(_createdResource).GetAwaiter().GetResult();
             FhirResponse<Resource> newPatient = Client.CreateAsync(Samples.GetDefaultPatient().ToPoco()).GetAwaiter().GetResult();
 
             var before = newPatient.Resource.Meta.LastUpdated.Value.AddMilliseconds(100);
-            Thread.Sleep(500);
+            Thread.Sleep(500);  // make sure that the before time is not in the future
 
             var sinceUriString = HttpUtility.UrlEncode(since.ToString("o"));
             var beforeUriString = HttpUtility.UrlEncode(before.ToString("o"));
@@ -134,12 +137,14 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             }
         }
 
-        [Fact]
+        [Fact(Skip = "History tests are unstable at the moment due to Cosmos DB issue with continuation tokens")]
         public async Task WhenGettingSystemHistory_GivenAValueForSinceAndBeforeCloseToLastModifiedTime_TheServerShouldNotMissRecords()
         {
             var since = GetStartTimeForHistoryTest();
 
             var newResources = new List<Resource>();
+
+            Thread.Sleep(500);  // put a small gap between since and the first edits
 
             // First make a few edits
             _createdResource.Resource.Comment = "Changed by E2E test";
@@ -170,7 +175,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.Equal(4, firstSet.Resource.Entry.Count);
 
             sinceUriString = beforeUriString;
-            before = lastUpdatedTimes.Last().Value.AddMilliseconds(100); // before is exclusive so we add 100 ms to make sure our before value includes the changes
+            before = DateTime.UtcNow;
             beforeUriString = HttpUtility.UrlEncode(before.Value.ToString("o"));
             Thread.Sleep(500); // wait 500 milliseconds to make sure that the value passed to the server for _before is not a time in the future
             var secondSet = await Client.SearchAsync("_history?_since=" + sinceUriString + "&_before=" + beforeUriString);
@@ -183,7 +188,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             }
         }
 
-        [Fact]
+        [Fact(Skip = "History tests are unstable at the moment due to Cosmos DB issue with continuation tokens")]
         public async Task WhenGettingSystemHistory_GivenAQueryThatReturnsMoreThan10Results_TheServerShouldBatchTheResponse()
         {
             // The batch test does not work reliably on local Cosmos DB Emulator
@@ -191,10 +196,12 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             // There is no remote FHIR server. Skip test
             if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("TestEnvironmentUrl")))
             {
-               return;
+                return;
             }
 
             var since = GetStartTimeForHistoryTest();
+
+            Thread.Sleep(500);  // put a small gap between since and the first edits
 
             var newResources = new List<Resource>();
 
@@ -263,18 +270,18 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Fact]
         public void WhenGettingSystemHistory_GivenAValueForSinceAndBeforeWithNoModifications_TheServerShouldReturnAnEmptyResult()
         {
-            Thread.Sleep(2000);
             _createdResource.Resource.Comment = "Changed by E2E test";
+            var updatedResource = Client.UpdateAsync<Observation>(_createdResource).Result;
 
             // ensure that the server has fully processed the PUT
             var since = GetStartTimeForHistoryTest();
-            var before = DateTime.UtcNow;
+            var before = updatedResource.Resource.Meta.LastUpdated.Value.AddMilliseconds(100);
 
             Thread.Sleep(500);
 
             var newPatient = Client.CreateAsync(Samples.GetDefaultPatient().ToPoco()).GetAwaiter().GetResult();
 
-            Thread.Sleep(500);
+            Assert.True(before < newPatient.Resource.Meta.LastUpdated.Value);
 
             var sinceUriString = HttpUtility.UrlEncode(since.ToString("o"));
             var beforeUriString = HttpUtility.UrlEncode(before.ToString("o"));


### PR DESCRIPTION
## Description
Marking some history tests as Skip as they have been unstable and we are investigating an issue with Cosmos DB related to ORDER BY and continuation tokens

## Related issues
Addresses [issue #496].

## Testing
Ran History E2E tests to make sure certain tests were Skipped
