### PR TITLE
Sets parsing error message if exception message is null on model validation

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
@@ -286,6 +286,15 @@ namespace Microsoft.Health.Fhir.Api {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Error occurred when parsing model..
+        /// </summary>
+        public static string ParsingError {
+            get {
+                return ResourceManager.GetString("ParsingError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to PATCH is not currently supported..
         /// </summary>
         public static string PatchNotSupported {

--- a/src/Microsoft.Health.Fhir.Api/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Api/Resources.resx
@@ -293,4 +293,7 @@
     <value>The number of entries in the bundle exceeded the configured limit of {0}.</value>
     <comment>{0} is the number of entries allowed.</comment>
   </data>
+  <data name="ParsingError" xml:space="preserve">
+    <value>Error occurred when parsing model.</value>
+  </data>
 </root>

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Formatters/FhirJsonInputFormatter.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Formatters/FhirJsonInputFormatter.cs
@@ -95,8 +95,10 @@ namespace Microsoft.Health.Fhir.Api.Features.Formatters
 
                 if (delayedException != null)
                 {
+                    var errorMessage = string.IsNullOrEmpty(delayedException.Message) ? Api.Resources.ParsingError : delayedException.Message;
+
                     // Add model state information to return to the client
-                    context.ModelState.TryAddModelError(string.Empty, delayedException.Message);
+                    context.ModelState.TryAddModelError(string.Empty, errorMessage);
                 }
 
                 return Task.FromResult(InputFormatterResult.Failure());

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Formatters/FhirXmlInputFormatter.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Formatters/FhirXmlInputFormatter.cs
@@ -73,7 +73,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Formatters
             }
             catch (Exception ex)
             {
-                context.ModelState.TryAddModelError(string.Empty, ex.Message);
+                var errorMessage = string.IsNullOrEmpty(ex.Message) ? Api.Resources.ParsingError : ex.Message;
+
+                context.ModelState.TryAddModelError(string.Empty, errorMessage);
             }
 
             return InputFormatterResult.Failure();


### PR DESCRIPTION
## Description
Sometimes, when model validation for create requests fails, we return a 500. This is due to to a null or empty exception message being added to the model.

This change sets the error message to `"Error occurred when parsing model."` in this scenario.

## Related issues
Addresses [#AB72062](https://microsofthealth.visualstudio.com/Health/_workitems/edit/72062).