### PR TITLE
Translates format and argument exceptions into FHIR exceptions

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Models/PartialDateTime.cs
+++ b/src/Microsoft.Health.Fhir.Core/Models/PartialDateTime.cs
@@ -59,13 +59,78 @@ namespace Microsoft.Health.Fhir.Core.Models
             decimal? fraction = null,
             TimeSpan? utcOffset = null)
         {
-            if (month.HasValue)
+            // Validate the parameters. Partial date is supported but the value must be specified from left to right.
+            // E.g., If month is not specified, then day, hour, minute and etc. cannot be specified.
+            (string Name, bool HasValue)[] parameters = new[]
             {
-                if (day != null)
+                (nameof(month), month.HasValue),
+                (nameof(day), day.HasValue),
+                (nameof(hour), hour.HasValue),
+                (nameof(minute), minute.HasValue),
+                (nameof(second), second.HasValue),
+                (nameof(fraction), fraction.HasValue),
+            };
+
+            bool previousParamHasValue = true;
+            string firstParamWithNullValue = null;
+
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                var currentParameter = parameters[i];
+
+                if (currentParameter.HasValue)
                 {
-                    EnsureArg.IsInRange(day.Value, 1, DateTime.DaysInMonth(year, month.Value), nameof(day));
+                    if (!previousParamHasValue)
+                    {
+                        // The current parameter has value but previous one doesn't. This is an invalid state.
+                        throw new ArgumentException(
+                            $"The {currentParameter.Name} portion of a date cannot be specified if the {firstParamWithNullValue} portion is not specified.",
+                            currentParameter.Name);
+                    }
+                }
+
+                if (!currentParameter.HasValue && firstParamWithNullValue == null)
+                {
+                    firstParamWithNullValue = currentParameter.Name;
+                }
+
+                previousParamHasValue = currentParameter.HasValue;
+            }
+
+            if (hour != null)
+            {
+                if (minute == null)
+                {
+                    // If hour is specified, then minutes must be specified.
+                    throw new ArgumentException(
+                        $"The '{nameof(minute)}' portion of a date must be specified if '{nameof(hour)}' is specified.",
+                        nameof(minute));
+                }
+
+                if (utcOffset == null)
+                {
+                    // If hour and minute are specified, then the timezone offset must be specified
+                    // per spec (http://hl7.org/fhir/datatypes.html#dateTime).
+                    // However, in search queries, the time zone information is optional (http://hl7.org/fhir/search.html#date).
+                    // The parsing logic will default to UTC time zone if the time zone information is not specified in the search query.
+                    throw new ArgumentException(
+                        $"The '{nameof(utcOffset)}' portion of a date must be specified if '{nameof(hour)}' and '{nameof(minute)}' are specified.",
+                        nameof(utcOffset));
                 }
             }
+
+            // Validate the range of each parameter.
+            ValidateRange(year, 1, 9999, nameof(year));
+            ValidateRange(month, 1, 12, nameof(month));
+
+            if (month.HasValue)
+            {
+                ValidateRange(day, 1, DateTime.DaysInMonth(year, month.Value), nameof(day));
+            }
+
+            ValidateRange(hour, 0, 23, nameof(hour));
+            ValidateRange(minute, 0, 59, nameof(minute));
+            ValidateRange(second, 0, 59, nameof(second));
 
             if (fraction != null)
             {
@@ -80,6 +145,14 @@ namespace Microsoft.Health.Fhir.Core.Models
             Second = second;
             Fraction = fraction;
             UtcOffset = utcOffset;
+
+            void ValidateRange(int? value, int min, int max, string paramName)
+            {
+                if (value != null)
+                {
+                    EnsureArg.IsInRange(value.Value, min, max, paramName);
+                }
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -232,6 +232,24 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The date time string &apos;{0}&apos; is not in a correct format..
+        /// </summary>
+        internal static string DateTimeStringIsIncorrectlyFormatted {
+            get {
+                return ResourceManager.GetString("DateTimeStringIsIncorrectlyFormatted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to At least one portion of the date time string &apos;{0}&apos; is out of range..
+        /// </summary>
+        internal static string DateTimeStringIsOutOfRange {
+            get {
+                return ResourceManager.GetString("DateTimeStringIsOutOfRange", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Deleting a specific record version is not supported..
         /// </summary>
         internal static string DeleteVersionNotAllowed {

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -178,6 +178,14 @@
   <data name="CustomHeaderPrefixCannotBeEmpty" xml:space="preserve">
     <value>The prefix used to identify custom audit headers cannot be empty.</value>
   </data>
+  <data name="DateTimeStringIsIncorrectlyFormatted" xml:space="preserve">
+    <value>The date time string '{0}' is not in a correct format.</value>
+    <comment>{0} is the incorrect date time string.</comment>
+  </data>
+  <data name="DateTimeStringIsOutOfRange" xml:space="preserve">
+    <value>At least one portion of the date time string '{0}' is out of range.</value>
+    <comment>{0} is the date time string that is out of range.</comment>
+  </data>
   <data name="DeleteVersionNotAllowed" xml:space="preserve">
     <value>Deleting a specific record version is not supported.</value>
   </data>


### PR DESCRIPTION
## Description
- Creates an `OperationOutcomeResult` for format and argument exceptions that are thrown
- Prevents a `500` from being returned in these situations

## Related issues
Addresses [AB#72293](https://microsofthealth.visualstudio.com/Health/_workitems/edit/72293) and [AB#72298](https://microsofthealth.visualstudio.com/Health/_workitems/edit/72298).

## Testing
Adds E2E tests.

Note 1: Date time tests will need to be updated once #25 and #411 are addressed.
Note 2: I created #911 to remove duplicate code found in `PartialDateTime.cs`

## Demo
![date-time-format-exceptions](https://user-images.githubusercontent.com/54082711/75822115-42593500-5d54-11ea-9714-fb3161552b5f.gif)

