### PR TITLE
Refactors _total parameter implementation to reset search options to its original state

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
                         _queryBuilder.BuildSqlQuerySpec(searchOptions),
                         searchOptions,
                         cancellationToken);
-                    
+
                     searchResult.TotalCount = totalSearchResult.TotalCount;
                 }
                 finally

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
@@ -45,15 +45,22 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
 
             if (searchOptions.IncludeTotal == TotalType.Accurate && !searchOptions.CountOnly)
             {
-                // TODO: Clone search options instead of mutating it (see User Story #720).
-                searchOptions.CountOnly = true;
+                try
+                {
+                    searchOptions.CountOnly = true;
 
-                var totalSearchResult = await ExecuteSearchAsync(
-                    _queryBuilder.BuildSqlQuerySpec(searchOptions),
-                    searchOptions,
-                    cancellationToken);
-
-                searchResult.TotalCount = totalSearchResult.TotalCount;
+                    var totalSearchResult = await ExecuteSearchAsync(
+                        _queryBuilder.BuildSqlQuerySpec(searchOptions),
+                        searchOptions,
+                        cancellationToken);
+                    
+                    searchResult.TotalCount = totalSearchResult.TotalCount;
+                }
+                finally
+                {
+                    // Reset search options to its original state.
+                    searchOptions.CountOnly = false;
+                }
             }
 
             return searchResult;

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -88,16 +88,16 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
 
                             // Perform a second read to get the count.
                             var countOnlySearchResult = await SearchImpl(searchOptions, false, connection, cancellationToken, transaction);
-                            
+
                             searchResult.TotalCount = countOnlySearchResult.TotalCount;
+
+                            transaction.Commit();
                         }
                         finally
                         {
                             // Reset search options to its original state.
                             searchOptions.CountOnly = false;
                         }
-
-                        transaction.Commit();
                     }
                 }
                 else

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -80,15 +80,22 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                     // Begin a transaction so we can perform two atomic reads.
                     using (var transaction = connection.BeginTransaction(IsolationLevel.ReadCommitted))
                     {
-                        searchResult = await SearchImpl(searchOptions, false, connection, cancellationToken, transaction);
+                        try
+                        {
+                            searchResult = await SearchImpl(searchOptions, false, connection, cancellationToken, transaction);
 
-                        // TODO: Clone search options instead of mutating it (see User Story #720).
-                        searchOptions.CountOnly = true;
+                            searchOptions.CountOnly = true;
 
-                        // Perform a second read to get the count.
-                        var countOnlySearchResult = await SearchImpl(searchOptions, false, connection, cancellationToken, transaction);
-
-                        searchResult.TotalCount = countOnlySearchResult.TotalCount;
+                            // Perform a second read to get the count.
+                            var countOnlySearchResult = await SearchImpl(searchOptions, false, connection, cancellationToken, transaction);
+                            
+                            searchResult.TotalCount = countOnlySearchResult.TotalCount;
+                        }
+                        finally
+                        {
+                            // Reset search options to its original state.
+                            searchOptions.CountOnly = false;
+                        }
 
                         transaction.Commit();
                     }


### PR DESCRIPTION
## Description
- Returns the SearchOptions object to its original state if it is modified for a query where `_total=accurate`

## Related issues
Addresses #729 and [#AB71063](https://microsofthealth.visualstudio.com/Health/_workitems/edit/71063).
