### PR TITLE
Implements SQL export job update and get by hash, id

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -745,15 +745,6 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Error from SQL database on export job update..
-        /// </summary>
-        internal static string SqlErrorOnExportUpdate {
-            get {
-                return ResourceManager.GetString("SqlErrorOnExportUpdate", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Unable to delete secret from SecretStore.
         /// </summary>
         internal static string UnableToDeleteSecret {

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -745,6 +745,15 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Error from SQL database on export job update..
+        /// </summary>
+        internal static string SqlErrorOnExportUpdate {
+            get {
+                return ResourceManager.GetString("SqlErrorOnExportUpdate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unable to delete secret from SecretStore.
         /// </summary>
         internal static string UnableToDeleteSecret {

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -355,9 +355,6 @@
   <data name="SortNotSupported" xml:space="preserve">
     <value>The _sort parameter is not supported.</value>
   </data>
-  <data name="SqlErrorOnExportUpdate" xml:space="preserve">
-    <value>Error from SQL database on export job update.</value>
-  </data>
   <data name="UnableToDeleteSecret" xml:space="preserve">
     <value>Unable to delete secret from SecretStore</value>
   </data>

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -355,6 +355,9 @@
   <data name="SortNotSupported" xml:space="preserve">
     <value>The _sort parameter is not supported.</value>
   </data>
+  <data name="SqlErrorOnExportUpdate" xml:space="preserve">
+    <value>Error from SQL database on export job update.</value>
+  </data>
   <data name="UnableToDeleteSecret" xml:space="preserve">
     <value>Unable to delete secret from SecretStore</value>
   </data>

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/1.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/1.sql
@@ -1790,6 +1790,8 @@ GO
 -- PARAMETERS
 --     @id
 --         * The ID of the export job record
+--     @hash
+--         * The SHA256 hash of the export job record ID
 --     @status
 --         * The status of the export job
 --     @queuedDateTime
@@ -1802,6 +1804,7 @@ GO
 --
 CREATE PROCEDURE dbo.CreateExportJob
     @id varchar(64),
+    @hash varchar(64),
     @status varchar(10),
     @queuedDateTime datetimeoffset(7),
     @rawJobRecord varchar(max)
@@ -1812,9 +1815,9 @@ AS
     BEGIN TRANSACTION
 
     INSERT INTO dbo.ExportJob
-        (Id, Status, QueuedDateTime, RawJobRecord)
+        (Id, Hash, Status, QueuedDateTime, RawJobRecord)
     VALUES
-        (@id, @status, @queuedDateTime, @rawJobRecord)
+        (@id, @hash, @status, @queuedDateTime, @rawJobRecord)
   
     SELECT CAST(MIN_ACTIVE_ROWVERSION() AS INT)
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/1.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/1.sql
@@ -1924,7 +1924,7 @@ AS
     SET Status = @status, HeartbeatDateTime = @heartbeatDateTime, RawJobRecord = @rawJobRecord
     WHERE Id = @id
   
-    SELECT CAST(MIN_ACTIVE_ROWVERSION() AS INT)
+    SELECT MIN_ACTIVE_ROWVERSION()
 
     COMMIT TRANSACTION
 GO

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/1.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/1.sql
@@ -1843,14 +1843,9 @@ CREATE PROCEDURE dbo.GetExportJobById
 AS
     SET NOCOUNT ON
 
-    SET XACT_ABORT ON
-    BEGIN TRANSACTION
-
     SELECT RawJobRecord, JobVersion
     FROM dbo.ExportJob
     WHERE Id = @id
-
-    COMMIT TRANSACTION
 GO
 
 --
@@ -1872,15 +1867,10 @@ CREATE PROCEDURE dbo.GetExportJobByHash
 AS
     SET NOCOUNT ON
 
-    SET XACT_ABORT ON
-    BEGIN TRANSACTION
-
     SELECT TOP(1) RawJobRecord, JobVersion
     FROM dbo.ExportJob
     WHERE Hash = @hash AND (Status = 'Queued' OR Status = 'Running')
     ORDER BY HeartbeatDateTime, QueuedDateTime ASC
-
-    COMMIT TRANSACTION
 GO
 
 --

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/1.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/1.sql
@@ -1909,6 +1909,10 @@ AS
     FROM dbo.ExportJob WITH (UPDLOCK, HOLDLOCK)
     WHERE Id = @id
 
+    IF (@currentJobVersion IS NULL) BEGIN
+        THROW 50404, 'Export job record not found', 1;
+    END
+
     IF (@jobVersion <> @currentJobVersion) BEGIN
         THROW 50412, 'Precondition failed', 1;
     END

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/1.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/1.sql
@@ -1909,8 +1909,10 @@ AS
 
     DECLARE @currentJobVersion binary(8)
 
+    -- Acquire and hold an update lock on a row in the ExportJob table for the entire transaction.
+    -- This ensures the version check and update occur atomically.
     SELECT @currentJobVersion = JobVersion
-    FROM dbo.ExportJob -- WITH (UPDLOCK, HOLDLOCK) -- TODO: Add locks, add test for locks
+    FROM dbo.ExportJob WITH (UPDLOCK, HOLDLOCK)
     WHERE Id = @id
 
     IF (@jobVersion <> @currentJobVersion) BEGIN

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/1.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/1.sql
@@ -1885,6 +1885,49 @@ GO
 
 --
 -- STORED PROCEDURE
+--     Updates an export job.
+--
+-- DESCRIPTION
+--     Modifies an existing job in the ExportJob table.
+--
+-- PARAMETERS
+--     @id
+--         * The ID of the export job record
+--     @status
+--         * The status of the export job
+--     @queuedDateTime
+--         * The time the export job is queued
+--     @rawJobRecord
+--         * A JSON document
+--
+-- RETURN VALUE
+--     The row version of the updated export job.
+--
+CREATE PROCEDURE dbo.UpdateExportJob
+    @id varchar(64),
+    @status varchar(10),
+    @queuedDateTime datetimeoffset(7),
+    @rawJobRecord varchar(max)
+AS
+    SET NOCOUNT ON
+
+    SET XACT_ABORT ON
+    BEGIN TRANSACTION
+
+    -- We will timestamp the jobs when we update them to track stale jobs.
+    DECLARE @heartbeatDateTime datetime2(7) = SYSUTCDATETIME()
+
+    UPDATE dbo.ExportJob
+    SET Status = @status, HeartbeatDateTime = @heartbeatDateTime, QueuedDateTime = @queuedDateTime, RawJobRecord = @rawJobRecord
+    WHERE Id = @id
+  
+    SELECT CAST(MIN_ACTIVE_ROWVERSION() AS INT)
+
+    COMMIT TRANSACTION
+GO
+
+--
+-- STORED PROCEDURE
 --     Acquires export jobs.
 --
 -- DESCRIPTION

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/1.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/1.sql
@@ -1821,6 +1821,35 @@ GO
 
 --
 -- STORED PROCEDURE
+--     Gets an export job given its ID.
+--
+-- DESCRIPTION
+--     Retrieves the export job record from the ExportJob table that has the matching ID.
+--
+-- PARAMETERS
+--     @id
+--         * The ID of the export job record to retrieve
+--
+-- RETURN VALUE
+--     The matching export job.
+--
+CREATE PROCEDURE dbo.GetExportJobById
+    @id varchar(64)
+AS
+    SET NOCOUNT ON
+
+    SET XACT_ABORT ON
+    BEGIN TRANSACTION
+
+    SELECT RawJobRecord, JobVersion
+    FROM dbo.ExportJob
+    WHERE Id = @id
+
+    COMMIT TRANSACTION
+GO
+
+--
+-- STORED PROCEDURE
 --     Acquires export jobs.
 --
 -- DESCRIPTION

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/V1.Generated.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/V1.Generated.cs
@@ -417,14 +417,16 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             }
 
             private readonly ParameterDefinition<System.String> _id = new ParameterDefinition<System.String>("@id", global::System.Data.SqlDbType.VarChar, false, 64);
+            private readonly ParameterDefinition<System.String> _hash = new ParameterDefinition<System.String>("@hash", global::System.Data.SqlDbType.VarChar, false, 64);
             private readonly ParameterDefinition<System.String> _status = new ParameterDefinition<System.String>("@status", global::System.Data.SqlDbType.VarChar, false, 10);
             private readonly ParameterDefinition<System.DateTimeOffset> _queuedDateTime = new ParameterDefinition<System.DateTimeOffset>("@queuedDateTime", global::System.Data.SqlDbType.DateTimeOffset, false, 7);
             private readonly ParameterDefinition<System.String> _rawJobRecord = new ParameterDefinition<System.String>("@rawJobRecord", global::System.Data.SqlDbType.VarChar, false, -1);
-            public void PopulateCommand(global::System.Data.SqlClient.SqlCommand command, System.String id, System.String status, System.DateTimeOffset queuedDateTime, System.String rawJobRecord)
+            public void PopulateCommand(global::System.Data.SqlClient.SqlCommand command, System.String id, System.String hash, System.String status, System.DateTimeOffset queuedDateTime, System.String rawJobRecord)
             {
                 command.CommandType = global::System.Data.CommandType.StoredProcedure;
                 command.CommandText = "dbo.CreateExportJob";
                 _id.AddParameter(command.Parameters, id);
+                _hash.AddParameter(command.Parameters, hash);
                 _status.AddParameter(command.Parameters, status);
                 _queuedDateTime.AddParameter(command.Parameters, queuedDateTime);
                 _rawJobRecord.AddParameter(command.Parameters, rawJobRecord);

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/V1.Generated.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/V1.Generated.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
         internal readonly static UriSearchParamTable UriSearchParam = new UriSearchParamTable();
         internal readonly static AcquireExportJobsProcedure AcquireExportJobs = new AcquireExportJobsProcedure();
         internal readonly static CreateExportJobProcedure CreateExportJob = new CreateExportJobProcedure();
+        internal readonly static GetExportJobByHashProcedure GetExportJobByHash = new GetExportJobByHashProcedure();
         internal readonly static GetExportJobByIdProcedure GetExportJobById = new GetExportJobByIdProcedure();
         internal readonly static HardDeleteResourceProcedure HardDeleteResource = new HardDeleteResourceProcedure();
         internal readonly static ReadResourceProcedure ReadResource = new ReadResourceProcedure();
@@ -98,6 +99,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             }
 
             internal readonly VarCharColumn Id = new VarCharColumn("Id", 64, "Latin1_General_100_CS_AS");
+            internal readonly VarCharColumn Hash = new VarCharColumn("Hash", 64, "Latin1_General_100_CS_AS");
             internal readonly VarCharColumn Status = new VarCharColumn("Status", 10);
             internal readonly NullableDateTime2Column HeartbeatDateTime = new NullableDateTime2Column("HeartbeatDateTime", 7);
             internal readonly DateTimeOffsetColumn QueuedDateTime = new DateTimeOffsetColumn("QueuedDateTime", 7);
@@ -426,6 +428,21 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
                 _status.AddParameter(command.Parameters, status);
                 _queuedDateTime.AddParameter(command.Parameters, queuedDateTime);
                 _rawJobRecord.AddParameter(command.Parameters, rawJobRecord);
+            }
+        }
+
+        internal class GetExportJobByHashProcedure : StoredProcedure
+        {
+            internal GetExportJobByHashProcedure(): base("dbo.GetExportJobByHash")
+            {
+            }
+
+            private readonly ParameterDefinition<System.String> _hash = new ParameterDefinition<System.String>("@hash", global::System.Data.SqlDbType.VarChar, false, 64);
+            public void PopulateCommand(global::System.Data.SqlClient.SqlCommand command, System.String hash)
+            {
+                command.CommandType = global::System.Data.CommandType.StoredProcedure;
+                command.CommandText = "dbo.GetExportJobByHash";
+                _hash.AddParameter(command.Parameters, hash);
             }
         }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/V1.Generated.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/V1.Generated.cs
@@ -523,7 +523,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             private readonly ParameterDefinition<System.String> _status = new ParameterDefinition<System.String>("@status", global::System.Data.SqlDbType.VarChar, false, 10);
             private readonly ParameterDefinition<System.DateTimeOffset> _queuedDateTime = new ParameterDefinition<System.DateTimeOffset>("@queuedDateTime", global::System.Data.SqlDbType.DateTimeOffset, false, 7);
             private readonly ParameterDefinition<System.String> _rawJobRecord = new ParameterDefinition<System.String>("@rawJobRecord", global::System.Data.SqlDbType.VarChar, false, -1);
-            public void PopulateCommand(global::System.Data.SqlClient.SqlCommand command, System.String id, System.String status, System.DateTimeOffset queuedDateTime, System.String rawJobRecord)
+            private readonly ParameterDefinition<System.Byte[]> _jobVersion = new ParameterDefinition<System.Byte[]>("@jobVersion", global::System.Data.SqlDbType.Binary, false, 8);
+            public void PopulateCommand(global::System.Data.SqlClient.SqlCommand command, System.String id, System.String status, System.DateTimeOffset queuedDateTime, System.String rawJobRecord, System.Byte[] jobVersion)
             {
                 command.CommandType = global::System.Data.CommandType.StoredProcedure;
                 command.CommandText = "dbo.UpdateExportJob";
@@ -531,6 +532,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
                 _status.AddParameter(command.Parameters, status);
                 _queuedDateTime.AddParameter(command.Parameters, queuedDateTime);
                 _rawJobRecord.AddParameter(command.Parameters, rawJobRecord);
+                _jobVersion.AddParameter(command.Parameters, jobVersion);
             }
         }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/V1.Generated.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/V1.Generated.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
         internal readonly static HardDeleteResourceProcedure HardDeleteResource = new HardDeleteResourceProcedure();
         internal readonly static ReadResourceProcedure ReadResource = new ReadResourceProcedure();
         internal readonly static SelectCurrentSchemaVersionProcedure SelectCurrentSchemaVersion = new SelectCurrentSchemaVersionProcedure();
+        internal readonly static UpdateExportJobProcedure UpdateExportJob = new UpdateExportJobProcedure();
         internal readonly static UpsertResourceProcedure UpsertResource = new UpsertResourceProcedure();
         internal readonly static UpsertSchemaVersionProcedure UpsertSchemaVersion = new UpsertSchemaVersionProcedure();
         internal class ClaimTypeTable : Table
@@ -509,6 +510,27 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             {
                 command.CommandType = global::System.Data.CommandType.StoredProcedure;
                 command.CommandText = "dbo.SelectCurrentSchemaVersion";
+            }
+        }
+
+        internal class UpdateExportJobProcedure : StoredProcedure
+        {
+            internal UpdateExportJobProcedure(): base("dbo.UpdateExportJob")
+            {
+            }
+
+            private readonly ParameterDefinition<System.String> _id = new ParameterDefinition<System.String>("@id", global::System.Data.SqlDbType.VarChar, false, 64);
+            private readonly ParameterDefinition<System.String> _status = new ParameterDefinition<System.String>("@status", global::System.Data.SqlDbType.VarChar, false, 10);
+            private readonly ParameterDefinition<System.DateTimeOffset> _queuedDateTime = new ParameterDefinition<System.DateTimeOffset>("@queuedDateTime", global::System.Data.SqlDbType.DateTimeOffset, false, 7);
+            private readonly ParameterDefinition<System.String> _rawJobRecord = new ParameterDefinition<System.String>("@rawJobRecord", global::System.Data.SqlDbType.VarChar, false, -1);
+            public void PopulateCommand(global::System.Data.SqlClient.SqlCommand command, System.String id, System.String status, System.DateTimeOffset queuedDateTime, System.String rawJobRecord)
+            {
+                command.CommandType = global::System.Data.CommandType.StoredProcedure;
+                command.CommandText = "dbo.UpdateExportJob";
+                _id.AddParameter(command.Parameters, id);
+                _status.AddParameter(command.Parameters, status);
+                _queuedDateTime.AddParameter(command.Parameters, queuedDateTime);
+                _rawJobRecord.AddParameter(command.Parameters, rawJobRecord);
             }
         }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/V1.Generated.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/V1.Generated.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
         internal readonly static UriSearchParamTable UriSearchParam = new UriSearchParamTable();
         internal readonly static AcquireExportJobsProcedure AcquireExportJobs = new AcquireExportJobsProcedure();
         internal readonly static CreateExportJobProcedure CreateExportJob = new CreateExportJobProcedure();
+        internal readonly static GetExportJobByIdProcedure GetExportJobById = new GetExportJobByIdProcedure();
         internal readonly static HardDeleteResourceProcedure HardDeleteResource = new HardDeleteResourceProcedure();
         internal readonly static ReadResourceProcedure ReadResource = new ReadResourceProcedure();
         internal readonly static SelectCurrentSchemaVersionProcedure SelectCurrentSchemaVersion = new SelectCurrentSchemaVersionProcedure();
@@ -425,6 +426,21 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
                 _status.AddParameter(command.Parameters, status);
                 _queuedDateTime.AddParameter(command.Parameters, queuedDateTime);
                 _rawJobRecord.AddParameter(command.Parameters, rawJobRecord);
+            }
+        }
+
+        internal class GetExportJobByIdProcedure : StoredProcedure
+        {
+            internal GetExportJobByIdProcedure(): base("dbo.GetExportJobById")
+            {
+            }
+
+            private readonly ParameterDefinition<System.String> _id = new ParameterDefinition<System.String>("@id", global::System.Data.SqlDbType.VarChar, false, 64);
+            public void PopulateCommand(global::System.Data.SqlClient.SqlCommand command, System.String id)
+            {
+                command.CommandType = global::System.Data.CommandType.StoredProcedure;
+                command.CommandText = "dbo.GetExportJobById";
+                _id.AddParameter(command.Parameters, id);
             }
         }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/V1.Generated.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/V1.Generated.cs
@@ -103,7 +103,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly VarCharColumn Hash = new VarCharColumn("Hash", 64, "Latin1_General_100_CS_AS");
             internal readonly VarCharColumn Status = new VarCharColumn("Status", 10);
             internal readonly NullableDateTime2Column HeartbeatDateTime = new NullableDateTime2Column("HeartbeatDateTime", 7);
-            internal readonly DateTimeOffsetColumn QueuedDateTime = new DateTimeOffsetColumn("QueuedDateTime", 7);
             internal readonly VarCharColumn RawJobRecord = new VarCharColumn("RawJobRecord", -1);
             internal readonly TimestampColumn JobVersion = new TimestampColumn("JobVersion");
         }
@@ -420,16 +419,14 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             private readonly ParameterDefinition<System.String> _id = new ParameterDefinition<System.String>("@id", global::System.Data.SqlDbType.VarChar, false, 64);
             private readonly ParameterDefinition<System.String> _hash = new ParameterDefinition<System.String>("@hash", global::System.Data.SqlDbType.VarChar, false, 64);
             private readonly ParameterDefinition<System.String> _status = new ParameterDefinition<System.String>("@status", global::System.Data.SqlDbType.VarChar, false, 10);
-            private readonly ParameterDefinition<System.DateTimeOffset> _queuedDateTime = new ParameterDefinition<System.DateTimeOffset>("@queuedDateTime", global::System.Data.SqlDbType.DateTimeOffset, false, 7);
             private readonly ParameterDefinition<System.String> _rawJobRecord = new ParameterDefinition<System.String>("@rawJobRecord", global::System.Data.SqlDbType.VarChar, false, -1);
-            public void PopulateCommand(global::System.Data.SqlClient.SqlCommand command, System.String id, System.String hash, System.String status, System.DateTimeOffset queuedDateTime, System.String rawJobRecord)
+            public void PopulateCommand(global::System.Data.SqlClient.SqlCommand command, System.String id, System.String hash, System.String status, System.String rawJobRecord)
             {
                 command.CommandType = global::System.Data.CommandType.StoredProcedure;
                 command.CommandText = "dbo.CreateExportJob";
                 _id.AddParameter(command.Parameters, id);
                 _hash.AddParameter(command.Parameters, hash);
                 _status.AddParameter(command.Parameters, status);
-                _queuedDateTime.AddParameter(command.Parameters, queuedDateTime);
                 _rawJobRecord.AddParameter(command.Parameters, rawJobRecord);
             }
         }
@@ -521,16 +518,14 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
 
             private readonly ParameterDefinition<System.String> _id = new ParameterDefinition<System.String>("@id", global::System.Data.SqlDbType.VarChar, false, 64);
             private readonly ParameterDefinition<System.String> _status = new ParameterDefinition<System.String>("@status", global::System.Data.SqlDbType.VarChar, false, 10);
-            private readonly ParameterDefinition<System.DateTimeOffset> _queuedDateTime = new ParameterDefinition<System.DateTimeOffset>("@queuedDateTime", global::System.Data.SqlDbType.DateTimeOffset, false, 7);
             private readonly ParameterDefinition<System.String> _rawJobRecord = new ParameterDefinition<System.String>("@rawJobRecord", global::System.Data.SqlDbType.VarChar, false, -1);
             private readonly ParameterDefinition<System.Byte[]> _jobVersion = new ParameterDefinition<System.Byte[]>("@jobVersion", global::System.Data.SqlDbType.Binary, false, 8);
-            public void PopulateCommand(global::System.Data.SqlClient.SqlCommand command, System.String id, System.String status, System.DateTimeOffset queuedDateTime, System.String rawJobRecord, System.Byte[] jobVersion)
+            public void PopulateCommand(global::System.Data.SqlClient.SqlCommand command, System.String id, System.String status, System.String rawJobRecord, System.Byte[] jobVersion)
             {
                 command.CommandType = global::System.Data.CommandType.StoredProcedure;
                 command.CommandText = "dbo.UpdateExportJob";
                 _id.AddParameter(command.Parameters, id);
                 _status.AddParameter(command.Parameters, status);
-                _queuedDateTime.AddParameter(command.Parameters, queuedDateTime);
                 _rawJobRecord.AddParameter(command.Parameters, rawJobRecord);
                 _jobVersion.AddParameter(command.Parameters, jobVersion);
             }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirOperationDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirOperationDataStore.cs
@@ -154,8 +154,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                     }
                     else
                     {
-                        // TODO: make this error message a resource?
-                        _logger.LogError(e, "Error from SQL database on export job update");
+                        _logger.LogError(e, Core.Resources.SqlErrorOnExportUpdate);
                         throw;
                     }
                 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirOperationDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirOperationDataStore.cs
@@ -135,14 +135,14 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
                 try
                 {
-                    var rowVersion = (int?)await sqlCommand.ExecuteScalarAsync(cancellationToken);
+                    var rowVersion = (byte[])await sqlCommand.ExecuteScalarAsync(cancellationToken);
 
-                    if (rowVersion == null)
+                    if (rowVersion.NullIfEmpty() == null)
                     {
                         throw new OperationFailedException(string.Format(Core.Resources.OperationFailed, OperationsConstants.Export, Resources.NullRowVersion), HttpStatusCode.InternalServerError);
                     }
 
-                    return new ExportJobOutcome(jobRecord, WeakETag.FromVersionId(rowVersion.ToString()));
+                    return new ExportJobOutcome(jobRecord, GetRowVersionAsEtag(rowVersion));
                 }
                 catch (SqlException e)
                 {

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirOperationDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirOperationDataStore.cs
@@ -181,8 +181,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                 Array.Reverse(rowVersionAsBytes);
             }
 
-            const int startIndex = 0;
-            var rowVersionAsDecimalString = BitConverter.ToInt64(rowVersionAsBytes, startIndex).ToString();
+            var rowVersionAsDecimalString = BitConverter.ToInt64(rowVersionAsBytes, startIndex: 0).ToString();
 
             return new ExportJobOutcome(exportJobRecord, WeakETag.FromVersionId(rowVersionAsDecimalString));
         }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirOperationDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirOperationDataStore.cs
@@ -58,7 +58,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                     jobRecord.Id,
                     jobRecord.Hash,
                     jobRecord.Status.ToString(),
-                    jobRecord.QueuedTime,
                     JsonConvert.SerializeObject(jobRecord, _jsonSerializerSettings));
 
                 var rowVersion = (int?)await sqlCommand.ExecuteScalarAsync(cancellationToken);
@@ -131,7 +130,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                     sqlCommand,
                     jobRecord.Id,
                     jobRecord.Status.ToString(),
-                    jobRecord.QueuedTime,
                     JsonConvert.SerializeObject(jobRecord, _jsonSerializerSettings),
                     rowVersionAsBytes);
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirOperationDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirOperationDataStore.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                 V1.CreateExportJob.PopulateCommand(
                     sqlCommand,
                     jobRecord.Id,
+                    jobRecord.Hash,
                     jobRecord.Status.ToString(),
                     jobRecord.QueuedTime,
                     JsonConvert.SerializeObject(jobRecord, _jsonSerializerSettings));

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirOperationDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirOperationDataStore.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                     }
                     else
                     {
-                        _logger.LogError(e, Core.Resources.SqlErrorOnExportUpdate);
+                        _logger.LogError(e, "Error from SQL database on export job update.");
                         throw;
                     }
                 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirOperationDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirOperationDataStore.cs
@@ -150,6 +150,10 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                     {
                         throw new JobConflictException();
                     }
+                    else if (e.Number == SqlErrorCodes.NotFound)
+                    {
+                        throw new JobNotFoundException(string.Format(Core.Resources.JobNotFound, jobRecord.Id));
+                    }
                     else
                     {
                         _logger.LogError(e, "Error from SQL database on export job update.");

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ExportTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ExportTests.cs
@@ -17,7 +17,7 @@ using Xunit;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
-    [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb, Format.Json)]
+    [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.Json)]
     public class ExportTests : IClassFixture<HttpIntegrationTestFixture>
     {
         private readonly HttpClient _client;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/FhirOperationDataStoreTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/FhirOperationDataStoreTests.cs
@@ -74,7 +74,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
         }
 
         [Fact]
-        [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb)]
         public async Task GivenAMatchingJob_WhenGettingByHash_ThenTheMatchingJobShouldBeReturned()
         {
             var jobRecord = await InsertNewExportJobRecordAsync();
@@ -85,7 +84,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
         }
 
         [Fact]
-        [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb)]
         public async Task GivenNoMatchingJob_WhenGettingByHash_ThenNoMatchingJobShouldBeReturned()
         {
             var jobRecord = await InsertNewExportJobRecordAsync();

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/FhirOperationDataStoreTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/FhirOperationDataStoreTests.cs
@@ -8,12 +8,15 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Health.Fhir.Core;
+using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export.Models;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Messages.Export;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.Integration.Persistence;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
@@ -290,7 +293,16 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
 
         private async Task<ExportJobRecord> InsertNewExportJobRecordAsync(Action<ExportJobRecord> jobRecordCustomizer = null)
         {
-            var jobRecord = new ExportJobRecord(_exportRequest.RequestUri, "Patient", "hash");
+            // Generate a unique hash
+            var hashObject = new
+            {
+                _exportRequest.RequestUri,
+                Clock.UtcNow,
+            };
+
+            string hash = JsonConvert.SerializeObject(hashObject).ComputeHash();
+
+            var jobRecord = new ExportJobRecord(_exportRequest.RequestUri, "Patient", hash);
 
             jobRecordCustomizer?.Invoke(jobRecord);
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/FhirOperationDataStoreTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/FhirOperationDataStoreTests.cs
@@ -245,6 +245,19 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
         }
 
         [Fact]
+        public async Task GivenANonexistentJob_WhenUpdatingTheJob_ThenJobNotFoundExceptionShouldBeThrown()
+        {
+            ExportJobOutcome jobOutcome = await CreateRunningJob();
+
+            ExportJobRecord job = jobOutcome.JobRecord;
+            WeakETag jobVersion = jobOutcome.ETag;
+
+            await _testHelper.DeleteAllExportJobRecordsAsync();
+
+            await Assert.ThrowsAsync<JobNotFoundException>(() => _operationDataStore.UpdateExportJobAsync(job, jobVersion, CancellationToken.None));
+        }
+
+        [Fact]
         public async Task GivenThereIsARunningJob_WhenSimultaneousUpdateCallsOccur_ThenJobConflictExceptionShouldBeThrown()
         {
             ExportJobOutcome runningJobOutcome = await CreateRunningJob();

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/FhirOperationDataStoreTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/FhirOperationDataStoreTests.cs
@@ -252,7 +252,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
             ExportJobRecord job = jobOutcome.JobRecord;
             WeakETag jobVersion = jobOutcome.ETag;
 
-            await _testHelper.DeleteAllExportJobRecordsAsync();
+            await _testHelper.DeleteExportJobRecordAsync(job.Id);
 
             await Assert.ThrowsAsync<JobNotFoundException>(() => _operationDataStore.UpdateExportJobAsync(job, jobVersion, CancellationToken.None));
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/FhirOperationDataStoreTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/FhirOperationDataStoreTests.cs
@@ -56,7 +56,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
         }
 
         [Fact]
-        [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb)]
         public async Task GivenAMatchingJob_WhenGettingById_ThenTheMatchingJobShouldBeReturned()
         {
             var jobRecord = await InsertNewExportJobRecordAsync();
@@ -67,7 +66,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
         }
 
         [Fact]
-        [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb)]
         public async Task GivenNoMatchingJob_WhenGettingById_ThehJobNotFoundExceptionShouldBeThrown()
         {
             var jobRecord = await InsertNewExportJobRecordAsync();

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestHelper.cs
@@ -19,13 +19,19 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
         private readonly IDocumentClient _documentClient;
         private readonly Uri _collectionUri;
+        private readonly string _databaseId;
+        private readonly string _collectionId;
 
         public CosmosDbFhirStorageTestHelper(
             IDocumentClient documentClient,
-            Uri collectionUri)
+            string databaseId,
+            string collectionId)
         {
             _documentClient = documentClient;
-            _collectionUri = collectionUri;
+            _databaseId = databaseId;
+            _collectionId = collectionId;
+
+            _collectionUri = UriFactory.CreateDocumentCollectionUri(_databaseId, _collectionId);
         }
 
         public async Task DeleteAllExportJobRecordsAsync(CancellationToken cancellationToken = default)
@@ -45,6 +51,12 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                     await _documentClient.DeleteDocumentAsync(doc.SelfLink, new RequestOptions() { PartitionKey = new PartitionKey(ExportJobPartitionKey) }, cancellationToken);
                 }
             }
+        }
+
+        public async Task DeleteExportJobRecordAsync(string id, CancellationToken cancellationToken = default)
+        {
+            Uri documentUri = UriFactory.CreateDocumentUri(_databaseId, _collectionId, id);
+            await _documentClient.DeleteDocumentAsync(documentUri, new RequestOptions { PartitionKey = new PartitionKey(ExportJobPartitionKey) }, cancellationToken);
         }
 
         async Task<object> IFhirStorageTestHelper.GetSnapshotToken()

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
@@ -124,7 +124,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
             _fhirStorageTestHelper = new CosmosDbFhirStorageTestHelper(
                 _documentClient,
-                UriFactory.CreateDocumentCollectionUri(_cosmosDataStoreConfiguration.DatabaseId, _cosmosCollectionConfiguration.CollectionId));
+                _cosmosDataStoreConfiguration.DatabaseId,
+                _cosmosCollectionConfiguration.CollectionId);
         }
 
         public async Task DisposeAsync()

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/IFhirStorageTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/IFhirStorageTestHelper.cs
@@ -18,6 +18,14 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         Task DeleteAllExportJobRecordsAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Deletes the specified export job record from the database.
+        /// </summary>
+        /// <param name="id">The id of the job to delete.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A task.</returns>
+        Task DeleteExportJobRecordAsync(string id, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Gets a token representing the state of the database.
         /// </summary>
         /// <returns>The state token</returns>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
@@ -31,6 +31,20 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             }
         }
 
+        public async Task DeleteExportJobRecordAsync(string id, CancellationToken cancellationToken = default)
+        {
+            using (var connection = new SqlConnection(_connectionString))
+            {
+                var command = new SqlCommand("DELETE FROM dbo.ExportJob WHERE Id = @id", connection);
+
+                var parameter = new SqlParameter { ParameterName = "@id", Value = id };
+                command.Parameters.Add(parameter);
+
+                await command.Connection.OpenAsync(cancellationToken);
+                await command.ExecuteNonQueryAsync(cancellationToken);
+            }
+        }
+
         async Task<object> IFhirStorageTestHelper.GetSnapshotToken()
         {
             using (var connection = new SqlConnection(_connectionString))


### PR DESCRIPTION
## Description
- Implements the final three SQL [bulk export](https://microsofthealth.visualstudio.com/Health/_wiki/wikis/Resolute.wiki/25/BulkExportDesignSpec) methods:
1. Get an export job given its ID
2. Get an export job given a hash of its ID
3. Update an export job
- Adds three new stored procedures, which follow the Cosmos side implementation

## Demo
1. Create a test patient (since we are starting with an empty SQL database)
2. Send an export request, passing in a Base64 encoded connection string to a test storage account
3. An export job will be created, and its status will change: queued --> running --> completed
4. The exported patient resource is visible in the Azure storage account

![sql-export-demo](https://user-images.githubusercontent.com/54082711/72853945-b7225500-3c67-11ea-960a-832959f73f7e.gif)

## Related issues
Addresses [#AB71335](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Resolute/Stories/?workitem=71335) and [#AB71336](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Resolute/Stories/?workitem=71336).

## Testing
- Enables running the existing Cosmos integration tests for export job getters with SQL
- Adds a new test for testing export job update
