### PR TITLE
Add auth secrets to keyvault

### DIFF
--- a/release/scripts/PowerShell/FhirServerRelease/Private/Set-FhirServerApiUsers.ps1
+++ b/release/scripts/PowerShell/FhirServerRelease/Private/Set-FhirServerApiUsers.ps1
@@ -76,6 +76,9 @@ function Set-FhirServerApiUsers {
             $aadUser = New-AzureADUser -DisplayName $userId -PasswordProfile $PasswordProfile -UserPrincipalName $userUpn -AccountEnabled $true -MailNickName $userId
         }
 
+        $upnSecureString = ConvertTo-SecureString -string $userUpn -AsPlainText -Force
+        Set-AzureKeyVaultSecret -VaultName $KeyVaultName -Name "user_$($userId)_id" -SecretValue $upnSecureString | Out-Null
+        Set-AzureKeyVaultSecret -VaultName $KeyVaultName -Name "user_$($userId)_secret" -SecretValue $passwordSecureString | Out-Null
         Set-AzureKeyVaultSecret -VaultName $KeyVaultName -Name "$userId-password" -SecretValue $passwordSecureString | Out-Null
 
         $environmentUsers += @{

--- a/release/scripts/PowerShell/FhirServerRelease/Private/Set-FhirServerApiUsers.ps1
+++ b/release/scripts/PowerShell/FhirServerRelease/Private/Set-FhirServerApiUsers.ps1
@@ -77,8 +77,8 @@ function Set-FhirServerApiUsers {
         }
 
         $upnSecureString = ConvertTo-SecureString -string $userUpn -AsPlainText -Force
-        Set-AzureKeyVaultSecret -VaultName $KeyVaultName -Name "user_$($userId)_id" -SecretValue $upnSecureString | Out-Null
-        Set-AzureKeyVaultSecret -VaultName $KeyVaultName -Name "user_$($userId)_secret" -SecretValue $passwordSecureString | Out-Null
+        Set-AzureKeyVaultSecret -VaultName $KeyVaultName -Name "user--$($userId)--id" -SecretValue $upnSecureString | Out-Null
+        Set-AzureKeyVaultSecret -VaultName $KeyVaultName -Name "user--$($userId)--secret" -SecretValue $passwordSecureString | Out-Null
         Set-AzureKeyVaultSecret -VaultName $KeyVaultName -Name "$userId-password" -SecretValue $passwordSecureString | Out-Null
 
         $environmentUsers += @{

--- a/release/scripts/PowerShell/FhirServerRelease/Private/Set-FhirServerApiUsers.ps1
+++ b/release/scripts/PowerShell/FhirServerRelease/Private/Set-FhirServerApiUsers.ps1
@@ -79,7 +79,6 @@ function Set-FhirServerApiUsers {
         $upnSecureString = ConvertTo-SecureString -string $userUpn -AsPlainText -Force
         Set-AzureKeyVaultSecret -VaultName $KeyVaultName -Name "user--$($user.id)--id" -SecretValue $upnSecureString | Out-Null
         Set-AzureKeyVaultSecret -VaultName $KeyVaultName -Name "user--$($user.id)--secret" -SecretValue $passwordSecureString | Out-Null
-        Set-AzureKeyVaultSecret -VaultName $KeyVaultName -Name "$userId-password" -SecretValue $passwordSecureString | Out-Null
 
         $environmentUsers += @{
             upn           = $userUpn

--- a/release/scripts/PowerShell/FhirServerRelease/Private/Set-FhirServerApiUsers.ps1
+++ b/release/scripts/PowerShell/FhirServerRelease/Private/Set-FhirServerApiUsers.ps1
@@ -77,8 +77,8 @@ function Set-FhirServerApiUsers {
         }
 
         $upnSecureString = ConvertTo-SecureString -string $userUpn -AsPlainText -Force
-        Set-AzureKeyVaultSecret -VaultName $KeyVaultName -Name "user--$($userId)--id" -SecretValue $upnSecureString | Out-Null
-        Set-AzureKeyVaultSecret -VaultName $KeyVaultName -Name "user--$($userId)--secret" -SecretValue $passwordSecureString | Out-Null
+        Set-AzureKeyVaultSecret -VaultName $KeyVaultName -Name "user--$($user.id)--id" -SecretValue $upnSecureString | Out-Null
+        Set-AzureKeyVaultSecret -VaultName $KeyVaultName -Name "user--$($user.id)--secret" -SecretValue $passwordSecureString | Out-Null
         Set-AzureKeyVaultSecret -VaultName $KeyVaultName -Name "$userId-password" -SecretValue $passwordSecureString | Out-Null
 
         $environmentUsers += @{

--- a/release/scripts/PowerShell/FhirServerRelease/Public/Add-AadTestAuthEnvironment.ps1
+++ b/release/scripts/PowerShell/FhirServerRelease/Public/Add-AadTestAuthEnvironment.ps1
@@ -93,7 +93,7 @@ function Add-AadTestAuthEnvironment {
 
     if ($currentObjectId) {
         Write-Host "Adding permission to keyvault for $currentObjectId"
-        Set-AzureRmKeyVaultAccessPolicy -VaultName $KeyVaultName -ObjectId $currentObjectId -PermissionsToSecrets Get, Set
+        Set-AzureRmKeyVaultAccessPolicy -VaultName $KeyVaultName -ObjectId $currentObjectId -PermissionsToSecrets Get,List,Set
     }
 
     Write-Host "Ensuring API application exists"
@@ -153,8 +153,8 @@ function Add-AadTestAuthEnvironment {
         }
         
         $appIdSecureString = ConvertTo-SecureString -String $aadClientApplication.AppId -AsPlainText -Force
-        Set-AzureKeyVaultSecret -VaultName $KeyVaultName -Name "app--$($displayName)--id" -SecretValue $appIdSecureString | Out-Null
-        Set-AzureKeyVaultSecret -VaultName $KeyVaultName -Name "app--$($displayName)--secret" -SecretValue $secretSecureString | Out-Null
+        Set-AzureKeyVaultSecret -VaultName $KeyVaultName -Name "app--$($clientApp.Id)--id" -SecretValue $appIdSecureString | Out-Null
+        Set-AzureKeyVaultSecret -VaultName $KeyVaultName -Name "app--$($clientApp.Id)--secret" -SecretValue $secretSecureString | Out-Null
         Set-AzureKeyVaultSecret -VaultName $KeyVaultName -Name "$displayName-secret" -SecretValue $secretSecureString | Out-Null
 
         Set-FhirServerClientAppRoleAssignments -ApiAppId $application.AppId -AppId $aadClientApplication.AppId -AppRoles $clientApp.roles | Out-Null

--- a/release/scripts/PowerShell/FhirServerRelease/Public/Add-AadTestAuthEnvironment.ps1
+++ b/release/scripts/PowerShell/FhirServerRelease/Public/Add-AadTestAuthEnvironment.ps1
@@ -153,8 +153,8 @@ function Add-AadTestAuthEnvironment {
         }
         
         $appIdSecureString = ConvertTo-SecureString -String $aadClientApplication.AppId -AsPlainText -Force
-        Set-AzureKeyVaultSecret -ValutName $KeyVaultName -Name "app--$($displayName)--id" -SecretValue $appIdSecureString | Out-Null
-        Set-AzureKeyVaultSecret -ValutName $KeyVaultName -Name "app--$($displayName)--secret" -SecretValue $secretSecureString | Out-Null
+        Set-AzureKeyVaultSecret -VaultName $KeyVaultName -Name "app--$($displayName)--id" -SecretValue $appIdSecureString | Out-Null
+        Set-AzureKeyVaultSecret -VaultName $KeyVaultName -Name "app--$($displayName)--secret" -SecretValue $secretSecureString | Out-Null
         Set-AzureKeyVaultSecret -VaultName $KeyVaultName -Name "$displayName-secret" -SecretValue $secretSecureString | Out-Null
 
         Set-FhirServerClientAppRoleAssignments -ApiAppId $application.AppId -AppId $aadClientApplication.AppId -AppRoles $clientApp.roles | Out-Null

--- a/release/scripts/PowerShell/FhirServerRelease/Public/Add-AadTestAuthEnvironment.ps1
+++ b/release/scripts/PowerShell/FhirServerRelease/Public/Add-AadTestAuthEnvironment.ps1
@@ -155,7 +155,6 @@ function Add-AadTestAuthEnvironment {
         $appIdSecureString = ConvertTo-SecureString -String $aadClientApplication.AppId -AsPlainText -Force
         Set-AzureKeyVaultSecret -VaultName $KeyVaultName -Name "app--$($clientApp.Id)--id" -SecretValue $appIdSecureString | Out-Null
         Set-AzureKeyVaultSecret -VaultName $KeyVaultName -Name "app--$($clientApp.Id)--secret" -SecretValue $secretSecureString | Out-Null
-        Set-AzureKeyVaultSecret -VaultName $KeyVaultName -Name "$displayName-secret" -SecretValue $secretSecureString | Out-Null
 
         Set-FhirServerClientAppRoleAssignments -ApiAppId $application.AppId -AppId $aadClientApplication.AppId -AppRoles $clientApp.roles | Out-Null
     }

--- a/release/scripts/PowerShell/FhirServerRelease/Public/Add-AadTestAuthEnvironment.ps1
+++ b/release/scripts/PowerShell/FhirServerRelease/Public/Add-AadTestAuthEnvironment.ps1
@@ -152,6 +152,9 @@ function Add-AadTestAuthEnvironment {
             appId       = $aadClientApplication.AppId
         }
         
+        $appIdSecureString = ConvertTo-SecureString -String $aadClientApplication.AppId -AsPlainText -Force
+        Set-AzureKeyVaultSecret -ValutName $KeyVaultName -Name "app_$($displayName)_id" -SecretValue $appIdSecureString | Out-Null
+        Set-AzureKeyVaultSecret -ValutName $KeyVaultName -Name "app_$($displayName)_secret" -SecretValue $secretSecureString | Out-Null
         Set-AzureKeyVaultSecret -VaultName $KeyVaultName -Name "$displayName-secret" -SecretValue $secretSecureString | Out-Null
 
         Set-FhirServerClientAppRoleAssignments -ApiAppId $application.AppId -AppId $aadClientApplication.AppId -AppRoles $clientApp.roles | Out-Null

--- a/release/scripts/PowerShell/FhirServerRelease/Public/Add-AadTestAuthEnvironment.ps1
+++ b/release/scripts/PowerShell/FhirServerRelease/Public/Add-AadTestAuthEnvironment.ps1
@@ -153,8 +153,8 @@ function Add-AadTestAuthEnvironment {
         }
         
         $appIdSecureString = ConvertTo-SecureString -String $aadClientApplication.AppId -AsPlainText -Force
-        Set-AzureKeyVaultSecret -ValutName $KeyVaultName -Name "app_$($displayName)_id" -SecretValue $appIdSecureString | Out-Null
-        Set-AzureKeyVaultSecret -ValutName $KeyVaultName -Name "app_$($displayName)_secret" -SecretValue $secretSecureString | Out-Null
+        Set-AzureKeyVaultSecret -ValutName $KeyVaultName -Name "app--$($displayName)--id" -SecretValue $appIdSecureString | Out-Null
+        Set-AzureKeyVaultSecret -ValutName $KeyVaultName -Name "app--$($displayName)--secret" -SecretValue $secretSecureString | Out-Null
         Set-AzureKeyVaultSecret -VaultName $KeyVaultName -Name "$displayName-secret" -SecretValue $secretSecureString | Out-Null
 
         Set-FhirServerClientAppRoleAssignments -ApiAppId $application.AppId -AppId $aadClientApplication.AppId -AppRoles $clientApp.roles | Out-Null

--- a/src/Microsoft.Health.Fhir.R4.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.R4.Web/appsettings.json
@@ -24,7 +24,7 @@
     },
     "CosmosDb": {
       "CollectionId": "fhirR4",
-      "InitialCollectionThroughput": null
+      "InitialCollectionThroughput": 1000
     },
     "Cors": {
       "Origins": [],

--- a/src/Microsoft.Health.Fhir.Stu3.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Stu3.Web/appsettings.json
@@ -24,7 +24,7 @@
     },
     "CosmosDb": {
       "CollectionId": "fhir",
-      "InitialCollectionThroughput": null
+      "InitialCollectionThroughput": 1000
     },
     "Cors": {
       "Origins": [],


### PR DESCRIPTION
## Description
This PR adds authentication secrets to keyvault so that we can support running the E2E tests in parallel.

## Related issues
Addresses [AB#69520](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/69520).

## Testing
Build will be updated to take advantage of these changes.
