### PR TITLE
Fixed the issue with meta property not being exported.

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Export/ResourceToNdjsonBytesSerializer.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Export/ResourceToNdjsonBytesSerializer.cs
@@ -35,20 +35,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
         {
             EnsureArg.IsNotNull(resourceWrapper, nameof(resourceWrapper));
 
-            string resourceData = null;
+            ResourceElement resource = _resourceDeserializer.DeserializeRaw(resourceWrapper.RawResource, resourceWrapper.Version, resourceWrapper.LastModified);
 
-            if (resourceWrapper.RawResource.Format == Core.Models.FhirResourceFormat.Json)
-            {
-                // This is JSON already, we can write as is.
-                resourceData = resourceWrapper.RawResource.Data;
-            }
-            else
-            {
-                // This is not JSON, so deserialize it and serialize it to JSON.
-                ResourceElement resource = _resourceDeserializer.DeserializeRaw(resourceWrapper.RawResource, resourceWrapper.Version, resourceWrapper.LastModified);
-
-                resourceData = _fhirJsonSerializer.SerializeToString(resource.ToPoco<Resource>());
-            }
+            string resourceData = _fhirJsonSerializer.SerializeToString(resource.ToPoco<Resource>());
 
             byte[] bytesToWrite = Encoding.UTF8.GetBytes($"{resourceData}\n");
 


### PR DESCRIPTION
## Description
The resources exported through bulk export didn't have the Meta property set. This was due to the optimization put in place that skipped some of the business logic. 

## Related issues
Addresses #593..

## Testing
Ran manual testing. The E2E tests for export will be done in a separate user story.
