### PR TITLE
Tests schema upgrade paths

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/2.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/2.sql
@@ -57,7 +57,7 @@ CREATE TABLE dbo.SchemaVersion
 
 INSERT INTO dbo.SchemaVersion
 VALUES
-    (2, 'started') -- TODO: Should we also insert (1, 'complete')?
+    (2, 'started')
 
 GO
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/2.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/2.sql
@@ -57,7 +57,7 @@ CREATE TABLE dbo.SchemaVersion
 
 INSERT INTO dbo.SchemaVersion
 VALUES
-    (1, 'started')
+    (2, 'started') -- TODO: Should we also insert (1, 'complete')?
 
 GO
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaInitializer.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaInitializer.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema
             _logger = logger;
         }
 
-        private void Initialize()
+        public void Initialize(bool applySqlSchemaSnapshot = false)
         {
             if (!CanInitialize())
             {
@@ -48,22 +48,36 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema
 
             _logger.LogInformation("Schema version is {version}", _schemaInformation.Current?.ToString() ?? "NULL");
 
-            // GetCurrentVersion doesn't exist, so run version 1.
+            // If the stored procedure to get the current schema version doesn't exist
             if (_schemaInformation.Current == null || _sqlServerDataStoreConfiguration.DeleteAllDataOnStartup)
             {
-                _schemaUpgradeRunner.ApplySchema(1);
+                // And if we are applying a complete snapshot of the SQL schema
+                if (applySqlSchemaSnapshot)
+                {
+                    // Apply the maximum supported version. This won't consider the .diff.sql files.
+                    _schemaUpgradeRunner.ApplySchema((int)_schemaInformation.MaximumSupportedVersion, isSnapshot: true);
+                }
+                else
+                {
+                    // Otherwise, run version 1. We'll use this as a base schema and apply .diff.sql files to upgrade the schema version.
+                    _schemaUpgradeRunner.ApplySchema(version: 1, isSnapshot: true);
+                }
+
                 GetCurrentSchemaVersion();
             }
 
-            if (_schemaInformation.Current < _schemaInformation.MaximumSupportedVersion)
+            // If we are looking to apply .diff.sql files and the current schema version needs to be upgraded
+            if (!applySqlSchemaSnapshot && _schemaInformation.Current < _schemaInformation.MaximumSupportedVersion)
             {
+                // Apply each .diff.sql file one by one.
                 int current = (int?)_schemaInformation.Current ?? 0;
-
                 for (int i = current + 1; i <= (int)_schemaInformation.MaximumSupportedVersion; i++)
                 {
-                    _schemaUpgradeRunner.ApplySchema(i);
+                    _schemaUpgradeRunner.ApplySchema(version: i, isSnapshot: false);
                 }
             }
+
+            GetCurrentSchemaVersion();
         }
 
         private void GetCurrentSchemaVersion()
@@ -194,8 +208,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema
             if (!string.IsNullOrWhiteSpace(_sqlServerDataStoreConfiguration.ConnectionString))
             {
                 Initialize();
-
-                GetCurrentSchemaVersion();
             }
             else
             {

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaUpgradeRunner.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaUpgradeRunner.cs
@@ -27,11 +27,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema
             _logger = logger;
         }
 
-        public void ApplySchema(int version)
+        public void ApplySchema(int version, bool isSnapshot)
         {
             _logger.LogInformation("Applying schema {version}", version);
 
-            if (version != 1)
+            if (!isSnapshot)
             {
                 InsertSchemaVersion(version);
             }
@@ -41,8 +41,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema
                 connection.Open();
                 var server = new Server(new ServerConnection(connection));
 
-                bool getDiffScript = version != 1;
-                server.ConnectionContext.ExecuteNonQuery(ScriptProvider.GetMigrationScript(version, getDiffScript));
+                server.ConnectionContext.ExecuteNonQuery(ScriptProvider.GetMigrationScript(version, !isSnapshot));
             }
 
             CompleteSchemaVersion(version);

--- a/test/Microsoft.Health.Fhir.R4.Tests.Integration/Microsoft.Health.Fhir.R4.Tests.Integration.csproj
+++ b/test/Microsoft.Health.Fhir.R4.Tests.Integration/Microsoft.Health.Fhir.R4.Tests.Integration.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Microsoft.SqlServer.DACFx" Version="150.4573.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.6.0" />

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/SqlServerFhirOperationDataStoreTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/SqlServerFhirOperationDataStoreTests.cs
@@ -29,18 +29,22 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
             var snapshotDatabaseName = $"SNAPSHOT_{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}_{BigInteger.Abs(new BigInteger(Guid.NewGuid().ToByteArray()))}";
             var diffDatabaseName = $"DIFF_{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}_{BigInteger.Abs(new BigInteger(Guid.NewGuid().ToByteArray()))}";
 
-            // Create two databases, one where we apply the the maximum supported version's snapshot SQL schema file
-            await _testHelper.CreateAndInitializeDatabase(snapshotDatabaseName, applySqlSchemaSnapshot: true);
+            try
+            {
+                // Create two databases, one where we apply the the maximum supported version's snapshot SQL schema file
+                await _testHelper.CreateAndInitializeDatabase(snapshotDatabaseName, applySqlSchemaSnapshot: true);
 
-            // And one where we apply .diff.sql files to upgrade the schema version to the maximum supported version.
-            await _testHelper.CreateAndInitializeDatabase(diffDatabaseName, applySqlSchemaSnapshot: false);
+                // And one where we apply .diff.sql files to upgrade the schema version to the maximum supported version.
+                await _testHelper.CreateAndInitializeDatabase(diffDatabaseName, applySqlSchemaSnapshot: false);
 
-            bool isEqual = _testHelper.CompareDatabaseSchemas(snapshotDatabaseName, diffDatabaseName);
-
-            await _testHelper.DeleteDatabase(snapshotDatabaseName);
-            await _testHelper.DeleteDatabase(diffDatabaseName);
-
-            Assert.True(isEqual);
+                bool isEqual = _testHelper.CompareDatabaseSchemas(snapshotDatabaseName, diffDatabaseName);
+                Assert.True(isEqual);
+            }
+            finally
+            {
+                await _testHelper.DeleteDatabase(snapshotDatabaseName);
+                await _testHelper.DeleteDatabase(diffDatabaseName);
+            }
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/SqlServerFhirOperationDataStoreTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/SqlServerFhirOperationDataStoreTests.cs
@@ -1,0 +1,44 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Numerics;
+using System.Threading.Tasks;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Microsoft.Health.Fhir.Tests.Integration.Persistence;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
+{
+    [Collection(FhirOperationTestConstants.FhirOperationTests)]
+    [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]
+    public class SqlServerFhirOperationDataStoreTests : IClassFixture<FhirStorageTestsFixture>
+    {
+        private readonly ISqlServerFhirStorageTestHelper _testHelper;
+
+        public SqlServerFhirOperationDataStoreTests(FhirStorageTestsFixture fixture)
+        {
+            _testHelper = (SqlServerFhirStorageTestHelper)fixture.TestHelper;
+        }
+
+        [Fact]
+        public async Task GivenTwoSchemaInitializationMethods_WhenCreatingTwoDatabases_BothSchemasShouldBeEquivalent()
+        {
+            var databaseName1 = $"TEST1_{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}_{BigInteger.Abs(new BigInteger(Guid.NewGuid().ToByteArray()))}";
+            var databaseName2 = $"TEST2_{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}_{BigInteger.Abs(new BigInteger(Guid.NewGuid().ToByteArray()))}";
+
+            // Create two databases, one where we apply the the maximum supported version's snapshot SQL schema file
+            await _testHelper.CreateAndInitializeDatabase(databaseName1, applySqlSchemaSnapshot: true);
+
+            // And one where we apply .diff.sql files to upgrade the schema version to the maximum supported version.
+            await _testHelper.CreateAndInitializeDatabase(databaseName2, applySqlSchemaSnapshot: false);
+
+            // TODO: Compare schemas.
+
+            await _testHelper.DeleteDatabase(databaseName1);
+            await _testHelper.DeleteDatabase(databaseName2);
+        }
+    }
+}

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/SqlServerFhirOperationDataStoreTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/SqlServerFhirOperationDataStoreTests.cs
@@ -26,19 +26,21 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
         [Fact]
         public async Task GivenTwoSchemaInitializationMethods_WhenCreatingTwoDatabases_BothSchemasShouldBeEquivalent()
         {
-            var databaseName1 = $"TEST1_{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}_{BigInteger.Abs(new BigInteger(Guid.NewGuid().ToByteArray()))}";
-            var databaseName2 = $"TEST2_{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}_{BigInteger.Abs(new BigInteger(Guid.NewGuid().ToByteArray()))}";
+            var snapshotDatabaseName = $"SNAPSHOT_{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}_{BigInteger.Abs(new BigInteger(Guid.NewGuid().ToByteArray()))}";
+            var diffDatabaseName = $"DIFF_{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}_{BigInteger.Abs(new BigInteger(Guid.NewGuid().ToByteArray()))}";
 
             // Create two databases, one where we apply the the maximum supported version's snapshot SQL schema file
-            await _testHelper.CreateAndInitializeDatabase(databaseName1, applySqlSchemaSnapshot: true);
+            await _testHelper.CreateAndInitializeDatabase(snapshotDatabaseName, applySqlSchemaSnapshot: true);
 
             // And one where we apply .diff.sql files to upgrade the schema version to the maximum supported version.
-            await _testHelper.CreateAndInitializeDatabase(databaseName2, applySqlSchemaSnapshot: false);
+            await _testHelper.CreateAndInitializeDatabase(diffDatabaseName, applySqlSchemaSnapshot: false);
 
-            // TODO: Compare schemas.
+            bool isEqual = _testHelper.CompareDatabaseSchemas(snapshotDatabaseName, diffDatabaseName);
 
-            await _testHelper.DeleteDatabase(databaseName1);
-            await _testHelper.DeleteDatabase(databaseName2);
+            await _testHelper.DeleteDatabase(snapshotDatabaseName);
+            await _testHelper.DeleteDatabase(diffDatabaseName);
+
+            Assert.True(isEqual);
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Microsoft.Health.Fhir.Shared.Tests.Integration.projitems
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Microsoft.Health.Fhir.Shared.Tests.Integration.projitems
@@ -12,7 +12,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\FhirOperationDataStoreTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\Export\CreateExportRequestHandlerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\FhirOperationTestConstants.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\SqlServerFhirOperationDataStoreTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlServerSchemaUpgradeTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\CosmosDbFhirStorageTestHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\CosmosDbFhirStorageTestsFixture.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\FhirStorageTests.cs" />

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Microsoft.Health.Fhir.Shared.Tests.Integration.projitems
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Microsoft.Health.Fhir.Shared.Tests.Integration.projitems
@@ -12,12 +12,14 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\FhirOperationDataStoreTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\Export\CreateExportRequestHandlerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\FhirOperationTestConstants.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\SqlServerFhirOperationDataStoreTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\CosmosDbFhirStorageTestHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\CosmosDbFhirStorageTestsFixture.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\FhirStorageTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\FhirStorageTestsFixture.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\FhirStorageTestsFixtureArgumentSetsAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\IFhirStorageTestHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Persistence\ISqlServerFhirStorageTestHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\NullFhirDocumentQueryLogger.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlDataReaderExtensionsTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlServerFhirStorageTestHelper.cs" />

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/ISqlServerFhirStorageTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/ISqlServerFhirStorageTestHelper.cs
@@ -24,5 +24,13 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         /// <param name="databaseName">The name of the database to delete.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         Task DeleteDatabase(string databaseName, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Compares two database schemas.
+        /// </summary>
+        /// <param name="databaseName1">The name of the first database to compare.</param>
+        /// <param name="databaseName2">The name of the second database to compare.</param>
+        /// <returns>True if the schemas are equal, false otherwise.</returns>
+        bool CompareDatabaseSchemas(string databaseName1, string databaseName2);
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/ISqlServerFhirStorageTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/ISqlServerFhirStorageTestHelper.cs
@@ -1,0 +1,28 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
+{
+    public interface ISqlServerFhirStorageTestHelper
+    {
+        /// <summary>
+        /// Creates and initializes a new SQL database.
+        /// </summary>
+        /// <param name="databaseName">The name of the database to create.</param>
+        /// <param name="applySqlSchemaSnapshot">True if the latest snapshot schema file should be run, false if diff SQL files should be applied to upgrade the schema.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        Task CreateAndInitializeDatabase(string databaseName, bool applySqlSchemaSnapshot, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Deletes the specified SQL database.
+        /// </summary>
+        /// <param name="databaseName">The name of the database to delete.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        Task DeleteDatabase(string databaseName, CancellationToken cancellationToken = default);
+    }
+}

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/ISqlServerFhirStorageTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/ISqlServerFhirStorageTestHelper.cs
@@ -5,6 +5,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Health.Fhir.SqlServer.Features.Schema;
 
 namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 {
@@ -15,8 +16,9 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         /// </summary>
         /// <param name="databaseName">The name of the database to create.</param>
         /// <param name="applySqlSchemaSnapshot">True if the latest snapshot schema file should be run, false if diff SQL files should be applied to upgrade the schema.</param>
+        /// <param name="schemaInitializer">The schema initializer to use for database initialization. If this is not provided, a new one is created.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        Task CreateAndInitializeDatabase(string databaseName, bool applySqlSchemaSnapshot, CancellationToken cancellationToken = default);
+        Task CreateAndInitializeDatabase(string databaseName, bool applySqlSchemaSnapshot, SchemaInitializer schemaInitializer = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Deletes the specified SQL database.

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
@@ -32,10 +32,10 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             _masterConnectionString = masterConnectionString;
         }
 
-        public async Task CreateAndInitializeDatabase(string databaseName, bool applySqlSchemaSnapshot, CancellationToken cancellationToken = default)
+        public async Task CreateAndInitializeDatabase(string databaseName, bool applySqlSchemaSnapshot, SchemaInitializer schemaInitializer = null, CancellationToken cancellationToken = default)
         {
             var testConnectionString = new SqlConnectionStringBuilder(_initialConnectionString) { InitialCatalog = databaseName }.ToString();
-            var schemaInitializer = CreateSchemaInitializer(testConnectionString);
+            schemaInitializer = schemaInitializer ?? CreateSchemaInitializer(testConnectionString);
 
             // Create the database.
             using (var connection = new SqlConnection(_masterConnectionString))

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Health.Fhir.SqlServer.Configs;
 using Microsoft.Health.Fhir.SqlServer.Features.Schema;
+using Microsoft.SqlServer.Dac.Compare;
 using Polly;
 using Xunit;
 
@@ -86,6 +87,19 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                     await command.ExecuteNonQueryAsync(cancellationToken);
                 }
             }
+        }
+
+        public bool CompareDatabaseSchemas(string databaseName1, string databaseName2)
+        {
+            var testConnectionString1 = new SqlConnectionStringBuilder(_initialConnectionString) { InitialCatalog = databaseName1 }.ToString();
+            var testConnectionString2 = new SqlConnectionStringBuilder(_initialConnectionString) { InitialCatalog = databaseName2 }.ToString();
+
+            var source = new SchemaCompareDatabaseEndpoint(testConnectionString1);
+            var target = new SchemaCompareDatabaseEndpoint(testConnectionString2);
+            var comparison = new SchemaComparison(source, target);
+            SchemaComparisonResult result = comparison.Compare();
+
+            return result.IsEqual;
         }
 
         public async Task DeleteAllExportJobRecordsAsync(CancellationToken cancellationToken = default)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
@@ -3,21 +3,89 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Data.SqlClient;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Health.Fhir.SqlServer.Configs;
+using Microsoft.Health.Fhir.SqlServer.Features.Schema;
+using Polly;
 using Xunit;
+
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 {
-    public class SqlServerFhirStorageTestHelper : IFhirStorageTestHelper
+    public class SqlServerFhirStorageTestHelper : IFhirStorageTestHelper, ISqlServerFhirStorageTestHelper
     {
         private readonly string _connectionString;
+        private readonly string _initialConnectionString;
+        private readonly string _masterConnectionString;
 
-        public SqlServerFhirStorageTestHelper(string connectionString)
+        public SqlServerFhirStorageTestHelper(string connectionString, string initialConnectionString, string masterConnectionString)
         {
             _connectionString = connectionString;
+            _initialConnectionString = initialConnectionString;
+            _masterConnectionString = masterConnectionString;
+        }
+
+        // TODO: The code for creating and deleting databases is duplicate code - it already exists in the SqlServerFhirStorageTestFixture class.
+        public async Task CreateAndInitializeDatabase(string databaseName, bool applySqlSchemaSnapshot, CancellationToken cancellationToken = default)
+        {
+            var testConnectionString = new SqlConnectionStringBuilder(_initialConnectionString) { InitialCatalog = databaseName }.ToString();
+            var schemaInitializer = CreateSchemaInitializer(testConnectionString);
+
+            // Create the database.
+            using (var connection = new SqlConnection(_masterConnectionString))
+            {
+                await connection.OpenAsync(cancellationToken);
+
+                using (SqlCommand command = connection.CreateCommand())
+                {
+                    command.CommandTimeout = 600;
+                    command.CommandText = $"CREATE DATABASE {databaseName}";
+                    await command.ExecuteNonQueryAsync(cancellationToken);
+                }
+            }
+
+            // Verify that we can connect to the new database. This sometimes does not work right away with Azure SQL.
+            await Policy
+                .Handle<SqlException>()
+                .WaitAndRetryAsync(
+                    retryCount: 7,
+                    sleepDurationProvider: retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)))
+                .ExecuteAsync(async () =>
+                {
+                    using (var connection = new SqlConnection(testConnectionString))
+                    {
+                        await connection.OpenAsync(cancellationToken);
+                        using (SqlCommand sqlCommand = connection.CreateCommand())
+                        {
+                            sqlCommand.CommandText = "SELECT 1";
+                            await sqlCommand.ExecuteScalarAsync(cancellationToken);
+                        }
+                    }
+                });
+
+            schemaInitializer.Initialize(applySqlSchemaSnapshot);
+        }
+
+        public async Task DeleteDatabase(string databaseName, CancellationToken cancellationToken = default)
+        {
+            using (var connection = new SqlConnection(_masterConnectionString))
+            {
+                await connection.OpenAsync(cancellationToken);
+                SqlConnection.ClearAllPools();
+
+                using (SqlCommand command = connection.CreateCommand())
+                {
+                    command.CommandTimeout = 600;
+                    command.CommandText = $"DROP DATABASE IF EXISTS {databaseName}";
+                    await command.ExecuteNonQueryAsync(cancellationToken);
+                }
+            }
         }
 
         public async Task DeleteAllExportJobRecordsAsync(CancellationToken cancellationToken = default)
@@ -99,6 +167,15 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                     }
                 }
             }
+        }
+
+        private SchemaInitializer CreateSchemaInitializer(string testConnectionString)
+        {
+            var config = new SqlServerDataStoreConfiguration { ConnectionString = testConnectionString, Initialize = true };
+            var schemaUpgradeRunner = new SchemaUpgradeRunner(config, NullLogger<SchemaUpgradeRunner>.Instance);
+            var schemaInformation = new SchemaInformation();
+
+            return new SchemaInitializer(config, schemaUpgradeRunner, schemaInformation, NullLogger<SchemaInitializer>.Instance);
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
@@ -32,7 +32,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             _masterConnectionString = masterConnectionString;
         }
 
-        // TODO: The code for creating and deleting databases is duplicate code - it already exists in the SqlServerFhirStorageTestFixture class.
         public async Task CreateAndInitializeDatabase(string databaseName, bool applySqlSchemaSnapshot, CancellationToken cancellationToken = default)
         {
             var testConnectionString = new SqlConnectionStringBuilder(_initialConnectionString) { InitialCatalog = databaseName }.ToString();

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Data.SqlClient;
 using System.Numerics;
+using System.Threading;
 using Hl7.Fhir.Model;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -130,18 +131,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
         public async Task DisposeAsync()
         {
-            using (var connection = new SqlConnection(_masterConnectionString))
-            {
-                await connection.OpenAsync();
-                SqlConnection.ClearAllPools();
-
-                using (SqlCommand command = connection.CreateCommand())
-                {
-                    command.CommandTimeout = 600;
-                    command.CommandText = $"DROP DATABASE IF EXISTS {_databaseName}";
-                    await command.ExecuteNonQueryAsync();
-                }
-            }
+            await _testHelper.DeleteDatabase(_databaseName, CancellationToken.None);
         }
 
         object IServiceProvider.GetService(Type serviceType)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
             _fhirOperationDataStore = new SqlServerFhirOperationDataStore(sqlConnectionWrapperFactory, NullLogger<SqlServerFhirOperationDataStore>.Instance);
 
-            _testHelper = new SqlServerFhirStorageTestHelper(TestConnectionString);
+            _testHelper = new SqlServerFhirStorageTestHelper(TestConnectionString, initialConnectionString, _masterConnectionString);
         }
 
         public string TestConnectionString { get; }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
@@ -7,18 +7,16 @@ using System;
 using System.Numerics;
 using System.Threading.Tasks;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
-using Microsoft.Health.Fhir.Tests.Integration.Persistence;
 using Xunit;
 
-namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
+namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 {
-    [Collection(FhirOperationTestConstants.FhirOperationTests)]
     [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]
-    public class SqlServerFhirOperationDataStoreTests : IClassFixture<FhirStorageTestsFixture>
+    public class SqlServerSchemaUpgradeTests : IClassFixture<FhirStorageTestsFixture>
     {
         private readonly ISqlServerFhirStorageTestHelper _testHelper;
 
-        public SqlServerFhirOperationDataStoreTests(FhirStorageTestsFixture fixture)
+        public SqlServerSchemaUpgradeTests(FhirStorageTestsFixture fixture)
         {
             _testHelper = (SqlServerFhirStorageTestHelper)fixture.TestHelper;
         }

--- a/test/Microsoft.Health.Fhir.Stu3.Tests.Integration/Microsoft.Health.Fhir.Stu3.Tests.Integration.csproj
+++ b/test/Microsoft.Health.Fhir.Stu3.Tests.Integration/Microsoft.Health.Fhir.Stu3.Tests.Integration.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Microsoft.SqlServer.DACFx" Version="150.4573.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.6.0" />


### PR DESCRIPTION
## Description
There are two potential schema initialization paths to initialize the SQL schema to version X:
1. Use diff files: run 1.sql, 2.diff.sql, 3.diff.sql, …, (X - 1).diff.sql, X.diff.sql (default path)
2. Use the latest snapshot file: run X.sql

This PR adds an integration test to verify that the same schema is achieved if either path is taken. This test:
1. Creates two new databases, one initialized using diff files and one initialized using the latest snapshot file
2. Compares the schema of the two databases using functionality provided in the [Microsoft.SqlServer.DACFx](https://www.nuget.org/packages/Microsoft.SqlServer.DACFx) nuget package
3. Deletes the databases

## Related issues
Addresses [#AB71197](https://microsofthealth.visualstudio.com/Health/_workitems/edit/71197).

This is a follow up to #865. 