### PR TITLE
Move exception handling for invalid continuation token.

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchService.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchService.cs
@@ -51,16 +51,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
         {
             SearchOptions searchOptions = _searchOptionsFactory.Create(resourceType, queryParameters);
 
-            try
-            {
-                // Execute the actual search.
-                return await SearchInternalAsync(searchOptions, cancellationToken);
-            }
-            catch (Exception)
-            {
-                // Should a logging statement be added?
-                throw new RequestNotValidException(Resources.InvalidContinuationToken);
-            }
+            // Execute the actual search.
+            return await SearchInternalAsync(searchOptions, cancellationToken);
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/FhirRequestContextDocumentClientExtensions.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/FhirRequestContextDocumentClientExtensions.cs
@@ -40,6 +40,10 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
                 {
                     throw new RequestRateExceededException(dce.RetryAfter);
                 }
+                else if (dce.Message.Contains("Invalid Continuation Token", StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new Core.Exceptions.RequestNotValidException(Core.Resources.InvalidContinuationToken);
+                }
             }
         }
 


### PR DESCRIPTION

## Description
Moved the exception handling for an invalid continuation token lower in the call stack and made it look at a specific exception type.

## Related issues
#453

## Testing
