### PR TITLE
LastUpdated search parameter is now included when performing other searches using SQL

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/SqlRootExpressionRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/SqlRootExpressionRewriter.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
                 }
                 else
                 {
-                    denormalizedPredicates?.Add(expression);
+                    denormalizedPredicates?.Add(childExpression);
                 }
             }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             ValidateSearchEntryMode(bundle, ResourceType.DiagnosticReport);
         }
 
-        [Fact(Skip = "https://github.com/microsoft/fhir-server/issues/563")]
+        [Fact]
         public async Task GivenAnIncludeSearchExpressionWithMultipleDenormalizedParametersAndTableParameters_WhenSearched_ThenCorrectBundleShouldBeReturned()
         {
             var newDiagnosticReportResponse = await Fixture.FhirClient.CreateAsync(
@@ -205,6 +205,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 Fixture.TrumanSnomedObservation);
 
             ValidateSearchEntryMode(bundle, ResourceType.DiagnosticReport);
+
+            await Fixture.FhirClient.DeleteAsync(newDiagnosticReportResponse.Resource);
         }
 
         [Fact]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
@@ -206,6 +206,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
             ValidateSearchEntryMode(bundle, ResourceType.DiagnosticReport);
 
+            // delete the extra entry added
             await Fixture.FhirClient.DeleteAsync(newDiagnosticReportResponse.Resource);
         }
 


### PR DESCRIPTION
## Description
This PR address the issue where when using the SQL search provider, when you search with both a normal parameter and a last updated parameter, the last updated parameter isn't applied to the search

## Related issues
Addresses [issue: https://github.com/microsoft/fhir-server/issues/563].

## Testing
Integration test that was failing due to this bug and was skipped is now running successfully.
