### PR TITLE
Makes IFhirAuthorizationService.CheckAccess() async

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Compartment/SearchCompartmentHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Compartment/SearchCompartmentHandler.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
         {
             EnsureArg.IsNotNull(message, nameof(message));
 
-            if (_authorizationService.CheckAccess(DataActions.Read) != DataActions.Read)
+            if (await _authorizationService.CheckAccess(DataActions.Read) != DataActions.Read)
             {
                 throw new UnauthorizedFhirActionException();
             }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CancelExportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CancelExportRequestHandler.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
         {
             EnsureArg.IsNotNull(request, nameof(request));
 
-            if (_authorizationService.CheckAccess(DataActions.Export) != DataActions.Export)
+            if (await _authorizationService.CheckAccess(DataActions.Export) != DataActions.Export)
             {
                 throw new UnauthorizedFhirActionException();
             }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
         {
             EnsureArg.IsNotNull(request, nameof(request));
 
-            if (_authorizationService.CheckAccess(DataActions.Export) != DataActions.Export)
+            if (await _authorizationService.CheckAccess(DataActions.Export) != DataActions.Export)
             {
                 throw new UnauthorizedFhirActionException();
             }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/GetExportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/GetExportRequestHandler.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
         {
             EnsureArg.IsNotNull(request, nameof(request));
 
-            if (_authorizationService.CheckAccess(DataActions.Export) != DataActions.Export)
+            if (await _authorizationService.CheckAccess(DataActions.Export) != DataActions.Export)
             {
                 throw new UnauthorizedFhirActionException();
             }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Validate/ValidateOperationHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Validate/ValidateOperationHandler.cs
@@ -31,18 +31,18 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
         /// </summary>
         /// <param name="request">The request</param>
         /// <param name="cancellationToken">The CancellationToken</param>
-        public Task<ValidateOperationResponse> Handle(ValidateOperationRequest request, CancellationToken cancellationToken)
+        public async Task<ValidateOperationResponse> Handle(ValidateOperationRequest request, CancellationToken cancellationToken)
         {
-            if (_authorizationService.CheckAccess(DataActions.ResourceValidate) != DataActions.ResourceValidate)
+            if (await _authorizationService.CheckAccess(DataActions.ResourceValidate) != DataActions.ResourceValidate)
             {
                 throw new UnauthorizedFhirActionException();
             }
 
-            return Task.FromResult(new ValidateOperationResponse(
+            return new ValidateOperationResponse(
                 new OperationOutcomeIssue(
                     OperationOutcomeConstants.IssueSeverity.Information,
                     OperationOutcomeConstants.IssueType.Informational,
-                    Resources.ValidationPassed)));
+                    Resources.ValidationPassed));
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Security/Authorization/DisabledFhirAuthorizationService.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Security/Authorization/DisabledFhirAuthorizationService.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Threading.Tasks;
+
 namespace Microsoft.Health.Fhir.Core.Features.Security.Authorization
 {
     /// <summary>
@@ -12,9 +14,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Security.Authorization
     {
         public static readonly DisabledFhirAuthorizationService Instance = new DisabledFhirAuthorizationService();
 
-        public DataActions CheckAccess(DataActions dataActions)
+        public ValueTask<DataActions> CheckAccess(DataActions dataActions)
         {
-            return dataActions;
+            return new ValueTask<DataActions>(dataActions);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Security/Authorization/IFhirAuthorizationService.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Security/Authorization/IFhirAuthorizationService.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Threading.Tasks;
+
 namespace Microsoft.Health.Fhir.Core.Features.Security.Authorization
 {
     /// <summary>
@@ -23,6 +25,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Security.Authorization
         /// (c) None, (0), meaning none of the requested actions are permitted.
         /// In all cases, no bits will set on the return value that were not set on input.
         /// </returns>
-        DataActions CheckAccess(DataActions dataActions);
+        ValueTask<DataActions> CheckAccess(DataActions dataActions);
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Security/Authorization/RoleBasedFhirAuthorizationService.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Security/Authorization/RoleBasedFhirAuthorizationService.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
+using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features.Context;
@@ -32,7 +33,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Security.Authorization
             _roles = authorizationConfiguration.Roles.ToDictionary(r => r.Name, StringComparer.OrdinalIgnoreCase);
         }
 
-        public DataActions CheckAccess(DataActions dataActions)
+        public ValueTask<DataActions> CheckAccess(DataActions dataActions)
         {
             ClaimsPrincipal principal = _requestContextAccessor.FhirRequestContext.Principal;
 
@@ -49,7 +50,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Security.Authorization
                 }
             }
 
-            return dataActions & permittedDataActions;
+            return new ValueTask<DataActions>(dataActions & permittedDataActions);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
             //     operations to use an IFhirAuthorizationService that implements CheckAccess based on these known permitted
             //     actions.
 
-            if (_authorizationService.CheckAccess(DataActions.All) == DataActions.None)
+            if (await _authorizationService.CheckAccess(DataActions.All) == DataActions.None)
             {
                 throw new UnauthorizedFhirActionException();
             }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Create/ConditionalCreateResourceHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Create/ConditionalCreateResourceHandler.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Create
         {
             EnsureArg.IsNotNull(message, nameof(message));
 
-            if (AuthorizationService.CheckAccess(DataActions.Read | DataActions.Write) != (DataActions.Read | DataActions.Write))
+            if (await AuthorizationService.CheckAccess(DataActions.Read | DataActions.Write) != (DataActions.Read | DataActions.Write))
             {
                 throw new UnauthorizedFhirActionException();
             }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Create/CreateResourceHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Create/CreateResourceHandler.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Create
         {
             EnsureArg.IsNotNull(message, nameof(message));
 
-            if (AuthorizationService.CheckAccess(DataActions.Write) != DataActions.Write)
+            if (await AuthorizationService.CheckAccess(DataActions.Write) != DataActions.Write)
             {
                 throw new UnauthorizedFhirActionException();
             }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeleteResourceHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeleteResourceHandler.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Delete
             EnsureArg.IsNotNull(message, nameof(message));
 
             DataActions requiredDataAction = message.HardDelete ? DataActions.Delete | DataActions.HardDelete : DataActions.Delete;
-            if (AuthorizationService.CheckAccess(requiredDataAction) != requiredDataAction)
+            if (await AuthorizationService.CheckAccess(requiredDataAction) != requiredDataAction)
             {
                 throw new UnauthorizedFhirActionException();
             }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Get/GetResourceHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Get/GetResourceHandler.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Get
         {
             EnsureArg.IsNotNull(message, nameof(message));
 
-            if (AuthorizationService.CheckAccess(DataActions.Read) != DataActions.Read)
+            if (await AuthorizationService.CheckAccess(DataActions.Read) != DataActions.Read)
             {
                 throw new UnauthorizedFhirActionException();
             }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Upsert/ConditionalUpsertResourceHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Upsert/ConditionalUpsertResourceHandler.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Upsert
         {
             EnsureArg.IsNotNull(message, nameof(message));
 
-            if (AuthorizationService.CheckAccess(DataActions.Read | DataActions.Write) != (DataActions.Read | DataActions.Write))
+            if (await AuthorizationService.CheckAccess(DataActions.Read | DataActions.Write) != (DataActions.Read | DataActions.Write))
             {
                 throw new UnauthorizedFhirActionException();
             }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Upsert/UpsertResourceHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Upsert/UpsertResourceHandler.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Upsert
         {
             EnsureArg.IsNotNull(message, nameof(message));
 
-            if (AuthorizationService.CheckAccess(DataActions.Write) != DataActions.Write)
+            if (await AuthorizationService.CheckAccess(DataActions.Write) != DataActions.Write)
             {
                 throw new UnauthorizedFhirActionException();
             }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchResourceHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchResourceHandler.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
         {
             EnsureArg.IsNotNull(message, nameof(message));
 
-            if (_authorizationService.CheckAccess(DataActions.Read) != DataActions.Read)
+            if (await _authorizationService.CheckAccess(DataActions.Read) != DataActions.Read)
             {
                 throw new UnauthorizedFhirActionException();
             }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchResourceHistoryHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchResourceHistoryHandler.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
         {
             EnsureArg.IsNotNull(message, nameof(message));
 
-            if (_authorizationService.CheckAccess(DataActions.Read) != DataActions.Read)
+            if (await _authorizationService.CheckAccess(DataActions.Read) != DataActions.Read)
             {
                 throw new UnauthorizedFhirActionException();
             }


### PR DESCRIPTION
Changes IFhirAuthorizationService.CheckAccess to be async, for secnarios where the access check involves a remote service call. 

We anticipate that implementations can often complete synchronously, so for that reason the method returns a ValueTask instead of a Task.