### PR TITLE
Adds location to validator error messages

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Validation/AttributeValidator.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Validation/AttributeValidator.cs
@@ -43,7 +43,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
                     foreach (var error in results)
                     {
                         ITypedElement typedElement = resourceElement.Instance;
-                        var fullFhirPath = typedElement.InstanceType + "." + error.MemberNames?.FirstOrDefault();
+
+                        var fullFhirPath = typedElement.InstanceType;
+                        fullFhirPath += error.MemberNames?.FirstOrDefault() == null ? $"" : "." + error.MemberNames?.FirstOrDefault();
 
                         yield return new ValidationFailure(fullFhirPath, error.ErrorMessage);
                     }

--- a/src/Microsoft.Health.Fhir.Core/Features/Validation/AttributeValidator.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Validation/AttributeValidator.cs
@@ -10,6 +10,7 @@ using EnsureThat;
 using FluentValidation;
 using FluentValidation.Results;
 using FluentValidation.Validators;
+using Hl7.Fhir.ElementModel;
 using Microsoft.Health.Fhir.Core.Models;
 using Task = System.Threading.Tasks.Task;
 using ValidationResult = System.ComponentModel.DataAnnotations.ValidationResult;
@@ -41,7 +42,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
                 {
                     foreach (var error in results)
                     {
-                        yield return new ValidationFailure(error.MemberNames?.FirstOrDefault(), error.ErrorMessage);
+                        ITypedElement typedElement = resourceElement.Instance;
+                        var fullFhirPath = typedElement.InstanceType + "." + error.MemberNames?.FirstOrDefault();
+
+                        yield return new ValidationFailure(fullFhirPath, error.ErrorMessage);
                     }
                 }
             }

--- a/src/Microsoft.Health.Fhir.Core/Features/Validation/AttributeValidator.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Validation/AttributeValidator.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
                         ITypedElement typedElement = resourceElement.Instance;
 
                         var fullFhirPath = typedElement.InstanceType;
-                        fullFhirPath += error.MemberNames?.FirstOrDefault() == null ? $"" : "." + error.MemberNames?.FirstOrDefault();
+                        fullFhirPath += string.IsNullOrEmpty(error.MemberNames?.FirstOrDefault()) ? string.Empty : "." + error.MemberNames?.FirstOrDefault();
 
                         yield return new ValidationFailure(fullFhirPath, error.ErrorMessage);
                     }

--- a/src/Microsoft.Health.Fhir.Core/Features/Validation/AttributeValidator.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Validation/AttributeValidator.cs
@@ -42,9 +42,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
                 {
                     foreach (var error in results)
                     {
-                        ITypedElement typedElement = resourceElement.Instance;
-
-                        var fullFhirPath = typedElement.InstanceType;
+                        var fullFhirPath = resourceElement.InstanceType;
                         fullFhirPath += string.IsNullOrEmpty(error.MemberNames?.FirstOrDefault()) ? string.Empty : "." + error.MemberNames?.FirstOrDefault();
 
                         yield return new ValidationFailure(fullFhirPath, error.ErrorMessage);

--- a/src/Microsoft.Health.Fhir.Core/Features/Validation/ResourceNotValidException.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Validation/ResourceNotValidException.cs
@@ -38,11 +38,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
                 }
                 else
                 {
+                    string[] location = failure.PropertyName == null ? null : new[] { failure.PropertyName };
+
                     Issues.Add(new OperationOutcomeIssue(
                             OperationOutcomeConstants.IssueSeverity.Error,
                             OperationOutcomeConstants.IssueType.Invalid,
                             failure.ErrorMessage,
-                            new[] { failure.PropertyName }));
+                            location));
                 }
             }
         }

--- a/src/Microsoft.Health.Fhir.Core/Features/Validation/ResourceNotValidException.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Validation/ResourceNotValidException.cs
@@ -41,7 +41,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
                     Issues.Add(new OperationOutcomeIssue(
                             OperationOutcomeConstants.IssueSeverity.Error,
                             OperationOutcomeConstants.IssueType.Invalid,
-                            failure.ErrorMessage));
+                            failure.ErrorMessage,
+                            new[] { failure.PropertyName }));
                 }
             }
         }

--- a/src/Microsoft.Health.Fhir.Core/Features/Validation/ResourceNotValidException.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Validation/ResourceNotValidException.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
                 }
                 else
                 {
-                    string[] location = failure.PropertyName == null ? null : new[] { failure.PropertyName };
+                    string[] location = string.IsNullOrEmpty(failure.PropertyName) ? null : new[] { failure.PropertyName };
 
                     Issues.Add(new OperationOutcomeIssue(
                             OperationOutcomeConstants.IssueSeverity.Error,

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Validation/FhirPrimitiveTypes/AttributeValidatorTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Validation/FhirPrimitiveTypes/AttributeValidatorTests.cs
@@ -1,0 +1,47 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+using System.Collections.Generic;
+using System.Linq;
+using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Model;
+using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Core.Features.Validation;
+using Microsoft.Health.Fhir.Tests.Common;
+using Xunit;
+using ValidationResult = System.ComponentModel.DataAnnotations.ValidationResult;
+
+namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Validation.FhirPrimitiveTypes
+{
+    public class AttributeValidatorTests
+    {
+        private IModelAttributeValidator _modelAttributeValidator;
+
+        public AttributeValidatorTests()
+        {
+            _modelAttributeValidator = new ModelAttributeValidator();
+        }
+
+        [Fact]
+        public void WhenProcessingAResource_GivenAMissingAttribute_ThenAValidationMessageWithAFhirPathIsCreated()
+        {
+            var defaultObservation = Samples.GetDefaultObservation().ToPoco<Observation>();
+            defaultObservation.StatusElement = null;
+
+            var results = new List<ValidationResult>();
+            bool isValid = _modelAttributeValidator.TryValidate(defaultObservation.ToResourceElement(), results, recurse: false);
+
+            Assert.False(isValid);
+
+            List<ValidationResult> validationFailures = results as List<ValidationResult> ?? results.ToList();
+            Assert.Single(validationFailures);
+
+            var error = validationFailures.FirstOrDefault();
+            var actualPartialFhirPath = string.IsNullOrEmpty(error.MemberNames?.FirstOrDefault()) ? string.Empty : error.MemberNames?.FirstOrDefault();
+
+            // TODO: Expected value should be "status" once actual path is fixed.
+            Assert.Equal("StatusElement", actualPartialFhirPath);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Validation/Narratives/NarrativeValidatorTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Validation/Narratives/NarrativeValidatorTests.cs
@@ -36,11 +36,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Validation.Narratives
             var defaultObservation = Samples.GetDefaultObservation().ToPoco<Observation>();
             defaultObservation.Text.Div = maliciousNarrative;
 
-            var resourceElement = defaultObservation.ToResourceElement();
-
             IEnumerable<ValidationFailure> result = _validator.Validate(
                 new PropertyValidatorContext(
-                    new ValidationContext(resourceElement),
+                    new ValidationContext(defaultObservation.ToResourceElement()),
                     PropertyRule.Create<ResourceElement, ResourceElement>(x => x),
                     "Resource"));
 
@@ -48,7 +46,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Validation.Narratives
             Assert.NotEmpty(validationFailures);
 
             var actualFhirPath = validationFailures.FirstOrDefault()?.PropertyName;
-            var expectedFhirPath = resourceElement.Instance.InstanceType + "." + KnownFhirPaths.ResourceNarrative;
+            var expectedFhirPath = defaultObservation.TypeName + "." + KnownFhirPaths.ResourceNarrative;
 
             Assert.Equal(expectedFhirPath, actualFhirPath);
         }
@@ -59,11 +57,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Validation.Narratives
         {
             var defaultObservation = Samples.GetDefaultObservation().ToPoco<Observation>();
             defaultObservation.Text.Div = maliciousNarrative;
-            var observationInstance = defaultObservation.ToResourceElement().Instance;
 
             var defaultPatient = Samples.GetDefaultPatient().ToPoco<Patient>();
             defaultPatient.Text.Div = maliciousNarrative;
-            var patientInstance = defaultPatient.ToResourceElement().Instance;
 
             var bundle = new Bundle();
             bundle.Entry.Add(new Bundle.EntryComponent { Resource = defaultObservation });
@@ -78,8 +74,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Validation.Narratives
             List<ValidationFailure> validationFailures = result as List<ValidationFailure> ?? result.ToList();
             Assert.NotEmpty(validationFailures);
 
-            var expectedObservationFhirPath = observationInstance.InstanceType + "." + KnownFhirPaths.ResourceNarrative;
-            var expectedPatientFhirPath = patientInstance.InstanceType + "." + KnownFhirPaths.ResourceNarrative;
+            var expectedObservationFhirPath = defaultObservation.TypeName + "." + KnownFhirPaths.ResourceNarrative;
+            var expectedPatientFhirPath = defaultPatient.TypeName + "." + KnownFhirPaths.ResourceNarrative;
 
             Assert.Equal(expectedObservationFhirPath, validationFailures[0].PropertyName);
             Assert.Equal(expectedPatientFhirPath, validationFailures[1].PropertyName);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
@@ -60,6 +60,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchValues\ReferenceSearchValueParserTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchValues\ReferenceSearchValueTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Security\AuthPermissionConfigTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Validation\FhirPrimitiveTypes\AttributeValidatorTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Validation\FhirPrimitiveTypes\IdValidatorTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Validation\Narratives\NarrativeDataTestBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Validation\Narratives\NarrativeHtmlSanitizerTests.cs" />


### PR DESCRIPTION
## Description

- The location is now included in the attribute validator error messages

![validation_messages_with_location](https://user-images.githubusercontent.com/54082711/65182577-77780200-da16-11e9-9306-9adb786591d7.png)

## Related issues

- [#AB70211](https://microsofthealth.visualstudio.com/Health/_workitems/edit/70211) #536

## Testing

- Updated existing unit tests to ensure a FHIR path is included in validation messages
- Added a new unit test for attribute validation
