### PR TITLE
Fix _type search parameter

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
@@ -27,10 +27,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
         private readonly ListedCapabilityStatement _statement;
         private readonly IModelInfoProvider _modelInfoProvider;
         private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager;
-        private static readonly IEnumerable<SearchParamComponent> SearchRestParams = new SearchParamComponent[]
-            {
-                new SearchParamComponent { Name = SearchParameterNames.ResourceType, Definition = SearchParameterNames.TypeUri, Type = SearchParamType.Token },
-            };
 
         private CapabilityStatementBuilder(ListedCapabilityStatement statement, IModelInfoProvider modelInfoProvider, ISearchParameterDefinitionManager searchParameterDefinitionManager)
         {
@@ -117,12 +113,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
             return this;
         }
 
-        public ICapabilityStatementBuilder AddRestSearchParams()
+        public ICapabilityStatementBuilder AddDefaultRestSearchParams()
         {
-            foreach (SearchParamComponent searchParam in SearchRestParams)
-            {
-                _statement.Rest.Server().SearchParam.Add(searchParam);
-            }
+            _statement.Rest.Server().SearchParam.Add(new SearchParamComponent { Name = SearchParameterNames.ResourceType, Definition = SearchParameterNames.TypeUri, Type = SearchParamType.Token });
 
             return this;
         }

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/ICapabilityStatementBuilder.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/ICapabilityStatementBuilder.cs
@@ -26,6 +26,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
 
         ICapabilityStatementBuilder AddDefaultSearchParameters();
 
+        ICapabilityStatementBuilder AddRestSearchParams();
+
         ITypedElement Build();
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/ICapabilityStatementBuilder.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/ICapabilityStatementBuilder.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
 
         ICapabilityStatementBuilder AddDefaultSearchParameters();
 
-        ICapabilityStatementBuilder AddRestSearchParams();
+        ICapabilityStatementBuilder AddDefaultRestSearchParams();
 
         ITypedElement Build();
     }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchParameterNames.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchParameterNames.cs
@@ -20,5 +20,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
         public const string ResourceType = "_type";
 
         public static readonly Uri ResourceTypeUri = new Uri("http://hl7.org/fhir/SearchParameter/Resource-type");
+
+        public static readonly Uri TypeUri = new Uri("http://hl7.org/fhir/SearchParameter/type");
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -252,7 +252,8 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
             EnsureArg.IsNotNull(builder, nameof(builder));
 
             builder.AddDefaultResourceInteractions()
-                .AddDefaultSearchParameters();
+                .AddDefaultSearchParameters()
+                .AddRestSearchParams();
 
             if (_coreFeatures.SupportsBatch)
             {

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -253,7 +253,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
 
             builder.AddDefaultResourceInteractions()
                 .AddDefaultSearchParameters()
-                .AddRestSearchParams();
+                .AddDefaultRestSearchParams();
 
             if (_coreFeatures.SupportsBatch)
             {

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Conformance/ConformanceBuilderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Conformance/ConformanceBuilderTests.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Conformance
         [Fact]
         public void GivenAConformanceBuilder_WhenAddingRestSearchParam_ThenTypeSearchParamIsAdded()
         {
-            _builder.AddRestSearchParams();
+            _builder.AddDefaultRestSearchParams();
 
             ITypedElement statement = _builder.Build();
 
@@ -115,9 +115,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Conformance
 
             ITypedElement statement = _builder.Build();
 
-            object typeDocumentation = statement.Scalar($"{ResourceQuery("Account")}.searchParam.where(name = '_type').documentation");
+            object typeName = statement.Scalar($"{ResourceQuery("Account")}.searchParam.where(name = '_type').name");
 
-            Assert.Null(typeDocumentation);
+            Assert.Null(typeName);
         }
 
         private static string ResourceQuery(string resource)

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Conformance/ConformanceBuilderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Conformance/ConformanceBuilderTests.cs
@@ -93,6 +93,33 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Conformance
             Assert.False(noParameters);
         }
 
+        [Fact]
+        public void GivenAConformanceBuilder_WhenAddingRestSearchParam_ThenTypeSearchParamIsAdded()
+        {
+            _builder.AddRestSearchParams();
+
+            ITypedElement statement = _builder.Build();
+
+            object typeDefinition = statement.Scalar($"CapabilityStatement.rest.searchParam.where(name = '_type').definition");
+
+            Assert.Equal("http://hl7.org/fhir/SearchParameter/type", typeDefinition.ToString());
+        }
+
+        [Fact]
+        public void GivenAConformanceBuilder_WhenAddingResourceSearchParam_ThenTypeSearchParamIsNotAddedUnderResource()
+        {
+            _searchParameterDefinitionManager.GetSearchParameters("Account")
+               .Returns(new[] { new SearchParameterInfo("_type", SearchParamType.Token, description: "description"), });
+
+            _builder.AddDefaultSearchParameters();
+
+            ITypedElement statement = _builder.Build();
+
+            object typeDocumentation = statement.Scalar($"{ResourceQuery("Account")}.searchParam.where(name = '_type').documentation");
+
+            Assert.Null(typeDocumentation);
+        }
+
         private static string ResourceQuery(string resource)
         {
             return $"CapabilityStatement.rest.resource.where(type = '{resource}')";

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -241,7 +241,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
             builder.AddDefaultResourceInteractions()
                    .AddDefaultSearchParameters()
-                   .AddRestSearchParams();
+                   .AddDefaultRestSearchParams();
 
             if (_coreFeatures.SupportsBatch)
             {

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -240,7 +240,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             EnsureArg.IsNotNull(builder, nameof(builder));
 
             builder.AddDefaultResourceInteractions()
-                   .AddDefaultSearchParameters();
+                   .AddDefaultSearchParameters()
+                   .AddRestSearchParams();
 
             if (_coreFeatures.SupportsBatch)
             {


### PR DESCRIPTION
## Description
_type search parameter removed from capabilityStatement.rest.resource.searchParam
_type search parameter added to capabilityStatement.rest.searchParam

## Related issues
Addresses #723

## Testing
Unit tests and manual test
![image](https://user-images.githubusercontent.com/57157506/70838353-aa832500-1dbc-11ea-8ed0-1b3edad7959f.png)


