### PR TITLE
Use webdeploy package instead of kudu builds

### DIFF
--- a/samples/templates/default-azuredeploy-sql.json
+++ b/samples/templates/default-azuredeploy-sql.json
@@ -63,18 +63,11 @@
                 "description": "Enable Azure AAD SMART on FHIR Proxy"
             }
         },
-        "repositoryUrl": {
+        "msdeployPackageUrl": {
             "type": "string",
-            "defaultValue": "https://github.com/Microsoft/fhir-server",
+            "defaultValue": "",
             "metadata": {
-                "description": "Respository to pull source code from. If blank, source code will not be deployed."
-            }
-        },
-        "repositoryBranch": {
-            "type": "string",
-            "defaultValue": "master",
-            "metadata": {
-                "description": "Source code branch to deploy."
+                "description": "Webdeploy package to use as depoyment code. If blank, the latest code package will be deployed."
             }
         },
         "deployApplicationInsights": {
@@ -129,11 +122,12 @@
                 "R4"
             ],
             "metadata": {
-                "description": "Only applies when specifying Repository Url"
+                "description": "Only applies when MsdeployPackageUrl is not specified."
             }
         }
     },
     "variables": {
+        "defaultMsdeployPackageUrl": "[concat('https://fhirserverforazure.blob.core.windows.net/builds/ci/Microsoft.Health.Fhir.', parameters('fhirVersion'),'.Web.zip')]",
         "isMAG": "[or(contains(resourceGroup().location,'usgov'),contains(resourceGroup().location,'usdod'))]",
         "serviceName": "[toLower(parameters('serviceName'))]",
         "keyvaultEndpoint": "[if(variables('isMAG'), concat('https://', variables('serviceName'), '.vault.usgovcloudapi.net/'), concat('https://', variables('serviceName'), '.vault.azure.net/'))]",
@@ -141,7 +135,7 @@
         "appServicePlanName": "[if(empty(parameters('appServicePlanName')),concat(variables('serviceName'),'-asp'),parameters('appServicePlanName'))]",
         "appServiceResourceId": "[resourceId('Microsoft.Web/sites', variables('serviceName'))]",
         "securityAuthenticationEnabled": "[and(not(empty(parameters('securityAuthenticationAuthority'))),not(empty(parameters('securityAuthenticationAudience'))))]",
-        "deploySourceCode": "[and(not(empty(parameters('repositoryUrl'))),not(empty(parameters('repositoryBranch'))))]",
+        "msdeployPackageUrlToUse": "[if(empty(parameters('msdeployPackageUrl')),variables('defaultMsdeployPackageUrl'),parameters('msdeployPackageUrl'))]",
         "deployAppInsights": "[and(parameters('deployApplicationInsights'),not(variables('isMAG')))]",
         "appInsightsName": "[concat('AppInsights-', variables('serviceName'))]",
         "staticFhirServerConfigProperties": {
@@ -158,11 +152,7 @@
             "SqlServer:Initialize": "true",
             "DataStore": "SqlServer"
         },
-        "emptyFhirServerConfigProperties": {},
-        "kuduFhirServerConfigProperties": {
-            "PROJECT": "[concat('src/Microsoft.Health.Fhir.', parameters('fhirVersion'),'.Web/Microsoft.Health.Fhir.', parameters('fhirVersion'), '.Web.csproj')]"
-        },
-        "combinedFhirServerConfigProperties": "[union(variables('staticFhirServerConfigProperties'), parameters('additionalFhirServerConfigProperties'), if(variables('deploySourceCode'), variables('kuduFhirServerConfigProperties'), variables('emptyFhirServerConfigProperties')))]",
+        "combinedFhirServerConfigProperties": "[union(variables('staticFhirServerConfigProperties'), parameters('additionalFhirServerConfigProperties'))]",
         "computedSqlServerReference": "[concat('Microsoft.Sql/servers/', variables('serviceName'))]"
     },
     "resources": [
@@ -229,17 +219,13 @@
                 },
                 {
                     "apiVersion": "2015-08-01",
-                    "name": "web",
-                    "type": "sourcecontrols",
-                    "condition": "[variables('deploySourceCode')]",
+                    "type": "extensions",
+                    "name": "MSDeploy",
                     "dependsOn": [
-                        "[variables('appServiceResourceId')]",
-                        "[resourceId('Microsoft.Web/Sites/config', variables('serviceName'), 'appsettings')]"
+                        "[variables('appServiceResourceId')]"
                     ],
                     "properties": {
-                        "RepoUrl": "[parameters('repositoryUrl')]",
-                        "branch": "[parameters('repositoryBranch')]",
-                        "IsManualIntegration": true
+                        "packageUri": "[variables('msdeployPackageUrlToUse')]"
                     }
                 }
             ]

--- a/samples/templates/default-azuredeploy.json
+++ b/samples/templates/default-azuredeploy.json
@@ -63,18 +63,11 @@
                 "description": "Enable Azure AAD SMART on FHIR Proxy"
             }
         },
-        "repositoryUrl": {
+        "msdeployPackageUrl": {
             "type": "string",
-            "defaultValue": "https://github.com/Microsoft/fhir-server",
+            "defaultValue": "",
             "metadata": {
-                "description": "Respository to pull source code from. If blank, source code will not be deployed."
-            }
-        },
-        "repositoryBranch": {
-            "type": "string",
-            "defaultValue": "master",
-            "metadata": {
-                "description": "Source code branch to deploy."
+                "description": "Webdeploy package to use as depoyment code. If blank, the latest code package will be deployed."
             }
         },
         "cosmosDbAccountConsistencyPolicy": {
@@ -132,11 +125,12 @@
                 "R4"
             ],
             "metadata": {
-                "description": "Only applies when specifying Repository Url"
+                "description": "Only applies when MsdeployPackageUrl is not specified."
             }
         }
     },
     "variables": {
+        "defaultMsdeployPackageUrl": "[concat('https://fhirserverforazure.blob.core.windows.net/builds/ci/Microsoft.Health.Fhir.', parameters('fhirVersion'),'.Web.zip')]",
         "isMAG": "[or(contains(resourceGroup().location,'usgov'),contains(resourceGroup().location,'usdod'))]",
         "serviceName": "[toLower(parameters('serviceName'))]",
         "keyvaultEndpoint": "[if(variables('isMAG'), concat('https://', variables('serviceName'), '.vault.usgovcloudapi.net/'), concat('https://', variables('serviceName'), '.vault.azure.net/'))]",
@@ -144,7 +138,7 @@
         "appServicePlanName": "[if(empty(parameters('appServicePlanName')),concat(variables('serviceName'),'-asp'),parameters('appServicePlanName'))]",
         "appServiceResourceId": "[resourceId('Microsoft.Web/sites', variables('serviceName'))]",
         "securityAuthenticationEnabled": "[and(not(empty(parameters('securityAuthenticationAuthority'))),not(empty(parameters('securityAuthenticationAudience'))))]",
-        "deploySourceCode": "[and(not(empty(parameters('repositoryUrl'))),not(empty(parameters('repositoryBranch'))))]",
+        "msdeployPackageUrlToUse": "[if(empty(parameters('msdeployPackageUrl')),variables('defaultMsdeployPackageUrl'),parameters('msdeployPackageUrl'))]",
         "deployAppInsights": "[and(parameters('deployApplicationInsights'),not(variables('isMAG')))]",
         "appInsightsName": "[concat('AppInsights-', variables('serviceName'))]",
         "staticFhirServerConfigProperties": {
@@ -160,11 +154,7 @@
             "CosmosDb:ContinuationTokenSizeLimitInKb": "1",
             "DataStore": "CosmosDb"
         },
-        "emptyFhirServerConfigProperties": {},
-        "kuduFhirServerConfigProperties": {
-            "PROJECT": "[concat('src/Microsoft.Health.Fhir.', parameters('fhirVersion'),'.Web/Microsoft.Health.Fhir.', parameters('fhirVersion'), '.Web.csproj')]"
-        },
-        "combinedFhirServerConfigProperties": "[union(variables('staticFhirServerConfigProperties'), parameters('additionalFhirServerConfigProperties'), if(variables('deploySourceCode'), variables('kuduFhirServerConfigProperties'), variables('emptyFhirServerConfigProperties')))]"
+        "combinedFhirServerConfigProperties": "[union(variables('staticFhirServerConfigProperties'), parameters('additionalFhirServerConfigProperties'))]"
     },
     "resources": [
         {
@@ -230,17 +220,13 @@
                 },
                 {
                     "apiVersion": "2015-08-01",
-                    "name": "web",
-                    "type": "sourcecontrols",
-                    "condition": "[variables('deploySourceCode')]",
+                    "type": "extensions",
+                    "name": "MSDeploy",
                     "dependsOn": [
-                        "[variables('appServiceResourceId')]",
-                        "[resourceId('Microsoft.Web/Sites/config', variables('serviceName'), 'appsettings')]"
+                        "[variables('appServiceResourceId')]"
                     ],
                     "properties": {
-                        "RepoUrl": "[parameters('repositoryUrl')]",
-                        "branch": "[parameters('repositoryBranch')]",
-                        "IsManualIntegration": true
+                        "packageUri": "[variables('msdeployPackageUrlToUse')]"
                     }
                 }
             ]


### PR DESCRIPTION
## Description
Kudu is not able to build .net core 3 projects, we need to move away from this approach for OSS template deployments.
This PR updates the templates to use a WebDeploy package that is created by the CI process and copied to blob storage.

## Related issues
Addresses #856.

## Testing
Manual deployments

Test from this branch:
```
New-AzResourceGroupDeployment -TemplateUri https://github.com/microsoft/fhir-server/raw/personal/bkowitz/issue-856-deploytemplate/samples/templates/default-azuredeploy.json -ResourceGroupName $rg.ResourceGroupName -serviceName $fhirServiceName
```