### PR TITLE
Removed the destination info from the request URI.

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
@@ -5,9 +5,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Web;
 using EnsureThat;
 using MediatR;
 using Microsoft.Health.Fhir.Core.Extensions;
@@ -59,7 +61,16 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
             if (outcome == null)
             {
-                var jobRecord = new ExportJobRecord(request.RequestUri, hash, requestorClaims);
+                // Remove the connection settings from the request URI store it in the secret store.
+                NameValueCollection queryParameters = HttpUtility.ParseQueryString(request.RequestUri.Query);
+
+                queryParameters.Remove(KnownQueryParameterNames.DestinationType);
+                queryParameters.Remove(KnownQueryParameterNames.DestinationConnectionSettings);
+
+                var uriBuilder = new UriBuilder(request.RequestUri);
+                uriBuilder.Query = queryParameters.ToString();
+
+                var jobRecord = new ExportJobRecord(uriBuilder.Uri, hash, requestorClaims);
 
                 // Store the destination secret.
                 await _secretStore.SetSecretAsync(jobRecord.SecretName, request.DestinationInfo.ToJson());

--- a/test/Microsoft.Health.Fhir.Tests.Integration/Features/Operations/Export/CreateExportRequestHandlerTests.cs
+++ b/test/Microsoft.Health.Fhir.Tests.Integration/Features/Operations/Export/CreateExportRequestHandlerTests.cs
@@ -158,9 +158,9 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Export
         [Fact]
         public async Task GivenDestinationTypeOrDestinationConnectionSettings_WhenCreatingAnExportJob_ThenItShouldBeRemovedFromRequestUri()
         {
-            const string baseUrl = "http://localhost/$export?_count=100";
+            const string baseUrlFormat = "http://localhost/$export?_count=100{0}&_another=123";
 
-            var requestUri = new Uri($"{baseUrl}&_destinationType=type&_destinationConnectionSettings=settings");
+            var requestUri = new Uri(string.Format(baseUrlFormat, "&_destinationType=type&_destinationConnectionSettings=settings"));
 
             var request = new CreateExportRequest(requestUri, DestinationType, ConnectionString);
 
@@ -168,7 +168,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Export
 
             ExportJobOutcome outcome = await _fhirOperationDataStore.GetExportJobByIdAsync(response.JobId, CancellationToken.None);
 
-            Assert.Equal(new Uri(baseUrl), outcome.JobRecord.RequestUri);
+            Assert.Equal(new Uri(string.Format(baseUrlFormat, string.Empty)), outcome.JobRecord.RequestUri);
         }
 
         private class MockClaimsExtractor : IClaimsExtractor

--- a/test/Microsoft.Health.Fhir.Tests.Integration/Features/Operations/Export/CreateExportRequestHandlerTests.cs
+++ b/test/Microsoft.Health.Fhir.Tests.Integration/Features/Operations/Export/CreateExportRequestHandlerTests.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export;
+using Microsoft.Health.Fhir.Core.Features.Operations.Export.Models;
 using Microsoft.Health.Fhir.Core.Features.SecretStore;
 using Microsoft.Health.Fhir.Core.Features.Security;
 using Microsoft.Health.Fhir.Core.Messages.Export;
@@ -152,6 +153,22 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Export
 
             Assert.NotNull(newResponse);
             Assert.NotEqual(response.JobId, newResponse.JobId);
+        }
+
+        [Fact]
+        public async Task GivenDestinationTypeOrDestinationConnectionSettings_WhenCreatingAnExportJob_ThenItShouldBeRemovedFromRequestUri()
+        {
+            const string baseUrl = "http://localhost/$export?_count=100";
+
+            var requestUri = new Uri($"{baseUrl}&_destinationType=type&_destinationConnectionSettings=settings");
+
+            var request = new CreateExportRequest(requestUri, DestinationType, ConnectionString);
+
+            CreateExportResponse response = await _createExportRequestHandler.Handle(request, _cancellationToken);
+
+            ExportJobOutcome outcome = await _fhirOperationDataStore.GetExportJobByIdAsync(response.JobId, CancellationToken.None);
+
+            Assert.Equal(new Uri(baseUrl), outcome.JobRecord.RequestUri);
         }
 
         private class MockClaimsExtractor : IClaimsExtractor


### PR DESCRIPTION
## Description
Removed the destination info from the request URI. The destination info contains secret and needs to be stored in the secret store and should not be saved along with the job record.

## Related issues
Addresses #503. Work item: [AB#69209](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/69209).

## Testing
Integration test.
