### PR TITLE
Remove timeout from local IHttpClientFactory

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/InProcTestFhirServer.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/InProcTestFhirServer.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Reflection;
+using System.Threading;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Hosting;
@@ -56,7 +57,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
                     // use a message handler for the test server
                     serviceCollection
                         .AddHttpClient(Options.DefaultName)
-                        .ConfigurePrimaryHttpMessageHandler(() => _messageHandler);
+                        .ConfigurePrimaryHttpMessageHandler(() => _messageHandler)
+                        .SetHandlerLifetime(Timeout.InfiniteTimeSpan); // So that it is not disposed after 2 minutes;
 
                     serviceCollection.PostConfigure<JwtBearerOptions>(
                         JwtBearerDefaults.AuthenticationScheme,


### PR DESCRIPTION
Many E2E tests would fail for me when running locally with 
```
  Message: 
    System.ObjectDisposedException : Cannot access a disposed object.
    Object name: 'Microsoft.Health.Fhir.Tests.E2E.Rest.SuppressExecutionContextHandler'.
  Stack Trace: 
    DelegatingHandler.CheckDisposed()
    DelegatingHandler.SetOperationStarted()
    DelegatingHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
    SuppressExecutionContextHandler.<>n__0(HttpRequestMessage request, CancellationToken cancellationToken)
    <>c__DisplayClass1_0.<SendAsync>b__0() line 31
    Task`1.InnerInvoke()
    Task.ExecuteWithThreadLocal(Task& currentTaskSlot)
    --- End of stack trace from previous location where exception was thrown ---
    <<SendAsync>b__0>d.MoveNext() line 160
    --- End of stack trace from previous location where exception was thrown ---
    AsyncRetryEngine.ImplementationAsync[TResult](Func`3 action, Context context, CancellationToken cancellationToken, ExceptionPredicates shouldRetryExceptionPredicates, ResultPredicates`1 shouldRetryResultPredicates, Func`5 onRetryAsync, Int32 permittedRetryCount, IEnumerable`1 sleepDurationsEnumerable, Func`4 sleepDurationProvider, Boolean continueOnCapturedContext)
    AsyncPolicy.ExecuteAsync[TResult](Func`3 action, Context context, CancellationToken cancellationToken, Boolean continueOnCapturedContext)
    SessionMessageHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) line 160
    HttpClient.FinishSendAsyncBuffered(Task`1 sendTask, HttpRequestMessage request, CancellationTokenSource cts, Boolean disposeCts)
    OperationVersionsTests.CheckContentType(String acceptHeaderValue) line 70
    OperationVersionsTests.WhenVersionsEndpointIsCalledWithXml_GivenAValidXmlAcceptHeaderIsProvided_ThenServerShouldReturnOK(String acceptHeaderValue) line 43
    --- End of stack trace from previous location where exception was thrown ---
```
It turns out that the reason for the failure was that the `HttpClientMessageHandler` that we create for connecting to the in-proc server is disposed after two minutes. This fix removes the timeout.
