### PR TITLE
Returns 406 for invalid Accept header or _format parameter

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Exceptions/NotAcceptableException.cs
+++ b/src/Microsoft.Health.Fhir.Core/Exceptions/NotAcceptableException.cs
@@ -1,0 +1,23 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+using System.Diagnostics;
+using Microsoft.Health.Fhir.Core.Models;
+
+namespace Microsoft.Health.Fhir.Core.Exceptions
+{
+    public class NotAcceptableException : FhirException
+    {
+        public NotAcceptableException(string message)
+            : base(message)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(message), "Exception message should not be empty");
+
+            Issues.Add(new OperationOutcomeIssue(
+                    OperationOutcomeConstants.IssueSeverity.Error,
+                    OperationOutcomeConstants.IssueType.NotSupported,
+                    message));
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/OperationOutcomeExceptionFilterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/OperationOutcomeExceptionFilterTests.cs
@@ -175,6 +175,12 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
             ValidateOperationOutcome(new OperationFailedException("Operation failed.", statusCode), statusCode);
         }
 
+        [Fact]
+        public void GivenANotAcceptableException_WhenExecutingAnAction_ThenTheResponseShouldBeAnOperationOutcome()
+        {
+            ValidateOperationOutcome(new NotAcceptableException("Not acceptable."), HttpStatusCode.NotAcceptable);
+        }
+
         private OperationOutcomeResult ValidateOperationOutcome(Exception exception, HttpStatusCode expectedStatusCode)
         {
             var filter = new OperationOutcomeExceptionFilterAttribute(_fhirRequestContextAccessor);

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/ValidateContentTypeFilterAttributeTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/ValidateContentTypeFilterAttributeTests.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
         [InlineData("ttl")]
         [InlineData("xml")]
         [InlineData("blah")]
-        public async Task GivenARequestWithAnInvalidFormatQueryStringAndNotAllowedContentTypeHeader_WhenValidatingTheContentType_ThenANotAcceptableExceptionShouldBeThrown(string requestFormat)
+        public async Task GivenARequestWithAnInvalidFormatQueryStringAndInvalidContentTypeHeader_WhenValidatingTheContentType_ThenANotAcceptableExceptionShouldBeThrown(string requestFormat)
         {
             var filter = CreateFilter();
 
@@ -136,7 +136,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
         [InlineData("application/blah")]
         [InlineData("application/xml")]
         [InlineData("application/fhir+xml")]
-        public async Task GivenARequestWithNotAllowedAcceptHeader_WhenValidatingTheContentType_ThenANotAcceptableExceptionShouldBeThrown(string acceptHeader)
+        public async Task GivenARequestWithInvalidAcceptHeader_WhenValidatingTheContentType_ThenANotAcceptableExceptionShouldBeThrown(string acceptHeader)
         {
             var filter = CreateFilter();
 
@@ -152,7 +152,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
         [InlineData("application/blah")]
         [InlineData("application/xml")]
         [InlineData("application/fhir+xml")]
-        public async Task GivenARequestWithNotAllowedAcceptHeaderAndNotAllowedContentTypeHeader_WhenValidatingTheContentType_ThenANotAcceptableExceptionShouldBeThrown(string acceptHeader)
+        public async Task GivenARequestWithInvalidAcceptHeaderAndInvalidContentTypeHeader_WhenValidatingTheContentType_ThenANotAcceptableExceptionShouldBeThrown(string acceptHeader)
         {
             var filter = CreateFilter();
 
@@ -207,7 +207,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
         [InlineData("xml")]
         [InlineData("json")]
         [InlineData("blah")]
-        public async Task GivenARequestWithAcceptHeaderToIgnoreAndNotAllowedContentTypeHeader_WhenValidatingTheContentType_ThenAnUnsupportedMediaTypeExceptionShouldBeThrown(string acceptHeader)
+        public async Task GivenARequestWithAcceptHeaderToIgnoreAndInvalidContentTypeHeader_WhenValidatingTheContentType_ThenAnUnsupportedMediaTypeExceptionShouldBeThrown(string acceptHeader)
         {
             var filter = CreateFilter();
 
@@ -227,7 +227,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
         [InlineData("application/xml")]
         [InlineData("application/fhir+xml")]
         [InlineData("")]
-        public async Task GivenARequestWithNotAllowedContentTypeHeader_WhenValidatingTheContentType_ThenAnUnsupportedMediaTypeExceptionShouldBeThrown(string contentTypeHeader)
+        public async Task GivenARequestWithInvalidContentTypeHeader_WhenValidatingTheContentType_ThenAnUnsupportedMediaTypeExceptionShouldBeThrown(string contentTypeHeader)
         {
             var filter = CreateFilter();
 
@@ -274,7 +274,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
         [Theory]
         [InlineData("json", "application/fhir+xml")]
         [InlineData("application/fhir+json", "application/fhir+xml")]
-        public async Task GivenARequestWithAnAllowedFormatAndNotAllowedContentTypeHeader_WhenValidatingTheContentType_ThenAnUnsupportedMediaTypeExceptionShouldBeThrown(string requestFormat, string contentTypeHeader)
+        public async Task GivenARequestWithAValidFormatAndInvalidContentTypeHeader_WhenValidatingTheContentType_ThenAnUnsupportedMediaTypeExceptionShouldBeThrown(string requestFormat, string contentTypeHeader)
         {
             var filter = CreateFilter();
 

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/ValidateContentTypeFilterAttributeTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/ValidateContentTypeFilterAttributeTests.cs
@@ -46,6 +46,53 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
         }
 
         [Theory]
+        [InlineData("application/fhir+json")]
+        [InlineData("application/json")]
+        [InlineData("json")]
+        public async Task GivenARequestWithAValidFormatQueryStringAndNoAcceptHeader_WhenValidatingTheContentType_ThenNoExceptionShouldBeThrown(string requestFormat)
+        {
+            var filter = CreateFilter();
+
+            var context = CreateContext(Guid.NewGuid().ToString());
+            var actionExecutedDelegate = CreateActionExecutedDelegate(context);
+
+            context.HttpContext.Request.QueryString = new QueryString($"?_format={requestFormat}");
+
+            await filter.OnActionExecutionAsync(context, actionExecutedDelegate);
+        }
+
+        [Fact]
+        public async Task GivenARequestWithAValidFormatQueryStringAndAnEmptyAcceptHeader_WhenValidatingTheContentType_ThenNoExceptionShouldBeThrown()
+        {
+            var filter = CreateFilter();
+
+            var context = CreateContext(Guid.NewGuid().ToString());
+            var actionExecutedDelegate = CreateActionExecutedDelegate(context);
+
+            context.HttpContext.Request.QueryString = new QueryString($"?_format=json");
+            context.HttpContext.Request.Headers.Add("Accept", string.Empty);
+
+            await filter.OnActionExecutionAsync(context, actionExecutedDelegate);
+        }
+
+        [Theory]
+        [InlineData("application/fhir+json")]
+        [InlineData("application/json")]
+        [InlineData("json")]
+        public async Task GivenARequestWithAValidFormatQueryStringAndAValidAcceptHeader_WhenValidatingTheContentType_ThenNoExceptionShouldBeThrown(string requestFormat)
+        {
+            var filter = CreateFilter();
+
+            var context = CreateContext(Guid.NewGuid().ToString());
+            var actionExecutedDelegate = CreateActionExecutedDelegate(context);
+
+            context.HttpContext.Request.QueryString = new QueryString($"?_format={requestFormat}");
+            context.HttpContext.Request.Headers.Add("Accept", "application/json");
+
+            await filter.OnActionExecutionAsync(context, actionExecutedDelegate);
+        }
+
+        [Theory]
         [InlineData("application/fhir+xml")]
         [InlineData("application/xml")]
         [InlineData("application/blah")]
@@ -66,6 +113,24 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
         }
 
         [Theory]
+        [InlineData("json", "application/fhir+xml")]
+        [InlineData("application/fhir+json", "application/fhir+xml")]
+        public async Task GivenARequestWithAValidFormatQueryStringAndAnInvalidContentTypeHeader_WhenValidatingTheContentType_ThenAnUnsupportedMediaTypeExceptionShouldBeThrown(string requestFormat, string contentTypeHeader)
+        {
+            var filter = CreateFilter();
+
+            var context = CreateContext(Guid.NewGuid().ToString());
+            var actionExecutedDelegate = CreateActionExecutedDelegate(context);
+
+            context.HttpContext.Request.QueryString = new QueryString($"?_format={requestFormat}");
+            context.HttpContext.Request.Method = HttpMethod.Post.ToString();
+            context.HttpContext.Request.Headers.Add("Content-Type", contentTypeHeader);
+            context.HttpContext.Request.Headers.Add("Accept", contentTypeHeader);
+
+            await Assert.ThrowsAsync<UnsupportedMediaTypeException>(async () => await filter.OnActionExecutionAsync(context, actionExecutedDelegate));
+        }
+
+        [Theory]
         [InlineData("application/fhir+xml")]
         [InlineData("application/xml")]
         [InlineData("application/blah")]
@@ -73,7 +138,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
         [InlineData("ttl")]
         [InlineData("xml")]
         [InlineData("blah")]
-        public async Task GivenARequestWithAnInvalidFormatQueryStringAndInvalidContentTypeHeader_WhenValidatingTheContentType_ThenANotAcceptableExceptionShouldBeThrown(string requestFormat)
+        public async Task GivenARequestWithAnInvalidFormatQueryStringAndAnInvalidContentTypeHeader_WhenValidatingTheContentType_ThenANotAcceptableExceptionShouldBeThrown(string requestFormat)
         {
             var filter = CreateFilter();
 
@@ -84,85 +149,6 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
 
             context.HttpContext.Request.Method = HttpMethod.Post.ToString();
             context.HttpContext.Request.Headers.Add("Content-Type", "application/fhir+xml");
-
-            await Assert.ThrowsAsync<NotAcceptableException>(async () => await filter.OnActionExecutionAsync(context, actionExecutedDelegate));
-        }
-
-        [Theory]
-        [InlineData("application/fhir+json")]
-        [InlineData("application/json")]
-        [InlineData("json")]
-        public async Task GivenARequestWithAValidFormatQueryString_WhenValidatingTheContentType_ThenNoExceptionShouldBeThrown(string requestFormat)
-        {
-            var filter = CreateFilter();
-
-            var context = CreateContext(Guid.NewGuid().ToString());
-            var actionExecutedDelegate = CreateActionExecutedDelegate(context);
-
-            context.HttpContext.Request.QueryString = new QueryString($"?_format={requestFormat}");
-            context.HttpContext.Request.Headers.Add("Accept", "application/json");
-
-            await filter.OnActionExecutionAsync(context, actionExecutedDelegate);
-        }
-
-        [Fact]
-        public async Task GivenARequestWithAValidFormatQueryStringAndNoAcceptHeader_WhenValidatingTheContentType_ThenNoExceptionShouldBeThrown()
-        {
-            var filter = CreateFilter();
-
-            var context = CreateContext(Guid.NewGuid().ToString());
-            var actionExecutedDelegate = CreateActionExecutedDelegate(context);
-
-            context.HttpContext.Request.QueryString = new QueryString($"?_format=json");
-
-            await filter.OnActionExecutionAsync(context, actionExecutedDelegate);
-        }
-
-        [Fact]
-        public async Task GivenARequestWithAValidFormatQueryStringAndEmptyAcceptHeader_WhenValidatingTheContentType_ThenNoExceptionShouldBeThrown()
-        {
-            var filter = CreateFilter();
-
-            var context = CreateContext(Guid.NewGuid().ToString());
-            var actionExecutedDelegate = CreateActionExecutedDelegate(context);
-
-            context.HttpContext.Request.QueryString = new QueryString($"?_format=json");
-            context.HttpContext.Request.Headers.Add("Accept", string.Empty);
-
-            await filter.OnActionExecutionAsync(context, actionExecutedDelegate);
-        }
-
-        [Theory]
-        [InlineData("application/blah")]
-        [InlineData("application/xml")]
-        [InlineData("application/fhir+xml")]
-        public async Task GivenARequestWithInvalidAcceptHeader_WhenValidatingTheContentType_ThenANotAcceptableExceptionShouldBeThrown(string acceptHeader)
-        {
-            var filter = CreateFilter();
-
-            var context = CreateContext(Guid.NewGuid().ToString());
-            var actionExecutedDelegate = CreateActionExecutedDelegate(context);
-
-            context.HttpContext.Request.Headers.Add("Accept", acceptHeader);
-
-            await Assert.ThrowsAsync<NotAcceptableException>(async () => await filter.OnActionExecutionAsync(context, actionExecutedDelegate));
-        }
-
-        [Theory]
-        [InlineData("application/blah")]
-        [InlineData("application/xml")]
-        [InlineData("application/fhir+xml")]
-        public async Task GivenARequestWithInvalidAcceptHeaderAndInvalidContentTypeHeader_WhenValidatingTheContentType_ThenANotAcceptableExceptionShouldBeThrown(string acceptHeader)
-        {
-            var filter = CreateFilter();
-
-            var context = CreateContext(Guid.NewGuid().ToString());
-            var actionExecutedDelegate = CreateActionExecutedDelegate(context);
-
-            context.HttpContext.Request.Headers.Add("Accept", acceptHeader);
-
-            context.HttpContext.Request.Method = HttpMethod.Post.ToString();
-            context.HttpContext.Request.Headers.Add("Content-Type", acceptHeader);
 
             await Assert.ThrowsAsync<NotAcceptableException>(async () => await filter.OnActionExecutionAsync(context, actionExecutedDelegate));
         }
@@ -173,7 +159,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
         [InlineData("application/json+fhir")]
         [InlineData("*/*")]
         [InlineData("application/xml,application/xhtml+xml,text/html;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5")]
-        public async Task GivenARequestWithAllowedAcceptHeader_WhenValidatingTheContentType_ThenNoExceptionShouldBeThrown(string acceptHeader)
+        public async Task GivenARequestWithAValidAcceptHeader_WhenValidatingTheContentType_ThenNoExceptionShouldBeThrown(string acceptHeader)
         {
             var filter = CreateFilter();
 
@@ -185,12 +171,13 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
             await filter.OnActionExecutionAsync(context, actionExecutedDelegate);
         }
 
+        // Invalid Accept headers are ignored, unless they are formatted "application/<invalid_format>".
         [Theory]
         [InlineData("")]
         [InlineData("xml")]
         [InlineData("json")]
         [InlineData("blah")]
-        public async Task GivenARequestWithAcceptHeaderToIgnore_WhenValidatingTheContentType_ThenNoExceptionShouldBeThrown(string acceptHeader)
+        public async Task GivenARequestWithAnInvalidAcceptHeader_WhenValidatingTheContentType_ThenNoExceptionShouldBeThrown(string acceptHeader)
         {
             var filter = CreateFilter();
 
@@ -202,12 +189,35 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
             await filter.OnActionExecutionAsync(context, actionExecutedDelegate);
         }
 
+        // Invalid Accept headers that are formatted "application/<invalid_format>" should throw an exception.
         [Theory]
-        [InlineData("")]
-        [InlineData("xml")]
-        [InlineData("json")]
-        [InlineData("blah")]
-        public async Task GivenARequestWithAcceptHeaderToIgnoreAndInvalidContentTypeHeader_WhenValidatingTheContentType_ThenAnUnsupportedMediaTypeExceptionShouldBeThrown(string acceptHeader)
+        [InlineData("application/blah")]
+        [InlineData("application/xml")]
+        [InlineData("application/fhir+xml")]
+        public async Task GivenARequestWithAnInvalidApplicationAcceptHeader_WhenValidatingTheContentType_ThenANotAcceptableExceptionShouldBeThrown(string acceptHeader)
+        {
+            var filter = CreateFilter();
+
+            var context = CreateContext(Guid.NewGuid().ToString());
+            var actionExecutedDelegate = CreateActionExecutedDelegate(context);
+
+            context.HttpContext.Request.Headers.Add("Accept", acceptHeader);
+
+            await Assert.ThrowsAsync<NotAcceptableException>(async () => await filter.OnActionExecutionAsync(context, actionExecutedDelegate));
+        }
+
+        // Invalid Accept headers are ignored, unless they are formatted "application/<invalid_format>".
+        [Theory]
+        [InlineData("", "application/blah")]
+        [InlineData("", "application/fhir+xml")]
+        [InlineData("", "")]
+        [InlineData("xml", "application/blah")]
+        [InlineData("xml", "application/fhir+xml")]
+        [InlineData("xml", "")]
+        [InlineData("blah", "application/blah")]
+        [InlineData("blah", "application/fhir+xml")]
+        [InlineData("blah", "")]
+        public async Task GivenARequestWithAnInvalidAcceptHeaderAndAnInvalidContentTypeHeader_WhenValidatingTheContentType_ThenAnUnsupportedMediaTypeExceptionShouldBeThrown(string acceptHeader, string contentTypeHeader)
         {
             var filter = CreateFilter();
 
@@ -217,9 +227,69 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
             context.HttpContext.Request.Headers.Add("Accept", acceptHeader);
 
             context.HttpContext.Request.Method = HttpMethod.Post.ToString();
-            context.HttpContext.Request.Headers.Add("Content-Type", "application/fhir+xml");
+            context.HttpContext.Request.Headers.Add("Content-Type", contentTypeHeader);
+
+            // The fact that the Accept header is invalid is ignored, but an exception related to the invalid Content Type header is still thrown.
+            await Assert.ThrowsAsync<UnsupportedMediaTypeException>(async () => await filter.OnActionExecutionAsync(context, actionExecutedDelegate));
+        }
+
+        // Invalid Accept headers that are formatted "application/<invalid_format>" should throw an exception.
+        [Theory]
+        [InlineData("application/blah", "application/blah")]
+        [InlineData("application/blah", "application/fhir+xml")]
+        [InlineData("application/blah", "")]
+        [InlineData("application/fhir+xml", "application/blah")]
+        [InlineData("application/fhir+xml", "application/fhir+xml")]
+        [InlineData("application/fhir+xml", "")]
+        public async Task GivenARequestWithAnInvalidApplicationAcceptHeaderAndAnInvalidContentTypeHeader_WhenValidatingTheContentType_ThenANotAcceptableExceptionShouldBeThrown(string acceptHeader, string contentTypeHeader)
+        {
+            var filter = CreateFilter();
+
+            var context = CreateContext(Guid.NewGuid().ToString());
+            var actionExecutedDelegate = CreateActionExecutedDelegate(context);
+
+            context.HttpContext.Request.Headers.Add("Accept", acceptHeader);
+
+            context.HttpContext.Request.Method = HttpMethod.Post.ToString();
+            context.HttpContext.Request.Headers.Add("Content-Type", contentTypeHeader);
+
+            // The Accept header is invalid and has the format "application/<invalid_format>", so an exception for that is thrown.
+            await Assert.ThrowsAsync<NotAcceptableException>(async () => await filter.OnActionExecutionAsync(context, actionExecutedDelegate));
+        }
+
+        [Theory]
+        [InlineData("application/blah")]
+        [InlineData("application/fhir+xml")]
+        [InlineData("")]
+        public async Task GivenARequestWithNoAcceptHeaderAndAnInvalidContentTypeHeader_WhenValidatingTheContentType_ThenAnUnsupportedMediaTypeExceptionShouldBeThrown(string contentTypeHeader)
+        {
+            var filter = CreateFilter();
+
+            var context = CreateContext(Guid.NewGuid().ToString());
+            var actionExecutedDelegate = CreateActionExecutedDelegate(context);
+
+            context.HttpContext.Request.Method = HttpMethod.Post.ToString();
+            context.HttpContext.Request.Headers.Add("Content-Type", contentTypeHeader);
 
             await Assert.ThrowsAsync<UnsupportedMediaTypeException>(async () => await filter.OnActionExecutionAsync(context, actionExecutedDelegate));
+        }
+
+        [Theory]
+        [InlineData("application/json")]
+        [InlineData("application/fhir+json")]
+        [InlineData("application/json+fhir")]
+        public async Task GivenARequestWithAValidAcceptHeaderAndAValidContentTypeHeader_WhenValidatingTheContentType_ThenNoExceptionShouldBeThrown(string contentTypeHeader)
+        {
+            var filter = CreateFilter();
+
+            var context = CreateContext(Guid.NewGuid().ToString());
+            var actionExecutedDelegate = CreateActionExecutedDelegate(context);
+
+            context.HttpContext.Request.Method = HttpMethod.Post.ToString();
+            context.HttpContext.Request.Headers.Add("Content-Type", contentTypeHeader);
+            context.HttpContext.Request.Headers.Add("Accept", contentTypeHeader);
+
+            await filter.OnActionExecutionAsync(context, actionExecutedDelegate);
         }
 
         [Theory]
@@ -227,12 +297,14 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
         [InlineData("application/xml")]
         [InlineData("application/fhir+xml")]
         [InlineData("")]
-        public async Task GivenARequestWithInvalidContentTypeHeader_WhenValidatingTheContentType_ThenAnUnsupportedMediaTypeExceptionShouldBeThrown(string contentTypeHeader)
+        public async Task GivenARequestWithAValidAcceptHeaderAndAnInvalidContentTypeHeader_WhenValidatingTheContentType_ThenAnUnsupportedMediaTypeExceptionShouldBeThrown(string contentTypeHeader)
         {
             var filter = CreateFilter();
 
             var context = CreateContext(Guid.NewGuid().ToString());
             var actionExecutedDelegate = CreateActionExecutedDelegate(context);
+
+            context.HttpContext.Request.Headers.Add("Accept", "application/json");
 
             context.HttpContext.Request.Method = HttpMethod.Post.ToString();
             context.HttpContext.Request.Headers.Add("Content-Type", contentTypeHeader);
@@ -249,42 +321,6 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
             var actionExecutedDelegate = CreateActionExecutedDelegate(context);
 
             context.HttpContext.Request.Method = HttpMethod.Post.ToString();
-
-            await Assert.ThrowsAsync<UnsupportedMediaTypeException>(async () => await filter.OnActionExecutionAsync(context, actionExecutedDelegate));
-        }
-
-        [Theory]
-        [InlineData("application/json")]
-        [InlineData("application/fhir+json")]
-        [InlineData("application/json+fhir")]
-        public async Task GivenARequestWithAllowedContentTypeHeader_WhenValidatingTheContentType_ThenNoExceptionShouldBeThrown(string contentTypeHeader)
-        {
-            var filter = CreateFilter();
-
-            var context = CreateContext(Guid.NewGuid().ToString());
-            var actionExecutedDelegate = CreateActionExecutedDelegate(context);
-
-            context.HttpContext.Request.Method = HttpMethod.Post.ToString();
-            context.HttpContext.Request.Headers.Add("Content-Type", contentTypeHeader);
-            context.HttpContext.Request.Headers.Add("Accept", contentTypeHeader);
-
-            await filter.OnActionExecutionAsync(context, actionExecutedDelegate);
-        }
-
-        [Theory]
-        [InlineData("json", "application/fhir+xml")]
-        [InlineData("application/fhir+json", "application/fhir+xml")]
-        public async Task GivenARequestWithAValidFormatAndInvalidContentTypeHeader_WhenValidatingTheContentType_ThenAnUnsupportedMediaTypeExceptionShouldBeThrown(string requestFormat, string contentTypeHeader)
-        {
-            var filter = CreateFilter();
-
-            var context = CreateContext(Guid.NewGuid().ToString());
-            var actionExecutedDelegate = CreateActionExecutedDelegate(context);
-
-            context.HttpContext.Request.QueryString = new QueryString($"?_format={requestFormat}");
-            context.HttpContext.Request.Method = HttpMethod.Post.ToString();
-            context.HttpContext.Request.Headers.Add("Content-Type", contentTypeHeader);
-            context.HttpContext.Request.Headers.Add("Accept", contentTypeHeader);
 
             await Assert.ThrowsAsync<UnsupportedMediaTypeException>(async () => await filter.OnActionExecutionAsync(context, actionExecutedDelegate));
         }
@@ -311,7 +347,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
         }
 
         [Fact]
-        public async Task GivenARequestWithAllowedAcceptHeaderAndFormatOverride_WhenSettingTheContentType_ThenClientAcceptHeadersShouldBeConsidered()
+        public async Task GivenARequestWithAValidAcceptHeaderAndFormatOverride_WhenSettingTheContentType_ThenClientAcceptHeadersShouldBeConsidered()
         {
             string applicationXml = "application/xml";
 

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/ContentTypes/ContentTypeService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/ContentTypes/ContentTypeService.cs
@@ -64,15 +64,10 @@ namespace Microsoft.Health.Fhir.Api.Features.ContentTypes
             }
             else
             {
-                var isAcceptHeaderValid = true;
+                if (acceptHeaders != null && acceptHeaders.All(a => a.MediaType != "*/*"))
+                {
+                    var isAcceptHeaderValid = false;
 
-                if (acceptHeaders == null)
-                {
-                    // A null Accept header indicates that an invalid or empty header value has been provided.
-                    isAcceptHeaderValid = false;
-                }
-                else if (acceptHeaders.All(a => a.MediaType != "*/*"))
-                {
                     foreach (MediaTypeHeaderValue acceptHeader in acceptHeaders)
                     {
                         isAcceptHeaderValid = await IsFormatSupportedAsync(acceptHeader.MediaType.ToString());
@@ -82,11 +77,11 @@ namespace Microsoft.Health.Fhir.Api.Features.ContentTypes
                             break;
                         }
                     }
-                }
 
-                if (!isAcceptHeaderValid)
-                {
-                    throw new NotAcceptableException(string.Format(Resources.UnsupportedHeaderValue, HeaderNames.Accept));
+                    if (!isAcceptHeaderValid)
+                    {
+                        throw new NotAcceptableException(string.Format(Resources.UnsupportedHeaderValue, HeaderNames.Accept));
+                    }
                 }
             }
         }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
@@ -109,6 +109,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
                     case OperationNotImplementedException _:
                         operationOutcomeResult.StatusCode = HttpStatusCode.NotImplemented;
                         break;
+                    case NotAcceptableException _:
+                        operationOutcomeResult.StatusCode = HttpStatusCode.NotAcceptable;
+                        break;
                 }
 
                 context.Result = operationOutcomeResult;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/MetadataTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/MetadataTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
-        public async Task WhenGettingMetadata_GivenInvalidFormatParameter_TheServerShouldThrowNotAcceptableException()
+        public async Task WhenGettingMetadata_GivenInvalidFormatParameter_TheServerShouldReturnNotAcceptable()
         {
             FhirException ex = await Assert.ThrowsAsync<FhirException>(async () => await Client.ReadAsync<CapabilityStatement>("metadata?_format=blah"));
             Assert.Equal(HttpStatusCode.NotAcceptable, ex.StatusCode);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/MetadataTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/MetadataTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Net;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
@@ -30,6 +31,14 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             FhirResponse<CapabilityStatement> readAsync = await Client.ReadAsync<CapabilityStatement>("metadata?system=true");
 
             Assert.NotEmpty(readAsync.Resource.Rest);
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task WhenGettingMetadata_GivenInvalidFormatParameter_TheServerShouldThrowNotAcceptableException()
+        {
+            FhirException ex = await Assert.ThrowsAsync<FhirException>(async () => await Client.ReadAsync<CapabilityStatement>("metadata?_format=blah"));
+            Assert.Equal(HttpStatusCode.NotAcceptable, ex.StatusCode);
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/OperationVersionsTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/OperationVersionsTests.cs
@@ -56,12 +56,12 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Theory]
         [InlineData("application/json1")]
         [InlineData("applicaiton/xml")]
-        public async Task WhenVersionsEndpointIsCalled_GivenInvalidAcceptHeaderIsProvided_ThenServerShouldReturnUnsupportedMediaType(string acceptHeaderValue)
+        public async Task WhenVersionsEndpointIsCalled_GivenInvalidAcceptHeaderIsProvided_ThenServerShouldReturnNotAcceptable(string acceptHeaderValue)
         {
             HttpRequestMessage request = GenerateOperationVersionsRequest(acceptHeaderValue);
             HttpResponseMessage response = await _client.SendAsync(request);
 
-            Assert.Equal(HttpStatusCode.UnsupportedMediaType, response.StatusCode);
+            Assert.Equal(HttpStatusCode.NotAcceptable, response.StatusCode);
         }
 
         private async Task CheckContentType(string acceptHeaderValue)


### PR DESCRIPTION
## Description

- The server now returns a 406 Not Acceptable status code if the Accept header or _format parameter requests a format that the server does not support (see [spec](http://hl7.org/fhir/formats.html#wire))
- Previously, a 415 Unsupported Media Type status code was returned
- Note that 415 is still returned for POST requests with an invalid Content-Type header (more info about the scenarios considered can be found [here](https://microsoft-my.sharepoint.com/:x:/g/personal/rotodd_microsoft_com1/EVWfudFyn4JFnT5o5LJrlNMBig2YlTSSbeRb-0WDmj4DVQ?e=giTOZi))

![requesting_invalid_format](https://user-images.githubusercontent.com/54082711/65560411-6dad3d80-def3-11e9-884a-9c16a4a9f447.gif)

## Related issues

- [#AB70307](https://microsofthealth.visualstudio.com/Health/_workitems/edit/70307)
- #649 

## Testing

- Updated old unit tests
- Added new unit tests
- Added new E2E test
