### PR TITLE
Ensure component index specified when using using fallback queries for unknown systems and quantity codes

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/DateTimeSearchParameterQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/DateTimeSearchParameterQueryGenerator.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     break;
                 case SqlFieldName.DateTimeIsLongerThanADay:
                     // we don't want to use a parameter here because we want the query plan to use the filtered index based on this field
-                    context.StringBuilder.Append(V1.DateTimeSearchParam.IsLongerThanADay, context.TableAlias).Append(expression.ComponentIndex + 1).Append(" = ").Append((bool)expression.Value ? '1' : '0');
+                    AppendColumnName(context, V1.DateTimeSearchParam.IsLongerThanADay, expression).Append(" = ").Append((bool)expression.Value ? '1' : '0');
                     return context;
                 default:
                     throw new ArgumentOutOfRangeException(expression.FieldName.ToString());

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/NumberSearchParameterQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/NumberSearchParameterQueryGenerator.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     throw new ArgumentOutOfRangeException(expression.FieldName.ToString());
             }
 
-            context.StringBuilder.Append(nullCheckColumn, context.TableAlias).Append(expression.ComponentIndex + 1).Append(" IS NOT NULL AND ");
+            AppendColumnName(context, nullCheckColumn, expression).Append(" IS NOT NULL AND ");
             return VisitSimpleBinary(expression.BinaryOperator, context, valueColumn, expression.ComponentIndex, expression.Value);
         }
     }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/QuantitySearchParameterQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/QuantitySearchParameterQueryGenerator.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     throw new ArgumentOutOfRangeException(expression.FieldName.ToString());
             }
 
-            context.StringBuilder.Append(nullCheckColumn, context.TableAlias).Append(expression.ComponentIndex + 1).Append(" IS NOT NULL AND ");
+            AppendColumnName(context, nullCheckColumn, expression).Append(" IS NOT NULL AND ");
             return VisitSimpleBinary(expression.BinaryOperator, context, valueColumn, expression.ComponentIndex, expression.Value);
         }
 
@@ -49,7 +49,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                         return VisitSimpleBinary(BinaryOperator.Equal, context, V1.QuantitySearchParam.QuantityCodeId, expression.ComponentIndex, quantityCodeId);
                     }
 
-                    context.StringBuilder.Append(V1.QuantitySearchParam.QuantityCodeId, context.TableAlias)
+                    AppendColumnName(context, V1.QuantitySearchParam.QuantityCodeId, expression)
                         .Append(" IN (SELECT ")
                         .Append(V1.QuantityCode.QuantityCodeId, null)
                         .Append(" FROM ").Append(V1.QuantityCode)
@@ -67,7 +67,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                         return VisitSimpleBinary(BinaryOperator.Equal, context, V1.QuantitySearchParam.SystemId, expression.ComponentIndex, systemId);
                     }
 
-                    context.StringBuilder.Append(V1.QuantitySearchParam.SystemId, context.TableAlias)
+                    AppendColumnName(context, V1.QuantitySearchParam.SystemId, expression)
                         .Append(" IN (SELECT ")
                         .Append(V1.System.SystemId, null)
                         .Append(" FROM ").Append(V1.System)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SearchParameterQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SearchParameterQueryGenerator.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
         protected SearchParameterQueryGeneratorContext VisitSimpleBinary(BinaryOperator binaryOperator, SearchParameterQueryGeneratorContext context, Column column, int? componentIndex, object value)
         {
-            context.StringBuilder.Append(column, context.TableAlias).Append(componentIndex + 1);
+            AppendColumnName(context, column, componentIndex);
 
             switch (binaryOperator)
             {
@@ -117,7 +117,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
         protected SearchParameterQueryGeneratorContext VisitSimpleString(StringExpression expression, SearchParameterQueryGeneratorContext context, StringColumn column, string value)
         {
-            context.StringBuilder.Append(column, context.TableAlias).Append(expression.ComponentIndex + 1);
+            AppendColumnName(context, column, expression);
 
             bool needsEscaping = false;
             switch (expression.StringOperator)
@@ -176,8 +176,18 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                 throw new InvalidOperationException($"Unexpected missing field {expression.FieldName}");
             }
 
-            context.StringBuilder.Append(column, context.TableAlias).Append(expression.ComponentIndex + 1).Append(" IS NULL");
+            AppendColumnName(context, column, expression).Append(" IS NULL");
             return context;
+        }
+
+        protected static IndentedStringBuilder AppendColumnName(SearchParameterQueryGeneratorContext context, Column column, IFieldExpression expression)
+        {
+            return AppendColumnName(context, column, expression.ComponentIndex);
+        }
+
+        protected static IndentedStringBuilder AppendColumnName(SearchParameterQueryGeneratorContext context, Column column, int? componentIndex)
+        {
+            return context.StringBuilder.Append(column, context.TableAlias).Append(componentIndex + 1);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/StringSearchParameterQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/StringSearchParameterQueryGenerator.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
         public override SearchParameterQueryGeneratorContext VisitString(StringExpression expression, SearchParameterQueryGeneratorContext context)
         {
-            context.StringBuilder.Append(V1.StringSearchParam.TextOverflow, context.TableAlias).Append(expression.ComponentIndex + 1);
+            AppendColumnName(context, V1.StringSearchParam.TextOverflow, expression);
 
             StringColumn column;
             switch (expression.FieldName)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/TokenSearchParameterQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/TokenSearchParameterQueryGenerator.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                         return VisitSimpleBinary(BinaryOperator.Equal, context, V1.TokenSearchParam.SystemId, expression.ComponentIndex, systemId);
                     }
 
-                    context.StringBuilder.Append(V1.TokenSearchParam.SystemId, context.TableAlias)
+                    AppendColumnName(context, V1.TokenSearchParam.SystemId, expression)
                         .Append(" IN (SELECT ")
                         .Append(V1.System.SystemId, null)
                         .Append(" FROM ").Append(V1.System)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CompositeSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CompositeSearchTests.cs
@@ -49,6 +49,9 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [InlineData("combo-code-value-quantity=85354-9$107")] // Not match: Observation.code against Observation.component[0].valueQuantity
         [InlineData("combo-code-value-quantity=8480-6$107", ObservationWithBloodPressure)] // Match: Observation.component[0].code against Observation.component[0].valueQuantity
         [InlineData("combo-code-value-quantity=8480-6$60")] // Not match: Observation.component[0].code against Observation.component[1].valueQuantity
+        [InlineData("code-value-quantity=unknownSystem|443849008$10")]
+        [InlineData("code-value-quantity=http://snomed.info/sct|443849008$eq10|unknownSystem|{score}")]
+        [InlineData("code-value-quantity=http://snomed.info/sct|443849008$eq10|http://unitsofmeasure.org|unknownQuantityId")]
         public async Task GivenACompositeSearchParameterWithTokenAndQuantity_WhenSearched_ThenCorrectBundleShouldBeReturned(string queryValue, params string[] expectedObservationNames)
         {
             await SearchAndValidateObservations(queryValue, expectedObservationNames);


### PR DESCRIPTION
Addresses #825. 

We were forgetting to include the composite index suffix when querying for unknown system and quantity codes.