### PR TITLE
Fix MSDeploy dependency issue

### DIFF
--- a/samples/templates/default-azuredeploy-sql.json
+++ b/samples/templates/default-azuredeploy-sql.json
@@ -213,6 +213,7 @@
                     "type": "config",
                     "dependsOn": [
                         "[variables('appServiceResourceId')]",
+                        "[concat(variables('appServiceResourceId'), '/Extensions/MSDeploy')]",
                         "[if(variables('deployAppInsights'),concat('Microsoft.Insights/components/', variables('appInsightsName')),resourceId('Microsoft.KeyVault/vaults', variables('serviceName')))]"
                     ],
                     "properties": "[if(variables('deployAppInsights'), union(variables('combinedFhirServerConfigProperties'), json(concat('{\"ApplicationInsights:InstrumentationKey\": \"', reference(concat('Microsoft.Insights/components/', variables('appInsightsName'))).InstrumentationKey, '\"}'))), variables('combinedFhirServerConfigProperties'))]"

--- a/samples/templates/default-azuredeploy.json
+++ b/samples/templates/default-azuredeploy.json
@@ -214,6 +214,7 @@
                     "type": "config",
                     "dependsOn": [
                         "[variables('appServiceResourceId')]",
+                        "[concat(variables('appServiceResourceId'), '/Extensions/MSDeploy')]",
                         "[if(variables('deployAppInsights'),concat('Microsoft.Insights/components/', variables('appInsightsName')),resourceId('Microsoft.KeyVault/vaults', variables('serviceName')))]"
                     ],
                     "properties": "[if(variables('deployAppInsights'), union(variables('combinedFhirServerConfigProperties'), json(concat('{\"ApplicationInsights:InstrumentationKey\": \"', reference(concat('Microsoft.Insights/components/', variables('appInsightsName'))).InstrumentationKey, '\"}'))), variables('combinedFhirServerConfigProperties'))]"


### PR DESCRIPTION
## Description
Using the azuredeploy.json template sometimes fails with 

> AppGallery Deploy Failed: 'System.Threading.ThreadAbortException: Thread was being aborted. 

This is caused when the deployment starts and appsettings are applied. This then causes the app to reset aborting the deployment. This change adds the MSDeploy extension as a dependency before applying the appsettings.
