### PR TITLE
Return description metadata in health check response

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Registration/FhirServerApplicationBuilderExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Api/Registration/FhirServerApplicationBuilderExtensions.cs
@@ -39,6 +39,7 @@ namespace Microsoft.AspNetCore.Builder
                             {
                                 name = entry.Key,
                                 status = Enum.GetName(typeof(HealthStatus), entry.Value.Status),
+                                description = entry.Value.Description,
                             }),
                         });
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HealthTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HealthTests.cs
@@ -28,5 +28,14 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
+
+        [Fact]
+        public async Task WhenStartingTheFhirServer_GivenAHealthEndpoint_ThenResponseContainsDescription()
+        {
+            var response = await _client.GetAsync("health/check");
+            string responseContent = await response.Content.ReadAsStringAsync();
+
+            Assert.Contains("description", responseContent);
+        }
     }
 }


### PR DESCRIPTION
## Description
Added code to return description metadata in health check response.

## Related issues
Addresses [issue #755 ].

## Testing
Added E2E test. Manual testing using Postman.
