### PR TITLE
Fix audit test.

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/AuditTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/AuditTests.cs
@@ -392,6 +392,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit
         {
             var batch = Samples.GetDefaultBatch().ToPoco<Bundle>();
 
+            await _client.UpdateAsync(batch.Entry[2].Resource as Patient);
+
             List<(string expectedActions, string expectedPathSegments, HttpStatusCode? expectedStatusCodes, ResourceType? resourceType)> expectedList = new List<(string, string, HttpStatusCode?, ResourceType?)>
             {
                 ("batch", string.Empty, HttpStatusCode.OK, ResourceType.Bundle),


### PR DESCRIPTION
## Description
Ensure that the item at index 2 is created before we attempt to execute the batch.

## Related issues
Addresses #833

## Testing
Unit test now passes.
