### PR TITLE
Updates location in operationOutcome

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/ValidateResourceIdFilterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/ValidateResourceIdFilterTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Hl7.Fhir.Model;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -14,6 +15,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Health.Fhir.Api.Features.Filters;
 using Microsoft.Health.Fhir.Api.Features.Routing;
 using Microsoft.Health.Fhir.Core.Features.Validation;
+using Microsoft.Health.Fhir.Core.Models;
 using Xunit;
 
 namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
@@ -47,7 +49,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
 
             var context = CreateContext(observation, observation.Id.ToUpper());
 
-            Assert.Throws<ResourceNotValidException>(() => filter.OnActionExecuting(context));
+            var exception = Assert.Throws<ResourceNotValidException>(() => filter.OnActionExecuting(context));
+            Assert.Equal("Observation.id", exception.Issues.First<OperationOutcomeIssue>().Location.First());
         }
 
         [Fact]
@@ -75,6 +78,9 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
             var context = CreateContext(observation, Guid.NewGuid().ToString());
 
             Assert.Throws<ResourceNotValidException>(() => filter.OnActionExecuting(context));
+
+            var exception = Assert.Throws<ResourceNotValidException>(() => filter.OnActionExecuting(context));
+            Assert.Equal("Observation.id", exception.Issues.First<OperationOutcomeIssue>().Location.First());
         }
 
         private static ActionExecutingContext CreateContext(Resource type, string id)

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/ValidateResourceIdFilterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/ValidateResourceIdFilterTests.cs
@@ -77,8 +77,6 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
 
             var context = CreateContext(observation, Guid.NewGuid().ToString());
 
-            Assert.Throws<ResourceNotValidException>(() => filter.OnActionExecuting(context));
-
             var exception = Assert.Throws<ResourceNotValidException>(() => filter.OnActionExecuting(context));
             Assert.Equal("Observation.id", exception.Issues.First<OperationOutcomeIssue>().Location.First());
         }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/ValidateResourceIdFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/ValidateResourceIdFilterAttribute.cs
@@ -24,9 +24,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
             if (context.RouteData.Values.TryGetValue(KnownActionParameterNames.Id, out var actionId) &&
                 context.ActionArguments.TryGetValue(KnownActionParameterNames.Resource, out var parsedModel))
             {
-                string location = context.RouteData.Values.TryGetValue(KnownActionParameterNames.ResourceType, out var resourceType) ?
-                    string.Concat(resourceType, ".id") : string.Empty;
-                if (string.IsNullOrWhiteSpace(((Resource)parsedModel).Id))
+                var resource = (Resource)parsedModel;
+                var location = $"{resource.TypeName}.id";
+                if (string.IsNullOrWhiteSpace(resource.Id))
                 {
                     throw new ResourceNotValidException(new List<ValidationFailure>
                     {
@@ -34,7 +34,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
                     });
                 }
 
-                if (!string.Equals((string)actionId, ((Resource)parsedModel).Id, StringComparison.Ordinal))
+                if (!string.Equals((string)actionId, resource.Id, StringComparison.Ordinal))
                 {
                     throw new ResourceNotValidException(new List<ValidationFailure>
                     {

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/ValidateResourceIdFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/ValidateResourceIdFilterAttribute.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using EnsureThat;
 using FluentValidation.Results;
 using Hl7.Fhir.Model;
@@ -25,7 +24,8 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
             if (context.RouteData.Values.TryGetValue(KnownActionParameterNames.Id, out var actionId) &&
                 context.ActionArguments.TryGetValue(KnownActionParameterNames.Resource, out var parsedModel))
             {
-                string location = string.Concat(parsedModel.GetType().ToString().Split('.').Last(), ".id");
+                string location = context.RouteData.Values.TryGetValue(KnownActionParameterNames.ResourceType, out var resourceType) ?
+                    string.Concat(resourceType, ".id") : string.Empty;
                 if (string.IsNullOrWhiteSpace(((Resource)parsedModel).Id))
                 {
                     throw new ResourceNotValidException(new List<ValidationFailure>

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/ValidateResourceIdFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/ValidateResourceIdFilterAttribute.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using EnsureThat;
 using FluentValidation.Results;
 using Hl7.Fhir.Model;
@@ -24,19 +25,20 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
             if (context.RouteData.Values.TryGetValue(KnownActionParameterNames.Id, out var actionId) &&
                 context.ActionArguments.TryGetValue(KnownActionParameterNames.Resource, out var parsedModel))
             {
-                if (!string.Equals((string)actionId, ((Resource)parsedModel).Id, StringComparison.Ordinal))
-                {
-                    throw new ResourceNotValidException(new List<ValidationFailure>
-                    {
-                        new ValidationFailure(nameof(Base.TypeName), Api.Resources.UrlResourceIdMismatch),
-                    });
-                }
-
+                string location = string.Concat(parsedModel.GetType().ToString().Split('.').Last(), ".id");
                 if (string.IsNullOrWhiteSpace(((Resource)parsedModel).Id))
                 {
                     throw new ResourceNotValidException(new List<ValidationFailure>
                     {
-                        new ValidationFailure(nameof(Base.TypeName), Api.Resources.ResourceIdRequired),
+                        new ValidationFailure(location, Api.Resources.ResourceIdRequired),
+                    });
+                }
+
+                if (!string.Equals((string)actionId, ((Resource)parsedModel).Id, StringComparison.Ordinal))
+                {
+                    throw new ResourceNotValidException(new List<ValidationFailure>
+                    {
+                        new ValidationFailure(location, Api.Resources.UrlResourceIdMismatch),
                     });
                 }
             }


### PR DESCRIPTION
## Description
The location updates to contain the relevant field "Observation.id" when Observation object resource Id not matched OR without Id
Fixes the order of not reachable code

## Related issues
Addresses #664

## Testing
Unit tests and manual tests.
![image](https://user-images.githubusercontent.com/57157506/70574082-1a44a600-1b58-11ea-8fc0-0b108cf0a5ca.png)

