### PR TITLE
Adds support for search parameter chaining with SQL

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/ChainedExpression.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/ChainedExpression.cs
@@ -17,22 +17,22 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// Initializes a new instance of the <see cref="ChainedExpression"/> class.
         /// </summary>
         /// <param name="resourceType">The resource type that supports this search expression.</param>
-        /// <param name="paramName">The search parameter name.</param>
+        /// <param name="referenceSearchParameter">The search parameter that establishes the reference</param>
         /// <param name="targetResourceType">The target resource type.</param>
         /// <param name="expression">The search expression.</param>
         public ChainedExpression(
             string resourceType,
-            string paramName,
+            SearchParameterInfo referenceSearchParameter,
             string targetResourceType,
             Expression expression)
         {
             EnsureArg.IsTrue(ModelInfoProvider.IsKnownResource(resourceType), nameof(resourceType));
-            EnsureArg.IsNotNullOrWhiteSpace(paramName, nameof(paramName));
+            EnsureArg.IsNotNull(referenceSearchParameter, nameof(referenceSearchParameter));
             EnsureArg.IsTrue(ModelInfoProvider.IsKnownResource(targetResourceType), nameof(targetResourceType));
             EnsureArg.IsNotNull(expression, nameof(expression));
 
             ResourceType = resourceType;
-            ParamName = paramName;
+            ReferenceSearchParameter = referenceSearchParameter;
             TargetResourceType = targetResourceType;
             Expression = expression;
         }
@@ -45,7 +45,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// <summary>
         /// Gets the parameter name.
         /// </summary>
-        public string ParamName { get; }
+        public SearchParameterInfo ReferenceSearchParameter { get; }
 
         /// <summary>
         /// Gets the target resource type.
@@ -66,7 +66,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
 
         public override string ToString()
         {
-            return $"(Chain {ParamName}:{TargetResourceType} {Expression})";
+            return $"(Chain {ReferenceSearchParameter.Name}:{TargetResourceType} {Expression})";
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Expression.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Expression.cs
@@ -59,13 +59,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// Creates a <see cref="ChainedExpression"/> that represents chained operation.
         /// </summary>
         /// <param name="resourceType">The resource type.</param>
-        /// <param name="paramName">The chained parameter name.</param>
+        /// <param name="referenceSearchParameter">The search parameter that establishes the reference between resources</param>
         /// <param name="targetResourceType">The target resource type.</param>
         /// <param name="expression">The expression.</param>
-        /// <returns>A <see cref="ChainedExpression"/> that represents chained operation on <paramref name="targetResourceType"/> through <paramref name="paramName"/>.</returns>
-        public static ChainedExpression Chained(string resourceType, string paramName, string targetResourceType, Expression expression)
+        /// <returns>A <see cref="ChainedExpression"/> that represents chained operation on <paramref name="targetResourceType"/> through <paramref name="referenceSearchParameter"/>.</returns>
+        public static ChainedExpression Chained(string resourceType, SearchParameterInfo referenceSearchParameter, string targetResourceType, Expression expression)
         {
-            return new ChainedExpression(resourceType, paramName, targetResourceType, expression);
+            return new ChainedExpression(resourceType, referenceSearchParameter, targetResourceType, expression);
         }
 
         /// <summary>

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/ExpressionRewriter.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/ExpressionRewriter.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
                 return expression;
             }
 
-            return new ChainedExpression(resourceType: expression.ResourceType, paramName: expression.ParamName, targetResourceType: expression.TargetResourceType, expression: visitedExpression);
+            return new ChainedExpression(resourceType: expression.ResourceType, referenceSearchParameter: expression.ReferenceSearchParameter, targetResourceType: expression.TargetResourceType, expression: visitedExpression);
         }
 
         public virtual Expression VisitMissingField(MissingFieldExpression expression, TContext context)

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -106,6 +106,15 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The reference search parameter &apos;{0}&apos; refers to multiple possible resource types. Please specify a type in the search expression: {1}.
+        /// </summary>
+        internal static string ChainedParameterSpecifyType {
+            get {
+                return ResourceManager.GetString("ChainedParameterSpecifyType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Comparator &apos;{0}&apos; is not supported for search parameter &apos;{1}&apos;..
         /// </summary>
         internal static string ComparatorNotSupported {
@@ -435,6 +444,15 @@ namespace Microsoft.Health.Fhir.Core {
         internal static string OpenIdConfiguration {
             get {
                 return ResourceManager.GetString("OpenIdConfiguration", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to  or .
+        /// </summary>
+        internal static string OrDelimiter {
+            get {
+                return ResourceManager.GetString("OrDelimiter", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -132,6 +132,10 @@
   <data name="ChainedParameterNotSupported" xml:space="preserve">
     <value>The chained parameter is not supported.</value>
   </data>
+  <data name="ChainedParameterSpecifyType" xml:space="preserve">
+    <value>The reference search parameter '{0}' refers to multiple possible resource types. Please specify a type in the search expression: {1}</value>
+    <comment>{1}: space-delimited list of search examples.</comment>
+  </data>
   <data name="ComparatorNotSupported" xml:space="preserve">
     <value>Comparator '{0}' is not supported for search parameter '{1}'.</value>
   </data>
@@ -244,6 +248,10 @@
   </data>
   <data name="OpenIdConfiguration" xml:space="preserve">
     <value>Failed to retrieve the OpenId configuration from the authentication provider.</value>
+  </data>
+  <data name="OrDelimiter" xml:space="preserve">
+    <value> or </value>
+    <comment>Used as a list delimiter. Note the spaces.</comment>
   </data>
   <data name="ReadHistoryDisabled" xml:space="preserve">
     <value>ReadHistory is disabled for resources of type '{0}'.</value>

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/ExpressionRewriterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/ExpressionRewriterTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions
             var simpleExpression2 = Expression.Equals(FieldName.Number, null, 5M);
             VerifyVisit(simpleExpression1);
             VerifyVisit(Expression.SearchParameter(new SearchParameterInfo("my-param"), simpleExpression1));
-            VerifyVisit(Expression.Chained("Observation", "subject", "Patient", simpleExpression1));
+            VerifyVisit(Expression.Chained("Observation", new SearchParameterInfo("subject"), "Patient", simpleExpression1));
             VerifyVisit(Expression.CompartmentSearch("Patient", "x"));
             VerifyVisit(Expression.Missing(FieldName.Quantity, null));
             VerifyVisit(Expression.MissingSearchParameter(new SearchParameterInfo("my-param"), true));
@@ -52,7 +52,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions
 
             VerifyVisit($"(Param my-param {expectedAndString1})", Expression.SearchParameter(new SearchParameterInfo("my-param"), simpleExpression1));
 
-            VerifyVisit($"(Chain subject:Patient {expectedAndString1})", Expression.Chained("Observation", "subject", "Patient", simpleExpression1));
+            VerifyVisit($"(Chain subject:Patient {expectedAndString1})", Expression.Chained("Observation", new SearchParameterInfo("subject"), "Patient", simpleExpression1));
             VerifyVisit($"(Or {expectedAndString1} {expectedAndString2})", Expression.Or(simpleExpression1, simpleExpression2));
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/ExpressionToStringTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/ExpressionToStringTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions
 
             VerifyExpression("(Compartment Patient 'x')", Expression.CompartmentSearch("Patient", "x"));
 
-            VerifyExpression("(Chain subject:Patient (FieldGreaterThan DateTimeEnd 2000-01-01T00:00:00.0000000))", Expression.Chained("Observation", "subject", "Patient", Expression.GreaterThan(FieldName.DateTimeEnd, null, new DateTime(2000, 1, 1))));
+            VerifyExpression("(Chain subject:Patient (FieldGreaterThan DateTimeEnd 2000-01-01T00:00:00.0000000))", Expression.Chained("Observation", new SearchParameterInfo("subject"), "Patient", Expression.GreaterThan(FieldName.DateTimeEnd, null, new DateTime(2000, 1, 1))));
         }
 
         private static void VerifyExpression(string expected, Expression expression)

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchExpressionTestHelper.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchExpressionTestHelper.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
+using Microsoft.Health.Fhir.Core.Models;
 using Xunit;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
@@ -29,14 +30,14 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         public static void ValidateChainedExpression(
             Expression expression,
             Hl7.Fhir.Model.ResourceType resourceType,
-            string key,
+            SearchParameterInfo referenceSearchParam,
             string targetResourceType,
             Action<Expression> childExpressionValidator)
         {
             ChainedExpression chainedExpression = Assert.IsType<ChainedExpression>(expression);
 
             Assert.Equal(resourceType.ToString(), chainedExpression.ResourceType);
-            Assert.Equal(key, chainedExpression.ParamName);
+            Assert.Equal(referenceSearchParam, chainedExpression.ReferenceSearchParameter);
             Assert.Equal(targetResourceType, chainedExpression.TargetResourceType);
 
             childExpressionValidator(chainedExpression.Expression);
@@ -45,14 +46,14 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         public static void ValidateChainedExpression(
             Expression expression,
             Type resourceType,
-            string key,
+            SearchParameterInfo referenceSearchParam,
             Type targetResourceType,
             Action<Expression> childExpressionValidator)
         {
             ChainedExpression chainedExpression = Assert.IsType<ChainedExpression>(expression);
 
             Assert.Equal(resourceType.ToString(), chainedExpression.ResourceType);
-            Assert.Equal(key, chainedExpression.ParamName);
+            Assert.Equal(referenceSearchParam, chainedExpression.ReferenceSearchParameter);
             Assert.Equal(targetResourceType.ToString(), chainedExpression.TargetResourceType.ToString());
 
             childExpressionValidator(chainedExpression.Expression);

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Expressions/Parsers/ExpressionParser.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Expressions/Parsers/ExpressionParser.cs
@@ -102,7 +102,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
                 $"The {nameof(currentIndex)} is invalid.");
 
             PathSegment path = paths[currentIndex];
-            string currentPath = path.Path;
             string targetResourceType = path.ModifierOrResourceType;
 
             // We have more paths after this so this is a chained expression.
@@ -136,7 +135,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
                     {
                         return Expression.Chained(
                             resourceType,
-                            currentPath,
+                            searchParameter,
                             targetType,
                             Parse(
                                 targetType,

--- a/src/Microsoft.Health.Fhir.SqlServer.Api/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.Api/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
@@ -91,6 +91,10 @@ namespace Microsoft.Extensions.DependencyInjection
                 .Singleton()
                 .AsSelf();
 
+            services.Add<ChainFlatteningRewriter>()
+                .Singleton()
+                .AsSelf();
+
             return fhirServerBuilder;
         }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/1.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/1.sql
@@ -835,6 +835,22 @@ INCLUDE
 WHERE IsHistory = 0
 WITH (DATA_COMPRESSION = PAGE)
 
+
+CREATE NONCLUSTERED INDEX IX_ReferenceSearchParam_SearchParamId_ResourceTypeId_ReferenceResourceTypeId_ReferenceResourceId
+ON dbo.ReferenceSearchParam
+(
+	SearchParamId,
+	ResourceTypeId,
+	ReferenceResourceTypeId,
+	ReferenceResourceId
+)
+INCLUDE
+(
+    ReferenceResourceVersion,
+	BaseUri
+)
+WHERE IsHistory = 0
+
 GO
 
 /*************************************************************

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaInitializer.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaInitializer.cs
@@ -163,6 +163,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema
                         }
                     }
                 }
+            }
 
             // now switch to the target database
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaInitializer.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaInitializer.cs
@@ -163,7 +163,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema
                         }
                     }
                 }
-            }
 
             // now switch to the target database
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/TableExpression.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/TableExpression.cs
@@ -18,8 +18,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions
         public TableExpression(
             NormalizedSearchParameterQueryGenerator searchParameterQueryGenerator,
             Expression normalizedPredicate,
-            Expression denormalizedPredicate = null,
-            TableExpressionKind kind = TableExpressionKind.Normal)
+            Expression denormalizedPredicate,
+            TableExpressionKind kind,
+            int chainLevel = 0)
         {
             switch (normalizedPredicate)
             {
@@ -36,9 +37,12 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions
             NormalizedPredicate = normalizedPredicate;
             DenormalizedPredicate = denormalizedPredicate;
             Kind = kind;
+            ChainLevel = chainLevel;
         }
 
         public TableExpressionKind Kind { get; }
+
+        public int ChainLevel { get; }
 
         public NormalizedSearchParameterQueryGenerator SearchParameterQueryGenerator { get; }
 
@@ -58,7 +62,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions
 
         public override string ToString()
         {
-            return $"(Table {SearchParameterQueryGenerator.Table} Normalized:{NormalizedPredicate} Denormalized:{DenormalizedPredicate})";
+            return $"(Table {Kind} {(ChainLevel == 0 ? null : $"ChainLevel:{ChainLevel} ")}{SearchParameterQueryGenerator?.Table} Normalized:{NormalizedPredicate} Denormalized:{DenormalizedPredicate})";
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/TableExpressionKind.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/TableExpressionKind.cs
@@ -37,5 +37,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions
         /// Represents a table expression that applies a TOP operator over its predecessor.
         /// </summary>
         Top,
+
+        ChainAnchor,
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/TableExpressionKind.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/TableExpressionKind.cs
@@ -38,6 +38,10 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions
         /// </summary>
         Top,
 
-        ChainAnchor,
+        /// <summary>
+        /// Represents a table expression that serves as the JOIN between a resource and target reference
+        /// in a chained search.
+        /// </summary>
+        Chain,
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/ChainFlatteningRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/ChainFlatteningRewriter.cs
@@ -1,0 +1,112 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EnsureThat;
+using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
+using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.QueryGenerators;
+
+namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
+{
+    internal class ChainFlatteningRewriter : SqlExpressionRewriterWithInitialContext<(TableExpression containingTableExpression, int chainLevel)>
+    {
+        private readonly NormalizedSearchParameterQueryGeneratorFactory _normalizedSearchParameterQueryGeneratorFactory;
+
+        public ChainFlatteningRewriter(NormalizedSearchParameterQueryGeneratorFactory normalizedSearchParameterQueryGeneratorFactory)
+        {
+            EnsureArg.IsNotNull(normalizedSearchParameterQueryGeneratorFactory, nameof(normalizedSearchParameterQueryGeneratorFactory));
+            _normalizedSearchParameterQueryGeneratorFactory = normalizedSearchParameterQueryGeneratorFactory;
+        }
+
+        public override Expression VisitChained(ChainedExpression expression, (TableExpression containingTableExpression, int chainLevel) context)
+        {
+            TableExpression thisTableExpression;
+            if (expression.Expression is ChainedExpression)
+            {
+                thisTableExpression = context.containingTableExpression ??
+                                      new TableExpression(
+                                          ChainAnchorQueryGenerator.Instance,
+                                          expression,
+                                          null,
+                                          TableExpressionKind.ChainAnchor,
+                                          context.chainLevel);
+
+                Expression visitedExpression = expression.Expression.AcceptVisitor(this, (null, context.chainLevel + 1));
+
+                switch (visitedExpression)
+                {
+                    case TableExpression child:
+                        return Expression.And(thisTableExpression, child);
+                    case MultiaryExpression multiary when multiary.MultiaryOperation == MultiaryOperator.And:
+                        var tableExpressions = new List<TableExpression> { thisTableExpression };
+                        tableExpressions.AddRange(multiary.Expressions.Cast<TableExpression>());
+                        return Expression.And(tableExpressions);
+                    default:
+                        throw new InvalidOperationException("Unexpected return type");
+                }
+            }
+
+            NormalizedSearchParameterQueryGenerator normalizedParameterQueryGenerator = expression.Expression.AcceptVisitor(_normalizedSearchParameterQueryGeneratorFactory);
+
+            thisTableExpression = context.containingTableExpression;
+
+            if (thisTableExpression == null || normalizedParameterQueryGenerator == null)
+            {
+                thisTableExpression = new TableExpression(
+                    ChainAnchorQueryGenerator.Instance,
+                    expression,
+                    denormalizedPredicate: normalizedParameterQueryGenerator == null ? expression.Expression : null,
+                    TableExpressionKind.ChainAnchor,
+                    context.chainLevel);
+            }
+
+            if (normalizedParameterQueryGenerator == null)
+            {
+                return thisTableExpression;
+            }
+
+            var childTableExpression = new TableExpression(normalizedParameterQueryGenerator, expression.Expression, null, TableExpressionKind.Normal, context.chainLevel);
+
+            return Expression.And(thisTableExpression, childTableExpression);
+        }
+
+        public override Expression VisitSqlRoot(SqlRootExpression expression, (TableExpression containingTableExpression, int chainLevel) context)
+        {
+            List<TableExpression> newTableExpressions = null;
+            for (var i = 0; i < expression.TableExpressions.Count; i++)
+            {
+                TableExpression tableExpression = expression.TableExpressions[i];
+                if (tableExpression.Kind != TableExpressionKind.ChainAnchor)
+                {
+                    newTableExpressions?.Add(tableExpression);
+                    continue;
+                }
+
+                Expression visitedNormalizedPredicate = tableExpression.NormalizedPredicate.AcceptVisitor(this, (tableExpression, tableExpression.ChainLevel));
+                switch (visitedNormalizedPredicate)
+                {
+                    case TableExpression convertedExpression:
+                        EnsureAllocatedAndPopulated(ref newTableExpressions, expression.TableExpressions, i);
+                        newTableExpressions.Add(convertedExpression);
+                        break;
+                    case MultiaryExpression multiary when multiary.MultiaryOperation == MultiaryOperator.And:
+                        EnsureAllocatedAndPopulated(ref newTableExpressions, expression.TableExpressions, i);
+
+                        newTableExpressions.AddRange(multiary.Expressions.Cast<TableExpression>());
+                        break;
+                }
+            }
+
+            if (newTableExpressions == null)
+            {
+                return expression;
+            }
+
+            return new SqlRootExpression(newTableExpressions, expression.DenormalizedExpressions);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/ChainFlatteningRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/ChainFlatteningRewriter.cs
@@ -12,6 +12,11 @@ using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Query
 
 namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
 {
+    /// <summary>
+    /// Flattens chained expressions into <see cref="SqlRootExpression"/>'s <see cref="SqlRootExpression.TableExpressions"/> list.
+    /// The expression within a chained expression is promoted to a top-level table expression, but we keep track of the height
+    /// via the <see cref="TableExpression.ChainLevel"/>.
+    /// </summary>
     internal class ChainFlatteningRewriter : SqlExpressionRewriterWithInitialContext<(TableExpression containingTableExpression, int chainLevel)>
     {
         private readonly NormalizedSearchParameterQueryGeneratorFactory _normalizedSearchParameterQueryGeneratorFactory;
@@ -32,7 +37,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
                                           ChainAnchorQueryGenerator.Instance,
                                           expression,
                                           null,
-                                          TableExpressionKind.ChainAnchor,
+                                          TableExpressionKind.Chain,
                                           context.chainLevel);
 
                 Expression visitedExpression = expression.Expression.AcceptVisitor(this, (null, context.chainLevel + 1));
@@ -60,7 +65,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
                     ChainAnchorQueryGenerator.Instance,
                     expression,
                     denormalizedPredicate: normalizedParameterQueryGenerator == null ? expression.Expression : null,
-                    TableExpressionKind.ChainAnchor,
+                    TableExpressionKind.Chain,
                     context.chainLevel);
             }
 
@@ -80,7 +85,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
             for (var i = 0; i < expression.TableExpressions.Count; i++)
             {
                 TableExpression tableExpression = expression.TableExpressions[i];
-                if (tableExpression.Kind != TableExpressionKind.ChainAnchor)
+                if (tableExpression.Kind != TableExpressionKind.Chain)
                 {
                     newTableExpressions?.Add(tableExpression);
                     continue;

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/ConcatenationRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/ConcatenationRewriter.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
                     if (!ReferenceEquals(newNormalizedPredicate, tableExpression.NormalizedPredicate))
                     {
                         found = true;
-                        tableExpression = new TableExpression(tableExpression.SearchParameterQueryGenerator, newNormalizedPredicate, tableExpression.DenormalizedPredicate);
+                        tableExpression = new TableExpression(tableExpression.SearchParameterQueryGenerator, newNormalizedPredicate, tableExpression.DenormalizedPredicate, tableExpression.Kind, tableExpression.ChainLevel);
                     }
                 }
                 else

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/ConcatenationRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/ConcatenationRewriter.cs
@@ -43,18 +43,24 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
                 TableExpression tableExpression = expression.TableExpressions[i];
                 bool found = false;
 
-                if (_rewritingScout != null)
+                // The expressions contained within a ChainExpression
+                // have been promoted to TableExpressions in this list.
+                // Those are considered, not these.
+                if (tableExpression.Kind != TableExpressionKind.Chain)
                 {
-                    var newNormalizedPredicate = tableExpression.NormalizedPredicate.AcceptVisitor(_rewritingScout, null);
-                    if (!ReferenceEquals(newNormalizedPredicate, tableExpression.NormalizedPredicate))
+                    if (_rewritingScout != null)
                     {
-                        found = true;
-                        tableExpression = new TableExpression(tableExpression.SearchParameterQueryGenerator, newNormalizedPredicate, tableExpression.DenormalizedPredicate, tableExpression.Kind, tableExpression.ChainLevel);
+                        var newNormalizedPredicate = tableExpression.NormalizedPredicate.AcceptVisitor(_rewritingScout, null);
+                        if (!ReferenceEquals(newNormalizedPredicate, tableExpression.NormalizedPredicate))
+                        {
+                            found = true;
+                            tableExpression = new TableExpression(tableExpression.SearchParameterQueryGenerator, newNormalizedPredicate, tableExpression.DenormalizedPredicate, tableExpression.Kind, tableExpression.ChainLevel);
+                        }
                     }
-                }
-                else
-                {
-                    found = tableExpression.NormalizedPredicate.AcceptVisitor(_booleanScout, null);
+                    else
+                    {
+                        found = tableExpression.NormalizedPredicate.AcceptVisitor(_booleanScout, null);
+                    }
                 }
 
                 if (found)
@@ -88,7 +94,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
                 tableExpression.SearchParameterQueryGenerator,
                 normalizedPredicate,
                 tableExpression.DenormalizedPredicate,
-                TableExpressionKind.Concatenation);
+                TableExpressionKind.Concatenation,
+                tableExpression.ChainLevel);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/DenormalizedPredicateRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/DenormalizedPredicateRewriter.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
 
         public Expression VisitSqlRoot(SqlRootExpression expression, object context)
         {
-            if (expression.TableExpressions.Count == 0 || expression.DenormalizedExpressions.Count == 0 || expression.TableExpressions.All(t => t.Kind == TableExpressionKind.ChainAnchor))
+            if (expression.TableExpressions.Count == 0 || expression.DenormalizedExpressions.Count == 0 || expression.TableExpressions.All(t => t.Kind == TableExpressionKind.Chain))
             {
                 return expression;
             }
@@ -59,7 +59,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
             var newTableExpressions = new List<TableExpression>(expression.TableExpressions.Count);
             foreach (var tableExpression in expression.TableExpressions)
             {
-                if (tableExpression.Kind == TableExpressionKind.ChainAnchor)
+                if (tableExpression.Kind == TableExpressionKind.Chain)
                 {
                     newTableExpressions.Add(tableExpression);
                 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/NormalizedSearchParameterQueryGeneratorFactory.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/NormalizedSearchParameterQueryGeneratorFactory.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
 
         public NormalizedSearchParameterQueryGenerator VisitChained(ChainedExpression expression, object context)
         {
-            throw new System.NotImplementedException();
+            return ChainAnchorQueryGenerator.Instance;
         }
 
         public NormalizedSearchParameterQueryGenerator VisitMissingField(MissingFieldExpression expression, object context)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/ChainAnchorQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/ChainAnchorQueryGenerator.cs
@@ -1,0 +1,16 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Fhir.SqlServer.Features.Schema.Model;
+
+namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.QueryGenerators
+{
+    internal class ChainAnchorQueryGenerator : NormalizedSearchParameterQueryGenerator
+    {
+        internal static readonly ChainAnchorQueryGenerator Instance = new ChainAnchorQueryGenerator();
+
+        public override Table Table => null;
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/CompartmentSearchParameterQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/CompartmentSearchParameterQueryGenerator.cs
@@ -14,17 +14,17 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
         public override Table Table => V1.CompartmentAssignment;
 
-        public override SqlQueryGenerator VisitCompartment(CompartmentSearchExpression expression, SqlQueryGenerator context)
+        public override SearchParameterQueryGeneratorContext VisitCompartment(CompartmentSearchExpression expression, SearchParameterQueryGeneratorContext context)
         {
             byte compartmentTypeId = context.Model.GetCompartmentTypeId(expression.CompartmentType);
 
             context.StringBuilder
-                .Append(V1.CompartmentAssignment.CompartmentTypeId)
+                .Append(V1.CompartmentAssignment.CompartmentTypeId, context.TableAlias)
                 .Append(" = ")
                 .Append(context.Parameters.AddParameter(V1.CompartmentAssignment.CompartmentTypeId, compartmentTypeId))
                 .AppendLine()
                 .Append("AND ")
-                .Append(V1.CompartmentAssignment.ReferenceResourceId)
+                .Append(V1.CompartmentAssignment.ReferenceResourceId, context.TableAlias)
                 .Append(" = ")
                 .Append(context.Parameters.AddParameter(V1.CompartmentAssignment.ReferenceResourceId, expression.CompartmentId));
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/CompositeSearchParameterQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/CompositeSearchParameterQueryGenerator.cs
@@ -18,17 +18,17 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             _componentHandlers = componentHandlers;
         }
 
-        public override SqlQueryGenerator VisitBinary(BinaryExpression expression, SqlQueryGenerator context)
+        public override SearchParameterQueryGeneratorContext VisitBinary(BinaryExpression expression, SearchParameterQueryGeneratorContext context)
         {
             return expression.AcceptVisitor(_componentHandlers[(int)expression.ComponentIndex], context);
         }
 
-        public override SqlQueryGenerator VisitString(StringExpression expression, SqlQueryGenerator context)
+        public override SearchParameterQueryGeneratorContext VisitString(StringExpression expression, SearchParameterQueryGeneratorContext context)
         {
             return expression.AcceptVisitor(_componentHandlers[(int)expression.ComponentIndex], context);
         }
 
-        public override SqlQueryGenerator VisitMissingField(MissingFieldExpression expression, SqlQueryGenerator context)
+        public override SearchParameterQueryGeneratorContext VisitMissingField(MissingFieldExpression expression, SearchParameterQueryGeneratorContext context)
         {
             return expression.AcceptVisitor(_componentHandlers[(int)expression.ComponentIndex], context);
         }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/DateTimeSearchParameterQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/DateTimeSearchParameterQueryGenerator.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
         public override Table Table => V1.DateTimeSearchParam;
 
-        public override SqlQueryGenerator VisitBinary(BinaryExpression expression, SqlQueryGenerator context)
+        public override SearchParameterQueryGeneratorContext VisitBinary(BinaryExpression expression, SearchParameterQueryGeneratorContext context)
         {
             DateTime2Column column;
             switch (expression.FieldName)
@@ -28,7 +28,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     break;
                 case SqlFieldName.DateTimeIsLongerThanADay:
                     // we don't want to use a parameter here because we want the query plan to use the filtered index based on this field
-                    context.StringBuilder.Append(V1.DateTimeSearchParam.IsLongerThanADay).Append(expression.ComponentIndex + 1).Append(" = ").Append((bool)expression.Value ? '1' : '0');
+                    context.StringBuilder.Append(V1.DateTimeSearchParam.IsLongerThanADay, context.TableAlias).Append(expression.ComponentIndex + 1).Append(" = ").Append((bool)expression.Value ? '1' : '0');
                     return context;
                 default:
                     throw new ArgumentOutOfRangeException(expression.FieldName.ToString());

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/DenormalizedSearchParameterQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/DenormalizedSearchParameterQueryGenerator.cs
@@ -7,14 +7,14 @@ using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
 
 namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.QueryGenerators
 {
-    internal class DenormalizedSearchParameterQueryGenerator : SearchParameterQueryGenerator
+    internal abstract class DenormalizedSearchParameterQueryGenerator : SearchParameterQueryGenerator
     {
-        public override SqlQueryGenerator VisitSearchParameter(SearchParameterExpression expression, SqlQueryGenerator context)
+        public override SearchParameterQueryGeneratorContext VisitSearchParameter(SearchParameterExpression expression, SearchParameterQueryGeneratorContext context)
         {
             return expression.Expression.AcceptVisitor(this, context);
         }
 
-        public override SqlQueryGenerator VisitMissingSearchParameter(MissingSearchParameterExpression expression, SqlQueryGenerator context)
+        public override SearchParameterQueryGeneratorContext VisitMissingSearchParameter(MissingSearchParameterExpression expression, SearchParameterQueryGeneratorContext context)
         {
             context.StringBuilder.Append(expression.IsMissing ? " 1 = 0 " : " 1 = 1 ");
             return context;

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/DispatchingDenormalizedSearchParameterQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/DispatchingDenormalizedSearchParameterQueryGenerator.cs
@@ -1,0 +1,41 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.Health.Fhir.Core.Features.Search;
+using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
+
+namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.QueryGenerators
+{
+    internal class DispatchingDenormalizedSearchParameterQueryGenerator : SearchParameterQueryGenerator
+    {
+        public static readonly DispatchingDenormalizedSearchParameterQueryGenerator Instance = new DispatchingDenormalizedSearchParameterQueryGenerator();
+
+        public override SearchParameterQueryGeneratorContext VisitSearchParameter(SearchParameterExpression expression, SearchParameterQueryGeneratorContext context)
+        {
+            return expression.Expression.AcceptVisitor(GetSearchParameterQueryGenerator(expression), context);
+        }
+
+        public override SearchParameterQueryGeneratorContext VisitMissingSearchParameter(MissingSearchParameterExpression expression, SearchParameterQueryGeneratorContext context)
+        {
+            return expression.AcceptVisitor(GetSearchParameterQueryGenerator(expression), context);
+        }
+
+        private SearchParameterQueryGenerator GetSearchParameterQueryGenerator(SearchParameterExpressionBase searchParameter)
+        {
+            switch (searchParameter.Parameter.Name)
+            {
+                case SearchParameterNames.Id:
+                    return ResourceIdParameterQueryGenerator.Instance;
+                case SearchParameterNames.ResourceType:
+                    return ResourceTypeIdParameterQueryGenerator.Instance;
+                case SqlSearchParameters.ResourceSurrogateIdParameterName:
+                    return ResourceSurrogateIdParameterQueryGenerator.Instance;
+                default:
+                    throw new NotSupportedException(searchParameter.Parameter.Name);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/NumberSearchParameterQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/NumberSearchParameterQueryGenerator.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
         public override Table Table => V1.NumberSearchParam;
 
-        public override SqlQueryGenerator VisitBinary(BinaryExpression expression, SqlQueryGenerator context)
+        public override SearchParameterQueryGeneratorContext VisitBinary(BinaryExpression expression, SearchParameterQueryGeneratorContext context)
         {
             NullableDecimalColumn valueColumn;
             NullableDecimalColumn nullCheckColumn;
@@ -35,7 +35,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     throw new ArgumentOutOfRangeException(expression.FieldName.ToString());
             }
 
-            context.StringBuilder.Append(nullCheckColumn).Append(expression.ComponentIndex + 1).Append(" IS NOT NULL AND ");
+            context.StringBuilder.Append(nullCheckColumn, context.TableAlias).Append(expression.ComponentIndex + 1).Append(" IS NOT NULL AND ");
             return VisitSimpleBinary(expression.BinaryOperator, context, valueColumn, expression.ComponentIndex, expression.Value);
         }
     }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/QuantitySearchParameterQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/QuantitySearchParameterQueryGenerator.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
         public override Table Table => V1.QuantitySearchParam;
 
-        public override SqlQueryGenerator VisitBinary(BinaryExpression expression, SqlQueryGenerator context)
+        public override SearchParameterQueryGeneratorContext VisitBinary(BinaryExpression expression, SearchParameterQueryGeneratorContext context)
         {
             NullableDecimalColumn valueColumn;
             NullableDecimalColumn nullCheckColumn;
@@ -35,11 +35,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     throw new ArgumentOutOfRangeException(expression.FieldName.ToString());
             }
 
-            context.StringBuilder.Append(nullCheckColumn).Append(expression.ComponentIndex + 1).Append(" IS NOT NULL AND ");
+            context.StringBuilder.Append(nullCheckColumn, context.TableAlias).Append(expression.ComponentIndex + 1).Append(" IS NOT NULL AND ");
             return VisitSimpleBinary(expression.BinaryOperator, context, valueColumn, expression.ComponentIndex, expression.Value);
         }
 
-        public override SqlQueryGenerator VisitString(StringExpression expression, SqlQueryGenerator context)
+        public override SearchParameterQueryGeneratorContext VisitString(StringExpression expression, SearchParameterQueryGeneratorContext context)
         {
             switch (expression.FieldName)
             {
@@ -49,12 +49,12 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                         return VisitSimpleBinary(BinaryOperator.Equal, context, V1.QuantitySearchParam.QuantityCodeId, expression.ComponentIndex, quantityCodeId);
                     }
 
-                    context.StringBuilder.Append(V1.QuantitySearchParam.QuantityCodeId)
+                    context.StringBuilder.Append(V1.QuantitySearchParam.QuantityCodeId, context.TableAlias)
                         .Append(" IN (SELECT ")
-                        .Append(V1.QuantityCode.QuantityCodeId)
+                        .Append(V1.QuantityCode.QuantityCodeId, null)
                         .Append(" FROM ").Append(V1.QuantityCode)
                         .Append(" WHERE ")
-                        .Append(V1.QuantityCode.Value)
+                        .Append(V1.QuantityCode.Value, null)
                         .Append(" = ")
                         .Append(context.Parameters.AddParameter(V1.QuantityCode.Value, expression.Value))
                         .Append(")");
@@ -67,12 +67,12 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                         return VisitSimpleBinary(BinaryOperator.Equal, context, V1.QuantitySearchParam.SystemId, expression.ComponentIndex, systemId);
                     }
 
-                    context.StringBuilder.Append(V1.QuantitySearchParam.SystemId)
+                    context.StringBuilder.Append(V1.QuantitySearchParam.SystemId, context.TableAlias)
                         .Append(" IN (SELECT ")
-                        .Append(V1.System.SystemId)
+                        .Append(V1.System.SystemId, null)
                         .Append(" FROM ").Append(V1.System)
                         .Append(" WHERE ")
-                        .Append(V1.System.Value)
+                        .Append(V1.System.Value, null)
                         .Append(" = ")
                         .Append(context.Parameters.AddParameter(V1.System.Value, expression.Value))
                         .Append(")");

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/ReferenceSearchParameterQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/ReferenceSearchParameterQueryGenerator.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
         public override Table Table => V1.ReferenceSearchParam;
 
-        public override SqlQueryGenerator VisitString(StringExpression expression, SqlQueryGenerator context)
+        public override SearchParameterQueryGeneratorContext VisitString(StringExpression expression, SearchParameterQueryGeneratorContext context)
         {
             switch (expression.FieldName)
             {
@@ -30,7 +30,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             }
         }
 
-        public override SqlQueryGenerator VisitMissingField(MissingFieldExpression expression, SqlQueryGenerator context)
+        public override SearchParameterQueryGeneratorContext VisitMissingField(MissingFieldExpression expression, SearchParameterQueryGeneratorContext context)
         {
             return VisitMissingFieldImpl(expression, context, FieldName.ReferenceBaseUri, V1.ReferenceSearchParam.BaseUri);
         }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/ResourceIdParameterQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/ResourceIdParameterQueryGenerator.cs
@@ -10,7 +10,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 {
     internal class ResourceIdParameterQueryGenerator : DenormalizedSearchParameterQueryGenerator
     {
-        public override SqlQueryGenerator VisitString(StringExpression expression, SqlQueryGenerator context)
+        public static readonly ResourceIdParameterQueryGenerator Instance = new ResourceIdParameterQueryGenerator();
+
+        public override SearchParameterQueryGeneratorContext VisitString(StringExpression expression, SearchParameterQueryGeneratorContext context)
         {
             VisitSimpleString(expression, context, V1.Resource.ResourceId, expression.Value);
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/ResourceSurrogateIdParameterQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/ResourceSurrogateIdParameterQueryGenerator.cs
@@ -10,7 +10,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 {
     internal class ResourceSurrogateIdParameterQueryGenerator : DenormalizedSearchParameterQueryGenerator
     {
-        public override SqlQueryGenerator VisitBinary(BinaryExpression expression, SqlQueryGenerator context)
+        public static readonly ResourceSurrogateIdParameterQueryGenerator Instance = new ResourceSurrogateIdParameterQueryGenerator();
+
+        public override SearchParameterQueryGeneratorContext VisitBinary(BinaryExpression expression, SearchParameterQueryGeneratorContext context)
         {
             VisitSimpleBinary(expression.BinaryOperator, context, V1.Resource.ResourceSurrogateId, expression.ComponentIndex, expression.Value);
             return context;

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/ResourceTypeIdParameterQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/ResourceTypeIdParameterQueryGenerator.cs
@@ -10,7 +10,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 {
     internal class ResourceTypeIdParameterQueryGenerator : DenormalizedSearchParameterQueryGenerator
     {
-        public override SqlQueryGenerator VisitString(StringExpression expression, SqlQueryGenerator context)
+        public static readonly ResourceTypeIdParameterQueryGenerator Instance = new ResourceTypeIdParameterQueryGenerator();
+
+        public override SearchParameterQueryGeneratorContext VisitString(StringExpression expression, SearchParameterQueryGeneratorContext context)
         {
             if (!context.Model.TryGetResourceTypeId(expression.Value, out var resourceTypeId))
             {

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SearchParameterQueryGeneratorContext.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SearchParameterQueryGeneratorContext.cs
@@ -1,0 +1,33 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using EnsureThat;
+using Microsoft.Health.Fhir.SqlServer.Features.Storage;
+
+namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.QueryGenerators
+{
+    internal readonly struct SearchParameterQueryGeneratorContext
+    {
+        internal SearchParameterQueryGeneratorContext(IndentedStringBuilder stringBuilder, SqlQueryParameterManager parameters, SqlServerFhirModel model, string tableAlias = null)
+        {
+            EnsureArg.IsNotNull(stringBuilder, nameof(stringBuilder));
+            EnsureArg.IsNotNull(parameters, nameof(parameters));
+            EnsureArg.IsNotNull(model, nameof(model));
+
+            StringBuilder = stringBuilder;
+            Parameters = parameters;
+            Model = model;
+            TableAlias = tableAlias;
+        }
+
+        public IndentedStringBuilder StringBuilder { get; }
+
+        public SqlQueryParameterManager Parameters { get; }
+
+        public SqlServerFhirModel Model { get; }
+
+        public string TableAlias { get; }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -172,7 +172,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     break;
 
                 case TableExpressionKind.Concatenation:
-                    StringBuilder.Append("SELECT Sid1 FROM ").AppendLine(TableExpressionName(_tableExpressionCounter - 1));
+                    StringBuilder.Append("SELECT * FROM ").AppendLine(TableExpressionName(_tableExpressionCounter - 1));
                     StringBuilder.AppendLine("UNION ALL");
 
                     goto case TableExpressionKind.Normal;
@@ -227,7 +227,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
                     break;
 
-                case TableExpressionKind.ChainAnchor:
+                case TableExpressionKind.Chain:
                     var chainedExpression = (ChainedExpression)tableExpression.NormalizedPredicate;
 
                     string referenceTableAlias = "ref";
@@ -314,7 +314,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             {
                 delimited.BeginDelimitedElement();
 
-                string columnToSelect = (tableExpression.Kind == TableExpressionKind.ChainAnchor ? tableExpression.ChainLevel - 1 : tableExpression.ChainLevel) == 0 ? "Sid1" : "Sid2";
+                string columnToSelect = (tableExpression.Kind == TableExpressionKind.Chain ? tableExpression.ChainLevel - 1 : tableExpression.ChainLevel) == 0 ? "Sid1" : "Sid2";
 
                 StringBuilder.Append(V1.Resource.ResourceSurrogateId, tableAlias).Append(" IN (SELECT ").Append(columnToSelect)
                     .Append(" FROM ").Append(TableExpressionName(predecessorIndex)).Append(")");
@@ -330,7 +330,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                 {
                     case TableExpressionKind.NotExists:
                     case TableExpressionKind.Normal:
-                    case TableExpressionKind.ChainAnchor:
+                    case TableExpressionKind.Chain:
                         return currentIndex - 1;
                     case TableExpressionKind.Concatenation:
                         return FindImpl(currentIndex - 1);

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -64,6 +64,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                 StringBuilder.AppendLine();
             }
 
+            string resourceTableAlias = "r";
+
             if (searchOptions.CountOnly)
             {
                 StringBuilder.AppendLine("SELECT COUNT(*)");
@@ -77,13 +79,13 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     StringBuilder.Append("TOP (").Append(Parameters.AddParameter(context.MaxItemCount + 1)).Append(") ");
                 }
 
-                StringBuilder.Append("r.").Append(V1.Resource.ResourceTypeId).Append(", ")
-                    .Append("r.").Append(V1.Resource.ResourceId).Append(", ")
-                    .Append("r.").Append(V1.Resource.Version).Append(", ")
-                    .Append("r.").Append(V1.Resource.IsDeleted).Append(", ")
-                    .Append("r.").Append(V1.Resource.ResourceSurrogateId).Append(", ")
-                    .Append("r.").Append(V1.Resource.RequestMethod).Append(", ")
-                    .Append("r.").AppendLine(V1.Resource.RawResource);
+                StringBuilder.Append(V1.Resource.ResourceTypeId, resourceTableAlias).Append(", ")
+                    .Append(V1.Resource.ResourceId, resourceTableAlias).Append(", ")
+                    .Append(V1.Resource.Version, resourceTableAlias).Append(", ")
+                    .Append(V1.Resource.IsDeleted, resourceTableAlias).Append(", ")
+                    .Append(V1.Resource.ResourceSurrogateId, resourceTableAlias).Append(", ")
+                    .Append(V1.Resource.RequestMethod, resourceTableAlias).Append(", ")
+                    .AppendLine(V1.Resource.RawResource, resourceTableAlias);
             }
 
             StringBuilder.Append("FROM ").Append(V1.Resource).AppendLine(" r");
@@ -93,13 +95,13 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                 if (expression.TableExpressions.Count > 0)
                 {
                     delimitedClause.BeginDelimitedElement();
-                    StringBuilder.Append("r.").Append(V1.Resource.ResourceSurrogateId).Append(" IN (SELECT Sid1 FROM ").Append(TableExpressionName(_tableExpressionCounter)).Append(")");
+                    StringBuilder.Append(V1.Resource.ResourceSurrogateId, resourceTableAlias).Append(" IN (SELECT Sid1 FROM ").Append(TableExpressionName(_tableExpressionCounter)).Append(")");
                 }
 
                 foreach (var denormalizedPredicate in expression.DenormalizedExpressions)
                 {
                     delimitedClause.BeginDelimitedElement();
-                    denormalizedPredicate.AcceptVisitor(this, context);
+                    denormalizedPredicate.AcceptVisitor(DispatchingDenormalizedSearchParameterQueryGenerator.Instance, GetContext());
                 }
 
                 if (expression.TableExpressions.Count == 0)
@@ -111,7 +113,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
             if (!searchOptions.CountOnly)
             {
-                StringBuilder.Append("ORDER BY r.").Append(V1.Resource.ResourceSurrogateId).AppendLine(" ASC");
+                StringBuilder.Append("ORDER BY ").Append(V1.Resource.ResourceSurrogateId, resourceTableAlias).AppendLine(" ASC");
             }
 
             StringBuilder.Append("OPTION(RECOMPILE)");
@@ -127,25 +129,43 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             {
                 case TableExpressionKind.Normal:
 
-                    StringBuilder.Append("SELECT ").Append(V1.Resource.ResourceSurrogateId).AppendLine(" AS Sid1")
-                        .Append("FROM ").AppendLine(tableExpression.SearchParameterQueryGenerator.Table);
+                    if (tableExpression.ChainLevel == 0)
+                    {
+                        StringBuilder.Append("SELECT ").Append(V1.Resource.ResourceSurrogateId, null).AppendLine(" AS Sid1")
+                            .Append("FROM ").AppendLine(tableExpression.SearchParameterQueryGenerator.Table);
+                    }
+                    else
+                    {
+                        StringBuilder.Append("SELECT Sid1, ").Append(V1.Resource.ResourceSurrogateId, null).AppendLine(" AS Sid2")
+                            .Append("FROM ").AppendLine(tableExpression.SearchParameterQueryGenerator.Table)
+                            .Append("INNER JOIN ").AppendLine(TableExpressionName(FindRestrictingPredecessorTableExpressionIndex()));
+
+                        using (var delimited = StringBuilder.BeginDelimitedOnClause())
+                        {
+                            delimited.BeginDelimitedElement().Append(V1.Resource.ResourceSurrogateId, null).Append(" = ").Append("Sid2");
+                        }
+                    }
 
                     using (var delimited = StringBuilder.BeginDelimitedWhereClause())
                     {
                         AppendHistoryClause(delimited);
 
-                        AppendIntersectionWithPredecessor(delimited, tableExpression);
+                        if (tableExpression.ChainLevel == 0)
+                        {
+                            // if chainLevel > 0, the intersection is already handled in the JOIN
+                            AppendIntersectionWithPredecessor(delimited, tableExpression);
+                        }
 
                         if (tableExpression.DenormalizedPredicate != null)
                         {
                             delimited.BeginDelimitedElement();
-                            tableExpression.DenormalizedPredicate?.AcceptVisitor(this, context);
+                            tableExpression.DenormalizedPredicate?.AcceptVisitor(DispatchingDenormalizedSearchParameterQueryGenerator.Instance, GetContext());
                         }
 
                         if (tableExpression.NormalizedPredicate != null)
                         {
                             delimited.BeginDelimitedElement();
-                            tableExpression.NormalizedPredicate.AcceptVisitor(tableExpression.SearchParameterQueryGenerator, this);
+                            tableExpression.NormalizedPredicate.AcceptVisitor(tableExpression.SearchParameterQueryGenerator, GetContext());
                         }
                     }
 
@@ -158,7 +178,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     goto case TableExpressionKind.Normal;
 
                 case TableExpressionKind.All:
-                    StringBuilder.Append("SELECT ").Append(V1.Resource.ResourceSurrogateId).AppendLine(" AS Sid1")
+                    StringBuilder.Append("SELECT ").Append(V1.Resource.ResourceSurrogateId, null).AppendLine(" AS Sid1")
                         .Append("FROM ").AppendLine(V1.Resource);
 
                     using (var delimited = StringBuilder.BeginDelimitedWhereClause())
@@ -168,7 +188,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                         if (tableExpression.DenormalizedPredicate != null)
                         {
                             delimited.BeginDelimitedElement();
-                            tableExpression.DenormalizedPredicate?.AcceptVisitor(this, context);
+                            tableExpression.DenormalizedPredicate?.AcceptVisitor(DispatchingDenormalizedSearchParameterQueryGenerator.Instance, GetContext());
                         }
                     }
 
@@ -180,7 +200,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
                     using (StringBuilder.Indent())
                     {
-                        StringBuilder.Append("SELECT ").AppendLine(V1.Resource.ResourceSurrogateId)
+                        StringBuilder.Append("SELECT ").AppendLine(V1.Resource.ResourceSurrogateId, null)
                             .Append("FROM ").AppendLine(tableExpression.SearchParameterQueryGenerator.Table);
                         using (var delimited = StringBuilder.BeginDelimitedWhereClause())
                         {
@@ -189,11 +209,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                             if (tableExpression.DenormalizedPredicate != null)
                             {
                                 delimited.BeginDelimitedElement();
-                                tableExpression.DenormalizedPredicate?.AcceptVisitor(this, context);
+                                tableExpression.DenormalizedPredicate?.AcceptVisitor(DispatchingDenormalizedSearchParameterQueryGenerator.Instance, GetContext());
                             }
 
                             delimited.BeginDelimitedElement();
-                            tableExpression.NormalizedPredicate.AcceptVisitor(tableExpression.SearchParameterQueryGenerator, this);
+                            tableExpression.NormalizedPredicate.AcceptVisitor(tableExpression.SearchParameterQueryGenerator, GetContext());
                         }
                     }
 
@@ -210,38 +230,60 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                 case TableExpressionKind.ChainAnchor:
                     var chainedExpression = (ChainedExpression)tableExpression.NormalizedPredicate;
 
-                    StringBuilder.Append("SELECT ref.").Append(V1.ReferenceSearchParam.ResourceSurrogateId).Append(" AS Sid1, r.").Append(V1.Resource.ResourceSurrogateId).AppendLine(" AS Sid2")
-                        .Append("FROM ").Append(V1.ReferenceSearchParam).AppendLine(" ref")
-                        .Append("INNER JOIN ").Append(V1.Resource).AppendLine(" r");
+                    string referenceTableAlias = "ref";
+                    string resourceTableAlias = "r";
+
+                    StringBuilder.Append("SELECT ");
+                    if (tableExpression.ChainLevel == 1)
+                    {
+                        StringBuilder.Append(V1.ReferenceSearchParam.ResourceSurrogateId, referenceTableAlias).Append(" AS Sid1, ");
+                    }
+                    else
+                    {
+                        StringBuilder.Append("Sid1, ");
+                    }
+
+                    StringBuilder.Append(V1.Resource.ResourceSurrogateId, resourceTableAlias).AppendLine(" AS Sid2")
+                        .Append("FROM ").Append(V1.ReferenceSearchParam).Append(' ').AppendLine(referenceTableAlias)
+                        .Append("INNER JOIN ").Append(V1.Resource).Append(' ').AppendLine(resourceTableAlias);
 
                     using (var delimited = StringBuilder.BeginDelimitedOnClause())
                     {
-                        delimited.BeginDelimitedElement().Append("ref.").Append(V1.ReferenceSearchParam.ReferenceResourceTypeId)
-                            .Append(" = r.").Append(V1.Resource.ResourceTypeId);
+                        delimited.BeginDelimitedElement().Append(V1.ReferenceSearchParam.ReferenceResourceTypeId, referenceTableAlias)
+                            .Append(" = ").Append(V1.Resource.ResourceTypeId, resourceTableAlias);
 
-                        delimited.BeginDelimitedElement().Append("ref.").Append(V1.ReferenceSearchParam.ReferenceResourceId)
-                            .Append(" = r.").Append(V1.Resource.ResourceId);
+                        delimited.BeginDelimitedElement().Append(V1.ReferenceSearchParam.ReferenceResourceId, referenceTableAlias)
+                            .Append(" = ").Append(V1.Resource.ResourceId, resourceTableAlias);
+                    }
+
+                    if (tableExpression.ChainLevel > 1)
+                    {
+                        StringBuilder.Append("INNER JOIN ").AppendLine(TableExpressionName(FindRestrictingPredecessorTableExpressionIndex()));
+
+                        using (var delimited = StringBuilder.BeginDelimitedOnClause())
+                        {
+                            delimited.BeginDelimitedElement().Append(V1.Resource.ResourceSurrogateId, referenceTableAlias).Append(" = ").Append("Sid2");
+                        }
                     }
 
                     using (var delimited = StringBuilder.BeginDelimitedWhereClause())
                     {
-                        delimited.BeginDelimitedElement().Append(V1.ReferenceSearchParam.SearchParamId).Append(" = ").Append(Parameters.AddParameter(V1.ReferenceSearchParam.SearchParamId, Model.GetSearchParamId(chainedExpression.ReferenceSearchParameter.Url)));
+                        delimited.BeginDelimitedElement().Append(V1.ReferenceSearchParam.SearchParamId, referenceTableAlias)
+                            .Append(" = ").Append(Parameters.AddParameter(V1.ReferenceSearchParam.SearchParamId, Model.GetSearchParamId(chainedExpression.ReferenceSearchParameter.Url)));
 
-                        AppendHistoryClause(delimited, "r");
-                        AppendHistoryClause(delimited, "ref");
+                        AppendHistoryClause(delimited, resourceTableAlias);
+                        AppendHistoryClause(delimited, referenceTableAlias);
 
-                        delimited.BeginDelimitedElement().Append("ref.").Append(V1.ReferenceSearchParam.ResourceTypeId)
+                        delimited.BeginDelimitedElement().Append(V1.ReferenceSearchParam.ResourceTypeId, referenceTableAlias)
                             .Append(" = ").Append(Parameters.AddParameter(V1.ReferenceSearchParam.ResourceTypeId, Model.GetResourceTypeId(chainedExpression.ResourceType)));
 
-                        delimited.BeginDelimitedElement().Append("ref.").Append(V1.ReferenceSearchParam.ReferenceResourceTypeId)
+                        delimited.BeginDelimitedElement().Append(V1.ReferenceSearchParam.ReferenceResourceTypeId, referenceTableAlias)
                             .Append(" = ").Append(Parameters.AddParameter(V1.ReferenceSearchParam.ReferenceResourceTypeId, Model.GetResourceTypeId(chainedExpression.TargetResourceType)));
-
-                        AppendIntersectionWithPredecessor(delimited, tableExpression, "ref");
 
                         if (tableExpression.DenormalizedPredicate != null)
                         {
                             delimited.BeginDelimitedElement();
-                            tableExpression.DenormalizedPredicate?.AcceptVisitor(this, context);
+                            tableExpression.DenormalizedPredicate?.AcceptVisitor(DispatchingDenormalizedSearchParameterQueryGenerator.Instance, GetContext(resourceTableAlias));
                         }
                     }
 
@@ -251,6 +293,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             }
 
             return null;
+        }
+
+        private SearchParameterQueryGeneratorContext GetContext(string tableAlias = null)
+        {
+            return new SearchParameterQueryGeneratorContext(StringBuilder, Parameters, Model, tableAlias);
         }
 
         private void AppendIntersectionWithPredecessor(IndentedStringBuilder.DelimitedScope delimited, TableExpression tableExpression, string tableAlias = null)
@@ -263,12 +310,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
                 string columnToSelect = (tableExpression.Kind == TableExpressionKind.ChainAnchor ? tableExpression.ChainLevel - 1 : tableExpression.ChainLevel) == 0 ? "Sid1" : "Sid2";
 
-                if (tableAlias != null)
-                {
-                    StringBuilder.Append(tableAlias).Append('.');
-                }
-
-                StringBuilder.Append(V1.Resource.ResourceSurrogateId).Append(" IN (SELECT ").Append(columnToSelect)
+                StringBuilder.Append(V1.Resource.ResourceSurrogateId, tableAlias).Append(" IN (SELECT ").Append(columnToSelect)
                     .Append(" FROM ").Append(TableExpressionName(predecessorIndex)).Append(")");
             }
         }
@@ -295,11 +337,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             return FindImpl(_tableExpressionCounter);
         }
 
-        private void AppendDeletedClause(in IndentedStringBuilder.DelimitedScope delimited)
+        private void AppendDeletedClause(in IndentedStringBuilder.DelimitedScope delimited, string tableAlias = null)
         {
             if (!_isHistorySearch)
             {
-                delimited.BeginDelimitedElement().Append(V1.Resource.IsDeleted).Append(" = 0");
+                delimited.BeginDelimitedElement().Append(V1.Resource.IsDeleted, tableAlias).Append(" = 0");
             }
         }
 
@@ -308,59 +350,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             if (!_isHistorySearch)
             {
                 delimited.BeginDelimitedElement();
-                if (tableAlias != null)
-                {
-                    StringBuilder.Append(tableAlias).Append('.');
-                }
 
-                StringBuilder.Append(V1.Resource.IsHistory).Append(" = 0");
-            }
-        }
-
-        public override object VisitSearchParameter(SearchParameterExpression expression, SearchOptions context)
-        {
-            expression.AcceptVisitor(GetSearchParameterQueryGenerator(expression), this);
-            return null;
-        }
-
-        public override object VisitMissingSearchParameter(MissingSearchParameterExpression expression, SearchOptions context)
-        {
-            expression.AcceptVisitor(GetSearchParameterQueryGenerator(expression), this);
-            return null;
-        }
-
-        public override object VisitMultiary(MultiaryExpression expression, SearchOptions context)
-        {
-            if (expression.MultiaryOperation == MultiaryOperator.Or)
-            {
-                StringBuilder.Append('(');
-            }
-
-            StringBuilder.AppendDelimited(
-                expression.MultiaryOperation == MultiaryOperator.And ? " AND " : " OR ",
-                expression.Expressions,
-                (sb, childExpr) => childExpr.AcceptVisitor(this, context));
-
-            if (expression.MultiaryOperation == MultiaryOperator.Or)
-            {
-                StringBuilder.AppendLine(")");
-            }
-
-            return context;
-        }
-
-        private SearchParameterQueryGenerator GetSearchParameterQueryGenerator(SearchParameterExpressionBase searchParameter)
-        {
-            switch (searchParameter.Parameter.Name)
-            {
-                case SearchParameterNames.Id:
-                    return new ResourceIdParameterQueryGenerator();
-                case SearchParameterNames.ResourceType:
-                    return new ResourceTypeIdParameterQueryGenerator();
-                case SqlSearchParameters.ResourceSurrogateIdParameterName:
-                    return new ResourceSurrogateIdParameterQueryGenerator();
-                default:
-                    throw new NotSupportedException(searchParameter.Parameter.Name);
+                StringBuilder.Append(V1.Resource.IsHistory, tableAlias).Append(" = 0");
             }
         }
     }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
             if (searchOptions.CountOnly)
             {
-                StringBuilder.AppendLine("SELECT COUNT(*)");
+                StringBuilder.AppendLine("SELECT COUNT(DISTINCT ").Append(V1.Resource.ResourceSurrogateId, resourceTableAlias).Append(")");
             }
             else
             {
@@ -279,6 +279,12 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
                         delimited.BeginDelimitedElement().Append(V1.ReferenceSearchParam.ReferenceResourceTypeId, referenceTableAlias)
                             .Append(" = ").Append(Parameters.AddParameter(V1.ReferenceSearchParam.ReferenceResourceTypeId, Model.GetResourceTypeId(chainedExpression.TargetResourceType)));
+
+                        if (tableExpression.ChainLevel == 1)
+                        {
+                            // if > 1, the intersection is handled by the JOIN
+                            AppendIntersectionWithPredecessor(delimited, tableExpression, referenceTableAlias);
+                        }
 
                         if (tableExpression.DenormalizedPredicate != null)
                         {

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/StringSearchParameterQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/StringSearchParameterQueryGenerator.cs
@@ -15,9 +15,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
         public override Table Table => V1.StringSearchParam;
 
-        public override SqlQueryGenerator VisitString(StringExpression expression, SqlQueryGenerator context)
+        public override SearchParameterQueryGeneratorContext VisitString(StringExpression expression, SearchParameterQueryGeneratorContext context)
         {
-            context.StringBuilder.Append(V1.StringSearchParam.TextOverflow).Append(expression.ComponentIndex + 1);
+            context.StringBuilder.Append(V1.StringSearchParam.TextOverflow, context.TableAlias).Append(expression.ComponentIndex + 1);
 
             StringColumn column;
             switch (expression.FieldName)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/TokenSearchParameterQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/TokenSearchParameterQueryGenerator.cs
@@ -16,12 +16,12 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
         public override Table Table => V1.TokenSearchParam;
 
-        public override SqlQueryGenerator VisitMissingField(MissingFieldExpression expression, SqlQueryGenerator context)
+        public override SearchParameterQueryGeneratorContext VisitMissingField(MissingFieldExpression expression, SearchParameterQueryGeneratorContext context)
         {
             return VisitMissingFieldImpl(expression, context, FieldName.TokenSystem, V1.TokenSearchParam.SystemId);
         }
 
-        public override SqlQueryGenerator VisitString(StringExpression expression, SqlQueryGenerator context)
+        public override SearchParameterQueryGeneratorContext VisitString(StringExpression expression, SearchParameterQueryGeneratorContext context)
         {
             Debug.Assert(expression.StringOperator == StringOperator.Equals, "Only equals is supported");
 
@@ -33,12 +33,12 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                         return VisitSimpleBinary(BinaryOperator.Equal, context, V1.TokenSearchParam.SystemId, expression.ComponentIndex, systemId);
                     }
 
-                    context.StringBuilder.Append(V1.TokenSearchParam.SystemId)
+                    context.StringBuilder.Append(V1.TokenSearchParam.SystemId, context.TableAlias)
                         .Append(" IN (SELECT ")
-                        .Append(V1.System.SystemId)
+                        .Append(V1.System.SystemId, null)
                         .Append(" FROM ").Append(V1.System)
                         .Append(" WHERE ")
-                        .Append(V1.System.Value)
+                        .Append(V1.System.Value, null)
                         .Append(" = ")
                         .Append(context.Parameters.AddParameter(V1.System.Value, expression.Value))
                         .Append(")");

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/TokenTextSearchParameterQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/TokenTextSearchParameterQueryGenerator.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
         public override Table Table => V1.TokenText;
 
-        public override SqlQueryGenerator VisitString(StringExpression expression, SqlQueryGenerator context)
+        public override SearchParameterQueryGeneratorContext VisitString(StringExpression expression, SearchParameterQueryGeneratorContext context)
         {
             return VisitSimpleString(expression, context, V1.TokenText.Text, expression.Value);
         }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/UriSearchParameterQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/UriSearchParameterQueryGenerator.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
         public override Table Table => V1.UriSearchParam;
 
-        public override SqlQueryGenerator VisitString(StringExpression expression, SqlQueryGenerator context)
+        public override SearchParameterQueryGeneratorContext VisitString(StringExpression expression, SearchParameterQueryGeneratorContext context)
         {
             return VisitSimpleString(expression, context, V1.UriSearchParam.Uri, expression.Value);
         }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/SqlExpressionRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/SqlExpressionRewriter.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
                 return tableExpression;
             }
 
-            return new TableExpression(tableExpression.SearchParameterQueryGenerator, normalizedPredicate, denormalizedPredicate);
+            return new TableExpression(tableExpression.SearchParameterQueryGenerator, normalizedPredicate, denormalizedPredicate, tableExpression.Kind);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/SqlRootExpressionRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/SqlRootExpressionRewriter.cs
@@ -37,12 +37,12 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
             for (var i = 0; i < expression.Expressions.Count; i++)
             {
                 Expression childExpression = expression.Expressions[i];
-                if (TryGetNormalizedGenerator(childExpression, out var normalizedGenerator))
+                if (TryGetNormalizedGenerator(childExpression, out var normalizedGenerator, out var tableExpressionKind))
                 {
                     EnsureAllocatedAndPopulated(ref denormalizedPredicates, expression.Expressions, i);
                     EnsureAllocatedAndPopulated(ref normalizedPredicates, Array.Empty<TableExpression>(), 0);
 
-                    normalizedPredicates.Add(new TableExpression(normalizedGenerator, childExpression));
+                    normalizedPredicates.Add(new TableExpression(normalizedGenerator, childExpression, null, tableExpressionKind, tableExpressionKind == TableExpressionKind.ChainAnchor ? 1 : 0));
                 }
                 else
                 {
@@ -66,18 +66,22 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
 
         public override Expression VisitMissingSearchParameter(MissingSearchParameterExpression expression, int context) => ConvertNonMultiary(expression);
 
-        public override Expression VisitChained(ChainedExpression expression, int context) => ConvertNonMultiary(expression);
+        public override Expression VisitChained(ChainedExpression expression, int context)
+        {
+            return ConvertNonMultiary(expression);
+        }
 
         private Expression ConvertNonMultiary(Expression expression)
         {
-            return TryGetNormalizedGenerator(expression, out var generator)
-                ? SqlRootExpression.WithTableExpressions(new TableExpression(generator, expression))
+            return TryGetNormalizedGenerator(expression, out var generator, out var kind)
+                ? SqlRootExpression.WithTableExpressions(new TableExpression(generator, normalizedPredicate: expression, denormalizedPredicate: null, kind, chainLevel: kind == TableExpressionKind.ChainAnchor ? 1 : 0))
                 : SqlRootExpression.WithDenormalizedExpressions(expression);
         }
 
-        private bool TryGetNormalizedGenerator(Expression expression, out NormalizedSearchParameterQueryGenerator normalizedGenerator)
+        private bool TryGetNormalizedGenerator(Expression expression, out NormalizedSearchParameterQueryGenerator normalizedGenerator, out TableExpressionKind kind)
         {
             normalizedGenerator = expression.AcceptVisitor(_normalizedSearchParameterQueryGeneratorFactory);
+            kind = normalizedGenerator is ChainAnchorQueryGenerator ? TableExpressionKind.ChainAnchor : TableExpressionKind.Normal;
             return normalizedGenerator != null;
         }
     }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/SqlRootExpressionRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/SqlRootExpressionRewriter.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
                     EnsureAllocatedAndPopulated(ref denormalizedPredicates, expression.Expressions, i);
                     EnsureAllocatedAndPopulated(ref normalizedPredicates, Array.Empty<TableExpression>(), 0);
 
-                    normalizedPredicates.Add(new TableExpression(normalizedGenerator, childExpression, null, tableExpressionKind, tableExpressionKind == TableExpressionKind.ChainAnchor ? 1 : 0));
+                    normalizedPredicates.Add(new TableExpression(normalizedGenerator, childExpression, null, tableExpressionKind, tableExpressionKind == TableExpressionKind.Chain ? 1 : 0));
                 }
                 else
                 {
@@ -74,14 +74,14 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
         private Expression ConvertNonMultiary(Expression expression)
         {
             return TryGetNormalizedGenerator(expression, out var generator, out var kind)
-                ? SqlRootExpression.WithTableExpressions(new TableExpression(generator, normalizedPredicate: expression, denormalizedPredicate: null, kind, chainLevel: kind == TableExpressionKind.ChainAnchor ? 1 : 0))
+                ? SqlRootExpression.WithTableExpressions(new TableExpression(generator, normalizedPredicate: expression, denormalizedPredicate: null, kind, chainLevel: kind == TableExpressionKind.Chain ? 1 : 0))
                 : SqlRootExpression.WithDenormalizedExpressions(expression);
         }
 
         private bool TryGetNormalizedGenerator(Expression expression, out NormalizedSearchParameterQueryGenerator normalizedGenerator, out TableExpressionKind kind)
         {
             normalizedGenerator = expression.AcceptVisitor(_normalizedSearchParameterQueryGeneratorFactory);
-            kind = normalizedGenerator is ChainAnchorQueryGenerator ? TableExpressionKind.ChainAnchor : TableExpressionKind.Normal;
+            kind = normalizedGenerator is ChainAnchorQueryGenerator ? TableExpressionKind.Chain : TableExpressionKind.Normal;
             return normalizedGenerator != null;
         }
     }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/TableExpressionCombiner.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/TableExpressionCombiner.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
                         }
                     }
 
-                    return new[] { new TableExpression(g.Key.queryGenerator, Expression.SearchParameter(g.Key.searchParameter, Expression.And(childExpressions))) };
+                    return new[] { new TableExpression(g.Key.queryGenerator, Expression.SearchParameter(g.Key.searchParameter, Expression.And(childExpressions)), null, TableExpressionKind.Normal) };
                 }).ToList();
 
             return new SqlRootExpression(newTableExpressions, expression.DenormalizedExpressions);

--- a/src/Microsoft.Health.Fhir.SqlServer/IndentedStringBuilder.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/IndentedStringBuilder.cs
@@ -37,12 +37,23 @@ namespace Microsoft.Health.Fhir.SqlServer
         /// <returns>A scope to be disposed when the indentation level is to be restored</returns>
         internal IndentedScope Indent() => new IndentedScope(this);
 
-        [Obsolete("Use overload with table alias instead")]
+        /// <summary>
+        /// Appends a column name to this instance.
+        /// </summary>
+        /// <param name="column">The column</param>
+        /// <returns>This instance</returns>
+        [Obsolete("Use overload with table alias instead")] // Catch calls an raise compiler warnings.
         public IndentedStringBuilder Append(Column column)
         {
             return Append(column, null);
         }
 
+        /// <summary>
+        /// Appends a column name to this instance.
+        /// </summary>
+        /// <param name="column">The column</param>
+        /// <param name="tableAlias">The table alias to quality the column reference with</param>
+        /// <returns>This instance</returns>
         public IndentedStringBuilder Append(Column column, string tableAlias)
         {
             if (!string.IsNullOrEmpty(tableAlias))
@@ -53,12 +64,23 @@ namespace Microsoft.Health.Fhir.SqlServer
             return Append(column.ToString());
         }
 
-        [Obsolete("Use overload with table alias instead")]
+        /// <summary>
+        /// Appends a column name to this instance.
+        /// </summary>
+        /// <param name="column">The column</param>
+        /// <returns>This instance</returns>
+        [Obsolete("Use overload with table alias instead")] // Catch calls an raise compiler warnings.
         public IndentedStringBuilder AppendLine(Column column)
         {
             return AppendLine(column, null);
         }
 
+        /// <summary>
+        /// Appends a column name to this instance.
+        /// </summary>
+        /// <param name="column">The column</param>
+        /// <param name="tableAlias">The table alias to quality the column reference with</param>
+        /// <returns>This instance</returns>
         public IndentedStringBuilder AppendLine(Column column, string tableAlias)
         {
             if (!string.IsNullOrEmpty(tableAlias))

--- a/src/Microsoft.Health.Fhir.SqlServer/IndentedStringBuilder.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/IndentedStringBuilder.cs
@@ -8,6 +8,7 @@ using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Text;
 using EnsureThat;
+using Microsoft.Health.Fhir.SqlServer.Features.Schema.Model;
 
 namespace Microsoft.Health.Fhir.SqlServer
 {
@@ -35,6 +36,38 @@ namespace Microsoft.Health.Fhir.SqlServer
         /// </summary>
         /// <returns>A scope to be disposed when the indentation level is to be restored</returns>
         internal IndentedScope Indent() => new IndentedScope(this);
+
+        [Obsolete("Use overload with table alias instead")]
+        public IndentedStringBuilder Append(Column column)
+        {
+            return Append(column, null);
+        }
+
+        public IndentedStringBuilder Append(Column column, string tableAlias)
+        {
+            if (!string.IsNullOrEmpty(tableAlias))
+            {
+                Append(tableAlias).Append('.');
+            }
+
+            return Append(column.ToString());
+        }
+
+        [Obsolete("Use overload with table alias instead")]
+        public IndentedStringBuilder AppendLine(Column column)
+        {
+            return AppendLine(column, null);
+        }
+
+        public IndentedStringBuilder AppendLine(Column column, string tableAlias)
+        {
+            if (!string.IsNullOrEmpty(tableAlias))
+            {
+                Append(tableAlias).Append('.');
+            }
+
+            return AppendLine(column.ToString());
+        }
 
         /// <summary>
         /// Similar to <see cref="StringBuilder.AppendJoin{T}(string,IEnumerable{T})"/>, but without needing to build up intermediate strings.

--- a/src/Microsoft.Health.Fhir.SqlServer/IndentedStringBuilderExtensions.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/IndentedStringBuilderExtensions.cs
@@ -3,8 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using Microsoft.Health.Fhir.SqlServer.Features.Schema.Model;
-
 namespace Microsoft.Health.Fhir.SqlServer
 {
     internal static class IndentedStringBuilderExtensions

--- a/src/Microsoft.Health.Fhir.SqlServer/IndentedStringBuilderExtensions.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/IndentedStringBuilderExtensions.cs
@@ -34,5 +34,25 @@ namespace Microsoft.Health.Fhir.SqlServer
                     sb.AppendLine();
                 });
         }
+
+        public static IndentedStringBuilder.DelimitedScope BeginDelimitedOnClause(this IndentedStringBuilder indentedStringBuilder)
+        {
+            return indentedStringBuilder.BeginDelimitedScope(
+                sb =>
+                {
+                    sb.Append("ON ");
+                    sb.IndentLevel++;
+                },
+                sb =>
+                {
+                    sb.AppendLine();
+                    sb.Append("AND ");
+                },
+                sb =>
+                {
+                    sb.IndentLevel--;
+                    sb.AppendLine();
+                });
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/IndentedStringBuilderExtensions.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/IndentedStringBuilderExtensions.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Microsoft.Health.Fhir.SqlServer.Features.Schema.Model;
+
 namespace Microsoft.Health.Fhir.SqlServer
 {
     internal static class IndentedStringBuilderExtensions

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Microsoft.Health.Fhir.Shared.Tests.E2E.projitems
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Microsoft.Health.Fhir.Shared.Tests.E2E.projitems
@@ -39,6 +39,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rest\HttpIntegrationTestFixture.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\ReadTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\Search\BasicSearchTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rest\Search\ChainingSearchTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\Search\CompositeSearchTestFixture.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\Search\CompositeSearchTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\Search\DateSearchTestFixture.cs" />

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
@@ -1,0 +1,128 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Hl7.Fhir.Model;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Microsoft.Health.Fhir.Tests.E2E.Common;
+using Microsoft.Health.Fhir.Tests.E2E.Rest;
+using Microsoft.Health.Fhir.Tests.E2E.Rest.Search;
+using Microsoft.Health.Fhir.Web;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Search
+{
+    [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
+    public class ChainingSearchTests : SearchTestsBase<ChainingSearchTests.ClassFixture>
+    {
+        public ChainingSearchTests(ClassFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        [Fact]
+        public async Task GivenAChainedSearchExpression_WhenSearched_ThenCorrectBundleShouldBeReturned()
+        {
+            string query = $"_tag={Fixture.Tag}&subject:Patient.name=Smith";
+
+            Bundle bundle = await Client.SearchAsync(ResourceType.DiagnosticReport, query);
+
+            ValidateBundle(bundle, Fixture.SmithDiagnosticReport);
+        }
+
+        [Fact]
+        public async Task GivenANestedChainedSearchExpression_WhenSearched_ThenCorrectBundleShouldBeReturned()
+        {
+            string query = $"_tag={Fixture.Tag}&result.subject:Patient.name=Smith";
+
+            Bundle bundle = await Client.SearchAsync(ResourceType.DiagnosticReport, query);
+
+            ValidateBundle(bundle, Fixture.SmithDiagnosticReport);
+        }
+
+        [Fact]
+        public async Task GivenANestedChainedSearchExpressionWithAnOrFinalCondition_WhenSearched_ThenCorrectBundleShouldBeReturned()
+        {
+            string query = $"_tag={Fixture.Tag}&result.subject:Patient.name=Smith,Truman";
+
+            Bundle bundle = await Client.SearchAsync(ResourceType.DiagnosticReport, query);
+
+            ValidateBundle(bundle, Fixture.SmithDiagnosticReport, Fixture.TrumanDiagnosticReport);
+        }
+
+        [Fact]
+        public async Task GivenAChainedSearchExpressionOverASimpleParameter_WhenSearched_ThenCorrectBundleShouldBeReturned()
+        {
+            string query = $"_tag={Fixture.Tag}&subject:Patient._type=Patient";
+
+            Bundle bundle = await Client.SearchAsync(ResourceType.DiagnosticReport, query);
+
+            ValidateBundle(bundle, Fixture.SmithDiagnosticReport, Fixture.TrumanDiagnosticReport);
+        }
+
+        [Fact]
+        public async Task GivenAChainedSearchExpressionOverASimpleParameterWithNoResults_WhenSearched_ThenCorrectBundleShouldBeReturned()
+        {
+            string query = $"_tag={Fixture.Tag}&subject:Patient._type=Observation";
+
+            Bundle bundle = await Client.SearchAsync(ResourceType.DiagnosticReport, query);
+
+            ValidateBundle(bundle);
+        }
+
+        public class ClassFixture : HttpIntegrationTestFixture<Startup>
+        {
+            public ClassFixture(DataStore dataStore, Format format)
+                : base(dataStore, format)
+            {
+                Tag = Guid.NewGuid().ToString();
+
+                // Construct an observation pointing to a patient and a diagnostic report pointing to the observation and the patient
+
+                Patient smithPatient = FhirClient.CreateAsync(new Patient { Name = new List<HumanName> { new HumanName { Family = "Smith" } } }).Result.Resource;
+                Patient trumanPatient = FhirClient.CreateAsync(new Patient { Name = new List<HumanName> { new HumanName { Family = "Truman" } } }).Result.Resource;
+
+                var smithObservation = CreateObservation(smithPatient);
+                var trumanObservation = CreateObservation(trumanPatient);
+
+                SmithDiagnosticReport = CreateDiagnosticReport(smithPatient, smithObservation);
+
+                TrumanDiagnosticReport = CreateDiagnosticReport(trumanPatient, trumanObservation);
+
+                DiagnosticReport CreateDiagnosticReport(Patient patient, Observation observation)
+                {
+                    return FhirClient.CreateAsync(
+                        new DiagnosticReport
+                        {
+                            Meta = new Meta { Tag = new List<Coding> { new Coding("testTag", Tag) } },
+                            Status = DiagnosticReport.DiagnosticReportStatus.Final,
+                            Code = new CodeableConcept("http://snomed.info/sct", "429858000"),
+                            Subject = new ResourceReference($"Patient/{patient.Id}"),
+                            Result = new List<ResourceReference> { new ResourceReference($"Observation/{observation.Id}") },
+                        }).Result.Resource;
+                }
+
+                Observation CreateObservation(Patient patient)
+                {
+                    return FhirClient.CreateAsync(
+                        new Observation()
+                        {
+                            Status = ObservationStatus.Final,
+                            Code = new CodeableConcept("http://snomed.info/sct", "429858000"),
+                            Subject = new ResourceReference($"Patient/{patient.Id}"),
+                        }).Result.Resource;
+                }
+            }
+
+            public string Tag { get; }
+
+            public DiagnosticReport TrumanDiagnosticReport { get; }
+
+            public DiagnosticReport SmithDiagnosticReport { get; }
+        }
+    }
+}


### PR DESCRIPTION
## Description
Implements search parameter chaining. Does NOT include reverse changing (`_has`).

### Examples:

`/Claim?organization.name=falmouth%20walk%20in%20medical%20center`

`/Encounter?participant:Practitioner.name=Jane,Norm`

`/DiagnosticReport?result.code-value-quantity=http://loinc.org|787-2$83`

Multi-level chaining:

`/Claim?encounter.service-provider.name=falmouth%20walk%20in%20medical%20center`

Note that in the case where a reference can be to multiple types you must specify the target type. (we could lift that restriction later if we want). So you cannot specify `/Observation?subject.name=lisa`, instead you must say `/Observation?subject:Patient.name=lisa`

## Related issues
Addresses [AB#68734](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/68734)

