### PR TITLE
Make bundle sub requests have correct audit info.

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
@@ -16,12 +16,14 @@ using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using MediatR;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Http.Features.Authentication;
 using Microsoft.AspNetCore.Http.Headers;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Health.Fhir.Api.Features.ContentTypes;
 using Microsoft.Health.Fhir.Api.Features.Headers;
+using Microsoft.Health.Fhir.Api.Features.Routing;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Context;
@@ -97,6 +99,8 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                 httpContext.Response.Body = new MemoryStream();
 
                 var requestUri = new Uri(_fhirRequestContextAccessor.FhirRequestContext.BaseUri, entry.Request.Url);
+                httpContext.Request.Scheme = requestUri.Scheme;
+                httpContext.Request.Host = new HostString(requestUri.Host, requestUri.Port);
                 httpContext.Request.Path = requestUri.LocalPath;
                 httpContext.Request.QueryString = new QueryString(requestUri.Query);
                 httpContext.Request.Method = entry.Request.Method.ToString();
@@ -146,6 +150,23 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                 if (request.Handler != null)
                 {
                     HttpContext httpContext = request.HttpContext;
+
+                    IFhirRequestContext originalFhirRequestContext = _fhirRequestContextAccessor.FhirRequestContext;
+
+                    request.RouteData.Values.TryGetValue(KnownActionParameterNames.ResourceType, out object resourceType);
+                    var newFhirRequestContext = new FhirRequestContext(
+                        httpContext.Request.Method,
+                        httpContext.Request.GetDisplayUrl(),
+                        originalFhirRequestContext.BaseUri.OriginalString,
+                        originalFhirRequestContext.CorrelationId,
+                        httpContext.Request.Headers,
+                        httpContext.Response.Headers,
+                        resourceType?.ToString())
+                    {
+                        Principal = originalFhirRequestContext.Principal,
+                    };
+                    _fhirRequestContextAccessor.FhirRequestContext = newFhirRequestContext;
+
                     await request.Handler.Invoke(httpContext);
 
                     httpContext.Response.Body.Seek(0, SeekOrigin.Begin);


### PR DESCRIPTION
## Description
Updates the bundle handler to set a new `FhirRequestContext` per sub request. This allows the audit logger to emit the correct information in the audit log including what the URL request would be if the call was made directly.

## Related issues
Addresses [AB#70317](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/70317)

## Testing
Manually tested. 
