### PR TITLE
Refactored the notification middleware.

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Controllers/AadSmartOnFhirProxyAuditLoggingFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Api/Controllers/AadSmartOnFhirProxyAuditLoggingFilterAttribute.cs
@@ -12,8 +12,8 @@ namespace Microsoft.Health.Fhir.Api.Controllers
     internal class AadSmartOnFhirProxyAuditLoggingFilterAttribute : AuditLoggingFilterAttribute
     {
         public AadSmartOnFhirProxyAuditLoggingFilterAttribute(
-           AadSmartOnFhirClaimsExtractor claimsExtractor,
-           IAuditHelper auditHelper)
+            AadSmartOnFhirClaimsExtractor claimsExtractor,
+            IAuditHelper auditHelper)
             : base(claimsExtractor, auditHelper)
         {
         }

--- a/src/Microsoft.Health.Fhir.Api/Extensions/HttpRequestExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Api/Extensions/HttpRequestExtensions.cs
@@ -1,0 +1,27 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using EnsureThat;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Health.Fhir.Api.Features.Routing;
+
+namespace Microsoft.Health.Fhir.Api.Extensions
+{
+    public static class HttpRequestExtensions
+    {
+        /// <summary>
+        /// Check to see whether the request is for health check or not.
+        /// </summary>
+        /// <param name="request">The request.</param>
+        /// <returns><c>true</c> if the request is for health check; otherwise <c>false</c>.</returns>
+        public static bool IsHealthCheck(this HttpRequest request)
+        {
+            EnsureArg.IsNotNull(request, nameof(request));
+
+            return request.Path.HasValue && request.Path.StartsWithSegments(KnownRoutes.HealthCheck, StringComparison.InvariantCultureIgnoreCase);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Api/Extensions/HttpRequestExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Api/Extensions/HttpRequestExtensions.cs
@@ -13,15 +13,16 @@ namespace Microsoft.Health.Fhir.Api.Extensions
     public static class HttpRequestExtensions
     {
         /// <summary>
-        /// Check to see whether the request is for health check or not.
+        /// Check to see whether the request is a FHIR request or not.
         /// </summary>
         /// <param name="request">The request.</param>
-        /// <returns><c>true</c> if the request is for health check; otherwise <c>false</c>.</returns>
-        public static bool IsHealthCheck(this HttpRequest request)
+        /// <returns><c>true</c> if the request is a FHIR request; otherwise <c>false</c>.</returns>
+        public static bool IsFhirRequest(this HttpRequest request)
         {
             EnsureArg.IsNotNull(request, nameof(request));
 
-            return request.Path.HasValue && request.Path.StartsWithSegments(KnownRoutes.HealthCheck, StringComparison.InvariantCultureIgnoreCase);
+            return !request.Path.StartsWithSegments(KnownRoutes.HealthCheck, StringComparison.InvariantCultureIgnoreCase) &&
+                   !request.Path.StartsWithSegments(KnownRoutes.CustomError, StringComparison.InvariantCultureIgnoreCase);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Features/ActionResults/ExportResult.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/ActionResults/ExportResult.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Health.Fhir.Api.Features.ActionResults
     /// <summary>
     /// Used to return the result of an export operation.
     /// </summary>
-    public class ExportResult : BaseActionResult<ExportJobResult>
+    public class ExportResult : ResourceActionResult<ExportJobResult>
     {
         public ExportResult(HttpStatusCode statusCode)
             : base(null, statusCode)

--- a/src/Microsoft.Health.Fhir.Api/Features/ActionResults/IResourceActionResult.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/ActionResults/IResourceActionResult.cs
@@ -5,7 +5,7 @@
 
 namespace Microsoft.Health.Fhir.Api.Features.ActionResults
 {
-    public interface IBaseActionResult
+    public interface IResourceActionResult
     {
         string GetResultTypeName();
     }

--- a/src/Microsoft.Health.Fhir.Api/Features/ActionResults/ResourceActionResult.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/ActionResults/ResourceActionResult.cs
@@ -13,18 +13,18 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Health.Fhir.Api.Features.ActionResults
 {
-    public abstract class BaseActionResult<TResult> : ActionResult, IBaseActionResult
+    public abstract class ResourceActionResult<TResult> : ActionResult, IResourceActionResult
     {
-        protected BaseActionResult()
+        protected ResourceActionResult()
         {
         }
 
-        protected BaseActionResult(TResult result)
+        protected ResourceActionResult(TResult result)
         {
             Result = result;
         }
 
-        protected BaseActionResult(TResult result, HttpStatusCode statusCode)
+        protected ResourceActionResult(TResult result, HttpStatusCode statusCode)
             : this(result)
         {
             StatusCode = statusCode;

--- a/src/Microsoft.Health.Fhir.Api/Features/ApiNotifications/ApiNotificationMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/ApiNotifications/ApiNotificationMiddleware.cs
@@ -9,55 +9,58 @@ using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using MediatR;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.Health.Fhir.Api.Extensions;
 using Microsoft.Health.Fhir.Core;
 using Microsoft.Health.Fhir.Core.Features.Context;
 
 namespace Microsoft.Health.Fhir.Api.Features.ApiNotifications
 {
-    public class ApiNotificationMiddleware
+    public class ApiNotificationMiddleware : IMiddleware
     {
-        private readonly RequestDelegate _next;
         private readonly IFhirRequestContextAccessor _fhirRequestContextAccessor;
         private readonly IMediator _mediator;
         private readonly ILogger<ApiNotificationMiddleware> _logger;
 
         public ApiNotificationMiddleware(
-            RequestDelegate next,
             IFhirRequestContextAccessor fhirRequestContextAccessor,
             IMediator mediator,
             ILogger<ApiNotificationMiddleware> logger)
         {
-            EnsureArg.IsNotNull(next, nameof(next));
             EnsureArg.IsNotNull(fhirRequestContextAccessor, nameof(fhirRequestContextAccessor));
             EnsureArg.IsNotNull(mediator, nameof(mediator));
             EnsureArg.IsNotNull(logger, nameof(logger));
 
-            _next = next;
             _fhirRequestContextAccessor = fhirRequestContextAccessor;
             _mediator = mediator;
             _logger = logger;
         }
 
-        public async Task Invoke(HttpContext context)
+        public async Task InvokeAsync(HttpContext context, RequestDelegate next)
         {
-            if (context.Request.Path.HasValue && context.Request.Path.StartsWithSegments(FhirServerApplicationBuilderExtensions.HealthCheckPath, System.StringComparison.InvariantCultureIgnoreCase))
+            EnsureArg.IsNotNull(context, nameof(context));
+            EnsureArg.IsNotNull(next, nameof(next));
+
+            if (context.Request.IsHealthCheck())
             {
                 // Don't emit events for health check
-
-                await _next(context);
+                await next(context);
                 return;
             }
 
+            await InvokeInternalAsync(context, next);
+        }
+
+        protected virtual async Task InvokeInternalAsync(HttpContext context, RequestDelegate next)
+        {
             var apiNotification = new ApiResponseNotification();
 
             using (var timer = _logger.BeginTimedScope("ApiNotificationMiddleware") as ActionTimer)
             {
                 try
                 {
-                    await _next(context);
+                    await next(context);
                 }
                 finally
                 {

--- a/src/Microsoft.Health.Fhir.Api/Features/ApiNotifications/ApiNotificationMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/ApiNotifications/ApiNotificationMiddleware.cs
@@ -12,7 +12,6 @@ using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.Fhir.Api.Extensions;
-using Microsoft.Health.Fhir.Api.Features.Routing;
 using Microsoft.Health.Fhir.Core;
 using Microsoft.Health.Fhir.Core.Features.Context;
 
@@ -50,14 +49,14 @@ namespace Microsoft.Health.Fhir.Api.Features.ApiNotifications
                 return;
             }
 
-            await InvokeInternalAsync(context, next);
+            await PublishNotificationAsync(context, next);
         }
 
-        protected virtual async Task InvokeInternalAsync(HttpContext context, RequestDelegate next)
+        protected virtual async Task PublishNotificationAsync(HttpContext context, RequestDelegate next)
         {
             var apiNotification = new ApiResponseNotification();
 
-            using (var timer = _logger.BeginTimedScope("ApiNotificationMiddleware") as ActionTimer)
+            using (var timer = _logger.BeginTimedScope(nameof(ApiNotificationMiddleware)) as ActionTimer)
             {
                 try
                 {

--- a/src/Microsoft.Health.Fhir.Api/Features/ApiNotifications/ApiNotificationMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/ApiNotifications/ApiNotificationMiddleware.cs
@@ -12,6 +12,7 @@ using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.Fhir.Api.Extensions;
+using Microsoft.Health.Fhir.Api.Features.Routing;
 using Microsoft.Health.Fhir.Core;
 using Microsoft.Health.Fhir.Core.Features.Context;
 
@@ -42,9 +43,9 @@ namespace Microsoft.Health.Fhir.Api.Features.ApiNotifications
             EnsureArg.IsNotNull(context, nameof(context));
             EnsureArg.IsNotNull(next, nameof(next));
 
-            if (context.Request.IsHealthCheck())
+            if (!context.Request.IsFhirRequest())
             {
-                // Don't emit events for health check
+                // Don't emit events for internal calls.
                 await next(context);
                 return;
             }

--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditHelper.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditHelper.cs
@@ -3,11 +3,9 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.Diagnostics;
 using System.Net;
 using EnsureThat;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Logging;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Security;
 
@@ -19,57 +17,51 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
     public class AuditHelper : IAuditHelper
     {
         private readonly IFhirRequestContextAccessor _fhirRequestContextAccessor;
-        private readonly IAuditEventTypeMapping _auditEventTypeMapping;
         private readonly IAuditLogger _auditLogger;
-        private readonly ILogger<AuditHelper> _logger;
         private readonly IAuditHeaderReader _auditHeaderReader;
 
         public AuditHelper(
             IFhirRequestContextAccessor fhirRequestContextAccessor,
-            IAuditEventTypeMapping auditEventTypeMapping,
             IAuditLogger auditLogger,
-            ILogger<AuditHelper> logger,
             IAuditHeaderReader auditHeaderReader)
         {
             EnsureArg.IsNotNull(fhirRequestContextAccessor, nameof(fhirRequestContextAccessor));
-            EnsureArg.IsNotNull(auditEventTypeMapping, nameof(auditEventTypeMapping));
             EnsureArg.IsNotNull(auditLogger, nameof(auditLogger));
-            EnsureArg.IsNotNull(logger, nameof(logger));
+            EnsureArg.IsNotNull(auditHeaderReader, nameof(auditHeaderReader));
 
             _fhirRequestContextAccessor = fhirRequestContextAccessor;
-            _auditEventTypeMapping = auditEventTypeMapping;
             _auditLogger = auditLogger;
-            _logger = logger;
             _auditHeaderReader = auditHeaderReader;
         }
 
         /// <inheritdoc />
-        public void LogExecuting(string controllerName, string actionName, HttpContext httpContext, IClaimsExtractor claimsExtractor)
+        public void LogExecuting(HttpContext httpContext, IClaimsExtractor claimsExtractor)
         {
             EnsureArg.IsNotNull(claimsExtractor, nameof(claimsExtractor));
             EnsureArg.IsNotNull(httpContext, nameof(httpContext));
 
-            Log(AuditAction.Executing, controllerName, actionName, statusCode: null, resourceType: null, httpContext, claimsExtractor);
+            Log(AuditAction.Executing, statusCode: null, resourceType: null, httpContext, claimsExtractor);
         }
 
         /// <inheritdoc />
-        public void LogExecuted(string controllerName, string actionName, string responseResultType, HttpContext httpContext, IClaimsExtractor claimsExtractor)
+        public void LogExecuted(HttpContext httpContext, IClaimsExtractor claimsExtractor)
         {
             EnsureArg.IsNotNull(claimsExtractor, nameof(claimsExtractor));
             EnsureArg.IsNotNull(httpContext, nameof(httpContext));
 
-            Log(AuditAction.Executed, controllerName, actionName, (HttpStatusCode)httpContext.Response.StatusCode, responseResultType, httpContext, claimsExtractor);
+            string resourceType = _fhirRequestContextAccessor.FhirRequestContext.ResourceType;
+
+            Log(AuditAction.Executed, (HttpStatusCode)httpContext.Response.StatusCode, resourceType, httpContext, claimsExtractor);
         }
 
-        private void Log(AuditAction auditAction, string controllerName, string actionName, HttpStatusCode? statusCode, string resourceType, HttpContext httpContext, IClaimsExtractor claimsExtractor)
+        private void Log(AuditAction auditAction, HttpStatusCode? statusCode, string resourceType, HttpContext httpContext, IClaimsExtractor claimsExtractor)
         {
             IFhirRequestContext fhirRequestContext = _fhirRequestContextAccessor.FhirRequestContext;
 
-            // fhirRequestContext.AuditEventType will not be set in the case of an unauthorized call because the filter that sets it will not be executed
-            string auditEventType = string.IsNullOrWhiteSpace(fhirRequestContext.AuditEventType) ? _auditEventTypeMapping.GetAuditEventType(controllerName, actionName) : fhirRequestContext.AuditEventType;
+            string auditEventType = fhirRequestContext.AuditEventType;
 
             // Audit the call if an audit event type is associated with the action.
-            if (auditEventType != null)
+            if (!string.IsNullOrEmpty(auditEventType))
             {
                 _auditLogger.LogAudit(
                     auditAction,

--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditLoggingFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditLoggingFilterAttribute.cs
@@ -4,11 +4,8 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Diagnostics;
 using EnsureThat;
-using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Filters;
-using Microsoft.Health.Fhir.Api.Features.ActionResults;
 using Microsoft.Health.Fhir.Core.Features.Security;
 
 namespace Microsoft.Health.Fhir.Api.Features.Audit
@@ -19,7 +16,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
         private readonly IClaimsExtractor _claimsExtractor;
         private readonly IAuditHelper _auditHelper;
 
-        public AuditLoggingFilterAttribute(IClaimsExtractor claimsExtractor, IAuditHelper auditHelper)
+        public AuditLoggingFilterAttribute(
+            IClaimsExtractor claimsExtractor,
+            IAuditHelper auditHelper)
         {
             EnsureArg.IsNotNull(claimsExtractor, nameof(claimsExtractor));
             EnsureArg.IsNotNull(auditHelper, nameof(auditHelper));
@@ -32,14 +31,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
         {
             EnsureArg.IsNotNull(context, nameof(context));
 
-            var actionDescriptor = context.ActionDescriptor as ControllerActionDescriptor;
-
-            Debug.Assert(actionDescriptor != null, "The ActionDescriptor must be ControllerActionDescriptor.");
-
-            if (actionDescriptor != null)
-            {
-                _auditHelper.LogExecuting(actionDescriptor.ControllerName, actionDescriptor.ActionName, context.HttpContext, _claimsExtractor);
-            }
+            _auditHelper.LogExecuting(context.HttpContext, _claimsExtractor);
 
             base.OnActionExecuting(context);
         }
@@ -48,19 +40,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
         {
             EnsureArg.IsNotNull(context, nameof(context));
 
-            var actionDescriptor = context.ActionDescriptor as ControllerActionDescriptor;
-
-            Debug.Assert(actionDescriptor != null, "The ActionDescriptor must be ControllerActionDescriptor.");
-
-            // The result can either be a FhirResult or an OperationOutcomeResult which both extend BaseActionResult.
-            var result = context.Result as IBaseActionResult;
-
-            _auditHelper.LogExecuted(
-                actionDescriptor.ControllerName,
-                actionDescriptor.ActionName,
-                result?.GetResultTypeName(),
-                context.HttpContext,
-                _claimsExtractor);
+            _auditHelper.LogExecuted(context.HttpContext, _claimsExtractor);
 
             base.OnResultExecuted(context);
         }

--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditMiddleware.cs
@@ -7,36 +7,29 @@ using System.Net;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Routing;
-using Microsoft.Health.Fhir.Api.Features.Routing;
-using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Security;
 
 namespace Microsoft.Health.Fhir.Api.Features.Audit
 {
     /// <summary>
-    /// A middleware that logs audit events that cannot be logged by <see cref="AuditLoggingFilterAttribute"/>.
+    /// A middleware that logs executed audit events.
     /// </summary>
     public class AuditMiddleware
     {
         private readonly RequestDelegate _next;
-        private readonly IFhirRequestContextAccessor _fhirRequestContextAccessor;
         private readonly IClaimsExtractor _claimsExtractor;
         private readonly IAuditHelper _auditHelper;
 
         public AuditMiddleware(
             RequestDelegate next,
-            IFhirRequestContextAccessor fhirRequestContextAccessor,
             IClaimsExtractor claimsExtractor,
             IAuditHelper auditHelper)
         {
             EnsureArg.IsNotNull(next, nameof(next));
-            EnsureArg.IsNotNull(fhirRequestContextAccessor, nameof(fhirRequestContextAccessor));
             EnsureArg.IsNotNull(claimsExtractor, nameof(claimsExtractor));
             EnsureArg.IsNotNull(auditHelper, nameof(auditHelper));
 
             _next = next;
-            _fhirRequestContextAccessor = fhirRequestContextAccessor;
             _claimsExtractor = claimsExtractor;
             _auditHelper = auditHelper;
         }
@@ -54,21 +47,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
                 // Since authorization filters runs first before any other filters, if the authorization fails,
                 // the AuditLoggingFilterAttribute, which is where the audit logging would normally happen, will not be executed.
                 // This middleware will log any Unauthorized or Forbidden request if it hasn't been logged yet.
-                if (_fhirRequestContextAccessor.FhirRequestContext.RouteName == null &&
-                    (statusCode == HttpStatusCode.Unauthorized || statusCode == HttpStatusCode.Forbidden))
+                if (statusCode == HttpStatusCode.Unauthorized || statusCode == HttpStatusCode.Forbidden)
                 {
-                    RouteData routeData = context.GetRouteData();
-
-                    routeData.Values.TryGetValue("controller", out object controllerName);
-                    routeData.Values.TryGetValue("action", out object actionName);
-                    routeData.Values.TryGetValue(KnownActionParameterNames.ResourceType, out object resourceType);
-
-                    _auditHelper.LogExecuted(
-                        controllerName?.ToString(),
-                        actionName?.ToString(),
-                        resourceType?.ToString(),
-                        context,
-                        _claimsExtractor);
+                    _auditHelper.LogExecuted(context, _claimsExtractor);
                 }
             }
         }

--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/IAuditHelper.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/IAuditHelper.cs
@@ -14,22 +14,17 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
     public interface IAuditHelper
     {
         /// <summary>
-        /// Logs an audit entry for executing the <paramref name="controllerName"/> and <paramref name="actionName"/>.
+        /// Logs an executing audit entry for the current operation.
         /// </summary>
-        /// <param name="controllerName">The controller name.</param>
-        /// <param name="actionName">The action name.</param>
         /// <param name="httpContext">The HTTP context.</param>
         /// <param name="claimsExtractor">The extractor used to extract claims.</param>
-        void LogExecuting(string controllerName, string actionName, HttpContext httpContext, IClaimsExtractor claimsExtractor);
+        void LogExecuting(HttpContext httpContext, IClaimsExtractor claimsExtractor);
 
         /// <summary>
-        /// Logs an audit entry for executed the <paramref name="controllerName"/> and <paramref name="actionName"/>.
+        /// Logs an executed audit entry for the current operation.
         /// </summary>
-        /// <param name="controllerName">The controller name.</param>
-        /// <param name="actionName">The action name.</param>
-        /// <param name="responseResultType">The optional response result type.</param>
         /// <param name="httpContext">The HTTP context.</param>
         /// <param name="claimsExtractor">The extractor used to extract claims.</param>
-        void LogExecuted(string controllerName, string actionName, string responseResultType, HttpContext httpContext, IClaimsExtractor claimsExtractor);
+        void LogExecuted(HttpContext httpContext, IClaimsExtractor claimsExtractor);
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Features/Context/FhirRequestContextAfterAuthenticationMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Context/FhirRequestContextAfterAuthenticationMiddleware.cs
@@ -10,6 +10,9 @@ using Microsoft.Health.Fhir.Core.Features.Context;
 
 namespace Microsoft.Health.Fhir.Api.Features.Context
 {
+    /// <summary>
+    /// Middleware that runs after authentication middleware so that it can retrieved authenticated user claims.
+    /// </summary>
     public class FhirRequestContextAfterAuthenticationMiddleware
     {
         private readonly RequestDelegate _next;
@@ -23,7 +26,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Context
 
         public Task Invoke(HttpContext context, IFhirRequestContextAccessor fhirRequestContextAccessor)
         {
-            // Set the user again to pick up anything that was set during authentication, e.g. claims.
+            // Now the authentication is completed successfully, sets the user.
             if (context.User != null)
             {
                 fhirRequestContextAccessor.FhirRequestContext.Principal = context.User;

--- a/src/Microsoft.Health.Fhir.Api/Features/Context/FhirRequestContextAuthenticationMiddlewareExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Context/FhirRequestContextAuthenticationMiddlewareExtensions.cs
@@ -8,14 +8,20 @@ using Microsoft.AspNetCore.Builder;
 
 namespace Microsoft.Health.Fhir.Api.Features.Context
 {
-    public static class FhirRequestContextAfterAuthenticationMiddlewareExtensions
+    public static class FhirRequestContextAuthenticationMiddlewareExtensions
     {
-        public static IApplicationBuilder UseFhirRequestContextAfterAuthentication(
+        public static IApplicationBuilder UseFhirRequestContextAuthentication(
             this IApplicationBuilder builder)
         {
             EnsureArg.IsNotNull(builder, nameof(builder));
 
-            return builder.UseMiddleware<FhirRequestContextAfterAuthenticationMiddleware>();
+            builder.UseMiddleware<FhirRequestContextBeforeAuthenticationMiddleware>();
+
+            builder.UseAuthentication();
+
+            builder.UseMiddleware<FhirRequestContextAfterAuthenticationMiddleware>();
+
+            return builder;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Features/Context/FhirRequestContextBeforeAuthenticationMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Context/FhirRequestContextBeforeAuthenticationMiddleware.cs
@@ -1,0 +1,76 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Net;
+using System.Threading.Tasks;
+using EnsureThat;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Health.Fhir.Api.Features.Audit;
+using Microsoft.Health.Fhir.Api.Features.Routing;
+using Microsoft.Health.Fhir.Core.Features.Context;
+
+namespace Microsoft.Health.Fhir.Api.Features.Context
+{
+    /// <summary>
+    /// Middlware that runs before authentication middleware.
+    /// </summary>
+    public class FhirRequestContextBeforeAuthenticationMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly IFhirRequestContextAccessor _fhirRequestContextAccessor;
+        private readonly IAuditEventTypeMapping _auditEventTypeMapping;
+
+        public FhirRequestContextBeforeAuthenticationMiddleware(
+            RequestDelegate next,
+            IFhirRequestContextAccessor fhirRequestContextAccessor,
+            IAuditEventTypeMapping auditEventTypeMapping)
+        {
+            EnsureArg.IsNotNull(next, nameof(next));
+            EnsureArg.IsNotNull(fhirRequestContextAccessor, nameof(fhirRequestContextAccessor));
+            EnsureArg.IsNotNull(auditEventTypeMapping, nameof(auditEventTypeMapping));
+
+            _next = next;
+            _fhirRequestContextAccessor = fhirRequestContextAccessor;
+            _auditEventTypeMapping = auditEventTypeMapping;
+        }
+
+        public Task Invoke(HttpContext context)
+        {
+            try
+            {
+                // Call the next delegate/middleware in the pipeline
+                return _next(context);
+            }
+            finally
+            {
+                var statusCode = (HttpStatusCode)context.Response.StatusCode;
+
+                // The authorization middleware runs before MVC middleware and therefore,
+                // information related to route and audit will not be populated if authentication fails.
+                // Handle such condition and populate them here if possible.
+                if (_fhirRequestContextAccessor.FhirRequestContext.RouteName == null &&
+                    (statusCode == HttpStatusCode.Unauthorized || statusCode == HttpStatusCode.Forbidden))
+                {
+                    RouteData routeData = context.GetRouteData();
+
+                    if (routeData?.Values != null)
+                    {
+                        routeData.Values.TryGetValue("controller", out object controllerName);
+                        routeData.Values.TryGetValue("action", out object actionName);
+                        routeData.Values.TryGetValue(KnownActionParameterNames.ResourceType, out object resourceType);
+
+                        IFhirRequestContext fhirRequestContext = _fhirRequestContextAccessor.FhirRequestContext;
+
+                        fhirRequestContext.AuditEventType = _auditEventTypeMapping.GetAuditEventType(
+                            controllerName?.ToString(),
+                            actionName?.ToString());
+                        fhirRequestContext.ResourceType = resourceType?.ToString();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Api/Features/Context/FhirRequestContextMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Context/FhirRequestContextMiddleware.cs
@@ -6,8 +6,6 @@
 using EnsureThat;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
-using Microsoft.AspNetCore.Routing;
-using Microsoft.Health.Fhir.Api.Features.Routing;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Task = System.Threading.Tasks.Task;
 
@@ -44,30 +42,15 @@ namespace Microsoft.Health.Fhir.Api.Features.Context
 
             string correlationId = correlationIdProvider.Invoke();
 
-            object resourceType = null;
-
-            RouteData routeData = context.GetRouteData();
-            if (routeData != null && routeData.Values != null)
-            {
-                routeData.Values.TryGetValue(KnownActionParameterNames.ResourceType, out resourceType);
-            }
-
             var fhirRequestContext = new FhirRequestContext(
                 method: request.Method,
                 uriString: uriInString,
                 baseUriString: baseUriInString,
                 correlationId: correlationId,
                 requestHeaders: context.Request.Headers,
-                responseHeaders: context.Response.Headers,
-                resourceType: resourceType?.ToString());
+                responseHeaders: context.Response.Headers);
 
             context.Response.Headers[RequestIdHeaderName] = correlationId;
-
-            // Note that if this is executed before authentication occurs, the user will not contain any claims.
-            if (context.User != null)
-            {
-                fhirRequestContext.Principal = context.User;
-            }
 
             fhirRequestContextAccessor.FhirRequestContext = fhirRequestContext;
 

--- a/src/Microsoft.Health.Fhir.Api/Features/Routing/KnownRoutes.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Routing/KnownRoutes.cs
@@ -40,5 +40,6 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
         public const string Versions = "$versions";
 
         public const string HealthCheck = "/health/check";
+        public const string CustomError = "/CustomError";
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Features/Routing/KnownRoutes.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Routing/KnownRoutes.cs
@@ -38,5 +38,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
         public const string Metadata = "metadata";
 
         public const string Versions = "$versions";
+
+        public const string HealthCheck = "/health/check";
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Modules/ApiNotificationModule.cs
+++ b/src/Microsoft.Health.Fhir.Api/Modules/ApiNotificationModule.cs
@@ -1,0 +1,22 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using EnsureThat;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Health.Fhir.Api.Features.ApiNotifications;
+
+namespace Microsoft.Health.Fhir.Api.Modules
+{
+    public class ApiNotificationModule : IStartupModule
+    {
+        public void Load(IServiceCollection services)
+        {
+            EnsureArg.IsNotNull(services, nameof(services));
+
+            services.AddTransient<ApiNotificationMiddleware>();
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Api/Registration/FhirServerApplicationBuilderExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Api/Registration/FhirServerApplicationBuilderExtensions.cs
@@ -10,14 +10,13 @@ using EnsureThat;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Health.Fhir.Api.Features.Routing;
 using Newtonsoft.Json;
 
 namespace Microsoft.AspNetCore.Builder
 {
     public static class FhirServerApplicationBuilderExtensions
     {
-        public static readonly PathString HealthCheckPath = "/health/check";
-
         /// <summary>
         /// Adds FHIR server functionality to the pipeline.
         /// </summary>
@@ -27,7 +26,7 @@ namespace Microsoft.AspNetCore.Builder
         {
             EnsureArg.IsNotNull(app, nameof(app));
 
-            app.UseHealthChecks(HealthCheckPath, new HealthCheckOptions
+            app.UseHealthChecks(new PathString(KnownRoutes.HealthCheck), new HealthCheckOptions
             {
                 ResponseWriter = async (httpContext, healthReport) =>
                 {

--- a/src/Microsoft.Health.Fhir.Core/Features/Context/FhirRequestContext.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Context/FhirRequestContext.cs
@@ -25,15 +25,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Context
             string baseUriString,
             string correlationId,
             IDictionary<string, StringValues> requestHeaders,
-            IDictionary<string, StringValues> responseHeaders,
-            string resourceType)
+            IDictionary<string, StringValues> responseHeaders)
         {
             EnsureArg.IsNotNullOrWhiteSpace(method, nameof(method));
             EnsureArg.IsNotNullOrWhiteSpace(uriString, nameof(uriString));
             EnsureArg.IsNotNullOrWhiteSpace(baseUriString, nameof(baseUriString));
             EnsureArg.IsNotNullOrWhiteSpace(correlationId, nameof(correlationId));
             EnsureArg.IsNotNull(responseHeaders, nameof(responseHeaders));
-            EnsureArg.IsNotNull(requestHeaders, nameof(requestHeaders));
 
             Method = method;
             _uriString = uriString;
@@ -41,7 +39,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Context
             CorrelationId = correlationId;
             RequestHeaders = requestHeaders;
             ResponseHeaders = responseHeaders;
-            ResourceType = resourceType;
         }
 
         public string Method { get; }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/ApiNotifications/ApiNotificationMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/ApiNotifications/ApiNotificationMiddlewareTests.cs
@@ -6,10 +6,11 @@
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Health.Fhir.Api.Features.ApiNotifications;
+using Microsoft.Health.Fhir.Api.Features.Routing;
+using Microsoft.Health.Fhir.Api.UnitTests.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using NSubstitute;
 using Xunit;
@@ -19,9 +20,10 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Notifications
     public class ApiNotificationMiddlewareTests
     {
         private readonly IFhirRequestContextAccessor _fhirRequestContextAccessor = Substitute.For<IFhirRequestContextAccessor>();
-        private readonly IFhirRequestContext _fhirRequestContext = Substitute.For<IFhirRequestContext>();
+        private readonly IFhirRequestContext _fhirRequestContext = new DefaultFhirRequestContext();
         private readonly IMediator _mediator = Substitute.For<IMediator>();
 
+        private readonly RequestDelegate _next = httpContext => Task.CompletedTask;
         private readonly ApiNotificationMiddleware _apiNotificationMiddleware;
         private readonly HttpContext _httpContext = new DefaultHttpContext();
 
@@ -30,7 +32,6 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Notifications
             _fhirRequestContextAccessor.FhirRequestContext.Returns(_fhirRequestContext);
 
             _apiNotificationMiddleware = new ApiNotificationMiddleware(
-                    httpContext => Task.CompletedTask,
                     _fhirRequestContextAccessor,
                     _mediator,
                     NullLogger<ApiNotificationMiddleware>.Instance);
@@ -39,9 +40,9 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Notifications
         [Fact]
         public async Task GivenRequestPath_WhenInvoked_DoesNotLogForHealthCheck()
         {
-            _httpContext.Request.Path = FhirServerApplicationBuilderExtensions.HealthCheckPath;
+            _httpContext.Request.Path = new PathString(KnownRoutes.HealthCheck);
 
-            await _apiNotificationMiddleware.Invoke(_httpContext);
+            await _apiNotificationMiddleware.InvokeAsync(_httpContext, _next);
 
             await _mediator.DidNotReceiveWithAnyArgs().Publish(Arg.Any<object>(), Arg.Any<CancellationToken>());
         }
@@ -50,18 +51,18 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Notifications
         public async Task GivenRequestPathButNoStorageRequestMetrics_WhenInvoked_EmitsMediatRApiEvents()
         {
             _httpContext.Request.Path = "/Observations";
-            await _apiNotificationMiddleware.Invoke(_httpContext);
+            await _apiNotificationMiddleware.InvokeAsync(_httpContext, _next);
 
-            await _mediator.ReceivedWithAnyArgs(1).Publish<ApiResponseNotification>(Arg.Any<ApiResponseNotification>(), Arg.Any<CancellationToken>());
+            await _mediator.ReceivedWithAnyArgs(1).Publish(Arg.Any<ApiResponseNotification>(), Arg.Any<CancellationToken>());
         }
 
         [Fact]
         public async Task GivenRequestPathAndStorageRequestMetrics_WhenInvoked_EmitsMediatRApiAndStorageEvents()
         {
             _httpContext.Request.Path = "/Observation";
-            await _apiNotificationMiddleware.Invoke(_httpContext);
+            await _apiNotificationMiddleware.InvokeAsync(_httpContext, _next);
 
-            await _mediator.ReceivedWithAnyArgs(1).Publish<ApiResponseNotification>(Arg.Any<ApiResponseNotification>(), Arg.Any<CancellationToken>());
+            await _mediator.ReceivedWithAnyArgs(1).Publish(Arg.Any<ApiResponseNotification>(), Arg.Any<CancellationToken>());
         }
 
         [Fact]
@@ -70,7 +71,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Notifications
             _fhirRequestContextAccessor.FhirRequestContext.Returns((IFhirRequestContext)null);
 
             _httpContext.Request.Path = "/Observation";
-            await _apiNotificationMiddleware.Invoke(_httpContext);
+            await _apiNotificationMiddleware.InvokeAsync(_httpContext, _next);
 
             await _mediator.DidNotReceiveWithAnyArgs().Publish(Arg.Any<object>(), Arg.Any<CancellationToken>());
         }
@@ -82,7 +83,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Notifications
             _mediator.WhenForAnyArgs(async x => await x.Publish(Arg.Any<ApiResponseNotification>(), Arg.Any<CancellationToken>())).Throw(new System.Exception("Failure"));
 
             _httpContext.Request.Path = "/Observation";
-            await _apiNotificationMiddleware.Invoke(_httpContext);
+            await _apiNotificationMiddleware.InvokeAsync(_httpContext, _next);
 
             await _mediator.DidNotReceiveWithAnyArgs().Publish(Arg.Any<object>(), Arg.Any<CancellationToken>());
         }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/ApiNotifications/ApiNotificationMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/ApiNotifications/ApiNotificationMiddlewareTests.cs
@@ -48,18 +48,11 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Notifications
         }
 
         [Fact]
-        public async Task GivenRequestPathButNoStorageRequestMetrics_WhenInvoked_EmitsMediatRApiEvents()
-        {
-            _httpContext.Request.Path = "/Observations";
-            await _apiNotificationMiddleware.InvokeAsync(_httpContext, _next);
-
-            await _mediator.ReceivedWithAnyArgs(1).Publish(Arg.Any<ApiResponseNotification>(), Arg.Any<CancellationToken>());
-        }
-
-        [Fact]
-        public async Task GivenRequestPathAndStorageRequestMetrics_WhenInvoked_EmitsMediatRApiAndStorageEvents()
+        public async Task GivenAuditEventTypeNotNull_WhenInvoked_EmitsMediatRApiAndStorageEvents()
         {
             _httpContext.Request.Path = "/Observation";
+            _fhirRequestContext.AuditEventType = "read";
+
             await _apiNotificationMiddleware.InvokeAsync(_httpContext, _next);
 
             await _mediator.ReceivedWithAnyArgs(1).Publish(Arg.Any<ApiResponseNotification>(), Arg.Any<CancellationToken>());

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Audit/AuditLoggingFilterAttributeTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Audit/AuditLoggingFilterAttributeTests.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Health.Fhir.Api.Features.ActionResults;
 using Microsoft.Health.Fhir.Api.Features.Audit;
+using Microsoft.Health.Fhir.Api.UnitTests.Features.Filters;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Security;
 using NSubstitute;
@@ -21,9 +22,6 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
 {
     public class AuditLoggingFilterAttributeTests
     {
-        private const string ControllerName = "controller";
-        private const string ActionName = "action";
-
         private readonly IClaimsExtractor _claimsExtractor = Substitute.For<IClaimsExtractor>();
         private readonly IAuditHelper _auditHelper = Substitute.For<IAuditHelper>();
 
@@ -43,33 +41,11 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
                 new ActionContext(_httpContext, new RouteData(), new ControllerActionDescriptor() { DisplayName = "Executing Context Test Descriptor" }),
                 new List<IFilterMetadata>(),
                 new Dictionary<string, object>(),
-                new MockController());
-
-            actionExecutingContext.ActionDescriptor = new ControllerActionDescriptor()
-            {
-                ControllerName = ControllerName,
-                ActionName = ActionName,
-            };
+                FilterTestsHelper.CreateMockFhirController());
 
             _filter.OnActionExecuting(actionExecutingContext);
 
-            _auditHelper.Received(1).LogExecuting(ControllerName, ActionName, _httpContext, _claimsExtractor);
-        }
-
-        [Fact]
-        public void GivenANonFhirResult_WhenExecutedAction_ThenAuditLogShouldBeLogged()
-        {
-            SetupExecutedAction(new OkResult());
-
-            _auditHelper.Received(1).LogExecuted(ControllerName, ActionName, null, _httpContext, _claimsExtractor);
-        }
-
-        [Fact]
-        public void GivenAFhirResultWithNullResource_WhenExecutedAction_ThenAuditLogShouldBeLogged()
-        {
-            SetupExecutedAction(new FhirResult());
-
-            _auditHelper.Received(1).LogExecuted(ControllerName, ActionName, null, _httpContext, _claimsExtractor);
+            _auditHelper.Received(1).LogExecuting(_httpContext, _claimsExtractor);
         }
 
         [Fact]
@@ -77,30 +53,15 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
         {
             var fhirResult = new FhirResult(new Patient() { Name = { new HumanName() { Text = "TestPatient" } } }.ToResourceElement());
 
-            SetupExecutedAction(fhirResult);
-
-            _auditHelper.Received(1).LogExecuted(ControllerName, ActionName, "Patient", _httpContext, _claimsExtractor);
-        }
-
-        private void SetupExecutedAction(IActionResult result)
-        {
             var resultExecutedContext = new ResultExecutedContext(
                 new ActionContext(_httpContext, new RouteData(), new ControllerActionDescriptor() { DisplayName = "Executed Context Test Descriptor" }),
                 new List<IFilterMetadata>(),
-                result,
-                new MockController());
-
-            resultExecutedContext.ActionDescriptor = new ControllerActionDescriptor()
-            {
-                ControllerName = ControllerName,
-                ActionName = ActionName,
-            };
+                fhirResult,
+                FilterTestsHelper.CreateMockFhirController());
 
             _filter.OnResultExecuted(resultExecutedContext);
-        }
 
-        private class MockController : Controller
-        {
+            _auditHelper.Received(1).LogExecuted(_httpContext, _claimsExtractor);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Audit/AuditMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Audit/AuditMiddlewareTests.cs
@@ -6,10 +6,7 @@
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Routing;
 using Microsoft.Health.Fhir.Api.Features.Audit;
-using Microsoft.Health.Fhir.Api.Features.Routing;
-using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Security;
 using NSubstitute;
 using Xunit;
@@ -18,55 +15,29 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
 {
     public class AuditMiddlewareTests
     {
-        private const string Controller = "Fhir";
-        private const string Action = "Action";
-
-        private readonly IFhirRequestContextAccessor _fhirRequestContextAccessor = Substitute.For<IFhirRequestContextAccessor>();
         private readonly IClaimsExtractor _claimsExtractor = Substitute.For<IClaimsExtractor>();
         private readonly IAuditHelper _auditHelper = Substitute.For<IAuditHelper>();
 
         private readonly AuditMiddleware _auditMiddleware;
 
         private readonly HttpContext _httpContext = new DefaultHttpContext();
-        private readonly IFhirRequestContext _fhirRequestContext = Substitute.For<IFhirRequestContext>();
 
         public AuditMiddlewareTests()
         {
-            _fhirRequestContextAccessor.FhirRequestContext.Returns(_fhirRequestContext);
-
             _auditMiddleware = new AuditMiddleware(
                 httpContext => Task.CompletedTask,
-                _fhirRequestContextAccessor,
                 _claimsExtractor,
                 _auditHelper);
         }
 
         [Fact]
-        public async Task GivenRouteNameSet_WhenInvoked_ThenAuditLogShouldNotBeLogged()
-        {
-            _fhirRequestContext.RouteName.Returns("route");
-
-            await _auditMiddleware.Invoke(_httpContext);
-
-            _auditHelper.DidNotReceiveWithAnyArgs().LogExecuted(
-                controllerName: default,
-                actionName: default,
-                responseResultType: default,
-                httpContext: default,
-                claimsExtractor: default);
-        }
-
-        [Fact]
-        public async Task GivenRouteNameNotSetAndNotAuthXFailure_WhenInvoked_ThenAuditLogShouldNotBeLogged()
+        public async Task GivenNotAuthXFailure_WhenInvoked_ThenAuditLogShouldNotBeLogged()
         {
             _httpContext.Response.StatusCode = (int)HttpStatusCode.OK;
 
             await _auditMiddleware.Invoke(_httpContext);
 
             _auditHelper.DidNotReceiveWithAnyArgs().LogExecuted(
-                controllerName: default,
-                actionName: default,
-                responseResultType: default,
                 httpContext: default,
                 claimsExtractor: default);
         }
@@ -74,65 +45,13 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
         [Theory]
         [InlineData(HttpStatusCode.Unauthorized)]
         [InlineData(HttpStatusCode.Forbidden)]
-        public async Task GivenRouteNameNotSetAndAuthXFailed_WhenInvoked_ThenAuditLogShouldBeLogged(HttpStatusCode statusCode)
+        public async Task GivenAuthXFailed_WhenInvoked_ThenAuditLogShouldBeLogged(HttpStatusCode statusCode)
         {
-            const string resourceType = "Patient";
-
             _httpContext.Response.StatusCode = (int)statusCode;
-
-            RouteData routeData = SetupRouteData(Controller, Action);
-
-            routeData.Values.Add(KnownActionParameterNames.ResourceType, resourceType);
 
             await _auditMiddleware.Invoke(_httpContext);
 
-            _auditHelper.Received(1).LogExecuted(Controller, Action, resourceType, _httpContext, _claimsExtractor);
-        }
-
-        [Fact]
-        public async Task GivenRouteNameNotSetAuthXFailedAndControllerActionNotSet_WhenInvoked_ThenAuditLogShouldBeLogged()
-        {
-            const HttpStatusCode statusCode = HttpStatusCode.Forbidden;
-
-            _httpContext.Response.StatusCode = (int)statusCode;
-
-            RouteData routeData = SetupRouteData(controllerName: null, actionName: null);
-
-            await _auditMiddleware.Invoke(_httpContext);
-
-            _auditHelper.Received(1).LogExecuted(null, null, null, _httpContext, _claimsExtractor);
-        }
-
-        [Fact]
-        public async Task GivenRouteNameNotSetAuthXFailedAndResourceTypeNotSet_WhenInvoked_ThenAuditLogShouldBeLogged()
-        {
-            const HttpStatusCode statusCode = HttpStatusCode.Forbidden;
-
-            _httpContext.Response.StatusCode = (int)statusCode;
-
-            RouteData routeData = SetupRouteData(Controller, Action);
-
-            await _auditMiddleware.Invoke(_httpContext);
-
-            _auditHelper.Received(1).LogExecuted(Controller, Action, null, _httpContext, _claimsExtractor);
-        }
-
-        private RouteData SetupRouteData(string controllerName = Controller, string actionName = Action)
-        {
-            _fhirRequestContext.RouteName.Returns((string)null);
-
-            var routeData = new RouteData();
-
-            routeData.Values.Add("controller", controllerName);
-            routeData.Values.Add("action", actionName);
-
-            IRoutingFeature routingFeature = Substitute.For<IRoutingFeature>();
-
-            routingFeature.RouteData.Returns(routeData);
-
-            _httpContext.Features[typeof(IRoutingFeature)] = routingFeature;
-
-            return routeData;
+            _auditHelper.Received(1).LogExecuted(_httpContext, _claimsExtractor);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Context/DefaultFhirRequestContext.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Context/DefaultFhirRequestContext.cs
@@ -1,0 +1,36 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using Microsoft.Extensions.Primitives;
+using Microsoft.Health.Fhir.Core.Features.Context;
+
+namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Context
+{
+    public class DefaultFhirRequestContext : IFhirRequestContext
+    {
+        public string Method { get; set; }
+
+        public Uri BaseUri { get; set; }
+
+        public Uri Uri { get; set; }
+
+        public string CorrelationId { get; set; }
+
+        public string RouteName { get; set; }
+
+        public string AuditEventType { get; set; }
+
+        public ClaimsPrincipal Principal { get; set; }
+
+        public IDictionary<string, StringValues> RequestHeaders { get; set; }
+
+        public IDictionary<string, StringValues> ResponseHeaders { get; set; }
+
+        public string ResourceType { get; set; }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Context/FhirRequestContextAfterAuthenticationMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Context/FhirRequestContextAfterAuthenticationMiddlewareTests.cs
@@ -1,0 +1,45 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Health.Fhir.Api.Features.Context;
+using Microsoft.Health.Fhir.Core.Features.Context;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Context
+{
+    public class FhirRequestContextAfterAuthenticationMiddlewareTests
+    {
+        private readonly FhirRequestContextAfterAuthenticationMiddleware _fhirRequestContextAfterAuthenticationMiddleware;
+
+        public FhirRequestContextAfterAuthenticationMiddlewareTests()
+        {
+            _fhirRequestContextAfterAuthenticationMiddleware = new FhirRequestContextAfterAuthenticationMiddleware(
+                httpContext => Task.CompletedTask);
+        }
+
+        [Fact]
+        public async Task GivenUserNotNull_WhenInvoked_ThenPrincipalShouldBeSet()
+        {
+            IFhirRequestContextAccessor fhirRequestContextAccessor = Substitute.For<IFhirRequestContextAccessor>();
+
+            var fhirRequestContext = new DefaultFhirRequestContext();
+
+            fhirRequestContextAccessor.FhirRequestContext.Returns(fhirRequestContext);
+
+            HttpContext httpContext = new DefaultHttpContext();
+
+            var expectedPrincipal = new System.Security.Claims.ClaimsPrincipal();
+
+            httpContext.User = expectedPrincipal;
+
+            await _fhirRequestContextAfterAuthenticationMiddleware.Invoke(httpContext, fhirRequestContextAccessor);
+
+            Assert.Same(expectedPrincipal, fhirRequestContext.Principal);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Context/FhirRequestContextBeforeAuthenticationMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Context/FhirRequestContextBeforeAuthenticationMiddlewareTests.cs
@@ -1,0 +1,137 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Health.Fhir.Api.Features.Audit;
+using Microsoft.Health.Fhir.Api.Features.Context;
+using Microsoft.Health.Fhir.Core.Features.Context;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Context
+{
+    public class FhirRequestContextBeforeAuthenticationMiddlewareTests
+    {
+        private const string ControllerName = "controller";
+        private const string ActionName = "action";
+        private const string DefaultAuditEventType = "audit";
+
+        private readonly IFhirRequestContextAccessor _fhirRequestContextAccessor = Substitute.For<IFhirRequestContextAccessor>();
+        private readonly IAuditEventTypeMapping _auditEventTypeMapping = Substitute.For<IAuditEventTypeMapping>();
+
+        private readonly FhirRequestContextBeforeAuthenticationMiddleware _fhirRequestContextBeforeAuthenticationMiddleware;
+
+        private readonly DefaultFhirRequestContext _fhirRequestContext = new DefaultFhirRequestContext();
+        private readonly HttpContext _httpContext = new DefaultHttpContext();
+
+        public FhirRequestContextBeforeAuthenticationMiddlewareTests()
+        {
+            _fhirRequestContextAccessor.FhirRequestContext.Returns(_fhirRequestContext);
+
+            _fhirRequestContextBeforeAuthenticationMiddleware = new FhirRequestContextBeforeAuthenticationMiddleware(
+                httpContext => Task.CompletedTask,
+                _fhirRequestContextAccessor,
+                _auditEventTypeMapping);
+        }
+
+        [Fact]
+        public async Task GivenRouteNameSet_WhenInvoked_ThenAuditLogShouldNotBeLogged()
+        {
+            _fhirRequestContext.RouteName = "route";
+
+            await _fhirRequestContextBeforeAuthenticationMiddleware.Invoke(_httpContext);
+
+            Assert.Null(_fhirRequestContext.AuditEventType);
+            Assert.Null(_fhirRequestContext.ResourceType);
+        }
+
+        [Fact]
+        public async Task GivenRouteNameNotSetAndNotAuthXFailure_WhenInvoked_ThenAuditLogShouldNotBeLogged()
+        {
+            _httpContext.Response.StatusCode = (int)HttpStatusCode.OK;
+
+            await _fhirRequestContextBeforeAuthenticationMiddleware.Invoke(_httpContext);
+
+            Assert.Null(_fhirRequestContext.AuditEventType);
+            Assert.Null(_fhirRequestContext.ResourceType);
+        }
+
+        [Theory]
+        [InlineData(HttpStatusCode.Unauthorized)]
+        [InlineData(HttpStatusCode.Forbidden)]
+        public async Task GivenRouteNameNotSetAndAuthXFailed_WhenInvoked_ThenAuditLogShouldBeLogged(HttpStatusCode statusCode)
+        {
+            const string resourceType = "Patient";
+
+            _auditEventTypeMapping.GetAuditEventType(ControllerName, ActionName).Returns(DefaultAuditEventType);
+
+            _httpContext.Response.StatusCode = (int)statusCode;
+
+            RouteData routeData = SetupRouteData(ControllerName, ActionName);
+
+            routeData.Values.Add("typeParameter", resourceType);
+
+            await _fhirRequestContextBeforeAuthenticationMiddleware.Invoke(_httpContext);
+
+            Assert.Equal(DefaultAuditEventType, _fhirRequestContext.AuditEventType);
+            Assert.Equal(resourceType, _fhirRequestContext.ResourceType);
+        }
+
+        [Fact]
+        public async Task GivenRouteNameNotSetAuthXFailedAndControllerActionNotSet_WhenInvoked_ThenAuditLogShouldBeLogged()
+        {
+            _auditEventTypeMapping.GetAuditEventType(default, default).ReturnsForAnyArgs((string)null);
+
+            const HttpStatusCode statusCode = HttpStatusCode.Forbidden;
+
+            _httpContext.Response.StatusCode = (int)statusCode;
+
+            SetupRouteData(controllerName: null, actionName: null);
+
+            await _fhirRequestContextBeforeAuthenticationMiddleware.Invoke(_httpContext);
+
+            Assert.Null(_fhirRequestContext.AuditEventType);
+            Assert.Null(_fhirRequestContext.ResourceType);
+        }
+
+        [Fact]
+        public async Task GivenRouteNameNotSetAuthXFailedAndResourceTypeNotSet_WhenInvoked_ThenAuditLogShouldBeLogged()
+        {
+            const HttpStatusCode statusCode = HttpStatusCode.Forbidden;
+
+            _auditEventTypeMapping.GetAuditEventType(ControllerName, ActionName).Returns(DefaultAuditEventType);
+
+            _httpContext.Response.StatusCode = (int)statusCode;
+
+            SetupRouteData(ControllerName, ActionName);
+
+            await _fhirRequestContextBeforeAuthenticationMiddleware.Invoke(_httpContext);
+
+            Assert.Equal(DefaultAuditEventType, _fhirRequestContext.AuditEventType);
+            Assert.Null(_fhirRequestContext.ResourceType);
+        }
+
+        private RouteData SetupRouteData(string controllerName = ControllerName, string actionName = ActionName)
+        {
+            _fhirRequestContext.RouteName = null;
+
+            var routeData = new RouteData();
+
+            routeData.Values.Add("controller", controllerName);
+            routeData.Values.Add("action", actionName);
+
+            IRoutingFeature routingFeature = Substitute.For<IRoutingFeature>();
+
+            routingFeature.RouteData.Returns(routeData);
+
+            _httpContext.Features[typeof(IRoutingFeature)] = routingFeature;
+
+            return routeData;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Context/FhirRequestContextMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Context/FhirRequestContextMiddlewareTests.cs
@@ -4,7 +4,6 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
@@ -48,20 +47,6 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Context
 
             Assert.True(httpContext.Response.Headers.TryGetValue("X-Request-Id", out StringValues value));
             Assert.Equal(new StringValues(expectedRequestId), value);
-        }
-
-        [Fact]
-        public async Task GivenAnHttpContextWithPrincipal_WhenExecutingFhirRequestContextMiddleware_ThenPrincipalShouldBeSet()
-        {
-            HttpContext httpContext = CreateHttpContext();
-
-            var principal = new ClaimsPrincipal();
-
-            httpContext.User = principal;
-
-            IFhirRequestContext fhirRequestContext = await SetupAsync(httpContext);
-
-            Assert.Same(principal, fhirRequestContext.Principal);
         }
 
         private async Task<IFhirRequestContext> SetupAsync(HttpContext httpContext)

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/OperationOutcomeExceptionFilterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/OperationOutcomeExceptionFilterTests.cs
@@ -16,6 +16,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Health.Abstractions.Exceptions;
 using Microsoft.Health.Fhir.Api.Features.ActionResults;
 using Microsoft.Health.Fhir.Api.Features.Filters;
+using Microsoft.Health.Fhir.Api.UnitTests.Features.Context;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Operations;
@@ -33,7 +34,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
     {
         private readonly ActionExecutedContext _context;
         private readonly IFhirRequestContextAccessor _fhirRequestContextAccessor = Substitute.For<IFhirRequestContextAccessor>();
-        private readonly IFhirRequestContext _fhirRequestContext = Substitute.For<IFhirRequestContext>();
+        private readonly DefaultFhirRequestContext _fhirRequestContext = new DefaultFhirRequestContext();
         private readonly string _correlationId = Guid.NewGuid().ToString();
 
         public OperationOutcomeExceptionFilterTests()
@@ -43,7 +44,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
                 new List<IFilterMetadata>(),
                 FilterTestsHelper.CreateMockFhirController());
 
-            _fhirRequestContext.CorrelationId.Returns(_correlationId);
+            _fhirRequestContext.CorrelationId = _correlationId;
             _fhirRequestContextAccessor.FhirRequestContext.Returns(_fhirRequestContext);
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerTests.cs
@@ -16,6 +16,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Health.Fhir.Api.Features.Bundle;
 using Microsoft.Health.Fhir.Api.Features.Resources.Bundle;
+using Microsoft.Health.Fhir.Api.UnitTests.Features.Context;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
@@ -42,9 +43,9 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
         {
             _router = Substitute.For<IRouter>();
 
-            var fhirRequestContext = Substitute.For<IFhirRequestContext>();
-            fhirRequestContext.BaseUri.Returns(new Uri("https://localhost/"));
-            fhirRequestContext.CorrelationId.Returns(Guid.NewGuid().ToString());
+            var fhirRequestContext = new DefaultFhirRequestContext();
+            fhirRequestContext.BaseUri = new Uri("https://localhost/");
+            fhirRequestContext.CorrelationId = Guid.NewGuid().ToString();
 
             _fhirRequestContextAccessor = Substitute.For<IFhirRequestContextAccessor>();
             _fhirRequestContextAccessor.FhirRequestContext.Returns(fhirRequestContext);

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Microsoft.Health.Fhir.Shared.Api.UnitTests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Microsoft.Health.Fhir.Shared.Api.UnitTests.projitems
@@ -23,10 +23,13 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Audit\AuditLoggingFilterAttributeTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Audit\AuditMiddlewareTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Bundle\BundleAwareJwtBearerHandlerTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Context\DefaultFhirRequestContext.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Context\FhirRequestContextAfterAuthenticationMiddlewareTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Context\FhirRequestContextBeforeAuthenticationMiddlewareTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Context\FhirRequestContextMiddlewareTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Cors\CorsModuleTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Exceptions\BaseExceptionMiddlewareTests.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Features\Filters\FhirRequestContextRouteNameFilterAttributeTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Filters\FhirRequestContextRouteDataPopulatingFilterAttributeTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Filters\FilterTestsHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Filters\OperationOutcomeExceptionFilterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Filters\ValidateContentTypeFilterAttributeTests.cs" />

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         }
 
         [ApiExplorerSettings(IgnoreApi = true)]
-        [Route("CustomError")]
+        [Route(KnownRoutes.CustomError)]
         [AllowAnonymous]
         public IActionResult CustomError(int? statusCode = null)
         {

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/ActionResults/FhirResult.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/ActionResults/FhirResult.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Health.Fhir.Api.Features.ActionResults
     /// <summary>
     /// Handles the output of a FHIR MVC Action Method
     /// </summary>
-    public class FhirResult : BaseActionResult<ResourceElement>
+    public class FhirResult : ResourceActionResult<ResourceElement>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FhirResult" /> class.

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/ActionResults/OperationOutcomeResult.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/ActionResults/OperationOutcomeResult.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Health.Fhir.Api.Features.ActionResults
     /// This action result is specifically used when we want to return an error
     /// to the client with the appropriate OperationOutcome.
     /// </summary>
-    public class OperationOutcomeResult : BaseActionResult<OperationOutcome>
+    public class OperationOutcomeResult : ResourceActionResult<OperationOutcome>
     {
         public OperationOutcomeResult(OperationOutcome outcome, HttpStatusCode statusCode)
             : base(outcome, statusCode)

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/ActionResults/OperationVersionsResult.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/ActionResults/OperationVersionsResult.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Health.Fhir.Api.Features.ActionResults
     /// <summary>
     /// Used to return the result of a versions operation.
     /// </summary>
-    public class OperationVersionsResult : BaseActionResult<VersionsResult>
+    public class OperationVersionsResult : ResourceActionResult<VersionsResult>
     {
         private readonly VersionsResult _versionsResult;
 

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
@@ -258,11 +258,12 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                         originalFhirRequestContext.BaseUri.OriginalString,
                         originalFhirRequestContext.CorrelationId,
                         httpContext.Request.Headers,
-                        httpContext.Response.Headers,
-                        resourceType?.ToString())
+                        httpContext.Response.Headers)
                     {
                         Principal = originalFhirRequestContext.Principal,
+                        ResourceType = resourceType?.ToString(),
                     };
+
                     _fhirRequestContextAccessor.FhirRequestContext = newFhirRequestContext;
 
                     _bundleHttpContextAccessor.HttpContext = httpContext;

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/MvcModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/MvcModule.cs
@@ -48,7 +48,9 @@ namespace Microsoft.Health.Fhir.Api.Modules
             services.PostConfigure<MvcOptions>(options =>
             {
                 options.ModelBinderProviders.Insert(0, new PartialDateTimeBinderProvider());
-                options.Filters.Add(typeof(FhirRequestContextRouteDataPopulatingFilterAttribute));
+
+                // This filter should run first because it populates data for FhirRequestContext.
+                options.Filters.Add(typeof(FhirRequestContextRouteDataPopulatingFilterAttribute), 0);
             });
 
             services.AddHttpContextAccessor();

--- a/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Api.Configs;
+using Microsoft.Health.Fhir.Api.Features.ApiNotifications;
 using Microsoft.Health.Fhir.Api.Features.Audit;
 using Microsoft.Health.Fhir.Api.Features.Context;
 using Microsoft.Health.Fhir.Api.Features.Exceptions;
@@ -133,14 +134,11 @@ namespace Microsoft.Extensions.DependencyInjection
                         app.UseStatusCodePagesWithReExecute("/CustomError", "?statusCode={0}");
                     }
 
-                    // The audit module needs to come after the exception handler because we need to catch
-                    // the response before it gets converted to custom error.
+                    // The audit module needs to come after the exception handler because we need to catch the response before it gets converted to custom error.
                     app.UseAudit();
+                    app.UseApiNotifications();
 
-                    app.UseAuthentication();
-
-                    // Now that we've authenticated the user, update the context with any post-authentication info.
-                    app.UseFhirRequestContextAfterAuthentication();
+                    app.UseFhirRequestContextAuthentication();
 
                     next(app);
                 };

--- a/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
@@ -17,6 +17,7 @@ using Microsoft.Health.Fhir.Api.Features.Context;
 using Microsoft.Health.Fhir.Api.Features.Exceptions;
 using Microsoft.Health.Fhir.Api.Features.Headers;
 using Microsoft.Health.Fhir.Api.Features.Operations.Export;
+using Microsoft.Health.Fhir.Api.Features.Routing;
 using Microsoft.Health.Fhir.Core.Features.Cors;
 using Microsoft.Health.Fhir.Core.Registration;
 
@@ -128,10 +129,10 @@ namespace Microsoft.Extensions.DependencyInjection
                         app.UseBaseException();
 
                         // This middleware will capture any unhandled exceptions and attempt to return an operation outcome using the customError page
-                        app.UseExceptionHandler("/CustomError");
+                        app.UseExceptionHandler(KnownRoutes.CustomError);
 
                         // This middleware will capture any handled error with the status code between 400 and 599 that hasn't had a body or content-type set. (i.e. 404 on unknown routes)
-                        app.UseStatusCodePagesWithReExecute("/CustomError", "?statusCode={0}");
+                        app.UseStatusCodePagesWithReExecute(KnownRoutes.CustomError, "?statusCode={0}");
                     }
 
                     // The audit module needs to come after the exception handler because we need to catch the response before it gets converted to custom error.

--- a/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
@@ -48,8 +48,6 @@ namespace Microsoft.Health.Fhir.Web
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public virtual void Configure(IApplicationBuilder app)
         {
-            app.UseApiNotifications();
-
             app.UseFhirServer();
 
             app.UseDevelopmentIdentityProvider();

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/AuditTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/AuditTests.cs
@@ -41,6 +41,24 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit
         }
 
         [Fact]
+        public async Task GivenMetadata_WhenRead_ThenAuditLogEntriesShouldNotBeCreated()
+        {
+            if (!_fixture.IsUsingInProcTestServer)
+            {
+                // This test only works with the in-proc server with customized middleware pipeline
+                return;
+            }
+
+            FhirResponse response = await _client.ReadAsync<CapabilityStatement>("metadata");
+
+            string correlationId = response.Headers.GetValues(RequestIdHeaderName).FirstOrDefault();
+
+            Assert.NotNull(correlationId);
+
+            Assert.Empty(_auditLogger.GetAuditEntriesByCorrelationId(correlationId));
+        }
+
+        [Fact]
         public async Task GivenAResource_WhenCreated_ThenAuditLogEntriesShouldBeCreated()
         {
             await ExecuteAndValidate(

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Metric/MetricTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Metric/MetricTests.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.Health.CosmosDb.Features.Storage;
 using Microsoft.Health.Fhir.Api.Features.ApiNotifications;
 using Microsoft.Health.Fhir.Core.Extensions;
@@ -59,7 +58,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Metric
             _metricHandler?.ResetCount();
 
             await ExecuteAndValidate(
-                () => _client.HttpClient.GetAsync(FhirServerApplicationBuilderExtensions.HealthCheckPath),
+                () => _client.HttpClient.GetAsync("/health/check"),
                 (type: typeof(ApiResponseNotification), count: 0, resourceType: (string)null),
                 (type: typeof(CosmosStorageRequestMetricsNotification), count: 2, resourceType: (string)null));
         }


### PR DESCRIPTION
## Description
Refactored the code base so that ApiNotificationMiddleware is now being registered in the IoC container so that the instance can be replaced when needed.

Also, cleaned up the code around how the FhirRequestContext is being initialized. In FhirRequestContextMiddleware, the RouteData and Principal will have the correct value anyways because Mvc middle has not executed yet so removed these. Added FhirRequestContextBeforeAuthenticationMiddleware and together with FhirRequestContextAfterAuthenticationMiddleware and FhirRequestContextRouteDataPopulatingFilterAttribute, it tries to initialize the FhirRequestContext as soon as possible.

FhirRequestContextBeforeAuthenticationMiddleware runs before the Authentication middleware and is needed in case the authentication/authorization fails. In this case, the Mvc middleware is not executed, which means the code will not populate anything related to route (audit event, resource type and etc). The logic in this middleware catches that condition and tries to populate these data.

FhirRequestContextAfterAuthenticationMiddleware  runs after the Authenticaiton middleware and will populate the principal.

FhirRequestContextRouteDataPopulatingFilterAttribute runs after Mvc middleware and will populate route when the request passed authentication/authorization check.

We should look at this and refactor some of the code and maybe remove dependencies on the authorization middleware at some point.

## TODO

One thing I started to clean up but end up not included in this PR is around audit. Currently, the executed audit event is logged in both AuditMiddleware and AuditLoggingFilterAttribute. This is again because Authentication middleware runs before Mvc middleware so AuditMiddleware is responsible for logging the case where the request failed with authentication/authorization error whereas AuditLoggingFilterAttribute logs the requests that passed authentication check. Ideally, all of the executed audit log should happen in AuditMiddlware (e.g., if we want to also log latency along with the audit log, which is something the many Azure service does). However, currently, the batch/transaction has dependencies on AuditLoggingFilterAttribute to log child requests. Once that change is checked in, I can revisit this later.

## Related issues
Addresses [AB#70213](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/70213).

## Testing
Unit test, integration test, and manu tests.
