### PR TITLE
Handle OperationCancelledException() thrown during health check

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/HealthCheck/HealthCheckCachingTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/HealthCheck/HealthCheckCachingTests.cs
@@ -91,5 +91,18 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.HealthCheck
 
             _healthCheckFunc.Received(2).Invoke(_serviceScope.ServiceProvider);
         }
+
+        [Fact]
+        public async Task GivenTheHealthCheckCache_WhenCancellationIsRequested_ThenWeDoNotThrowAndReturnHealthyStatus()
+        {
+            var ctSource = new CancellationTokenSource();
+            ctSource.Cancel();
+
+            HealthCheckResult result = await _cahcedHealthCheck.CheckHealthAsync(_context, ctSource.Token);
+
+            await _healthCheck.DidNotReceive().CheckHealthAsync(Arg.Any<HealthCheckContext>(), Arg.Any<CancellationToken>());
+            Assert.Equal(HealthStatus.Healthy, result.Status);
+            Assert.Contains("Health check was canceled", result.Description);
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/HealthChecks/CachedHealthCheck.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/HealthChecks/CachedHealthCheck.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Health.Fhir.Api.Modules.HealthChecks
             catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested)
             {
                 _logger.LogInformation(oce, $"Cancellation was requested for {nameof(CheckHealthAsync)}");
-                return HealthCheckResult.Healthy("Health check was canceled before completion.");
+                return _lastResult;
             }
 
             try

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/HealthChecks/CachedHealthCheck.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/HealthChecks/CachedHealthCheck.cs
@@ -44,7 +44,16 @@ namespace Microsoft.Health.Fhir.Api.Modules.HealthChecks
                 return _lastResult;
             }
 
-            await _semaphore.WaitAsync(cancellationToken);
+            try
+            {
+                await _semaphore.WaitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested)
+            {
+                _logger.LogInformation(oce, $"Cancellation was requested for {nameof(CheckHealthAsync)}");
+                return HealthCheckResult.Healthy("Health check was canceled before completion.");
+            }
+
             try
             {
                 if (_lastChecked >= ExpirationWindow)


### PR DESCRIPTION
## Description
Our current health check implementation has a race condition which can end up causing an unhandled exception to be thrown. This happens when we are calling WaitAsync(cancellationToken) on the semaphoreslim and the cancellation token gets cancelled before the method returns. The WaitAsync method throws an OperationCanceledException in such scenarios and we don't catch it.

## Related issues
Addresses [issue [AB#72115](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/72115)].

## Testing
Added UT for corresponding change.
