### PR TITLE
Removes unsupported _sort parameters from next and self links in search results

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportJobTaskTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportJobTaskTests.cs
@@ -386,7 +386,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
                 resourceWrappers = Array.Empty<ResourceWrapper>();
             }
 
-            return new SearchResult(resourceWrappers, new Tuple<string, string>[0], continuationToken);
+            return new SearchResult(resourceWrappers, new Tuple<string, string>[0], Array.Empty<(string parameterName, string reason)>(), continuationToken);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/SearchResultTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/SearchResultTests.cs
@@ -18,11 +18,13 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         {
             var expectedResourceWrapper = new ResourceWrapper[0];
             var expectedUnsupportedSearchParameters = new List<Tuple<string, string>>();
+            var expectedUnsupportedSortingParameters = new List<(string searchParameterName, string reason)>();
 
-            var searchResult = new SearchResult(expectedResourceWrapper, expectedUnsupportedSearchParameters, null);
+            var searchResult = new SearchResult(expectedResourceWrapper, expectedUnsupportedSearchParameters, expectedUnsupportedSortingParameters, null);
 
             Assert.Same(expectedResourceWrapper, searchResult.Results);
             Assert.Same(expectedUnsupportedSearchParameters, searchResult.UnsupportedSearchParameters);
+            Assert.Same(expectedUnsupportedSortingParameters, searchResult.UnsupportedSortingParameters);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/KnownQueryParameterNames.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/KnownQueryParameterNames.cs
@@ -33,5 +33,7 @@ namespace Microsoft.Health.Fhir.Core.Features
         public const string DestinationType = "_destinationType";
 
         public const string DestinationConnectionSettings = "_destinationConnectionSettings";
+
+        public const string Sort = "_sort";
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Routing/IUrlResolver.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Routing/IUrlResolver.cs
@@ -33,9 +33,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Routing
         /// Resolves the URL for the specified route
         /// </summary>
         /// <param name="unsupportedSearchParams">A list of unsupported search parameters.</param>
+        /// <param name="unsupportedSortingParameters">A lite of unsupported sorting parameters</param>
         /// <param name="continuationToken">The continuation token.</param>
         /// <returns>The URL.</returns>
-        Uri ResolveRouteUrl(IEnumerable<Tuple<string, string>> unsupportedSearchParams = null, string continuationToken = null);
+        Uri ResolveRouteUrl(IEnumerable<Tuple<string, string>> unsupportedSearchParams = null, IReadOnlyList<(string parameterName, string reason)> unsupportedSortingParameters = null, string continuationToken = null);
 
         /// <summary>
         /// Resolves the URL for the specified routeName.

--- a/src/Microsoft.Health.Fhir.Core/Features/Routing/IUrlResolver.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Routing/IUrlResolver.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Routing
         /// Resolves the URL for the specified route
         /// </summary>
         /// <param name="unsupportedSearchParams">A list of unsupported search parameters.</param>
-        /// <param name="unsupportedSortingParameters">A lite of unsupported sorting parameters</param>
+        /// <param name="unsupportedSortingParameters">A list of unsupported sorting parameters</param>
         /// <param name="continuationToken">The continuation token.</param>
         /// <returns>The URL.</returns>
         Uri ResolveRouteUrl(IEnumerable<Tuple<string, string>> unsupportedSearchParams = null, IReadOnlyList<(string parameterName, string reason)> unsupportedSortingParameters = null, string continuationToken = null);

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchOptions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchOptions.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
+using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Core.Features.Search
 {
@@ -60,8 +61,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
         public IReadOnlyList<Tuple<string, string>> UnsupportedSearchParams { get; internal set; }
 
         /// <summary>
-        /// Gets the list of sorting parameters. The second item in a tuple is whether the sort is accending or decending.
+        /// Gets the list of unsupported sorting search parameters that were ignored in the search.
         /// </summary>
-        public IEnumerable<Tuple<string, SortOrder>> Sort { get; internal set; }
+        public IReadOnlyList<(string parameterName, string reason)> UnsupportedSortingParams { get; internal set; }
+
+        /// <summary>
+        /// Gets the list of sorting parameters.
+        /// </summary>
+        public IReadOnlyList<(SearchParameterInfo searchParameterInfo, SortOrder sortOrder)> Sort { get; internal set; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchResult.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchResult.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
         /// </summary>
         /// <param name="results">The search results.</param>
         /// <param name="unsupportedSearchParameters">The list of unsupported search parameters.</param>
-        /// /// <param name="unsupportedSortingParameters">The list of unsupported sorting search parameters</param>
+        /// <param name="unsupportedSortingParameters">The list of unsupported sorting search parameters.</param>
         /// <param name="continuationToken">The continuation token.</param>
         public SearchResult(IEnumerable<ResourceWrapper> results, IReadOnlyList<Tuple<string, string>> unsupportedSearchParameters, IReadOnlyList<(string parameterName, string reason)> unsupportedSortingParameters, string continuationToken)
         {

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchResult.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchResult.cs
@@ -21,15 +21,18 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
         /// </summary>
         /// <param name="results">The search results.</param>
         /// <param name="unsupportedSearchParameters">The list of unsupported search parameters.</param>
+        /// /// <param name="unsupportedSortingParameters">The list of unsupported sorting search parameters</param>
         /// <param name="continuationToken">The continuation token.</param>
-        public SearchResult(IEnumerable<ResourceWrapper> results, IReadOnlyList<Tuple<string, string>> unsupportedSearchParameters, string continuationToken)
+        public SearchResult(IEnumerable<ResourceWrapper> results, IReadOnlyList<Tuple<string, string>> unsupportedSearchParameters, IReadOnlyList<(string parameterName, string reason)> unsupportedSortingParameters, string continuationToken)
         {
             EnsureArg.IsNotNull(results, nameof(results));
             EnsureArg.IsNotNull(unsupportedSearchParameters, nameof(unsupportedSearchParameters));
+            EnsureArg.IsNotNull(unsupportedSortingParameters, nameof(unsupportedSortingParameters));
 
             Results = results;
             UnsupportedSearchParameters = unsupportedSearchParameters;
             ContinuationToken = continuationToken;
+            UnsupportedSortingParameters = unsupportedSortingParameters;
         }
 
         public SearchResult(int totalCount, IReadOnlyList<Tuple<string, string>> unsupportedSearchParameters)
@@ -39,6 +42,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             Results = Enumerable.Empty<ResourceWrapper>();
             UnsupportedSearchParameters = unsupportedSearchParameters;
             TotalCount = totalCount;
+            UnsupportedSortingParameters = Array.Empty<(string parameterName, string reason)>();
         }
 
         /// <summary>
@@ -50,6 +54,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
         /// Gets the list of unsupported search parameters.
         /// </summary>
         public IReadOnlyList<Tuple<string, string>> UnsupportedSearchParameters { get; }
+
+        /// <summary>
+        /// Gets the list of unsupported sorting parameters.
+        /// </summary>
+        public IReadOnlyList<(string parameterName, string reason)> UnsupportedSortingParameters { get; }
 
         /// <summary>
         /// Gets total number of documents

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Health.Fhir.Core {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -696,6 +696,15 @@ namespace Microsoft.Health.Fhir.Core {
         internal static string ServiceUnavailable {
             get {
                 return ResourceManager.GetString("ServiceUnavailable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The _sort parameter is not supported..
+        /// </summary>
+        internal static string SortNotSupported {
+            get {
+                return ResourceManager.GetString("SortNotSupported", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -335,6 +335,9 @@
   <data name="ServiceUnavailable" xml:space="preserve">
     <value>The operation could not be completed, because the service was unable to accept new requests. It is safe to retry the operation. If the issue persists, please contact support.</value>
   </data>
+  <data name="SortNotSupported" xml:space="preserve">
+    <value>The _sort parameter is not supported.</value>
+  </data>
   <data name="UnsupportedConfigurationMessage" xml:space="preserve">
     <value>Unsupported configuration found.</value>
   </data>

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -79,9 +80,21 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
             FhirCosmosResourceWrapper[] wrappers = fetchedResults
                 .Select(r => r.GetPropertyValue<FhirCosmosResourceWrapper>(SearchValueConstants.RootAliasName)).ToArray();
 
+            IReadOnlyList<(string parameterName, string reason)> unsupportedSortingParameters;
+            if (searchOptions.Sort?.Count > 0)
+            {
+                // we don't currently support sort
+                unsupportedSortingParameters = searchOptions.UnsupportedSortingParams.Concat(searchOptions.Sort.Select(s => (s.searchParameterInfo.Name, Core.Resources.SortNotSupported))).ToList();
+            }
+            else
+            {
+                unsupportedSortingParameters = searchOptions.UnsupportedSortingParams;
+            }
+
             return new SearchResult(
                 wrappers,
                 searchOptions.UnsupportedSearchParams,
+                unsupportedSortingParameters,
                 fetchedResults.ResponseContinuation);
         }
     }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Routing/UrlResolverTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Routing/UrlResolverTests.cs
@@ -250,6 +250,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Routing
         [InlineData("?_sort=a,-b&_sort=-c,d", new[] { "b", "c", "d" }, "a")]
         [InlineData("?_sort=a,-b&_sort=-c,d", new[] { "a", "b", "c", "d" })]
         [InlineData("?_sort=a,b,c", new[] { "a" }, "b,c")]
+        [InlineData("?_sort=", null)]
+        [InlineData("?_sort=", new[] { "a" })]
         [Theory]
         public void GivenSortingParameters_WhenSearchUrlIsResolved_ThenCorrectUrlShouldBeReReturned(string queryString, string[] unsupportedSortingValues, params string[] expectedValues)
         {

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Compartment/SearchCompartmentHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Compartment/SearchCompartmentHandlerTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Compartment
         {
             var request = new SearchCompartmentRequest("Patient", "123", "Observation", new Tuple<string, string>[0]);
 
-            var searchResult = new SearchResult(Enumerable.Empty<ResourceWrapper>(), new Tuple<string, string>[0], null);
+            var searchResult = new SearchResult(Enumerable.Empty<ResourceWrapper>(), new Tuple<string, string>[0], Array.Empty<(string parameterName, string reason)>(), null);
 
             _searchService.SearchCompartmentAsync(
                 request.CompartmentType,

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/BundleFactoryTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/BundleFactoryTests.cs
@@ -34,6 +34,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         private static readonly Uri _selfUrl = new Uri("http://self/");
         private static readonly Uri _nextUrl = new Uri("http://next/");
         private static readonly IReadOnlyList<Tuple<string, string>> _unsupportedSearchParameters = new Tuple<string, string>[0];
+        private static readonly IReadOnlyList<(string searchParameter, string reason)> _unsupportedSortingParameters = Array.Empty<(string parameterName, string reason)>();
+
         private static readonly DateTimeOffset _dateTime = new DateTimeOffset(2019, 1, 5, 15, 30, 23, TimeSpan.FromHours(8));
 
         public BundleFactoryTests()
@@ -56,13 +58,13 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         [Fact]
         public void GivenAnEmptySearchResult_WhenCreateSearchBundle_ThenCorrectBundleShouldBeReturned()
         {
-            _urlResolver.ResolveRouteUrl(_unsupportedSearchParameters).Returns(_selfUrl);
+            _urlResolver.ResolveRouteUrl(_unsupportedSearchParameters, _unsupportedSortingParameters).Returns(_selfUrl);
 
             ResourceElement actual = null;
 
             using (Mock.Property(() => Clock.UtcNowFunc, () => _dateTime))
             {
-                actual = _bundleFactory.CreateSearchBundle(new SearchResult(new ResourceWrapper[0], _unsupportedSearchParameters, null));
+                actual = _bundleFactory.CreateSearchBundle(new SearchResult(new ResourceWrapper[0], _unsupportedSearchParameters, _unsupportedSortingParameters, null));
             }
 
             Assert.NotNull(actual);
@@ -76,7 +78,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         public void GivenASearchResult_WhenCreateSearchBundle_ThenCorrectBundleShouldBeReturned()
         {
             _urlResolver.ResolveResourceUrl(Arg.Any<ResourceElement>()).Returns(x => new Uri(string.Format(_resourceUrlFormat, x.ArgAt<ResourceElement>(0).Id)));
-            _urlResolver.ResolveRouteUrl(_unsupportedSearchParameters).Returns(_selfUrl);
+            _urlResolver.ResolveRouteUrl(_unsupportedSearchParameters, _unsupportedSortingParameters).Returns(_selfUrl);
 
             ResourceElement observation1 = Samples.GetDefaultObservation().UpdateId("123");
             ResourceElement observation2 = Samples.GetDefaultObservation().UpdateId("abc");
@@ -87,7 +89,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
                 CreateResourceWrapper(observation2),
             };
 
-            var searchResult = new SearchResult(resourceWrappers, _unsupportedSearchParameters, continuationToken: null);
+            var searchResult = new SearchResult(resourceWrappers, _unsupportedSearchParameters, _unsupportedSortingParameters, continuationToken: null);
 
             ResourceElement actual = null;
 
@@ -130,10 +132,10 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         public void GivenASearchResultWithContinuationToken_WhenCreateSearchBundle_ThenCorrectBundleShouldBeReturned()
         {
             string encodedContinuationToken = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(_continuationToken));
-            _urlResolver.ResolveRouteUrl(_unsupportedSearchParameters, encodedContinuationToken).Returns(_nextUrl);
-            _urlResolver.ResolveRouteUrl(_unsupportedSearchParameters).Returns(_selfUrl);
+            _urlResolver.ResolveRouteUrl(_unsupportedSearchParameters, _unsupportedSortingParameters, encodedContinuationToken).Returns(_nextUrl);
+            _urlResolver.ResolveRouteUrl(_unsupportedSearchParameters, _unsupportedSortingParameters).Returns(_selfUrl);
 
-            var searchResult = new SearchResult(new ResourceWrapper[0], _unsupportedSearchParameters, _continuationToken);
+            var searchResult = new SearchResult(new ResourceWrapper[0], _unsupportedSearchParameters, _unsupportedSortingParameters, _continuationToken);
 
             ResourceElement actual = _bundleFactory.CreateSearchBundle(searchResult);
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchResourceHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchResourceHandlerTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         {
             var request = new SearchResourceRequest("Patient", null);
 
-            var searchResult = new SearchResult(Enumerable.Empty<ResourceWrapper>(), new Tuple<string, string>[0], null);
+            var searchResult = new SearchResult(Enumerable.Empty<ResourceWrapper>(), new Tuple<string, string>[0], Array.Empty<(string parameterName, string reason)>(), null);
 
             _searchService.SearchAsync(request.ResourceType, request.Queries, CancellationToken.None).Returns(searchResult);
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchResourceHistoryHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchResourceHistoryHandlerTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         {
             var request = new SearchResourceHistoryRequest("Patient");
 
-            var searchResult = new SearchResult(Enumerable.Empty<ResourceWrapper>(), new Tuple<string, string>[0], null);
+            var searchResult = new SearchResult(Enumerable.Empty<ResourceWrapper>(), new Tuple<string, string>[0], Array.Empty<(string parameterName, string reason)>(), null);
 
             _searchService.SearchHistoryAsync(request.ResourceType, null, null, null, null, null, null, CancellationToken.None).Returns(searchResult);
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchServiceTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchServiceTests.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
         private readonly IReadOnlyList<Tuple<string, string>> _queryParameters = new Tuple<string, string>[0];
         private readonly IReadOnlyList<Tuple<string, string>> _unsupportedQueryParameters = new Tuple<string, string>[0];
+        private readonly IReadOnlyList<(string searchParameterName, string reason)> _unsupportedSortingParameters = Array.Empty<(string searchParameterName, string reason)>();
 
         public SearchServiceTests()
         {
@@ -53,7 +54,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
             _searchOptionsFactory.Create(resourceType, _queryParameters).Returns(expectedSearchOptions);
 
-            var expectedSearchResult = new SearchResult(new ResourceWrapper[0], _unsupportedQueryParameters, null);
+            var expectedSearchResult = new SearchResult(new ResourceWrapper[0], _unsupportedQueryParameters, _unsupportedSortingParameters, null);
 
             _searchService.SearchImplementation = options =>
             {
@@ -78,7 +79,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
             _searchOptionsFactory.Create(compartmentType, compartmentId, resourceType, _queryParameters).Returns(expectedSearchOptions);
 
-            var expectedSearchResult = new SearchResult(new ResourceWrapper[0], _unsupportedQueryParameters, null);
+            var expectedSearchResult = new SearchResult(new ResourceWrapper[0], _unsupportedQueryParameters, _unsupportedSortingParameters, null);
 
             _searchService.SearchImplementation = options =>
             {
@@ -98,7 +99,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             const string resourceType = "Observation";
             const string resourceId = "abc";
 
-            _searchService.SearchImplementation = options => new SearchResult(new ResourceWrapper[0], _unsupportedQueryParameters, null);
+            _searchService.SearchImplementation = options => new SearchResult(new ResourceWrapper[0], _unsupportedQueryParameters, _unsupportedSortingParameters, null);
 
             await Assert.ThrowsAsync<ResourceNotFoundException>(() => _searchService.SearchHistoryAsync(resourceType, resourceId, null, null, null, null, null, CancellationToken.None));
         }
@@ -113,7 +114,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
             var resourceWrapper =
                 new ResourceWrapper(observation, _rawResourceFactory.Create(observation), _resourceRequest, false, null, null, null);
-            _searchService.SearchImplementation = options => new SearchResult(new ResourceWrapper[0], _unsupportedQueryParameters, null);
+            _searchService.SearchImplementation = options => new SearchResult(new ResourceWrapper[0], _unsupportedQueryParameters, _unsupportedSortingParameters, null);
 
             _fhirDataStore.GetAsync(Arg.Any<ResourceKey>(), Arg.Any<CancellationToken>()).Returns(resourceWrapper);
 

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/BundleFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/BundleFactory.cs
@@ -96,12 +96,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                 {
                     bundle.NextLink = _urlResolver.ResolveRouteUrl(
                         result.UnsupportedSearchParameters,
+                        result.UnsupportedSortingParameters,
                         Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(result.ContinuationToken)));
                 }
             }
 
             // Add the self link to indicate which search parameters were used.
-            bundle.SelfLink = _urlResolver.ResolveRouteUrl(result.UnsupportedSearchParameters);
+            bundle.SelfLink = _urlResolver.ResolveRouteUrl(result.UnsupportedSearchParameters, result.UnsupportedSortingParameters);
 
             bundle.Id = _fhirRequestContextAccessor.FhirRequestContext.CorrelationId;
             bundle.Type = type;

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
         private static readonly Regex Base64FormatRegex = new Regex("^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$", RegexOptions.Compiled | RegexOptions.Singleline);
 
         private readonly IExpressionParser _expressionParser;
+        private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager;
         private readonly ILogger _logger;
         private readonly SearchParameterInfo _resourceTypeSearchParameter;
 
@@ -37,6 +38,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             EnsureArg.IsNotNull(logger, nameof(logger));
 
             _expressionParser = expressionParser;
+            _searchParameterDefinitionManager = searchParameterDefinitionManager;
             _logger = logger;
 
             _resourceTypeSearchParameter = searchParameterDefinitionManager.GetSearchParameter(ResourceType.Resource.ToString(), SearchParameterNames.ResourceType);
@@ -182,10 +184,31 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
 
             searchOptions.UnsupportedSearchParams = unsupportedSearchParameters;
 
-            // Sort is currently not implimented. The sort parameters are added to the search options to allow for future development.
-            if (searchParams.Sort != null && searchParams.Sort.Count > 0)
+            if (searchParams.Sort?.Count > 0)
             {
-                searchOptions.Sort = searchParams.Sort.Select(sorting => Tuple.Create(sorting.Item1, (SortOrder)sorting.Item2));
+                var sortings = new List<(SearchParameterInfo, SortOrder)>();
+                List<(string parameterName, string reason)> unsupportedSortings = null;
+
+                foreach (Tuple<string, Hl7.Fhir.Rest.SortOrder> sorting in searchParams.Sort)
+                {
+                    try
+                    {
+                        SearchParameterInfo searchParameterInfo = _searchParameterDefinitionManager.GetSearchParameter(parsedResourceType.ToString(), sorting.Item1);
+                        sortings.Add((searchParameterInfo, sorting.Item2.ToCoreSortOrder()));
+                    }
+                    catch (SearchParameterNotSupportedException)
+                    {
+                        (unsupportedSortings ?? (unsupportedSortings = new List<(string parameterName, string reason)>())).Add((sorting.Item1, string.Format(Core.Resources.SearchParameterNotSupported, sorting.Item1, resourceType)));
+                    }
+                }
+
+                searchOptions.Sort = sortings;
+                searchOptions.UnsupportedSortingParams = (IReadOnlyList<(string parameterName, string reason)>)unsupportedSortings ?? Array.Empty<(string parameterName, string reason)>();
+            }
+            else
+            {
+                searchOptions.Sort = Array.Empty<(SearchParameterInfo searchParameterInfo, SortOrder sortOrder)>();
+                searchOptions.UnsupportedSortingParams = Array.Empty<(string parameterName, string reason)>();
             }
 
             return searchOptions;

--- a/src/Microsoft.Health.Fhir.Shared.Core/FhirExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/FhirExtensions.cs
@@ -6,6 +6,7 @@
 using System;
 using EnsureThat;
 using Hl7.Fhir.Model;
+using Microsoft.Health.Fhir.Core.Features.Search;
 
 namespace Microsoft.Health.Fhir.Core
 {
@@ -62,6 +63,16 @@ namespace Microsoft.Health.Fhir.Core
 
             // TODO: This does not work with external reference.
             return reference?.Reference?.StartsWith(ModelInfo.FhirTypeToFhirTypeName(resourceType), StringComparison.Ordinal) ?? false;
+        }
+
+        /// <summary>
+        /// Converts a <see cref="Hl7.Fhir.Rest.SortOrder"/> to a <see cref="SortOrder"/>.
+        /// </summary>
+        /// <param name="input">The <see cref="Hl7.Fhir.Rest.SortOrder"/></param>
+        /// <returns>The <see cref="SortOrder"/></returns>
+        public static SortOrder ToCoreSortOrder(this Hl7.Fhir.Rest.SortOrder input)
+        {
+            return input == Hl7.Fhir.Rest.SortOrder.Ascending ? SortOrder.Ascending : SortOrder.Descending;
         }
     }
 }


### PR DESCRIPTION
## Description
When a search parameter specified in a `_sort` parameter is either unrecognized of not supported by the data provider, we will remove it from the next and self links that are part of a search result. In a future change, we will include warning messages explaining why it was not supported (see #612).

## Related issues
Addresses #620.

## Testing
Unit tested.
