### PR TITLE
Fix FhirOperation value emitted in ApiNotificationMiddleware

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/ApiNotifications/ApiNotificationMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/ApiNotifications/ApiNotificationMiddleware.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Health.Fhir.Api.Features.ApiNotifications
                     apiNotification.Latency = timer.GetElapsedTime();
 
                     apiNotification.Authentication = _fhirRequestContextAccessor.FhirRequestContext.Principal.Identity.AuthenticationType;
-                    apiNotification.FhirOperation = _fhirRequestContextAccessor.FhirRequestContext.RouteName;
+                    apiNotification.FhirOperation = _fhirRequestContextAccessor.FhirRequestContext.RequestType.Code;
                     apiNotification.Protocol = context.Request.Scheme;
                     apiNotification.ResourceType = _fhirRequestContextAccessor.FhirRequestContext.ResourceType;
                     apiNotification.StatusCode = (HttpStatusCode)context.Response.StatusCode;

--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditEventTypeMapping.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditEventTypeMapping.cs
@@ -1,0 +1,80 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EnsureThat;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Health.Fhir.Api.Extensions;
+
+namespace Microsoft.Health.Fhir.Api.Features.Audit
+{
+    /// <summary>
+    /// Provides the ability to lookup audit event type.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Normally, the MVC middleware handles the routing which maps the controller name and action name to a method within the controller.
+    /// </para>
+    /// <para>
+    /// The <see cref="AuditEventTypeAttribute"/> that contains the audit event type information is defined on the method so we need the method
+    /// in order to be able to retrieve the attribute. However, since authentication middleware runs before the MVC middleware, if the authentication
+    /// rejects the call for whatever reason, we will not be able to retrieve the attribute and therefore, will not be able to get the corresponding audit event type.
+    /// </para>
+    /// <para>
+    /// This class builds the mapping ahead of time so that we can lookup the audit event type any time during the pipeline given the controller name and action name.
+    /// </para>
+    /// </remarks>
+    public class AuditEventTypeMapping : IAuditEventTypeMapping, IStartable
+    {
+        private readonly IActionDescriptorCollectionProvider _actionDescriptorCollectionProvider;
+
+        private IReadOnlyDictionary<(string ControllerName, string ActionName), Attribute> _attributeDictionary;
+
+        public AuditEventTypeMapping(IActionDescriptorCollectionProvider actionDescriptorCollectionProvider)
+        {
+            EnsureArg.IsNotNull(actionDescriptorCollectionProvider, nameof(actionDescriptorCollectionProvider));
+
+            _actionDescriptorCollectionProvider = actionDescriptorCollectionProvider;
+        }
+
+        /// <inheritdoc />
+        public string GetAuditEventType(string controllerName, string actionName)
+        {
+            if (!_attributeDictionary.TryGetValue((controllerName, actionName), out Attribute attribute))
+            {
+                throw new MissingAuditEventTypeMappingException(controllerName, actionName);
+            }
+
+            if (attribute is AuditEventTypeAttribute auditEventTypeAttribute)
+            {
+                return auditEventTypeAttribute.AuditEventType;
+            }
+
+            return null;
+        }
+
+        void IStartable.Start()
+        {
+            _attributeDictionary = _actionDescriptorCollectionProvider.ActionDescriptors.Items
+                .OfType<ControllerActionDescriptor>()
+                .Select(ad =>
+                {
+                    Attribute attribute = ad.MethodInfo?.GetCustomAttributes<AllowAnonymousAttribute>().FirstOrDefault() ??
+                        (Attribute)ad.MethodInfo?.GetCustomAttributes<AuditEventTypeAttribute>().FirstOrDefault();
+
+                    return (ad.ControllerName, ad.ActionName, Attribute: attribute);
+                })
+                .Where(item => item.Attribute != null)
+                .ToDictionary(
+                    item => (item.ControllerName, item.ActionName),
+                    item => item.Attribute);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditHelper.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditHelper.cs
@@ -3,18 +3,10 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using EnsureThat;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc.Controllers;
-using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.Extensions.Logging;
-using Microsoft.Health.Extensions.DependencyInjection;
-using Microsoft.Health.Fhir.Api.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Security;
 
@@ -23,43 +15,28 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
     /// <summary>
     /// Provides helper methods for auditing.
     /// </summary>
-    public class AuditHelper : IAuditHelper, IStartable
+    public class AuditHelper : IAuditHelper
     {
-        private readonly IActionDescriptorCollectionProvider _actionDescriptorCollectionProvider;
         private readonly IFhirRequestContextAccessor _fhirRequestContextAccessor;
+        private readonly IAuditEventTypeMapping _auditEventTypeMapping;
         private readonly IAuditLogger _auditLogger;
         private readonly ILogger<AuditHelper> _logger;
 
-        private IReadOnlyDictionary<(string ControllerName, string ActionName), Attribute> _attributeDictionary;
-
         public AuditHelper(
-            IActionDescriptorCollectionProvider actionDescriptorCollectionProvider,
             IFhirRequestContextAccessor fhirRequestContextAccessor,
+            IAuditEventTypeMapping auditEventTypeMapping,
             IAuditLogger auditLogger,
             ILogger<AuditHelper> logger)
         {
-            EnsureArg.IsNotNull(actionDescriptorCollectionProvider, nameof(actionDescriptorCollectionProvider));
             EnsureArg.IsNotNull(fhirRequestContextAccessor, nameof(fhirRequestContextAccessor));
+            EnsureArg.IsNotNull(auditEventTypeMapping, nameof(auditEventTypeMapping));
             EnsureArg.IsNotNull(auditLogger, nameof(auditLogger));
             EnsureArg.IsNotNull(logger, nameof(logger));
 
-            _actionDescriptorCollectionProvider = actionDescriptorCollectionProvider;
             _fhirRequestContextAccessor = fhirRequestContextAccessor;
+            _auditEventTypeMapping = auditEventTypeMapping;
             _auditLogger = auditLogger;
             _logger = logger;
-        }
-
-        /// <inheritdoc />
-        public string GetAuditEventType(string controllerName, string actionName)
-        {
-            Attribute attribute = GetAttribute(controllerName, actionName);
-
-            if (attribute is AuditEventTypeAttribute auditEventTypeAttribute)
-            {
-                return auditEventTypeAttribute.AuditEventType;
-            }
-
-            return null;
         }
 
         /// <inheritdoc />
@@ -80,49 +57,18 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
             Log(AuditAction.Executed, controllerName, actionName, (HttpStatusCode)httpContext.Response.StatusCode, responseResultType, httpContext, claimsExtractor);
         }
 
-        void IStartable.Start()
-        {
-            _attributeDictionary = _actionDescriptorCollectionProvider.ActionDescriptors.Items
-                .OfType<ControllerActionDescriptor>()
-                .Select(ad =>
-                {
-                    Attribute attribute = ad.MethodInfo?.GetCustomAttributes<AllowAnonymousAttribute>().FirstOrDefault() ??
-                        (Attribute)ad.MethodInfo?.GetCustomAttributes<AuditEventTypeAttribute>().FirstOrDefault();
-
-                    return (ad.ControllerName, ad.ActionName, Attribute: attribute);
-                })
-                .Where(item => item.Attribute != null)
-                .ToDictionary(
-                    item => (item.ControllerName, item.ActionName),
-                    item => item.Attribute);
-        }
-
-        private Attribute GetAttribute(string controllerName, string actionName)
-        {
-            if (_attributeDictionary.TryGetValue((controllerName, actionName), out Attribute attribute))
-            {
-                return attribute;
-            }
-
-            throw new AuditException(controllerName, actionName);
-        }
-
         private void Log(AuditAction auditAction, string controllerName, string actionName, HttpStatusCode? statusCode, string resourceType, HttpContext httpContext, IClaimsExtractor claimsExtractor)
         {
-            Attribute attribute = GetAttribute(controllerName, actionName);
+            string auditEventType = _auditEventTypeMapping.GetAuditEventType(controllerName, actionName);
 
-            // If anonymous allowed, don't audit.
-            if (attribute is AllowAnonymousAttribute)
-            {
-                return;
-            }
-            else if (attribute is AuditEventTypeAttribute auditEventTypeAttribute)
+            // Audit the call if an audit event type is associated with the action.
+            if (auditEventType != null)
             {
                 IFhirRequestContext fhirRequestContext = _fhirRequestContextAccessor.FhirRequestContext;
 
                 _auditLogger.LogAudit(
                     auditAction,
-                    operation: auditEventTypeAttribute.AuditEventType,
+                    operation: auditEventType,
                     resourceType: resourceType,
                     requestUri: fhirRequestContext.Uri,
                     statusCode: statusCode,

--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/IAuditEventTypeMapping.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/IAuditEventTypeMapping.cs
@@ -1,0 +1,22 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Fhir.Api.Features.Audit
+{
+    /// <summary>
+    /// Provides the ability to lookup audit event type.
+    /// </summary>
+    public interface IAuditEventTypeMapping
+    {
+        /// <summary>
+        /// Gets the audit event type from the <paramref name="controllerName"/> and <paramref name="actionName"/>.
+        /// </summary>
+        /// <param name="controllerName">The controller name.</param>
+        /// <param name="actionName">The action name.</param>
+        /// <returns>The audit event type if exists; <c>null</c> if anonymous access is allowed.</returns>
+        /// <exception cref="AuditEventTypeMapping">Thrown when there is no audit event type associated with the <paramref name="controllerName"/> and <paramref name="actionName"/>.</exception>
+        string GetAuditEventType(string controllerName, string actionName);
+    }
+}

--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/IAuditHelper.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/IAuditHelper.cs
@@ -14,15 +14,6 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
     public interface IAuditHelper
     {
         /// <summary>
-        /// Gets the audit event type from the <paramref name="controllerName"/> and <paramref name="actionName"/>.
-        /// </summary>
-        /// <param name="controllerName">The controller name.</param>
-        /// <param name="actionName">The action name.</param>
-        /// <returns>The audit event type if exists; <c>null</c> if anonymous access is allowed.</returns>
-        /// <exception cref="AuditException">Thrown when the audit event type could not be found.</exception>
-        string GetAuditEventType(string controllerName, string actionName);
-
-        /// <summary>
         /// Logs an audit entry for executing the <paramref name="controllerName"/> and <paramref name="actionName"/>.
         /// </summary>
         /// <param name="controllerName">The controller name.</param>

--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/MissingAuditEventTypeMappingException.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/MissingAuditEventTypeMappingException.cs
@@ -1,0 +1,17 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.Health.Fhir.Api.Features.Audit
+{
+    public class MissingAuditEventTypeMappingException : Exception
+    {
+        public MissingAuditEventTypeMappingException(string controllerName, string actionName)
+        : base(string.Format(Resources.MissingAuditInformation, controllerName, actionName))
+        {
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Api/Features/Context/FhirRequestContextMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Context/FhirRequestContextMiddleware.cs
@@ -9,8 +9,6 @@ using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Health.Fhir.Api.Features.Routing;
 using Microsoft.Health.Fhir.Core.Features.Context;
-using Microsoft.Health.Fhir.Core.Models;
-using Microsoft.Health.Fhir.ValueSets;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Api.Features.Context
@@ -58,7 +56,6 @@ namespace Microsoft.Health.Fhir.Api.Features.Context
                 method: request.Method,
                 uriString: uriInString,
                 baseUriString: baseUriInString,
-                requestType: new CodingInfo(AuditEventType.System, AuditEventType.RestFulOperationCode),
                 correlationId: correlationId,
                 requestHeaders: context.Request.Headers,
                 responseHeaders: context.Response.Headers,

--- a/src/Microsoft.Health.Fhir.Api/Modules/AuditModule.cs
+++ b/src/Microsoft.Health.Fhir.Api/Modules/AuditModule.cs
@@ -33,7 +33,11 @@ namespace Microsoft.Health.Fhir.Api.Modules
 
             services.Add<AuditHelper>()
                 .Singleton()
-                .AsService<IAuditHelper>()
+                .AsService<IAuditHelper>();
+
+            services.Add<AuditEventTypeMapping>()
+                .Singleton()
+                .AsService<IAuditEventTypeMapping>()
                 .AsService<IStartable>();
         }
     }

--- a/src/Microsoft.Health.Fhir.Core/Features/Context/FhirRequestContext.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Context/FhirRequestContext.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Security.Claims;
 using EnsureThat;
 using Microsoft.Extensions.Primitives;
-using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Core.Features.Context
 {
@@ -24,7 +23,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Context
             string method,
             string uriString,
             string baseUriString,
-            CodingInfo requestType,
             string correlationId,
             IDictionary<string, StringValues> requestHeaders,
             IDictionary<string, StringValues> responseHeaders,
@@ -33,7 +31,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Context
             EnsureArg.IsNotNullOrWhiteSpace(method, nameof(method));
             EnsureArg.IsNotNullOrWhiteSpace(uriString, nameof(uriString));
             EnsureArg.IsNotNullOrWhiteSpace(baseUriString, nameof(baseUriString));
-            EnsureArg.IsNotNull(requestType, nameof(requestType));
             EnsureArg.IsNotNullOrWhiteSpace(correlationId, nameof(correlationId));
             EnsureArg.IsNotNull(responseHeaders, nameof(responseHeaders));
             EnsureArg.IsNotNull(requestHeaders, nameof(requestHeaders));
@@ -41,7 +38,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Context
             Method = method;
             _uriString = uriString;
             _baseUriString = baseUriString;
-            RequestType = requestType;
             CorrelationId = correlationId;
             RequestHeaders = requestHeaders;
             ResponseHeaders = responseHeaders;
@@ -56,9 +52,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Context
 
         public string CorrelationId { get; }
 
-        public CodingInfo RequestType { get; }
-
         public string RouteName { get; set; }
+
+        public string AuditEventType { get; set; }
 
         public ClaimsPrincipal Principal { get; set; }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Context/IFhirRequestContext.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Context/IFhirRequestContext.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.Security.Claims;
 using Microsoft.Extensions.Primitives;
-using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Core.Features.Context
 {
@@ -21,9 +20,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Context
 
         string CorrelationId { get; }
 
-        CodingInfo RequestType { get; }
-
         string RouteName { get; set; }
+
+        string AuditEventType { get; set; }
 
         ClaimsPrincipal Principal { get; set; }
 

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/FhirRequestContextDocumentClientExtensions.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/FhirRequestContextDocumentClientExtensions.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
             // Also, at the time of writing, we do not typically issue more than one request to the database per request anyway, so the performance impact should
             // not be felt.
 
-            requestContext.StorageRequestMetrics = requestContext.StorageRequestMetrics ?? new CosmosStorageRequestMetrics(requestContext.RequestType.Code, requestContext.ResourceType);
+            requestContext.StorageRequestMetrics = requestContext.StorageRequestMetrics ?? new CosmosStorageRequestMetrics(requestContext.AuditEventType, requestContext.ResourceType);
 
             var cosmosMetrics = requestContext.StorageRequestMetrics as CosmosStorageRequestMetrics;
 

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/FhirRequestContextDocumentClientExtensions.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/FhirRequestContextDocumentClientExtensions.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
             // Also, at the time of writing, we do not typically issue more than one request to the database per request anyway, so the performance impact should
             // not be felt.
 
-            requestContext.StorageRequestMetrics = requestContext.StorageRequestMetrics ?? new CosmosStorageRequestMetrics(requestContext.RouteName, requestContext.ResourceType);
+            requestContext.StorageRequestMetrics = requestContext.StorageRequestMetrics ?? new CosmosStorageRequestMetrics(requestContext.RequestType.Code, requestContext.ResourceType);
 
             var cosmosMetrics = requestContext.StorageRequestMetrics as CosmosStorageRequestMetrics;
 

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Audit/AuditEventTypeMappingTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Audit/AuditEventTypeMappingTests.cs
@@ -1,0 +1,97 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Health.Fhir.Api.Features.Audit;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
+{
+    public class AuditEventTypeMappingTests
+    {
+        private const string ControllerName = nameof(MockController);
+        private const string AnonymousMethodName = nameof(MockController.Anonymous);
+        private const string AudittedMethodName = nameof(MockController.Auditted);
+        private const string NoAttributeMethodName = nameof(MockController.NoAttribute);
+        private const string AuditEventType = "audit";
+
+        private readonly IActionDescriptorCollectionProvider _actionDescriptorCollectionProvider = Substitute.For<IActionDescriptorCollectionProvider>();
+        private readonly AuditEventTypeMapping _auditEventTypeMapping;
+
+        public AuditEventTypeMappingTests()
+        {
+            Type mockControllerType = typeof(MockController);
+
+            var actionDescriptors = new List<ActionDescriptor>()
+            {
+                new ControllerActionDescriptor()
+                {
+                    ControllerName = ControllerName,
+                    ActionName = AnonymousMethodName,
+                    MethodInfo = mockControllerType.GetMethod(AnonymousMethodName),
+                },
+                new ControllerActionDescriptor()
+                {
+                    ControllerName = ControllerName,
+                    ActionName = AudittedMethodName,
+                    MethodInfo = mockControllerType.GetMethod(AudittedMethodName),
+                },
+                new ControllerActionDescriptor()
+                {
+                    ControllerName = ControllerName,
+                    ActionName = NoAttributeMethodName,
+                    MethodInfo = mockControllerType.GetMethod(NoAttributeMethodName),
+                },
+                new PageActionDescriptor()
+                {
+                },
+            };
+
+            var actionDescriptorCollection = new ActionDescriptorCollection(actionDescriptors, 1);
+
+            _actionDescriptorCollectionProvider.ActionDescriptors.Returns(actionDescriptorCollection);
+
+            _auditEventTypeMapping = new AuditEventTypeMapping(_actionDescriptorCollectionProvider);
+
+            ((IStartable)_auditEventTypeMapping).Start();
+        }
+
+        [Theory]
+        [InlineData(ControllerName, AnonymousMethodName, null)]
+        [InlineData(ControllerName, AudittedMethodName, AuditEventType)]
+        public void GivenControllerNameAndActionName_WhenGetAuditEventTypeIsCalled_ThenAuditEventTypeShouldBeReturned(string controllerName, string actionName, string expectedAuditEventType)
+        {
+            string actualAuditEventType = _auditEventTypeMapping.GetAuditEventType(controllerName, actionName);
+
+            Assert.Equal(expectedAuditEventType, actualAuditEventType);
+        }
+
+        [Fact]
+        public void GivenUnknownControllerNameAndActionName_WhenGetAuditEventTypeIsCalled_ThenAuditExceptionShouldBeThrown()
+        {
+            Assert.Throws<MissingAuditEventTypeMappingException>(() => _auditEventTypeMapping.GetAuditEventType("test", "action"));
+        }
+
+        private class MockController : Controller
+        {
+            [AllowAnonymous]
+            public IActionResult Anonymous() => new OkResult();
+
+            [AuditEventType(AuditEventType)]
+            public IActionResult Auditted() => new OkResult();
+
+            public IActionResult NoAttribute() => new OkResult();
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Audit/AuditHelperTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Audit/AuditHelperTests.cs
@@ -6,15 +6,8 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Abstractions;
-using Microsoft.AspNetCore.Mvc.Controllers;
-using Microsoft.AspNetCore.Mvc.Infrastructure;
-using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Api.Features.Audit;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Security;
@@ -25,10 +18,9 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
 {
     public class AuditHelperTests
     {
-        private const string ControllerName = nameof(MockController);
-        private const string AnonymousMethodName = nameof(MockController.Anonymous);
-        private const string AudittedMethodName = nameof(MockController.Auditted);
-        private const string NoAttributeMethodName = nameof(MockController.NoAttribute);
+        private const string ControllerName = "controller";
+        private const string AnonymousActionName = "anonymous";
+        private const string NonAnonymousActionName = "non-anonymous";
         private const string AuditEventType = "audit";
         private const string CorrelationId = "correlation";
         private static readonly Uri Uri = new Uri("http://localhost/123");
@@ -36,8 +28,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
         private static readonly IPAddress CallerIpAddress = new IPAddress(new byte[] { 0xA, 0x0, 0x0, 0x0 }); // 10.0.0.0
         private const string CallerIpAddressInString = "10.0.0.0";
 
-        private readonly IActionDescriptorCollectionProvider _actionDescriptorCollectionProvider = Substitute.For<IActionDescriptorCollectionProvider>();
         private readonly IFhirRequestContextAccessor _fhirRequestContextAccessor = Substitute.For<IFhirRequestContextAccessor>();
+        private readonly IAuditEventTypeMapping _auditEventTypeMapping = Substitute.For<IAuditEventTypeMapping>();
         private readonly IAuditLogger _auditLogger = Substitute.For<IAuditLogger>();
 
         private readonly IFhirRequestContext _fhirRequestContext = Substitute.For<IFhirRequestContext>();
@@ -49,71 +41,25 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
 
         public AuditHelperTests()
         {
-            Type mockControllerType = typeof(MockController);
-
-            var actionDescriptors = new List<ActionDescriptor>()
-            {
-                new ControllerActionDescriptor()
-                {
-                    ControllerName = ControllerName,
-                    ActionName = AnonymousMethodName,
-                    MethodInfo = mockControllerType.GetMethod(AnonymousMethodName),
-                },
-                new ControllerActionDescriptor()
-                {
-                    ControllerName = ControllerName,
-                    ActionName = AudittedMethodName,
-                    MethodInfo = mockControllerType.GetMethod(AudittedMethodName),
-                },
-                new ControllerActionDescriptor()
-                {
-                    ControllerName = ControllerName,
-                    ActionName = NoAttributeMethodName,
-                    MethodInfo = mockControllerType.GetMethod(NoAttributeMethodName),
-                },
-                new PageActionDescriptor()
-                {
-                },
-            };
-
-            var actionDescriptorCollection = new ActionDescriptorCollection(actionDescriptors, 1);
-
-            _actionDescriptorCollectionProvider.ActionDescriptors.Returns(actionDescriptorCollection);
-
             _fhirRequestContext.Uri.Returns(Uri);
             _fhirRequestContext.CorrelationId.Returns(CorrelationId);
 
             _fhirRequestContextAccessor.FhirRequestContext = _fhirRequestContext;
 
+            _auditEventTypeMapping.GetAuditEventType(ControllerName, AnonymousActionName).Returns((string)null);
+            _auditEventTypeMapping.GetAuditEventType(ControllerName, NonAnonymousActionName).Returns(AuditEventType);
+
             _httpContext.Connection.RemoteIpAddress = CallerIpAddress;
 
             _claimsExtractor.Extract().Returns(Claims);
 
-            _auditHelper = new AuditHelper(_actionDescriptorCollectionProvider, _fhirRequestContextAccessor, _auditLogger, NullLogger<AuditHelper>.Instance);
-
-            ((IStartable)_auditHelper).Start();
-        }
-
-        [Theory]
-        [InlineData(ControllerName, AnonymousMethodName, null)]
-        [InlineData(ControllerName, AudittedMethodName, AuditEventType)]
-        public void GivenControllerNameAndActionName_WhenGetAuditEventTypeIsCalled_ThenAuditEventTypeShouldBeReturned(string controllerName, string actionName, string expectedAuditEventType)
-        {
-            string actualAuditEventType = _auditHelper.GetAuditEventType(controllerName, actionName);
-
-            Assert.Equal(expectedAuditEventType, actualAuditEventType);
-        }
-
-        [Fact]
-        public void GivenUnknownControllerNameAndActionName_WhenGetAuditEventTypeIsCalled_ThenAuditExceptionShouldBeThrown()
-        {
-            Assert.Throws<AuditException>(() => _auditHelper.GetAuditEventType("test", "action"));
+            _auditHelper = new AuditHelper(_fhirRequestContextAccessor, _auditEventTypeMapping, _auditLogger, NullLogger<AuditHelper>.Instance);
         }
 
         [Fact]
         public void GivenAnActionHasAllowAnonymousAttribute_WhenLogExecutingIsCalled_ThenAuditLogShouldNotBeLogged()
         {
-            _auditHelper.LogExecuting(ControllerName, AnonymousMethodName, _httpContext, _claimsExtractor);
+            _auditHelper.LogExecuting(ControllerName, AnonymousActionName, _httpContext, _claimsExtractor);
 
             _auditLogger.DidNotReceiveWithAnyArgs().LogAudit(
                 auditAction: default,
@@ -129,7 +75,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
         [Fact]
         public void GivenAnActionHasAuditEventTypeAttribute_WhenLogExecutingIsCalled_ThenAuditLogShouldBeLogged()
         {
-            _auditHelper.LogExecuting(ControllerName, AudittedMethodName, _httpContext, _claimsExtractor);
+            _auditHelper.LogExecuting(ControllerName, NonAnonymousActionName, _httpContext, _claimsExtractor);
 
             _auditLogger.Received(1).LogAudit(
                 AuditAction.Executing,
@@ -143,16 +89,10 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
         }
 
         [Fact]
-        public void GivenUnknownActon_WhenLogExecutingIsCalled_ThenAuditExceptionShouldBeThrown()
-        {
-            Assert.Throws<AuditException>(() => _auditHelper.LogExecuting("test", "action", _httpContext, _claimsExtractor));
-        }
-
-        [Fact]
         public void GivenAnActionHasAllowAnonymousAttribute_WhenLogExecutedIsCalled_ThenAuditLogShouldNotBeLogged()
         {
             // OK
-            _auditHelper.LogExecuted(ControllerName, AnonymousMethodName, "Patient", _httpContext, _claimsExtractor);
+            _auditHelper.LogExecuted(ControllerName, AnonymousActionName, "Patient", _httpContext, _claimsExtractor);
 
             _auditLogger.DidNotReceiveWithAnyArgs().LogAudit(
                 auditAction: default,
@@ -173,7 +113,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
 
             _httpContext.Response.StatusCode = (int)expectedStatusCode;
 
-            _auditHelper.LogExecuted(ControllerName, AudittedMethodName, expectedResourceType, _httpContext, _claimsExtractor);
+            _auditHelper.LogExecuted(ControllerName, NonAnonymousActionName, expectedResourceType, _httpContext, _claimsExtractor);
 
             _auditLogger.Received(1).LogAudit(
                 AuditAction.Executed,
@@ -184,24 +124,6 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
                 CorrelationId,
                 CallerIpAddressInString,
                 Claims);
-        }
-
-        [Fact]
-        public void GivenUnknownActon_WhenLogExecutedIsCalled_ThenAuditExceptionShouldBeThrown()
-        {
-            // Created
-            Assert.Throws<AuditException>(() => _auditHelper.LogExecuted("test", "action", "Patient", _httpContext, _claimsExtractor));
-        }
-
-        private class MockController : Controller
-        {
-            [AllowAnonymous]
-            public IActionResult Anonymous() => new OkResult();
-
-            [AuditEventType(AuditEventType)]
-            public IActionResult Auditted() => new OkResult();
-
-            public IActionResult NoAttribute() => new OkResult();
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Context/FhirRequestContextMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Context/FhirRequestContextMiddlewareTests.cs
@@ -18,17 +18,6 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Context
     public class FhirRequestContextMiddlewareTests
     {
         [Fact]
-        public async Task GivenAnHttpRequest_WhenExecutingFhirRequestContextMiddleware_ThenCorrectRequestTypeShouldBeSet()
-        {
-            IFhirRequestContext fhirRequestContext = await SetupAsync(CreateHttpContext());
-
-            Assert.NotNull(fhirRequestContext.RequestType);
-
-            Assert.Equal(ValueSets.AuditEventType.System, fhirRequestContext.RequestType.System);
-            Assert.Equal(ValueSets.AuditEventType.RestFulOperationCode, fhirRequestContext.RequestType.Code);
-        }
-
-        [Fact]
         public async Task GivenAnHttpRequest_WhenExecutingFhirRequestContextMiddleware_ThenCorrectUriShouldBeSet()
         {
             IFhirRequestContext fhirRequestContext = await SetupAsync(CreateHttpContext());

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Notifications/ApiNotificationMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Notifications/ApiNotificationMiddlewareTests.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Health.Fhir.Api.Features.ApiNotifications;
 using Microsoft.Health.Fhir.Core.Features.Context;
+using Microsoft.Health.Fhir.Core.Models;
 using NSubstitute;
 using Xunit;
 
@@ -28,6 +29,7 @@ namespace Microsoft.Health.Fhir.Shared.Api.UnitTests.Features.Notifications
         public ApiNotificationMiddlewareTests()
         {
             _fhirRequestContextAccessor.FhirRequestContext.Returns(_fhirRequestContext);
+            _fhirRequestContext.RequestType.Returns(new CodingInfo("system", "code"));
 
             _apiNotificationMiddleware = new ApiNotificationMiddleware(
                     httpContext => Task.CompletedTask,

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Notifications/ApiNotificationMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Notifications/ApiNotificationMiddlewareTests.cs
@@ -11,7 +11,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Health.Fhir.Api.Features.ApiNotifications;
 using Microsoft.Health.Fhir.Core.Features.Context;
-using Microsoft.Health.Fhir.Core.Models;
 using NSubstitute;
 using Xunit;
 
@@ -29,7 +28,6 @@ namespace Microsoft.Health.Fhir.Shared.Api.UnitTests.Features.Notifications
         public ApiNotificationMiddlewareTests()
         {
             _fhirRequestContextAccessor.FhirRequestContext.Returns(_fhirRequestContext);
-            _fhirRequestContext.RequestType.Returns(new CodingInfo("system", "code"));
 
             _apiNotificationMiddleware = new ApiNotificationMiddleware(
                     httpContext => Task.CompletedTask,

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Microsoft.Health.Fhir.Shared.Api.UnitTests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Microsoft.Health.Fhir.Shared.Api.UnitTests.projitems
@@ -16,6 +16,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Controllers\FhirControllerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controllers\TestHttpMessageHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\ActionResults\FhirResultTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Audit\AuditEventTypeMappingTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Audit\AuditHelperTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Audit\AuditLoggingFilterAttributeTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Audit\AuditMiddlewareTests.cs" />

--- a/src/Microsoft.Health.Fhir.SqlServer.Api/Controllers/SchemaController.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.Api/Controllers/SchemaController.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using EnsureThat;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.Fhir.Core.Features.Routing;
@@ -36,6 +37,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Api.Controllers
         }
 
         [HttpGet]
+        [AllowAnonymous]
         [Route(KnownRoutes.Versions)]
         public ActionResult AvailableVersions()
         {
@@ -54,6 +56,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Api.Controllers
         }
 
         [HttpGet]
+        [AllowAnonymous]
         [Route(KnownRoutes.Current)]
         public ActionResult CurrentVersion()
         {
@@ -63,6 +66,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Api.Controllers
         }
 
         [HttpGet]
+        [AllowAnonymous]
         [Route(KnownRoutes.Script, Name = RouteNames.Script)]
         public ActionResult SqlScript(int id)
         {
@@ -72,6 +76,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Api.Controllers
         }
 
         [HttpGet]
+        [AllowAnonymous]
         [Route(KnownRoutes.Compatibility)]
         public ActionResult Compatibility()
         {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/OperationVersionsTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/OperationVersionsTests.cs
@@ -13,7 +13,7 @@ using Microsoft.Net.Http.Headers;
 using Xunit;
 using Task = System.Threading.Tasks.Task;
 
-namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
+namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
     [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.All)]
     public class OperationVersionsTests : IClassFixture<HttpIntegrationTestFixture<Startup>>


### PR DESCRIPTION
## Description
The value we were emitting for the FHIR operation was incorrect. This PR fixes it.

## Related issues
Addresses [issue #].

## Testing
Unit tests.
