### PR TITLE
Returns 412 error for incorrect if-match header in R4

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
                 switch (dce.GetSubStatusCode())
                 {
                     case HttpStatusCode.PreconditionFailed:
-                        throw new ResourceConflictException(weakETag);
+                        throw new PreconditionFailedException(string.Format(Core.Resources.ResourceVersionConflict, weakETag?.VersionId));
                     case HttpStatusCode.NotFound:
                         if (cosmosWrapper.IsDeleted)
                         {

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
 
                         if (weakETag != null)
                         {
-                            throw new ResourceConflictException(weakETag);
+                            throw new ResourceNotFoundException(string.Format(Core.Resources.ResourceNotFoundByIdAndVersion, resource.ResourceTypeName, resource.ResourceId, weakETag.VersionId));
                         }
                         else if (!allowCreate)
                         {

--- a/src/Microsoft.Health.Fhir.R4.Core/Features/Resources/Upsert/UpsertResourceHandler.cs
+++ b/src/Microsoft.Health.Fhir.R4.Core/Features/Resources/Upsert/UpsertResourceHandler.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Upsert
             }
             catch (ResourceConflictException)
             {
+                // In R4, the server returns a 412 Precondition Failed status code if the version id given in the If-Match header does not match
                 throw new PreconditionFailedException(string.Format(Core.Resources.ResourceVersionConflict, message.WeakETag?.VersionId));
             }
 

--- a/src/Microsoft.Health.Fhir.R4.Core/Features/Resources/Upsert/UpsertResourceHandler.cs
+++ b/src/Microsoft.Health.Fhir.R4.Core/Features/Resources/Upsert/UpsertResourceHandler.cs
@@ -1,0 +1,33 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.Health.Fhir.Core.Exceptions;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Microsoft.Health.Fhir.Core.Messages.Upsert;
+
+namespace Microsoft.Health.Fhir.Core.Features.Resources.Upsert
+{
+    public partial class UpsertResourceHandler : BaseResourceHandler, IRequestHandler<UpsertResourceRequest, UpsertResourceResponse>
+    {
+        private async Task<UpsertOutcome> UpsertAsync(UpsertResourceRequest message, ResourceWrapper resourceWrapper, bool allowCreate, bool keepHistory, CancellationToken cancellationToken)
+        {
+            UpsertOutcome result;
+
+            try
+            {
+                result = await FhirDataStore.UpsertAsync(resourceWrapper, message.WeakETag, allowCreate, keepHistory, cancellationToken);
+            }
+            catch (ResourceConflictException)
+            {
+                throw new PreconditionFailedException(string.Format(Core.Resources.ResourceVersionConflict, message.WeakETag?.VersionId));
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.R4.Core/Features/Resources/Upsert/UpsertResourceHandler.cs
+++ b/src/Microsoft.Health.Fhir.R4.Core/Features/Resources/Upsert/UpsertResourceHandler.cs
@@ -6,7 +6,6 @@
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
-using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Messages.Upsert;
 
@@ -16,17 +15,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Upsert
     {
         private async Task<UpsertOutcome> UpsertAsync(UpsertResourceRequest message, ResourceWrapper resourceWrapper, bool allowCreate, bool keepHistory, CancellationToken cancellationToken)
         {
-            UpsertOutcome result;
-
-            try
-            {
-                result = await FhirDataStore.UpsertAsync(resourceWrapper, message.WeakETag, allowCreate, keepHistory, cancellationToken);
-            }
-            catch (ResourceConflictException)
-            {
-                // In R4, the server returns a 412 Precondition Failed status code if the version id given in the If-Match header does not match
-                throw new PreconditionFailedException(string.Format(Core.Resources.ResourceVersionConflict, message.WeakETag?.VersionId));
-            }
+            // In R4, the server returns a 412 Precondition Failed status code if the version id given in the If-Match header does not match
+            UpsertOutcome result = await FhirDataStore.UpsertAsync(resourceWrapper, message.WeakETag, allowCreate, keepHistory, cancellationToken);
 
             return result;
         }

--- a/src/Microsoft.Health.Fhir.R4.Core/Features/Resources/Upsert/UpsertResourceHandler.cs
+++ b/src/Microsoft.Health.Fhir.R4.Core/Features/Resources/Upsert/UpsertResourceHandler.cs
@@ -15,10 +15,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Upsert
     {
         private async Task<UpsertOutcome> UpsertAsync(UpsertResourceRequest message, ResourceWrapper resourceWrapper, bool allowCreate, bool keepHistory, CancellationToken cancellationToken)
         {
-            // In R4, the server returns a 412 Precondition Failed status code if the version id given in the If-Match header does not match
-            UpsertOutcome result = await FhirDataStore.UpsertAsync(resourceWrapper, message.WeakETag, allowCreate, keepHistory, cancellationToken);
-
-            return result;
+            return await FhirDataStore.UpsertAsync(resourceWrapper, message.WeakETag, allowCreate, keepHistory, cancellationToken);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Upsert/UpsertResourceHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Upsert/UpsertResourceHandler.cs
@@ -19,7 +19,7 @@ using Microsoft.Health.Fhir.ValueSets;
 
 namespace Microsoft.Health.Fhir.Core.Features.Resources.Upsert
 {
-    public class UpsertResourceHandler : BaseResourceHandler, IRequestHandler<UpsertResourceRequest, UpsertResourceResponse>
+    public partial class UpsertResourceHandler : BaseResourceHandler, IRequestHandler<UpsertResourceRequest, UpsertResourceResponse>
     {
         public UpsertResourceHandler(
             IFhirDataStore fhirDataStore,
@@ -44,7 +44,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Upsert
             bool keepHistory = await ConformanceProvider.Value.CanKeepHistory(resource.TypeName, cancellationToken);
 
             ResourceWrapper resourceWrapper = CreateResourceWrapper(resource, deleted: false);
-            UpsertOutcome result = await FhirDataStore.UpsertAsync(resourceWrapper, message.WeakETag, allowCreate, keepHistory, cancellationToken);
+            UpsertOutcome result = await UpsertAsync(message, resourceWrapper, allowCreate, keepHistory, cancellationToken);
+
             resource.VersionId = result.Wrapper.Version;
 
             return new UpsertResourceResponse(new SaveOutcome(resource.ToResourceElement(), result.OutcomeType));

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/1.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/1.sql
@@ -1383,6 +1383,11 @@ AS
     IF (@previousResourceSurrogateId IS NULL) BEGIN
         -- There is no previous version of this resource
 
+        IF (@etag IS NOT NULL) BEGIN
+        -- You can't update a resource with a specified version if the resource does not exist
+            THROW 50404, 'Resource with specified version not found', 1;
+        END
+
         IF (@isDeleted = 1) BEGIN
             -- Don't bother marking the resource as deleted since it already does not exist.
             COMMIT TRANSACTION

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/1.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/1.sql
@@ -1395,7 +1395,7 @@ AS
         END
 
         IF (@allowCreate = 0) BEGIN
-            THROW 50404, 'Resource does not exist and create is not allowed', 1;
+            THROW 50405, 'Resource does not exist and create is not allowed', 1;
         END
 
         SET @version = 1

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/1.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/1.sql
@@ -1383,15 +1383,15 @@ AS
     IF (@previousResourceSurrogateId IS NULL) BEGIN
         -- There is no previous version of this resource
 
-        IF (@etag IS NOT NULL) BEGIN
-        -- You can't update a resource with a specified version if the resource does not exist
-            THROW 50404, 'Resource with specified version not found', 1;
-        END
-
         IF (@isDeleted = 1) BEGIN
             -- Don't bother marking the resource as deleted since it already does not exist.
             COMMIT TRANSACTION
             RETURN
+        END
+
+        IF (@etag IS NOT NULL) BEGIN
+        -- You can't update a resource with a specified version if the resource does not exist
+            THROW 50404, 'Resource with specified version not found', 1;
         END
 
         IF (@allowCreate = 0) BEGIN

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlErrorCodes.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlErrorCodes.cs
@@ -21,6 +21,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
         public const int NotFound = CustomErrorCodeBase + 404;
 
         /// <summary>
+        /// The client used an unacceptable HTTP method during the request
+        /// </summary>
+        public const int MethodNotAllowed = CustomErrorCodeBase + 405;
+
+        /// <summary>
         /// An optimistic concurrency precondition failed
         /// </summary>
         public const int PreconditionFailed = CustomErrorCodeBase + 412;

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             int etag = 0;
             if (weakETag != null && !int.TryParse(weakETag.VersionId, out etag))
             {
-                throw new PreconditionFailedException(string.Format(Core.Resources.ResourceVersionConflict, weakETag?.VersionId));
+                etag = -1;
             }
 
             var resourceMetadata = new ResourceMetadata(

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                             case SqlErrorCodes.NotFound:
                                 throw new MethodNotAllowedException(Core.Resources.ResourceCreationNotAllowed);
                             case SqlErrorCodes.PreconditionFailed:
-                                throw new ResourceConflictException(weakETag);
+                                throw new PreconditionFailedException(string.Format(Core.Resources.ResourceVersionConflict, weakETag?.VersionId));
                             default:
                                 _logger.LogError(e, "Error from SQL database on upsert");
                                 throw;

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -128,12 +128,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                                     throw new ResourceNotFoundException(string.Format(Core.Resources.ResourceNotFoundByIdAndVersion, resource.ResourceTypeName, resource.ResourceId, weakETag.VersionId));
                                 }
 
-                                if (!allowCreate)
-                                {
-                                    throw new MethodNotAllowedException(Core.Resources.ResourceCreationNotAllowed);
-                                }
-
                                 break;
+                            case SqlErrorCodes.MethodNotAllowed:
+                                throw new MethodNotAllowedException(Core.Resources.ResourceCreationNotAllowed);
                             default:
                                 _logger.LogError(e, "Error from SQL database on upsert");
                                 throw;

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                                 throw;
                         }
 
-                        _logger.LogError(e, "Unhandled Document Client Exception");
+                        _logger.LogError(e, "Unhandled SQL Exception");
 
                         throw;
                     }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                         switch (e.Number)
                         {
                             case SqlErrorCodes.NotFound:
-                                throw new MethodNotAllowedException(Core.Resources.ResourceCreationNotAllowed);
+                                throw new ResourceNotFoundException(string.Format(Core.Resources.ResourceNotFoundByIdAndVersion, resource.ResourceTypeName, resource.ResourceId, weakETag?.VersionId));
                             case SqlErrorCodes.PreconditionFailed:
                                 throw new PreconditionFailedException(string.Format(Core.Resources.ResourceVersionConflict, weakETag?.VersionId));
                             default:

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             int etag = 0;
             if (weakETag != null && !int.TryParse(weakETag.VersionId, out etag))
             {
-                throw new ResourceConflictException(weakETag);
+                throw new PreconditionFailedException(string.Format(Core.Resources.ResourceVersionConflict, weakETag?.VersionId));
             }
 
             var resourceMetadata = new ResourceMetadata(

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -128,17 +128,13 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                                     throw new ResourceNotFoundException(string.Format(Core.Resources.ResourceNotFoundByIdAndVersion, resource.ResourceTypeName, resource.ResourceId, weakETag.VersionId));
                                 }
 
-                                break;
+                                goto default;
                             case SqlErrorCodes.MethodNotAllowed:
                                 throw new MethodNotAllowedException(Core.Resources.ResourceCreationNotAllowed);
                             default:
                                 _logger.LogError(e, "Error from SQL database on upsert");
                                 throw;
                         }
-
-                        _logger.LogError(e, "Unhandled SQL Exception");
-
-                        throw;
                     }
                 }
             }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -68,6 +68,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             int etag = 0;
             if (weakETag != null && !int.TryParse(weakETag.VersionId, out etag))
             {
+                // Set the etag to a sentinel value to enable expected failure paths when updating with both existing and nonexistent resources.
                 etag = -1;
             }
 

--- a/src/Microsoft.Health.Fhir.Stu3.Core/Features/Resources/Upsert/UpsertResourceHandler.cs
+++ b/src/Microsoft.Health.Fhir.Stu3.Core/Features/Resources/Upsert/UpsertResourceHandler.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Upsert
     {
         private async Task<UpsertOutcome> UpsertAsync(UpsertResourceRequest message, ResourceWrapper resourceWrapper, bool allowCreate, bool keepHistory, CancellationToken cancellationToken)
         {
-            // In STU3, the server returns a 409 Conflict status code if the version id given in the If-Match header does not match
             UpsertOutcome result;
 
             try
@@ -25,7 +24,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Upsert
             }
             catch (PreconditionFailedException)
             {
-                // In R4, the server returns a 412 Precondition Failed status code if the version id given in the If-Match header does not match
                 throw new ResourceConflictException(message.WeakETag);
             }
 

--- a/src/Microsoft.Health.Fhir.Stu3.Core/Features/Resources/Upsert/UpsertResourceHandler.cs
+++ b/src/Microsoft.Health.Fhir.Stu3.Core/Features/Resources/Upsert/UpsertResourceHandler.cs
@@ -1,0 +1,22 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Microsoft.Health.Fhir.Core.Messages.Upsert;
+
+namespace Microsoft.Health.Fhir.Core.Features.Resources.Upsert
+{
+    public partial class UpsertResourceHandler : BaseResourceHandler, IRequestHandler<UpsertResourceRequest, UpsertResourceResponse>
+    {
+        private async Task<UpsertOutcome> UpsertAsync(UpsertResourceRequest message, ResourceWrapper resourceWrapper, bool allowCreate, bool keepHistory, CancellationToken cancellationToken)
+        {
+            UpsertOutcome result = await FhirDataStore.UpsertAsync(resourceWrapper, message.WeakETag, allowCreate, keepHistory, cancellationToken);
+            return result;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Stu3.Core/Features/Resources/Upsert/UpsertResourceHandler.cs
+++ b/src/Microsoft.Health.Fhir.Stu3.Core/Features/Resources/Upsert/UpsertResourceHandler.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Upsert
     {
         private async Task<UpsertOutcome> UpsertAsync(UpsertResourceRequest message, ResourceWrapper resourceWrapper, bool allowCreate, bool keepHistory, CancellationToken cancellationToken)
         {
+            // In STU3, the server returns a 409 Conflict status code if the version id given in the If-Match header does not match
             UpsertOutcome result = await FhirDataStore.UpsertAsync(resourceWrapper, message.WeakETag, allowCreate, keepHistory, cancellationToken);
             return result;
         }

--- a/test/Microsoft.Health.Fhir.R4.Tests.E2E/Rest/UpdateTests.cs
+++ b/test/Microsoft.Health.Fhir.R4.Tests.E2E/Rest/UpdateTests.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Tests.Common;
@@ -15,13 +14,29 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
     public partial class UpdateTests : IClassFixture<HttpIntegrationTestFixture>
     {
+        [Theory]
+        [InlineData("invalidVersion")]
+        [InlineData("-1")]
+        [InlineData("0")]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task WhenUpdatingAResourceWithInvalidETagHeader_GivenR4Server_TheServerShouldReturnAPreconditionFailedResponse(string versionId)
+        {
+            Observation createdResource = await Client.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>());
+
+            FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.UpdateAsync(createdResource, versionId));
+
+            Assert.Equal(System.Net.HttpStatusCode.PreconditionFailed, ex.StatusCode);
+        }
+
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
         public async Task WhenUpdatingAResourceWithIncorrectETagHeader_GivenR4Server_TheServerShouldReturnAPreconditionFailedResponse()
         {
             Observation createdResource = await Client.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>());
 
-            FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.UpdateAsync(createdResource, Guid.NewGuid().ToString()));
+            // Specify a version that is one off from the version of the existing resource
+            var incorrectVersionId = int.Parse(createdResource.Meta.VersionId) + 1;
+            FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.UpdateAsync(createdResource, incorrectVersionId.ToString()));
 
             Assert.Equal(System.Net.HttpStatusCode.PreconditionFailed, ex.StatusCode);
         }

--- a/test/Microsoft.Health.Fhir.R4.Tests.E2E/Rest/UpdateTests.cs
+++ b/test/Microsoft.Health.Fhir.R4.Tests.E2E/Rest/UpdateTests.cs
@@ -1,0 +1,29 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Hl7.Fhir.Model;
+using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Fhir.Tests.E2E.Common;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Fhir.Tests.E2E.Rest
+{
+    public partial class UpdateTests : IClassFixture<HttpIntegrationTestFixture>
+    {
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task WhenUpdatingAResourceWithIncorrectETagHeader_GivenR4Server_TheServerShouldReturnAPreconditionFailedResponse()
+        {
+            Observation createdResource = await Client.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>());
+
+            FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.UpdateAsync(createdResource, Guid.NewGuid().ToString()));
+
+            Assert.Equal(System.Net.HttpStatusCode.PreconditionFailed, ex.StatusCode);
+        }
+    }
+}

--- a/test/Microsoft.Health.Fhir.R4.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.R4.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -28,25 +28,5 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             await Assert.ThrowsAsync<PreconditionFailedException>(async () =>
                 await Mediator.UpsertResourceAsync(newResourceValues.ToResourceElement(), WeakETag.FromVersionId("invalidVersion")));
         }
-
-        [Fact]
-        [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]
-        public async Task WhenUpsertingANonexistentResourceWithCreateDisabledAndInvalidETagHeader_GivenR4ServerAndSqlServer_ThenPreconditionFailedIsThrown()
-        {
-            SetAllowCreate(false);
-
-            await Assert.ThrowsAsync<PreconditionFailedException>(() => Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight"), WeakETag.FromVersionId("invalidVersion")));
-        }
-
-        [Fact]
-        [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]
-        public async Task WhenUpsertingANonexistentResourceWithInvalidETagHeader_GivenR4ServerAndSqlServer_ThenPreconditionFailedIsThrown()
-        {
-            Resource newResourceValues = Samples.GetJsonSample("WeightInGrams").ToPoco();
-            newResourceValues.Id = Guid.NewGuid().ToString();
-
-            await Assert.ThrowsAsync<PreconditionFailedException>(async () =>
-                await Mediator.UpsertResourceAsync(newResourceValues.ToResourceElement(), WeakETag.FromVersionId("incorrectVersion")));
-        }
     }
 }

--- a/test/Microsoft.Health.Fhir.R4.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.R4.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -1,0 +1,29 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Fhir.Core.Exceptions;
+using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Microsoft.Health.Fhir.Tests.Common;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
+{
+    public partial class FhirStorageTests : IClassFixture<FhirStorageTestsFixture>
+    {
+        [Fact]
+        public async Task WhenUpsertingASavedResourceWithIncorrectVersionId_GivenR4Server_ThenPreconditionFailedIsThrown()
+        {
+            var saveResult = await Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight"));
+
+            var newResourceValues = Samples.GetJsonSample("WeightInGrams").ToPoco();
+            newResourceValues.Id = saveResult.Resource.Id;
+
+            await Assert.ThrowsAsync<PreconditionFailedException>(async () =>
+                await Mediator.UpsertResourceAsync(newResourceValues.ToResourceElement(), WeakETag.FromVersionId("incorrectVersion")));
+        }
+    }
+}

--- a/test/Microsoft.Health.Fhir.R4.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.R4.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -33,9 +33,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]
         public async Task WhenUpsertingANonexistentResourceWithCreateDisabledAndInvalidETagHeader_GivenR4ServerAndSqlServer_ThenPreconditionFailedIsThrown()
         {
-            var observation = _conformance.Rest[0].Resource.Find(r => r.Type == ResourceType.Observation);
-            observation.UpdateCreate = false;
-            observation.Versioning = CapabilityStatement.ResourceVersionPolicy.Versioned;
+            SetAllowCreate(false);
+
             await Assert.ThrowsAsync<PreconditionFailedException>(() => Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight"), WeakETag.FromVersionId("invalidVersion")));
         }
 

--- a/test/Microsoft.Health.Fhir.R4.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.R4.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -26,7 +26,17 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             newResourceValues.Id = saveResult.Resource.Id;
 
             await Assert.ThrowsAsync<PreconditionFailedException>(async () =>
-                await Mediator.UpsertResourceAsync(newResourceValues.ToResourceElement(), WeakETag.FromVersionId("incorrectVersion")));
+                await Mediator.UpsertResourceAsync(newResourceValues.ToResourceElement(), WeakETag.FromVersionId("invalidVersion")));
+        }
+
+        [Fact]
+        [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]
+        public async Task WhenUpsertingANonexistentResourceWithCreateDisabledAndInvalidVersionId_GivenR4ServerAndSqlServer_ThenPreconditionFailedIsThrown()
+        {
+            var observation = _conformance.Rest[0].Resource.Find(r => r.Type == ResourceType.Observation);
+            observation.UpdateCreate = false;
+            observation.Versioning = CapabilityStatement.ResourceVersionPolicy.Versioned;
+            await Assert.ThrowsAsync<PreconditionFailedException>(() => Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight"), WeakETag.FromVersionId("invalidVersion")));
         }
 
         [Fact]

--- a/test/Microsoft.Health.Fhir.R4.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.R4.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -40,17 +40,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         }
 
         [Fact]
-        [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb)]
-        public async Task WhenUpsertingANonexistentResourceWithInvalidETagHeader_GivenR4ServerAndCosmosDb_ThenResourceNotFoundIsThrown()
-        {
-            Resource newResourceValues = Samples.GetJsonSample("WeightInGrams").ToPoco();
-            newResourceValues.Id = Guid.NewGuid().ToString();
-
-            await Assert.ThrowsAsync<ResourceNotFoundException>(async () =>
-                await Mediator.UpsertResourceAsync(newResourceValues.ToResourceElement(), WeakETag.FromVersionId("incorrectVersion")));
-        }
-
-        [Fact]
         [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]
         public async Task WhenUpsertingANonexistentResourceWithInvalidETagHeader_GivenR4ServerAndSqlServer_ThenPreconditionFailedIsThrown()
         {

--- a/test/Microsoft.Health.Fhir.R4.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.R4.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -3,10 +3,13 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
+using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Xunit;
 using Task = System.Threading.Tasks.Task;
 
@@ -15,12 +18,34 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
     public partial class FhirStorageTests : IClassFixture<FhirStorageTestsFixture>
     {
         [Fact]
-        public async Task WhenUpsertingASavedResourceWithIncorrectVersionId_GivenR4Server_ThenPreconditionFailedIsThrown()
+        public async Task WhenUpsertingASavedResourceWithInvalidVersionId_GivenR4Server_ThenPreconditionFailedIsThrown()
         {
             var saveResult = await Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight"));
 
             var newResourceValues = Samples.GetJsonSample("WeightInGrams").ToPoco();
             newResourceValues.Id = saveResult.Resource.Id;
+
+            await Assert.ThrowsAsync<PreconditionFailedException>(async () =>
+                await Mediator.UpsertResourceAsync(newResourceValues.ToResourceElement(), WeakETag.FromVersionId("incorrectVersion")));
+        }
+
+        [Fact]
+        [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb)]
+        public async Task WhenUpsertingANonexistentResourceWithInvalidVersionId_GivenR4ServerAndCosmosDb_ThenResourceNotFoundIsThrown()
+        {
+            Resource newResourceValues = Samples.GetJsonSample("WeightInGrams").ToPoco();
+            newResourceValues.Id = Guid.NewGuid().ToString();
+
+            await Assert.ThrowsAsync<ResourceNotFoundException>(async () =>
+                await Mediator.UpsertResourceAsync(newResourceValues.ToResourceElement(), WeakETag.FromVersionId("incorrectVersion")));
+        }
+
+        [Fact]
+        [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]
+        public async Task WhenUpsertingANonexistentResourceWithInvalidVersionId_GivenR4ServerAndSqlServer_ThenPreconditionFailedIsThrown()
+        {
+            Resource newResourceValues = Samples.GetJsonSample("WeightInGrams").ToPoco();
+            newResourceValues.Id = Guid.NewGuid().ToString();
 
             await Assert.ThrowsAsync<PreconditionFailedException>(async () =>
                 await Mediator.UpsertResourceAsync(newResourceValues.ToResourceElement(), WeakETag.FromVersionId("incorrectVersion")));

--- a/test/Microsoft.Health.Fhir.R4.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.R4.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -3,13 +3,10 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
-using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Tests.Common;
-using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Xunit;
 using Task = System.Threading.Tasks.Task;
 

--- a/test/Microsoft.Health.Fhir.R4.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.R4.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
     public partial class FhirStorageTests : IClassFixture<FhirStorageTestsFixture>
     {
         [Fact]
-        public async Task WhenUpsertingASavedResourceWithInvalidVersionId_GivenR4Server_ThenPreconditionFailedIsThrown()
+        public async Task WhenUpsertingASavedResourceWithInvalidETagHeader_GivenR4Server_ThenPreconditionFailedIsThrown()
         {
             var saveResult = await Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight"));
 
@@ -31,7 +31,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
         [Fact]
         [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]
-        public async Task WhenUpsertingANonexistentResourceWithCreateDisabledAndInvalidVersionId_GivenR4ServerAndSqlServer_ThenPreconditionFailedIsThrown()
+        public async Task WhenUpsertingANonexistentResourceWithCreateDisabledAndInvalidETagHeader_GivenR4ServerAndSqlServer_ThenPreconditionFailedIsThrown()
         {
             var observation = _conformance.Rest[0].Resource.Find(r => r.Type == ResourceType.Observation);
             observation.UpdateCreate = false;
@@ -41,7 +41,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
         [Fact]
         [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb)]
-        public async Task WhenUpsertingANonexistentResourceWithInvalidVersionId_GivenR4ServerAndCosmosDb_ThenResourceNotFoundIsThrown()
+        public async Task WhenUpsertingANonexistentResourceWithInvalidETagHeader_GivenR4ServerAndCosmosDb_ThenResourceNotFoundIsThrown()
         {
             Resource newResourceValues = Samples.GetJsonSample("WeightInGrams").ToPoco();
             newResourceValues.Id = Guid.NewGuid().ToString();
@@ -52,7 +52,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
         [Fact]
         [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]
-        public async Task WhenUpsertingANonexistentResourceWithInvalidVersionId_GivenR4ServerAndSqlServer_ThenPreconditionFailedIsThrown()
+        public async Task WhenUpsertingANonexistentResourceWithInvalidETagHeader_GivenR4ServerAndSqlServer_ThenPreconditionFailedIsThrown()
         {
             Resource newResourceValues = Samples.GetJsonSample("WeightInGrams").ToPoco();
             newResourceValues.Id = Guid.NewGuid().ToString();

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/UpdateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/UpdateTests.cs
@@ -16,7 +16,7 @@ using Task = System.Threading.Tasks.Task;
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
     [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.All)]
-    public class UpdateTests : IClassFixture<HttpIntegrationTestFixture>
+    public partial class UpdateTests : IClassFixture<HttpIntegrationTestFixture>
     {
         public UpdateTests(HttpIntegrationTestFixture fixture)
         {
@@ -146,17 +146,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             Assert.Contains(updatedResource.Meta.VersionId, updateResponse.Headers.ETag.Tag);
             TestHelper.AssertLastUpdatedAndLastModifiedAreEqual(updatedResource.Meta.LastUpdated, updateResponse.Content.Headers.LastModified);
-        }
-
-        [Fact]
-        [Trait(Traits.Priority, Priority.One)]
-        public async Task WhenUpdatingAResource_GivenAnIncorrectETagHeader_TheServerShouldReturnAConflictResponse()
-        {
-            Observation createdResource = await Client.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>());
-
-            FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.UpdateAsync(createdResource, Guid.NewGuid().ToString()));
-
-            Assert.Equal(System.Net.HttpStatusCode.Conflict, ex.StatusCode);
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/UpdateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/UpdateTests.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         {
             Observation createdResource = await Client.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>());
 
-            FhirResponse<Observation> updateResponse = await Client.UpdateAsync(createdResource);
+            FhirResponse<Observation> updateResponse = await Client.UpdateAsync(createdResource, createdResource.Meta.VersionId);
 
             Assert.Equal(System.Net.HttpStatusCode.OK, updateResponse.StatusCode);
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -147,6 +147,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         [InlineData("1")]
         [InlineData("-1")]
         [InlineData("0")]
+        [InlineData("InvalidVersion")]
         public async Task WhenUpsertingWithCreateEnabledAndIntegerETagHeader_GivenANonexistentResource_TheServerShouldReturnResourceNotFoundResponse(string versionId)
         {
             SetAllowCreate(true);
@@ -159,6 +160,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         [InlineData("1")]
         [InlineData("-1")]
         [InlineData("0")]
+        [InlineData("InvalidVersion")]
         public async Task WhenUpsertingWithCreateDisabledAndIntegerETagHeader_GivenANonexistentResource_TheServerShouldReturnResourceNotFoundResponse(string versionId)
         {
             SetAllowCreate(false);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         }
 
         [Fact]
-        public async Task GivenANewResource_WhenUpsertingWithCreateDisabled_ThenAMethodNotAllowedExceptionIsThrown()
+        public async Task WhenUpsertingWithCreateDisabled_GivenANonexistentResource_ThenAMethodNotAllowedExceptionIsThrown()
         {
             var observation = _conformance.Rest[0].Resource.Find(r => r.Type == ResourceType.Observation);
             observation.UpdateCreate = false;
@@ -192,21 +192,13 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         }
 
         [Fact]
-        public async Task GivenANewResource_WhenUpsertingWithCreateEnabledAndJunkEtag_ThenAMethodNotAllowedExceptionIsThrown()
-        {
-            var observation = _conformance.Rest[0].Resource.Find(r => r.Type == ResourceType.Observation);
-            observation.UpdateCreate = true;
-            observation.Versioning = CapabilityStatement.ResourceVersionPolicy.Versioned;
-            await Assert.ThrowsAsync<ResourceConflictException>(() => Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight"), WeakETag.FromVersionId("junk")));
-        }
-
-        [Fact]
-        public async Task GivenANewResource_WhenUpsertingWithCreateDisabledAndJunkEtag_ThenAMethodNotAllowedExceptionIsThrown()
+        [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb)]
+        public async Task WhenUpsertingWithCreateDisabledAndInvalidVersionId_GivenANonexistentResourceAndCosmosDb_ThenAResourceNotFoundIsThrown()
         {
             var observation = _conformance.Rest[0].Resource.Find(r => r.Type == ResourceType.Observation);
             observation.UpdateCreate = false;
             observation.Versioning = CapabilityStatement.ResourceVersionPolicy.Versioned;
-            await Assert.ThrowsAsync<ResourceConflictException>(() => Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight"), WeakETag.FromVersionId("junk")));
+            await Assert.ThrowsAsync<ResourceNotFoundException>(() => Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight"), WeakETag.FromVersionId("invalidVersion")));
         }
 
         [Fact]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -37,7 +37,7 @@ using Task = System.Threading.Tasks.Task;
 namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 {
     [FhirStorageTestsFixtureArgumentSets(DataStore.All)]
-    public class FhirStorageTests : IClassFixture<FhirStorageTestsFixture>
+    public partial class FhirStorageTests : IClassFixture<FhirStorageTestsFixture>
     {
         private readonly FhirStorageTestsFixture _fixture;
         private readonly CapabilityStatement _conformance;
@@ -245,18 +245,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
             var allObservations = list.Select(x => ((Quantity)x.Result.Resource.Instance.ToPoco<Observation>().Value).Value.GetValueOrDefault()).Distinct();
             Assert.Equal(itemsToCreate, allObservations.Count());
-        }
-
-        [Fact]
-        public async Task GivenASavedResource_WhenUpsertingWithIncorrectVersionId_ThenAResourceConflictIsThrown()
-        {
-            var saveResult = await Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight"));
-
-            var newResourceValues = Samples.GetJsonSample("WeightInGrams").ToPoco();
-            newResourceValues.Id = saveResult.Resource.Id;
-
-            await Assert.ThrowsAsync<ResourceConflictException>(async () =>
-                await Mediator.UpsertResourceAsync(newResourceValues.ToResourceElement(), WeakETag.FromVersionId("incorrectVersion")));
         }
 
         [Fact]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -147,13 +147,28 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         [InlineData("1")]
         [InlineData("-1")]
         [InlineData("0")]
-        public async Task WhenUpsertingWithIntegerETagHeader_GivenAResourceThatDoesNotExist_TheServerShouldReturnResourceNotFoundResponse(string versionId)
+        public async Task WhenUpsertingWithCreateEnabledAndIntegerETagHeader_GivenANonexistentResource_TheServerShouldReturnResourceNotFoundResponse(string versionId)
         {
-            Resource newResourceValues = Samples.GetJsonSample("WeightInGrams").ToPoco();
-            newResourceValues.Id = Guid.NewGuid().ToString();
+            var observation = _conformance.Rest[0].Resource.Find(r => r.Type == ResourceType.Observation);
+            observation.UpdateCreate = true;
+            observation.Versioning = CapabilityStatement.ResourceVersionPolicy.Versioned;
 
             await Assert.ThrowsAsync<ResourceNotFoundException>(async () =>
-                await Mediator.UpsertResourceAsync(newResourceValues.ToResourceElement(), WeakETag.FromVersionId(versionId)));
+                await Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight"), WeakETag.FromVersionId(versionId)));
+        }
+
+        [Theory]
+        [InlineData("1")]
+        [InlineData("-1")]
+        [InlineData("0")]
+        public async Task WhenUpsertingWithCreateDisabledAndIntegerETagHeader_GivenANonexistentResource_TheServerShouldReturnResourceNotFoundResponse(string versionId)
+        {
+            var observation = _conformance.Rest[0].Resource.Find(r => r.Type == ResourceType.Observation);
+            observation.UpdateCreate = false;
+            observation.Versioning = CapabilityStatement.ResourceVersionPolicy.Versioned;
+
+            await Assert.ThrowsAsync<ResourceNotFoundException>(async () =>
+                await Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight"), WeakETag.FromVersionId(versionId)));
         }
 
         [Fact]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -143,6 +143,19 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             Assert.Equal(saveResult.Resource.Id, updateResult.Resource.Id);
         }
 
+        [Theory]
+        [InlineData("1")]
+        [InlineData("-1")]
+        [InlineData("0")]
+        public async Task WhenUpsertingWithIntegerETagHeader_GivenAResourceThatDoesNotExist_TheServerShouldReturnResourceNotFoundResponse(string versionId)
+        {
+            Resource newResourceValues = Samples.GetJsonSample("WeightInGrams").ToPoco();
+            newResourceValues.Id = Guid.NewGuid().ToString();
+
+            await Assert.ThrowsAsync<ResourceNotFoundException>(async () =>
+                await Mediator.UpsertResourceAsync(newResourceValues.ToResourceElement(), WeakETag.FromVersionId(versionId)));
+        }
+
         [Fact]
         public async Task GivenAResource_WhenUpsertingDifferentTypeWithTheSameId_ThenTheExistingResourceIsNotOverridden()
         {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -202,6 +202,16 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         }
 
         [Fact]
+        [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb)]
+        public async Task WhenUpsertingWithCreateEnabledAndInvalidETagHeader_GivenANonexistentResourceAndCosmosDb_ThenResourceNotFoundIsThrown()
+        {
+            var observation = _conformance.Rest[0].Resource.Find(r => r.Type == ResourceType.Observation);
+            observation.UpdateCreate = true;
+            observation.Versioning = CapabilityStatement.ResourceVersionPolicy.Versioned;
+            await Assert.ThrowsAsync<ResourceNotFoundException>(() => Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight"), WeakETag.FromVersionId("invalidVersion")));
+        }
+
+        [Fact]
         public async Task GivenASavedResource_WhenUpsertingWithNoETagHeader_ThenTheExistingResourceIsUpdated()
         {
             var saveResult = await Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight"));

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -193,7 +193,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
         [Fact]
         [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb)]
-        public async Task WhenUpsertingWithCreateDisabledAndInvalidVersionId_GivenANonexistentResourceAndCosmosDb_ThenAResourceNotFoundIsThrown()
+        public async Task WhenUpsertingWithCreateDisabledAndInvalidETagHeader_GivenANonexistentResourceAndCosmosDb_ThenAResourceNotFoundIsThrown()
         {
             var observation = _conformance.Rest[0].Resource.Find(r => r.Type == ResourceType.Observation);
             observation.UpdateCreate = false;
@@ -202,7 +202,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         }
 
         [Fact]
-        public async Task GivenASavedResource_WhenUpsertingWithNoVersionId_ThenTheExistingResourceIsUpdated()
+        public async Task GivenASavedResource_WhenUpsertingWithNoETagHeader_ThenTheExistingResourceIsUpdated()
         {
             var saveResult = await Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight"));
 
@@ -219,7 +219,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         }
 
         [Fact]
-        public async Task GivenASavedResource_WhenConcurrentlyUpsertingWithNoVersionId_ThenTheExistingResourceIsUpdated()
+        public async Task GivenASavedResource_WhenConcurrentlyUpsertingWithNoETagHeader_ThenTheExistingResourceIsUpdated()
         {
             var saveResult = await Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight"));
 

--- a/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/Rest/UpdateTests.cs
+++ b/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/Rest/UpdateTests.cs
@@ -1,0 +1,29 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Hl7.Fhir.Model;
+using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Fhir.Tests.E2E.Common;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Fhir.Tests.E2E.Rest
+{
+    public partial class UpdateTests : IClassFixture<HttpIntegrationTestFixture>
+    {
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task WhenUpdatingAResourceWithIncorrectETagHeader_GivenStu3Server_TheServerShouldReturnAConflictResponse()
+        {
+            Observation createdResource = await Client.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>());
+
+            FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.UpdateAsync(createdResource, Guid.NewGuid().ToString()));
+
+            Assert.Equal(System.Net.HttpStatusCode.Conflict, ex.StatusCode);
+        }
+    }
+}

--- a/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/Rest/UpdateTests.cs
+++ b/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/Rest/UpdateTests.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Tests.Common;
@@ -15,13 +14,29 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
     public partial class UpdateTests : IClassFixture<HttpIntegrationTestFixture>
     {
+        [Theory]
+        [InlineData("invalidVersion")]
+        [InlineData("-1")]
+        [InlineData("0")]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task WhenUpdatingAResourceWithInvalidETagHeader_GivenStu3Server_TheServerShouldReturnAConflictResponse(string versionId)
+        {
+            Observation createdResource = await Client.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>());
+
+            FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.UpdateAsync(createdResource, versionId));
+
+            Assert.Equal(System.Net.HttpStatusCode.Conflict, ex.StatusCode);
+        }
+
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
         public async Task WhenUpdatingAResourceWithIncorrectETagHeader_GivenStu3Server_TheServerShouldReturnAConflictResponse()
         {
             Observation createdResource = await Client.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>());
 
-            FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.UpdateAsync(createdResource, Guid.NewGuid().ToString()));
+            // Specify a version that is one off from the version of the existing resource
+            var incorrectVersionId = int.Parse(createdResource.Meta.VersionId) + 1;
+            FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.UpdateAsync(createdResource, incorrectVersionId.ToString()));
 
             Assert.Equal(System.Net.HttpStatusCode.Conflict, ex.StatusCode);
         }

--- a/test/Microsoft.Health.Fhir.Stu3.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.Stu3.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -26,7 +26,17 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             newResourceValues.Id = saveResult.Resource.Id;
 
             await Assert.ThrowsAsync<ResourceConflictException>(async () =>
-                await Mediator.UpsertResourceAsync(newResourceValues.ToResourceElement(), WeakETag.FromVersionId("incorrectVersion")));
+                await Mediator.UpsertResourceAsync(newResourceValues.ToResourceElement(), WeakETag.FromVersionId("invalidVersion")));
+        }
+
+        [Fact]
+        [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]
+        public async Task WhenUpsertingANonexistentResourceWithCreateDisabledAndInvalidVersionId_GivenStu3ServerAndSqlServer_ThenAResourceConflictIsThrown()
+        {
+            var observation = _conformance.Rest[0].Resource.Find(r => r.Type == ResourceType.Observation);
+            observation.UpdateCreate = false;
+            observation.Versioning = CapabilityStatement.ResourceVersionPolicy.Versioned;
+            await Assert.ThrowsAsync<ResourceConflictException>(() => Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight"), WeakETag.FromVersionId("invalidVersion")));
         }
 
         [Fact]

--- a/test/Microsoft.Health.Fhir.Stu3.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.Stu3.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -32,9 +32,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]
         public async Task WhenUpsertingANonexistentResourceWithCreateDisabledAndInvalidETagHeader_GivenStu3ServerAndSqlServer_ThenAResourceConflictIsThrown()
         {
-            var observation = _conformance.Rest[0].Resource.Find(r => r.Type == ResourceType.Observation);
-            observation.UpdateCreate = false;
-            observation.Versioning = CapabilityStatement.ResourceVersionPolicy.Versioned;
+            SetAllowCreate(false);
+
             await Assert.ThrowsAsync<ResourceConflictException>(() => Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight"), WeakETag.FromVersionId("invalidVersion")));
         }
 

--- a/test/Microsoft.Health.Fhir.Stu3.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.Stu3.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -40,17 +40,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         }
 
         [Fact]
-        [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb)]
-        public async Task WhenUpsertingANonexistentResourceWithInvalidETagHeader_GivenStu3ServerAndCosmosDb_ThenResourceNotFoundIsThrown()
-        {
-            Resource newResourceValues = Samples.GetJsonSample("WeightInGrams").ToPoco();
-            newResourceValues.Id = Guid.NewGuid().ToString();
-
-            await Assert.ThrowsAsync<ResourceNotFoundException>(async () =>
-                await Mediator.UpsertResourceAsync(newResourceValues.ToResourceElement(), WeakETag.FromVersionId("incorrectVersion")));
-        }
-
-        [Fact]
         [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]
         public async Task WhenUpsertingANonexistentResourceWithInvalidETagHeader_GivenStu3ServerAndSqlServer_ThenAResourceConflictIsThrown()
         {

--- a/test/Microsoft.Health.Fhir.Stu3.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.Stu3.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -5,7 +5,6 @@
 
 using System;
 using Hl7.Fhir.Model;
-using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Tests.Common;

--- a/test/Microsoft.Health.Fhir.Stu3.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.Stu3.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -3,11 +3,13 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using Hl7.Fhir.ElementModel;
-using MediatR;
+using System;
+using Hl7.Fhir.Model;
+using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Xunit;
 using Task = System.Threading.Tasks.Task;
 
@@ -16,12 +18,34 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
     public partial class FhirStorageTests : IClassFixture<FhirStorageTestsFixture>
     {
         [Fact]
-        public async Task WhenUpsertingASavedResourceWithIncorrectVersionId_GivenStu3Server_ThenAResourceConflictIsThrown()
+        public async Task WhenUpsertingASavedResourceWithInvalidVersionId_GivenStu3Server_ThenAResourceConflictIsThrown()
         {
             var saveResult = await Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight"));
 
             var newResourceValues = Samples.GetJsonSample("WeightInGrams").ToPoco();
             newResourceValues.Id = saveResult.Resource.Id;
+
+            await Assert.ThrowsAsync<ResourceConflictException>(async () =>
+                await Mediator.UpsertResourceAsync(newResourceValues.ToResourceElement(), WeakETag.FromVersionId("incorrectVersion")));
+        }
+
+        [Fact]
+        [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb)]
+        public async Task WhenUpsertingANonexistentResourceWithInvalidVersionId_GivenStu3ServerAndCosmosDb_ThenResourceNotFoundIsThrown()
+        {
+            Resource newResourceValues = Samples.GetJsonSample("WeightInGrams").ToPoco();
+            newResourceValues.Id = Guid.NewGuid().ToString();
+
+            await Assert.ThrowsAsync<ResourceNotFoundException>(async () =>
+                await Mediator.UpsertResourceAsync(newResourceValues.ToResourceElement(), WeakETag.FromVersionId("incorrectVersion")));
+        }
+
+        [Fact]
+        [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]
+        public async Task WhenUpsertingANonexistentResourceWithInvalidVersionId_GivenStu3ServerAndSqlServer_ThenAResourceConflictIsThrown()
+        {
+            Resource newResourceValues = Samples.GetJsonSample("WeightInGrams").ToPoco();
+            newResourceValues.Id = Guid.NewGuid().ToString();
 
             await Assert.ThrowsAsync<ResourceConflictException>(async () =>
                 await Mediator.UpsertResourceAsync(newResourceValues.ToResourceElement(), WeakETag.FromVersionId("incorrectVersion")));

--- a/test/Microsoft.Health.Fhir.Stu3.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.Stu3.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -1,0 +1,30 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Hl7.Fhir.ElementModel;
+using MediatR;
+using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Microsoft.Health.Fhir.Tests.Common;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
+{
+    public partial class FhirStorageTests : IClassFixture<FhirStorageTestsFixture>
+    {
+        [Fact]
+        public async Task WhenUpsertingASavedResourceWithIncorrectVersionId_GivenStu3Server_ThenAResourceConflictIsThrown()
+        {
+            var saveResult = await Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight"));
+
+            var newResourceValues = Samples.GetJsonSample("WeightInGrams").ToPoco();
+            newResourceValues.Id = saveResult.Resource.Id;
+
+            await Assert.ThrowsAsync<ResourceConflictException>(async () =>
+                await Mediator.UpsertResourceAsync(newResourceValues.ToResourceElement(), WeakETag.FromVersionId("incorrectVersion")));
+        }
+    }
+}

--- a/test/Microsoft.Health.Fhir.Stu3.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.Stu3.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
     public partial class FhirStorageTests : IClassFixture<FhirStorageTestsFixture>
     {
         [Fact]
-        public async Task WhenUpsertingASavedResourceWithInvalidVersionId_GivenStu3Server_ThenAResourceConflictIsThrown()
+        public async Task WhenUpsertingASavedResourceWithInvalidETagHeader_GivenStu3Server_ThenAResourceConflictIsThrown()
         {
             var saveResult = await Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight"));
 
@@ -31,7 +31,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
         [Fact]
         [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]
-        public async Task WhenUpsertingANonexistentResourceWithCreateDisabledAndInvalidVersionId_GivenStu3ServerAndSqlServer_ThenAResourceConflictIsThrown()
+        public async Task WhenUpsertingANonexistentResourceWithCreateDisabledAndInvalidETagHeader_GivenStu3ServerAndSqlServer_ThenAResourceConflictIsThrown()
         {
             var observation = _conformance.Rest[0].Resource.Find(r => r.Type == ResourceType.Observation);
             observation.UpdateCreate = false;
@@ -41,7 +41,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
         [Fact]
         [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb)]
-        public async Task WhenUpsertingANonexistentResourceWithInvalidVersionId_GivenStu3ServerAndCosmosDb_ThenResourceNotFoundIsThrown()
+        public async Task WhenUpsertingANonexistentResourceWithInvalidETagHeader_GivenStu3ServerAndCosmosDb_ThenResourceNotFoundIsThrown()
         {
             Resource newResourceValues = Samples.GetJsonSample("WeightInGrams").ToPoco();
             newResourceValues.Id = Guid.NewGuid().ToString();
@@ -52,7 +52,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
         [Fact]
         [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]
-        public async Task WhenUpsertingANonexistentResourceWithInvalidVersionId_GivenStu3ServerAndSqlServer_ThenAResourceConflictIsThrown()
+        public async Task WhenUpsertingANonexistentResourceWithInvalidETagHeader_GivenStu3ServerAndSqlServer_ThenAResourceConflictIsThrown()
         {
             Resource newResourceValues = Samples.GetJsonSample("WeightInGrams").ToPoco();
             newResourceValues.Id = Guid.NewGuid().ToString();

--- a/test/Microsoft.Health.Fhir.Stu3.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.Stu3.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -27,25 +27,5 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             await Assert.ThrowsAsync<ResourceConflictException>(async () =>
                 await Mediator.UpsertResourceAsync(newResourceValues.ToResourceElement(), WeakETag.FromVersionId("invalidVersion")));
         }
-
-        [Fact]
-        [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]
-        public async Task WhenUpsertingANonexistentResourceWithCreateDisabledAndInvalidETagHeader_GivenStu3ServerAndSqlServer_ThenAResourceConflictIsThrown()
-        {
-            SetAllowCreate(false);
-
-            await Assert.ThrowsAsync<ResourceConflictException>(() => Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight"), WeakETag.FromVersionId("invalidVersion")));
-        }
-
-        [Fact]
-        [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]
-        public async Task WhenUpsertingANonexistentResourceWithInvalidETagHeader_GivenStu3ServerAndSqlServer_ThenAResourceConflictIsThrown()
-        {
-            Resource newResourceValues = Samples.GetJsonSample("WeightInGrams").ToPoco();
-            newResourceValues.Id = Guid.NewGuid().ToString();
-
-            await Assert.ThrowsAsync<ResourceConflictException>(async () =>
-                await Mediator.UpsertResourceAsync(newResourceValues.ToResourceElement(), WeakETag.FromVersionId("incorrectVersion")));
-        }
     }
 }

--- a/test/Microsoft.Health.Fhir.Stu3.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.Stu3.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -3,12 +3,9 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
-using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Tests.Common;
-using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Xunit;
 using Task = System.Threading.Tasks.Task;
 


### PR DESCRIPTION
## Description

- In R4, the server returns a 412 Precondition Failed status code if the version id given in the If-Match header does not match (see [R4 spec](http://hl7.org/fhir/http.html#concurrency))
![r4_response](https://user-images.githubusercontent.com/54082711/64550635-2cf4d800-d2e8-11e9-8f30-151cef1393b5.png)
- In STU3, the server returns a 409 Conflict status code if the version id given in the If-Match header does not match (see [STU3 spec](http://hl7.org/fhir/STU3/http.html#concurrency))
![stu3_response](https://user-images.githubusercontent.com/54082711/64550631-29f9e780-d2e8-11e9-9e15-d9e94d6b5b5c.png)

## Related issues

- [#AB69420](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/69420)

## Testing

- Separated out existing E2E tests to account for version-dependent behavior
- Added new E2E and integration tests