### PR TITLE
Require seconds in a date time where hours and minutes are given.

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/SearchValues/DateTimeSearchValueTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/SearchValues/DateTimeSearchValueTests.cs
@@ -24,8 +24,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.SearchValues
             yield return new object[] { "2013-02", "2013-02-01T00:00:00Z", "2013-02-28T23:59:59.9999999Z" }; // Year and month (non-leap year).
             yield return new object[] { "2012-02", "2012-02-01T00:00:00Z", "2012-02-29T23:59:59.9999999Z" }; // Year and month (leap year).
             yield return new object[] { "2015-07-01", "2015-07-01T00:00:00Z", "2015-07-01T23:59:59.9999999Z" }; // Year, month, and day.
-            yield return new object[] { "2013-03-12T12:30", "2013-03-12T12:30:00Z", "2013-03-12T12:30:59.9999999Z" }; // Year, month, day, hour and second.
-            yield return new object[] { "2013-03-12T12:30:35", "2013-03-12T12:30:35Z", "2013-03-12T12:30:35.9999999Z" }; // Year, month, day, hour and second.
+            yield return new object[] { "2013-03-12T12:30:35", "2013-03-12T12:30:35Z", "2013-03-12T12:30:35.9999999Z" }; // Year, month, day, hour, minute, and second.
             yield return new object[] { "2014-03-29T15:33:59.495+10:00", "2014-03-29T15:33:59.495+10:00", "2014-03-29T15:33:59.495+10:00" }; // Everything.
         }
 
@@ -38,8 +37,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.SearchValues
             yield return new object[] { "2013-02", "2013-02-01T00:00:00.000Z" }; // Year and month (non-leap year).
             yield return new object[] { "2012-02", "2012-02-01T00:00:00.000Z" }; // Year and month (leap year).
             yield return new object[] { "2015-07-01", "2015-07-01T00:00:00.000Z" }; // Year, month, and day.
-            yield return new object[] { "2013-03-12T12:30", "2013-03-12T12:30:00Z", }; // Year, month, day, hour and second.
-            yield return new object[] { "2013-03-12T12:30:35", "2013-03-12T12:30:35Z" }; // Year, month, day, hour and second.
+            yield return new object[] { "2013-03-12T12:30:35", "2013-03-12T12:30:35Z" }; // Year, month, day, hour, minute, and second.
             yield return new object[] { "2014-03-29T15:33:59.495+10:00", "2014-03-29T15:33:59.495+10:00" }; // Everything.
         }
 
@@ -52,8 +50,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.SearchValues
             yield return new object[] { "2022-02", "2022-02-28T23:59:59.9999999Z" }; // Year and month (non-leap year).
             yield return new object[] { "2016-02", "2016-02-29T23:59:59.9999999Z" }; // Year and month (leap year).
             yield return new object[] { "2017-01-01", "2017-01-01T23:59:59.9999999Z" }; // Year, month, and day.
-            yield return new object[] { "2013-03-12T12:30", "2013-03-12T12:30:59.9999999Z" }; // Year, month, day, hour and second.
-            yield return new object[] { "2013-03-12T12:30:35", "2013-03-12T12:30:35.9999999Z" }; // Year, month, day, hour and second.
+            yield return new object[] { "2013-03-12T12:30:35", "2013-03-12T12:30:35.9999999Z" }; // Year, month, day, hour, minute, and second.
             yield return new object[] { "2018-02-12T13:22:01.000+05:00", "2018-02-12T13:22:01.000+05:00" }; // Everything.
         }
 

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Models/PartialDateTimeTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Models/PartialDateTimeTests.cs
@@ -94,6 +94,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Models
         public static IEnumerable<object[]> GetParameterInvalidData()
         {
             yield return new object[] { ParamNameMinute, 10, 30, 23, null, null, null, 60 }; // Minute must be specified if Hour is specified.
+            yield return new object[] { ParamNameSecond, 10, 20, 25, 40, null, null, 60 }; // Second must be specified if Hour and Minute are specified.
             yield return new object[] { ParamNameUtcOffset, 3, 5, 17, 30, 15, 0.400123m, null }; // UtcOffset must be specified if Hour and Minutes are specified.
         }
 
@@ -172,7 +173,6 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Models
             yield return new object[] { null, null, null, null, null, null, null };
             yield return new object[] { 1, null, null, null, null, null, null };
             yield return new object[] { 3, 5, null, null, null, null, null };
-            yield return new object[] { 6, 1, 12, 35, null, null, 60 };
             yield return new object[] { 12, 2, 23, 8, 24, null, -150 };
             yield return new object[] { 1, 3, 5, 2, 15, 0.9991532m, 30 };
         }
@@ -391,8 +391,6 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Models
         [InlineData("2017", "2017")]
         [InlineData("2017-01", "2017-01")]
         [InlineData("2018-01-25", "2018-01-25")]
-        [InlineData("2018-01-25T12:15", "2018-01-25T12:15+00:00")]
-        [InlineData("2018-01-25T07:55+05:30", "2018-01-25T07:55+05:30")]
         [InlineData("2018-01-25T10:12:15", "2018-01-25T10:12:15+00:00")]
         [InlineData("2018-01-25T10:12:03.229", "2018-01-25T10:12:03.2290000+00:00")]
         [InlineData("2018-01-25T03:01:58+05:30", "2018-01-25T03:01:58+05:30")]

--- a/src/Microsoft.Health.Fhir.Core/Models/PartialDateTime.cs
+++ b/src/Microsoft.Health.Fhir.Core/Models/PartialDateTime.cs
@@ -107,6 +107,14 @@ namespace Microsoft.Health.Fhir.Core.Models
                         nameof(minute));
                 }
 
+                if (second == null)
+                {
+                    // If hour and minute are specified, then seconds must be specified.
+                    throw new ArgumentException(
+                        $"The '{nameof(second)}' portion of a date must be specified if '{nameof(hour)}' and '{nameof(minute)}' are specified.",
+                        nameof(second));
+                }
+
                 if (utcOffset == null)
                 {
                     // If hour and minute are specified, then the timezone offset must be specified

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/FhirDateTimeToDateTimeSearchValueTypeConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/FhirDateTimeToDateTimeSearchValueTypeConverterTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
         [Fact]
         public void GivenAFhirDateTimeWithValue_WhenConverted_ThenADateTimeSearchValueShouldBeCreated()
         {
-            const string partialDate = "2018-03-30T05:12";
+            const string partialDate = "2018-03-30T05:12:25";
 
             Test(
                 date => date.Value = partialDate,

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/PeriodToDateTimeSearchValueTypeConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/PeriodToDateTimeSearchValueTypeConverterTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
     public class PeriodToDateTimeSearchValueTypeConverterTests : FhirElementToSearchValueTypeConverterTests<PeriodToDateTimeSearchValueTypeConverter, Period>
     {
         [Theory]
-        [InlineData("2018-01", "2018-12-25T15:30")]
+        [InlineData("2018-01", "2018-12-25T15:30:25")]
         [InlineData(null, "2017")]
         [InlineData("2018-10-15T12:33:55", null)]
         public void GivenAPeriodWithValue_WhenConverted_ThenADateTimeSearchValueShouldBeCreated(string start, string end)

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/Parsers/SearchValueExpressionBuilderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/Parsers/SearchValueExpressionBuilderTests.cs
@@ -257,8 +257,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
         [InlineData("2018")]
         [InlineData("2018-02")]
         [InlineData("2018-02-01")]
-        [InlineData("2018-02-01T10:00")]
-        [InlineData("2018-02-01T10:00-07:00")]
+        [InlineData("2018-02-01T10:00:00")]
+        [InlineData("2018-02-01T10:00:00-07:00")]
         public void GivenADateWithNoComparator_WhenBuilt_ThenCorrectExpressionShouldBeCreated(string input)
         {
             var partialDateTime = PartialDateTime.Parse(input);
@@ -279,8 +279,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
         [InlineData("eq2018")]
         [InlineData("eq2018-02")]
         [InlineData("eq2018-02-01")]
-        [InlineData("eq2018-02-01T10:00")]
-        [InlineData("eq2018-02-01T10:00-07:00")]
+        [InlineData("eq2018-02-01T10:00:00")]
+        [InlineData("eq2018-02-01T10:00:00-07:00")]
         public void GivenADateWithEqComparator_WhenBuilt_ThenCorrectExpressionShouldBeCreated(string input)
         {
             var partialDateTime = PartialDateTime.Parse(input);
@@ -301,8 +301,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
         [InlineData("ne2018")]
         [InlineData("ne2018-02")]
         [InlineData("ne2018-02-01")]
-        [InlineData("ne2018-02-01T10:00")]
-        [InlineData("ne2018-02-01T10:00-07:00")]
+        [InlineData("ne2018-02-01T10:00:00")]
+        [InlineData("ne2018-02-01T10:00:00-07:00")]
         public void GivenADateWithNeComparator_WhenBuilt_ThenCorrectExpressionShouldBeCreated(string input)
         {
             var partialDateTime = PartialDateTime.Parse(input);
@@ -323,33 +323,33 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
         [InlineData("lt2018", FieldName.DateTimeStart, BinaryOperator.LessThan, true)]
         [InlineData("lt2018-02", FieldName.DateTimeStart, BinaryOperator.LessThan, true)]
         [InlineData("lt2018-02-01", FieldName.DateTimeStart, BinaryOperator.LessThan, true)]
-        [InlineData("lt2018-02-01T10:00", FieldName.DateTimeStart, BinaryOperator.LessThan, true)]
-        [InlineData("lt2018-02-01T10:00-07:00", FieldName.DateTimeStart, BinaryOperator.LessThan, true)]
+        [InlineData("lt2018-02-01T10:00:00", FieldName.DateTimeStart, BinaryOperator.LessThan, true)]
+        [InlineData("lt2018-02-01T10:00:00-07:00", FieldName.DateTimeStart, BinaryOperator.LessThan, true)]
         [InlineData("gt2018", FieldName.DateTimeEnd, BinaryOperator.GreaterThan, false)]
         [InlineData("gt2018-02", FieldName.DateTimeEnd, BinaryOperator.GreaterThan, false)]
         [InlineData("gt2018-02-01", FieldName.DateTimeEnd, BinaryOperator.GreaterThan, false)]
-        [InlineData("gt2018-02-01T10:00", FieldName.DateTimeEnd, BinaryOperator.GreaterThan, false)]
-        [InlineData("gt2018-02-01T10:00-07:00", FieldName.DateTimeEnd, BinaryOperator.GreaterThan, false)]
+        [InlineData("gt2018-02-01T10:00:00", FieldName.DateTimeEnd, BinaryOperator.GreaterThan, false)]
+        [InlineData("gt2018-02-01T10:00:00-07:00", FieldName.DateTimeEnd, BinaryOperator.GreaterThan, false)]
         [InlineData("le2018", FieldName.DateTimeStart, BinaryOperator.LessThanOrEqual, false)]
         [InlineData("le2018-02", FieldName.DateTimeStart, BinaryOperator.LessThanOrEqual, false)]
         [InlineData("le2018-02-01", FieldName.DateTimeStart, BinaryOperator.LessThanOrEqual, false)]
-        [InlineData("le2018-02-01T10:00", FieldName.DateTimeStart, BinaryOperator.LessThanOrEqual, false)]
-        [InlineData("le2018-02-01T10:00-07:00", FieldName.DateTimeStart, BinaryOperator.LessThanOrEqual, false)]
+        [InlineData("le2018-02-01T10:00:00", FieldName.DateTimeStart, BinaryOperator.LessThanOrEqual, false)]
+        [InlineData("le2018-02-01T10:00:00-07:00", FieldName.DateTimeStart, BinaryOperator.LessThanOrEqual, false)]
         [InlineData("ge2018", FieldName.DateTimeEnd, BinaryOperator.GreaterThanOrEqual, true)]
         [InlineData("ge2018-02", FieldName.DateTimeEnd, BinaryOperator.GreaterThanOrEqual, true)]
         [InlineData("ge2018-02-01", FieldName.DateTimeEnd, BinaryOperator.GreaterThanOrEqual, true)]
-        [InlineData("ge2018-02-01T10:00", FieldName.DateTimeEnd, BinaryOperator.GreaterThanOrEqual, true)]
-        [InlineData("ge2018-02-01T10:00-07:00", FieldName.DateTimeEnd, BinaryOperator.GreaterThanOrEqual, true)]
+        [InlineData("ge2018-02-01T10:00:00", FieldName.DateTimeEnd, BinaryOperator.GreaterThanOrEqual, true)]
+        [InlineData("ge2018-02-01T10:00:00-07:00", FieldName.DateTimeEnd, BinaryOperator.GreaterThanOrEqual, true)]
         [InlineData("sa2018", FieldName.DateTimeStart, BinaryOperator.GreaterThan, false)]
         [InlineData("sa2018-02", FieldName.DateTimeStart, BinaryOperator.GreaterThan, false)]
         [InlineData("sa2018-02-01", FieldName.DateTimeStart, BinaryOperator.GreaterThan, false)]
-        [InlineData("sa2018-02-01T10:00", FieldName.DateTimeStart, BinaryOperator.GreaterThan, false)]
-        [InlineData("sa2018-02-01T10:00-07:00", FieldName.DateTimeStart, BinaryOperator.GreaterThan, false)]
+        [InlineData("sa2018-02-01T10:00:00", FieldName.DateTimeStart, BinaryOperator.GreaterThan, false)]
+        [InlineData("sa2018-02-01T10:00:00-07:00", FieldName.DateTimeStart, BinaryOperator.GreaterThan, false)]
         [InlineData("eb2018", FieldName.DateTimeEnd, BinaryOperator.LessThan, true)]
         [InlineData("eb2018-02", FieldName.DateTimeEnd, BinaryOperator.LessThan, true)]
         [InlineData("eb2018-02-01", FieldName.DateTimeEnd, BinaryOperator.LessThan, true)]
-        [InlineData("eb2018-02-01T10:00", FieldName.DateTimeEnd, BinaryOperator.LessThan, true)]
-        [InlineData("eb2018-02-01T10:00-07:00", FieldName.DateTimeEnd, BinaryOperator.LessThan, true)]
+        [InlineData("eb2018-02-01T10:00:00", FieldName.DateTimeEnd, BinaryOperator.LessThan, true)]
+        [InlineData("eb2018-02-01T10:00:00-07:00", FieldName.DateTimeEnd, BinaryOperator.LessThan, true)]
         public void GivenADateWithComparatorOfSingleBinaryOperator_WhenBuilt_ThenCorrectExpressionShouldBeCreated(string input, FieldName fieldName, BinaryOperator binaryOperator, bool expectStartTimeValue)
         {
             var partialDateTime = PartialDateTime.Parse(input);
@@ -370,13 +370,13 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
         [InlineData("ap2016", "2015-11-25T12:00:00.0000000+00:00", "2017-02-06T11:59:59.9999999+00:00")]
         [InlineData("ap2016-02", "2015-11-25T21:36:00.0000000+00:00", "2016-05-07T02:23:59.9999999+00:00")]
         [InlineData("ap2016-02-01", "2015-11-23T02:24:00.0000000+00:00", "2016-04-11T21:35:59.9999999+00:00")]
-        [InlineData("ap2016-02-01T10:00", "2015-11-23T11:00:06.0000000+00:00", "2016-04-11T09:00:53.9999999+00:00")]
-        [InlineData("ap2016-02-01T10:00-07:00", "2015-11-23T18:42:06.0000000+00:00", "2016-04-11T15:18:53.9999999+00:00")]
+        [InlineData("ap2016-02-01T10:00:00", "2015-11-23T11:00:00.1000000+00:00", "2016-04-11T09:00:00.8999999+00:00")]
+        [InlineData("ap2016-02-01T10:00:00-07:00", "2015-11-23T18:42:00.1000000+00:00", "2016-04-11T15:18:00.8999999+00:00")]
         [InlineData("ap2220", "2240-04-19T09:36:00.0000000+00:00", "2200-09-13T14:23:59.9999999+00:00")]
         [InlineData("ap2220-02", "2240-04-19T19:12:00.0000000+00:00", "2199-12-12T04:47:59.9999999+00:00")]
         [InlineData("ap2220-02-01", "2240-04-17T00:00:00.0000000+00:00", "2199-11-16T23:59:59.9999999+00:00")]
-        [InlineData("ap2220-02-01T10:00", "2240-04-17T08:36:06.0000000+00:00", "2199-11-16T11:24:53.9999999+00:00")]
-        [InlineData("ap2220-02-01T10:00-07:00", "2240-04-17T16:18:06.0000000+00:00", "2199-11-16T17:42:53.9999999+00:00")]
+        [InlineData("ap2220-02-01T10:00:00", "2240-04-17T08:36:00.1000000+00:00", "2199-11-16T11:24:00.8999999+00:00")]
+        [InlineData("ap2220-02-01T10:00:00-07:00", "2240-04-17T16:18:00.1000000+00:00", "2199-11-16T17:42:00.8999999+00:00")]
         public void GivenADateWithApComparator_WhenBuilt_ThenCorrectExpressionShouldBeCreated(string input, string expectedStartValue, string expectedEndValue)
         {
             using (Mock.Property(() => Clock.UtcNowFunc, () => DateTimeOffset.Parse("2018-01-01T00:00Z")))


### PR DESCRIPTION
## Description
Require that a value is given for seconds when a date time is entered that contains hours and minutes.

## Related issues
Addresses #411.

## Testing
New test added to check the requirement. Existing tests updated to not fail due to new requirement.
