### PR TITLE
Add Authorization category to Batch test that requires auth

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BatchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BatchTests.cs
@@ -66,6 +66,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
+        [Trait(Traits.Category, Categories.Authorization)]
         public async Task WhenSubmittingABatch_GivenAValidBundleWithReadonlyUser_ThenForbiddenAndOutcomeIsReturned()
         {
             FhirClient tempClient = Client.CreateClientForUser(TestUsers.ReadOnlyUser, TestApplications.NativeClient);


### PR DESCRIPTION
## Description
Add the Authorization category to a Batch test that requires auth.

## Related issues
Addresses [AB#71922](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/71922)

## Testing
Ran Batch tests excluding Authorization and verified WhenSubmittingABatch_GivenAValidBundleWithReadonlyUser_ThenForbiddenAndOutcomeIsReturned was not executed.