### PR TITLE
Removed caller IP address from default logging.

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditLogger.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditLogger.cs
@@ -31,7 +31,6 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
             "Action: {Action}" + Environment.NewLine +
             "StatusCode: {StatusCode}" + Environment.NewLine +
             "CorrelationId: {CorrelationId}" + Environment.NewLine +
-            "CallerIPAddress: {CallerIPAddress}" + Environment.NewLine +
             "Claims: {Claims}";
 
         private readonly SecurityConfiguration _securityConfiguration;
@@ -77,7 +76,6 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
                 action,
                 statusCode,
                 correlationId,
-                callerIpAddress,
                 claimsInString);
         }
     }


### PR DESCRIPTION
## Description
Removed caller IP address from the default audit logging since it's considered as PII. But still leaving the interface so that if there is a PHI compliance logger, it can be used down the road.

## Related issues
Addresses #606.

## Testing
Unit test, E2E test
