### PR TITLE
Returns error on invalid _pretty parameter input

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Health.Fhir.Api {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -327,6 +327,15 @@ namespace Microsoft.Health.Fhir.Api {
         public static string UnsupportedParameterValue {
             get {
                 return ResourceManager.GetString("UnsupportedParameterValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The requested &quot;_pretty&quot; parameter is not supported..
+        /// </summary>
+        public static string UnsupportedPrettyParameter {
+            get {
+                return ResourceManager.GetString("UnsupportedPrettyParameter", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
@@ -124,6 +124,15 @@ namespace Microsoft.Health.Fhir.Api {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The requested &quot;_pretty&quot; parameter is invalid..
+        /// </summary>
+        public static string InvalidPrettyParameter {
+            get {
+                return ResourceManager.GetString("InvalidPrettyParameter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Provided value for redirect Uri: {0} is not a valid Uri..
         /// </summary>
         public static string InvalidRedirectUri {
@@ -327,15 +336,6 @@ namespace Microsoft.Health.Fhir.Api {
         public static string UnsupportedParameterValue {
             get {
                 return ResourceManager.GetString("UnsupportedParameterValue", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The requested &quot;_pretty&quot; parameter is not supported..
-        /// </summary>
-        public static string UnsupportedPrettyParameter {
-            get {
-                return ResourceManager.GetString("UnsupportedPrettyParameter", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Health.Fhir.Api/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Api/Resources.resx
@@ -139,6 +139,10 @@
   <data name="InvalidLaunchContext" xml:space="preserve">
     <value>Invalid launch context parameters.</value>
   </data>
+  <data name="InvalidPrettyParameter" xml:space="preserve">
+    <value>The requested "_pretty" parameter is invalid.</value>
+    <comment>{NumberedPlaceHolder="_pretty"}</comment>
+  </data>
   <data name="InvalidRedirectUri" xml:space="preserve">
     <value>Provided value for redirect Uri: {0} is not a valid Uri.</value>
     <comment>{0} is a parameter passed in for redirection.</comment>
@@ -218,9 +222,6 @@
   <data name="UnsupportedParameterValue" xml:space="preserve">
     <value>The supplied value for "{0}" paramter is invalid.</value>
     <comment>{0} is parameter name</comment>
-  </data>
-  <data name="UnsupportedPrettyParameter" xml:space="preserve">
-    <value>The requested "_pretty" parameter is not supported.</value>
   </data>
   <data name="UnsupportedResourceType" xml:space="preserve">
     <value>Requested operation does not support resource type: {0}.</value>

--- a/src/Microsoft.Health.Fhir.Api/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Api/Resources.resx
@@ -219,6 +219,9 @@
     <value>The supplied value for "{0}" paramter is invalid.</value>
     <comment>{0} is parameter name</comment>
   </data>
+  <data name="UnsupportedPrettyParameter" xml:space="preserve">
+    <value>The requested "_pretty" parameter is not supported.</value>
+  </data>
   <data name="UnsupportedResourceType" xml:space="preserve">
     <value>Requested operation does not support resource type: {0}.</value>
     <comment>{0} is the resource type.</comment>

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/ContentTypes/ContentTypeService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/ContentTypes/ContentTypeService.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Health.Fhir.Api.Features.ContentTypes
 
             string prettyParameterValue = GetParameterValueFromQueryString(httpContext, KnownQueryParameterNames.Pretty);
 
-            if (prettyParameterValue != null && !bool.TryParse(prettyParameterValue, out bool isPretty))
+            if (prettyParameterValue != null && !bool.TryParse(prettyParameterValue, out _))
             {
                 throw new BadRequestException(Api.Resources.UnsupportedPrettyParameter);
             }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/ContentTypes/ContentTypeService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/ContentTypes/ContentTypeService.cs
@@ -18,6 +18,7 @@ using Microsoft.Health.Fhir.Api.Features.Formatters;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Features;
 using Microsoft.Health.Fhir.Core.Features.Conformance;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Net.Http.Headers;
 using Task = System.Threading.Tasks.Task;
@@ -87,7 +88,7 @@ namespace Microsoft.Health.Fhir.Api.Features.ContentTypes
 
             if (prettyParameterValue != null && !bool.TryParse(prettyParameterValue, out bool isPretty))
             {
-                throw new NotAcceptableException(Api.Resources.UnsupportedPrettyParameter);
+                throw new BadRequestException(Api.Resources.UnsupportedPrettyParameter);
             }
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/ContentTypes/ContentTypeService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/ContentTypes/ContentTypeService.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Health.Fhir.Api.Features.ContentTypes
 
             if (prettyParameterValue != null && !bool.TryParse(prettyParameterValue, out _))
             {
-                throw new BadRequestException(Api.Resources.UnsupportedPrettyParameter);
+                throw new BadRequestException(Api.Resources.InvalidPrettyParameter);
             }
         }
 
@@ -96,7 +96,7 @@ namespace Microsoft.Health.Fhir.Api.Features.ContentTypes
         {
             EnsureArg.IsNotNull(context, nameof(context));
 
-            // If executing in a rethrown error context, ensure we carry the specified formatting.
+            // If executing in a rethrown error context, ensure we carry the specified query string value.
             var previous = context.Features.Get<IStatusCodeReExecuteFeature>()?.OriginalQueryString;
             var previousQuery = QueryHelpers.ParseNullableQuery(previous);
 

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Formatters/HttpContextExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Formatters/HttpContextExtensions.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Formatters
             {
                 if (!bool.TryParse(query, out bool isPretty))
                 {
-                    // Assume no pretty formatting if parameter can't be parsed.
+                    // ContentTypeService validates the _pretty parameter. This is reached if other errors are encountered when parsing the query string.
                     isPretty = default;
                 }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/MetadataTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/MetadataTests.cs
@@ -31,5 +31,17 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             FhirException ex = await Assert.ThrowsAsync<FhirException>(async () => await Client.ReadAsync<CapabilityStatement>("metadata?_format=blah"));
             Assert.Equal(HttpStatusCode.NotAcceptable, ex.StatusCode);
         }
+
+        [Theory]
+        [InlineData("abc")]
+        [InlineData("")]
+        [InlineData("1")]
+        [InlineData("0")]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task WhenGettingMetadata_GivenInvalidPrettyParameter_TheServerShouldReturnNotAcceptable(string value)
+        {
+            FhirException ex = await Assert.ThrowsAsync<FhirException>(async () => await Client.ReadAsync<CapabilityStatement>($"metadata?_pretty={value}"));
+            Assert.Equal(HttpStatusCode.NotAcceptable, ex.StatusCode);
+        }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/MetadataTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/MetadataTests.cs
@@ -38,10 +38,10 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [InlineData("1")]
         [InlineData("0")]
         [Trait(Traits.Priority, Priority.One)]
-        public async Task WhenGettingMetadata_GivenInvalidPrettyParameter_TheServerShouldReturnNotAcceptable(string value)
+        public async Task WhenGettingMetadata_GivenInvalidPrettyParameter_TheServerShouldReturnBadRequest(string value)
         {
             FhirException ex = await Assert.ThrowsAsync<FhirException>(async () => await Client.ReadAsync<CapabilityStatement>($"metadata?_pretty={value}"));
-            Assert.Equal(HttpStatusCode.NotAcceptable, ex.StatusCode);
+            Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
         }
     }
 }


### PR DESCRIPTION
## Description
- Returns 400 Bad Request when an invalid [_pretty parameter](https://www.hl7.org/fhir/http.html#parameters) is passed in (previously, the default value of false was assumed)

![invalid-pretty](https://user-images.githubusercontent.com/54082711/68257607-b70ba500-ffe8-11e9-9508-7c7855ec6214.png)

## Related issues
Addresses [#AB70807](https://microsofthealth.visualstudio.com/Health/_workitems/edit/70807).

## Testing
Adds a new e2e test.