### PR TITLE
Add BundleHttpContextAccessor to UrlResolver

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Routing/UrlResolver.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Routing/UrlResolver.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Primitives;
+using Microsoft.Health.Fhir.Api.Features.Bundle;
 using Microsoft.Health.Fhir.Core.Features;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Operations;
@@ -35,6 +36,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
         // https://github.com/aspnet/Hosting/issues/793
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly IActionContextAccessor _actionContextAccessor;
+        private readonly IBundleHttpContextAccessor _bundleHttpContextAccessor;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UrlResolver"/> class.
@@ -43,24 +45,39 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
         /// <param name="urlHelperFactory">The ASP.NET Core URL helper factory.</param>
         /// <param name="httpContextAccessor">The ASP.NET Core HTTP context accessor.</param>
         /// <param name="actionContextAccessor">The ASP.NET Core Action context accessor.</param>
+        /// <param name="bundleHttpContextAccessor">The bundle aware http context accessor.</param>
         public UrlResolver(
             IFhirRequestContextAccessor fhirRequestContextAccessor,
             IUrlHelperFactory urlHelperFactory,
             IHttpContextAccessor httpContextAccessor,
-            IActionContextAccessor actionContextAccessor)
+            IActionContextAccessor actionContextAccessor,
+            IBundleHttpContextAccessor bundleHttpContextAccessor)
         {
             EnsureArg.IsNotNull(fhirRequestContextAccessor, nameof(fhirRequestContextAccessor));
             EnsureArg.IsNotNull(urlHelperFactory, nameof(urlHelperFactory));
             EnsureArg.IsNotNull(httpContextAccessor, nameof(httpContextAccessor));
             EnsureArg.IsNotNull(actionContextAccessor, nameof(actionContextAccessor));
+            EnsureArg.IsNotNull(bundleHttpContextAccessor, nameof(bundleHttpContextAccessor));
 
             _fhirRequestContextAccessor = fhirRequestContextAccessor;
             _urlHelperFactory = urlHelperFactory;
             _httpContextAccessor = httpContextAccessor;
             _actionContextAccessor = actionContextAccessor;
+            _bundleHttpContextAccessor = bundleHttpContextAccessor;
         }
 
-        private HttpRequest Request => _httpContextAccessor.HttpContext.Request;
+        private HttpRequest Request
+        {
+            get
+            {
+                if (_bundleHttpContextAccessor.HttpContext != null)
+                {
+                    return _bundleHttpContextAccessor.HttpContext.Request;
+                }
+
+                return _httpContextAccessor.HttpContext.Request;
+            }
+        }
 
         private ActionContext ActionContext => _actionContextAccessor.ActionContext;
 

--- a/src/Microsoft.Health.Fhir.Api/Modules/SecurityModule.cs
+++ b/src/Microsoft.Health.Fhir.Api/Modules/SecurityModule.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Health.Fhir.Api.Modules
             EnsureArg.IsNotNull(services, nameof(services));
 
             services.AddSingleton<IAuthorizationPolicyProvider, AuthorizationPolicyProvider>();
-            services.AddScoped<IBundleHttpContextAccessor, BundleHttpContextAccessor>();
+            services.AddSingleton<IBundleHttpContextAccessor, BundleHttpContextAccessor>();
 
             // Set the token handler to not do auto inbound mapping. (e.g. "roles" -> "http://schemas.microsoft.com/ws/2008/06/identity/claims/role")
             JwtSecurityTokenHandler.DefaultInboundClaimTypeMap.Clear();

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Routing/UrlResolverTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Routing/UrlResolverTests.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Primitives;
+using Microsoft.Health.Fhir.Api.Features.Bundle;
 using Microsoft.Health.Fhir.Api.Features.Routing;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features;
@@ -35,6 +36,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Routing
         private readonly IUrlHelperFactory _urlHelperFactory = Substitute.For<IUrlHelperFactory>();
         private readonly IHttpContextAccessor _httpContextAccessor = Substitute.For<IHttpContextAccessor>();
         private readonly IActionContextAccessor _actionContextAccessor = Substitute.For<IActionContextAccessor>();
+        private readonly IBundleHttpContextAccessor _bundleHttpContextAccessor = Substitute.For<IBundleHttpContextAccessor>();
 
         private readonly IUrlHelper _urlHelper = Substitute.For<IUrlHelper>();
         private readonly DefaultHttpContext _httpContext = new DefaultHttpContext();
@@ -50,7 +52,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Routing
                 _fhirRequestContextAccessor,
                 _urlHelperFactory,
                 _httpContextAccessor,
-                _actionContextAccessor);
+                _actionContextAccessor,
+                _bundleHttpContextAccessor);
 
             _fhirRequestContextAccessor.FhirRequestContext.RouteName = DefaultRouteName;
 
@@ -67,6 +70,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Routing
             _urlHelperFactory.GetUrlHelper(_actionContext).Returns(_urlHelper);
 
             _urlHelper.RouteUrl(Arg.Any<UrlRouteContext>()).Returns($"{Scheme}://{Host}");
+
+            _bundleHttpContextAccessor.HttpContext.Returns((HttpContext)null);
         }
 
         [Fact]
@@ -286,6 +291,28 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Routing
             const string opName = "import";
 
             Assert.Throws<OperationNotImplementedException>(() => _urlResolver.ResolveOperationResultUrl(opName, id));
+        }
+
+        [Fact]
+        public void GivenABundleBeingProcessed_WhenUrlIsResolvedWithQuery_ThenTheCorrectValueIsReturned()
+        {
+            string inputQueryString = "?param1=value1&param2=value2";
+            Tuple<string, string>[] unsupportedSearchParams = null;
+            string continuationToken = "continue";
+            Dictionary<string, object> expectedRouteValues = new Dictionary<string, object>()
+            {
+                { "param3", new StringValues("value3") },
+                { "param4", new StringValues("value4") },
+                { "ct", new StringValues("continue") },
+            };
+
+            var bundleHttpContext = new DefaultHttpContext();
+            bundleHttpContext.Request.QueryString = new QueryString("?param3=value3&param4=value4");
+            bundleHttpContext.Request.Scheme = Scheme;
+            bundleHttpContext.Request.Host = new HostString(Host);
+            _bundleHttpContextAccessor.HttpContext.Returns(bundleHttpContext);
+
+            TestAndValidateRouteWithQueryParameter(inputQueryString, unsupportedSearchParams, unsupportedSortingParameters: null, continuationToken, expectedRouteValues);
         }
 
         private void TestAndValidateRouteWithQueryParameter(

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Routing/UrlResolverTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Routing/UrlResolverTests.cs
@@ -299,11 +299,11 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Routing
             string inputQueryString = "?param1=value1&param2=value2";
             Tuple<string, string>[] unsupportedSearchParams = null;
             string continuationToken = "continue";
-            Dictionary<string, object> expectedRouteValues = new Dictionary<string, object>()
+            var expectedRouteValues = new Dictionary<string, object>()
             {
                 { "param3", new StringValues("value3") },
                 { "param4", new StringValues("value4") },
-                { "ct", new StringValues("continue") },
+                { ContinuationTokenQueryParamName, continuationToken },
             };
 
             var bundleHttpContext = new DefaultHttpContext();


### PR DESCRIPTION
## Description
Updates the URL resolver to be aware of the BundleHttpContextAccessor that's used within batches/transactions

## Related issues
Addresses [AB#71172](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/71172)

## Testing
Manually tested the batch/transaction case, added an additional unit test, all previous tests still pass. 
