### PR TITLE
Fixes null reference when validating narratives

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Validation/FhirValidationFailure.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Validation/FhirValidationFailure.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.Collections.Generic;
+using EnsureThat;
 using FluentValidation.Results;
 using Microsoft.Health.Fhir.Core.Models;
 
@@ -11,22 +11,16 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
 {
     public class FhirValidationFailure : ValidationFailure
     {
-        public FhirValidationFailure(string propertyName, string errorMessage, IList<OperationOutcomeIssue> issueComponent)
+        public FhirValidationFailure(string propertyName, string errorMessage, OperationOutcomeIssue issueComponent)
             : base(propertyName, errorMessage)
         {
+            EnsureArg.IsNotNullOrEmpty(propertyName, nameof(propertyName));
+            EnsureArg.IsNotNullOrEmpty(errorMessage, nameof(errorMessage));
+            EnsureArg.IsNotNull(issueComponent, nameof(issueComponent));
+
             IssueComponent = issueComponent;
         }
 
-        public FhirValidationFailure(string propertyName, string errorMessage)
-            : base(propertyName, errorMessage)
-        {
-        }
-
-        public FhirValidationFailure(string propertyName, string errorMessage, object attemptedValue)
-            : base(propertyName, errorMessage, attemptedValue)
-        {
-        }
-
-        public IList<OperationOutcomeIssue> IssueComponent { get; }
+        public OperationOutcomeIssue IssueComponent { get; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Validation/NarrativeValidator.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Validation/NarrativeValidator.cs
@@ -71,8 +71,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation.Narratives
                     fullFhirPath,
                     error,
                     new OperationOutcomeIssue(
-                        OperationOutcomeConstants.IssueType.Structure,
                         OperationOutcomeConstants.IssueSeverity.Error,
+                        OperationOutcomeConstants.IssueType.Structure,
                         error,
                         location: new[] { fullFhirPath }));
             }

--- a/src/Microsoft.Health.Fhir.Core/Features/Validation/ResourceNotValidException.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Validation/ResourceNotValidException.cs
@@ -31,9 +31,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
             {
                 if (failure is FhirValidationFailure fhirValidationFailure)
                 {
-                    foreach (var item in fhirValidationFailure.IssueComponent)
+                    if (fhirValidationFailure.IssueComponent != null)
                     {
-                        Issues.Add(item);
+                        Issues.Add(fhirValidationFailure.IssueComponent);
                     }
                 }
                 else

--- a/src/Microsoft.Health.Fhir.Core/Features/Validation/ValidateRequestPreProcessor.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Validation/ValidateRequestPreProcessor.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
         {
             EnsureArg.IsNotNull(request, nameof(request));
 
-            var allResults = (await Task.WhenAll(_validators.Select(x => x.ValidateAsync(request)))).Where(x => x != null).ToArray();
+            var allResults = (await Task.WhenAll(_validators.Select(x => x.ValidateAsync(request, cancellationToken)))).Where(x => x != null).ToArray();
 
             if (!allResults.All(x => x.IsValid))
             {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/CreateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/CreateTests.cs
@@ -191,7 +191,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             // Xml can't even serialize these broken fragments
             if (Client.Format != ResourceFormat.Xml)
             {
-                await Assert.ThrowsAsync<FhirException>(() => Client.CreateAsync(observation));
+                var exception = await Assert.ThrowsAsync<FhirException>(() => Client.CreateAsync(observation));
+                Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
             }
         }
 


### PR DESCRIPTION
## Description
Fixes codepath where validation errors from Narrative might throw a null reference exception

## Related issues
Addresses #587

## Testing
Added regression tests for this issue. 
Updated existing tests to be more explicit in status code checks.
