### PR TITLE
Mark the history test that pages through results as KnownBroken.

### DIFF
--- a/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/Crucible/CrucibleTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/Crucible/CrucibleTestFixture.cs
@@ -474,6 +474,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Crucible
             "connectathon-15-patient-fhirserver-99-all-server-id-xml/02-UpdatePatient",
             "connectathon-15-patient-fhirserver-99-all-server-id-json/07-PatientDelete",
             "connectathon-15-patient-fhirserver-99-all-server-id-xml/07-PatientDelete",
+            "history001/HI09",  // Related to Cosmos DB failure, issue: https://github.com/microsoft/fhir-server/issues/475
         };
 
         private readonly CrucibleDataSource _dataSource;


### PR DESCRIPTION
## Description
The Crucible history test which pages through results fails regularly.  This is due to an issue we are looking into on Cosmos DB.  Until we get it addressed we don't want the test to block other PRs.  Marking it as known broken with a note to fix when the Cosmos db issue is fixed.

## Related issues
Addresses [issue #475 ].
