### PR TITLE
Fixed potential nullref when throwing OperationFailedException.

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/GetExportRequestHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/GetExportRequestHandlerTests.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
                 Status = jobStatus,
             };
 
-            if ((jobStatus == OperationStatus.Canceled || jobStatus == OperationStatus.Failed) & addFailureDetails)
+            if ((jobStatus == OperationStatus.Canceled || jobStatus == OperationStatus.Failed) && addFailureDetails)
             {
                 jobRecord.FailureDetails = new ExportJobFailureDetails(_failureReason, _failureStatusCode);
             }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/GetExportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/GetExportRequestHandler.cs
@@ -48,9 +48,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
             }
             else if (outcome.JobRecord.Status == OperationStatus.Failed || outcome.JobRecord.Status == OperationStatus.Canceled)
             {
+                string failureReason = outcome.JobRecord.FailureDetails != null ? outcome.JobRecord.FailureDetails.FailureReason : Resources.UnknownError;
+                HttpStatusCode failureStatusCode = outcome.JobRecord.FailureDetails != null ? outcome.JobRecord.FailureDetails.FailureStatusCode : HttpStatusCode.InternalServerError;
+
                 throw new OperationFailedException(
-                    string.Format(Resources.OperationFailed, OperationsConstants.Export, outcome.JobRecord.FailureDetails.FailureReason),
-                    outcome.JobRecord.FailureDetails.FailureStatusCode);
+                    string.Format(Resources.OperationFailed, OperationsConstants.Export, failureReason), failureStatusCode);
             }
             else
             {


### PR DESCRIPTION
## Description
We are trying to access `FailureDetails` in `ExportJobRecord` without doing a null check first.

## Related issues
Addresses [issue [AB#70143](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/70143)].

## Testing
Added relevant UT
