### PR TITLE
Add check for reference type

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerTests.cs
@@ -274,7 +274,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
         }
 
         [Fact]
-        public async Task GivenATransactionBundleWithConditonalReferences_WhenNotResolved_ThenRequestNotValidExceptionShouldBeThrown()
+        public async Task GivenATransactionBundleWithConditionalReferences_WhenNotResolved_ThenRequestNotValidExceptionShouldBeThrown()
         {
             var requestBundle = Samples.GetJsonSample("Bundle-TransactionWithConditionalReferenceInResourceBody");
             var bundle = requestBundle.ToPoco<Hl7.Fhir.Model.Bundle>();
@@ -290,7 +290,6 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
             var referenceIdDictionary = new Dictionary<string, (string resourceId, string resourceType)>();
             foreach (var entry in bundle.Entry)
             {
-                IEnumerable<ResourceReference> references = entry.Resource.GetAllChildren<ResourceReference>();
                 var exception = await Assert.ThrowsAsync<RequestNotValidException>(() => _bundleHandler.ResolveBundleReferences(entry, referenceIdDictionary, CancellationToken.None));
                 Assert.Equal(exception.Message, expectedMessage);
             }
@@ -307,7 +306,6 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
             var referenceIdDictionary = new Dictionary<string, (string resourceId, string resourceType)>();
             foreach (var entry in bundle.Entry)
             {
-                IEnumerable<ResourceReference> references = entry.Resource.GetAllChildren<ResourceReference>();
                 var exception = await Assert.ThrowsAsync<RequestNotValidException>(() => _bundleHandler.ResolveBundleReferences(entry, referenceIdDictionary, CancellationToken.None));
                 Assert.Equal(exception.Message, expectedMessage);
             }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
@@ -266,6 +266,11 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
 
             foreach (ResourceReference reference in references)
             {
+                if (string.IsNullOrWhiteSpace(reference.Reference))
+                {
+                    continue;
+                }
+
                 // Checks to see if this reference has already been assigned an Id
                 if (referenceIdDictionary.TryGetValue(reference.Reference, out var referenceInformation))
                 {


### PR DESCRIPTION
## Description
Currently if you `POST` a transaction with a reference that is an `Identifier` as opposed to a `Reference` a `NullRefException` is thrown.

## Related issues
Addresses [AB#71488](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/71488).

## Testing
Added unit tests. Manual E2E test verifies behavior.
