### PR TITLE
Downgrade DocumentDB.Core nuget to 2.2.2

### DIFF
--- a/src/Microsoft.Health.CosmosDb/Microsoft.Health.CosmosDb.csproj
+++ b/src/Microsoft.Health.CosmosDb/Microsoft.Health.CosmosDb.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="8.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.2.3" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.2.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.4" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />

--- a/src/Microsoft.Health.Fhir.CosmosDb/Microsoft.Health.Fhir.CosmosDb.csproj
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Microsoft.Health.Fhir.CosmosDb.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="6.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.2.3" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.2.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
   </ItemGroup>
 

--- a/test/Microsoft.Health.Fhir.Tests.E2E/Microsoft.Health.Fhir.Tests.E2E.csproj
+++ b/test/Microsoft.Health.Fhir.Tests.E2E/Microsoft.Health.Fhir.Tests.E2E.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="selenium.webdriver" Version="3.141.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.2.3" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Health.Fhir.Tests.E2E/Rest/HistoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Tests.E2E/Rest/HistoryTests.cs
@@ -92,7 +92,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.Contains("Changed by E2E test", obsHistory.Comment);
         }
 
-        [Fact(Skip ="History tests are unstable at the moment due to Cosmos DB issue with continuation tokens")]
+        // [Fact(Skip ="History tests are unstable at the moment due to Cosmos DB issue with continuation tokens")]
+        [Fact]
         public void WhenGettingSystemHistory_GivenAValueForSinceAndBeforeWithModifications_TheServerShouldOnlyCorrectResources()
         {
             var since = GetStartTimeForHistoryTest();
@@ -137,7 +138,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             }
         }
 
-        [Fact(Skip = "History tests are unstable at the moment due to Cosmos DB issue with continuation tokens")]
+        // [Fact(Skip = "History tests are unstable at the moment due to Cosmos DB issue with continuation tokens")]
+        [Fact]
         public async Task WhenGettingSystemHistory_GivenAValueForSinceAndBeforeCloseToLastModifiedTime_TheServerShouldNotMissRecords()
         {
             var since = GetStartTimeForHistoryTest();
@@ -188,16 +190,17 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             }
         }
 
-        [Fact(Skip = "History tests are unstable at the moment due to Cosmos DB issue with continuation tokens")]
+        // [Fact(Skip = "History tests are unstable at the moment due to Cosmos DB issue with continuation tokens")]
+        [Fact]
         public async Task WhenGettingSystemHistory_GivenAQueryThatReturnsMoreThan10Results_TheServerShouldBatchTheResponse()
         {
             // The batch test does not work reliably on local Cosmos DB Emulator
             // Skip the test if this is local
             // There is no remote FHIR server. Skip test
-            if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("TestEnvironmentUrl")))
-            {
-                return;
-            }
+            // if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("TestEnvironmentUrl")))
+           // {
+            //    return;
+            // }
 
             var since = GetStartTimeForHistoryTest();
 

--- a/test/Microsoft.Health.Fhir.Tests.Integration/Microsoft.Health.Fhir.Tests.Integration.csproj
+++ b/test/Microsoft.Health.Fhir.Tests.Integration/Microsoft.Health.Fhir.Tests.Integration.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.2.3" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/Microsoft.Health.Extensions.BuildTimeCodeGenerator.csproj
+++ b/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/Microsoft.Health.Extensions.BuildTimeCodeGenerator.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="8.1.1" />
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.2.3" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.2.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="2.10.0" />
     <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.4384.2-preview" />
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.2.0-alpha.19174.3" />


### PR DESCRIPTION
## Description
Downgrade DocumentDB.Core nuget to 2.2.2 to avoid null reference exception with continuation tokens

## Related issues
Addresses [issue #].

## Testing
History tests which result in batched responses were enabled.
