### PR TITLE
Fix race condition in role assignment during deployment

### DIFF
--- a/samples/templates/default-azuredeploy-sql.json
+++ b/samples/templates/default-azuredeploy-sql.json
@@ -362,7 +362,8 @@
             ],
             "properties": {
                 "roleDefinitionId": "[variables('storageBlobDataContributerRoleId')]",
-                "principalId": "[reference(concat('Microsoft.Web/sites/', variables('serviceName')), '2018-11-01', 'full').identity.principalId]"
+                "principalId": "[reference(concat('Microsoft.Web/sites/', variables('serviceName')), '2018-11-01', 'full').identity.principalId]",
+                "principalType": "ServicePrincipal"
             }
         }
     ]

--- a/samples/templates/default-azuredeploy.json
+++ b/samples/templates/default-azuredeploy.json
@@ -347,7 +347,8 @@
             ],
             "properties": {
                 "roleDefinitionId": "[variables('storageBlobDataContributerRoleId')]",
-                "principalId": "[reference(concat('Microsoft.Web/sites/', variables('serviceName')), '2018-11-01', 'full').identity.principalId]"
+                "principalId": "[reference(concat('Microsoft.Web/sites/', variables('serviceName')), '2018-11-01', 'full').identity.principalId]",
+                "principalType": "ServicePrincipal"
             }
         }
     ]


### PR DESCRIPTION
## Description
During deployment we are running into a transient issue where the role assignment to the storage account is failing because it can't find the service principal. Seems like a race condition. Updating the template with the fix.

## Related issues
Addresses [issue [AB#72850](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/72850)].

## Testing
No functional change. Template was tested by deploying
