### PR TITLE
Corrects metadata for the R4 _profile search parameter

### DIFF
--- a/Microsoft.Health.Fhir.sln
+++ b/Microsoft.Health.Fhir.sln
@@ -36,6 +36,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{404C6C33-DB00-4182-BD90-F10A8B17C321}"
 	ProjectSection(SolutionItems) = preProject
 		Directory.Build.props = Directory.Build.props
+		global.json = global.json
 		testauthenvironment.json = testauthenvironment.json
 	EndProjectSection
 EndProject

--- a/src/Microsoft.Health.Fhir.R4.Core/Features/Definition/search-parameters.json
+++ b/src/Microsoft.Health.Fhir.R4.Core/Features/Definition/search-parameters.json
@@ -181,48 +181,6 @@
     }
   },
   {
-    "fullUrl" : "http://hl7.org/fhir/SearchParameter/Resource-profile",
-    "resource" : {
-      "resourceType" : "SearchParameter",
-      "id" : "Resource-profile",
-      "extension" : [{
-        "url" : "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
-        "valueCode" : "trial-use"
-      }],
-      "url" : "http://hl7.org/fhir/SearchParameter/Resource-profile",
-      "version" : "4.0.0",
-      "name" : "_profile",
-      "status" : "draft",
-      "experimental" : false,
-      "date" : "2018-12-27T22:37:54+11:00",
-      "publisher" : "Health Level Seven International (FHIR Infrastructure)",
-      "contact" : [{
-        "telecom" : [{
-          "system" : "url",
-          "value" : "http://hl7.org/fhir"
-        }]
-      },
-      {
-        "telecom" : [{
-          "system" : "url",
-          "value" : "http://www.hl7.org/Special/committees/fiwg/index.cfm"
-        }]
-      }],
-      "description" : "Profiles this resource claims to conform to",
-      "code" : "_profile",
-      "base" : ["Resource"],
-      "type" : "reference",
-      "expression" : "Resource.meta.profile",
-      "xpath" : "f:Resource/f:meta/f:profile",
-      "xpathUsage" : "normal",
-      "multipleOr" : true,
-      "multipleAnd" : true,
-      "modifier" : ["missing",
-      "type",
-      "identifier"]
-    }
-  },
-  {
     "fullUrl" : "http://hl7.org/fhir/SearchParameter/Resource-query",
     "resource" : {
       "resourceType" : "SearchParameter",

--- a/test/Microsoft.Health.Fhir.R4.Tests.E2E/Rest/Search/SearchProfileTests.cs
+++ b/test/Microsoft.Health.Fhir.R4.Tests.E2E/Rest/Search/SearchProfileTests.cs
@@ -1,0 +1,43 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Hl7.Fhir.Model;
+using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Microsoft.Health.Fhir.Tests.E2E.Common;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
+{
+    [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.All)]
+    public class SearchProfileTests : IClassFixture<HttpIntegrationTestFixture>
+    {
+        public SearchProfileTests(HttpIntegrationTestFixture fixture)
+        {
+            Client = fixture.FhirClient;
+        }
+
+        protected FhirClient Client { get; set; }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task WhenSearchingForAResourceWithProfile_GivenAnR4Server_TheServerShouldDropTheParamFromTheSelfLink()
+        {
+            string profile = $"https://e2e-test-profile|{Guid.NewGuid()}";
+
+            Observation observation = Samples.GetDefaultObservation().ToPoco<Observation>();
+            observation.Meta = new Meta();
+            observation.Meta.Profile = new[] { profile };
+            await Client.CreateAsync(observation);
+
+            FhirResponse<Bundle> searchResult = await Client.SearchAsync(ResourceType.Observation, "_profile=" + profile);
+
+            Assert.DoesNotContain("_profile", searchResult.Resource.SelfLink.ToString());
+        }
+    }
+}

--- a/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/Rest/Search/SearchProfileTests.cs
+++ b/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/Rest/Search/SearchProfileTests.cs
@@ -1,0 +1,44 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Hl7.Fhir.Model;
+using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Microsoft.Health.Fhir.Tests.E2E.Common;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
+{
+    [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.All)]
+    public class SearchProfileTests : IClassFixture<HttpIntegrationTestFixture>
+    {
+        public SearchProfileTests(HttpIntegrationTestFixture fixture)
+        {
+            Client = fixture.FhirClient;
+        }
+
+        protected FhirClient Client { get; set; }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task WhenSearchingForAResourceWithProfile_GivenAStu3Server_TheServerShouldReturnCorrectResults()
+        {
+            string profile = $"https://e2e-test-profile|{Guid.NewGuid()}";
+
+            Observation observation = Samples.GetDefaultObservation().ToPoco<Observation>();
+            observation.Meta = new Meta();
+            observation.Meta.Profile = new[] { profile };
+            await Client.CreateAsync(observation);
+
+            FhirResponse<Bundle> searchResult = await Client.SearchAsync(ResourceType.Observation, "_profile=" + profile);
+
+            Assert.Single(searchResult.Resource.Entry);
+            Assert.Contains("_profile", searchResult.Resource.SelfLink.ToString());
+        }
+    }
+}


### PR DESCRIPTION
## Description
The metadata endpoint in R4 specifies that _profile is supported, when it is not. This PR removes _profile from metadata.

## Related issues
Mitigates #880.

## Testing
Adds E2E tests to verify
