### PR TITLE
Health check returns healthy when cosmos reports a 429 (too many requests)

### DIFF
--- a/src/Microsoft.Health.CosmosDb/Features/Health/CosmosHealthCheck.cs
+++ b/src/Microsoft.Health.CosmosDb/Features/Health/CosmosHealthCheck.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
@@ -11,6 +12,7 @@ using Microsoft.Azure.Documents;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Health.Abstractions.Exceptions;
 using Microsoft.Health.CosmosDb.Configs;
 using Microsoft.Health.CosmosDb.Features.Storage;
 using Microsoft.Health.Extensions.DependencyInjection;
@@ -65,6 +67,10 @@ namespace Microsoft.Health.CosmosDb.Features.Health
                 await _testProvider.PerformTest(_documentClient.Value, _configuration, _cosmosCollectionConfiguration);
 
                 return HealthCheckResult.Healthy("Successfully connected to the data store.");
+            }
+            catch (RequestRateExceededException)
+            {
+                return HealthCheckResult.Healthy("Connection to the data store was successful, however, the rate limit has been exceeded.");
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Description
Reports the instance as "healthy" even when a cosmosdb has reached a rate limit

## Related issues
Addresses [AB#71054](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/71054).

## Testing
Added unit test
Manually tested
