### PR TITLE
Fix cors tests

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/CorsTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/CorsTests.cs
@@ -32,23 +32,24 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Trait(Traits.Priority, Priority.One)]
         public async Task WhenGettingOptions_GivenAppropriateHeaders_TheServerShouldReturnTheAppropriateCorsHeaders()
         {
-            var message = new HttpRequestMessage
-            {
-                Method = HttpMethod.Options,
-            };
+            var message = new HttpRequestMessage(HttpMethod.Options, "patient");
 
             message.Headers.Add(HeaderNames.Origin, "https://localhost:6001");
             message.Headers.Add(HeaderNames.AccessControlRequestMethod, "PUT");
             message.Headers.Add(HeaderNames.AccessControlRequestHeaders, "authorization");
             message.Headers.Add(HeaderNames.AccessControlRequestHeaders, "content-type");
-            message.RequestUri = new Uri(_client.HttpClient.BaseAddress, "/patient");
 
             HttpResponseMessage response = await _client.HttpClient.SendAsync(message);
 
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
             Assert.Contains("https://localhost:6001", response.Headers.GetValues(HeaderNames.AccessControlAllowOrigin));
 
-            Assert.Contains("PUT", response.Headers.GetValues(HeaderNames.AccessControlAllowMethods));
+            var allowMethods = response.Headers.GetValues(HeaderNames.AccessControlAllowMethods);
+#pragma warning disable xUnit2012 // Do not use Enumerable.Any() to check if a value exists in a collection
+
+            // The response can be in a single comma separated string, we want to check that it exists in any of them.
+            Assert.True(allowMethods.Any(x => x.Contains("PUT")));
+#pragma warning restore xUnit2012 // Do not use Enumerable.Any() to check if a value exists in a collection
 
             Assert.Contains("authorization,content-type", response.Headers.GetValues(HeaderNames.AccessControlAllowHeaders));
 


### PR DESCRIPTION
## Description
The CORS E2E test can fail if the base URL of the FHIR server under test has additional path segments.

Additionally, checking for PUT in the 'Access-Control-Allow-Methods' of the response failed if the CORS settings of the FHIR server was not '*' and contained PUT with at least one other method.

## Related issues
Addresses [issue #677 ].

## Testing
Tested under both scenarios above that failed previously.
