### PR TITLE
Updated the IsSystem property to be true for ExportJobRecord.

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Operations/Export/CosmosExportJobRecordWrapper.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Operations/Export/CosmosExportJobRecordWrapper.cs
@@ -42,6 +42,6 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Operations.Export
         public string ETag { get; protected set; }
 
         [JsonProperty(KnownDocumentProperties.IsSystem)]
-        public bool IsSystem { get; } = false;
+        public bool IsSystem { get; } = true;
     }
 }


### PR DESCRIPTION
## Description
Update the IsSystem property on ExportJobRecord to be true so it won't be treated as a resource.

## Related issues
Addresses #508. Work item: [AB#69207](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/69207).

## Testing
Manually tested. Automated test requires some significant refactoring work and therefore was not included here.