### PR TITLE
Add SQL support for Reverse Chaining

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/ChainedExpression.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/ChainedExpression.cs
@@ -19,11 +19,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// <param name="resourceType">The resource type that supports this search expression.</param>
         /// <param name="referenceSearchParameter">The search parameter that establishes the reference</param>
         /// <param name="targetResourceType">The target resource type.</param>
+        /// <param name="reversed">If this is a reversed chain parameter.</param>
         /// <param name="expression">The search expression.</param>
         public ChainedExpression(
             string resourceType,
             SearchParameterInfo referenceSearchParameter,
             string targetResourceType,
+            bool reversed,
             Expression expression)
         {
             EnsureArg.IsTrue(ModelInfoProvider.IsKnownResource(resourceType), nameof(resourceType));
@@ -34,6 +36,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
             ResourceType = resourceType;
             ReferenceSearchParameter = referenceSearchParameter;
             TargetResourceType = targetResourceType;
+            Reversed = reversed;
             Expression = expression;
         }
 
@@ -51,6 +54,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// Gets the target resource type.
         /// </summary>
         public string TargetResourceType { get; }
+
+        public bool Reversed { get; set; }
 
         /// <summary>
         /// Gets the search expression.

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/ChainedExpression.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/ChainedExpression.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// <param name="resourceType">The resource type that supports this search expression.</param>
         /// <param name="referenceSearchParameter">The search parameter that establishes the reference</param>
         /// <param name="targetResourceType">The target resource type.</param>
-        /// <param name="reversed">If this is a reversed chain parameter.</param>
+        /// <param name="reversed">If this is a reversed chained expression.</param>
         /// <param name="expression">The search expression.</param>
         public ChainedExpression(
             string resourceType,
@@ -55,7 +55,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// </summary>
         public string TargetResourceType { get; }
 
-        public bool Reversed { get; set; }
+        /// <summary>
+        /// Get if the expression is reversed.
+        /// </summary>
+        public bool Reversed { get; }
 
         /// <summary>
         /// Gets the search expression.
@@ -71,7 +74,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
 
         public override string ToString()
         {
-            return $"(Chain {ReferenceSearchParameter.Name}:{TargetResourceType} {Expression})";
+            return $"({(Reversed ? "Reverse " : string.Empty)}Chain {ReferenceSearchParameter.Name}:{TargetResourceType} {Expression})";
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Expression.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Expression.cs
@@ -61,11 +61,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// <param name="resourceType">The resource type.</param>
         /// <param name="referenceSearchParameter">The search parameter that establishes the reference between resources</param>
         /// <param name="targetResourceType">The target resource type.</param>
+        /// <param name="reversed">If this is a reversed chained parameter.</param>
         /// <param name="expression">The expression.</param>
         /// <returns>A <see cref="ChainedExpression"/> that represents chained operation on <paramref name="targetResourceType"/> through <paramref name="referenceSearchParameter"/>.</returns>
-        public static ChainedExpression Chained(string resourceType, SearchParameterInfo referenceSearchParameter, string targetResourceType, Expression expression)
+        public static ChainedExpression Chained(string resourceType, SearchParameterInfo referenceSearchParameter, string targetResourceType, bool reversed, Expression expression)
         {
-            return new ChainedExpression(resourceType, referenceSearchParameter, targetResourceType, expression);
+            return new ChainedExpression(resourceType, referenceSearchParameter, targetResourceType, reversed, expression);
         }
 
         /// <summary>

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Expression.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Expression.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// <param name="resourceType">The resource type.</param>
         /// <param name="referenceSearchParameter">The search parameter that establishes the reference between resources</param>
         /// <param name="targetResourceType">The target resource type.</param>
-        /// <param name="reversed">If this is a reversed chained parameter.</param>
+        /// <param name="reversed">If this is a reversed chained expression.</param>
         /// <param name="expression">The expression.</param>
         /// <returns>A <see cref="ChainedExpression"/> that represents chained operation on <paramref name="targetResourceType"/> through <paramref name="referenceSearchParameter"/>.</returns>
         public static ChainedExpression Chained(string resourceType, SearchParameterInfo referenceSearchParameter, string targetResourceType, bool reversed, Expression expression)

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/ExpressionRewriter.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/ExpressionRewriter.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
                 return expression;
             }
 
-            return new ChainedExpression(resourceType: expression.ResourceType, referenceSearchParameter: expression.ReferenceSearchParameter, targetResourceType: expression.TargetResourceType, expression: visitedExpression);
+            return new ChainedExpression(resourceType: expression.ResourceType, referenceSearchParameter: expression.ReferenceSearchParameter, targetResourceType: expression.TargetResourceType, reversed: expression.Reversed, expression: visitedExpression);
         }
 
         public virtual Expression VisitMissingField(MissingFieldExpression expression, TContext context)

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -529,6 +529,24 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The reverse chain search is missing the reference to search..
+        /// </summary>
+        internal static string ReverseChainMissingReference {
+            get {
+                return ResourceManager.GetString("ReverseChainMissingReference", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The reverse chain search is missing the type to search..
+        /// </summary>
+        internal static string ReverseChainMissingType {
+            get {
+                return ResourceManager.GetString("ReverseChainMissingType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Role name cannot be null or empty..
         /// </summary>
         internal static string RoleNameEmpty {

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -278,6 +278,12 @@
     <value>The supplied version '{0}' did not match.</value>
     <comment>{0}: ETag</comment>
   </data>
+  <data name="ReverseChainMissingReference" xml:space="preserve">
+    <value>The reverse chain search is missing the reference to search.</value>
+  </data>
+  <data name="ReverseChainMissingType" xml:space="preserve">
+    <value>The reverse chain search is missing the type to search.</value>
+  </data>
   <data name="RoleNameEmpty" xml:space="preserve">
     <value>Role name cannot be null or empty.</value>
   </data>

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/ExpressionRewriterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/ExpressionRewriterTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions
             var simpleExpression2 = Expression.Equals(FieldName.Number, null, 5M);
             VerifyVisit(simpleExpression1);
             VerifyVisit(Expression.SearchParameter(new SearchParameterInfo("my-param"), simpleExpression1));
-            VerifyVisit(Expression.Chained("Observation", new SearchParameterInfo("subject"), "Patient", simpleExpression1));
+            VerifyVisit(Expression.Chained("Observation", new SearchParameterInfo("subject"), "Patient", false, simpleExpression1));
             VerifyVisit(Expression.CompartmentSearch("Patient", "x"));
             VerifyVisit(Expression.Missing(FieldName.Quantity, null));
             VerifyVisit(Expression.MissingSearchParameter(new SearchParameterInfo("my-param"), true));
@@ -52,7 +52,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions
 
             VerifyVisit($"(Param my-param {expectedAndString1})", Expression.SearchParameter(new SearchParameterInfo("my-param"), simpleExpression1));
 
-            VerifyVisit($"(Chain subject:Patient {expectedAndString1})", Expression.Chained("Observation", new SearchParameterInfo("subject"), "Patient", simpleExpression1));
+            VerifyVisit($"(Chain subject:Patient {expectedAndString1})", Expression.Chained("Observation", new SearchParameterInfo("subject"), "Patient", false, simpleExpression1));
             VerifyVisit($"(Or {expectedAndString1} {expectedAndString2})", Expression.Or(simpleExpression1, simpleExpression2));
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/ExpressionRewriterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/ExpressionRewriterTests.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions
             VerifyVisit(simpleExpression1);
             VerifyVisit(Expression.SearchParameter(new SearchParameterInfo("my-param"), simpleExpression1));
             VerifyVisit(Expression.Chained("Observation", new SearchParameterInfo("subject"), "Patient", false, simpleExpression1));
+            VerifyVisit(Expression.Chained("Patient", new SearchParameterInfo("subject"), "Observation", true, simpleExpression1));
             VerifyVisit(Expression.CompartmentSearch("Patient", "x"));
             VerifyVisit(Expression.Missing(FieldName.Quantity, null));
             VerifyVisit(Expression.MissingSearchParameter(new SearchParameterInfo("my-param"), true));
@@ -53,6 +54,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions
             VerifyVisit($"(Param my-param {expectedAndString1})", Expression.SearchParameter(new SearchParameterInfo("my-param"), simpleExpression1));
 
             VerifyVisit($"(Chain subject:Patient {expectedAndString1})", Expression.Chained("Observation", new SearchParameterInfo("subject"), "Patient", false, simpleExpression1));
+            VerifyVisit($"(Reverse Chain subject:Observation {expectedAndString1})", Expression.Chained("Patient", new SearchParameterInfo("subject"), "Observation", true, simpleExpression1));
             VerifyVisit($"(Or {expectedAndString1} {expectedAndString2})", Expression.Or(simpleExpression1, simpleExpression2));
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/ExpressionToStringTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/ExpressionToStringTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions
 
             VerifyExpression("(Compartment Patient 'x')", Expression.CompartmentSearch("Patient", "x"));
 
-            VerifyExpression("(Chain subject:Patient (FieldGreaterThan DateTimeEnd 2000-01-01T00:00:00.0000000))", Expression.Chained("Observation", new SearchParameterInfo("subject"), "Patient", Expression.GreaterThan(FieldName.DateTimeEnd, null, new DateTime(2000, 1, 1))));
+            VerifyExpression("(Chain subject:Patient (FieldGreaterThan DateTimeEnd 2000-01-01T00:00:00.0000000))", Expression.Chained("Observation", new SearchParameterInfo("subject"), "Patient", false, Expression.GreaterThan(FieldName.DateTimeEnd, null, new DateTime(2000, 1, 1))));
         }
 
         private static void VerifyExpression(string expected, Expression expression)

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/ExpressionToStringTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/ExpressionToStringTests.cs
@@ -36,6 +36,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions
             VerifyExpression("(Compartment Patient 'x')", Expression.CompartmentSearch("Patient", "x"));
 
             VerifyExpression("(Chain subject:Patient (FieldGreaterThan DateTimeEnd 2000-01-01T00:00:00.0000000))", Expression.Chained("Observation", new SearchParameterInfo("subject"), "Patient", false, Expression.GreaterThan(FieldName.DateTimeEnd, null, new DateTime(2000, 1, 1))));
+
+            VerifyExpression("(Reverse Chain subject:Observation (FieldGreaterThan DateTimeEnd 2000-01-01T00:00:00.0000000))", Expression.Chained("Patient", new SearchParameterInfo("subject"), "Observation", true, Expression.GreaterThan(FieldName.DateTimeEnd, null, new DateTime(2000, 1, 1))));
         }
 
         private static void VerifyExpression(string expected, Expression expression)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/DenormalizedPredicateRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/DenormalizedPredicateRewriter.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
 {
     /// <summary>
     /// Promotes predicates applied directly in on the Resource table to the search parameter tables.
-    /// These are predicates on the ResoruceSurrogateId and ResourceType columns. The idea is to make these
+    /// These are predicates on the ResourceSurrogateId and ResourceType columns. The idea is to make these
     /// queries as selective as possible.
     /// </summary>
     internal class DenormalizedPredicateRewriter : ExpressionRewriterWithInitialContext<object>, ISqlExpressionVisitor<object, Expression>

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -283,7 +283,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                         if (tableExpression.ChainLevel == 1)
                         {
                             // if > 1, the intersection is handled by the JOIN
-                            AppendIntersectionWithPredecessor(delimited, tableExpression, referenceTableAlias);
+                            AppendIntersectionWithPredecessor(delimited, tableExpression, chainedExpression.Reversed ? resourceTableAlias : referenceTableAlias);
                         }
 
                         if (tableExpression.DenormalizedPredicate != null)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -236,14 +236,14 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     StringBuilder.Append("SELECT ");
                     if (tableExpression.ChainLevel == 1)
                     {
-                        StringBuilder.Append(V1.ReferenceSearchParam.ResourceSurrogateId, referenceTableAlias).Append(" AS Sid1, ");
+                        StringBuilder.Append(V1.ReferenceSearchParam.ResourceSurrogateId, referenceTableAlias).Append(" AS ").Append(chainedExpression.Reversed ? "Sid2" : "Sid1").Append(", ");
                     }
                     else
                     {
                         StringBuilder.Append("Sid1, ");
                     }
 
-                    StringBuilder.Append(V1.Resource.ResourceSurrogateId, resourceTableAlias).AppendLine(" AS Sid2")
+                    StringBuilder.Append(V1.Resource.ResourceSurrogateId, (chainedExpression.Reversed && tableExpression.ChainLevel == 1) || !chainedExpression.Reversed ? resourceTableAlias : referenceTableAlias).Append(" AS ").AppendLine(chainedExpression.Reversed && tableExpression.ChainLevel == 1 ? "Sid1 " : "Sid2 ")
                         .Append("FROM ").Append(V1.ReferenceSearchParam).Append(' ').AppendLine(referenceTableAlias)
                         .Append("INNER JOIN ").Append(V1.Resource).Append(' ').AppendLine(resourceTableAlias);
 
@@ -262,7 +262,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
                         using (var delimited = StringBuilder.BeginDelimitedOnClause())
                         {
-                            delimited.BeginDelimitedElement().Append(V1.Resource.ResourceSurrogateId, referenceTableAlias).Append(" = ").Append("Sid2");
+                            delimited.BeginDelimitedElement().Append(V1.Resource.ResourceSurrogateId, (chainedExpression.Reversed && tableExpression.ChainLevel == 1) || !chainedExpression.Reversed ? referenceTableAlias : resourceTableAlias).Append(" = ").Append("Sid2");
                         }
                     }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -243,7 +243,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                         StringBuilder.Append("Sid1, ");
                     }
 
-                    StringBuilder.Append(V1.Resource.ResourceSurrogateId, (chainedExpression.Reversed && tableExpression.ChainLevel == 1) || !chainedExpression.Reversed ? resourceTableAlias : referenceTableAlias).Append(" AS ").AppendLine(chainedExpression.Reversed && tableExpression.ChainLevel == 1 ? "Sid1 " : "Sid2 ")
+                    StringBuilder.Append(V1.Resource.ResourceSurrogateId, chainedExpression.Reversed && tableExpression.ChainLevel > 1 ? referenceTableAlias : resourceTableAlias).Append(" AS ").AppendLine(chainedExpression.Reversed && tableExpression.ChainLevel == 1 ? "Sid1 " : "Sid2 ")
                         .Append("FROM ").Append(V1.ReferenceSearchParam).Append(' ').AppendLine(referenceTableAlias)
                         .Append("INNER JOIN ").Append(V1.Resource).Append(' ').AppendLine(resourceTableAlias);
 
@@ -262,7 +262,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
                         using (var delimited = StringBuilder.BeginDelimitedOnClause())
                         {
-                            delimited.BeginDelimitedElement().Append(V1.Resource.ResourceSurrogateId, (chainedExpression.Reversed && tableExpression.ChainLevel == 1) || !chainedExpression.Reversed ? referenceTableAlias : resourceTableAlias).Append(" = ").Append("Sid2");
+                            delimited.BeginDelimitedElement().Append(V1.Resource.ResourceSurrogateId, chainedExpression.Reversed ? resourceTableAlias : referenceTableAlias).Append(" = ").Append("Sid2");
                         }
                     }
 

--- a/src/Microsoft.Health.Fhir.Stu3.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Stu3.Web/appsettings.json
@@ -4,7 +4,7 @@
       "UseStrictConformance": true
     },
     "Security": {
-      "Enabled": true,
+      "Enabled": false,
       "EnableAadSmartOnFhirProxy": true,
       "Authentication": {
         "Audience": null,

--- a/src/Microsoft.Health.Fhir.Stu3.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Stu3.Web/appsettings.json
@@ -4,7 +4,7 @@
       "UseStrictConformance": true
     },
     "Security": {
-      "Enabled": false,
+      "Enabled": true,
       "EnableAadSmartOnFhirProxy": true,
       "Authentication": {
         "Audience": null,

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Search
         [Fact]
         public async Task GivenAReverseChainSearchExpressionOverASimpleParameter_WhenSearched_ThenCorrectBundleShouldBeReturned()
         {
-            string query = $"_has:Observation:patient:code=429858000&_tag={Fixture.Tag}";
+            string query = $"_tag={Fixture.Tag}&_has:Observation:patient:code=429858000";
 
             Bundle bundle = await Client.SearchAsync(ResourceType.Patient, query);
 
@@ -86,7 +86,7 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Search
         [Fact]
         public async Task GivenANestedReverseChainSearchExpressionOverASimpleParameter_WhenSearched_ThenCorrectBundleShouldBeReturned()
         {
-            string query = $"_has:Observation:patient:_has:DiagnosticReport:result:code=429858000&_tag={Fixture.Tag}";
+            string query = $"_tag={Fixture.Tag}&_has:Observation:patient:_has:DiagnosticReport:result:code=429858000";
 
             Bundle bundle = await Client.SearchAsync(ResourceType.Patient, query);
 
@@ -96,7 +96,7 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Search
         [Fact]
         public async Task GivenACombinationOfChainingReverseChainSearchExpressionOverASimpleParameter_WhenSearched_ThenCorrectBundleShouldBeReturned()
         {
-            string query = $"patient:Patient._has:Observation:subject:code=429858000&_tag={Fixture.Tag}";
+            string query = $"_tag={Fixture.Tag}&patient:Patient._has:Observation:subject:code=429858000";
 
             Bundle bundle = await Client.SearchAsync(ResourceType.DiagnosticReport, query);
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Search
         [Fact]
         public async Task GivenAChainedSearchExpressionOverASimpleParameter_WhenSearched_ThenCorrectBundleShouldBeReturned()
         {
-            string query = $"subject:Patient._type=Patient&_tag={Fixture.Tag}";
+            string query = $"_tag={Fixture.Tag}&subject:Patient._type=Patient";
 
             Bundle bundle = await Client.SearchAsync(ResourceType.DiagnosticReport, query);
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
@@ -7,13 +7,11 @@ using System;
 using System.Collections.Generic;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
-using Microsoft.Health.Fhir.Tests.E2E.Rest;
-using Microsoft.Health.Fhir.Tests.E2E.Rest.Search;
 using Microsoft.Health.Fhir.Web;
 using Xunit;
 using Task = System.Threading.Tasks.Task;
 
-namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Search
+namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 {
     [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
     public class ChainingSearchTests : SearchTestsBase<ChainingSearchTests.ClassFixture>
@@ -30,7 +28,7 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Search
 
             Bundle bundle = await Client.SearchAsync(ResourceType.DiagnosticReport, query);
 
-            ValidateBundle(bundle, Fixture.SmithDiagnosticReport);
+            ValidateBundle(bundle, Fixture.SmithSnomedDiagnosticReport, Fixture.SmithLoincDiagnosticReport);
         }
 
         [Fact]
@@ -40,7 +38,7 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Search
 
             Bundle bundle = await Client.SearchAsync(ResourceType.DiagnosticReport, query);
 
-            ValidateBundle(bundle, Fixture.SmithDiagnosticReport);
+            ValidateBundle(bundle, Fixture.SmithSnomedDiagnosticReport, Fixture.SmithLoincDiagnosticReport);
         }
 
         [Fact]
@@ -50,7 +48,7 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Search
 
             Bundle bundle = await Client.SearchAsync(ResourceType.DiagnosticReport, query);
 
-            ValidateBundle(bundle, Fixture.SmithDiagnosticReport, Fixture.TrumanDiagnosticReport);
+            ValidateBundle(bundle, Fixture.SmithSnomedDiagnosticReport, Fixture.SmithLoincDiagnosticReport, Fixture.TrumanSnomedDiagnosticReport, Fixture.TrumanLoincDiagnosticReport);
         }
 
         [Fact]
@@ -60,7 +58,7 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Search
 
             Bundle bundle = await Client.SearchAsync(ResourceType.DiagnosticReport, query);
 
-            ValidateBundle(bundle, Fixture.SmithDiagnosticReport, Fixture.TrumanDiagnosticReport);
+            ValidateBundle(bundle, Fixture.SmithSnomedDiagnosticReport, Fixture.SmithLoincDiagnosticReport, Fixture.TrumanSnomedDiagnosticReport, Fixture.TrumanLoincDiagnosticReport);
         }
 
         [Fact]
@@ -94,13 +92,33 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Search
         }
 
         [Fact]
+        public async Task GivenANestedReverseChainSearchExpressionOverADenormalizedParameter_WhenSearched_ThenCorrectBundleShouldBeReturned()
+        {
+            string query = $"_tag={Fixture.Tag}&_has:Group:member:_id={Fixture.PatientGroup.Id}";
+
+            Bundle bundle = await Client.SearchAsync(ResourceType.Patient, query);
+
+            ValidateBundle(bundle, Fixture.AdamsPatient, Fixture.SmithPatient, Fixture.TrumanPatient);
+        }
+
+        [Fact]
         public async Task GivenACombinationOfChainingReverseChainSearchExpressionOverASimpleParameter_WhenSearched_ThenCorrectBundleShouldBeReturned()
         {
-            string query = $"_tag={Fixture.Tag}&patient:Patient._has:Observation:subject:code=429858000";
+            string query = $"_tag={Fixture.Tag}&code=429858000&patient:Patient._has:Group:member:_tag={Fixture.Tag}";
 
             Bundle bundle = await Client.SearchAsync(ResourceType.DiagnosticReport, query);
 
-            ValidateBundle(bundle, Fixture.SmithDiagnosticReport, Fixture.TrumanDiagnosticReport);
+            ValidateBundle(bundle, Fixture.SmithSnomedDiagnosticReport, Fixture.TrumanSnomedDiagnosticReport);
+        }
+
+        [Fact]
+        public async Task GivenACombinationOfChainingReverseChainSearchExpressionOverADenormalizedParameter_WhenSearched_ThenCorrectBundleShouldBeReturned()
+        {
+            string query = $"_tag={Fixture.Tag}&code=429858000&patient:Patient._has:Group:member:_id={Fixture.PatientGroup.Id}";
+
+            Bundle bundle = await Client.SearchAsync(ResourceType.DiagnosticReport, query);
+
+            ValidateBundle(bundle, Fixture.SmithSnomedDiagnosticReport, Fixture.TrumanSnomedDiagnosticReport);
         }
 
         public class ClassFixture : HttpIntegrationTestFixture<Startup>
@@ -110,51 +128,81 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Search
             {
                 Tag = Guid.NewGuid().ToString();
 
-                // Construct an observation pointing to a patient and a diagnostic report pointing to the observation and the patient
+                // Construct an observation pointing to a patient and a diagnostic report pointing to the observation and the patient along with some not matching entries
+                var snomedCode = new CodeableConcept("http://snomed.info/sct", "429858000");
+                var loincCode = new CodeableConcept("http://loinc.org", "4548-4");
 
+                AdamsPatient = FhirClient.CreateAsync(new Patient { Meta = new Meta { Tag = new List<Coding> { new Coding("testTag", Tag) } }, Name = new List<HumanName> { new HumanName { Family = "Adams" } } }).Result.Resource;
                 SmithPatient = FhirClient.CreateAsync(new Patient { Meta = new Meta { Tag = new List<Coding> { new Coding("testTag", Tag) } }, Name = new List<HumanName> { new HumanName { Family = "Smith" } } }).Result.Resource;
                 TrumanPatient = FhirClient.CreateAsync(new Patient { Meta = new Meta { Tag = new List<Coding> { new Coding("testTag", Tag) } }, Name = new List<HumanName> { new HumanName { Family = "Truman" } } }).Result.Resource;
 
-                var smithObservation = CreateObservation(SmithPatient);
-                var trumanObservation = CreateObservation(TrumanPatient);
+                var adamsLoincObservation = CreateObservation(AdamsPatient, loincCode);
+                var smithLoincObservation = CreateObservation(SmithPatient, loincCode);
+                var smithSnomedObservation = CreateObservation(SmithPatient, snomedCode);
+                var trumanLoincObservation = CreateObservation(TrumanPatient, loincCode);
+                var trumanSnomedObservation = CreateObservation(TrumanPatient, snomedCode);
 
-                SmithDiagnosticReport = CreateDiagnosticReport(SmithPatient, smithObservation);
-                TrumanDiagnosticReport = CreateDiagnosticReport(TrumanPatient, trumanObservation);
+                SmithSnomedDiagnosticReport = CreateDiagnosticReport(SmithPatient, smithSnomedObservation, snomedCode);
+                TrumanSnomedDiagnosticReport = CreateDiagnosticReport(TrumanPatient, trumanSnomedObservation, snomedCode);
+                SmithLoincDiagnosticReport = CreateDiagnosticReport(SmithPatient, smithLoincObservation, loincCode);
+                TrumanLoincDiagnosticReport = CreateDiagnosticReport(TrumanPatient, trumanLoincObservation, loincCode);
 
-                DiagnosticReport CreateDiagnosticReport(Patient patient, Observation observation)
+                var group = new Group
+                {
+                    Meta = new Meta { Tag = new List<Coding> { new Coding("testTag", Tag) } },
+                    Type = Group.GroupType.Person, Actual = true,
+                    Member = new List<Group.MemberComponent>
+                    {
+                        new Group.MemberComponent { Entity = new ResourceReference($"Patient/{AdamsPatient.Id}") },
+                        new Group.MemberComponent { Entity = new ResourceReference($"Patient/{SmithPatient.Id}") },
+                        new Group.MemberComponent { Entity = new ResourceReference($"Patient/{TrumanPatient.Id}") },
+                    },
+                };
+
+                PatientGroup = FhirClient.CreateAsync(group).Result.Resource;
+
+                DiagnosticReport CreateDiagnosticReport(Patient patient, Observation observation, CodeableConcept code)
                 {
                     return FhirClient.CreateAsync(
                         new DiagnosticReport
                         {
                             Meta = new Meta { Tag = new List<Coding> { new Coding("testTag", Tag) } },
                             Status = DiagnosticReport.DiagnosticReportStatus.Final,
-                            Code = new CodeableConcept("http://snomed.info/sct", "429858000"),
+                            Code = code,
                             Subject = new ResourceReference($"Patient/{patient.Id}"),
                             Result = new List<ResourceReference> { new ResourceReference($"Observation/{observation.Id}") },
                         }).Result.Resource;
                 }
 
-                Observation CreateObservation(Patient patient)
+                Observation CreateObservation(Patient patient, CodeableConcept code)
                 {
                     return FhirClient.CreateAsync(
                         new Observation()
                         {
                             Status = ObservationStatus.Final,
-                            Code = new CodeableConcept("http://snomed.info/sct", "429858000"),
+                            Code = code,
                             Subject = new ResourceReference($"Patient/{patient.Id}"),
                         }).Result.Resource;
                 }
             }
 
+            public Group PatientGroup { get; }
+
             public string Tag { get; }
 
-            public Patient SmithPatient { get; }
+            public Patient AdamsPatient { get; }
 
             public Patient TrumanPatient { get; }
 
-            public DiagnosticReport TrumanDiagnosticReport { get; }
+            public DiagnosticReport TrumanSnomedDiagnosticReport { get; }
 
-            public DiagnosticReport SmithDiagnosticReport { get; }
+            public DiagnosticReport TrumanLoincDiagnosticReport { get; }
+
+            public Patient SmithPatient { get; }
+
+            public DiagnosticReport SmithSnomedDiagnosticReport { get; }
+
+            public DiagnosticReport SmithLoincDiagnosticReport { get; }
         }
     }
 }


### PR DESCRIPTION
## Description
Updates parsing to support reverse chaining and add SQL server support for reverse chain queries

## Related issues
Addresses [AB#69375](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/69375).

## Testing
Added additional E2E tests for reverse chains and combinations of reverse and forward chaining. Additionally, the existing chained search tests still work. 
