### PR TITLE
Add PATCH route and E2E test

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Health.Fhir.Api {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -192,6 +192,15 @@ namespace Microsoft.Health.Fhir.Api {
         public static string PageTitle {
             get {
                 return ResourceManager.GetString("PageTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to PATCH is not currently supported..
+        /// </summary>
+        public static string PatchNotSupported {
+            get {
+                return ResourceManager.GetString("PatchNotSupported", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Health.Fhir.Api/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Api/Resources.resx
@@ -168,6 +168,10 @@
     <value>FHIR Server</value>
     <comment>{NumberedPlaceHolder=”FHIR”}</comment>
   </data>
+  <data name="PatchNotSupported" xml:space="preserve">
+    <value>PATCH is not currently supported.</value>
+    <comment>{NumberedPlaceHolder="PATCH"}</comment>
+  </data>
   <data name="RequireHttpsMetadataError" xml:space="preserve">
     <value>The security configuration requires the authority to be set to an https address.</value>
   </data>

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
@@ -25,6 +25,7 @@ using Microsoft.Health.Fhir.Api.Features.Filters;
 using Microsoft.Health.Fhir.Api.Features.Headers;
 using Microsoft.Health.Fhir.Api.Features.Routing;
 using Microsoft.Health.Fhir.Api.Features.Security;
+using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features;
 using Microsoft.Health.Fhir.Core.Features.Context;
@@ -387,6 +388,22 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             DeleteResourceResponse response = await _mediator.DeleteResourceAsync(new ResourceKey(typeParameter, idParameter), hardDelete, HttpContext.RequestAborted);
 
             return FhirResult.NoContent().SetETagHeader(response.WeakETag);
+        }
+
+        /// <summary>
+        /// Patches the specified resource
+        /// </summary>
+        /// <param name="typeParameter">The type.</param>
+        /// <param name="idParameter">The identifier.</param>
+        [HttpPatch]
+        [Route(KnownRoutes.ResourceTypeById)]
+        [AuditEventType(AuditEventSubType.Patch)]
+        [Authorize(PolicyNames.WritePolicy)]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Controller methods won't be called if static.")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA1801:Review unused parameters", Justification = "Need the parameters for routing to work.")]
+        public Task<IActionResult> Patch(string typeParameter, string idParameter)
+        {
+            throw new MethodNotAllowedException(Resources.PatchNotSupported);
         }
 
         /// <summary>

--- a/src/Microsoft.Health.Fhir.ValueSets/AuditEventSubType.cs
+++ b/src/Microsoft.Health.Fhir.ValueSets/AuditEventSubType.cs
@@ -48,6 +48,8 @@ namespace Microsoft.Health.Fhir.ValueSets
 
         public const string Transaction = "transaction";
 
+        public const string Patch = "patch";
+
         // The spec has an "operation" audit-event-sub-type, but that only refers to an operation
         // that is defined by an OperationDefinition. And export does not fall under that list as
         // of 2019/03/19. So we have to use our own sub-type.

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E.Common/FhirClient.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E.Common/FhirClient.cs
@@ -217,6 +217,21 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Common
             return DeleteAsync($"{resource.ResourceType}/{resource.Id}?hardDelete=true");
         }
 
+        public async Task<FhirResponse> PatchAsync(string uri, string content)
+        {
+            var message = new HttpRequestMessage(HttpMethod.Patch, uri)
+            {
+                Content = new StringContent(content),
+            };
+            message.Headers.Accept.Add(_mediaType);
+
+            HttpResponseMessage response = await HttpClient.SendAsync(message);
+
+            await EnsureSuccessStatusCodeAsync(response);
+
+            return new FhirResponse(response);
+        }
+
         public Task<FhirResponse<Bundle>> SearchAsync(ResourceType resourceType, string query = null, int? count = null)
         {
             StringBuilder sb = new StringBuilder();

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Microsoft.Health.Fhir.Shared.Tests.E2E.projitems
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Microsoft.Health.Fhir.Shared.Tests.E2E.projitems
@@ -34,6 +34,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rest\InProcTestFhirServer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\MetadataTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\OperationVersionsTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rest\PatchTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\ReadTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\RemoteTestFhirServer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\Search\BasicSearchTests.cs" />

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/PatchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/PatchTests.cs
@@ -1,0 +1,34 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Net;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Microsoft.Health.Fhir.Tests.E2E.Common;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Fhir.Tests.E2E.Rest
+{
+    [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.All)]
+    public class PatchTests : IClassFixture<HttpIntegrationTestFixture>
+    {
+        public PatchTests(HttpIntegrationTestFixture fixture)
+        {
+            Client = fixture.FhirClient;
+        }
+
+        protected FhirClient Client { get; set; }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task WhenSubmittingAPatch_GivenAServerThatDoesNotSupportIt_ThenMethodNotAllowedIsReturned()
+        {
+            FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.PatchAsync("Patient/1234", "patch content"));
+
+            Assert.Equal(HttpStatusCode.MethodNotAllowed, ex.StatusCode);
+        }
+    }
+}


### PR DESCRIPTION
## Description
Adds a `PATCH` route that returns a 405 status code and an operation outcome that says patch is not supported. 

## Related issues
Addresses [AB#70318](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/70318).

## Testing
An E2E test was added to make sure a patch request returns the appropriate status code.
