### PR TITLE
Fixed the async issues with a few middleware.

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Context/FhirRequestContextAfterAuthenticationMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Context/FhirRequestContextAfterAuthenticationMiddleware.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Context
             _next = next;
         }
 
-        public Task Invoke(HttpContext context, IFhirRequestContextAccessor fhirRequestContextAccessor)
+        public async Task Invoke(HttpContext context, IFhirRequestContextAccessor fhirRequestContextAccessor)
         {
             // Now the authentication is completed successfully, sets the user.
             if (context.User != null)
@@ -33,7 +33,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Context
             }
 
             // Call the next delegate/middleware in the pipeline
-            return _next(context);
+            await _next(context);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Features/Context/FhirRequestContextBeforeAuthenticationMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Context/FhirRequestContextBeforeAuthenticationMiddleware.cs
@@ -37,12 +37,12 @@ namespace Microsoft.Health.Fhir.Api.Features.Context
             _auditEventTypeMapping = auditEventTypeMapping;
         }
 
-        public Task Invoke(HttpContext context)
+        public async Task Invoke(HttpContext context)
         {
             try
             {
                 // Call the next delegate/middleware in the pipeline
-                return _next(context);
+                await _next(context);
             }
             finally
             {

--- a/src/Microsoft.Health.Fhir.Api/Features/Context/FhirRequestContextMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Context/FhirRequestContextMiddleware.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Context
             _next = next;
         }
 
-        public Task Invoke(HttpContext context, IFhirRequestContextAccessor fhirRequestContextAccessor, CorrelationIdProvider correlationIdProvider)
+        public async Task Invoke(HttpContext context, IFhirRequestContextAccessor fhirRequestContextAccessor, CorrelationIdProvider correlationIdProvider)
         {
             HttpRequest request = context.Request;
 
@@ -55,7 +55,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Context
             fhirRequestContextAccessor.FhirRequestContext = fhirRequestContext;
 
             // Call the next delegate/middleware in the pipeline
-            return _next(context);
+            await _next(context);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Features/Headers/BaseHeadersMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Headers/BaseHeadersMiddleware.cs
@@ -21,12 +21,12 @@ namespace Microsoft.Health.Fhir.Api.Features.Headers
             _next = next;
         }
 
-        public Task Invoke(HttpContext context)
+        public async Task Invoke(HttpContext context)
         {
             context.Response.OnStarting(SecurityHeadersHelper.SetSecurityHeaders, state: context);
 
             // Call the next delegate/middleware in the pipeline
-            return _next(context);
+            await _next(context);
         }
     }
 }


### PR DESCRIPTION
## Description
If the first call results in 403, a corresponding audit entry was not being created.

After some investigation, this is because of the code defect in middlewares where the middleware was not using the Task correctly. In a few middlewares, instead of making the method async and await on the next delegate, it simply returns the next delegate. This works fine if the middleware doesn't do any additional processing after the next delegate is processed but in a few cases, it was processing based on the assumption that the next request delegate has already completed, which is not the case.

Therefore, depending on how quickly the next delegate processes, the result was unpredictable. For the original issue with 403, because the first time we handle the token, we have to discover the OpenID configuration, which takes some time to process. But because the finally block is executed right away, it considered the response as 200 (which is the default status code assigned to the response before the response is actually processed) and therefore did not audit the call. Subsequent calls worked almost all the time because it processes much faster in most cases. If the server is under load or something, this could also have surfaced after the first call.

Some of the these middlewares didn't need to changes but to keep the code consistent, I updated all of them to use async/await.

## Related issues
Addresses issue #794.

## Testing
Manually ran multiple times and verified that things are working correctly.
