### PR TITLE
Added null check for missing scopes

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Controllers/AadSmartOnFhirProxyController.cs
+++ b/src/Microsoft.Health.Fhir.Api/Controllers/AadSmartOnFhirProxyController.cs
@@ -389,23 +389,27 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             tokenResponse["client_id"] = clientId;
 
             // Replace fully qualifies scopes with short scopes and replace $
-            string[] scopes = tokenResponse["scope"].ToString().Split(' ');
-            var scopesBuilder = new StringBuilder();
+            string[] scopes = tokenResponse["scope"]?.ToString().Split(' ');
 
-            foreach (var s in scopes)
+            if (scopes != null)
             {
-                if (IsAbsoluteUrl(s))
-                {
-                    var scopeUri = new Uri(s);
-                    scopesBuilder.Append($"{scopeUri.Segments.Last().Replace('$', '/')} ");
-                }
-                else
-                {
-                    scopesBuilder.Append($"{s.Replace('$', '/')} ");
-                }
-            }
+                var scopesBuilder = new StringBuilder();
 
-            tokenResponse["scope"] = scopesBuilder.ToString().TrimEnd(' ');
+                foreach (var s in scopes)
+                {
+                    if (IsAbsoluteUrl(s))
+                    {
+                        var scopeUri = new Uri(s);
+                        scopesBuilder.Append($"{scopeUri.Segments.Last().Replace('$', '/')} ");
+                    }
+                    else
+                    {
+                        scopesBuilder.Append($"{s.Replace('$', '/')} ");
+                    }
+                }
+
+                tokenResponse["scope"] = scopesBuilder.ToString().TrimEnd(' ');
+            }
 
             return new ContentResult()
             {

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/AadSmartOnFhirProxyControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/AadSmartOnFhirProxyControllerTests.cs
@@ -199,7 +199,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
         {
             const string grantType = "authorization_code";
             const string clientId = "1234";
-            const string clientSecret = "XYZ";
+            const string clientStringPlaceHolder = "XYZ";
             const string compoundCode = "eyAiY29kZSIgOiAiZm9vIiB9";
             Uri redirectUri = new Uri("https://localhost");
 
@@ -218,7 +218,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
                 Content = new StringContent(content.ToString(Formatting.None)),
             };
 
-            var result = _controller.Token(grantType, compoundCode, redirectUri, clientId, clientSecret).Result as ContentResult;
+            var result = _controller.Token(grantType, compoundCode, redirectUri, clientId, clientStringPlaceHolder).Result as ContentResult;
             Assert.NotNull(result);
 
             var resultJson = JObject.Parse(result.Content);


### PR DESCRIPTION
## Description
Adds check for null when no scopes are returned in SMART on FHIR proxy token endpoint.

## Related issues
Addresses #703.