### PR TITLE
Optimizes _total parameter counting

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Routing/UrlResolver.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Routing/UrlResolver.cs
@@ -134,7 +134,6 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
                     if (string.Equals(searchParam.Key, KnownQueryParameterNames.Total, StringComparison.OrdinalIgnoreCase) && removeTotalParameter)
                     {
                         // Don't add the _total parameter to the route values.
-                        // TODO: Check how this impacts multiple parameters with the same name?
                         continue;
                     }
 

--- a/src/Microsoft.Health.Fhir.Api/Features/Routing/UrlResolver.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Routing/UrlResolver.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
             return new Uri(uriString);
         }
 
-        public Uri ResolveRouteUrl(IEnumerable<Tuple<string, string>> unsupportedSearchParams = null, IReadOnlyList<(string parameterName, string reason)> unsupportedSortingParameters = null, string continuationToken = null)
+        public Uri ResolveRouteUrl(IEnumerable<Tuple<string, string>> unsupportedSearchParams = null, IReadOnlyList<(string parameterName, string reason)> unsupportedSortingParameters = null, string continuationToken = null, bool removeTotalParameter = false)
         {
             string routeName = _fhirRequestContextAccessor.FhirRequestContext.RouteName;
 
@@ -130,8 +130,15 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
                 foreach (KeyValuePair<string, StringValues> searchParam in Request.Query)
                 {
                     // Remove the parameter if:
-                    // 1. It is the _sort parameter and the parameter is not supported for sorting
-                    // 2. The parameter is not supported.
+                    // 1. It is the _total parameter, since we only want to count for the first page of results.
+                    if (string.Equals(searchParam.Key, KnownQueryParameterNames.Total, StringComparison.OrdinalIgnoreCase) && removeTotalParameter)
+                    {
+                        // Don't add the _total parameter to the route values.
+                        // TODO: Check how this impacts multiple parameters with the same name?
+                        continue;
+                    }
+
+                    // 2. It is the _sort parameter and the parameter is not supported for sorting.
                     if (unsupportedSortingParameters?.Count > 0 && string.Equals(searchParam.Key, KnownQueryParameterNames.Sort, StringComparison.OrdinalIgnoreCase))
                     {
                         var filteredValues = new List<string>(searchParam.Value.Count);
@@ -169,6 +176,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
                     }
                     else
                     {
+                        // 3. The parameter is not supported.
                         IEnumerable<string> removedValues = searchParamsToRemove[searchParam.Key];
 
                         StringValues usedValues = removedValues.Any()

--- a/src/Microsoft.Health.Fhir.Api/Features/Routing/UrlResolver.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Routing/UrlResolver.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
                 {
                     // Remove the parameter if:
                     // 1. It is the _total parameter, since we only want to count for the first page of results.
-                    if (string.Equals(searchParam.Key, KnownQueryParameterNames.Total, StringComparison.OrdinalIgnoreCase) && removeTotalParameter)
+                    if (removeTotalParameter && string.Equals(searchParam.Key, KnownQueryParameterNames.Total, StringComparison.OrdinalIgnoreCase))
                     {
                         // Don't add the _total parameter to the route values.
                         continue;

--- a/src/Microsoft.Health.Fhir.Core/Features/Routing/IUrlResolver.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Routing/IUrlResolver.cs
@@ -35,8 +35,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Routing
         /// <param name="unsupportedSearchParams">A list of unsupported search parameters.</param>
         /// <param name="unsupportedSortingParameters">A list of unsupported sorting parameters</param>
         /// <param name="continuationToken">The continuation token.</param>
+        /// <param name="removeTotalParameter">True if the _total parameter should be removed from the url, false otherwise.</param>
         /// <returns>The URL.</returns>
-        Uri ResolveRouteUrl(IEnumerable<Tuple<string, string>> unsupportedSearchParams = null, IReadOnlyList<(string parameterName, string reason)> unsupportedSortingParameters = null, string continuationToken = null);
+        Uri ResolveRouteUrl(IEnumerable<Tuple<string, string>> unsupportedSearchParams = null, IReadOnlyList<(string parameterName, string reason)> unsupportedSortingParameters = null, string continuationToken = null, bool removeTotalParameter = false);
 
         /// <summary>
         /// Resolves the URL for the specified routeName.

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
@@ -43,10 +43,10 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
                 searchOptions,
                 cancellationToken);
 
-            if (searchOptions.IncludeTotal == TotalType.Accurate && !searchOptions.CountOnly && searchOptions.ContinuationToken == null)
+            if (searchOptions.IncludeTotal == TotalType.Accurate && !searchOptions.CountOnly)
             {
-                // If all the results fit on one page
-                if (searchResult.ContinuationToken == null)
+                // If this is the first page and there aren't any more pages
+                if (searchOptions.ContinuationToken == null && searchResult.ContinuationToken == null)
                 {
                     // Count the results on the page.
                     searchResult.TotalCount = searchResult.Results.Count();
@@ -68,7 +68,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
                     }
                     finally
                     {
-                        // Reset search options to its original state.
+                        // Ensure search options is set to its original state.
                         searchOptions.CountOnly = false;
                     }
                 }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/BundleFactoryTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/BundleFactoryTests.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         public void GivenASearchResultWithContinuationToken_WhenCreateSearchBundle_ThenCorrectBundleShouldBeReturned()
         {
             string encodedContinuationToken = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(_continuationToken));
-            _urlResolver.ResolveRouteUrl(_unsupportedSearchParameters, _unsupportedSortingParameters, encodedContinuationToken).Returns(_nextUrl);
+            _urlResolver.ResolveRouteUrl(_unsupportedSearchParameters, _unsupportedSortingParameters, encodedContinuationToken, true).Returns(_nextUrl);
             _urlResolver.ResolveRouteUrl(_unsupportedSearchParameters, _unsupportedSortingParameters).Returns(_selfUrl);
 
             var searchResult = new SearchResult(new SearchResultEntry[0], _unsupportedSearchParameters, _unsupportedSortingParameters, _continuationToken);

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/BundleFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/BundleFactory.cs
@@ -96,7 +96,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                     bundle.NextLink = _urlResolver.ResolveRouteUrl(
                         result.UnsupportedSearchParameters,
                         result.UnsupportedSortingParameters,
-                        Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(result.ContinuationToken)));
+                        Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(result.ContinuationToken)),
+                        true);
                 }
             }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -68,70 +68,52 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
 
         protected override async Task<SearchResult> SearchInternalAsync(SearchOptions searchOptions, CancellationToken cancellationToken)
         {
-            using (var connection = new SqlConnection(_configuration.ConnectionString))
+            SearchResult searchResult;
+
+            // If we should include the total count of matching search results
+            if (searchOptions.IncludeTotal == TotalType.Accurate && !searchOptions.CountOnly)
             {
-                connection.Open();
+                searchResult = await SearchImpl(searchOptions, false, cancellationToken);
 
-                SearchResult searchResult;
-
-                // If we should include the total count of matching search results
-                if (searchOptions.IncludeTotal == TotalType.Accurate && !searchOptions.CountOnly)
+                // If this is the first page and there aren't any more pages
+                if (searchOptions.ContinuationToken == null && searchResult.ContinuationToken == null)
                 {
-                    // Begin a transaction so we can perform two atomic reads.
-                    using (var transaction = connection.BeginTransaction(IsolationLevel.ReadCommitted))
-                    {
-                        searchResult = await SearchImpl(searchOptions, false, connection, cancellationToken, transaction);
-
-                        // If this is the first page and there aren't any more pages
-                        if (searchOptions.ContinuationToken == null && searchResult.ContinuationToken == null)
-                        {
-                            // Count the results on the page.
-                            searchResult.TotalCount = searchResult.Results.Count();
-
-                            transaction.Commit();
-                        }
-                        else
-                        {
-                            try
-                            {
-                                // Otherwise, indicate that we'd like to get the count
-                                searchOptions.CountOnly = true;
-
-                                // And perform a second read.
-                                var countOnlySearchResult = await SearchImpl(searchOptions, false, connection, cancellationToken, transaction);
-
-                                searchResult.TotalCount = countOnlySearchResult.TotalCount;
-
-                                transaction.Commit();
-                            }
-                            finally
-                            {
-                                // Ensure search options is set to its original state.
-                                searchOptions.CountOnly = false;
-                            }
-                        }
-                    }
+                    // Count the results on the page.
+                    searchResult.TotalCount = searchResult.Results.Count();
                 }
                 else
                 {
-                    searchResult = await SearchImpl(searchOptions, false, connection, cancellationToken);
-                }
+                    try
+                    {
+                        // Otherwise, indicate that we'd like to get the count
+                        searchOptions.CountOnly = true;
 
-                return searchResult;
+                        // And perform a second read.
+                        var countOnlySearchResult = await SearchImpl(searchOptions, false, cancellationToken);
+
+                        searchResult.TotalCount = countOnlySearchResult.TotalCount;
+                    }
+                    finally
+                    {
+                        // Ensure search options is set to its original state.
+                        searchOptions.CountOnly = false;
+                    }
+                }
             }
+            else
+            {
+                searchResult = await SearchImpl(searchOptions, false, cancellationToken);
+            }
+
+            return searchResult;
         }
 
         protected override async Task<SearchResult> SearchHistoryInternalAsync(SearchOptions searchOptions, CancellationToken cancellationToken)
         {
-            using (var connection = new SqlConnection(_configuration.ConnectionString))
-            {
-                connection.Open();
-
-                return await SearchImpl(searchOptions, true, connection, cancellationToken);
-            }
+            return await SearchImpl(searchOptions, true, cancellationToken);
         }
 
-        private async Task<SearchResult> SearchImpl(SearchOptions searchOptions, bool historySearch, SqlConnection connection, CancellationToken cancellationToken, SqlTransaction transaction = null)
+        private async Task<SearchResult> SearchImpl(SearchOptions searchOptions, bool historySearch, CancellationToken cancellationToken)
         {
             await _model.EnsureInitialized();
 
@@ -169,13 +151,10 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                                                .AcceptVisitor(IncludeRewriter.Instance)
                                            ?? SqlRootExpression.WithDenormalizedExpressions();
 
+            using (var connection = new SqlConnection(_configuration.ConnectionString))
             using (SqlCommand sqlCommand = connection.CreateCommand())
             {
-                // If we are sending multiple search queries in one transaction
-                if (transaction != null)
-                {
-                    sqlCommand.Transaction = transaction;
-                }
+                connection.Open();
 
                 var stringBuilder = new IndentedStringBuilder(new StringBuilder());
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -75,15 +75,15 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                 SearchResult searchResult;
 
                 // If we should include the total count of matching search results
-                if (searchOptions.IncludeTotal == TotalType.Accurate && !searchOptions.CountOnly && searchOptions.ContinuationToken == null)
+                if (searchOptions.IncludeTotal == TotalType.Accurate && !searchOptions.CountOnly)
                 {
                     // Begin a transaction so we can perform two atomic reads.
                     using (var transaction = connection.BeginTransaction(IsolationLevel.ReadCommitted))
                     {
                         searchResult = await SearchImpl(searchOptions, false, connection, cancellationToken, transaction);
 
-                        // If all results fit on one page
-                        if (searchResult.ContinuationToken == null)
+                        // If this is the first page and there aren't any more pages
+                        if (searchOptions.ContinuationToken == null && searchResult.ContinuationToken == null)
                         {
                             // Count the results on the page.
                             searchResult.TotalCount = searchResult.Results.Count();

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -305,7 +305,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
-        public async Task GivenListOfResources_WhenSearchedWithTotalTypeAccurate_ThenTotalCountShouldBeIncludedInReturnedBundleForSubsequentPages()
+        public async Task GivenListOfResources_WhenSearchedWithTotalTypeAccurate_ThenTotalCountShouldNotBeIncludedInReturnedBundleForSubsequentPages()
         {
             const int numberOfResources = 5;
 
@@ -331,7 +331,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
             Assert.NotNull(bundle);
             Assert.NotEmpty(bundle.Entry);
-            Assert.Equal(numberOfResources, bundle.Total);
+            Assert.Null(bundle.Total);
         }
 
         [Fact]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -326,6 +326,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             Assert.NotNull(bundle);
             Assert.NotEmpty(bundle.Entry);
             Assert.Equal(numberOfResources, bundle.Total);
+            Assert.DoesNotContain("_total", bundle.NextLink.ToString(), StringComparison.OrdinalIgnoreCase);
 
             bundle = await Client.SearchAsync(bundle.NextLink.ToString());
 


### PR DESCRIPTION
## Description
- Implements an optimization for the [_total parameter](http://hl7.org/fhir/search.html#total) so that counting the number of matching resources only happens once

- Considers two scenarios:
  1. The results fit on one page
      - The Total value is calculated by counting the number of results returned from the first query
      - Only one query is issued
      - The possibility of a race condition is eliminated

  2. The results span multiple pages
      - Two queries are issued to include the Total value on the first page
      - The _total parameter is removed from the link to the next page, so the Total value is excluded from subsequent pages unless the user explicitly adds it to the Next link

![total-parameter-counts-once](https://user-images.githubusercontent.com/54082711/68721382-03199500-0567-11ea-911a-6a46b4f8766b.gif)

## Related issues
Addresses [#AB70827](https://microsofthealth.visualstudio.com/Health/_workitems/edit/70827).

## Testing
- Updates existing E2E test
