### PR TITLE
Removed the forwarded header middleware by default.

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
@@ -8,7 +8,6 @@ using System.Reflection;
 using EnsureThat;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Api.Configs;
@@ -44,11 +43,6 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddMvc(options =>
             {
                 options.RespectBrowserAcceptHeader = true;
-            });
-
-            services.Configure<ForwardedHeadersOptions>(options =>
-            {
-                options.ForwardedHeaders = ForwardedHeaders.All;
             });
 
             var fhirServerConfiguration = new FhirServerConfiguration();
@@ -111,8 +105,6 @@ namespace Microsoft.Extensions.DependencyInjection
                 return app =>
                 {
                     IHostingEnvironment env = app.ApplicationServices.GetRequiredService<IHostingEnvironment>();
-
-                    app.UseForwardedHeaders();
 
                     // This middleware will add delegates to the OnStarting method of httpContext.Response for setting headers.
                     app.UseBaseHeaders();


### PR DESCRIPTION
## Description
Removed the ForwardedHeadersMiddleware.

## Related issues
Work item: [AB#70038](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/70038).

## Testing
Manual testing.
