### PR TITLE
Fixes incorrect query on string overflow

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/ISearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/ISearchParameterDefinitionManager.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.ValueSets;
 
 namespace Microsoft.Health.Fhir.Core.Features.Definition
 {
@@ -49,5 +50,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         /// <param name="definitionUri">The search parameter definition URL.</param>
         /// <returns>The search parameter with the given <paramref name="definitionUri"/>.</returns>
         SearchParameterInfo GetSearchParameter(Uri definitionUri);
+
+        /// <summary>
+        /// Gets the type of a search parameter expression. In the case of a composite search parameter, the component parameter
+        /// can be specified, to retrieve the type of that component.
+        /// </summary>
+        /// <param name="searchParameter">The search parameter</param>
+        /// <param name="componentIndex">The optional component index if the search parameter is a composite</param>
+        /// <returns>The search parameter type.</returns>
+        SearchParamType GetSearchParameterType(SearchParameterInfo searchParameter, int? componentIndex);
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Models/SearchParameterInfo.cs
+++ b/src/Microsoft.Health.Fhir.Core/Models/SearchParameterInfo.cs
@@ -14,15 +14,15 @@ namespace Microsoft.Health.Fhir.Core.Models
     {
         public SearchParameterInfo(
             string name,
+            string searchParamType,
             Uri url = null,
-            string searchParamType = null,
             IReadOnlyList<SearchParameterComponentInfo> components = null,
             string expression = null,
             IReadOnlyCollection<string> targetResourceTypes = null)
             : this(
                 name,
+                Enum.Parse<SearchParamType>(searchParamType),
                 url,
-                Enum.TryParse<SearchParamType>(searchParamType, out var type) ? (SearchParamType?)type : null,
                 components,
                 expression,
                 targetResourceTypes)
@@ -31,8 +31,8 @@ namespace Microsoft.Health.Fhir.Core.Models
 
         public SearchParameterInfo(
             string name,
+            SearchParamType searchParamType,
             Uri url = null,
-            SearchParamType? searchParamType = null,
             IReadOnlyList<SearchParameterComponentInfo> components = null,
             string expression = null,
             IReadOnlyCollection<string> targetResourceTypes = null)
@@ -62,7 +62,7 @@ namespace Microsoft.Health.Fhir.Core.Models
 
         public Uri Url { get; }
 
-        public SearchParamType? Type { get; }
+        public SearchParamType Type { get; }
 
         public IReadOnlyList<SearchParameterComponentInfo> Component { get; }
     }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchOptionsFactoryTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchOptionsFactoryTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         public SearchOptionsFactoryTests()
         {
             var searchParameterDefinitionManager = Substitute.For<ISearchParameterDefinitionManager>();
-            searchParameterDefinitionManager.GetSearchParameter(ResourceType.Resource.ToString(), SearchParameterNames.ResourceType).Returns(new SearchParameter { Name = SearchParameterNames.ResourceType }.ToInfo());
+            searchParameterDefinitionManager.GetSearchParameter(ResourceType.Resource.ToString(), SearchParameterNames.ResourceType).Returns(new SearchParameter { Name = SearchParameterNames.ResourceType, Type = SearchParamType.String }.ToInfo());
 
             _factory = new SearchOptionsFactory(
                 _expressionParser,

--- a/src/Microsoft.Health.Fhir.Shared.Core/Extensions/ModelExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Extensions/ModelExtensions.cs
@@ -100,8 +100,8 @@ namespace Microsoft.Health.Fhir.Core.Extensions
 
             return new SearchParameterInfo(
                 searchParam.Name,
-                string.IsNullOrEmpty(searchParam.Url) ? null : new Uri(searchParam.Url),
                 searchParam.Type?.ToString(),
+                string.IsNullOrEmpty(searchParam.Url) ? null : new Uri(searchParam.Url),
                 searchParam.Component?.Select(x => new SearchParameterComponentInfo(x.GetComponentDefinitionUri(), x.Expression)).ToArray(),
                 searchParam.Expression,
                 searchParam.Target?.Select(x => x?.ToString()).ToArray());

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Definition/SearchParameterDefinitionBuilder.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Definition/SearchParameterDefinitionBuilder.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             var validatedSearchParameters = new List<(string ResourceType, SearchParameterInfo SearchParameter)>
             {
                 // _type is currently missing from the search params definition bundle, so we inject it in here.
-                (ResourceType.Resource.ToString(), new SearchParameterInfo(SearchParameterNames.ResourceType, SearchParameterNames.ResourceTypeUri, SearchParamType.Token.ToString(), null, "Resource.type().name", null)),
+                (ResourceType.Resource.ToString(), new SearchParameterInfo(SearchParameterNames.ResourceType, SearchParamType.Token.ToString(), SearchParameterNames.ResourceTypeUri, null, "Resource.type().name", null)),
             };
 
             // Do the second pass to make sure the definition is valid.

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Definition/SearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Definition/SearchParameterDefinitionManager.cs
@@ -91,6 +91,19 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             throw new SearchParameterNotSupportedException(definitionUri);
         }
 
+        public ValueSets.SearchParamType GetSearchParameterType(SearchParameterInfo searchParameter, int? componentIndex)
+        {
+            if (componentIndex == null)
+            {
+                return searchParameter.Type;
+            }
+
+            SearchParameterComponentInfo component = searchParameter.Component[componentIndex.Value];
+            SearchParameterInfo componentSearchParameter = GetSearchParameter(component.DefinitionUrl);
+
+            return componentSearchParameter.Type;
+        }
+
         void IProvideCapability.Build(IListedCapabilityStatement statement)
         {
             EnsureArg.IsNotNull(statement, nameof(statement));
@@ -101,7 +114,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
                         searchParameter => new CapabilityStatement.SearchParamComponent
                         {
                             Name = searchParameter.Key,
-                            Type = Enum.Parse<SearchParamType>(searchParameter.Value.Type?.ToString()),
+                            Type = Enum.Parse<SearchParamType>(searchParameter.Value.Type.ToString()),
                         });
 
                 var capabilityStatement = (ListedCapabilityStatement)statement;

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Expressions/Parsers/SearchParameterExpressionParser.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Expressions/Parsers/SearchParameterExpressionParser.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
             }
 
             // Parse the value.
-            Func<string, ISearchValue> parser = _parserDictionary[Enum.Parse<SearchParamType>(searchParameter.Type?.ToString())];
+            Func<string, ISearchValue> parser = _parserDictionary[Enum.Parse<SearchParamType>(searchParameter.Type.ToString())];
 
             // Build the expression.
             var helper = new SearchValueExpressionBuilderHelper();

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -10,7 +10,6 @@ using EnsureThat;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using Microsoft.Extensions.Logging;
-using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
 using Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers;

--- a/src/Microsoft.Health.Fhir.SqlServer.Api/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.Api/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
@@ -95,6 +95,10 @@ namespace Microsoft.Extensions.DependencyInjection
                 .Singleton()
                 .AsSelf();
 
+            services.Add<StringOverflowRewriter>()
+                .Singleton()
+                .AsSelf();
+
             return fhirServerBuilder;
         }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/StringSearchParameterQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/StringSearchParameterQueryGenerator.cs
@@ -28,6 +28,19 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     break;
                 case SqlFieldName.TextOverflow:
                     column = V1.StringSearchParam.TextOverflow;
+                    switch (expression.StringOperator)
+                    {
+                        case StringOperator.StartsWith:
+                        case StringOperator.NotStartsWith:
+                        case StringOperator.Equals:
+                            if (expression.Value.Length < V1.StringSearchParam.Text.Metadata.MaxLength / 2)
+                            {
+                                column = V1.StringSearchParam.Text;
+                            }
+
+                            break;
+                    }
+
                     context.StringBuilder.Append(" IS NOT NULL AND ");
                     break;
                 default:

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/StringSearchParameterQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/StringSearchParameterQueryGenerator.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                         case StringOperator.StartsWith:
                         case StringOperator.NotStartsWith:
                         case StringOperator.Equals:
-                            if (expression.Value.Length < V1.StringSearchParam.Text.Metadata.MaxLength / 2)
+                            if (expression.Value.Length <= V1.StringSearchParam.Text.Metadata.MaxLength)
                             {
                                 column = V1.StringSearchParam.Text;
                             }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/StringOverflowRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/StringOverflowRewriter.cs
@@ -77,21 +77,13 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
                     return false;
                 }
 
-                switch (expression.StringOperator)
+                if (expression.StringOperator == StringOperator.Equals && expression.Value.Length <= V1.StringSearchParam.Text.Metadata.MaxLength)
                 {
-                    case StringOperator.Equals:
-                    case StringOperator.NotStartsWith:
-                        if (expression.Value.Length <= V1.StringSearchParam.Text.Metadata.MaxLength)
-                        {
-                            // in these cases, we will know for sure that we do not need to consider the overflow column
-                            return false;
-                        }
-
-                        return true;
-
-                    default:
-                        return true;
+                    // in these cases, we will know for sure that we do not need to consider the overflow column
+                    return false;
                 }
+
+                return true;
             }
         }
     }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/StringOverflowRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/StringOverflowRewriter.cs
@@ -23,8 +23,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
         public StringOverflowRewriter(ISearchParameterDefinitionManager searchParameterDefinitionManager)
             : base(new Scout(searchParameterDefinitionManager))
         {
-            _searchParameterDefinitionManager = searchParameterDefinitionManager;
             EnsureArg.IsNotNull(searchParameterDefinitionManager, nameof(searchParameterDefinitionManager));
+            _searchParameterDefinitionManager = searchParameterDefinitionManager;
         }
 
         public override Expression VisitSearchParameter(SearchParameterExpression expression, object context)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlSearchParameters.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlSearchParameters.cs
@@ -15,6 +15,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
 
         public static readonly Uri ResourceSurrogateIdUri = new Uri("http://fhirserverforazure.microsoft.com/fhir/SearchParameter/Resource-surrogateid");
 
-        public static readonly SearchParameterInfo ResourceSurrogateIdParameter = new SearchParameterInfo(ResourceSurrogateIdParameterName, ResourceSurrogateIdUri, SearchParamType.Number, null);
+        public static readonly SearchParameterInfo ResourceSurrogateIdParameter = new SearchParameterInfo(ResourceSurrogateIdParameterName, SearchParamType.Number, ResourceSurrogateIdUri, null);
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
         private readonly SqlServerFhirModel _model;
         private readonly SqlRootExpressionRewriter _sqlRootExpressionRewriter;
         private readonly ChainFlatteningRewriter _chainFlatteningRewriter;
+        private readonly StringOverflowRewriter _stringOverflowRewriter;
         private readonly SqlServerDataStoreConfiguration _configuration;
         private readonly ILogger<SqlServerSearchService> _logger;
 
@@ -44,17 +45,20 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
             SqlServerFhirModel model,
             SqlRootExpressionRewriter sqlRootExpressionRewriter,
             ChainFlatteningRewriter chainFlatteningRewriter,
+            StringOverflowRewriter stringOverflowRewriter,
             SqlServerDataStoreConfiguration configuration,
             ILogger<SqlServerSearchService> logger)
             : base(searchOptionsFactory, fhirDataStore, modelInfoProvider)
         {
             EnsureArg.IsNotNull(sqlRootExpressionRewriter, nameof(sqlRootExpressionRewriter));
             EnsureArg.IsNotNull(chainFlatteningRewriter, nameof(chainFlatteningRewriter));
+            EnsureArg.IsNotNull(stringOverflowRewriter, nameof(stringOverflowRewriter));
             EnsureArg.IsNotNull(logger, nameof(logger));
 
             _model = model;
             _sqlRootExpressionRewriter = sqlRootExpressionRewriter;
             _chainFlatteningRewriter = chainFlatteningRewriter;
+            _stringOverflowRewriter = stringOverflowRewriter;
             _configuration = configuration;
             _logger = logger;
         }
@@ -99,7 +103,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                                                .AcceptVisitor(NormalizedPredicateReorderer.Instance)
                                                .AcceptVisitor(_chainFlatteningRewriter)
                                                .AcceptVisitor(DateTimeBoundedRangeRewriter.Instance)
-                                               .AcceptVisitor(StringOverflowRewriter.Instance)
+                                               .AcceptVisitor(_stringOverflowRewriter)
                                                .AcceptVisitor(NumericRangeRewriter.Instance)
                                                .AcceptVisitor(MissingSearchParamVisitor.Instance)
                                                .AcceptVisitor(TopRewriter.Instance, searchOptions)

--- a/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
+++ b/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
@@ -68,6 +68,7 @@
     <None Remove="TestFiles\R4\ObservationWithEyeColor.json" />
     <None Remove="TestFiles\R4\ObservationWithInvalidStatus.json" />
     <None Remove="TestFiles\R4\ObservationWithInvalidStatus.xml" />
+    <None Remove="TestFiles\R4\ObservationWithLongEyeColor.json" />
     <None Remove="TestFiles\R4\ObservationWithNoCode.json" />
     <None Remove="TestFiles\R4\ObservationWithNoCode.xml" />
     <None Remove="TestFiles\R4\ObservationWithTemperature.json" />
@@ -83,6 +84,7 @@
     <None Remove="TestFiles\Stu3\DocumentReference-example-002.json" />
     <None Remove="TestFiles\Stu3\DocumentReference-example-003.json" />
     <None Remove="TestFiles\Stu3\DocumentReference-example.json" />
+    <None Remove="TestFiles\Stu3\ObservationWithLongEyeColor.json" />
     <None Remove="TestFiles\ValidCompartmentDefinition.json" />
     <None Remove="TestFiles\Weight.json" />
     <None Remove="TestFiles\WeightInGrams.json" />
@@ -119,6 +121,7 @@
     <EmbeddedResource Include="TestFiles\R4\ObservationWith1MinuteApgarScore.json" />
     <EmbeddedResource Include="TestFiles\R4\ObservationWith20MinuteApgarScore.json" />
     <EmbeddedResource Include="TestFiles\R4\ObservationWithBloodPressure.json" />
+    <EmbeddedResource Include="TestFiles\R4\ObservationWithLongEyeColor.json" />
     <EmbeddedResource Include="TestFiles\R4\ObservationWithEyeColor.json" />
     <EmbeddedResource Include="TestFiles\R4\ObservationWithInvalidStatus.json" />
     <EmbeddedResource Include="TestFiles\R4\ObservationWithInvalidStatus.xml" />
@@ -148,6 +151,7 @@
     <EmbeddedResource Include="TestFiles\Stu3\ObservationWith1MinuteApgarScore.json" />
     <EmbeddedResource Include="TestFiles\Stu3\ObservationWith20MinuteApgarScore.json" />
     <EmbeddedResource Include="TestFiles\Stu3\ObservationWithBloodPressure.json" />
+    <EmbeddedResource Include="TestFiles\Stu3\ObservationWithLongEyeColor.json" />
     <EmbeddedResource Include="TestFiles\Stu3\ObservationWithEyeColor.json" />
     <EmbeddedResource Include="TestFiles\Stu3\ObservationWithTemperature.json" />
     <EmbeddedResource Include="TestFiles\Stu3\ObservationWithTPMTDiplotype.json" />

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/R4/ObservationWithLongEyeColor.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/R4/ObservationWithLongEyeColor.json
@@ -1,0 +1,24 @@
+﻿{
+    "resourceType": "Observation",
+    "id": "eye-color",
+    "text": {
+        "status": "generated",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: eye-color</p><p><b>status</b>: final</p><p><b>code</b>: eye color <span>(Details )</span></p><p><b>subject</b>: <a>Patient/example</a></p><p><b>effective</b>: 18/05/2016</p><p><b>value</b>: blue</p></div>"
+    },
+    "status": "final",
+    "code": {
+        "coding": [
+            {
+                "system": "http://snomed.info/sct",
+                "code": "162806009",
+                "display": "On examination - general eye examination (finding)"
+            }
+        ],
+        "text": "eye color"
+    },
+    "subject": {
+        "reference": "Patient/example"
+    },
+    "effectiveDateTime": "2016-05-18",
+    "valueString": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut eget ultricies justo. Maecenas bibendum convallis sodales. Vestibulum quis molestie dui. Nulla porta elementum tristique. Aenean neque libero convallis sit amet dui ullamcorper congue lacinia erat. Sed finibus ex ac massa tincidunt tristique. In sed auctor massa. Proin cursus porttitor arcu. Maecenas a leo nunc. Sed pretium porta volutpat. In aliquet tempor sapien vitae laoreet nisl tempor ac. Vestibulum lacus leo luctus vitae pharetra at tempus ac diam. Integer at dui eu dolor gravida vehicula. Phasellus malesuada elit orci quis maximus purus consectetur ac. In semper consequat augue sit amet ultricies."
+}

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Stu3/ObservationWithLongEyeColor.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Stu3/ObservationWithLongEyeColor.json
@@ -1,0 +1,24 @@
+{
+    "resourceType": "Observation",
+    "id": "eye-color",
+    "text": {
+        "status": "generated",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: eye-color</p><p><b>status</b>: final</p><p><b>code</b>: eye color <span>(Details )</span></p><p><b>subject</b>: <a>Patient/example</a></p><p><b>effective</b>: 18/05/2016</p><p><b>value</b>: blue</p></div>"
+    },
+    "status": "final",
+    "code": {
+        "coding": [
+            {
+                "system": "http://snomed.info/sct",
+                "code": "162806009",
+                "display": "On examination - general eye examination (finding)"
+            }
+        ],
+        "text": "eye color"
+    },
+    "subject": {
+        "reference": "Patient/example"
+    },
+    "effectiveDateTime": "2016-05-18",
+    "valueString": "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut eget ultricies justo. Maecenas bibendum convallis sodales. Vestibulum quis molestie dui. Nulla porta elementum tristique. Aenean neque libero convallis sit amet dui ullamcorper congue lacinia erat. Sed finibus ex ac massa tincidunt tristique. In sed auctor massa. Proin cursus porttitor arcu. Maecenas a leo nunc. Sed pretium porta volutpat. In aliquet tempor sapien vitae laoreet nisl tempor ac. Vestibulum lacus leo luctus vitae pharetra at tempus ac diam. Integer at dui eu dolor gravida vehicula. Phasellus malesuada elit orci quis maximus purus consectetur ac. In semper consequat augue sit amet ultricies."
+}

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CompositeSearchTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CompositeSearchTestFixture.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             "ObservationWith1MinuteApgarScore",
             "ObservationWith20MinuteApgarScore",
             "ObservationWithEyeColor",
+            "ObservationWithLongEyeColor",
             "ObservationWithTemperature",
             "ObservationWithTPMTDiplotype",
             "ObservationWithTPMTHaplotypeOne",

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CompositeSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CompositeSearchTests.cs
@@ -57,6 +57,9 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [Theory]
         [InlineData("code-value-string=http://snomed.info/sct|162806009$blue", "ObservationWithEyeColor")]
         [InlineData("code-value-string=162806009$blue", "ObservationWithEyeColor")]
+        [InlineData("code-value-string=162806009$Lorem", "ObservationWithLongEyeColor")]
+        [InlineData("code-value-string=162806009$" + StringSearchTestFixture.LongString, "ObservationWithLongEyeColor")]
+        [InlineData("code-value-string=162806009$" + StringSearchTestFixture.LongString + "Not")]
         [InlineData("code-value-string=http://snomed.info/sct|$blue", "ObservationWithEyeColor")]
         [InlineData("code-value-string=http://snomed.info/sct|162806009$red")]
         public async Task GivenACompositeSearchParameterWithTokenAndString_WhenSearched_ThenCorrectBundleShouldBeReturned(string queryValue, params string[] expectedObservationNames)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/StringSearchTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/StringSearchTestFixture.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 {
     public class StringSearchTestFixture : HttpIntegrationTestFixture<Startup>
     {
+        internal const string LongString = "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut eget ultricies justo. Maecenas bibendum convallis sodales. Vestibulum quis molestie dui. Nulla porta elementum tristique. Aenean neque libero convallis sit amet dui ullamcorper congue lacinia erat. Sed finibus ex ac massa tincidunt tristique. In sed auctor massa. Proin cursus porttitor arcu. Maecenas a leo nunc. Sed pretium porta volutpat. In aliquet tempor sapien vitae laoreet nisl tempor ac. Vestibulum lacus leo luctus vitae pharetra at tempus ac diam. Integer at dui eu dolor gravida vehicula. Phasellus malesuada elit orci quis maximus purus consectetur ac. In semper consequat augue sit amet ultricies.";
+
         public StringSearchTestFixture(DataStore dataStore, Format format)
             : base(dataStore, format)
         {
@@ -22,7 +24,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             Patients = FhirClient.CreateResourcesAsync<Patient>(
                 p => SetPatientInfo(p, "Seattle", "Smith"),
                 p => SetPatientInfo(p, "Portland", "Williams"),
-                p => SetPatientInfo(p, "Vancouver", "Anderson"))
+                p => SetPatientInfo(p, "Vancouver", "Anderson"),
+                p => SetPatientInfo(p, LongString, "Murphy"))
                 .Result;
 
             void SetPatientInfo(Patient patient, string city, string family)

--- a/test/Microsoft.Health.Fhir.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -55,8 +55,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             var searchParameterDefinitionManager = Substitute.For<ISearchParameterDefinitionManager>();
             searchParameterDefinitionManager.AllSearchParameters.Returns(new[]
             {
-                new SearchParameter { Name = SearchParameterNames.Id, Url = SearchParameterNames.IdUri.ToString() }.ToInfo(),
-                new SearchParameter { Name = SearchParameterNames.LastUpdated, Url = SearchParameterNames.LastUpdatedUri.ToString() }.ToInfo(),
+                new SearchParameter { Name = SearchParameterNames.Id, Type = SearchParamType.Token, Url = SearchParameterNames.IdUri.ToString() }.ToInfo(),
+                new SearchParameter { Name = SearchParameterNames.LastUpdated, Type = SearchParamType.Date, Url = SearchParameterNames.LastUpdatedUri.ToString() }.ToInfo(),
             });
 
             var securityConfiguration = new SecurityConfiguration { PrincipalClaims = { "oid" } };


### PR DESCRIPTION
## Description
The logic that accounts for string search parameter values being greater than the maximum we index, and falling into an overflow column, was incorrect. 