### PR TITLE
Returns 406 error for invalid Accept header on GET request

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Exceptions/NotAcceptableException.cs
+++ b/src/Microsoft.Health.Fhir.Core/Exceptions/NotAcceptableException.cs
@@ -1,0 +1,23 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+using System.Diagnostics;
+using Microsoft.Health.Fhir.Core.Models;
+
+namespace Microsoft.Health.Fhir.Core.Exceptions
+{
+    public class NotAcceptableException : FhirException
+    {
+        public NotAcceptableException(string message)
+            : base(message)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(message), "Exception message should not be empty");
+
+            Issues.Add(new OperationOutcomeIssue(
+                    OperationOutcomeConstants.IssueSeverity.Error,
+                    OperationOutcomeConstants.IssueType.NotSupported,
+                    message));
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/ValidateContentTypeFilterAttributeTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/ValidateContentTypeFilterAttributeTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
         [InlineData("text/xml")]
         [InlineData("ttl")]
         [InlineData("xml")]
-        public async Task GivenARequestWithAnInvalidFormatQuerystring_WhenValidatingTheContentType_ThenAnUnsupportedMediaTypeExceptionShouldBeThrown(string requestFormat)
+        public async Task GivenARequestWithAnInvalidFormatQuerystring_WhenValidatingTheContentType_ThenANotAcceptableExceptionShouldBeThrown(string requestFormat)
         {
             var filter = CreateFilter();
 
@@ -60,7 +60,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
 
             context.HttpContext.Request.QueryString = new QueryString($"?_format={requestFormat}");
 
-            await Assert.ThrowsAsync<UnsupportedMediaTypeException>(async () => await filter.OnActionExecutionAsync(context, actionExecutedDelegate));
+            await Assert.ThrowsAsync<NotAcceptableException>(async () => await filter.OnActionExecutionAsync(context, actionExecutedDelegate));
         }
 
         [Theory]

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/ContentTypes/ContentTypeService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/ContentTypes/ContentTypeService.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Health.Fhir.Api.Features.ContentTypes
                 ResourceFormat resourceFormat = ContentType.GetResourceFormatFromFormatParam(formatOverride);
                 if (!await IsFormatSupportedAsync(resourceFormat))
                 {
-                    throw new UnsupportedMediaTypeException(Resources.UnsupportedFormatParameter);
+                    throw new NotAcceptableException(Resources.UnsupportedFormatParameter);
                 }
 
                 string closestClientMediaType = _outputFormatters.GetClosestClientMediaType(resourceFormat.ToContentType(), acceptHeaders?.Select(x => x.MediaType.Value));

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
@@ -109,6 +109,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
                     case OperationNotImplementedException _:
                         operationOutcomeResult.StatusCode = HttpStatusCode.NotImplemented;
                         break;
+                    case NotAcceptableException _:
+                        operationOutcomeResult.StatusCode = HttpStatusCode.NotAcceptable;
+                        break;
                 }
 
                 context.Result = operationOutcomeResult;


### PR DESCRIPTION
## Description

- The server now returns a 406 Not Acceptable status code if the Accept header requests a format that the server does not support (see [spec](http://hl7.org/fhir/formats.html#wire))
- Previously, a 415 Unsupported Media Type status code was returned

![406_error_on_get_with_invalid_header](https://user-images.githubusercontent.com/54082711/65363302-eb094300-dbbf-11e9-8630-8ece45a3eccb.png)

## Related issues

- [#AB70307](https://microsofthealth.visualstudio.com/Health/_workitems/edit/70307)
- #649 

## Testing

- Updated existing unit test
