### PR TITLE
add configuration option for database creation

### DIFF
--- a/src/Microsoft.Health.Fhir.R4.Web/Properties/launchSettings.json
+++ b/src/Microsoft.Health.Fhir.R4.Web/Properties/launchSettings.json
@@ -16,6 +16,7 @@
             "environmentVariables": {
                 "SqlServer:ConnectionString": "server=(local);Initial Catalog=FHIR_R4;Integrated Security=true",
                 "SqlServer:Initialize": "true",
+                "SqlServer:AllowDatabaseCreation": "true",
                 "TestAuthEnvironment:FilePath": "..//..//testauthenvironment.json",
                 "DataStore": "SqlServer",
                 "ASPNETCORE_ENVIRONMENT": "development"

--- a/src/Microsoft.Health.Fhir.SqlServer/Configs/SqlServerDataStoreConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Configs/SqlServerDataStoreConfiguration.cs
@@ -23,6 +23,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Configs
         /// <summary>
         /// Allows the experimental schema initializer to attempt to create the database if not present.
         /// </summary>
-        public bool EnsureDatabase { get; set; }
+        public bool AllowDatabaseCreation { get; set; }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Configs/SqlServerDataStoreConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Configs/SqlServerDataStoreConfiguration.cs
@@ -19,5 +19,10 @@ namespace Microsoft.Health.Fhir.SqlServer.Configs
         /// If set, this applies schema 1 which resets all the data in the database. This is temporary until the schema migration tool is complete.
         /// </summary>
         public bool DeleteAllDataOnStartup { get; set; }
+
+        /// <summary>
+        /// Allows the experimental schema initializer to attempt to create the database if not present.
+        /// </summary>
+        public bool EnsureDatabase { get; set; }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaInitializer.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaInitializer.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema
                 throw new InvalidOperationException("The initial catalog in the connection string cannot be a system database");
             }
 
-            if (_sqlServerDataStoreConfiguration.EnsureDatabase)
+            if (_sqlServerDataStoreConfiguration.AllowDatabaseCreation)
             {
                 // connect to master database to evaluate if the requested database exists
                 var masterConnectionBuilder = new SqlConnectionStringBuilder(_sqlServerDataStoreConfiguration.ConnectionString) { InitialCatalog = string.Empty };

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaInitializer.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaInitializer.cs
@@ -129,36 +129,39 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema
                 throw new InvalidOperationException("The initial catalog in the connection string cannot be a system database");
             }
 
-            // connect to master database to evaluate if the requested database exists
-            var masterConnectionBuilder = new SqlConnectionStringBuilder(_sqlServerDataStoreConfiguration.ConnectionString) { InitialCatalog = string.Empty };
-            using (var connection = new SqlConnection(masterConnectionBuilder.ToString()))
+            if (_sqlServerDataStoreConfiguration.EnsureDatabase)
             {
-                connection.Open();
-
-                using (var checkDatabaseExistsCommand = connection.CreateCommand())
+                // connect to master database to evaluate if the requested database exists
+                var masterConnectionBuilder = new SqlConnectionStringBuilder(_sqlServerDataStoreConfiguration.ConnectionString) { InitialCatalog = string.Empty };
+                using (var connection = new SqlConnection(masterConnectionBuilder.ToString()))
                 {
-                    checkDatabaseExistsCommand.CommandText = "SELECT 1 FROM sys.databases where name = @databaseName";
-                    checkDatabaseExistsCommand.Parameters.AddWithValue("@databaseName", databaseName);
-                    bool exists = (int?)checkDatabaseExistsCommand.ExecuteScalar() == 1;
+                    connection.Open();
 
-                    if (!exists)
+                    using (var checkDatabaseExistsCommand = connection.CreateCommand())
                     {
-                        _logger.LogInformation("Database does not exist");
+                        checkDatabaseExistsCommand.CommandText = "SELECT 1 FROM sys.databases where name = @databaseName";
+                        checkDatabaseExistsCommand.Parameters.AddWithValue("@databaseName", databaseName);
+                        bool exists = (int?)checkDatabaseExistsCommand.ExecuteScalar() == 1;
 
-                        using (var canCreateDatabaseCommand = new SqlCommand("SELECT count(*) FROM fn_my_permissions (NULL, 'DATABASE') WHERE permission_name = 'CREATE DATABASE'", connection))
+                        if (!exists)
                         {
-                            if ((int)canCreateDatabaseCommand.ExecuteScalar() > 0)
+                            _logger.LogInformation("Database does not exist");
+
+                            using (var canCreateDatabaseCommand = new SqlCommand("SELECT count(*) FROM fn_my_permissions (NULL, 'DATABASE') WHERE permission_name = 'CREATE DATABASE'", connection))
                             {
-                                using (var createDatabaseCommand = new SqlCommand($"CREATE DATABASE {databaseName}", connection))
+                                if ((int)canCreateDatabaseCommand.ExecuteScalar() > 0)
                                 {
-                                    createDatabaseCommand.ExecuteNonQuery();
-                                    _logger.LogInformation("Created database");
+                                    using (var createDatabaseCommand = new SqlCommand($"CREATE DATABASE {databaseName}", connection))
+                                    {
+                                        createDatabaseCommand.ExecuteNonQuery();
+                                        _logger.LogInformation("Created database");
+                                    }
                                 }
-                            }
-                            else
-                            {
-                                _logger.LogWarning("Insufficient permissions to create the database");
-                                return false;
+                                else
+                                {
+                                    _logger.LogWarning("Insufficient permissions to create the database");
+                                    return false;
+                                }
                             }
                         }
                     }

--- a/src/Microsoft.Health.Fhir.Stu3.Web/Properties/launchSettings.json
+++ b/src/Microsoft.Health.Fhir.Stu3.Web/Properties/launchSettings.json
@@ -14,6 +14,7 @@
       "environmentVariables": {
         "SqlServer:ConnectionString": "server=(local);Initial Catalog=FHIR_STU3;Integrated Security=true",
         "SqlServer:Initialize": "true",
+        "SqlServer:AllowDatabaseCreation": "true",
         "TestAuthEnvironment:FilePath": "..//..//testauthenvironment.json",
         "DataStore": "SqlServer",
         "ASPNETCORE_ENVIRONMENT": "development"


### PR DESCRIPTION
## Description
Adds a configuration option whether to create or not the SQL database (if not already present).
  
This allows support of the following scenario:
When using a connection string that specifies a contained database user, the initial catalog must be specified

[To connect as a contained database user, the connection string must always contain a parameter for the user database so that the Database Engine knows which database is responsible for managing the authentication process.](https://docs.microsoft.com/en-us/sql/relational-databases/security/contained-database-users-making-your-database-portable?view=sql-server-ver15)

## Related issues


## Testing
Manually tested
