### PR TITLE
Add batch/transaction route

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Routing/RouteNames.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Routing/RouteNames.cs
@@ -38,5 +38,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
         internal const string GetExportStatusById = "GetExportStatusById";
 
         internal const string CancelExport = "CancelExport";
+
+        internal const string PostBundle = "PostBundle";
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Validation/ValidateBundlePreProcessor.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Validation/ValidateBundlePreProcessor.cs
@@ -1,0 +1,27 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Threading;
+using MediatR.Pipeline;
+using Microsoft.Health.Fhir.Core.Exceptions;
+using Microsoft.Health.Fhir.Core.Messages.Bundle;
+using Microsoft.Health.Fhir.Core.Models;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Fhir.Core.Features.Validation
+{
+    public class ValidateBundlePreProcessor : IRequestPreProcessor<BundleRequest>
+    {
+        public Task Process(BundleRequest request, CancellationToken cancellationToken)
+        {
+            if (request.Bundle.InstanceType != KnownResourceTypes.Bundle)
+            {
+                throw new RequestNotValidException(Core.Resources.BundleRequiredForBatchOrTransaction);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Messages/Bundle/BundleRequest.cs
+++ b/src/Microsoft.Health.Fhir.Core/Messages/Bundle/BundleRequest.cs
@@ -1,0 +1,32 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using EnsureThat;
+using MediatR;
+using Microsoft.Health.Fhir.Core.Features.Conformance;
+using Microsoft.Health.Fhir.Core.Models;
+
+namespace Microsoft.Health.Fhir.Core.Messages.Bundle
+{
+    public class BundleRequest : IRequest<BundleResponse>, IRequest, IRequireCapability
+    {
+        public BundleRequest(ResourceElement bundle)
+        {
+            EnsureArg.IsNotNull(bundle, nameof(bundle));
+
+            Bundle = bundle;
+        }
+
+        public ResourceElement Bundle { get; }
+
+        public IEnumerable<CapabilityQuery> RequiredCapabilities()
+        {
+            var bundleType = Bundle.Scalar<string>(KnownFhirPaths.BundleType);
+
+            yield return new CapabilityQuery($"CapabilityStatement.rest.interaction.where(code = '{bundleType}').exists()");
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Messages/Bundle/BundleResponse.cs
+++ b/src/Microsoft.Health.Fhir.Core/Messages/Bundle/BundleResponse.cs
@@ -1,0 +1,22 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using EnsureThat;
+using Microsoft.Health.Fhir.Core.Models;
+
+namespace Microsoft.Health.Fhir.Core.Messages.Bundle
+{
+    public class BundleResponse
+    {
+        public BundleResponse(ResourceElement bundle)
+        {
+            EnsureArg.IsNotNull(bundle, nameof(bundle));
+
+            Bundle = bundle;
+        }
+
+        public ResourceElement Bundle { get; }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Models/KnownFhirPaths.cs
+++ b/src/Microsoft.Health.Fhir.Core/Models/KnownFhirPaths.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Health.Fhir.Core.Models
 
         public const string BundleSelfLink = "Resource.link.where(relation = 'self').url";
 
+        public const string BundleType = "Resource.type";
+
         public const string ResourceNarrative = "text.div";
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -79,6 +79,15 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Only a bundle can be submitted for batch or transaction processing..
+        /// </summary>
+        internal static string BundleRequiredForBatchOrTransaction {
+            get {
+                return ResourceManager.GetString("BundleRequiredForBatchOrTransaction", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to CapabilityStatement must have only a single item in the &apos;Rest&apos; collection..
         /// </summary>
         internal static string CapabilityStatementSingleRestItem {

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -123,6 +123,10 @@
   <data name="AuthorizationPermissionDefinitionInvalid" xml:space="preserve">
     <value>The authorization permission definition contains one or more invalid entries.</value>
   </data>
+  <data name="BundleRequiredForBatchOrTransaction" xml:space="preserve">
+    <value>Only a bundle can be submitted for batch or transaction processing.</value>
+    <comment>Bundle is a FHIR resource type.</comment>
+  </data>
   <data name="CapabilityStatementSingleRestItem" xml:space="preserve">
     <value>CapabilityStatement must have only a single item in the 'Rest' collection.</value>
   </data>

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
@@ -378,6 +378,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         /// <summary>
         /// Searches across all resource types.
         /// </summary>
+        [HttpGet]
         [Route("", Name = RouteNames.SearchAllResources)]
         [AuditEventType(AuditEventSubType.SearchSystem)]
         [Authorize(PolicyNames.ReadPolicy)]
@@ -511,6 +512,21 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             VersionsResult response = await _mediator.GetOperationVersionsAsync(HttpContext.RequestAborted);
 
             return new OperationVersionsResult(response, HttpStatusCode.OK);
+        }
+
+        /// <summary>
+        /// Handles batch and transaction requests
+        /// </summary>
+        /// <param name="bundle">The bundle being posted</param>
+        [HttpPost]
+        [Route("", Name = RouteNames.PostBundle)]
+        [AuditEventType(AuditEventSubType.Batch)] // TODO: Our current auditing implementation only allows one audit event type attribute even though this action handles two.
+        [Authorize(PolicyNames.WritePolicy)]
+        public async Task<IActionResult> BatchAndTransactions([FromBody] Resource bundle)
+        {
+            ResourceElement bundleResponse = await _mediator.PostBundle(bundle.ToResourceElement());
+
+            return FhirResult.Create(bundleResponse);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
@@ -18,6 +18,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Health.Fhir.Api.Configs;
+using Microsoft.Health.Fhir.Api.Features.ActionConstraints;
 using Microsoft.Health.Fhir.Api.Features.ActionResults;
 using Microsoft.Health.Fhir.Api.Features.Audit;
 using Microsoft.Health.Fhir.Api.Features.Filters;
@@ -148,27 +149,39 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         [Authorize(PolicyNames.WritePolicy)]
         public async Task<IActionResult> Create([FromBody] Resource resource)
         {
+            ResourceElement response = await _mediator.CreateResourceAsync(resource.ToResourceElement(), HttpContext.RequestAborted);
+
+            return FhirResult.Create(response, HttpStatusCode.Created)
+                .SetETagHeader()
+                .SetLastModifiedHeader()
+                .SetLocationHeader(_urlResolver);
+        }
+
+        /// <summary>
+        /// Conditionally creates a new resource
+        /// </summary>
+        /// <param name="resource">The resource.</param>
+        [HttpPost]
+        [ConditionalConstraint]
+        [Route(KnownRoutes.ResourceType)]
+        [AuditEventType(AuditEventSubType.Create)]
+        [Authorize(PolicyNames.ReadPolicy)]
+        [Authorize(PolicyNames.WritePolicy)]
+        public async Task<IActionResult> ConditionalCreate([FromBody] Resource resource)
+        {
             StringValues conditionalCreateHeader = HttpContext.Request.Headers[KnownFhirHeaders.IfNoneExist];
 
-            ResourceElement response;
-            if (!string.IsNullOrEmpty(conditionalCreateHeader))
+            Tuple<string, string>[] conditionalParameters = QueryHelpers.ParseQuery(conditionalCreateHeader)
+                .SelectMany(query => query.Value, (query, value) => Tuple.Create(query.Key, value)).ToArray();
+
+            UpsertResourceResponse createResponse = await _mediator.Send<UpsertResourceResponse>(new ConditionalCreateResourceRequest(resource.ToResourceElement(), conditionalParameters), HttpContext.RequestAborted);
+
+            if (createResponse == null)
             {
-                Tuple<string, string>[] conditionalParameters = QueryHelpers.ParseQuery(conditionalCreateHeader)
-                    .SelectMany(query => query.Value, (query, value) => Tuple.Create(query.Key, value)).ToArray();
-
-                UpsertResourceResponse createResponse = await _mediator.Send<UpsertResourceResponse>(new ConditionalCreateResourceRequest(resource.ToResourceElement(), conditionalParameters), HttpContext.RequestAborted);
-
-                if (createResponse == null)
-                {
-                    return Ok();
-                }
-
-                response = createResponse.Outcome.Resource;
+                return Ok();
             }
-            else
-            {
-                response = await _mediator.CreateResourceAsync(resource.ToResourceElement(), HttpContext.RequestAborted);
-            }
+
+            ResourceElement response = createResponse.Outcome.Resource;
 
             return FhirResult.Create(response, HttpStatusCode.Created)
                 .SetETagHeader()
@@ -200,6 +213,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         [HttpPut]
         [Route(KnownRoutes.ResourceType)]
         [AuditEventType(AuditEventSubType.Update)]
+        [Authorize(PolicyNames.ReadPolicy)]
         [Authorize(PolicyNames.WritePolicy)]
         public async Task<IActionResult> ConditionalUpdate([FromBody] Resource resource)
         {
@@ -521,6 +535,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         [HttpPost]
         [Route("", Name = RouteNames.PostBundle)]
         [AuditEventType(AuditEventSubType.Batch)] // TODO: Our current auditing implementation only allows one audit event type attribute even though this action handles two.
+        [Authorize(PolicyNames.ReadPolicy)]
         [Authorize(PolicyNames.WritePolicy)]
         public async Task<IActionResult> BatchAndTransactions([FromBody] Resource bundle)
         {

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/ActionConstraints/ConditionalConstraintAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/ActionConstraints/ConditionalConstraintAttribute.cs
@@ -1,0 +1,30 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.AspNetCore.Mvc.ActionConstraints;
+using Microsoft.Extensions.Primitives;
+using Microsoft.Health.Fhir.Api.Features.Headers;
+
+namespace Microsoft.Health.Fhir.Api.Features.ActionConstraints
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    public class ConditionalConstraintAttribute : Attribute, IActionConstraint
+    {
+        public int Order => 0;
+
+        public bool Accept(ActionConstraintContext context)
+        {
+            StringValues conditionalCreateHeader = context.RouteContext.HttpContext.Request.Headers[KnownFhirHeaders.IfNoneExist];
+
+            if (!string.IsNullOrEmpty(conditionalCreateHeader))
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api/Microsoft.Health.Fhir.Shared.Api.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Microsoft.Health.Fhir.Shared.Api.projitems
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Controllers\ExportController.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controllers\FhirController.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\ActionConstraints\ConditionalConstraintAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\ActionResults\FhirResult.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\ActionResults\OperationOutcomeResult.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\ActionResults\OperationVersionsResult.cs" />

--- a/src/Microsoft.Health.Fhir.Shared.Core/Extensions/FhirMediatorExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Extensions/FhirMediatorExtensions.cs
@@ -11,6 +11,7 @@ using EnsureThat;
 using MediatR;
 using Microsoft.Health.Fhir.Core.Features.Operations.Versions;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Microsoft.Health.Fhir.Core.Messages.Bundle;
 using Microsoft.Health.Fhir.Core.Messages.Create;
 using Microsoft.Health.Fhir.Core.Messages.Delete;
 using Microsoft.Health.Fhir.Core.Messages.Get;
@@ -128,6 +129,16 @@ namespace Microsoft.Health.Fhir.Core.Extensions
             var response = await mediator.Send(new GetOperationVersionsRequest(), cancellationToken);
 
             return new VersionsResult(response.SupportedVersions, response.DefaultVersion);
+        }
+
+        public static async Task<ResourceElement> PostBundle(this IMediator mediator, ResourceElement bundle, CancellationToken cancellationToken = default)
+        {
+            EnsureArg.IsNotNull(mediator, nameof(mediator));
+            EnsureArg.IsNotNull(bundle, nameof(bundle));
+
+            BundleResponse result = await mediator.Send<BundleResponse>(new BundleRequest(bundle), cancellationToken);
+
+            return result.Bundle;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Bundle/BundleHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Bundle/BundleHandler.cs
@@ -1,0 +1,20 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.Health.Fhir.Core.Messages.Bundle;
+
+namespace Microsoft.Health.Fhir.Shared.Core.Features.Resources.Bundle
+{
+    public class BundleHandler : IRequestHandler<BundleRequest, BundleResponse>
+    {
+        public Task<BundleResponse> Handle(BundleRequest request, CancellationToken cancellationToken)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Core/Microsoft.Health.Fhir.Shared.Core.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Microsoft.Health.Fhir.Shared.Core.projitems
@@ -31,6 +31,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\Export\ResourceToNdjsonBytesSerializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Persistence\RawResourceFactory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\BaseResourceHandler.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Bundle\BundleHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Create\ConditionalCreateResourceHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Create\ConditionalCreateResourceValidator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Create\CreateResourceHandler.cs" />

--- a/src/Microsoft.Health.Fhir.Shared.Tests/Samples.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Tests/Samples.cs
@@ -39,6 +39,16 @@ namespace Microsoft.Health.Fhir.Tests.Common
             return GetJsonSample("Organization");
         }
 
+        public static ResourceElement GetDefaultBatch()
+        {
+            return GetJsonSample("Bundle-Batch");
+        }
+
+        public static ResourceElement GetDefaultTransaction()
+        {
+            return GetJsonSample("Bundle-Transaction");
+        }
+
         /// <summary>
         /// Gets back a resource from a json sample file.
         /// </summary>

--- a/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
+++ b/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
@@ -54,6 +54,8 @@
     <None Remove="TestFiles\R4\BasicExampleNarrative.xml" />
     <None Remove="TestFiles\R4\BloodGlucose.json" />
     <None Remove="TestFiles\R4\BloodPressure.json" />
+    <None Remove="TestFiles\R4\Bundle-Batch.json" />
+    <None Remove="TestFiles\R4\Bundle-Transaction.json" />
     <None Remove="TestFiles\R4\Condition-For-Patient-f001.json" />
     <None Remove="TestFiles\R4\Device-d1.json" />
     <None Remove="TestFiles\R4\DocumentReference-example-002.json" />
@@ -85,6 +87,8 @@
     <None Remove="TestFiles\R4\Weight.json" />
     <None Remove="TestFiles\R4\WeightInGrams.json" />
     <None Remove="TestFiles\ResourceWrapperNoVersion.json" />
+    <None Remove="TestFiles\Stu3\Bundle-Batch.json" />
+    <None Remove="TestFiles\Stu3\Bundle-Transaction.json" />
     <None Remove="TestFiles\Stu3\DocumentReference-example-002.json" />
     <None Remove="TestFiles\Stu3\DocumentReference-example-003.json" />
     <None Remove="TestFiles\Stu3\DocumentReference-example.json" />
@@ -115,6 +119,8 @@
     <EmbeddedResource Include="TestFiles\R4\BasicExampleNarrative.xml" />
     <EmbeddedResource Include="TestFiles\R4\BloodGlucose.json" />
     <EmbeddedResource Include="TestFiles\R4\BloodPressure.json" />
+    <EmbeddedResource Include="TestFiles\R4\Bundle-Batch.json" />
+    <EmbeddedResource Include="TestFiles\R4\Bundle-Transaction.json" />
     <EmbeddedResource Include="TestFiles\R4\Condition-For-Patient-f001.json" />
     <EmbeddedResource Include="TestFiles\R4\Device-d1.json" />
     <EmbeddedResource Include="TestFiles\R4\DocumentReference-example-002.json" />
@@ -149,6 +155,8 @@
     <EmbeddedResource Include="TestFiles\Stu3\BasicExampleNarrative.xml" />
     <EmbeddedResource Include="TestFiles\Stu3\BloodGlucose.json" />
     <EmbeddedResource Include="TestFiles\Stu3\BloodPressure.json" />
+    <EmbeddedResource Include="TestFiles\Stu3\Bundle-Batch.json" />
+    <EmbeddedResource Include="TestFiles\Stu3\Bundle-Transaction.json" />
     <EmbeddedResource Include="TestFiles\Stu3\Condition-For-Patient-f001.json" />
     <EmbeddedResource Include="TestFiles\Stu3\Device-d1.json" />
     <EmbeddedResource Include="TestFiles\Stu3\DeviceComponent-For-Device-d1.json" />

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/R4/Bundle-Batch.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/R4/Bundle-Batch.json
@@ -1,0 +1,206 @@
+﻿{
+    "resourceType": "Bundle",
+    "id": "bundle-batch",
+    "meta": {
+        "lastUpdated": "2014-08-18T01:43:30Z"
+    },
+    "type": "batch",
+    "entry": [
+        {
+            "fullUrl": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a",
+            "resource": {
+                "resourceType": "Patient",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"
+                },
+                "active": true,
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "Chalmers",
+                        "given": [
+                            "Peter",
+                            "James"
+                        ]
+                    }
+                ],
+                "gender": "male",
+                "birthDate": "1974-12-25"
+            },
+            "request": {
+                "method": "POST",
+                "url": "Patient"
+            }
+        },
+        {
+            "fullUrl": "urn:uuid:88f151c0-a954-468a-88bd-5ae15c08e059",
+            "resource": {
+                "resourceType": "Patient",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"
+                },
+                "identifier": [
+                    {
+                        "system": "http:/example.org/fhir/ids",
+                        "value": "234234"
+                    }
+                ],
+                "active": true,
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "Chalmers",
+                        "given": [
+                            "Peter",
+                            "James"
+                        ]
+                    }
+                ],
+                "gender": "male",
+                "birthDate": "1974-12-25"
+            },
+            "request": {
+                "method": "POST",
+                "url": "Patient",
+                "ifNoneExist": "identifier=http:/example.org/fhir/ids|234234"
+            }
+        },
+        {
+            "fullUrl": "http://example.org/fhir/Patient/123",
+            "resource": {
+                "resourceType": "Patient",
+                "id": "123",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"
+                },
+                "active": true,
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "Chalmers",
+                        "given": [
+                            "Peter",
+                            "James"
+                        ]
+                    }
+                ],
+                "gender": "male",
+                "birthDate": "1974-12-25"
+            },
+            "request": {
+                "method": "PUT",
+                "url": "Patient/123"
+            }
+        },
+        {
+            "fullUrl": "urn:uuid:74891afc-ed52-42a2-bcd7-f13d9b60f096",
+            "resource": {
+                "resourceType": "Patient",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"
+                },
+                "identifier": [
+                    {
+                        "system": "http:/example.org/fhir/ids",
+                        "value": "456456"
+                    }
+                ],
+                "active": true,
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "Chalmers",
+                        "given": [
+                            "Peter",
+                            "James"
+                        ]
+                    }
+                ],
+                "gender": "male",
+                "birthDate": "1974-12-25"
+            },
+            "request": {
+                "method": "PUT",
+                "url": "Patient?identifier=http:/example.org/fhir/ids|456456"
+            }
+        },
+        {
+            "fullUrl": "http://example.org/fhir/Patient/123a",
+            "resource": {
+                "resourceType": "Patient",
+                "id": "123a",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"
+                },
+                "active": true,
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "Chalmers",
+                        "given": [
+                            "Peter",
+                            "James"
+                        ]
+                    }
+                ],
+                "gender": "male",
+                "birthDate": "1974-12-25"
+            },
+            "request": {
+                "method": "PUT",
+                "url": "Patient/123a",
+                "ifMatch": "W/\"2\""
+            }
+        },
+        {
+            "request": {
+                "method": "DELETE",
+                "url": "Patient/234"
+            }
+        },
+        {
+            "request": {
+                "method": "DELETE",
+                "url": "Patient?identifier=123456"
+            }
+        },
+        {
+            "fullUrl": "urn:uuid:79378cb8-8f58-48e8-a5e8-60ac2755b674",
+            "resource": {
+                "resourceType": "Parameters",
+                "parameter": [
+                    {
+                        "name": "coding",
+                        "valueCoding": {
+                            "system": "http://loinc.org",
+                            "code": "1963-8"
+                        }
+                    }
+                ]
+            },
+            "request": {
+                "method": "POST",
+                "url": "ValueSet/$lookup"
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "url": "Patient?name=peter"
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "url": "Patient/12334",
+                "ifNoneMatch": "W/\"4\"",
+                "ifModifiedSince": "2015-08-31T08:14:33+10:00"
+            }
+        }
+    ]
+}

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/R4/Bundle-Transaction.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/R4/Bundle-Transaction.json
@@ -1,0 +1,206 @@
+﻿{
+    "resourceType": "Bundle",
+    "id": "bundle-transaction",
+    "meta": {
+        "lastUpdated": "2014-08-18T01:43:30Z"
+    },
+    "type": "transaction",
+    "entry": [
+        {
+            "fullUrl": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a",
+            "resource": {
+                "resourceType": "Patient",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"
+                },
+                "active": true,
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "Chalmers",
+                        "given": [
+                            "Peter",
+                            "James"
+                        ]
+                    }
+                ],
+                "gender": "male",
+                "birthDate": "1974-12-25"
+            },
+            "request": {
+                "method": "POST",
+                "url": "Patient"
+            }
+        },
+        {
+            "fullUrl": "urn:uuid:88f151c0-a954-468a-88bd-5ae15c08e059",
+            "resource": {
+                "resourceType": "Patient",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"
+                },
+                "identifier": [
+                    {
+                        "system": "http:/example.org/fhir/ids",
+                        "value": "234234"
+                    }
+                ],
+                "active": true,
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "Chalmers",
+                        "given": [
+                            "Peter",
+                            "James"
+                        ]
+                    }
+                ],
+                "gender": "male",
+                "birthDate": "1974-12-25"
+            },
+            "request": {
+                "method": "POST",
+                "url": "Patient",
+                "ifNoneExist": "identifier=http:/example.org/fhir/ids|234234"
+            }
+        },
+        {
+            "fullUrl": "http://example.org/fhir/Patient/123",
+            "resource": {
+                "resourceType": "Patient",
+                "id": "123",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"
+                },
+                "active": true,
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "Chalmers",
+                        "given": [
+                            "Peter",
+                            "James"
+                        ]
+                    }
+                ],
+                "gender": "male",
+                "birthDate": "1974-12-25"
+            },
+            "request": {
+                "method": "PUT",
+                "url": "Patient/123"
+            }
+        },
+        {
+            "fullUrl": "urn:uuid:74891afc-ed52-42a2-bcd7-f13d9b60f096",
+            "resource": {
+                "resourceType": "Patient",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"
+                },
+                "identifier": [
+                    {
+                        "system": "http:/example.org/fhir/ids",
+                        "value": "456456"
+                    }
+                ],
+                "active": true,
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "Chalmers",
+                        "given": [
+                            "Peter",
+                            "James"
+                        ]
+                    }
+                ],
+                "gender": "male",
+                "birthDate": "1974-12-25"
+            },
+            "request": {
+                "method": "PUT",
+                "url": "Patient?identifier=http:/example.org/fhir/ids|456456"
+            }
+        },
+        {
+            "fullUrl": "http://example.org/fhir/Patient/123a",
+            "resource": {
+                "resourceType": "Patient",
+                "id": "123a",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"
+                },
+                "active": true,
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "Chalmers",
+                        "given": [
+                            "Peter",
+                            "James"
+                        ]
+                    }
+                ],
+                "gender": "male",
+                "birthDate": "1974-12-25"
+            },
+            "request": {
+                "method": "PUT",
+                "url": "Patient/123a",
+                "ifMatch": "W/\"2\""
+            }
+        },
+        {
+            "request": {
+                "method": "DELETE",
+                "url": "Patient/234"
+            }
+        },
+        {
+            "request": {
+                "method": "DELETE",
+                "url": "Patient?identifier=123456"
+            }
+        },
+        {
+            "fullUrl": "urn:uuid:79378cb8-8f58-48e8-a5e8-60ac2755b674",
+            "resource": {
+                "resourceType": "Parameters",
+                "parameter": [
+                    {
+                        "name": "coding",
+                        "valueCoding": {
+                            "system": "http://loinc.org",
+                            "code": "1963-8"
+                        }
+                    }
+                ]
+            },
+            "request": {
+                "method": "POST",
+                "url": "ValueSet/$lookup"
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "url": "Patient?name=peter"
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "url": "Patient/12334",
+                "ifNoneMatch": "W/\"4\"",
+                "ifModifiedSince": "2015-08-31T08:14:33+10:00"
+            }
+        }
+    ]
+}

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Stu3/Bundle-Batch.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Stu3/Bundle-Batch.json
@@ -1,0 +1,194 @@
+﻿{
+    "resourceType": "Bundle",
+    "id": "bundle-batch",
+    "meta": {
+        "lastUpdated": "2014-08-18T01:43:30Z"
+    },
+    "type": "batch",
+    "entry": [
+        {
+            "fullUrl": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a",
+            "resource": {
+                "resourceType": "Patient",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"
+                },
+                "active": true,
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "Chalmers",
+                        "given": [
+                            "Peter",
+                            "James"
+                        ]
+                    }
+                ],
+                "gender": "male",
+                "birthDate": "1974-12-25"
+            },
+            "request": {
+                "method": "POST",
+                "url": "Patient"
+            }
+        },
+        {
+            "fullUrl": "urn:uuid:88f151c0-a954-468a-88bd-5ae15c08e059",
+            "resource": {
+                "resourceType": "Patient",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"
+                },
+                "active": true,
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "Chalmers",
+                        "given": [
+                            "Peter",
+                            "James"
+                        ]
+                    }
+                ],
+                "gender": "male",
+                "birthDate": "1974-12-25"
+            },
+            "request": {
+                "method": "POST",
+                "url": "Patient",
+                "ifNoneExist": "identifier=234234"
+            }
+        },
+        {
+            "fullUrl": "http://example.org/fhir/Patient/123",
+            "resource": {
+                "resourceType": "Patient",
+                "id": "123",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"
+                },
+                "active": true,
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "Chalmers",
+                        "given": [
+                            "Peter",
+                            "James"
+                        ]
+                    }
+                ],
+                "gender": "male",
+                "birthDate": "1974-12-25"
+            },
+            "request": {
+                "method": "PUT",
+                "url": "Patient/123"
+            }
+        },
+        {
+            "fullUrl": "urn:uuid:74891afc-ed52-42a2-bcd7-f13d9b60f096",
+            "resource": {
+                "resourceType": "Patient",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"
+                },
+                "active": true,
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "Chalmers",
+                        "given": [
+                            "Peter",
+                            "James"
+                        ]
+                    }
+                ],
+                "gender": "male",
+                "birthDate": "1974-12-25"
+            },
+            "request": {
+                "method": "PUT",
+                "url": "Patient?identifier=234234"
+            }
+        },
+        {
+            "fullUrl": "http://example.org/fhir/Patient/123a",
+            "resource": {
+                "resourceType": "Patient",
+                "id": "123a",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"
+                },
+                "active": true,
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "Chalmers",
+                        "given": [
+                            "Peter",
+                            "James"
+                        ]
+                    }
+                ],
+                "gender": "male",
+                "birthDate": "1974-12-25"
+            },
+            "request": {
+                "method": "PUT",
+                "url": "Patient/123a",
+                "ifMatch": "W/\"2\""
+            }
+        },
+        {
+            "request": {
+                "method": "DELETE",
+                "url": "Patient/234"
+            }
+        },
+        {
+            "request": {
+                "method": "DELETE",
+                "url": "Patient?identifier=123456"
+            }
+        },
+        {
+            "fullUrl": "urn:uuid:79378cb8-8f58-48e8-a5e8-60ac2755b674",
+            "resource": {
+                "resourceType": "Parameters",
+                "parameter": [
+                    {
+                        "name": "coding",
+                        "valueCoding": {
+                            "system": "http://loinc.org",
+                            "code": "1963-8"
+                        }
+                    }
+                ]
+            },
+            "request": {
+                "method": "POST",
+                "url": "ValueSet/$lookup"
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "url": "Patient?name=peter"
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "url": "Patient/12334",
+                "ifNoneMatch": "W/\"4\"",
+                "ifModifiedSince": "2015-08-31T08:14:33+10:00"
+            }
+        }
+    ]
+}

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Stu3/Bundle-Transaction.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Stu3/Bundle-Transaction.json
@@ -1,0 +1,194 @@
+﻿{
+    "resourceType": "Bundle",
+    "id": "bundle-transaction",
+    "meta": {
+        "lastUpdated": "2014-08-18T01:43:30Z"
+    },
+    "type": "transaction",
+    "entry": [
+        {
+            "fullUrl": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a",
+            "resource": {
+                "resourceType": "Patient",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"
+                },
+                "active": true,
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "Chalmers",
+                        "given": [
+                            "Peter",
+                            "James"
+                        ]
+                    }
+                ],
+                "gender": "male",
+                "birthDate": "1974-12-25"
+            },
+            "request": {
+                "method": "POST",
+                "url": "Patient"
+            }
+        },
+        {
+            "fullUrl": "urn:uuid:88f151c0-a954-468a-88bd-5ae15c08e059",
+            "resource": {
+                "resourceType": "Patient",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"
+                },
+                "active": true,
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "Chalmers",
+                        "given": [
+                            "Peter",
+                            "James"
+                        ]
+                    }
+                ],
+                "gender": "male",
+                "birthDate": "1974-12-25"
+            },
+            "request": {
+                "method": "POST",
+                "url": "Patient",
+                "ifNoneExist": "identifier=234234"
+            }
+        },
+        {
+            "fullUrl": "http://example.org/fhir/Patient/123",
+            "resource": {
+                "resourceType": "Patient",
+                "id": "123",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"
+                },
+                "active": true,
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "Chalmers",
+                        "given": [
+                            "Peter",
+                            "James"
+                        ]
+                    }
+                ],
+                "gender": "male",
+                "birthDate": "1974-12-25"
+            },
+            "request": {
+                "method": "PUT",
+                "url": "Patient/123"
+            }
+        },
+        {
+            "fullUrl": "urn:uuid:74891afc-ed52-42a2-bcd7-f13d9b60f096",
+            "resource": {
+                "resourceType": "Patient",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"
+                },
+                "active": true,
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "Chalmers",
+                        "given": [
+                            "Peter",
+                            "James"
+                        ]
+                    }
+                ],
+                "gender": "male",
+                "birthDate": "1974-12-25"
+            },
+            "request": {
+                "method": "PUT",
+                "url": "Patient?identifier=234234"
+            }
+        },
+        {
+            "fullUrl": "http://example.org/fhir/Patient/123a",
+            "resource": {
+                "resourceType": "Patient",
+                "id": "123a",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"
+                },
+                "active": true,
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "Chalmers",
+                        "given": [
+                            "Peter",
+                            "James"
+                        ]
+                    }
+                ],
+                "gender": "male",
+                "birthDate": "1974-12-25"
+            },
+            "request": {
+                "method": "PUT",
+                "url": "Patient/123a",
+                "ifMatch": "W/\"2\""
+            }
+        },
+        {
+            "request": {
+                "method": "DELETE",
+                "url": "Patient/234"
+            }
+        },
+        {
+            "request": {
+                "method": "DELETE",
+                "url": "Patient?identifier=123456"
+            }
+        },
+        {
+            "fullUrl": "urn:uuid:79378cb8-8f58-48e8-a5e8-60ac2755b674",
+            "resource": {
+                "resourceType": "Parameters",
+                "parameter": [
+                    {
+                        "name": "coding",
+                        "valueCoding": {
+                            "system": "http://loinc.org",
+                            "code": "1963-8"
+                        }
+                    }
+                ]
+            },
+            "request": {
+                "method": "POST",
+                "url": "ValueSet/$lookup"
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "url": "Patient?name=peter"
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "url": "Patient/12334",
+                "ifNoneMatch": "W/\"4\"",
+                "ifModifiedSince": "2015-08-31T08:14:33+10:00"
+            }
+        }
+    ]
+}

--- a/src/Microsoft.Health.Fhir.ValueSets/AuditEventSubType.cs
+++ b/src/Microsoft.Health.Fhir.ValueSets/AuditEventSubType.cs
@@ -44,6 +44,10 @@ namespace Microsoft.Health.Fhir.ValueSets
 
         public const string SmartOnFhirToken = "smart-on-fhir-token";
 
+        public const string Batch = "batch";
+
+        public const string Transaction = "transaction";
+
         // The spec has an "operation" audit-event-sub-type, but that only refers to an operation
         // that is defined by an OperationDefinition. And export does not fall under that list as
         // of 2019/03/19. So we have to use our own sub-type.

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E.Common/FhirClient.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E.Common/FhirClient.cs
@@ -283,6 +283,22 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Common
             return contentLocation.First();
         }
 
+        public async Task<FhirResponse<Bundle>> PostBundleAsync(Resource bundle)
+        {
+            var message = new HttpRequestMessage(HttpMethod.Post, string.Empty)
+            {
+                Content = CreateStringContent(bundle),
+            };
+
+            message.Headers.Accept.Add(_mediaType);
+
+            HttpResponseMessage response = await HttpClient.SendAsync(message);
+
+            await EnsureSuccessStatusCodeAsync(response);
+
+            return await CreateResponseAsync<Bundle>(response);
+        }
+
         private StringContent CreateStringContent(Resource resource)
         {
             return new StringContent(_serialize(resource, SummaryType.False), Encoding.UTF8, _contentType);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Microsoft.Health.Fhir.Shared.Tests.E2E.projitems
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Microsoft.Health.Fhir.Shared.Tests.E2E.projitems
@@ -17,6 +17,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rest\Audit\StartupWithTraceAuditLogger.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\Audit\TraceAuditLogger.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\BasicAuthTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rest\BatchTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\CompartmentTestFixture.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\CompartmentTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\ConditionalCreateTests.cs" />
@@ -61,6 +62,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rest\TestFhirServer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\TestFhirServerFactory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\TestHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rest\TransactionTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\UpdateTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\VersionSpecificTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\VReadTests.cs" />

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BatchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BatchTests.cs
@@ -1,0 +1,45 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Net;
+using Hl7.Fhir.Model;
+using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Microsoft.Health.Fhir.Tests.E2E.Common;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Fhir.Tests.E2E.Rest
+{
+    [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.All)]
+    public class BatchTests : IClassFixture<HttpIntegrationTestFixture>
+    {
+        public BatchTests(HttpIntegrationTestFixture fixture)
+        {
+            Client = fixture.FhirClient;
+        }
+
+        protected FhirClient Client { get; set; }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task WhenSubmittingABatch_GivenAProperBundle_ThenNotSupportedIsReturned()
+        {
+            FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.PostBundleAsync(Samples.GetDefaultBatch().ToPoco<Bundle>()));
+
+            Assert.Equal(HttpStatusCode.MethodNotAllowed, ex.StatusCode);
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task WhenSubmittingABatch_GivenANonBundleResource_ThenBadRequestIsReturned()
+        {
+            FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.PostBundleAsync(Samples.GetDefaultObservation().ToPoco<Observation>()));
+
+            Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
+        }
+    }
+}

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TransactionTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TransactionTests.cs
@@ -1,0 +1,45 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Net;
+using Hl7.Fhir.Model;
+using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Microsoft.Health.Fhir.Tests.E2E.Common;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Fhir.Tests.E2E.Rest
+{
+    [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.All)]
+    public class TransactionTests : IClassFixture<HttpIntegrationTestFixture>
+    {
+        public TransactionTests(HttpIntegrationTestFixture fixture)
+        {
+            Client = fixture.FhirClient;
+        }
+
+        protected FhirClient Client { get; set; }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task WhenSubmittingATransaction_GivenAProperBundle_ThenNotSupportedIsReturned()
+        {
+            FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.PostBundleAsync(Samples.GetDefaultTransaction().ToPoco<Bundle>()));
+
+            Assert.Equal(HttpStatusCode.MethodNotAllowed, ex.StatusCode);
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task WhenSubmittingATransaction_GivenANonBundleResource_ThenBadRequestIsReturned()
+        {
+            FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.PostBundleAsync(Samples.GetDefaultObservation().ToPoco<Observation>()));
+
+            Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
+        }
+    }
+}

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TransactionTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TransactionTests.cs
@@ -32,14 +32,5 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             Assert.Equal(HttpStatusCode.MethodNotAllowed, ex.StatusCode);
         }
-
-        [Fact]
-        [Trait(Traits.Priority, Priority.One)]
-        public async Task WhenSubmittingATransaction_GivenANonBundleResource_ThenBadRequestIsReturned()
-        {
-            FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.PostBundleAsync(Samples.GetDefaultObservation().ToPoco<Observation>()));
-
-            Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
-        }
     }
 }


### PR DESCRIPTION
## Description
Adds the batch/transaction route to the server. The route is current non-functional and should return either a `405` in the case of a bundle posted or a `400` if anything else is posted.

## Related issues
Addresses [AB#70188](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/70188)

## Testing
Add E2E tests for batch and transaction to check that expected status codes are returned.
