### PR TITLE
Failures in emitting API notifications should not cause the response to fail

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/ApiNotifications/ApiNotificationMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/ApiNotifications/ApiNotificationMiddleware.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Health.Fhir.Api.Features.ApiNotifications
                     catch (Exception e)
                     {
                         // Failures in publishing API notifications should not cause the API to return an error.
-                        _logger.LogError(e, "Failure while publishing API notification.");
+                        _logger.LogCritical(e, "Failure while publishing API notification.");
                     }
                 }
             }


### PR DESCRIPTION
## Description
This PR addresses two issues:

1) There are cases when the FhirRequestContext is not set. We should check for null in those cases and not attempt to publish an API notification.
2) If any errors occur while publishing the notification, they should not cause the API to fail.

## Related issues
Addresses [issue #669].

## Testing
Unit tests were added that replicate the failure case. Verified they failed before the fix and succeed after.
