### PR TITLE
Wait to be able to connect to integration test DB before running tests

### DIFF
--- a/test/Microsoft.Health.Fhir.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -19,15 +19,19 @@ using Microsoft.Health.Fhir.SqlServer.Features.Schema;
 using Microsoft.Health.Fhir.SqlServer.Features.Schema.Model;
 using Microsoft.Health.Fhir.SqlServer.Features.Storage;
 using NSubstitute;
+using Polly;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 {
-    public class SqlServerFhirStorageTestsFixture : IServiceProvider, IDisposable
+    public class SqlServerFhirStorageTestsFixture : IServiceProvider, IAsyncLifetime
     {
         private readonly string _masterConnectionString;
         private readonly string _databaseName;
         private readonly IFhirDataStore _fhirDataStore;
         private readonly SqlServerFhirStorageTestHelper _testHelper;
+        private SchemaInitializer _schemaInitializer;
 
         public SqlServerFhirStorageTestsFixture()
         {
@@ -36,26 +40,13 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             _masterConnectionString = new SqlConnectionStringBuilder(initialConnectionString) { InitialCatalog = "master" }.ToString();
             TestConnectionString = new SqlConnectionStringBuilder(initialConnectionString) { InitialCatalog = _databaseName }.ToString();
 
-            using (var connection = new SqlConnection(_masterConnectionString))
-            {
-                connection.Open();
-
-                using (SqlCommand command = connection.CreateCommand())
-                {
-                    command.CommandTimeout = 600;
-                    command.CommandText = $"CREATE DATABASE {_databaseName}";
-                    command.ExecuteNonQuery();
-                }
-            }
-
             var config = new SqlServerDataStoreConfiguration { ConnectionString = TestConnectionString, Initialize = true };
 
             var schemaUpgradeRunner = new SchemaUpgradeRunner(config);
 
             var schemaInformation = new SchemaInformation();
 
-            var schemaInitializer = new SchemaInitializer(config, schemaUpgradeRunner, schemaInformation, NullLogger<SchemaInitializer>.Instance);
-            schemaInitializer.Start();
+            _schemaInitializer = new SchemaInitializer(config, schemaUpgradeRunner, schemaInformation, NullLogger<SchemaInitializer>.Instance);
 
             var searchParameterDefinitionManager = Substitute.For<ISearchParameterDefinitionManager>();
             searchParameterDefinitionManager.AllSearchParameters.Returns(new[]
@@ -83,18 +74,55 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
         public string TestConnectionString { get; }
 
-        public void Dispose()
+        public async Task InitializeAsync()
+        {
+            // Create the database
+            using (var connection = new SqlConnection(_masterConnectionString))
+            {
+                await connection.OpenAsync();
+
+                using (SqlCommand command = connection.CreateCommand())
+                {
+                    command.CommandTimeout = 600;
+                    command.CommandText = $"CREATE DATABASE {_databaseName}";
+                    await command.ExecuteNonQueryAsync();
+                }
+            }
+
+            // verify that we can connect to the new database. This sometimes does not work right away with Azure SQL.
+            await Policy
+                .Handle<SqlException>()
+                .WaitAndRetryAsync(
+                    retryCount: 7,
+                    sleepDurationProvider: retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)))
+                .ExecuteAsync(async () =>
+                {
+                    using (var connection = new SqlConnection(TestConnectionString))
+                    {
+                        await connection.OpenAsync();
+                        using (SqlCommand sqlCommand = connection.CreateCommand())
+                        {
+                            sqlCommand.CommandText = "SELECT 1";
+                            await sqlCommand.ExecuteScalarAsync();
+                        }
+                    }
+                });
+
+            _schemaInitializer.Start();
+        }
+
+        public async Task DisposeAsync()
         {
             using (var connection = new SqlConnection(_masterConnectionString))
             {
-                connection.Open();
+                await connection.OpenAsync();
                 SqlConnection.ClearAllPools();
 
                 using (SqlCommand command = connection.CreateCommand())
                 {
                     command.CommandTimeout = 600;
                     command.CommandText = $"DROP DATABASE IF EXISTS {_databaseName}";
-                    command.ExecuteNonQuery();
+                    await command.ExecuteNonQueryAsync();
                 }
             }
         }


### PR DESCRIPTION
We've seen integration tests fail in PR/CI where connecting to the Azure SQL database we create on the fly does not work right away. 
Now in the fixture, we check in a retry loop that we can connect to the database before proceeding.