### PR TITLE
Remove non-essential data from response for export completion

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
@@ -268,6 +268,15 @@ namespace Microsoft.Health.Fhir.Api {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The requested &quot;{0}&quot; operation is not enabled.
+        /// </summary>
+        public static string OperationNotEnabled {
+            get {
+                return ResourceManager.GetString("OperationNotEnabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The requested &quot;{0}&quot; operation is not implemented..
         /// </summary>
         public static string OperationNotImplemented {
@@ -417,15 +426,6 @@ namespace Microsoft.Health.Fhir.Api {
         public static string UnsupportedHeaderValue {
             get {
                 return ResourceManager.GetString("UnsupportedHeaderValue", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The requested &quot;{0}&quot; operation is not supported..
-        /// </summary>
-        public static string UnsupportedOperation {
-            get {
-                return ResourceManager.GetString("UnsupportedOperation", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Health.Fhir.Api/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Api/Resources.resx
@@ -230,8 +230,8 @@
     <value>Value supplied for the "{0}" header is not supported.</value>
     <comment>{0} is the header name.</comment>
   </data>
-  <data name="UnsupportedOperation" xml:space="preserve">
-    <value>The requested "{0}" operation is not supported.</value>
+  <data name="OperationNotEnabled" xml:space="preserve">
+    <value>The requested "{0}" operation is not enabled</value>
     <comment>{0} is the operation name</comment>
   </data>
   <data name="UnsupportedParameter" xml:space="preserve">

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/GetExportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/GetExportRequestHandler.cs
@@ -52,8 +52,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                     outcome.JobRecord.QueuedTime,
                     outcome.JobRecord.RequestUri,
                     requiresAccessToken: false,
-                    outcome.JobRecord.Output.Values.OrderBy(x => x.Type, StringComparer.Ordinal).ToList(),
-                    outcome.JobRecord.Error);
+                    outcome.JobRecord.Output.Values.Select(x => x.ToExportOutputResponse()).OrderBy(x => x.Type, StringComparer.Ordinal).ToList(),
+                    outcome.JobRecord.Error.Select(x => x.ToExportOutputResponse()).ToList());
 
                 exportResponse = new GetExportResponse(HttpStatusCode.OK, jobResult);
             }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobResult.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobResult.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
     /// </summary>
     public class ExportJobResult
     {
-        public ExportJobResult(DateTimeOffset transactionTime, Uri requestUri, bool requiresAccessToken, IList<ExportFileInfo> output, IList<ExportFileInfo> errors)
+        public ExportJobResult(DateTimeOffset transactionTime, Uri requestUri, bool requiresAccessToken, IList<ExportOutputResponse> output, IList<ExportOutputResponse> errors)
         {
             EnsureArg.IsNotDefault<DateTimeOffset>(transactionTime, nameof(transactionTime));
             EnsureArg.IsNotNull(requestUri, nameof(requestUri));
@@ -40,9 +40,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
         public bool RequiresAccessToken { get; }
 
         [JsonProperty("output")]
-        public IList<ExportFileInfo> Output { get; }
+        public IList<ExportOutputResponse> Output { get; }
 
         [JsonProperty("error")]
-        public IList<ExportFileInfo> Error { get; }
+        public IList<ExportOutputResponse> Error { get; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportOutputResponse.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportOutputResponse.cs
@@ -10,26 +10,24 @@ using Newtonsoft.Json;
 namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
 {
     /// <summary>
-    /// Represents metadata required for each file that is generated as part of the
-    /// export operation.
+    /// Class that represents the information regarding each file that is being exported.
+    /// This is the output response that we send back to the client once export is complete.
+    /// Subset of <see cref="ExportFileInfo"/>.
     /// </summary>
-    public class ExportFileInfo
+    public class ExportOutputResponse
     {
-        public ExportFileInfo(
-            string type,
-            Uri fileUri,
-            int sequence)
+        public ExportOutputResponse(string type, Uri fileUri, int count)
         {
-            EnsureArg.IsNotNullOrWhiteSpace(type);
-            EnsureArg.IsNotNull(fileUri);
+            EnsureArg.IsNotNullOrWhiteSpace(type, nameof(type));
+            EnsureArg.IsNotNull(fileUri, nameof(fileUri));
 
             Type = type;
             FileUri = fileUri;
-            Sequence = sequence;
+            Count = count;
         }
 
         [JsonConstructor]
-        protected ExportFileInfo()
+        protected ExportOutputResponse()
         {
         }
 
@@ -39,24 +37,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
         [JsonProperty(JobRecordProperties.Url)]
         public Uri FileUri { get; private set; }
 
-        [JsonProperty(JobRecordProperties.Sequence)]
-        public int Sequence { get; private set; }
-
         [JsonProperty(JobRecordProperties.Count)]
         public int Count { get; private set; }
-
-        [JsonProperty(JobRecordProperties.CommitedBytes)]
-        public long CommittedBytes { get; private set; }
-
-        public void IncrementCount(int numberOfBytes)
-        {
-            Count++;
-            CommittedBytes += numberOfBytes;
-        }
-
-        public ExportOutputResponse ToExportOutputResponse()
-        {
-            return new ExportOutputResponse(Type, FileUri, Count);
-        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ExportController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ExportController.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         {
             if (!_exportConfig.Enabled)
             {
-                throw new RequestNotValidException(string.Format(Resources.UnsupportedOperation, OperationsConstants.Export));
+                throw new RequestNotValidException(string.Format(Resources.OperationNotEnabled, OperationsConstants.Export));
             }
 
             CreateExportResponse response = await _mediator.ExportAsync(_fhirRequestContextAccessor.FhirRequestContext.Uri, HttpContext.RequestAborted);
@@ -162,7 +162,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         {
             if (!_exportConfig.Enabled)
             {
-                throw new RequestNotValidException(string.Format(Resources.UnsupportedOperation, OperationsConstants.Export));
+                throw new RequestNotValidException(string.Format(Resources.OperationNotEnabled, OperationsConstants.Export));
             }
 
             throw new OperationNotImplementedException(string.Format(Resources.OperationNotImplemented, OperationsConstants.Export));


### PR DESCRIPTION
## Description
We are currently returning sequence and committed bytes as part of our response to GET Export Status call (once an export is completed). We just need to return type, count and url. Updated code to convert the response to the appropriate format before returning it.

## Related issues
Addresses [issue [AB#72600](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/72600)].

## Testing
Existing tests. Manual testing to validate that sequence and committedbytes are not present in the response for a completed export.
