### PR TITLE
Split out HttpIntegrationTestFixture and introduce caching

### DIFF
--- a/test/Microsoft.Health.Fhir.R4.Tests.E2E/Rest/VersionSpecificTests.cs
+++ b/test/Microsoft.Health.Fhir.R4.Tests.E2E/Rest/VersionSpecificTests.cs
@@ -8,7 +8,6 @@ using System.Net;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Fhir.Tests.E2E.Common;
-using Microsoft.Health.Fhir.Web;
 using Xunit;
 using Task = System.Threading.Tasks.Task;
 
@@ -17,7 +16,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
     /// <summary>
     /// Provides R4 specific tests.
     /// </summary>
-    public partial class VersionSpecificTests : IClassFixture<HttpIntegrationTestFixture<Startup>>
+    public partial class VersionSpecificTests : IClassFixture<HttpIntegrationTestFixture>
     {
         [Fact]
         public async Task GivenR4Server_WhenCapabilityStatementIsRetrieved_ThenCorrectVersionShouldBeReturned()

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Crucible/CrucibleDataSource.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Crucible/CrucibleDataSource.cs
@@ -5,11 +5,12 @@
 
 using System;
 using System.Linq;
-using System.Net.Http;
 using System.Threading.Tasks;
+using EnsureThat;
 using Hl7.Fhir.Rest;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.E2E.Crucible.Client;
-using FhirClient = Microsoft.Health.Fhir.Tests.E2E.Common.FhirClient;
+using Microsoft.Health.Fhir.Tests.E2E.Rest;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Crucible
 {
@@ -17,8 +18,10 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Crucible
     {
         private const int PastResultsValidInMinutes = 10;
 
-        public CrucibleDataSource()
+        public CrucibleDataSource(TestFhirServerFactory testFhirServerFactory)
         {
+            EnsureArg.IsNotNull(testFhirServerFactory, nameof(testFhirServerFactory));
+
             TestRun = new Lazy<ServerTestRun>(() => GetTestRunAsync().GetAwaiter().GetResult());
         }
 
@@ -46,23 +49,24 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Crucible
         public static async Task<string[]> GetSupportedIdsAsync(CrucibleClient client)
         {
             await client.RefreshConformanceStatementAsync();
-            var httpClient = new HttpClient
-            {
-                BaseAddress = new Uri(TestEnvironmentUrl),
-            };
 
-            var fhirClient = new FhirClient(httpClient, ResourceFormat.Json);
-
-            if (fhirClient.SecuritySettings.SecurityEnabled)
+            using (var testFhirServerFactory = new TestFhirServerFactory())
             {
-                await client.AuthorizeServerAsync(fhirClient.SecuritySettings.AuthorizeUrl, fhirClient.SecuritySettings.TokenUrl);
+                var fhirClient = testFhirServerFactory
+                    .GetTestFhirServer(DataStore.CosmosDb, null)
+                    .GetFhirClient(ResourceFormat.Json);
+
+                if (fhirClient.SecuritySettings.SecurityEnabled)
+                {
+                    await client.AuthorizeServerAsync(fhirClient.SecuritySettings.AuthorizeUrl, fhirClient.SecuritySettings.TokenUrl);
+                }
+
+                var supportedTests = await client.GetSupportedTestsAsync();
+
+                var ids = supportedTests.Where(x => x.Supported).Select(x => x.Id).ToArray();
+
+                return ids;
             }
-
-            var supportedTests = await client.GetSupportedTestsAsync();
-
-            var ids = supportedTests.Where(x => x.Supported).Select(x => x.Id).ToArray();
-
-            return ids;
         }
 
         private async Task<ServerTestRun> GetTestRunAsync()

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Crucible/CrucibleDataSource.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Crucible/CrucibleDataSource.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using EnsureThat;
 using Hl7.Fhir.Rest;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.E2E.Crucible.Client;
@@ -18,10 +17,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Crucible
     {
         private const int PastResultsValidInMinutes = 10;
 
-        public CrucibleDataSource(TestFhirServerFactory testFhirServerFactory)
+        public CrucibleDataSource()
         {
-            EnsureArg.IsNotNull(testFhirServerFactory, nameof(testFhirServerFactory));
-
             TestRun = new Lazy<ServerTestRun>(() => GetTestRunAsync().GetAwaiter().GetResult());
         }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Crucible/CrucibleTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Crucible/CrucibleTestFixture.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Crucible
                     {
                         var testName = $"{x.TestId ?? findTest.TestId}/{x.Id}";
                         return x.Status == "fail" && !KnownCrucibleTests.KnownFailures.Contains(testName) && !KnownCrucibleTests.KnownBroken.Contains(testName)
-                            && !x.Message.ToString().Contains(KnownCrucibleTests.BundleCountFilter);
+                               && !x.Message.ToString().Contains(KnownCrucibleTests.BundleCountFilter);
                     })
                     .ToArray();
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E.Common/FhirClient.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E.Common/FhirClient.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Common
 
         public FhirClient Clone()
         {
-            return _testFhirServer.GetFhirClient(Format, _clientApplication, _user, cacheable: false);
+            return _testFhirServer.GetFhirClient(Format, _clientApplication, _user, reusable: false);
         }
 
         public Task<FhirResponse<T>> CreateAsync<T>(T resource)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E.Common/TestApplication.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E.Common/TestApplication.cs
@@ -3,11 +3,12 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using static Microsoft.Health.Fhir.Tests.Common.EnvironmentVariables;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Common
 {
-    public class TestApplication
+    public class TestApplication : IEquatable<TestApplication>
     {
         public TestApplication(string id)
         {
@@ -21,5 +22,24 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Common
         public string ClientSecret => GetEnvironmentVariableWithDefault($"app_{Id}_secret", Id);
 
         public string GrantType => GetEnvironmentVariableWithDefault($"app_{Id}_grant_type", "client_credentials");
+
+        public bool Equals(TestApplication other)
+        {
+            if (ReferenceEquals(null, other))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return Id == other.Id;
+        }
+
+        public override bool Equals(object obj) => Equals(obj as TestApplication);
+
+        public override int GetHashCode() => (Id?.GetHashCode()).GetValueOrDefault();
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E.Common/TestUser.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E.Common/TestUser.cs
@@ -3,11 +3,12 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using static Microsoft.Health.Fhir.Tests.Common.EnvironmentVariables;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Common
 {
-    public class TestUser
+    public class TestUser : IEquatable<TestUser>
     {
         public TestUser(string id)
         {
@@ -21,5 +22,24 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Common
         public string Password => GetEnvironmentVariableWithDefault($"user_{Id}_secret", Id);
 
         public string GrantType => "password";
+
+        public bool Equals(TestUser other)
+        {
+            if (ReferenceEquals(null, other))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return Id == other.Id;
+        }
+
+        public override bool Equals(object obj) => Equals((TestUser)obj);
+
+        public override int GetHashCode() => (Id?.GetHashCode()).GetValueOrDefault();
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/AssemblyInfo.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/AssemblyInfo.cs
@@ -5,7 +5,9 @@
 
 using Microsoft.Health.Extensions.Xunit;
 using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Fhir.Tests.E2E.Rest;
 using Xunit;
 
 [assembly: TestFramework(typeName: CustomXunitTestFramework.TypeName, assemblyName: CustomXunitTestFramework.AssemblyName)]
 [assembly: AssemblyFixture(typeof(SetModelInfoProviderAssemblyFixture))]
+[assembly: AssemblyFixture(typeof(TestFhirServerFactory))]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Microsoft.Health.Fhir.Shared.Tests.E2E.projitems
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Microsoft.Health.Fhir.Shared.Tests.E2E.projitems
@@ -22,12 +22,15 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rest\CorsTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\CreateTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\DeleteTests.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Rest\ExceptionTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\ExportTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\HealthTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\HistoryTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\HttpIntegrationTestFixture.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rest\HttpIntegrationTestFixture{TStartup}.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rest\ExceptionTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rest\InProcTestFhirServer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\ReadTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rest\RemoteTestFhirServer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\Search\BasicSearchTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\Search\ChainingSearchTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\Search\CompositeSearchTestFixture.cs" />
@@ -49,6 +52,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rest\Search\UriSearchTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\Sql\SchemaTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\SuppressExecutionContextHandler.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rest\TestFhirServer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rest\TestFhirServerFactory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\TestHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\UpdateTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\VersionSpecificTests.cs" />

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/AuditTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/AuditTestFixture.cs
@@ -13,22 +13,14 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit
     {
         private TraceAuditLogger _auditLogger;
 
-        public AuditTestFixture(DataStore dataStore, Format format)
-            : base(dataStore, format)
+        public AuditTestFixture(DataStore dataStore, Format format, TestFhirServerFactory testFhirServerFactory)
+            : base(dataStore, format, testFhirServerFactory)
         {
         }
 
         public TraceAuditLogger AuditLogger
         {
-            get
-            {
-                if (_auditLogger == null)
-                {
-                    _auditLogger = (TraceAuditLogger)Server?.Host.Services.GetRequiredService<IAuditLogger>();
-                }
-
-                return _auditLogger;
-            }
+            get => _auditLogger ?? (_auditLogger = (TraceAuditLogger)(TestFhirServer as InProcTestFhirServer)?.Server.Host.Services.GetRequiredService<IAuditLogger>());
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/CompartmentTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/CompartmentTestFixture.cs
@@ -6,16 +6,15 @@
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
-using Microsoft.Health.Fhir.Web;
 using Xunit;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
-    public class CompartmentTestFixture : HttpIntegrationTestFixture<Startup>, IAsyncLifetime
+    public class CompartmentTestFixture : HttpIntegrationTestFixture, IAsyncLifetime
     {
-        public CompartmentTestFixture(DataStore dataStore, Format format)
-            : base(dataStore, format)
+        public CompartmentTestFixture(DataStore dataStore, Format format, TestFhirServerFactory testFhirServerFactory)
+            : base(dataStore, format, testFhirServerFactory)
         {
         }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/CorsTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/CorsTests.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.E2E.Common;
-using Microsoft.Health.Fhir.Web;
 using Microsoft.Net.Http.Headers;
 using Xunit;
 using HttpMethod = System.Net.Http.HttpMethod;
@@ -20,11 +19,11 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
     [Trait(Traits.Category, Categories.Cors)]
     [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.Json)]
-    public class CorsTests : IClassFixture<HttpIntegrationTestFixture<Startup>>
+    public class CorsTests : IClassFixture<HttpIntegrationTestFixture>
     {
         private readonly FhirClient _client;
 
-        public CorsTests(HttpIntegrationTestFixture<Startup> fixture)
+        public CorsTests(HttpIntegrationTestFixture fixture)
         {
             _client = fixture.FhirClient;
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/CreateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/CreateTests.cs
@@ -15,7 +15,6 @@ using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.E2E.Common;
-using Microsoft.Health.Fhir.Web;
 using Xunit;
 using FhirClient = Microsoft.Health.Fhir.Tests.E2E.Common.FhirClient;
 using Task = System.Threading.Tasks.Task;
@@ -23,9 +22,9 @@ using Task = System.Threading.Tasks.Task;
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
     [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.All)]
-    public class CreateTests : IClassFixture<HttpIntegrationTestFixture<Startup>>
+    public class CreateTests : IClassFixture<HttpIntegrationTestFixture>
     {
-        public CreateTests(HttpIntegrationTestFixture<Startup> fixture)
+        public CreateTests(HttpIntegrationTestFixture fixture)
         {
             Client = fixture.FhirClient;
         }
@@ -116,7 +115,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Trait(Traits.Priority, Priority.One)]
         public async Task WhenPostingToHttp_GivenUnsetContentType_TheServerShouldRespondWithAUnsupportedMediaTypeResponse()
         {
-            var result = await Client.HttpClient.PostAsync("Observation", new StringContent("Content!"));
+            var result = await Client.
+                HttpClient.PostAsync("Observation", new StringContent("Content!"));
 
             Assert.Equal(HttpStatusCode.UnsupportedMediaType, result.StatusCode);
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/DeleteTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/DeleteTests.cs
@@ -13,7 +13,6 @@ using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.E2E.Common;
-using Microsoft.Health.Fhir.Web;
 using Xunit;
 using FhirClient = Microsoft.Health.Fhir.Tests.E2E.Common.FhirClient;
 using Task = System.Threading.Tasks.Task;
@@ -21,9 +20,9 @@ using Task = System.Threading.Tasks.Task;
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
     [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.All)]
-    public class DeleteTests : IClassFixture<HttpIntegrationTestFixture<Startup>>
+    public class DeleteTests : IClassFixture<HttpIntegrationTestFixture>
     {
-        public DeleteTests(HttpIntegrationTestFixture<Startup> fixture)
+        public DeleteTests(HttpIntegrationTestFixture fixture)
         {
             Client = fixture.FhirClient;
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ExceptionTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ExceptionTests.cs
@@ -14,7 +14,6 @@ using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.E2E.Common;
 using Microsoft.Health.Fhir.Web;
 using Xunit;
-using FhirClient = Microsoft.Health.Fhir.Tests.E2E.Common.FhirClient;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ExportTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ExportTests.cs
@@ -12,14 +12,13 @@ using Hl7.Fhir.Rest;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
-using Microsoft.Health.Fhir.Web;
 using Microsoft.Net.Http.Headers;
 using Xunit;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
     [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb, Format.Json)]
-    public class ExportTests : IClassFixture<HttpIntegrationTestFixture<Startup>>
+    public class ExportTests : IClassFixture<HttpIntegrationTestFixture>
     {
         private readonly HttpClient _client;
         private const string PreferHeaderName = "Prefer";
@@ -27,7 +26,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         private const string DestinationConnectionQueryParamName = "_destinationConnectionSettings";
         private const string SupportedDestinationType = "in-memory";
 
-        public ExportTests(HttpIntegrationTestFixture<Startup> fixture)
+        public ExportTests(HttpIntegrationTestFixture fixture)
         {
             _client = fixture.HttpClient;
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HealthTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HealthTests.cs
@@ -7,19 +7,18 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
-using Microsoft.Health.Fhir.Web;
 using Xunit;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
     [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.Json)]
-    public class HealthTests : IClassFixture<HttpIntegrationTestFixture<Startup>>
+    public class HealthTests : IClassFixture<HttpIntegrationTestFixture>
     {
         private readonly HttpClient _client;
 
-        public HealthTests(HttpIntegrationTestFixture<Startup> fixture)
+        public HealthTests(HttpIntegrationTestFixture fixture)
         {
-            _client = fixture.HttpClient;
+            _client = fixture.FhirClient.HttpClient;
         }
 
         [Fact]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HistoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HistoryTests.cs
@@ -14,7 +14,6 @@ using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.E2E.Common;
-using Microsoft.Health.Fhir.Web;
 using Xunit;
 using FhirClient = Microsoft.Health.Fhir.Tests.E2E.Common.FhirClient;
 using Task = System.Threading.Tasks.Task;
@@ -24,11 +23,11 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
     [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.All)]
     [CollectionDefinition("History", DisableParallelization = true)]
     [Collection("History")]
-    public class HistoryTests : IClassFixture<HttpIntegrationTestFixture<Startup>>, IDisposable
+    public class HistoryTests : IClassFixture<HttpIntegrationTestFixture>, IDisposable
     {
         private FhirResponse<Observation> _createdResource;
 
-        public HistoryTests(HttpIntegrationTestFixture<Startup> fixture)
+        public HistoryTests(HttpIntegrationTestFixture fixture)
         {
             Client = fixture.FhirClient;
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HttpIntegrationTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HttpIntegrationTestFixture.cs
@@ -8,6 +8,10 @@ using Microsoft.Health.Fhir.Web;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
+    /// <summary>
+    /// An <see cref="HttpIntegrationTestFixture{TStartup}"/> where the TStartup is the same <see cref="Startup"/>
+    /// class as the web project.
+    /// </summary>
     public class HttpIntegrationTestFixture : HttpIntegrationTestFixture<Startup>
     {
         public HttpIntegrationTestFixture(DataStore dataStore, Format format, TestFhirServerFactory testFhirServerFactory)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HttpIntegrationTestFixture{TStartup}.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HttpIntegrationTestFixture{TStartup}.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
     /// <summary>
     /// A test fixture that is intended to provide a <see cref="FhirClient"/> to end-to-end FHIR test classes.
     /// </summary>
-    /// <typeparamref name="TStartup">The type to use as the ASP.NET startup type when hosting the fhir server in-process</typeparamref>
+    /// <typeparam name="TStartup">The type to use as the ASP.NET startup type when hosting the fhir server in-process</typeparam>
     public class HttpIntegrationTestFixture<TStartup>
     {
         public HttpIntegrationTestFixture(DataStore dataStore, Format format, TestFhirServerFactory testFhirServerFactory)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HttpIntegrationTestFixture{TStartup}.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HttpIntegrationTestFixture{TStartup}.cs
@@ -1,0 +1,59 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Net.Http;
+using EnsureThat;
+using Hl7.Fhir.Rest;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using FhirClient = Microsoft.Health.Fhir.Tests.E2E.Common.FhirClient;
+
+namespace Microsoft.Health.Fhir.Tests.E2E.Rest
+{
+    /// <summary>
+    /// A test fixture which hosts the target web project in an in-process test server.
+    /// Code adapted from https://docs.microsoft.com/en-us/aspnet/core/mvc/controllers/testing#integration-testing
+    /// </summary>
+    /// <typeparam name="TStartup">The target web project startup</typeparam>
+    public class HttpIntegrationTestFixture<TStartup>
+    {
+        public HttpIntegrationTestFixture(DataStore dataStore, Format format, TestFhirServerFactory testFhirServerFactory)
+        {
+            EnsureArg.IsNotNull(testFhirServerFactory, nameof(testFhirServerFactory));
+
+            TestFhirServer = testFhirServerFactory.GetTestFhirServer(dataStore, typeof(TStartup));
+
+            ResourceFormat resourceFormat;
+            switch (format)
+            {
+                case Format.Json:
+                    resourceFormat = ResourceFormat.Json;
+                    break;
+                case Format.Xml:
+                    resourceFormat = ResourceFormat.Xml;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(format), format, null);
+            }
+
+            FhirClient = TestFhirServer.GetFhirClient(resourceFormat);
+
+            IsUsingInProcTestServer = TestFhirServer is InProcTestFhirServer;
+        }
+
+        public bool IsUsingInProcTestServer { get; }
+
+        public HttpClient HttpClient => FhirClient.HttpClient;
+
+        public FhirClient FhirClient { get; }
+
+        protected TestFhirServer TestFhirServer { get; }
+
+        public string GenerateFullUrl(string relativeUrl)
+        {
+            return $"{TestFhirServer.BaseAddress}{relativeUrl}";
+        }
+    }
+}

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HttpIntegrationTestFixture{TStartup}.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HttpIntegrationTestFixture{TStartup}.cs
@@ -13,10 +13,9 @@ using FhirClient = Microsoft.Health.Fhir.Tests.E2E.Common.FhirClient;
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
     /// <summary>
-    /// A test fixture which hosts the target web project in an in-process test server.
-    /// Code adapted from https://docs.microsoft.com/en-us/aspnet/core/mvc/controllers/testing#integration-testing
+    /// A test fixture that is intended to provide a <see cref="FhirClient"/> to end-to-end FHIR test classes.
     /// </summary>
-    /// <typeparam name="TStartup">The target web project startup</typeparam>
+    /// <typeparamref name="TStartup">The type to use as the ASP.NET startup type when hosting the fhir server in-process</typeparamref>
     public class HttpIntegrationTestFixture<TStartup>
     {
         public HttpIntegrationTestFixture(DataStore dataStore, Format format, TestFhirServerFactory testFhirServerFactory)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/InProcTestFhirServer.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/InProcTestFhirServer.cs
@@ -1,0 +1,119 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Reflection;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Microsoft.Health.Fhir.Web;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Health.Fhir.Tests.E2E.Rest
+{
+    public class InProcTestFhirServer : TestFhirServer
+    {
+        private readonly HttpMessageHandler _messageHandler;
+
+        public InProcTestFhirServer(DataStore dataStore, Type startupType)
+            : base(new Uri("http://localhost/"))
+        {
+            var contentRoot = GetProjectPath("src", startupType);
+            var corsPath = Path.GetFullPath("corstestconfiguration.json");
+            var exportPath = Path.GetFullPath("exporttestconfiguration.json");
+
+            var launchSettings = JObject.Parse(File.ReadAllText(Path.Combine(contentRoot, "Properties", "launchSettings.json")));
+
+            var configuration = launchSettings["profiles"][dataStore.ToString()]["environmentVariables"].Cast<JProperty>().ToDictionary(p => p.Name, p => p.Value.ToString());
+
+            var builder = WebHost.CreateDefaultBuilder()
+                .UseContentRoot(contentRoot)
+                .ConfigureAppConfiguration(configurationBuilder =>
+                {
+                    configurationBuilder.AddDevelopmentAuthEnvironment("testauthenvironment.json");
+                    configurationBuilder.AddJsonFile(corsPath);
+                    configurationBuilder.AddJsonFile(exportPath);
+                    configurationBuilder.AddInMemoryCollection(configuration);
+                })
+                .UseStartup(startupType)
+                .ConfigureServices(serviceCollection =>
+                {
+                    // ensure that HttpClients
+                    // use a message handler for the test server
+                    serviceCollection
+                        .AddHttpClient(Options.DefaultName)
+                        .ConfigurePrimaryHttpMessageHandler(() => _messageHandler);
+
+                    serviceCollection.PostConfigure<JwtBearerOptions>(
+                        JwtBearerDefaults.AuthenticationScheme,
+                        options => options.BackchannelHttpHandler = _messageHandler);
+                });
+
+            Server = new TestServer(builder);
+            _messageHandler = new SuppressExecutionContextHandler(Server.CreateHandler());
+        }
+
+        public TestServer Server { get; }
+
+        protected override HttpMessageHandler CreateMessageHandler()
+        {
+            return _messageHandler;
+        }
+
+        public override void Dispose()
+        {
+            Server?.Dispose();
+        }
+
+        /// <summary>
+        /// Gets the full path to the target project that we wish to test
+        /// </summary>
+        /// <param name="projectRelativePath">
+        /// The parent directory of the target project.
+        /// e.g. src, samples, test, or test/Websites
+        /// </param>
+        /// <param name="startupType">The startup type</param>
+        /// <returns>The full path to the target project.</returns>
+        private static string GetProjectPath(string projectRelativePath, Type startupType)
+        {
+            for (Type type = startupType; type != null; type = type.BaseType)
+            {
+                // Get name of the target project which we want to test
+                var projectName = type.GetTypeInfo().Assembly.GetName().Name;
+
+                // Get currently executing test project path
+                var applicationBasePath = System.AppContext.BaseDirectory;
+
+                // Find the path to the target project
+                var directoryInfo = new DirectoryInfo(applicationBasePath);
+                do
+                {
+                    directoryInfo = directoryInfo.Parent;
+
+                    var projectDirectoryInfo = new DirectoryInfo(Path.Combine(directoryInfo.FullName, projectRelativePath));
+                    if (projectDirectoryInfo.Exists)
+                    {
+                        var projectFileInfo = new FileInfo(Path.Combine(projectDirectoryInfo.FullName, projectName, $"{projectName}.csproj"));
+                        if (projectFileInfo.Exists)
+                        {
+                            return Path.Combine(projectDirectoryInfo.FullName, projectName);
+                        }
+                    }
+                }
+                while (directoryInfo.Parent != null);
+            }
+
+            throw new InvalidOperationException($"Project root could not be located for startup type {startupType.FullName}");
+        }
+    }
+}

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/InProcTestFhirServer.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/InProcTestFhirServer.cs
@@ -77,6 +77,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         public override void Dispose()
         {
             Server?.Dispose();
+            base.Dispose();
         }
 
         /// <summary>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/InProcTestFhirServer.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/InProcTestFhirServer.cs
@@ -21,6 +21,10 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
+    /// <summary>
+    /// A <see cref="TestFhirServer"/> that runs the FHIR server in-process and creates
+    /// using asp.net's <see cref="TestServer"/>.
+    /// </summary>
     public class InProcTestFhirServer : TestFhirServer
     {
         private readonly HttpMessageHandler _messageHandler;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ReadTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ReadTests.cs
@@ -9,7 +9,6 @@ using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.E2E.Common;
-using Microsoft.Health.Fhir.Web;
 using Xunit;
 using FhirClient = Microsoft.Health.Fhir.Tests.E2E.Common.FhirClient;
 using Task = System.Threading.Tasks.Task;
@@ -17,9 +16,9 @@ using Task = System.Threading.Tasks.Task;
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
     [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.All)]
-    public class ReadTests : IClassFixture<HttpIntegrationTestFixture<Startup>>
+    public class ReadTests : IClassFixture<HttpIntegrationTestFixture>
     {
-        public ReadTests(HttpIntegrationTestFixture<Startup> fixture)
+        public ReadTests(HttpIntegrationTestFixture fixture)
         {
             Client = fixture.FhirClient;
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/RemoteTestFhirServer.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/RemoteTestFhirServer.cs
@@ -8,6 +8,10 @@ using System.Net.Http;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
+    /// <summary>
+    /// Represents a <see cref="TestFhirServer"/> that resides out of process that we will
+    /// communicate with over TCP/IP.
+    /// </summary>
     public class RemoteTestFhirServer : TestFhirServer
     {
         public RemoteTestFhirServer(string environmentUrl)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/RemoteTestFhirServer.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/RemoteTestFhirServer.cs
@@ -3,16 +3,21 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
-using Microsoft.Health.Fhir.Web;
+using System;
+using System.Net.Http;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
-    public class HttpIntegrationTestFixture : HttpIntegrationTestFixture<Startup>
+    public class RemoteTestFhirServer : TestFhirServer
     {
-        public HttpIntegrationTestFixture(DataStore dataStore, Format format, TestFhirServerFactory testFhirServerFactory)
-            : base(dataStore, format, testFhirServerFactory)
+        public RemoteTestFhirServer(string environmentUrl)
+            : base(new Uri(environmentUrl))
         {
+        }
+
+        protected override HttpMessageHandler CreateMessageHandler()
+        {
+            return new HttpClientHandler();
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -11,16 +11,15 @@ using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.E2E.Common;
-using Microsoft.Health.Fhir.Web;
 using Xunit;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 {
     [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.Json)]
-    public class BasicSearchTests : SearchTestsBase<HttpIntegrationTestFixture<Startup>>
+    public class BasicSearchTests : SearchTestsBase<HttpIntegrationTestFixture>
     {
-        public BasicSearchTests(HttpIntegrationTestFixture<Startup> fixture)
+        public BasicSearchTests(HttpIntegrationTestFixture fixture)
             : base(fixture)
         {
             // Delete all patients before starting the test.

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
-using Microsoft.Health.Fhir.Web;
 using Xunit;
 using Task = System.Threading.Tasks.Task;
 
@@ -187,10 +186,10 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             ValidateBundle(bundle, Fixture.TrumanSnomedDiagnosticReport);
         }
 
-        public class ClassFixture : HttpIntegrationTestFixture<Startup>
+        public class ClassFixture : HttpIntegrationTestFixture
         {
-            public ClassFixture(DataStore dataStore, Format format)
-                : base(dataStore, format)
+            public ClassFixture(DataStore dataStore, Format format, TestFhirServerFactory testFhirServerFactory)
+                : base(dataStore, format, testFhirServerFactory)
             {
                 Tag = Guid.NewGuid().ToString();
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CompositeSearchTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CompositeSearchTestFixture.cs
@@ -9,11 +9,10 @@ using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.E2E.Common;
-using Microsoft.Health.Fhir.Web;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 {
-    public class CompositeSearchTestFixture : HttpIntegrationTestFixture<Startup>
+    public class CompositeSearchTestFixture : HttpIntegrationTestFixture
     {
         private static readonly string[] ObservationTestFileNames =
         {
@@ -34,8 +33,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             "DocumentReference-example-003",
         };
 
-        public CompositeSearchTestFixture(DataStore dataStore, Format format)
-            : base(dataStore, format)
+        public CompositeSearchTestFixture(DataStore dataStore, Format format, TestFhirServerFactory testFhirServerFactory)
+            : base(dataStore, format, testFhirServerFactory)
         {
             Observations = CreateResultDictionary<Observation>(ObservationTestFileNames);
             DocumentReferences = CreateResultDictionary<DocumentReference>(DocumentReferenceTestFiles);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/DateSearchTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/DateSearchTestFixture.cs
@@ -8,14 +8,13 @@ using System.Collections.Generic;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.E2E.Common;
-using Microsoft.Health.Fhir.Web;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 {
-    public class DateSearchTestFixture : HttpIntegrationTestFixture<Startup>
+    public class DateSearchTestFixture : HttpIntegrationTestFixture
     {
-        public DateSearchTestFixture(DataStore dataStore, Format format)
-            : base(dataStore, format)
+        public DateSearchTestFixture(DataStore dataStore, Format format, TestFhirServerFactory testFhirServerFactory)
+            : base(dataStore, format, testFhirServerFactory)
         {
             // Creates a unique code for searches
             Coding = new Coding

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/NumberSearchTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/NumberSearchTestFixture.cs
@@ -7,14 +7,13 @@ using System.Collections.Generic;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.E2E.Common;
-using Microsoft.Health.Fhir.Web;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 {
-    public class NumberSearchTestFixture : HttpIntegrationTestFixture<Startup>
+    public class NumberSearchTestFixture : HttpIntegrationTestFixture
     {
-        public NumberSearchTestFixture(DataStore dataStore, Format format)
-            : base(dataStore, format)
+        public NumberSearchTestFixture(DataStore dataStore, Format format, TestFhirServerFactory testFhirServerFactory)
+            : base(dataStore, format, testFhirServerFactory)
         {
             // Prepare the resources used for number search tests.
             FhirClient.DeleteAllResources(ResourceType.RiskAssessment).Wait();

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/QuantitySearchTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/QuantitySearchTestFixture.cs
@@ -7,14 +7,13 @@ using System.Collections.Generic;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.E2E.Common;
-using Microsoft.Health.Fhir.Web;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 {
-    public class QuantitySearchTestFixture : HttpIntegrationTestFixture<Startup>
+    public class QuantitySearchTestFixture : HttpIntegrationTestFixture
     {
-        public QuantitySearchTestFixture(DataStore dataStore, Format format)
-            : base(dataStore, format)
+        public QuantitySearchTestFixture(DataStore dataStore, Format format, TestFhirServerFactory testFhirServerFactory)
+            : base(dataStore, format, testFhirServerFactory)
         {
             // Prepare the resources used for number search tests.
             FhirClient.DeleteAllResources(ResourceType.Observation).Wait();

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ReferenceSearchTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ReferenceSearchTestFixture.cs
@@ -7,14 +7,13 @@ using System.Collections.Generic;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.E2E.Common;
-using Microsoft.Health.Fhir.Web;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 {
-    public class ReferenceSearchTestFixture : HttpIntegrationTestFixture<Startup>
+    public class ReferenceSearchTestFixture : HttpIntegrationTestFixture
     {
-        public ReferenceSearchTestFixture(DataStore dataStore, Format format)
-            : base(dataStore, format)
+        public ReferenceSearchTestFixture(DataStore dataStore, Format format, TestFhirServerFactory testFhirServerFactory)
+            : base(dataStore, format, testFhirServerFactory)
         {
             // Prepare the resources used for string search tests.
             FhirClient.DeleteAllResources(ResourceType.Patient).Wait();

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SearchTestsBase.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SearchTestsBase.cs
@@ -8,14 +8,13 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Hl7.Fhir.Model;
-using Microsoft.Health.Fhir.Web;
 using Xunit;
 using FhirClient = Microsoft.Health.Fhir.Tests.E2E.Common.FhirClient;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 {
     public abstract class SearchTestsBase<TFixture> : IClassFixture<TFixture>
-        where TFixture : HttpIntegrationTestFixture<Startup>
+        where TFixture : HttpIntegrationTestFixture
     {
         protected SearchTestsBase(TFixture fixture)
         {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/StringSearchTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/StringSearchTestFixture.cs
@@ -7,16 +7,15 @@ using System.Collections.Generic;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.E2E.Common;
-using Microsoft.Health.Fhir.Web;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 {
-    public class StringSearchTestFixture : HttpIntegrationTestFixture<Startup>
+    public class StringSearchTestFixture : HttpIntegrationTestFixture
     {
         internal const string LongString = "Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut eget ultricies justo. Maecenas bibendum convallis sodales. Vestibulum quis molestie dui. Nulla porta elementum tristique. Aenean neque libero convallis sit amet dui ullamcorper congue lacinia erat. Sed finibus ex ac massa tincidunt tristique. In sed auctor massa. Proin cursus porttitor arcu. Maecenas a leo nunc. Sed pretium porta volutpat. In aliquet tempor sapien vitae laoreet nisl tempor ac. Vestibulum lacus leo luctus vitae pharetra at tempus ac diam. Integer at dui eu dolor gravida vehicula. Phasellus malesuada elit orci quis maximus purus consectetur ac. In semper consequat augue sit amet ultricies.";
 
-        public StringSearchTestFixture(DataStore dataStore, Format format)
-            : base(dataStore, format)
+        public StringSearchTestFixture(DataStore dataStore, Format format, TestFhirServerFactory testFhirServerFactory)
+            : base(dataStore, format, testFhirServerFactory)
         {
             // Prepare the resources used for string search tests.
             FhirClient.DeleteAllResources(ResourceType.Patient).Wait();

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/TokenSearchTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/TokenSearchTestFixture.cs
@@ -8,14 +8,13 @@ using System.Collections.Generic;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.E2E.Common;
-using Microsoft.Health.Fhir.Web;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 {
-    public class TokenSearchTestFixture : HttpIntegrationTestFixture<Startup>
+    public class TokenSearchTestFixture : HttpIntegrationTestFixture
     {
-        public TokenSearchTestFixture(DataStore dataStore, Format format)
-            : base(dataStore, format)
+        public TokenSearchTestFixture(DataStore dataStore, Format format, TestFhirServerFactory testFhirServerFactory)
+            : base(dataStore, format, testFhirServerFactory)
         {
             // Prepare the resources used for number search tests.
             FhirClient.DeleteAllResources(ResourceType.Observation).Wait();

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/UriSearchTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/UriSearchTestFixture.cs
@@ -7,14 +7,13 @@ using System.Collections.Generic;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.E2E.Common;
-using Microsoft.Health.Fhir.Web;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 {
-    public class UriSearchTestFixture : HttpIntegrationTestFixture<Startup>
+    public class UriSearchTestFixture : HttpIntegrationTestFixture
     {
-        public UriSearchTestFixture(DataStore dataStore, Format format)
-            : base(dataStore, format)
+        public UriSearchTestFixture(DataStore dataStore, Format format, TestFhirServerFactory testFhirServerFactory)
+            : base(dataStore, format, testFhirServerFactory)
         {
             // Prepare the resources used for URI search tests.
             FhirClient.DeleteAllResources(ResourceType.ValueSet).Wait();

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Sql/SchemaTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Sql/SchemaTests.cs
@@ -9,18 +9,17 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
-using Microsoft.Health.Fhir.Web;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Sql
 {
     [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
-    public class SchemaTests : IClassFixture<HttpIntegrationTestFixture<Startup>>
+    public class SchemaTests : IClassFixture<HttpIntegrationTestFixture>
     {
         private readonly HttpClient _client;
 
-        public SchemaTests(HttpIntegrationTestFixture<Startup> fixture)
+        public SchemaTests(HttpIntegrationTestFixture fixture)
         {
             _client = fixture.HttpClient;
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TestFhirServer.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TestFhirServer.cs
@@ -39,9 +39,9 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             return GetFhirClient(format, TestApplications.ServiceClient, null, reusable);
         }
 
-        public FhirClient GetFhirClient(ResourceFormat format, TestApplication clientApplication, TestUser user, bool cacheable = true)
+        public FhirClient GetFhirClient(ResourceFormat format, TestApplication clientApplication, TestUser user, bool reusable = true)
         {
-            if (!cacheable)
+            if (!reusable)
             {
                 return CreateFhirClient(format, clientApplication, user);
             }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TestFhirServer.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TestFhirServer.cs
@@ -1,0 +1,98 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using EnsureThat;
+using Hl7.Fhir.Rest;
+using Microsoft.Health.Fhir.Tests.E2E.Common;
+using FhirClient = Microsoft.Health.Fhir.Tests.E2E.Common.FhirClient;
+
+namespace Microsoft.Health.Fhir.Tests.E2E.Rest
+{
+    public abstract class TestFhirServer : IDisposable
+    {
+        private readonly ConcurrentDictionary<(ResourceFormat format, TestApplication clientApplication, TestUser user), Lazy<FhirClient>> _cache = new ConcurrentDictionary<(ResourceFormat format, TestApplication clientApplication, TestUser user), Lazy<FhirClient>>();
+
+        protected TestFhirServer(Uri baseAddress)
+        {
+            EnsureArg.IsNotNull(baseAddress, nameof(baseAddress));
+
+            BaseAddress = baseAddress;
+        }
+
+        public Uri BaseAddress { get; }
+
+        public FhirClient GetFhirClient(ResourceFormat format, bool cacheable = true)
+        {
+            return GetFhirClient(format, TestApplications.ServiceClient, null, cacheable);
+        }
+
+        public FhirClient GetFhirClient(ResourceFormat format, TestApplication clientApplication, TestUser user, bool cacheable = true)
+        {
+            if (!cacheable)
+            {
+                return new FhirClient(CreateHttpClient(), this, format, clientApplication, user);
+            }
+
+            return _cache.GetOrAdd(
+                    (format, clientApplication, user),
+                    (tuple, fhirServer) =>
+                        new Lazy<FhirClient>(() =>
+                            new FhirClient(CreateHttpClient(), fhirServer, tuple.format, tuple.clientApplication, tuple.user)),
+                    this)
+                .Value;
+        }
+
+        protected abstract HttpMessageHandler CreateMessageHandler();
+
+        private HttpClient CreateHttpClient()
+        {
+            return new HttpClient(new SessionMessageHandler(CreateMessageHandler())) { BaseAddress = BaseAddress };
+        }
+
+        public virtual void Dispose()
+        {
+        }
+
+        /// <summary>
+        /// An <see cref="HttpMessageHandler"/> that maintains Cosmos DB session consistency between requests.
+        /// </summary>
+        private class SessionMessageHandler : DelegatingHandler
+        {
+            private readonly AsyncLocal<string> _sessionToken = new AsyncLocal<string>();
+
+            public SessionMessageHandler(HttpMessageHandler innerHandler)
+                : base(innerHandler)
+            {
+            }
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                string latestValue = _sessionToken.Value;
+
+                if (!string.IsNullOrEmpty(latestValue))
+                {
+                    request.Headers.TryAddWithoutValidation("x-ms-session-token", latestValue);
+                }
+
+                request.Headers.TryAddWithoutValidation("x-ms-consistency-level", "Session");
+
+                var response = await base.SendAsync(request, cancellationToken);
+
+                if (response.Headers.TryGetValues("x-ms-session-token", out var tokens))
+                {
+                    _sessionToken.Value = tokens.SingleOrDefault();
+                }
+
+                return response;
+            }
+        }
+    }
+}

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TestFhirServerFactory.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TestFhirServerFactory.cs
@@ -1,0 +1,65 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+
+namespace Microsoft.Health.Fhir.Tests.E2E.Rest
+{
+    public class TestFhirServerFactory : IDisposable
+    {
+        private readonly ConcurrentDictionary<(DataStore dataStore, Type startupType), Lazy<TestFhirServer>> _cache = new ConcurrentDictionary<(DataStore dataStore, Type startupType), Lazy<TestFhirServer>>();
+
+        public TestFhirServer GetTestFhirServer(DataStore dataStore, Type startupType)
+        {
+            return _cache.GetOrAdd(
+                    (dataStore, startupType),
+                    tuple =>
+                        new Lazy<TestFhirServer>(() =>
+                        {
+                            string environmentUrl = GetEnvironmentUrl(tuple.dataStore);
+
+                            if (string.IsNullOrEmpty(environmentUrl))
+                            {
+                                return new InProcTestFhirServer(tuple.dataStore, tuple.startupType);
+                            }
+
+                            if (environmentUrl.Last() != '/')
+                            {
+                                environmentUrl = $"{environmentUrl}/";
+                            }
+
+                            return new RemoteTestFhirServer(environmentUrl);
+                        }))
+                .Value;
+        }
+
+        private static string GetEnvironmentUrl(DataStore dataStore)
+        {
+            switch (dataStore)
+            {
+                case DataStore.CosmosDb:
+                    return Environment.GetEnvironmentVariable($"TestEnvironmentUrl{Constants.TestEnvironmentVariableVersionSuffix}");
+                case DataStore.SqlServer:
+                    return Environment.GetEnvironmentVariable($"TestEnvironmentUrl{Constants.TestEnvironmentVariableVersionSuffix}_Sql");
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(dataStore), dataStore, null);
+            }
+        }
+
+        public void Dispose()
+        {
+            foreach (Lazy<TestFhirServer> cacheValue in _cache.Values)
+            {
+                if (cacheValue.IsValueCreated)
+                {
+                    cacheValue.Value.Dispose();
+                }
+            }
+        }
+    }
+}

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TestFhirServerFactory.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TestFhirServerFactory.cs
@@ -10,6 +10,10 @@ using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
+    /// <summary>
+    /// Creates and caches <see cref="TestFhirServer"/> instances. This class is intended to be used as an assembly fixture,
+    /// so that the <see cref="TestFhirServer"/> instances can be reused across test classes in an assembly.
+    /// </summary>
     public class TestFhirServerFactory : IDisposable
     {
         private readonly ConcurrentDictionary<(DataStore dataStore, Type startupType), Lazy<TestFhirServer>> _cache = new ConcurrentDictionary<(DataStore dataStore, Type startupType), Lazy<TestFhirServer>>();

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/UpdateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/UpdateTests.cs
@@ -9,7 +9,6 @@ using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.E2E.Common;
-using Microsoft.Health.Fhir.Web;
 using Xunit;
 using FhirClient = Microsoft.Health.Fhir.Tests.E2E.Common.FhirClient;
 using Task = System.Threading.Tasks.Task;
@@ -17,9 +16,9 @@ using Task = System.Threading.Tasks.Task;
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
     [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.All)]
-    public class UpdateTests : IClassFixture<HttpIntegrationTestFixture<Startup>>
+    public class UpdateTests : IClassFixture<HttpIntegrationTestFixture>
     {
-        public UpdateTests(HttpIntegrationTestFixture<Startup> fixture)
+        public UpdateTests(HttpIntegrationTestFixture fixture)
         {
             Client = fixture.FhirClient;
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/VReadTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/VReadTests.cs
@@ -10,7 +10,6 @@ using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.E2E.Common;
-using Microsoft.Health.Fhir.Web;
 using Xunit;
 using FhirClient = Microsoft.Health.Fhir.Tests.E2E.Common.FhirClient;
 using Task = System.Threading.Tasks.Task;
@@ -18,9 +17,9 @@ using Task = System.Threading.Tasks.Task;
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
     [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.All)]
-    public class VReadTests : IClassFixture<HttpIntegrationTestFixture<Startup>>
+    public class VReadTests : IClassFixture<HttpIntegrationTestFixture>
     {
-        public VReadTests(HttpIntegrationTestFixture<Startup> fixture)
+        public VReadTests(HttpIntegrationTestFixture fixture)
         {
             Client = fixture.FhirClient;
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/VersionSpecificTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/VersionSpecificTests.cs
@@ -5,7 +5,6 @@
 
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
-using Microsoft.Health.Fhir.Web;
 using Xunit;
 using FhirClient = Microsoft.Health.Fhir.Tests.E2E.Common.FhirClient;
 using Task = System.Threading.Tasks.Task;
@@ -16,11 +15,11 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
     /// Provides version specific tests.
     /// </summary>
     [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb, Format.Json)]
-    public partial class VersionSpecificTests : IClassFixture<HttpIntegrationTestFixture<Startup>>
+    public partial class VersionSpecificTests : IClassFixture<HttpIntegrationTestFixture>
     {
         private readonly FhirClient _client;
 
-        public VersionSpecificTests(HttpIntegrationTestFixture<Startup> fixture)
+        public VersionSpecificTests(HttpIntegrationTestFixture fixture)
         {
             _client = fixture.FhirClient;
         }

--- a/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/Rest/VersionSpecificTests.cs
+++ b/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/Rest/VersionSpecificTests.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using Microsoft.Health.Fhir.Web;
 using Xunit;
 using Task = System.Threading.Tasks.Task;
 
@@ -12,7 +11,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
     /// <summary>
     /// Provides STU3 specific tests.
     /// </summary>
-    public partial class VersionSpecificTests : IClassFixture<HttpIntegrationTestFixture<Startup>>
+    public partial class VersionSpecificTests : IClassFixture<HttpIntegrationTestFixture>
     {
         [Fact]
         public async Task GivenStu3Server_WhenCapabilityStatementIsRetrieved_ThenCorrectVersionShouldBeReturned()

--- a/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/SmartProxy/SmartProxyBadRequestTests.cs
+++ b/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/SmartProxy/SmartProxyBadRequestTests.cs
@@ -9,17 +9,16 @@ using System.Threading.Tasks;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.E2E.Common;
 using Microsoft.Health.Fhir.Tests.E2E.Rest;
-using Microsoft.Health.Fhir.Web;
 using Xunit;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.SmartProxy
 {
     [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb, Format.All)]
-    public class SmartProxyBadRequestTests : IClassFixture<HttpIntegrationTestFixture<Startup>>
+    public class SmartProxyBadRequestTests : IClassFixture<HttpIntegrationTestFixture>
     {
         private readonly FhirClient _client;
 
-        public SmartProxyBadRequestTests(HttpIntegrationTestFixture<Startup> fixture)
+        public SmartProxyBadRequestTests(HttpIntegrationTestFixture fixture)
         {
             _client = fixture.FhirClient;
         }


### PR DESCRIPTION
## Description
This changes the way we use and reuse `FhirClient`s across our end to end tests. The existing `HttpIntegrationTestFixture` has been broken apart into reusable pieces. The breakdown now looks like this:

- A `TestFhirServerFactory` is registered as an assembly fixture, meaning it can be reused across the tests in the assembly. It's job is to create and cache `TestFhirServer`.
- `TestFhirServer` is an abstract with two concrete implementations: `InProcTestFhirServer` and `RemoteTestFhirServer`. `TestFhirServer` creates and caches `FhirClient` instances that are setup to connect to the server in question (either one hosted in-proc or remote). 
- `HttpIntegrationTestFixture` now just calls `TestFhirServerFactory.GetTestFhirServer()` and `TestFhirServer.GetFhirClient()` to get a FHIR client for a test class.

I also changed the `FhirClient` API slightly for switching principals. Rather than mutating the instance, these methods will now return a new `FhirClient` instance using the desired identity.

Overall, this reduces E2E test execution time on a local box (where we use the in-proc test server) from ~4.5 minutes to ~1.5 minutes, a **3x** improvement.

We still have disabled parallelization within the E2E projects, so there is more we can do (see #12), but this is a good start.