### PR TITLE
Auto-update for packages related to 'Hl7'

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Microsoft.Health.Fhir.Api.csproj
+++ b/src/Microsoft.Health.Fhir.Api/Microsoft.Health.Fhir.Api.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="8.1.1" />
     <PackageReference Include="FluentValidation" Version="8.4.0" />
-    <PackageReference Include="Hl7.Fhir.Serialization" Version="1.2.1" />
+    <PackageReference Include="Hl7.Fhir.Serialization" Version="1.3.0" />
     <PackageReference Include="MediatR" Version="7.0.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.2.0" />

--- a/src/Microsoft.Health.Fhir.Core/Microsoft.Health.Fhir.Core.csproj
+++ b/src/Microsoft.Health.Fhir.Core/Microsoft.Health.Fhir.Core.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-    <PackageReference Include="Hl7.Fhir.Serialization" Version="1.2.1" />
-    <PackageReference Include="Hl7.FhirPath" Version="1.2.1" />
+    <PackageReference Include="Hl7.Fhir.Serialization" Version="1.3.0" />
+    <PackageReference Include="Hl7.FhirPath" Version="1.3.0" />
     <PackageReference Include="Polly" Version="7.1.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/src/Microsoft.Health.Fhir.R4.Api/Microsoft.Health.Fhir.R4.Api.csproj
+++ b/src/Microsoft.Health.Fhir.R4.Api/Microsoft.Health.Fhir.R4.Api.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="8.1.1" />
     <PackageReference Include="FluentValidation" Version="8.4.0" />
-    <PackageReference Include="Hl7.Fhir.R4" Version="1.2.1" />
+    <PackageReference Include="Hl7.Fhir.R4" Version="1.3.0" />
     <PackageReference Include="MediatR" Version="7.0.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.2.0" />

--- a/src/Microsoft.Health.Fhir.R4.Core/Microsoft.Health.Fhir.R4.Core.csproj
+++ b/src/Microsoft.Health.Fhir.R4.Core/Microsoft.Health.Fhir.R4.Core.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-    <PackageReference Include="Hl7.Fhir.R4" Version="1.2.1" />
+    <PackageReference Include="Hl7.Fhir.R4" Version="1.3.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>

--- a/src/Microsoft.Health.Fhir.Stu3.Api/Microsoft.Health.Fhir.Stu3.Api.csproj
+++ b/src/Microsoft.Health.Fhir.Stu3.Api/Microsoft.Health.Fhir.Stu3.Api.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="8.1.1" />
     <PackageReference Include="FluentValidation" Version="8.4.0" />
-    <PackageReference Include="Hl7.Fhir.STU3" Version="1.2.1" />
+    <PackageReference Include="Hl7.Fhir.STU3" Version="1.3.0" />
     <PackageReference Include="MediatR" Version="7.0.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.2.0" />

--- a/src/Microsoft.Health.Fhir.Stu3.Core/Microsoft.Health.Fhir.Stu3.Core.csproj
+++ b/src/Microsoft.Health.Fhir.Stu3.Core/Microsoft.Health.Fhir.Stu3.Core.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-    <PackageReference Include="Hl7.Fhir.STU3" Version="1.2.1" />
+    <PackageReference Include="Hl7.Fhir.STU3" Version="1.3.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>

--- a/src/Microsoft.Health.Fhir.ValueSets/Microsoft.Health.Fhir.ValueSets.csproj
+++ b/src/Microsoft.Health.Fhir.ValueSets/Microsoft.Health.Fhir.ValueSets.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="8.1.1" />
     <PackageReference Include="FluentValidation" Version="8.4.0" />
-    <PackageReference Include="Hl7.Fhir.Serialization" Version="1.2.1" />
+    <PackageReference Include="Hl7.Fhir.Serialization" Version="1.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />


### PR DESCRIPTION
Updates package 'Hl7.Fhir.Serialization' to version '1.3.0'
Updates package 'Hl7.FhirPath' to version '1.3.0'
Updates package 'Hl7.Fhir.R4' to version '1.3.0'
Updates package 'Hl7.Fhir.STU3' to version '1.3.0'

Release notes: http://docs.simplifier.net/fhirnetapi/releasenotes.html