### PR TITLE
Encode the continuation token

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Routing/IUrlResolver.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Routing/IUrlResolver.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using Hl7.Fhir.ElementModel;
 using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Core.Features.Routing

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchService.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchService.cs
@@ -51,8 +51,16 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
         {
             SearchOptions searchOptions = _searchOptionsFactory.Create(resourceType, queryParameters);
 
-            // Execute the actual search.
-            return await SearchInternalAsync(searchOptions, cancellationToken);
+            try
+            {
+                // Execute the actual search.
+                return await SearchInternalAsync(searchOptions, cancellationToken);
+            }
+            catch (Exception)
+            {
+                // Should a logging statement be added?
+                throw new RequestNotValidException(Resources.InvalidContinuationToken);
+            }
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/BundleFactoryTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/BundleFactoryTests.cs
@@ -129,14 +129,14 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         [Fact]
         public void GivenASearchResultWithContinuationToken_WhenCreateSearchBundle_ThenCorrectBundleShouldBeReturned()
         {
-            _urlResolver.ResolveRouteUrl(_unsupportedSearchParameters, _continuationToken).Returns(_nextUrl);
+            string encodedContinuationToken = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(_continuationToken));
+            _urlResolver.ResolveRouteUrl(_unsupportedSearchParameters, encodedContinuationToken).Returns(_nextUrl);
             _urlResolver.ResolveRouteUrl(_unsupportedSearchParameters).Returns(_selfUrl);
 
             var searchResult = new SearchResult(new ResourceWrapper[0], _unsupportedSearchParameters, _continuationToken);
 
             ResourceElement actual = _bundleFactory.CreateSearchBundle(searchResult);
 
-            // Since there is no continuation token, there should not be next link.
             Assert.Equal(_nextUrl.OriginalString, actual.Scalar<string>("Bundle.link.where(relation='next').url"));
         }
     }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/BundleFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/BundleFactory.cs
@@ -36,55 +36,50 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
 
         public ResourceElement CreateSearchBundle(SearchResult result)
         {
-            EnsureArg.IsNotNull(result, nameof(result));
-
-            // Create the bundle from the result.
-            var bundle = new Bundle();
-
-            if (result != null)
+            return CreateBundle(result, Bundle.BundleType.Searchset, r =>
             {
-                IEnumerable<Bundle.EntryComponent> entries = result.Results.Select(r =>
-                {
-                    ResourceElement resource = _deserializer.Deserialize(r);
+                ResourceElement resource = _deserializer.Deserialize(r);
 
-                    return new Bundle.EntryComponent
+                return new Bundle.EntryComponent
+                {
+                    FullUrlElement = new FhirUri(_urlResolver.ResolveResourceUrl(resource)),
+                    Resource = resource.Instance.ToPoco<Resource>(),
+                    Search = new Bundle.SearchComponent
                     {
-                        FullUrlElement = new FhirUri(_urlResolver.ResolveResourceUrl(resource)),
-                        Resource = resource.Instance.ToPoco<Resource>(),
-                        Search = new Bundle.SearchComponent
-                        {
-                            // TODO: For now, everything returned is a match. We will need to
-                            // distinct between match and include once we support it.
-                            Mode = Bundle.SearchEntryMode.Match,
-                        },
-                    };
-                });
-
-                bundle.Entry.AddRange(entries);
-
-                if (result.ContinuationToken != null)
-                {
-                    bundle.NextLink = _urlResolver.ResolveRouteUrl(
-                        result.UnsupportedSearchParameters,
-                        result.ContinuationToken);
-                }
-            }
-
-            // Add the self link to indicate which search parameters were used.
-            bundle.SelfLink = _urlResolver.ResolveRouteUrl(result.UnsupportedSearchParameters);
-
-            bundle.Id = _fhirRequestContextAccessor.FhirRequestContext.CorrelationId;
-            bundle.Type = Bundle.BundleType.Searchset;
-            bundle.Total = result?.TotalCount;
-            bundle.Meta = new Meta
-            {
-                LastUpdated = Clock.UtcNow,
-            };
-
-            return bundle.ToResourceElement();
+                        // TODO: For now, everything returned is a match. We will need to
+                        // distinct between match and include once we support it.
+                        Mode = Bundle.SearchEntryMode.Match,
+                    },
+                };
+            });
         }
 
         public ResourceElement CreateHistoryBundle(SearchResult result)
+        {
+            return CreateBundle(result, Bundle.BundleType.History, r =>
+            {
+                var resource = _deserializer.Deserialize(r);
+                var hasVerb = Enum.TryParse(r.Request?.Method, true, out Bundle.HTTPVerb httpVerb);
+
+                return new Bundle.EntryComponent
+                {
+                    FullUrlElement = new FhirUri(_urlResolver.ResolveResourceUrl(resource, true)),
+                    Resource = resource.Instance.ToPoco<Resource>(),
+                    Request = new Bundle.RequestComponent
+                    {
+                        Method = hasVerb ? (Bundle.HTTPVerb?)httpVerb : null,
+                        Url = hasVerb ? $"{resource.InstanceType}/{(httpVerb == Bundle.HTTPVerb.POST ? null : resource.Id)}" : null,
+                    },
+                    Response = new Bundle.ResponseComponent
+                    {
+                        LastModified = r.LastModified,
+                        Etag = WeakETag.FromVersionId(r.Version).ToString(),
+                    },
+                };
+            });
+        }
+
+        private ResourceElement CreateBundle(SearchResult result, Bundle.BundleType type, Func<ResourceWrapper, Bundle.EntryComponent> selectionFunction)
         {
             EnsureArg.IsNotNull(result, nameof(result));
 
@@ -93,27 +88,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
 
             if (result != null)
             {
-                IEnumerable<Bundle.EntryComponent> entries = result.Results.Select(r =>
-                {
-                    var resource = _deserializer.Deserialize(r);
-                    var hasVerb = Enum.TryParse(r.Request?.Method, true, out Bundle.HTTPVerb httpVerb);
-
-                    return new Bundle.EntryComponent
-                    {
-                        FullUrlElement = new FhirUri(_urlResolver.ResolveResourceUrl(resource, true)),
-                        Resource = resource.Instance.ToPoco<Resource>(),
-                        Request = new Bundle.RequestComponent
-                        {
-                            Method = hasVerb ? (Bundle.HTTPVerb?)httpVerb : null,
-                            Url = hasVerb ? $"{resource.InstanceType}/{(httpVerb == Bundle.HTTPVerb.POST ? null : resource.Id)}" : null,
-                        },
-                        Response = new Bundle.ResponseComponent
-                        {
-                            LastModified = r.LastModified,
-                            Etag = WeakETag.FromVersionId(r.Version).ToString(),
-                        },
-                    };
-                });
+                IEnumerable<Bundle.EntryComponent> entries = result.Results.Select(selectionFunction);
 
                 bundle.Entry.AddRange(entries);
 
@@ -121,7 +96,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                 {
                     bundle.NextLink = _urlResolver.ResolveRouteUrl(
                         result.UnsupportedSearchParameters,
-                        result.ContinuationToken);
+                        Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(result.ContinuationToken)));
                 }
             }
 
@@ -129,7 +104,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             bundle.SelfLink = _urlResolver.ResolveRouteUrl(result.UnsupportedSearchParameters);
 
             bundle.Id = _fhirRequestContextAccessor.FhirRequestContext.CorrelationId;
-            bundle.Type = Bundle.BundleType.History;
+            bundle.Type = type;
             bundle.Total = result?.TotalCount;
             bundle.Meta = new Meta
             {

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using EnsureThat;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
@@ -58,13 +59,22 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             {
                 if (query.Item1 == KnownQueryParameterNames.ContinuationToken)
                 {
+                    // This is an unreachable case. The mapping of the query parameters makes it so only one continuation token can exist.
                     if (continuationToken != null)
                     {
                         throw new InvalidSearchOperationException(
                             string.Format(Core.Resources.MultipleQueryParametersNotAllowed, KnownQueryParameterNames.ContinuationToken));
                     }
 
-                    continuationToken = query.Item2;
+                    // Checks if the continuation token is base 64 bit encoded. Needed for systems that have cached continuation tokens from before they were encoded.
+                    if (Regex.IsMatch(query.Item2, "^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$"))
+                    {
+                        continuationToken = System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(query.Item2));
+                    }
+                    else
+                    {
+                        continuationToken = query.Item2;
+                    }
                 }
                 else if (query.Item1 == KnownQueryParameterNames.Format)
                 {


### PR DESCRIPTION
## Description
Base 64 encode the continuation token and send a proper error message when a bad continuation token is passed.

## Related issues
Addresses #452 and #453.

## Testing
Updated existing unit test to check that the token is encoded.
