### PR TITLE
Fixes _total parameter for multiple-paged search results

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
 
             if (searchOptions.IncludeTotal == TotalType.Accurate && !searchOptions.CountOnly)
             {
-                // TODO: Clone search options instead of mutating it.
+                // TODO: Clone search options instead of mutating it (see User Story #720).
                 searchOptions.CountOnly = true;
 
                 var totalSearchResult = await ExecuteSearchAsync(

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
             {
                 EnableCrossPartitionQuery = true,
                 MaxItemCount = searchOptions.MaxItemCount,
-                RequestContinuation = searchOptions.ContinuationToken,
+                RequestContinuation = calculateTotalCount ? null : searchOptions.ContinuationToken,
             };
 
             if (searchOptions.CountOnly || calculateTotalCount)

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
@@ -47,11 +47,13 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
 
             if (searchOptions.IncludeTotal == TotalType.Accurate && !searchOptions.CountOnly)
             {
+                // TODO: Clone search options instead of mutating it.
+                searchOptions.CountOnly = true;
+
                 var totalSearchResult = await ExecuteSearchAsync(
-                    _queryBuilder.BuildSqlQuerySpec(searchOptions, true),
+                    _queryBuilder.BuildSqlQuerySpec(searchOptions),
                     searchOptions,
-                    cancellationToken,
-                    true);
+                    cancellationToken);
 
                 searchResult.TotalCount = totalSearchResult.TotalCount;
             }
@@ -72,17 +74,16 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
         private async Task<SearchResult> ExecuteSearchAsync(
             SqlQuerySpec sqlQuerySpec,
             SearchOptions searchOptions,
-            CancellationToken cancellationToken,
-            bool calculateTotalCount = false)
+            CancellationToken cancellationToken)
         {
             var feedOptions = new FeedOptions
             {
                 EnableCrossPartitionQuery = true,
                 MaxItemCount = searchOptions.MaxItemCount,
-                RequestContinuation = calculateTotalCount ? null : searchOptions.ContinuationToken,
+                RequestContinuation = searchOptions.CountOnly ? null : searchOptions.ContinuationToken,
             };
 
-            if (searchOptions.CountOnly || calculateTotalCount)
+            if (searchOptions.CountOnly)
             {
                 return new SearchResult(
                     (await _fhirDataStore.ExecuteDocumentQueryAsync<int>(sqlQuerySpec, feedOptions, cancellationToken)).Single(),

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/IQueryBuilder.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/IQueryBuilder.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries
 {
     public interface IQueryBuilder
     {
-        SqlQuerySpec BuildSqlQuerySpec(SearchOptions searchOptions, bool calculateTotalCount = false);
+        SqlQuerySpec BuildSqlQuerySpec(SearchOptions searchOptions);
 
         SqlQuerySpec GenerateHistorySql(SearchOptions searchOptions);
     }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/QueryBuilder.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/QueryBuilder.cs
@@ -15,9 +15,9 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries
 {
     public class QueryBuilder : IQueryBuilder
     {
-        public SqlQuerySpec BuildSqlQuerySpec(SearchOptions searchOptions, bool calculateTotalCount = false)
+        public SqlQuerySpec BuildSqlQuerySpec(SearchOptions searchOptions)
         {
-            return new QueryBuilderHelper().BuildSqlQuerySpec(searchOptions, calculateTotalCount);
+            return new QueryBuilderHelper().BuildSqlQuerySpec(searchOptions);
         }
 
         public SqlQuerySpec GenerateHistorySql(SearchOptions searchOptions)
@@ -38,11 +38,11 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries
                 _queryHelper = new QueryHelper(_queryBuilder, _queryParameterManager, SearchValueConstants.RootAliasName);
             }
 
-            public SqlQuerySpec BuildSqlQuerySpec(SearchOptions searchOptions, bool calculateTotalCount = false)
+            public SqlQuerySpec BuildSqlQuerySpec(SearchOptions searchOptions)
             {
                 EnsureArg.IsNotNull(searchOptions, nameof(searchOptions));
 
-                if (searchOptions.CountOnly || calculateTotalCount)
+                if (searchOptions.CountOnly)
                 {
                     AppendSelectFromRoot("VALUE COUNT(1)");
                 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -18,11 +18,10 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
         private string _cteMainSelect; // This is represents the CTE that is the main selector for use with includes
         private List<string> _includeCtes;
         private readonly bool _isHistorySearch;
-        private readonly bool _calculateTotalCount;
         private int _tableExpressionCounter = -1;
         private SqlRootExpression _rootExpression;
 
-        public SqlQueryGenerator(IndentedStringBuilder sb, SqlQueryParameterManager parameters, SqlServerFhirModel model, bool isHistorySearch, bool calculateTotalCount)
+        public SqlQueryGenerator(IndentedStringBuilder sb, SqlQueryParameterManager parameters, SqlServerFhirModel model, bool isHistorySearch)
         {
             EnsureArg.IsNotNull(sb, nameof(sb));
             EnsureArg.IsNotNull(parameters, nameof(parameters));
@@ -32,7 +31,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             Parameters = parameters;
             Model = model;
             _isHistorySearch = isHistorySearch;
-            _calculateTotalCount = calculateTotalCount;
         }
 
         public IndentedStringBuilder StringBuilder { get; }
@@ -71,7 +69,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
             string resourceTableAlias = "r";
 
-            if (searchOptions.CountOnly || _calculateTotalCount)
+            if (searchOptions.CountOnly)
             {
                 StringBuilder.AppendLine("SELECT COUNT(DISTINCT ").Append(V1.Resource.ResourceSurrogateId, resourceTableAlias).Append(")");
             }
@@ -120,7 +118,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                 }
             }
 
-            if (!searchOptions.CountOnly && !_calculateTotalCount)
+            if (!searchOptions.CountOnly)
             {
                 StringBuilder.Append("ORDER BY ").Append(V1.Resource.ResourceSurrogateId, resourceTableAlias).AppendLine(" ASC");
             }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                     {
                         searchResult = await SearchImpl(searchOptions, false, connection, cancellationToken, transaction);
 
-                        // TODO: Clone search options instead of mutating it.
+                        // TODO: Clone search options instead of mutating it (see User Story #720).
                         searchOptions.CountOnly = true;
 
                         // Perform a second read to get the count.

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -83,8 +83,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                     {
                         searchResult = await SearchImpl(searchOptions, false, connection, cancellationToken, transaction);
 
+                        // TODO: Clone search options instead of mutating it.
+                        searchOptions.CountOnly = true;
+
                         // Perform a second read to get the count.
-                        var countOnlySearchResult = await SearchImpl(searchOptions, false, connection, cancellationToken, transaction, true);
+                        var countOnlySearchResult = await SearchImpl(searchOptions, false, connection, cancellationToken, transaction);
 
                         searchResult.TotalCount = countOnlySearchResult.TotalCount;
 
@@ -110,14 +113,14 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
             }
         }
 
-        private async Task<SearchResult> SearchImpl(SearchOptions searchOptions, bool historySearch, SqlConnection connection, CancellationToken cancellationToken, SqlTransaction transaction = null, bool calculateTotalCount = false)
+        private async Task<SearchResult> SearchImpl(SearchOptions searchOptions, bool historySearch, SqlConnection connection, CancellationToken cancellationToken, SqlTransaction transaction = null)
         {
             await _model.EnsureInitialized();
 
             Expression searchExpression = searchOptions.Expression;
 
             // AND in the continuation token
-            if (!string.IsNullOrWhiteSpace(searchOptions.ContinuationToken) && !calculateTotalCount)
+            if (!string.IsNullOrWhiteSpace(searchOptions.ContinuationToken) && !searchOptions.CountOnly)
             {
                 if (long.TryParse(searchOptions.ContinuationToken, NumberStyles.None, CultureInfo.InvariantCulture, out var token))
                 {
@@ -160,7 +163,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
 
                 EnableTimeAndIoMessageLogging(stringBuilder, connection);
 
-                var queryGenerator = new SqlQueryGenerator(stringBuilder, new SqlQueryParameterManager(sqlCommand.Parameters), _model, historySearch, calculateTotalCount);
+                var queryGenerator = new SqlQueryGenerator(stringBuilder, new SqlQueryParameterManager(sqlCommand.Parameters), _model, historySearch);
 
                 expression.AcceptVisitor(queryGenerator, searchOptions);
 
@@ -170,7 +173,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
 
                 using (var reader = await sqlCommand.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken))
                 {
-                    if (searchOptions.CountOnly || calculateTotalCount)
+                    if (searchOptions.CountOnly)
                     {
                         await reader.ReadAsync(cancellationToken);
                         return new SearchResult(reader.GetInt32(0), searchOptions.UnsupportedSearchParams);

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
             Expression searchExpression = searchOptions.Expression;
 
             // AND in the continuation token
-            if (!string.IsNullOrWhiteSpace(searchOptions.ContinuationToken))
+            if (!string.IsNullOrWhiteSpace(searchOptions.ContinuationToken) && !calculateTotalCount)
             {
                 if (long.TryParse(searchOptions.ContinuationToken, NumberStyles.None, CultureInfo.InvariantCulture, out var token))
                 {


### PR DESCRIPTION
## Description

- Fixes the[ _total parameter](https://www.hl7.org/fhir/search.html#total) value on search result pages greater than the first page
- Previous behavior:
  - In SQL: the _total parameter returned incorrect counts when search results spanned multiple pages
  - In Cosmos: an exception was thrown when the second page of search results was requested and _total was set to accurate
- Note: there are plans to clone the SearchOptions object (instead of mutating it) in [#AB70913](https://microsofthealth.visualstudio.com/Health/_workitems/edit/70913)

![total-paging](https://user-images.githubusercontent.com/54082711/68145980-d7a20500-feeb-11e9-8a25-d8e7850da2d6.gif)

## Related issues
Addresses [#AB70884](https://microsofthealth.visualstudio.com/Health/_workitems/edit/70884) and #715.

## Testing

- Adds a new E2E test to check this behavior
- Updates other E2E tests
