### PR TITLE
Revert "Updates package 'Microsoft.CodeAnalysis.CSharp.Scripting' to version '3.3.1'"

### DIFF
--- a/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/Microsoft.Health.Extensions.BuildTimeCodeGenerator.csproj
+++ b/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/Microsoft.Health.Extensions.BuildTimeCodeGenerator.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="8.1.1" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.5.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="2.10.0" />
     <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.4384.2-preview" />
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.2.0-alpha.19174.3" />
     <PackageReference Include="System.Data.SqlClient" Version="4.7.0" />


### PR DESCRIPTION
This seems to be causing build/tooling issues

Reverts microsoft/fhir-server#689