### PR TITLE
Add customer request headers to audit log

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Configs/FhirServerConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Api/Configs/FhirServerConfiguration.cs
@@ -18,5 +18,7 @@ namespace Microsoft.Health.Fhir.Api.Configs
         public virtual CorsConfiguration Cors { get; } = new CorsConfiguration();
 
         public OperationsConfiguration Operations { get; } = new OperationsConfiguration();
+
+        public AuditConfiguration Audit { get; } = new AuditConfiguration();
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Controllers/AadSmartOnFhirProxyController.cs
+++ b/src/Microsoft.Health.Fhir.Api/Controllers/AadSmartOnFhirProxyController.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Redirect URL passed to Authorize failed to resolve.");
+                _logger.LogDebug(ex, "Redirect URL passed to Authorize failed to resolve.");
             }
 
             if (!_isAadV2 && !string.IsNullOrEmpty(aud))

--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditConstants.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditConstants.cs
@@ -1,0 +1,18 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Fhir.Api.Features.Audit
+{
+    public static class AuditConstants
+    {
+        public const string CustomAuditHeaderPrefix = "X-MS-HEALTHCAREAPIS-AUDIT-";
+
+        public const string CustomAuditHeaderKeyValue = "CustomAuditHeaderCollection";
+
+        public const int MaximumNumberOfCustomHeaders = 10;
+
+        public const int MaximumLengthOfCustomHeader = 2048;
+    }
+}

--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditHeaderException.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditHeaderException.cs
@@ -1,0 +1,22 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Fhir.Core.Exceptions;
+
+namespace Microsoft.Health.Fhir.Api.Features.Audit
+{
+    public class AuditHeaderException : FhirException
+    {
+        public AuditHeaderException(string headerName, int size)
+            : base(string.Format(Resources.CustomAuditHeaderTooLarge, headerName, size, AuditConstants.MaximumLengthOfCustomHeader))
+        {
+        }
+
+        public AuditHeaderException(int size)
+            : base(string.Format(Resources.TooManyCustomAuditHeaders, AuditConstants.MaximumNumberOfCustomHeaders, size))
+        {
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditHeaderException.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditHeaderException.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
     public class AuditHeaderException : FhirException
     {
         public AuditHeaderException(string headerName, int size)
-            : base(string.Format(Resources.CustomAuditHeaderTooLarge, headerName, size, AuditConstants.MaximumLengthOfCustomHeader))
+            : base(string.Format(Resources.CustomAuditHeaderTooLarge, AuditConstants.MaximumLengthOfCustomHeader, headerName, size))
         {
         }
 

--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditHeaderReader.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditHeaderReader.cs
@@ -1,0 +1,48 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.Health.Fhir.Api.Features.Audit
+{
+    public class AuditHeaderReader : IAuditHeaderReader
+    {
+        public IReadOnlyDictionary<string, string> Read(HttpContext httpContext)
+        {
+            if (!httpContext.Items.ContainsKey(AuditConstants.CustomAuditHeaderKeyValue))
+            {
+                var customHeaders = new Dictionary<string, string>();
+
+                foreach (var headerName in httpContext.Request.Headers.Keys)
+                {
+                    if (headerName.StartsWith(AuditConstants.CustomAuditHeaderPrefix, StringComparison.OrdinalIgnoreCase))
+                    {
+                        var headerValue = httpContext.Request.Headers[headerName].ToString();
+                        if (headerValue.Length > AuditConstants.MaximumLengthOfCustomHeader)
+                        {
+                            throw new AuditHeaderException(headerName, headerValue.Length);
+                        }
+
+                        customHeaders[headerName] = headerValue;
+                    }
+                }
+
+                if (customHeaders.Count > 10)
+                {
+                    throw new AuditHeaderException(customHeaders.Count);
+                }
+
+                httpContext.Items[AuditConstants.CustomAuditHeaderKeyValue] = customHeaders;
+                return customHeaders;
+            }
+            else
+            {
+                return httpContext.Items[AuditConstants.CustomAuditHeaderKeyValue] as IReadOnlyDictionary<string, string>;
+            }
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditHeaderReader.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditHeaderReader.cs
@@ -6,11 +6,20 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Fhir.Core.Configs;
 
 namespace Microsoft.Health.Fhir.Api.Features.Audit
 {
     public class AuditHeaderReader : IAuditHeaderReader
     {
+        private readonly AuditConfiguration _auditConfiguration;
+
+        public AuditHeaderReader(IOptions<AuditConfiguration> auditConfiguration)
+        {
+            _auditConfiguration = auditConfiguration.Value;
+        }
+
         public IReadOnlyDictionary<string, string> Read(HttpContext httpContext)
         {
             if (!httpContext.Items.ContainsKey(AuditConstants.CustomAuditHeaderKeyValue))
@@ -19,7 +28,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
 
                 foreach (var headerName in httpContext.Request.Headers.Keys)
                 {
-                    if (headerName.StartsWith(AuditConstants.CustomAuditHeaderPrefix, StringComparison.OrdinalIgnoreCase))
+                    if (headerName.StartsWith(_auditConfiguration.CustomAuditHeaderPrefix, StringComparison.OrdinalIgnoreCase))
                     {
                         var headerValue = httpContext.Request.Headers[headerName].ToString();
                         if (headerValue.Length > AuditConstants.MaximumLengthOfCustomHeader)
@@ -31,7 +40,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
                     }
                 }
 
-                if (customHeaders.Count > 10)
+                if (customHeaders.Count > AuditConstants.MaximumNumberOfCustomHeaders)
                 {
                     throw new AuditHeaderException(customHeaders.Count);
                 }

--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditHelper.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditHelper.cs
@@ -21,12 +21,14 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
         private readonly IAuditEventTypeMapping _auditEventTypeMapping;
         private readonly IAuditLogger _auditLogger;
         private readonly ILogger<AuditHelper> _logger;
+        private readonly IAuditHeaderReader _auditHeaderReader;
 
         public AuditHelper(
             IFhirRequestContextAccessor fhirRequestContextAccessor,
             IAuditEventTypeMapping auditEventTypeMapping,
             IAuditLogger auditLogger,
-            ILogger<AuditHelper> logger)
+            ILogger<AuditHelper> logger,
+            IAuditHeaderReader auditHeaderReader)
         {
             EnsureArg.IsNotNull(fhirRequestContextAccessor, nameof(fhirRequestContextAccessor));
             EnsureArg.IsNotNull(auditEventTypeMapping, nameof(auditEventTypeMapping));
@@ -37,6 +39,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
             _auditEventTypeMapping = auditEventTypeMapping;
             _auditLogger = auditLogger;
             _logger = logger;
+            _auditHeaderReader = auditHeaderReader;
         }
 
         /// <inheritdoc />
@@ -74,7 +77,8 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
                     statusCode: statusCode,
                     correlationId: fhirRequestContext.CorrelationId,
                     callerIpAddress: httpContext.Connection?.RemoteIpAddress?.ToString(),
-                    callerClaims: claimsExtractor.Extract());
+                    callerClaims: claimsExtractor.Extract(),
+                    customHeaders: _auditHeaderReader.Read(httpContext));
             }
         }
     }

--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditLogger.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditLogger.cs
@@ -31,7 +31,8 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
             "Action: {Action}" + Environment.NewLine +
             "StatusCode: {StatusCode}" + Environment.NewLine +
             "CorrelationId: {CorrelationId}" + Environment.NewLine +
-            "Claims: {Claims}";
+            "Claims: {Claims}" + Environment.NewLine +
+            "CustomHeaderValues: {CustomHeaderValues}";
 
         private readonly SecurityConfiguration _securityConfiguration;
         private readonly ILogger<IAuditLogger> _logger;

--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditLogger.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditLogger.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
             string correlationId,
             string callerIpAddress,
             IReadOnlyCollection<KeyValuePair<string, string>> callerClaims,
-            IReadOnlyCollection<KeyValuePair<string, string>> customerHeaders)
+            IReadOnlyDictionary<string, string> customerHeaders = null)
         {
             string claimsInString = null;
             string customerHeadersInString = null;

--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditLogger.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditLogger.cs
@@ -56,13 +56,20 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
             HttpStatusCode? statusCode,
             string correlationId,
             string callerIpAddress,
-            IReadOnlyCollection<KeyValuePair<string, string>> callerClaims)
+            IReadOnlyCollection<KeyValuePair<string, string>> callerClaims,
+            IReadOnlyCollection<KeyValuePair<string, string>> customerHeaders)
         {
             string claimsInString = null;
+            string customerHeadersInString = null;
 
             if (callerClaims != null)
             {
                 claimsInString = string.Join(";", callerClaims.Select(claim => $"{claim.Key}={claim.Value}"));
+            }
+
+            if (customerHeaders != null)
+            {
+                customerHeadersInString = string.Join(";", customerHeaders.Select(header => $"{header.Key}={header.Value}"));
             }
 
             _logger.LogInformation(
@@ -76,7 +83,8 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
                 action,
                 statusCode,
                 correlationId,
-                claimsInString);
+                claimsInString,
+                customerHeadersInString);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditLogger.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditLogger.cs
@@ -31,8 +31,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
             "Action: {Action}" + Environment.NewLine +
             "StatusCode: {StatusCode}" + Environment.NewLine +
             "CorrelationId: {CorrelationId}" + Environment.NewLine +
-            "Claims: {Claims}" + Environment.NewLine +
-            "CustomHeaderValues: {CustomHeaderValues}";
+            "Claims: {Claims}";
 
         private readonly SecurityConfiguration _securityConfiguration;
         private readonly ILogger<IAuditLogger> _logger;

--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/IAuditHeaderReader.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/IAuditHeaderReader.cs
@@ -1,0 +1,15 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.Health.Fhir.Api.Features.Audit
+{
+    public interface IAuditHeaderReader
+    {
+        IReadOnlyDictionary<string, string> Read(HttpContext httpContext);
+    }
+}

--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/IAuditLogger.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/IAuditLogger.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
         /// <param name="correlationId">The correlation ID.</param>
         /// <param name="callerIpAddress">The caller IP address.</param>
         /// <param name="callerClaims">The claims of the caller.</param>
+        /// <param name="customHeaders">Headers added by the caller with data to be added to the audit logs.</param>
         void LogAudit(
             AuditAction auditAction,
             string operation,
@@ -33,6 +34,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
             HttpStatusCode? statusCode,
             string correlationId,
             string callerIpAddress,
-            IReadOnlyCollection<KeyValuePair<string, string>> callerClaims);
+            IReadOnlyCollection<KeyValuePair<string, string>> callerClaims,
+            IReadOnlyCollection<KeyValuePair<string,string>> customHeaders);
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/IAuditLogger.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/IAuditLogger.cs
@@ -35,6 +35,6 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
             string correlationId,
             string callerIpAddress,
             IReadOnlyCollection<KeyValuePair<string, string>> callerClaims,
-            IReadOnlyCollection<KeyValuePair<string,string>> customHeaders);
+            IReadOnlyDictionary<string, string> customHeaders = null);
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Modules/AuditModule.cs
+++ b/src/Microsoft.Health.Fhir.Api/Modules/AuditModule.cs
@@ -31,6 +31,8 @@ namespace Microsoft.Health.Fhir.Api.Modules
 
             services.AddSingleton<IAuditLogger, AuditLogger>();
 
+            services.AddSingleton<IAuditHeaderReader, AuditHeaderReader>();
+
             services.Add<AuditHelper>()
                 .Singleton()
                 .AsService<IAuditHelper>();

--- a/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
@@ -79,6 +79,15 @@ namespace Microsoft.Health.Fhir.Api {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The value of the header {0} is  {1} and is too long so will not be added to the audit logs.  The maximum allowed size is {2}.  Please retry the request with a smaller value..
+        /// </summary>
+        public static string CustomAuditHeaderTooLarge {
+            get {
+                return ResourceManager.GetString("CustomAuditHeaderTooLarge", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Authorization failed..
         /// </summary>
         public static string Forbidden {
@@ -228,6 +237,15 @@ namespace Microsoft.Health.Fhir.Api {
         public static string ToggleNavigation {
             get {
                 return ResourceManager.GetString("ToggleNavigation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A maximum of {0} custom audit headers allowed in the request.  {1} headers were detected.  Please retry the request with fewer cutom headers..
+        /// </summary>
+        public static string TooManyCustomAuditHeaders {
+            get {
+                return ResourceManager.GetString("TooManyCustomAuditHeaders", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Health.Fhir.Api {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -79,7 +79,7 @@ namespace Microsoft.Health.Fhir.Api {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The value of the header {0} is  {1} and is too long so will not be added to the audit logs.  The maximum allowed size is {2}.  Please retry the request with a smaller value..
+        ///   Looks up a localized string similar to The value of the header {0} is {1} and is too long so will not be added to the audit logs.  The maximum allowed size is {2}.  Please retry the request with a smaller value..
         /// </summary>
         public static string CustomAuditHeaderTooLarge {
             get {

--- a/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Health.Fhir.Api {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The value of the header {0} is {1} and is too long so will not be added to the audit logs.  The maximum allowed size is {2}.  Please retry the request with a smaller value..
+        ///   Looks up a localized string similar to The maximum length of a custom audit header value is {0}. The supplied custom audit header &apos;{1}&apos; has length of {2}..
         /// </summary>
         public static string CustomAuditHeaderTooLarge {
             get {
@@ -241,7 +241,7 @@ namespace Microsoft.Health.Fhir.Api {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A maximum of {0} custom audit headers allowed in the request.  {1} headers were detected.  Please retry the request with fewer cutom headers..
+        ///   Looks up a localized string similar to The maximum number of custom audit headers allowed is {0}. The number of custom audit headers supplied is {1}..
         /// </summary>
         public static string TooManyCustomAuditHeaders {
             get {

--- a/src/Microsoft.Health.Fhir.Api/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Api/Resources.resx
@@ -124,7 +124,7 @@
     <value>The "content-type" header is required.</value>
   </data>
   <data name="CustomAuditHeaderTooLarge" xml:space="preserve">
-    <value>The value of the header {0} is {1} and is too long so will not be added to the audit logs.  The maximum allowed size is {2}.  Please retry the request with a smaller value.</value>
+    <value>The size of the header {0} is {1}.  The maximum allowed size is {2}.  Please retry the request with a smaller value.</value>
   </data>
   <data name="Forbidden" xml:space="preserve">
     <value>Authorization failed.</value>
@@ -183,7 +183,7 @@
     <value>Toggle navigation</value>
   </data>
   <data name="TooManyCustomAuditHeaders" xml:space="preserve">
-    <value>A maximum of {0} custom audit headers allowed in the request.  {1} headers were detected.  Please retry the request with fewer cutom headers.</value>
+    <value>A maximum of {0} custom audit headers allowed in the request.  {1} headers were detected.  Please retry the request with fewer custom headers.</value>
   </data>
   <data name="UnableToObtainOpenIdConfiguration" xml:space="preserve">
     <value>Unable to obtain OpenID configuration.</value>

--- a/src/Microsoft.Health.Fhir.Api/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Api/Resources.resx
@@ -123,6 +123,9 @@
   <data name="ContentTypeHeaderRequired" xml:space="preserve">
     <value>The "content-type" header is required.</value>
   </data>
+  <data name="CustomAuditHeaderTooLarge" xml:space="preserve">
+    <value>The value of the header {0} is  {1} and is too long so will not be added to the audit logs.  The maximum allowed size is {2}.  Please retry the request with a smaller value.</value>
+  </data>
   <data name="Forbidden" xml:space="preserve">
     <value>Authorization failed.</value>
   </data>
@@ -178,6 +181,9 @@
   </data>
   <data name="ToggleNavigation" xml:space="preserve">
     <value>Toggle navigation</value>
+  </data>
+  <data name="TooManyCustomAuditHeaders" xml:space="preserve">
+    <value>A maximum of {0} custom audit headers allowed in the request.  {1} headers were detected.  Please retry the request with fewer cutom headers.</value>
   </data>
   <data name="UnableToObtainOpenIdConfiguration" xml:space="preserve">
     <value>Unable to obtain OpenID configuration.</value>

--- a/src/Microsoft.Health.Fhir.Api/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Api/Resources.resx
@@ -124,7 +124,7 @@
     <value>The "content-type" header is required.</value>
   </data>
   <data name="CustomAuditHeaderTooLarge" xml:space="preserve">
-    <value>The value of the header {0} is  {1} and is too long so will not be added to the audit logs.  The maximum allowed size is {2}.  Please retry the request with a smaller value.</value>
+    <value>The value of the header {0} is {1} and is too long so will not be added to the audit logs.  The maximum allowed size is {2}.  Please retry the request with a smaller value.</value>
   </data>
   <data name="Forbidden" xml:space="preserve">
     <value>Authorization failed.</value>

--- a/src/Microsoft.Health.Fhir.Api/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Api/Resources.resx
@@ -124,7 +124,8 @@
     <value>The "content-type" header is required.</value>
   </data>
   <data name="CustomAuditHeaderTooLarge" xml:space="preserve">
-    <value>The size of the header {0} is {1}.  The maximum allowed size is {2}.  Please retry the request with a smaller value.</value>
+    <value>The maximum length of a custom audit header value is {0}. The supplied custom audit header '{1}' has length of {2}.</value>
+    <comment>PH0 is a constant defining the max length of a header.  PH1 is the name  of the header sent in the request.  PH2 is the length of the incoming header value.  Example: The maximum length of a custom audit header value is 2048. The supplied custom audit header 'X-MS-AZUREFHIR-AUDIT-SITE' has length of 3072.</comment>
   </data>
   <data name="Forbidden" xml:space="preserve">
     <value>Authorization failed.</value>
@@ -183,7 +184,8 @@
     <value>Toggle navigation</value>
   </data>
   <data name="TooManyCustomAuditHeaders" xml:space="preserve">
-    <value>A maximum of {0} custom audit headers allowed in the request.  {1} headers were detected.  Please retry the request with fewer custom headers.</value>
+    <value>The maximum number of custom audit headers allowed is {0}. The number of custom audit headers supplied is {1}.</value>
+    <comment>PH0 is a constant defining the max number of custom headers.  PH1 is the count of custom headers sent in the request.  Example: The maximum number of custom audit headers allowed is 10. The number of custom audit headers supplied is 12.</comment>
   </data>
   <data name="UnableToObtainOpenIdConfiguration" xml:space="preserve">
     <value>Unable to obtain OpenID configuration.</value>

--- a/src/Microsoft.Health.Fhir.Core/Configs/AuditConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/AuditConfiguration.cs
@@ -3,14 +3,10 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-namespace Microsoft.Health.Fhir.Api.Features.Audit
+namespace Microsoft.Health.Fhir.Core.Configs
 {
-    public static class AuditConstants
+    public class AuditConfiguration
     {
-        public const string CustomAuditHeaderKeyValue = "CustomAuditHeaderCollectionKeyValue";
-
-        public const int MaximumNumberOfCustomHeaders = 10;
-
-        public const int MaximumLengthOfCustomHeader = 2048;
+        public string CustomAuditHeaderPrefix { get; set; } = "X-MS-AZUREFHIR-AUDIT-";
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Configs/AuditConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/AuditConfiguration.cs
@@ -3,10 +3,30 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Microsoft.Health.Fhir.Core.Exceptions;
+
 namespace Microsoft.Health.Fhir.Core.Configs
 {
     public class AuditConfiguration
     {
-        public string CustomAuditHeaderPrefix { get; set; } = "X-MS-AZUREFHIR-AUDIT-";
+        private string _customAuditHeaderPrefix = "X-MS-AZUREFHIR-AUDIT-";
+
+        public string CustomAuditHeaderPrefix
+        {
+            get
+            {
+                return _customAuditHeaderPrefix;
+            }
+
+            set
+            {
+                if (string.IsNullOrEmpty(value))
+                {
+                    throw new InvalidDefinitionException(Resources.CustomHeaderPrefixCannotBeEmpty);
+                }
+
+                _customAuditHeaderPrefix = value;
+            }
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -241,6 +241,15 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The prefix used to identify custom audit headers cannot be empty..
+        /// </summary>
+        internal static string CustomHeaderPrefixCannotBeEmpty {
+            get {
+                return ResourceManager.GetString("CustomHeaderPrefixCannotBeEmpty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Deleting a specific record version is not supported..
         /// </summary>
         internal static string DeleteVersionNotAllowed {

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -181,6 +181,9 @@
     <value>Found result with Id '{0}', which did not match the provided Id '{1}'.</value>
     <comment>{0} is an Id e.g. 123456</comment>
   </data>
+  <data name="CustomHeaderPrefixCannotBeEmpty" xml:space="preserve">
+    <value>The prefix used to identify custom audit headers cannot be empty.</value>
+  </data>
   <data name="DeleteVersionNotAllowed" xml:space="preserve">
     <value>Deleting a specific record version is not supported.</value>
   </data>

--- a/src/Microsoft.Health.Fhir.R4.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.R4.Web/appsettings.json
@@ -1,85 +1,88 @@
 ﻿{
-  "FhirServer": {
-    "Conformance": {
-      "UseStrictConformance": true
-    },
-    "Security": {
-      "Enabled": true,
-      "EnableAadSmartOnFhirProxy": true,
-      "Authentication": {
-        "Audience": null,
-        "Authority": "https://localhost:44348"
-      },
-      "PrincipalClaims": [
-        "iss",
-        "oid"
-      ],
-      "Authorization": {
-        "Enabled": true
-      }
-    },
-    "Features": {
-      "SupportsConditionalCreate": true,
-      "SupportsConditionalUpdate": true,
-      "SupportsUI": false,
-      "SupportsXml": true
+    "FhirServer": {
+        "Conformance": {
+            "UseStrictConformance": true
+        },
+        "Security": {
+            "Enabled": true,
+            "EnableAadSmartOnFhirProxy": true,
+            "Authentication": {
+                "Audience": null,
+                "Authority": "https://localhost:44348"
+            },
+            "PrincipalClaims": [
+                "iss",
+                "oid"
+            ],
+            "Authorization": {
+                "Enabled": true
+            }
+        },
+        "Features": {
+            "SupportsConditionalCreate": true,
+            "SupportsConditionalUpdate": true,
+            "SupportsUI": false,
+            "SupportsXml": true
+        },
+        "CosmosDb": {
+            "CollectionId": "fhirR4",
+            "InitialCollectionThroughput": 1000
+        },
+        "Cors": {
+            "Origins": [],
+            "Methods": [],
+            "Headers": [],
+            "MaxAge": null,
+            "AllowCredentials": false
+        },
+        "Operations": {
+            "Export": {
+                "Enabled": false,
+                "MaximumNumberOfConcurrentJobsAllowed": 1,
+                "JobHeartbeatTimeoutThreshold": "00:10:00",
+                "JobPollingFrequency": "00:00:10",
+                "MaximumNumberOfResourcesPerQuery": 100,
+                "NumberOfPagesPerCommit": 10
+            }
+        },
+        "Audit": {
+            "CustomAuditHeaderPrefix": "X-MS-AZUREFHIR-AUDIT-"
+        }
     },
     "CosmosDb": {
-      "CollectionId": "fhirR4",
-      "InitialCollectionThroughput": 1000
+        "Host": null,
+        "Key": null,
+        "DatabaseId": "health",
+        "InitialDatabaseThroughput": null,
+        "ConnectionMode": "Direct",
+        "ConnectionProtocol": "Tcp",
+        "ContinuationTokenSizeLimitInKb": 2,
+        "DefaultConsistencyLevel": "Session",
+        "PreferredLocations": [],
+        "RetryOptions": {
+            "MaxNumberOfRetries": 3,
+            "MaxWaitTimeInSeconds": 5
+        }
     },
-    "Cors": {
-      "Origins": [],
-      "Methods": [],
-      "Headers": [],
-      "MaxAge": null,
-      "AllowCredentials": false
+    "DataStore": "CosmosDb",
+    "KeyVault": {
+        "Endpoint": null
     },
-    "Operations": {
-      "Export": {
-        "Enabled": false,
-        "MaximumNumberOfConcurrentJobsAllowed": 1,
-        "JobHeartbeatTimeoutThreshold": "00:10:00",
-        "JobPollingFrequency": "00:00:10",
-        "MaximumNumberOfResourcesPerQuery": 100,
-        "NumberOfPagesPerCommit": 10
-      }
-    }
-  },
-  "CosmosDb": {
-    "Host": null,
-    "Key": null,
-    "DatabaseId": "health",
-    "InitialDatabaseThroughput": null,
-    "ConnectionMode": "Direct",
-    "ConnectionProtocol": "Tcp",
-    "ContinuationTokenSizeLimitInKb": 2,
-    "DefaultConsistencyLevel": "Session",
-    "PreferredLocations": [],
-    "RetryOptions": {
-      "MaxNumberOfRetries": 3,
-      "MaxWaitTimeInSeconds": 5
-    }
-  },
-  "DataStore": "CosmosDb",
-  "KeyVault": {
-    "Endpoint": null
-  },
-  "Logging": {
-    "IncludeScopes": false,
-    "LogLevel": {
-      "Default": "Warning"
+    "Logging": {
+        "IncludeScopes": false,
+        "LogLevel": {
+            "Default": "Warning"
+        },
+        "ApplicationInsights": {
+            "LogLevel": {
+                "Default": "Information",
+                "Microsoft.Health": "Information",
+                "Microsoft": "Warning",
+                "System": "Warning"
+            }
+        }
     },
     "ApplicationInsights": {
-      "LogLevel": {
-        "Default": "Information",
-        "Microsoft.Health": "Information",
-        "Microsoft": "Warning",
-        "System": "Warning"
-      }
+        "InstrumentationKey": ""
     }
-  },
-  "ApplicationInsights": {
-    "InstrumentationKey": ""
-  }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Audit/AuditHeaderReaderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Audit/AuditHeaderReaderTests.cs
@@ -1,0 +1,188 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+using Microsoft.Health.Fhir.Api.Features.Audit;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
+{
+    public class AuditHeaderReaderTests
+    {
+        private readonly HttpContext _httpContext;
+
+        public AuditHeaderReaderTests()
+        {
+            _httpContext = new DefaultHttpContext();
+        }
+
+        [Fact]
+        public void GivenNoCustomHeaders_EmptyDictionaryReturned()
+        {
+            var headerReader = new AuditHeaderReader();
+
+            // No headers at all
+            var result = headerReader.Read(_httpContext);
+            Assert.Empty(result);
+
+            // Some non-audit headers
+            var headers = GenerateRandomHeaders(1, 0).ToList()[0][0] as Dictionary<string, string>;
+            foreach (var header in headers)
+            {
+                _httpContext.Request.Headers.Add(header.Key, new StringValues(header.Value));
+            }
+
+            result = headerReader.Read(_httpContext);
+            Assert.Empty(result);
+        }
+
+        [Theory]
+        [MemberData(nameof(GenerateRandomHeaders), 10, -1)]
+        public void GivenMixedHeaders_OnlyCorrectCustomHeadersReturn(IReadOnlyDictionary<string, string> headers, int expectedCustomHeaderCount)
+        {
+            var headerReader = new AuditHeaderReader();
+            _httpContext.Request.Headers.Clear();
+
+            foreach (var header in headers)
+            {
+                _httpContext.Request.Headers.Add(header.Key, new StringValues(header.Value));
+            }
+
+            var result = headerReader.Read(_httpContext);
+            Assert.Equal(result.Count, expectedCustomHeaderCount);
+        }
+
+        [Fact]
+        public void GivenHeaderWithNoValue_HeaderNameWithEmptyValueIsReturned()
+        {
+            var headerReader = new AuditHeaderReader();
+            var headers = GenerateRandomHeaders(1, 5).ToList()[0][0] as Dictionary<string, string>;
+            foreach (var header in headers)
+            {
+                _httpContext.Request.Headers.Add(header.Key, default);
+            }
+
+            var result = headerReader.Read(_httpContext);
+
+            Assert.Equal(5, result.Count);
+
+            foreach (var customHeader in result)
+            {
+                Assert.True(string.IsNullOrEmpty(customHeader.Value));
+            }
+        }
+
+        [Fact]
+        public void GivenMultipleValuesOfSameHeader_ConcatenatedStringValueReturend()
+        {
+            var headerReader = new AuditHeaderReader();
+            _httpContext.Request.Headers.Add(AuditConstants.CustomAuditHeaderPrefix + "repeated", new StringValues(new[] { "item1", "item2" }));
+
+            var result = headerReader.Read(_httpContext);
+            Assert.Equal("item1,item2", result[AuditConstants.CustomAuditHeaderPrefix + "repeated"]);
+        }
+
+        [Fact]
+        public void GivenTooManyCustomHeaders_AuditHeaderExceptionIsThrown()
+        {
+            var headerReader = new AuditHeaderReader();
+            _httpContext.Request.Headers.Clear();
+            var headers = GenerateRandomHeaders(1, 11).ToList()[0][0] as Dictionary<string, string>;
+            foreach (var header in headers)
+            {
+                _httpContext.Request.Headers.Add(header.Key, new StringValues(header.Value));
+            }
+
+            Assert.Throws<AuditHeaderException>(() => headerReader.Read(_httpContext));
+        }
+
+        [Fact]
+        public void GivenAHeaderWithTooLargeValue_AuditHeaderExceptionIsThrown()
+        {
+            var d = new Dictionary<string, string>() { ["a"] = "b" };
+            var headerReader = new AuditHeaderReader();
+            _httpContext.Request.Headers.Clear();
+            var headers = GenerateRandomHeaders(1, 9).ToList()[0][0] as Dictionary<string, string>;
+            foreach (var header in headers)
+            {
+                _httpContext.Request.Headers.Add(header.Key, new StringValues(header.Value));
+            }
+
+            _httpContext.Request.Headers.Add(AuditConstants.CustomAuditHeaderPrefix + "big", GenerateRandomString(2049));
+
+            Assert.Throws<AuditHeaderException>(() => headerReader.Read(_httpContext));
+        }
+
+        [Fact]
+        public void WithMultipleCallsUsingTheSameHttpContext_HttpContextItemsIsUsed()
+        {
+            var headerReader = new AuditHeaderReader();
+
+            var headers = GenerateRandomHeaders(1, 5).ToList()[0][0] as Dictionary<string, string>;
+            foreach (var header in headers)
+            {
+                _httpContext.Request.Headers.Add(header.Key, new StringValues(header.Value));
+            }
+
+            var result = headerReader.Read(_httpContext);
+            Assert.Equal(5, result.Count);
+
+            var changedHeaders = new Dictionary<string, string>() { ["changed"] = "changed" };
+
+            _httpContext.Items[AuditConstants.CustomAuditHeaderKeyValue] = changedHeaders;
+
+            result = headerReader.Read(_httpContext);
+            Assert.Equal(changedHeaders, result);
+        }
+
+        public static IEnumerable<object[]> GenerateRandomHeaders(int testCount, int numberOfAuditHeaders)
+        {
+            var tests = new List<object[]>();
+            var random = new Random();
+            for (var testIndex = 0; testIndex < testCount; testIndex++)
+            {
+                if (numberOfAuditHeaders == -1)
+                {
+                    numberOfAuditHeaders = random.Next(1, 10);
+                }
+
+                var headers = new Dictionary<string, string>();
+                for (var headerIndex = 0; headerIndex < numberOfAuditHeaders; headerIndex++)
+                {
+                    var headerName = new StringBuilder(AuditConstants.CustomAuditHeaderPrefix);
+                    headerName.Append(GenerateRandomString(20));
+                    headers[headerName.ToString()] = GenerateRandomString(random.Next(1, 2048));
+                }
+
+                var numberOfOtherHeaders = random.Next(1, 10);
+                for (var headerIndex = 0; headerIndex < numberOfOtherHeaders; headerIndex++)
+                {
+                    headers[GenerateRandomString(10)] = GenerateRandomString(random.Next(1, 2048));
+                }
+
+                tests.Add(new object[] { headers, numberOfAuditHeaders });
+            }
+
+            return tests;
+        }
+
+        private static string GenerateRandomString(int length)
+        {
+            var random = new Random();
+            var randomChars = new char[length];
+            for (int i = 0; i < length; i++)
+            {
+                randomChars[i] = (char)random.Next(65, 126);
+            }
+
+            return new string(randomChars);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Audit/AuditHeaderReaderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Audit/AuditHeaderReaderTests.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Health.Fhir.Api.Features.Audit;
 using Microsoft.Health.Fhir.Core.Configs;
+using Microsoft.Health.Fhir.Core.Exceptions;
 using NSubstitute;
 using Xunit;
 
@@ -153,6 +154,15 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
 
             result = headerReader.Read(_httpContext);
             Assert.Equal(changedHeaders, result);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void GivenEmptyPrefixValue_InvalidDefinitionExceptionIsThrown(string prefix)
+        {
+            var auditConfiguration = new AuditConfiguration();
+            Assert.Throws<InvalidDefinitionException>(() => auditConfiguration.CustomAuditHeaderPrefix = prefix);
         }
 
         public static IEnumerable<object[]> GenerateRandomHeaders(int testCount, int numberOfAuditHeaders)

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Audit/AuditHeaderReaderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Audit/AuditHeaderReaderTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
         }
 
         [Fact]
-        public void GivenNoCustomHeaders_EmptyDictionaryReturned()
+        public void GivenNoCustomHeaders_WhenHeadersRead_ThenEmptyDictionaryReturned()
         {
             var headerReader = new AuditHeaderReader(_optionsAuditConfiguration);
 
@@ -59,7 +59,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
 
         [Theory]
         [MemberData(nameof(GenerateRandomHeaders), 10, -1)]
-        public void GivenMixedHeaders_OnlyCorrectCustomHeadersReturn(IReadOnlyDictionary<string, string> headers, int expectedCustomHeaderCount)
+        public void GivenMixedHeaders_WhenHeadersRead_ThenOnlyCorrectCustomHeadersReturn(IReadOnlyDictionary<string, string> headers, int expectedCustomHeaderCount)
         {
             var headerReader = new AuditHeaderReader(_optionsAuditConfiguration);
             _httpContext.Request.Headers.Clear();
@@ -74,7 +74,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
         }
 
         [Fact]
-        public void GivenHeaderWithNoValue_HeaderNameWithEmptyValueIsReturned()
+        public void GivenHeaderWithNoValue_WhenHeadersRead_ThenHeaderNameWithEmptyValueIsReturned()
         {
             var headerReader = new AuditHeaderReader(_optionsAuditConfiguration);
             var headers = GenerateRandomHeaders(1, 5).ToList()[0][0] as Dictionary<string, string>;
@@ -94,7 +94,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
         }
 
         [Fact]
-        public void GivenMultipleValuesOfSameHeader_ConcatenatedStringValueReturend()
+        public void GivenMultipleValuesOfSameHeader_WhenHeadersRead_ThenConcatenatedStringValueReturend()
         {
             var headerReader = new AuditHeaderReader(_optionsAuditConfiguration);
             _httpContext.Request.Headers.Add(_optionsAuditConfiguration.Value.CustomAuditHeaderPrefix + "repeated", new StringValues(new[] { "item1", "item2" }));
@@ -104,7 +104,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
         }
 
         [Fact]
-        public void GivenTooManyCustomHeaders_AuditHeaderExceptionIsThrown()
+        public void GivenTooManyCustomHeaders_WhenHeadersRead_ThenAuditHeaderExceptionIsThrown()
         {
             var headerReader = new AuditHeaderReader(_optionsAuditConfiguration);
             _httpContext.Request.Headers.Clear();
@@ -118,7 +118,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
         }
 
         [Fact]
-        public void GivenAHeaderWithTooLargeValue_AuditHeaderExceptionIsThrown()
+        public void GivenAHeaderWithTooLargeValue_WhenHeadersRead_ThenAuditHeaderExceptionIsThrown()
         {
             var d = new Dictionary<string, string>() { ["a"] = "b" };
             var headerReader = new AuditHeaderReader(_optionsAuditConfiguration);
@@ -135,7 +135,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
         }
 
         [Fact]
-        public void WithMultipleCallsUsingTheSameHttpContext_HttpContextItemsIsUsed()
+        public void GivenCustomHeaders_WhenMultipleCallsUsingTheSameHttpContext_ThenHttpContextItemsIsUsed()
         {
             var headerReader = new AuditHeaderReader(_optionsAuditConfiguration);
 
@@ -159,7 +159,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
         [Theory]
         [InlineData(null)]
         [InlineData("")]
-        public void GivenEmptyPrefixValue_InvalidDefinitionExceptionIsThrown(string prefix)
+        public void GivenEmptyPrefixValue_WhenConfigurationValueSet_ThenInvalidDefinitionExceptionIsThrown(string prefix)
         {
             var auditConfiguration = new AuditConfiguration();
             Assert.Throws<InvalidDefinitionException>(() => auditConfiguration.CustomAuditHeaderPrefix = prefix);

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Audit/AuditHelperTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Audit/AuditHelperTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
 
             _claimsExtractor.Extract().Returns(Claims);
 
-            _auditHelper = new AuditHelper(_fhirRequestContextAccessor, _auditEventTypeMapping, _auditLogger, NullLogger<AuditHelper>.Instance);
+            _auditHelper = new AuditHelper(_fhirRequestContextAccessor, _auditEventTypeMapping, _auditLogger, NullLogger<AuditHelper>.Instance, _auditHeaderReader);
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Audit/AuditHelperTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Audit/AuditHelperTests.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
 
         private readonly HttpContext _httpContext = new DefaultHttpContext();
         private readonly IClaimsExtractor _claimsExtractor = Substitute.For<IClaimsExtractor>();
+        private readonly IAuditHeaderReader _auditHeaderReader = new AuditHeaderReader();
 
         public AuditHelperTests()
         {
@@ -85,7 +86,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
                 statusCode: null,
                 correlationId: CorrelationId,
                 callerIpAddress: CallerIpAddressInString,
-                callerClaims: Claims);
+                callerClaims: Claims,
+                customHeaders: _auditHeaderReader.Read(_httpContext));
         }
 
         [Fact]
@@ -123,7 +125,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
                 expectedStatusCode,
                 CorrelationId,
                 CallerIpAddressInString,
-                Claims);
+                Claims,
+                customHeaders: _auditHeaderReader.Read(_httpContext));
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Audit/AuditHelperTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Audit/AuditHelperTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
 
         private readonly HttpContext _httpContext = new DefaultHttpContext();
         private readonly IClaimsExtractor _claimsExtractor = Substitute.For<IClaimsExtractor>();
-        private readonly IAuditHeaderReader _auditHeaderReader = new AuditHeaderReader();
+        private readonly IAuditHeaderReader _auditHeaderReader = Substitute.For<IAuditHeaderReader>();
 
         public AuditHelperTests()
         {

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Microsoft.Health.Fhir.Shared.Api.UnitTests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Microsoft.Health.Fhir.Shared.Api.UnitTests.projitems
@@ -16,6 +16,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Controllers\FhirControllerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controllers\TestHttpMessageHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\ActionResults\FhirResultTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Audit\AuditHeaderReaderTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Audit\AuditEventTypeMappingTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Audit\AuditHelperTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Audit\AuditLoggingFilterAttributeTests.cs" />

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
@@ -100,6 +100,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
                     case AuditException _:
                         operationOutcomeResult.StatusCode = HttpStatusCode.InternalServerError;
                         break;
+                    case AuditHeaderException _:
+                        operationOutcomeResult.StatusCode = HttpStatusCode.RequestHeaderFieldsTooLarge;
+                        break;
                     case OperationFailedException ofe:
                         operationOutcomeResult.StatusCode = ofe.ResponseStatusCode;
                         break;

--- a/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
@@ -57,6 +57,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton(Options.Options.Create(fhirServerConfiguration.Cors));
             services.AddSingleton(Options.Options.Create(fhirServerConfiguration.Operations));
             services.AddSingleton(Options.Options.Create(fhirServerConfiguration.Operations.Export));
+            services.AddSingleton(Options.Options.Create(fhirServerConfiguration.Audit));
 
             services.AddTransient<IStartupFilter, FhirServerStartupFilter>();
 

--- a/src/Microsoft.Health.Fhir.Stu3.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Stu3.Web/appsettings.json
@@ -1,85 +1,88 @@
 ﻿{
-  "FhirServer": {
-    "Conformance": {
-      "UseStrictConformance": true
-    },
-    "Security": {
-      "Enabled": true,
-      "EnableAadSmartOnFhirProxy": true,
-      "Authentication": {
-        "Audience": null,
-        "Authority": "https://localhost:44348"
-      },
-      "PrincipalClaims": [
-        "iss",
-        "oid"
-      ],
-      "Authorization": {
-        "Enabled": true
-      }
-    },
-    "Features": {
-      "SupportsConditionalCreate": true,
-      "SupportsConditionalUpdate": true,
-      "SupportsUI": false,
-      "SupportsXml": true
+    "FhirServer": {
+        "Conformance": {
+            "UseStrictConformance": true
+        },
+        "Security": {
+            "Enabled": true,
+            "EnableAadSmartOnFhirProxy": true,
+            "Authentication": {
+                "Audience": null,
+                "Authority": "https://localhost:44348"
+            },
+            "PrincipalClaims": [
+                "iss",
+                "oid"
+            ],
+            "Authorization": {
+                "Enabled": true
+            }
+        },
+        "Features": {
+            "SupportsConditionalCreate": true,
+            "SupportsConditionalUpdate": true,
+            "SupportsUI": false,
+            "SupportsXml": true
+        },
+        "CosmosDb": {
+            "CollectionId": "fhir",
+            "InitialCollectionThroughput": 1000
+        },
+        "Cors": {
+            "Origins": [],
+            "Methods": [],
+            "Headers": [],
+            "MaxAge": null,
+            "AllowCredentials": false
+        },
+        "Operations": {
+            "Export": {
+                "Enabled": false,
+                "MaximumNumberOfConcurrentJobsAllowed": 1,
+                "JobHeartbeatTimeoutThreshold": "00:10:00",
+                "JobPollingFrequency": "00:00:10",
+                "MaximumNumberOfResourcesPerQuery": 100,
+                "NumberOfPagesPerCommit": 10
+            }
+        },
+        "Audit": {
+            "CustomAuditHeaderPrefix": "X-MS-AZUREFHIR-AUDIT-"
+        }
     },
     "CosmosDb": {
-      "CollectionId": "fhir",
-      "InitialCollectionThroughput": 1000
+        "Host": null,
+        "Key": null,
+        "DatabaseId": "health",
+        "InitialDatabaseThroughput": null,
+        "ConnectionMode": "Direct",
+        "ConnectionProtocol": "Tcp",
+        "ContinuationTokenSizeLimitInKb": 2,
+        "DefaultConsistencyLevel": "Session",
+        "PreferredLocations": [],
+        "RetryOptions": {
+            "MaxNumberOfRetries": 3,
+            "MaxWaitTimeInSeconds": 5
+        }
     },
-    "Cors": {
-      "Origins": [],
-      "Methods": [],
-      "Headers": [],
-      "MaxAge": null,
-      "AllowCredentials": false
+    "DataStore": "CosmosDb",
+    "KeyVault": {
+        "Endpoint": null
     },
-    "Operations": {
-      "Export": {
-        "Enabled": false,
-        "MaximumNumberOfConcurrentJobsAllowed": 1,
-        "JobHeartbeatTimeoutThreshold": "00:10:00",
-        "JobPollingFrequency": "00:00:10",
-        "MaximumNumberOfResourcesPerQuery": 100,
-        "NumberOfPagesPerCommit": 10
-      }
-    }
-  },
-  "CosmosDb": {
-    "Host": null,
-    "Key": null,
-    "DatabaseId": "health",
-    "InitialDatabaseThroughput": null,
-    "ConnectionMode": "Direct",
-    "ConnectionProtocol": "Tcp",
-    "ContinuationTokenSizeLimitInKb": 2,
-    "DefaultConsistencyLevel": "Session",
-    "PreferredLocations": [],
-    "RetryOptions": {
-      "MaxNumberOfRetries": 3,
-      "MaxWaitTimeInSeconds": 5
-    }
-  },
-  "DataStore": "CosmosDb",
-  "KeyVault": {
-    "Endpoint": null
-  },
-  "Logging": {
-    "IncludeScopes": false,
-    "LogLevel": {
-      "Default": "Warning"
+    "Logging": {
+        "IncludeScopes": false,
+        "LogLevel": {
+            "Default": "Warning"
+        },
+        "ApplicationInsights": {
+            "LogLevel": {
+                "Default": "Information",
+                "Microsoft.Health": "Information",
+                "Microsoft": "Warning",
+                "System": "Warning"
+            }
+        }
     },
     "ApplicationInsights": {
-      "LogLevel": {
-        "Default": "Information",
-        "Microsoft.Health": "Information",
-        "Microsoft": "Warning",
-        "System": "Warning"
-      }
+        "InstrumentationKey": ""
     }
-  },
-  "ApplicationInsights": {
-    "InstrumentationKey": ""
-  }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/AuditEntry.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/AuditEntry.cs
@@ -12,7 +12,16 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit
 {
     public class AuditEntry
     {
-        public AuditEntry(AuditAction auditAction, string action, string resourceType, Uri requestUri, HttpStatusCode? statusCode, string correlationId, string callerIpAddress, IReadOnlyCollection<KeyValuePair<string, string>> callerClaims)
+        public AuditEntry(
+            AuditAction auditAction,
+            string action,
+            string resourceType,
+            Uri requestUri,
+            HttpStatusCode? statusCode,
+            string correlationId,
+            string callerIpAddress,
+            IReadOnlyCollection<KeyValuePair<string, string>> callerClaims,
+            IReadOnlyCollection<KeyValuePair<string, string>> customHeaders)
         {
             AuditAction = auditAction;
             Action = action;
@@ -22,6 +31,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit
             CorrelationId = correlationId;
             CallerIpAddress = callerIpAddress;
             CallerClaims = callerClaims;
+            CustomHeaders = customHeaders;
         }
 
         public AuditAction AuditAction { get; }
@@ -39,5 +49,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit
         public string CallerIpAddress { get; }
 
         public IReadOnlyCollection<KeyValuePair<string, string>> CallerClaims { get; }
+
+        public IReadOnlyCollection<KeyValuePair<string, string>> CustomHeaders { get; }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/AuditTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/AuditTests.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit
     public class AuditTests : IClassFixture<AuditTestFixture>
     {
         private const string RequestIdHeaderName = "X-Request-Id";
+        private const string CustomAuditHeaderPrefix = "X-MS-AZUREFHIR-AUDIT-";
         private const string ExpectedClaimKey = "appid";
 
         private readonly AuditTestFixture _fixture;
@@ -339,7 +340,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit
             };
 
             var content = new FormUrlEncodedContent(formFields);
-            content.Headers.Add(AuditConstants.CustomAuditHeaderPrefix + "test", "test");
+            content.Headers.Add(CustomAuditHeaderPrefix + "test", "test");
             await ExecuteAndValidate(
                 async () => await _client.HttpClient.PostAsync(pathSegment, content),
                 "smart-on-fhir-token",
@@ -347,7 +348,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit
                 HttpStatusCode.BadRequest,
                 "1234",
                 "client_id",
-                new Dictionary<string, string>() { [AuditConstants.CustomAuditHeaderPrefix + "test"] = "test" });
+                new Dictionary<string, string>() { [CustomAuditHeaderPrefix + "test"] = "test" });
         }
 
         [Fact]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/AuditTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/AuditTests.cs
@@ -339,13 +339,15 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit
             };
 
             var content = new FormUrlEncodedContent(formFields);
+            content.Headers.Add(AuditConstants.CustomAuditHeaderPrefix + "test", "test");
             await ExecuteAndValidate(
                 async () => await _client.HttpClient.PostAsync(pathSegment, content),
                 "smart-on-fhir-token",
                 pathSegment,
                 HttpStatusCode.BadRequest,
                 "1234",
-                "client_id");
+                "client_id",
+                new Dictionary<string, string>() { [AuditConstants.CustomAuditHeaderPrefix + "test"] = "test" });
         }
 
         [Fact]
@@ -384,7 +386,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit
                 ae => ValidateExecutedAuditEntry(ae, expectedAction, expectedResourceType, expectedUri, expectedStatusCode, correlationId, expectedAppId, ExpectedClaimKey));
         }
 
-        private async Task ExecuteAndValidate(Func<Task<HttpResponseMessage>> action, string expectedAction, string expectedPathSegment, HttpStatusCode expectedStatusCode, string expectedClaimValue, string expectedClaimKey)
+        private async Task ExecuteAndValidate(Func<Task<HttpResponseMessage>> action, string expectedAction, string expectedPathSegment, HttpStatusCode expectedStatusCode, string expectedClaimValue, string expectedClaimKey, Dictionary<string, string> expectedCustomAuditHeaders = null)
         {
             if (!_fixture.IsUsingInProcTestServer)
             {
@@ -402,8 +404,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit
 
             Assert.Collection(
                 _auditLogger.GetAuditEntriesByCorrelationId(correlationId),
-                ae => ValidateExecutingAuditEntry(ae, expectedAction, expectedUri, correlationId, expectedClaimValue, expectedClaimKey),
-                ae => ValidateExecutedAuditEntry(ae, expectedAction, null, expectedUri, expectedStatusCode, correlationId, expectedClaimValue, expectedClaimKey));
+                ae => ValidateExecutingAuditEntry(ae, expectedAction, expectedUri, correlationId, expectedClaimValue, expectedClaimKey, expectedCustomAuditHeaders),
+                ae => ValidateExecutedAuditEntry(ae, expectedAction, null, expectedUri, expectedStatusCode, correlationId, expectedClaimValue, expectedClaimKey, expectedCustomAuditHeaders));
         }
 
         private async Task ExecuteAndValidate(Func<FhirClient> createClient, HttpStatusCode expectedStatusCode, string expectedAppId)
@@ -432,17 +434,17 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit
                 ae => ValidateExecutedAuditEntry(ae, "read", ResourceType.Patient, expectedUri, expectedStatusCode, correlationId, expectedAppId, ExpectedClaimKey));
         }
 
-        private void ValidateExecutingAuditEntry(AuditEntry auditEntry, string expectedAction, Uri expectedUri, string expectedCorrelationId, string expectedClaimValue, string expectedClaimKey)
+        private void ValidateExecutingAuditEntry(AuditEntry auditEntry, string expectedAction, Uri expectedUri, string expectedCorrelationId, string expectedClaimValue, string expectedClaimKey, Dictionary<string, string> expectedCustomAuditHeaders = null)
         {
-            ValidateAuditEntry(auditEntry, AuditAction.Executing, expectedAction, null, expectedUri, null, expectedCorrelationId, expectedClaimValue, expectedClaimKey);
+            ValidateAuditEntry(auditEntry, AuditAction.Executing, expectedAction, null, expectedUri, null, expectedCorrelationId, expectedClaimValue, expectedClaimKey, expectedCustomAuditHeaders);
         }
 
-        private void ValidateExecutedAuditEntry(AuditEntry auditEntry, string expectedAction, ResourceType? expectedResourceType, Uri expectedUri, HttpStatusCode? expectedStatusCode, string expectedCorrelationId, string expectedClaimValue, string expectedClaimKey)
+        private void ValidateExecutedAuditEntry(AuditEntry auditEntry, string expectedAction, ResourceType? expectedResourceType, Uri expectedUri, HttpStatusCode? expectedStatusCode, string expectedCorrelationId, string expectedClaimValue, string expectedClaimKey, Dictionary<string, string> expectedCustomAuditHeaders = null)
         {
-            ValidateAuditEntry(auditEntry, AuditAction.Executed, expectedAction, expectedResourceType, expectedUri, expectedStatusCode, expectedCorrelationId, expectedClaimValue, expectedClaimKey);
+            ValidateAuditEntry(auditEntry, AuditAction.Executed, expectedAction, expectedResourceType, expectedUri, expectedStatusCode, expectedCorrelationId, expectedClaimValue, expectedClaimKey, expectedCustomAuditHeaders);
         }
 
-        private void ValidateAuditEntry(AuditEntry auditEntry, AuditAction expectedAuditAction, string expectedAction, ResourceType? expectedResourceType, Uri expectedUri, HttpStatusCode? expectedStatusCode, string expectedCorrelationId, string expectedClaimValue, string expectedClaimKey)
+        private void ValidateAuditEntry(AuditEntry auditEntry, AuditAction expectedAuditAction, string expectedAction, ResourceType? expectedResourceType, Uri expectedUri, HttpStatusCode? expectedStatusCode, string expectedCorrelationId, string expectedClaimValue, string expectedClaimKey, Dictionary<string, string> expectedCustomAuditHeaders = null)
         {
             Assert.NotNull(auditEntry);
             Assert.Equal(expectedAuditAction, auditEntry.AuditAction);
@@ -467,6 +469,15 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit
             else
             {
                 Assert.Empty(auditEntry.CallerClaims);
+            }
+
+            if (expectedCustomAuditHeaders != null)
+            {
+                Assert.Equal(expectedCustomAuditHeaders, auditEntry.CustomHeaders);
+            }
+            else
+            {
+                Assert.Empty(auditEntry.CustomHeaders);
             }
         }
     }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/TraceAuditLogger.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/TraceAuditLogger.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit
             string correlationId,
             string callerIpAddress,
             IReadOnlyCollection<KeyValuePair<string, string>> callerClaims,
-            IReadOnlyCollection<KeyValuePair<string,string>> customHeaders)
+            IReadOnlyDictionary<string, string> customHeaders)
         {
             _auditEntries.Add(new AuditEntry(auditAction, action, resourceType, requestUri, statusCode, correlationId, callerIpAddress, callerClaims, customHeaders));
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/TraceAuditLogger.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/TraceAuditLogger.cs
@@ -16,9 +16,18 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit
     {
         private BlockingCollection<AuditEntry> _auditEntries = new BlockingCollection<AuditEntry>();
 
-        public void LogAudit(AuditAction auditAction, string action, string resourceType, Uri requestUri, HttpStatusCode? statusCode, string correlationId, string callerIpAddress, IReadOnlyCollection<KeyValuePair<string, string>> callerClaims)
+        public void LogAudit(
+            AuditAction auditAction,
+            string action,
+            string resourceType,
+            Uri requestUri,
+            HttpStatusCode? statusCode,
+            string correlationId,
+            string callerIpAddress,
+            IReadOnlyCollection<KeyValuePair<string, string>> callerClaims,
+            IReadOnlyCollection<KeyValuePair<string,string>> customHeaders)
         {
-            _auditEntries.Add(new AuditEntry(auditAction, action, resourceType, requestUri, statusCode, correlationId, callerIpAddress, callerClaims));
+            _auditEntries.Add(new AuditEntry(auditAction, action, resourceType, requestUri, statusCode, correlationId, callerIpAddress, callerClaims, customHeaders));
         }
 
         public IReadOnlyList<AuditEntry> GetAuditEntriesByCorrelationId(string correlationId)


### PR DESCRIPTION
## Description
Add the capability to store custom information in the audit logs by including headers in the request with a unique prefix.

## Related issues
Addresses [issue [AB#69944](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/69944)].

## Testing
New automated tests added, as well as manual testing.
