### PR TITLE
Fixes bug where Resources with no search parameters could not be saved

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Definition/SearchParameterDefinitionBuilderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Definition/SearchParameterDefinitionBuilderTests.cs
@@ -113,6 +113,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Definition
         {
             return new SearchParameterDefinitionBuilder(
                 _jsonParser,
+                ModelInfoProvider.Instance,
                 typeof(EmbeddedResourceManager).Assembly,
                 $"{typeof(Definitions).Namespace}.DefinitionFiles.{ModelInfoProvider.Version}.{fileName}.json");
         }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Definition/SearchParameterDefinitionBuilderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Definition/SearchParameterDefinitionBuilderTests.cs
@@ -77,6 +77,16 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Definition
         }
 
         [Fact]
+        public void GivenAValidSearchParameterDefinitionFile_WhenBuilt_ThenAllResourceTypesShouldBeIncluded()
+        {
+            _builderWithValidEntries.Build();
+
+            Assert.Equal(
+                ModelInfoProvider.GetResourceTypeNames().OrderBy(x => x),
+                _builderWithValidEntries.ResourceTypeDictionary.Select(x => x.Key).OrderBy(x => x).ToArray());
+        }
+
+        [Fact]
         public void GivenAValidSearchParameterDefinitionFile_WhenBuilt_ThenCorrectListOfSearchParametersIsBuiltForEntriesWithSingleBase()
         {
             _builderWithValidEntries.Build();

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Definition/SearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Definition/SearchParameterDefinitionManager.cs
@@ -22,15 +22,18 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
     public class SearchParameterDefinitionManager : ISearchParameterDefinitionManager, IStartable, IProvideCapability
     {
         private readonly FhirJsonParser _fhirJsonParser;
+        private readonly IModelInfoProvider _modelInfoProvider;
 
         private IDictionary<string, IDictionary<string, SearchParameterInfo>> _typeLookup;
         private IDictionary<Uri, SearchParameterInfo> _urlLookup;
 
-        public SearchParameterDefinitionManager(FhirJsonParser fhirJsonParser)
+        public SearchParameterDefinitionManager(FhirJsonParser fhirJsonParser, IModelInfoProvider modelInfoProvider)
         {
             EnsureArg.IsNotNull(fhirJsonParser, nameof(fhirJsonParser));
+            EnsureArg.IsNotNull(modelInfoProvider, nameof(modelInfoProvider));
 
             _fhirJsonParser = fhirJsonParser;
+            _modelInfoProvider = modelInfoProvider;
         }
 
         public IEnumerable<SearchParameterInfo> AllSearchParameters => _urlLookup.Values;
@@ -41,6 +44,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
 
             var builder = new SearchParameterDefinitionBuilder(
                 _fhirJsonParser,
+                _modelInfoProvider,
                 type.Assembly,
                 $"{type.Namespace}.search-parameters.json");
 

--- a/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
+++ b/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
@@ -63,6 +63,7 @@
     <None Remove="TestFiles\R4\InvalidCompartmentDefinition.json" />
     <None Remove="TestFiles\R4\MedicinalProduct.json" />
     <None Remove="TestFiles\R4\Observation-For-Patient-f001.json" />
+    <None Remove="TestFiles\R4\ObservationDefinition-example.json" />
     <None Remove="TestFiles\R4\ObservationWith1MinuteApgarScore.json" />
     <None Remove="TestFiles\R4\ObservationWith20MinuteApgarScore.json" />
     <None Remove="TestFiles\R4\ObservationWithBloodPressure.json" />
@@ -120,6 +121,7 @@
     <EmbeddedResource Include="TestFiles\R4\InvalidCompartmentDefinition.json" />
     <EmbeddedResource Include="TestFiles\R4\MedicinalProduct.json" />
     <EmbeddedResource Include="TestFiles\R4\Observation-For-Patient-f001.json" />
+    <EmbeddedResource Include="TestFiles\R4\ObservationDefinition-example.json" />
     <EmbeddedResource Include="TestFiles\R4\ObservationWith1MinuteApgarScore.json" />
     <EmbeddedResource Include="TestFiles\R4\ObservationWith20MinuteApgarScore.json" />
     <EmbeddedResource Include="TestFiles\R4\ObservationWithBloodPressure.json" />

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/R4/ObservationDefinition-example.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/R4/ObservationDefinition-example.json
@@ -1,0 +1,17 @@
+﻿{
+"resourceType": "ObservationDefinition",
+"id": "example",
+    "text": {
+        "status": "generated",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: example</p><p><b>code</b>: Glucose [Moles/volume] in Blood <span>(Details : {LOINC code '15074-8' = 'Glucose [Moles/volume] in Blood', given as 'Glucose [Moles/volume] in Blood'})</span></p></div>"
+    },
+"code": {
+    "coding": [
+    {
+        "system": "http://loinc.org",
+        "code": "15074-8",
+        "display": "Glucose [Moles/volume] in Blood"
+    }
+    ]
+}
+}

--- a/test/Microsoft.Health.Fhir.R4.Tests.E2E/Microsoft.Health.Fhir.R4.Tests.E2E.csproj
+++ b/test/Microsoft.Health.Fhir.R4.Tests.E2E/Microsoft.Health.Fhir.R4.Tests.E2E.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <IsPackable>true</IsPackable>
+    <RootNamespace>Microsoft.Health.Fhir.Tests.E2E</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Health.Fhir.R4.Tests.E2E/Rest/VersionSpecificTests.cs
+++ b/test/Microsoft.Health.Fhir.R4.Tests.E2E/Rest/VersionSpecificTests.cs
@@ -26,6 +26,16 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         }
 
         [Fact]
+        public async Task GivenAnObservationDefinition_WhenCreating_ThenTheCorrectResponseShouldBeReturned()
+        {
+            var resource = Samples.GetJsonSample<ObservationDefinition>("ObservationDefinition-example");
+
+            Resource actual = await _client.CreateAsync(resource);
+
+            Assert.NotNull(actual);
+        }
+
+        [Fact]
         public async Task GivenANewR4ResourceType_WhenCreated_ThenCorrectResourceShouldBeReturned()
         {
             var testId = Guid.NewGuid().ToString();


### PR DESCRIPTION
## Description
Fixes bug where Resources with no search parameters could not be saved

## Related issues
Addresses [AB#69396](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/69396).

## Testing
Added regression test case to E2E tests with new resource type that was previously causing the error
