### PR TITLE
Adds a GenericXmlOutputSerializer that only activates for non-fhir types

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Formatters/NonFhirResourceXmlOutputFormatter.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Formatters/NonFhirResourceXmlOutputFormatter.cs
@@ -1,0 +1,27 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using EnsureThat;
+using Hl7.Fhir.Model;
+using Microsoft.AspNetCore.Mvc.Formatters;
+
+namespace Microsoft.Health.Fhir.Api.Features.Formatters
+{
+    public class NonFhirResourceXmlOutputFormatter : XmlSerializerOutputFormatter
+    {
+        protected override bool CanWriteType(Type type)
+        {
+            EnsureArg.IsNotNull(type, nameof(type));
+
+            if (typeof(Resource).IsAssignableFrom(type))
+            {
+                return false;
+            }
+
+            return base.CanWriteType(type);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api/Microsoft.Health.Fhir.Shared.Api.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Microsoft.Health.Fhir.Shared.Api.projitems
@@ -30,6 +30,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Formatters\FormatterExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Formatters\HtmlOutputFormatter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Formatters\HttpContextExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Formatters\NonFhirResourceXmlOutputFormatter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Headers\FhirResultExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Headers\KnownFhirHeaders.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Security\SecurityProvider.cs" />

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/FeatureFlags/XmlFormatter/XmlFormatterFeatureModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/FeatureFlags/XmlFormatter/XmlFormatterFeatureModule.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Health.Fhir.Api.Modules.FeatureFlags.XmlFormatter
                     .AsSelf()
                     .AsService<TextOutputFormatter>();
 
-                services.Add<XmlSerializerOutputFormatter>()
+                services.Add<NonFhirResourceXmlOutputFormatter>()
                     .Singleton()
                     .AsSelf()
                     .AsService<TextOutputFormatter>();


### PR DESCRIPTION
## Description
Adds a GenericXmlSerializer that only serializes non-FHIR types

## Related issues
Addresses #657

## Testing
Manually inspected console output