### PR TITLE
Implements SQL export job creation

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/1.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/1.sql
@@ -1273,7 +1273,7 @@ CREATE UNIQUE NONCLUSTERED INDEX IX_ExportJob_Status_HeartbeatDateTime_QueuedDat
     Status,
     HeartbeatDateTime,
     QueuedDateTime
-) -- TODO: Modify indexes as needed when implementing method to acquire export jobs.
+) -- TODO: Modify indexes as needed when implementing remaining sql export methods.
 
 GO
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/1.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/1.sql
@@ -1260,7 +1260,7 @@ CREATE TABLE dbo.ExportJob
     HeartbeatDateTime datetimeoffset(7) NULL,
     QueuedDateTime datetimeoffset(7) NOT NULL,
     RawJobRecord varbinary(max) NOT NULL,
-	JobVersion rowversion NOT NULL
+    JobVersion rowversion NOT NULL
 )
 
 CREATE UNIQUE CLUSTERED INDEX IXC_ExportJob ON dbo.ExportJob

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/1.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/1.sql
@@ -1259,7 +1259,8 @@ CREATE TABLE dbo.ExportJob
     JobStatus varchar(10) NOT NULL,
     HeartbeatTimeStamp datetimeoffset(7) NULL,
     QueuedDateTime datetimeoffset(7) NOT NULL,
-    RawJobRecord varbinary(max) NOT NULL
+    RawJobRecord varbinary(max) NOT NULL,
+	JobVersion rowversion NOT NULL
 )
 
 CREATE UNIQUE CLUSTERED INDEX IXC_ExportJob ON dbo.ExportJob

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/1.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/1.sql
@@ -1331,6 +1331,8 @@ AS
     VALUES
         (@jobId, @jobStatus, @heartbeatTimeStamp, @queuedDateTime, @rawJobRecord)
   
+    SELECT CAST(MIN_ACTIVE_ROWVERSION() AS INT)
+
     COMMIT TRANSACTION
 GO
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/Column.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/Column.cs
@@ -434,9 +434,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
         }
     }
 
-    public class RowVersionColumn : Column<byte[]>
+    public class TimestampColumn : Column<byte[]>
     {
-        public RowVersionColumn(string name)
+        public TimestampColumn(string name)
             : base(name, SqlDbType.Timestamp, true)
         {
         }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/Column.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/Column.cs
@@ -439,6 +439,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
     /// </summary>
     /// <remarks>
     /// The timestamp data type is a synonym for the rowversion data type, and its syntax is now deprecated in SQL.
+    /// The rowversion data type is used in the SQL code, and it is translated to timestamp on the C# side because
+    /// the SqlDbType enum only supports timestamp.
     /// </remarks>
     public class TimestampColumn : Column<byte[]>
     {

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/Column.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/Column.cs
@@ -455,7 +455,10 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             const int length = 8;
 
             byte[] bytes = new byte[length];
-            reader.GetBytes(Metadata.Name, ordinal, 0, bytes, 0, length);
+            long fieldOffset = 0;
+            int bufferOffset = 0;
+
+            reader.GetBytes(Metadata.Name, ordinal, fieldOffset, bytes, bufferOffset, length);
 
             return bytes;
         }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/Column.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/Column.cs
@@ -434,6 +434,12 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
         }
     }
 
+    /// <summary>
+    /// Represents a rowversion type column.
+    /// </summary>
+    /// <remarks>
+    /// The timestamp data type is a synonym for the rowversion data type, and its syntax is now deprecated in SQL.
+    /// </remarks>
     public class TimestampColumn : Column<byte[]>
     {
         public TimestampColumn(string name)
@@ -443,7 +449,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
 
         public override byte[] Read(SqlDataReader reader, int ordinal)
         {
-            // The row version storage size is 8 bytes.
+            // The rowversion storage size is 8 bytes.
             const int length = 8;
 
             byte[] bytes = new byte[length];

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/Column.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/Column.cs
@@ -434,6 +434,30 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
         }
     }
 
+    public class RowVersionColumn : Column<byte[]>
+    {
+        public RowVersionColumn(string name)
+            : base(name, SqlDbType.Timestamp, true)
+        {
+        }
+
+        public override byte[] Read(SqlDataReader reader, int ordinal)
+        {
+            // The row version storage size is 8 bytes.
+            const int length = 8;
+
+            byte[] bytes = new byte[length];
+            reader.GetBytes(Metadata.Name, ordinal, 0, bytes, 0, length);
+
+            return bytes;
+        }
+
+        public override void Set(SqlDataRecord record, int ordinal, byte[] value)
+        {
+            record.SetBytes(ordinal, 0, value, 0, value.Length);
+        }
+    }
+
     public abstract class StringColumn : Column<string>
     {
         public StringColumn(string name, SqlDbType type, bool nullable, int length, string collation = null)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/Column.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/Column.cs
@@ -465,7 +465,10 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
 
         public override void Set(SqlDataRecord record, int ordinal, byte[] value)
         {
-            record.SetBytes(ordinal, 0, value, 0, value.Length);
+            long fieldOffset = 0;
+            int bufferOffset = 0;
+
+            record.SetBytes(ordinal, fieldOffset, value, bufferOffset, value.Length);
         }
     }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/V1.Generated.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/V1.Generated.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly NullableDateTimeOffsetColumn HeartbeatTimeStamp = new NullableDateTimeOffsetColumn("HeartbeatTimeStamp", 7);
             internal readonly DateTimeOffsetColumn QueuedDateTime = new DateTimeOffsetColumn("QueuedDateTime", 7);
             internal readonly VarBinaryColumn RawJobRecord = new VarBinaryColumn("RawJobRecord", -1);
-            internal readonly RowVersionColumn JobVersion = new RowVersionColumn("JobVersion");
+            internal readonly TimestampColumn JobVersion = new TimestampColumn("JobVersion");
         }
 
         internal class NumberSearchParamTable : Table

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/V1.Generated.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/V1.Generated.cs
@@ -100,6 +100,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly NullableDateTimeOffsetColumn HeartbeatTimeStamp = new NullableDateTimeOffsetColumn("HeartbeatTimeStamp", 7);
             internal readonly DateTimeOffsetColumn QueuedDateTime = new DateTimeOffsetColumn("QueuedDateTime", 7);
             internal readonly VarBinaryColumn RawJobRecord = new VarBinaryColumn("RawJobRecord", -1);
+            internal readonly RowVersionColumn JobVersion = new RowVersionColumn("JobVersion");
         }
 
         internal class NumberSearchParamTable : Table

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/V1.Generated.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/V1.Generated.cs
@@ -95,9 +95,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             {
             }
 
-            internal readonly VarCharColumn JobId = new VarCharColumn("JobId", 64, "Latin1_General_100_CS_AS");
-            internal readonly VarCharColumn JobStatus = new VarCharColumn("JobStatus", 10);
-            internal readonly NullableDateTimeOffsetColumn HeartbeatTimeStamp = new NullableDateTimeOffsetColumn("HeartbeatTimeStamp", 7);
+            internal readonly VarCharColumn Id = new VarCharColumn("Id", 64, "Latin1_General_100_CS_AS");
+            internal readonly VarCharColumn Status = new VarCharColumn("Status", 10);
+            internal readonly NullableDateTimeOffsetColumn HeartbeatDateTime = new NullableDateTimeOffsetColumn("HeartbeatDateTime", 7);
             internal readonly DateTimeOffsetColumn QueuedDateTime = new DateTimeOffsetColumn("QueuedDateTime", 7);
             internal readonly VarBinaryColumn RawJobRecord = new VarBinaryColumn("RawJobRecord", -1);
             internal readonly TimestampColumn JobVersion = new TimestampColumn("JobVersion");
@@ -395,18 +395,16 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             {
             }
 
-            private readonly ParameterDefinition<System.String> _jobId = new ParameterDefinition<System.String>("@jobId", global::System.Data.SqlDbType.VarChar, false, 64);
-            private readonly ParameterDefinition<System.String> _jobStatus = new ParameterDefinition<System.String>("@jobStatus", global::System.Data.SqlDbType.VarChar, false, 10);
-            private readonly ParameterDefinition<System.Nullable<System.DateTimeOffset>> _heartbeatTimeStamp = new ParameterDefinition<System.Nullable<System.DateTimeOffset>>("@heartbeatTimeStamp", global::System.Data.SqlDbType.DateTimeOffset, true, 7);
+            private readonly ParameterDefinition<System.String> _id = new ParameterDefinition<System.String>("@id", global::System.Data.SqlDbType.VarChar, false, 64);
+            private readonly ParameterDefinition<System.String> _status = new ParameterDefinition<System.String>("@status", global::System.Data.SqlDbType.VarChar, false, 10);
             private readonly ParameterDefinition<System.DateTimeOffset> _queuedDateTime = new ParameterDefinition<System.DateTimeOffset>("@queuedDateTime", global::System.Data.SqlDbType.DateTimeOffset, false, 7);
             private readonly ParameterDefinition<global::System.IO.Stream> _rawJobRecord = new ParameterDefinition<global::System.IO.Stream>("@rawJobRecord", global::System.Data.SqlDbType.VarBinary, false, -1);
-            public void PopulateCommand(global::System.Data.SqlClient.SqlCommand command, System.String jobId, System.String jobStatus, System.Nullable<System.DateTimeOffset> heartbeatTimeStamp, System.DateTimeOffset queuedDateTime, global::System.IO.Stream rawJobRecord)
+            public void PopulateCommand(global::System.Data.SqlClient.SqlCommand command, System.String id, System.String status, System.DateTimeOffset queuedDateTime, global::System.IO.Stream rawJobRecord)
             {
                 command.CommandType = global::System.Data.CommandType.StoredProcedure;
                 command.CommandText = "dbo.CreateExportJob";
-                _jobId.AddParameter(command.Parameters, jobId);
-                _jobStatus.AddParameter(command.Parameters, jobStatus);
-                _heartbeatTimeStamp.AddParameter(command.Parameters, heartbeatTimeStamp);
+                _id.AddParameter(command.Parameters, id);
+                _status.AddParameter(command.Parameters, status);
                 _queuedDateTime.AddParameter(command.Parameters, queuedDateTime);
                 _rawJobRecord.AddParameter(command.Parameters, rawJobRecord);
             }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirOperationDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirOperationDataStore.cs
@@ -72,12 +72,14 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                         jobRecord.QueuedTime,
                         stream);
 
-                    await command.ExecuteScalarAsync(cancellationToken);
+                    int? rowVersion = (int?)await command.ExecuteScalarAsync(cancellationToken);
+
+                    // The row version should nerver be null.
+                    Ensure.That(rowVersion).IsNotNull();
+
+                    return new ExportJobOutcome(jobRecord, WeakETag.FromVersionId(rowVersion.ToString()));
                 }
             }
-
-            // TODO: Where should the e tag come from?
-            return new ExportJobOutcome(jobRecord, WeakETag.FromVersionId("1"));
         }
 
         public Task<ExportJobOutcome> GetExportJobByIdAsync(string id, CancellationToken cancellationToken)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirOperationDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirOperationDataStore.cs
@@ -68,7 +68,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                         command,
                         jobRecord.Id,
                         jobRecord.Status.ToString(),
-                        null,
                         jobRecord.QueuedTime,
                         stream);
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirOperationDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirOperationDataStore.cs
@@ -11,6 +11,7 @@ using System.IO.Compression;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using EnsureThat;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export.Models;
@@ -32,6 +33,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
         public SqlServerFhirOperationDataStore(SqlServerDataStoreConfiguration configuration, ILogger<SqlServerFhirOperationDataStore> logger)
         {
+            EnsureArg.IsNotNull(configuration, nameof(configuration));
+            EnsureArg.IsNotNull(logger, nameof(logger));
+
             _configuration = configuration;
             _logger = logger;
             _memoryStreamManager = new RecyclableMemoryStreamManager();

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirOperationDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirOperationDataStore.cs
@@ -81,10 +81,10 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             throw new NotImplementedException();
         }
 
-        public async Task<ExportJobOutcome> GetExportJobByHashAsync(string hash, CancellationToken cancellationToken)
+        public Task<ExportJobOutcome> GetExportJobByHashAsync(string hash, CancellationToken cancellationToken)
         {
-            await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
-            return null;
+            // TODO: Implement this method (returning null for now to allow the create method to run).
+            return Task.FromResult<ExportJobOutcome>(null);
         }
 
         public Task<ExportJobOutcome> UpdateExportJobAsync(ExportJobRecord jobRecord, WeakETag eTag, CancellationToken cancellationToken)

--- a/src/Microsoft.Health.Fhir.SqlServer/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Health.Fhir.SqlServer {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -66,6 +66,15 @@ namespace Microsoft.Health.Fhir.SqlServer {
         internal static string InvalidContinuationToken {
             get {
                 return ResourceManager.GetString("InvalidContinuationToken", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The row version should never be null..
+        /// </summary>
+        internal static string NullRowVersion {
+            get {
+                return ResourceManager.GetString("NullRowVersion", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Health.Fhir.SqlServer/Resources.resx
+++ b/src/Microsoft.Health.Fhir.SqlServer/Resources.resx
@@ -120,6 +120,9 @@
   <data name="InvalidContinuationToken" xml:space="preserve">
     <value>The provided continuation token is not valid.</value>
   </data>
+  <data name="NullRowVersion" xml:space="preserve">
+    <value>The row version should never be null.</value>
+  </data>
   <data name="ScriptNotFound" xml:space="preserve">
     <value>The provided version is unknown.</value>
   </data>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/CosmosFhirOperationDataStoreTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/CosmosFhirOperationDataStoreTests.cs
@@ -17,8 +17,7 @@ using Xunit;
 
 namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
 {
-    [Collection(FhirOperationTestConstants.FhirOperationTests)]
-    [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb)]
+    [FhirStorageTestsFixtureArgumentSets(DataStore.All)]
     public class CosmosFhirOperationDataStoreTests : IClassFixture<FhirStorageTestsFixture>, IAsyncLifetime
     {
         private IFhirOperationDataStore _operationDataStore;
@@ -56,6 +55,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
         }
 
         [Fact]
+        [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb)]
         public async Task GivenAMatchingJob_WhenGettingById_ThenTheMatchingJobShouldBeReturned()
         {
             var jobRecord = await InsertNewExportJobRecordAsync();
@@ -66,6 +66,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
         }
 
         [Fact]
+        [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb)]
         public async Task GivenNoMatchingJob_WhenGettingById_ThehJobNotFoundExceptionShouldBeThrown()
         {
             var jobRecord = await InsertNewExportJobRecordAsync();
@@ -74,6 +75,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
         }
 
         [Fact]
+        [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb)]
         public async Task GivenAMatchingJob_WhenGettingByHash_ThenTheMatchingJobShouldBeReturned()
         {
             var jobRecord = await InsertNewExportJobRecordAsync();
@@ -84,6 +86,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
         }
 
         [Fact]
+        [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb)]
         public async Task GivenNoMatchingJob_WhenGettingByHash_ThenNoMatchingJobShouldBeReturned()
         {
             var jobRecord = await InsertNewExportJobRecordAsync();
@@ -94,6 +97,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
         }
 
         [Fact]
+        [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb)]
         public async Task GivenThereIsNoRunningJob_WhenAcquiringJobs_ThenAvailableJobsShouldBeReturned()
         {
             ExportJobRecord jobRecord = await InsertNewExportJobRecordAsync();
@@ -114,6 +118,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
         [InlineData(OperationStatus.Completed)]
         [InlineData(OperationStatus.Failed)]
         [InlineData(OperationStatus.Running)]
+        [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb)]
         public async Task GivenJobIsNotInQueuedState_WhenAcquiringJobs_ThenNoJobShouldBeReturned(OperationStatus operationStatus)
         {
             ExportJobRecord jobRecord = await InsertNewExportJobRecordAsync(jr => jr.Status = operationStatus);
@@ -128,6 +133,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
         [InlineData(1, 0)]
         [InlineData(2, 1)]
         [InlineData(3, 2)]
+        [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb)]
         public async Task GivenNumberOfRunningJobs_WhenAcquiringJobs_ThenAvailableJobsShouldBeReturned(ushort limit, int expectedNumberOfJobsReturned)
         {
             ExportJobRecord jobRecord1 = await InsertNewExportJobRecordAsync();
@@ -159,6 +165,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
         }
 
         [Fact]
+        [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb)]
         public async Task GivenThereIsRunningJobThatExpired_WhenAcquiringJobs_ThenTheExpiredJobShouldBeReturned()
         {
             ExportJobRecord jobRecord = await InsertNewExportJobRecordAsync(jr => jr.Status = OperationStatus.Running);
@@ -174,6 +181,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
         }
 
         [Fact]
+        [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb)]
         public async Task GivenThereAreQueuedJobs_WhenSimultaneouslyAcquiringJobs_ThenCorrectJobsShouldBeReturned()
         {
             ExportJobRecord[] jobRecords = new[]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Export/CreateExportRequestHandlerTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Export/CreateExportRequestHandlerTests.cs
@@ -23,7 +23,7 @@ using Xunit;
 namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Export
 {
     [Collection(FhirOperationTestConstants.FhirOperationTests)]
-    [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb)]
+    [FhirStorageTestsFixtureArgumentSets(DataStore.All)]
     public class CreateExportRequestHandlerTests : IClassFixture<FhirStorageTestsFixture>, IAsyncLifetime
     {
         private static readonly Uri RequestUrl = new Uri("https://localhost/$export/");
@@ -73,6 +73,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Export
         }
 
         [Fact]
+        [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb)]
         public async Task GivenThereIsAMatchingJob_WhenCreatingAnExportJob_ThenExistingJobShouldBeReturned()
         {
             var request = new CreateExportRequest(RequestUrl, DestinationType, ConnectionString);
@@ -122,6 +123,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Export
         }
 
         [Fact]
+        [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb)]
         public async Task GivenThereIsAMatchingJob_WhenRequestorClaimsInDifferentOrder_ThenExistingJobShouldBeReturned()
         {
             var claim1 = KeyValuePair.Create("oid", "user1");
@@ -158,6 +160,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Export
         }
 
         [Fact]
+        [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb)]
         public async Task GivenDestinationTypeOrDestinationConnectionSettings_WhenCreatingAnExportJob_ThenItShouldBeRemovedFromRequestUri()
         {
             const string baseUrlFormat = "http://localhost/$export?_count=100{0}&_another=123";

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Export/CreateExportRequestHandlerTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Export/CreateExportRequestHandlerTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Export
 
         public Task InitializeAsync()
         {
-            return _fhirStorageTestHelper.DeleteAllExportJobRecordsAsync();
+            return _fhirStorageTestHelper.DeleteAllExportJobRecordsAsync(_cancellationToken);
         }
 
         public Task DisposeAsync()

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/FhirOperationDataStoreTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/FhirOperationDataStoreTests.cs
@@ -20,8 +20,9 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
     [FhirStorageTestsFixtureArgumentSets(DataStore.All)]
     public class FhirOperationDataStoreTests : IClassFixture<FhirStorageTestsFixture>, IAsyncLifetime
     {
-        private IFhirOperationDataStore _operationDataStore;
-        private IFhirStorageTestHelper _testHelper;
+        private readonly IFhirOperationDataStore _operationDataStore;
+        private readonly IFhirStorageTestHelper _testHelper;
+        private readonly CancellationToken _cancellationToken;
 
         private readonly CreateExportRequest _exportRequest = new CreateExportRequest(new Uri("http://localhost/ExportJob"), "destinationType", "destinationConnection");
 
@@ -29,11 +30,12 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
         {
             _operationDataStore = fixture.OperationDataStore;
             _testHelper = fixture.TestHelper;
+            _cancellationToken = new CancellationTokenSource().Token;
         }
 
         public async Task InitializeAsync()
         {
-            await _testHelper.DeleteAllExportJobRecordsAsync();
+            await _testHelper.DeleteAllExportJobRecordsAsync(_cancellationToken);
         }
 
         public Task DisposeAsync()

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/FhirOperationDataStoreTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/FhirOperationDataStoreTests.cs
@@ -18,14 +18,14 @@ using Xunit;
 namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
 {
     [FhirStorageTestsFixtureArgumentSets(DataStore.All)]
-    public class CosmosFhirOperationDataStoreTests : IClassFixture<FhirStorageTestsFixture>, IAsyncLifetime
+    public class FhirOperationDataStoreTests : IClassFixture<FhirStorageTestsFixture>, IAsyncLifetime
     {
         private IFhirOperationDataStore _operationDataStore;
         private IFhirStorageTestHelper _testHelper;
 
         private readonly CreateExportRequest _exportRequest = new CreateExportRequest(new Uri("http://localhost/ExportJob"), "destinationType", "destinationConnection");
 
-        public CosmosFhirOperationDataStoreTests(FhirStorageTestsFixture fixture)
+        public FhirOperationDataStoreTests(FhirStorageTestsFixture fixture)
         {
             _operationDataStore = fixture.OperationDataStore;
             _testHelper = fixture.TestHelper;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/FhirOperationDataStoreTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/FhirOperationDataStoreTests.cs
@@ -17,6 +17,7 @@ using Xunit;
 
 namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
 {
+    [Collection(FhirOperationTestConstants.FhirOperationTests)]
     [FhirStorageTestsFixtureArgumentSets(DataStore.All)]
     public class FhirOperationDataStoreTests : IClassFixture<FhirStorageTestsFixture>, IAsyncLifetime
     {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Microsoft.Health.Fhir.Shared.Tests.Integration.projitems
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Microsoft.Health.Fhir.Shared.Tests.Integration.projitems
@@ -9,7 +9,7 @@
     <Import_RootNamespace>Microsoft.Health.Fhir.Shared.Tests.Integration</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\CosmosFhirOperationDataStoreTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\FhirOperationDataStoreTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\Export\CreateExportRequestHandlerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\FhirOperationTestConstants.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\CosmosDbFhirStorageTestHelper.cs" />

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestHelper.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Documents;
 using Microsoft.Azure.Documents.Client;
@@ -27,7 +28,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             _collectionUri = collectionUri;
         }
 
-        public async Task DeleteAllExportJobRecordsAsync()
+        public async Task DeleteAllExportJobRecordsAsync(CancellationToken cancellationToken)
         {
             IDocumentQuery<Document> query = _documentClient.CreateDocumentQuery<Document>(
                 _collectionUri,
@@ -37,11 +38,11 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
             while (query.HasMoreResults)
             {
-                FeedResponse<Document> documents = await query.ExecuteNextAsync<Document>();
+                FeedResponse<Document> documents = await query.ExecuteNextAsync<Document>(cancellationToken);
 
                 foreach (Document doc in documents)
                 {
-                    await _documentClient.DeleteDocumentAsync(doc.SelfLink, new RequestOptions() { PartitionKey = new PartitionKey(ExportJobPartitionKey) });
+                    await _documentClient.DeleteDocumentAsync(doc.SelfLink, new RequestOptions() { PartitionKey = new PartitionKey(ExportJobPartitionKey) }, cancellationToken);
                 }
             }
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/IFhirStorageTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/IFhirStorageTestHelper.cs
@@ -3,13 +3,14 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 {
     public interface IFhirStorageTestHelper
     {
-        Task DeleteAllExportJobRecordsAsync();
+        Task DeleteAllExportJobRecordsAsync(CancellationToken cancellationToken);
 
         /// <summary>
         /// Gets a token representing the state of the database.

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
@@ -25,7 +25,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             using (var connection = new SqlConnection(_connectionString))
             {
                 var command = new SqlCommand("DELETE FROM dbo.ExportJob", connection);
-                command.Connection.Open();
+
+                await command.Connection.OpenAsync(cancellationToken);
                 await command.ExecuteNonQueryAsync(cancellationToken);
             }
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
@@ -5,6 +5,7 @@
 
 using System.Data.SqlClient;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -19,13 +20,13 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             _connectionString = connectionString;
         }
 
-        public async Task DeleteAllExportJobRecordsAsync()
+        public async Task DeleteAllExportJobRecordsAsync(CancellationToken cancellationToken)
         {
             using (var connection = new SqlConnection(_connectionString))
             {
                 var command = new SqlCommand("DELETE FROM dbo.ExportJob", connection);
                 command.Connection.Open();
-                await command.ExecuteNonQueryAsync();
+                await command.ExecuteNonQueryAsync(cancellationToken);
             }
         }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
@@ -19,9 +19,14 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             _connectionString = connectionString;
         }
 
-        public Task DeleteAllExportJobRecordsAsync()
+        public async Task DeleteAllExportJobRecordsAsync()
         {
-            throw new System.NotImplementedException();
+            using (var connection = new SqlConnection(_connectionString))
+            {
+                var command = new SqlCommand("DELETE FROM dbo.ExportJob", connection);
+                command.Connection.Open();
+                await command.ExecuteNonQueryAsync();
+            }
         }
 
         async Task<object> IFhirStorageTestHelper.GetSnapshotToken()

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         private readonly string _masterConnectionString;
         private readonly string _databaseName;
         private readonly IFhirDataStore _fhirDataStore;
-        private IFhirOperationDataStore _fhirOperationDataStore;
+        private readonly IFhirOperationDataStore _fhirOperationDataStore;
         private readonly SqlServerFhirStorageTestHelper _testHelper;
         private readonly SchemaInitializer _schemaInitializer;
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Definition;
+using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.SqlServer.Configs;
@@ -33,6 +34,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         private readonly string _masterConnectionString;
         private readonly string _databaseName;
         private readonly IFhirDataStore _fhirDataStore;
+        private IFhirOperationDataStore _fhirOperationDataStore;
         private readonly SqlServerFhirStorageTestHelper _testHelper;
         private readonly SchemaInitializer _schemaInitializer;
 
@@ -76,6 +78,9 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             SqlConnectionWrapperFactory = new SqlConnectionWrapperFactory(config, SqlTransactionHandler);
 
             _fhirDataStore = new SqlServerFhirDataStore(config, sqlServerFhirModel, searchParameterToSearchValueTypeMap, upsertResourceTvpGenerator, Options.Create(new CoreFeatureConfiguration()), SqlConnectionWrapperFactory, NullLogger<SqlServerFhirDataStore>.Instance);
+
+            _fhirOperationDataStore = new SqlServerFhirOperationDataStore(config, NullLogger<SqlServerFhirOperationDataStore>.Instance);
+
             _testHelper = new SqlServerFhirStorageTestHelper(TestConnectionString);
         }
 
@@ -143,6 +148,11 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             if (serviceType == typeof(IFhirDataStore))
             {
                 return _fhirDataStore;
+            }
+
+            if (serviceType == typeof(IFhirOperationDataStore))
+            {
+                return _fhirOperationDataStore;
             }
 
             if (serviceType == typeof(IFhirStorageTestHelper))

--- a/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/Sql/SqlVisitor.cs
+++ b/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/Sql/SqlVisitor.cs
@@ -230,7 +230,7 @@ namespace Microsoft.Health.Extensions.BuildTimeCodeGenerator.Sql
                 if (string.Compare(sqlDbTypeToNormalize, "RowVersion", StringComparison.InvariantCultureIgnoreCase) == 0)
                 {
                     // The timestamp data type is a synonym for the rowversion data type. Its syntax is now deprecated in SQL.
-                    normalizedSqlDbType = nameof(SqlDbType.Timestamp);
+                    normalizedSqlDbType = SqlDbType.Timestamp.ToString();
                 }
             }
 

--- a/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/Sql/SqlVisitor.cs
+++ b/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/Sql/SqlVisitor.cs
@@ -218,7 +218,21 @@ namespace Microsoft.Health.Extensions.BuildTimeCodeGenerator.Sql
 
         protected MemberDeclarationSyntax CreatePropertyForColumn(ColumnDefinition column)
         {
-            string normalizedSqlDbType = Enum.Parse<SqlDbType>(column.DataType.Name.BaseIdentifier.Value, true).ToString();
+            string normalizedSqlDbType = null;
+            var sqlDbTypeToNormalize = column.DataType.Name.BaseIdentifier.Value;
+
+            if (Enum.TryParse(sqlDbTypeToNormalize, true, out SqlDbType sqlDbType))
+            {
+                normalizedSqlDbType = sqlDbType.ToString();
+            }
+            else
+            {
+                if (string.Compare(sqlDbTypeToNormalize, "RowVersion", StringComparison.InvariantCultureIgnoreCase) == 0)
+                {
+                    // The timestamp data type is a synonym for the rowversion data type. Its syntax is now deprecated in SQL.
+                    normalizedSqlDbType = nameof(SqlDbType.Timestamp);
+                }
+            }
 
             IdentifierNameSyntax typeName = IdentifierName($"{(IsColumnNullable(column) ? "Nullable" : string.Empty)}{normalizedSqlDbType}Column");
 

--- a/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/Sql/SqlVisitor.cs
+++ b/tools/Microsoft.Health.Extensions.BuildTimeCodeGenerator/Sql/SqlVisitor.cs
@@ -230,6 +230,7 @@ namespace Microsoft.Health.Extensions.BuildTimeCodeGenerator.Sql
                 if (string.Compare(sqlDbTypeToNormalize, "RowVersion", StringComparison.InvariantCultureIgnoreCase) == 0)
                 {
                     // The timestamp data type is a synonym for the rowversion data type. Its syntax is now deprecated in SQL.
+                    // We are translating rowversion (used in the SQL code) to timestamp here because the SqlDbType enum only supports timestamp.
                     normalizedSqlDbType = SqlDbType.Timestamp.ToString();
                 }
             }


### PR DESCRIPTION
## Description
 
- Implements the method to create an export job, the first step in adding SQL support for [bulk export](https://microsofthealth.visualstudio.com/Health/_wiki/wikis/Resolute.wiki/25/BulkExportDesignSpec)
- Creates a new `ExportJob` table with the following columns:
  - `Id`: the unique ID of the job
  - `Status`: the status of the job (set to `Queued` during export job creation)
  - `HeartbeatDateTime`: used to check if jobs are stale when acquiring export jobs (set to `null` during export job creation)
  - `QueuedDateTime`: the time the job is created/queued
  - `RawJobRecord`: the raw job record, zipped (similar to the `RawResource` column in `UpsertResource`)
  - `JobVersion`: used to manage concurrency when deleting jobs
- Adds a stored procedure for adding a new job record to the `ExportJob` table
- Updates SQL code generation files to allow the [rowversion](https://docs.microsoft.com/en-us/sql/t-sql/data-types/rowversion-transact-sql?view=sql-server-ver15) SQL data type to be used for the `JobVersion` column in `ExportJob`
 
- Note: merging into a feature branch

![sql-export-create](https://user-images.githubusercontent.com/54082711/70584963-97cbde80-1b77-11ea-9be0-e96b4a036faf.gif)

## Related issues
Addresses [#AB71329](https://microsofthealth.visualstudio.com/Health/_workitems/edit/71329).

## Testing

- Enables running the integration test for export job creation with SQL and adds support for operation datastore tests on the SQL side
