### PR TITLE
Adding retries for export when auth token expires

### DIFF
--- a/src/Microsoft.Health.Fhir.Azure.UnitTests/ExportDestinationClient/CloudBlockBlobWrapperTests.cs
+++ b/src/Microsoft.Health.Fhir.Azure.UnitTests/ExportDestinationClient/CloudBlockBlobWrapperTests.cs
@@ -1,0 +1,60 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Azure.Storage.Blob;
+using Microsoft.Health.Fhir.Azure.ExportDestinationClient;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Azure.UnitTests.ExportDestinationClient
+{
+    public class CloudBlockBlobWrapperTests
+    {
+        private const string StorageAddress = "https://basestorage/";
+        private const string ContainerId = "containerId";
+        private const string BlobIdWithPrefix = "/blob1";
+
+        private Uri _blobUri;
+        private CloudBlockBlob _cloudBlockBlob;
+        private CloudBlobClient _blobClient;
+        private CloudBlockBlobWrapper _blobWrapper;
+
+        public CloudBlockBlobWrapperTests()
+        {
+            _blobUri = new Uri(StorageAddress + ContainerId + BlobIdWithPrefix);
+            _blobClient = new CloudBlobClient(new Uri(StorageAddress));
+            _cloudBlockBlob = new CloudBlockBlob(_blobUri, _blobClient);
+            _blobWrapper = new CloudBlockBlobWrapper(_cloudBlockBlob);
+        }
+
+        [Fact]
+        public void GivenNewCloudBlockBlobNull_WhenUpdateCloudBlockBlob_ThenThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => _blobWrapper.UpdateCloudBlockBlob(cloudBlockBlob: null));
+        }
+
+        [InlineData(StorageAddress + "/blob2")]
+        [InlineData("https://wrongbase/" + ContainerId + BlobIdWithPrefix)]
+        [InlineData(StorageAddress + BlobIdWithPrefix)]
+        [InlineData(StorageAddress + ContainerId + "/blob2")]
+        [Theory]
+        public void GivenNewCloudBlockBlobWrongUri_WhenUpdateCloudBlockBlob_ThenThrowsArgumentException(string blobUri)
+        {
+            CloudBlockBlob newBlob = new CloudBlockBlob(new Uri(blobUri), _blobClient);
+
+            Assert.Throws<ArgumentException>(() => _blobWrapper.UpdateCloudBlockBlob(newBlob));
+        }
+
+        [Fact]
+        public void GivenNewCloudBlockBlobCorrectUri_WhenUpdateCloudBlockBlob_ThenSuccessfullyUpdated()
+        {
+            CloudBlockBlob newBlob = new CloudBlockBlob(new Uri(StorageAddress + ContainerId + BlobIdWithPrefix), _blobClient);
+
+            _blobWrapper.UpdateCloudBlockBlob(newBlob);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Azure.UnitTests/ExportDestinationClient/StorageExceptionParserTests.cs
+++ b/src/Microsoft.Health.Fhir.Azure.UnitTests/ExportDestinationClient/StorageExceptionParserTests.cs
@@ -1,0 +1,54 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Net;
+using Microsoft.Azure.Storage;
+using Microsoft.Health.Fhir.Azure.ExportDestinationClient;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Azure.UnitTests.ExportDestinationClient
+{
+    public class StorageExceptionParserTests
+    {
+        [InlineData(HttpStatusCode.Forbidden)]
+        [InlineData(HttpStatusCode.Unauthorized)]
+        [InlineData(HttpStatusCode.NotFound)]
+        [Theory]
+        public void GivenValidErrorStatusCode_WhenParseStorageException_ThenCorrespondingHttpStatusCode(HttpStatusCode statusCode)
+        {
+            RequestResult requestResult = new RequestResult { HttpStatusCode = (int)statusCode };
+            StorageException ex = new StorageException(requestResult, "exception message", new Exception("inner exception message"));
+
+            var resultCode = StorageExceptionParser.ParseStorageException(ex);
+
+            Assert.Equal(statusCode, resultCode);
+        }
+
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(777)]
+        [Theory]
+        public void GivenInValidStatusCode_WhenParseStorageException_ThenReturnsInternalServerError(int statusCode)
+        {
+            RequestResult requestResult = new RequestResult { HttpStatusCode = statusCode };
+            StorageException ex = new StorageException(requestResult, "exception message", new Exception("inner exception message"));
+
+            var resultCode = StorageExceptionParser.ParseStorageException(ex);
+
+            Assert.Equal(HttpStatusCode.InternalServerError, resultCode);
+        }
+
+        [Fact]
+        public void GivenNoRequestInformationAndUnknownHostMessage_WhenParseStorageException_ThenReturnsBadRequest()
+        {
+            StorageException ex = new StorageException("No such host is known");
+
+            var resultCode = StorageExceptionParser.ParseStorageException(ex);
+
+            Assert.Equal(HttpStatusCode.BadRequest, resultCode);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Azure/ExportDestinationClient/AzureExportDestinationClient.cs
+++ b/src/Microsoft.Health.Fhir.Azure/ExportDestinationClient/AzureExportDestinationClient.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Health.Fhir.Azure.ExportDestinationClient
             {
                 _logger.LogWarning(se, se.Message);
 
-                HttpStatusCode responseCode = ParseStorageException(se);
+                HttpStatusCode responseCode = StorageExceptionParser.ParseStorageException(se);
                 throw new DestinationConnectionException(se.Message, responseCode);
             }
         }
@@ -245,31 +245,6 @@ namespace Microsoft.Health.Fhir.Azure.ExportDestinationClient
             {
                 throw new DestinationConnectionException(Resources.DestinationClientNotConnected, HttpStatusCode.InternalServerError);
             }
-        }
-
-        private HttpStatusCode ParseStorageException(StorageException storageException)
-        {
-            EnsureArg.IsNotNull(storageException, nameof(storageException));
-
-            HttpStatusCode responseCode = HttpStatusCode.InternalServerError;
-            if (storageException.RequestInformation != null)
-            {
-                _logger.LogWarning($"RequestResult ErrorCode: {storageException.RequestInformation.ErrorCode}, RequestResult HttpStatusCode: {storageException.RequestInformation.HttpStatusCode}");
-
-                try
-                {
-                    if (Enum.IsDefined(typeof(HttpStatusCode), storageException.RequestInformation.HttpStatusCode))
-                    {
-                        responseCode = Enum.Parse<HttpStatusCode>(storageException.RequestInformation.HttpStatusCode.ToString());
-                    }
-                }
-                catch (Exception)
-                {
-                    _logger.LogWarning("Unable to parse httpstatus code information from storage exception");
-                }
-            }
-
-            return responseCode;
         }
 
         /// <summary>

--- a/src/Microsoft.Health.Fhir.Azure/ExportDestinationClient/AzureExportDestinationClient.cs
+++ b/src/Microsoft.Health.Fhir.Azure/ExportDestinationClient/AzureExportDestinationClient.cs
@@ -276,6 +276,7 @@ namespace Microsoft.Health.Fhir.Azure.ExportDestinationClient
             foreach (KeyValuePair<Uri, CloudBlockBlobWrapper> kvp in _uriToBlobMapping)
             {
                 var newBlob = new CloudBlockBlob(kvp.Key, _blobClient);
+                newBlob.Properties.ContentType = "application/fhir+ndjson";
                 kvp.Value.UpdateCloudBlockBlob(newBlob);
             }
         }

--- a/src/Microsoft.Health.Fhir.Azure/ExportDestinationClient/AzureExportDestinationClient.cs
+++ b/src/Microsoft.Health.Fhir.Azure/ExportDestinationClient/AzureExportDestinationClient.cs
@@ -16,6 +16,7 @@ using Microsoft.Azure.Storage;
 using Microsoft.Azure.Storage.Blob;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export.ExportDestinationClient;
+using Polly;
 
 namespace Microsoft.Health.Fhir.Azure.ExportDestinationClient
 {
@@ -88,7 +89,6 @@ namespace Microsoft.Health.Fhir.Azure.ExportDestinationClient
             CheckIfClientIsConnected();
 
             CloudBlockBlob blockBlob = _blobContainer.GetBlockBlobReference(fileName);
-
             if (!_uriToBlobMapping.ContainsKey(blockBlob.Uri))
             {
                 blockBlob.Properties.ContentType = "application/fhir+ndjson";
@@ -119,9 +119,66 @@ namespace Microsoft.Health.Fhir.Azure.ExportDestinationClient
         {
             CheckIfClientIsConnected();
 
+            try
+            {
+                await Policy.Handle<StorageException>()
+                    .WaitAndRetryAsync(
+                        retryCount: 2,
+                        sleepDurationProvider: (retryCount) => TimeSpan.FromSeconds(5 * (retryCount - 1)),
+                        onRetryAsync: async (exception, retryCount) =>
+                        {
+                            _logger.LogWarning(exception, "Error while uploading blobs.");
+                            await RefreshClientAsync(cancellationToken);
+                        })
+                    .ExecuteAsync(() => UploadBlobHelperAsync(cancellationToken));
+            }
+            catch (DestinationConnectionException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Can't get an authorized client");
+                throw new DestinationConnectionException(Resources.CannotGetAuthorizedClient, HttpStatusCode.Unauthorized);
+            }
+
+            try
+            {
+                await Policy.Handle<StorageException>()
+                    .WaitAndRetryAsync(
+                        retryCount: 2,
+                        sleepDurationProvider: (retryCount) => TimeSpan.FromSeconds(5 * (retryCount - 1)),
+                        onRetryAsync: async (exception, retryCount) =>
+                        {
+                            _logger.LogWarning(exception, "Error while committing block list.");
+                            await RefreshClientAsync(cancellationToken);
+                        })
+                    .ExecuteAsync(() => UploadBlockListHelperAsync(cancellationToken));
+            }
+            catch (DestinationConnectionException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Can't get an authorized client");
+                throw new DestinationConnectionException(Resources.CannotGetAuthorizedClient, HttpStatusCode.Unauthorized);
+            }
+
+            // If we are here, we managed to upload and commit everything successfully.
+            // We can clear the stream mappings once we commit everything.
+            foreach (Stream stream in _streamMappings.Values)
+            {
+                stream.Dispose();
+            }
+
+            _streamMappings.Clear();
+        }
+
+        private async Task UploadBlobHelperAsync(CancellationToken cancellationToken)
+        {
             // Upload all blocks for each blob that was modified.
             Task[] uploadTasks = new Task[_streamMappings.Count];
-            CloudBlockBlobWrapper[] wrappersToCommit = new CloudBlockBlobWrapper[_streamMappings.Count];
 
             int index = 0;
             foreach (KeyValuePair<(Uri, uint), Stream> mapping in _streamMappings)
@@ -134,23 +191,26 @@ namespace Microsoft.Health.Fhir.Azure.ExportDestinationClient
                 var blockId = Convert.ToBase64String(Encoding.ASCII.GetBytes(mapping.Key.Item2.ToString("d6")));
 
                 uploadTasks[index] = blobWrapper.UploadBlockAsync(blockId, stream, md5Hash: null, cancellationToken);
-                wrappersToCommit[index] = blobWrapper;
                 index++;
             }
 
             await Task.WhenAll(uploadTasks);
+        }
+
+        private async Task UploadBlockListHelperAsync(CancellationToken cancellationToken)
+        {
+            CloudBlockBlobWrapper[] wrappersToCommit = new CloudBlockBlobWrapper[_streamMappings.Count];
+
+            int index = 0;
+            foreach (KeyValuePair<(Uri, uint), Stream> mapping in _streamMappings)
+            {
+                wrappersToCommit[index] = _uriToBlobMapping[mapping.Key.Item1];
+                index++;
+            }
 
             // Commit all the blobs that were uploaded.
             Task[] commitTasks = wrappersToCommit.Select(wrapper => wrapper.CommitBlockListAsync(cancellationToken)).ToArray();
             await Task.WhenAll(commitTasks);
-
-            // We can clear the stream mappings once we commit everything.
-            foreach (Stream stream in _streamMappings.Values)
-            {
-                stream.Dispose();
-            }
-
-            _streamMappings.Clear();
         }
 
         public async Task OpenFileAsync(Uri fileUri, CancellationToken cancellationToken)
@@ -205,11 +265,44 @@ namespace Microsoft.Health.Fhir.Azure.ExportDestinationClient
                 }
                 catch (Exception)
                 {
-                    _logger.LogInformation("Unable to parse httpstatus code information from storage exception");
+                    _logger.LogWarning("Unable to parse httpstatus code information from storage exception");
                 }
             }
 
             return responseCode;
+        }
+
+        /// <summary>
+        /// Helper method that will get a new CloudBlobClient (for when the old one's auth expires).
+        /// Also updates the existing blob container and CloudBlockBlob objects so that they will
+        /// use the new CloudBlobClient.
+        /// </summary>
+        private async Task RefreshClientAsync(CancellationToken cancellationToken)
+        {
+            CloudBlobClient refreshedClient;
+            try
+            {
+                refreshedClient = await _exportClientInitializer.GetAuthorizedClientAsync(cancellationToken);
+            }
+            catch (ExportClientInitializerException ex)
+            {
+                _logger.LogError(ex, "Unable to get new authorized client");
+
+                throw new DestinationConnectionException(Resources.CannotGetAuthorizedClient, HttpStatusCode.Unauthorized);
+            }
+
+            _logger.LogInformation("Successfully got a new authorized export client");
+            _blobClient = refreshedClient;
+
+            // Update container reference with new client.
+            await CreateContainerAsync(_blobClient, _blobContainer.Name);
+
+            // Recreate all cloud block blobs and update corresponding CloudBlockBlobWrapper.
+            foreach (KeyValuePair<Uri, CloudBlockBlobWrapper> kvp in _uriToBlobMapping)
+            {
+                var newBlob = new CloudBlockBlob(kvp.Key, _blobClient);
+                kvp.Value.UpdateCloudBlockBlob(newBlob);
+            }
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Azure/ExportDestinationClient/CloudBlockBlobWrapper.cs
+++ b/src/Microsoft.Health.Fhir.Azure/ExportDestinationClient/CloudBlockBlobWrapper.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
@@ -21,7 +22,7 @@ namespace Microsoft.Health.Fhir.Azure.ExportDestinationClient
     public class CloudBlockBlobWrapper
     {
         private readonly OrderedSetOfBlockIds _existingBlockIds;
-        private readonly CloudBlockBlob _cloudBlob;
+        private CloudBlockBlob _cloudBlob;
 
         public CloudBlockBlobWrapper(CloudBlockBlob blockBlob)
             : this(blockBlob, new List<string>())
@@ -50,6 +51,14 @@ namespace Microsoft.Health.Fhir.Azure.ExportDestinationClient
         public async Task CommitBlockListAsync(CancellationToken cancellationToken)
         {
             await _cloudBlob.PutBlockListAsync(_existingBlockIds.ToList(), cancellationToken);
+        }
+
+        public void UpdateCloudBlockBlob(CloudBlockBlob cloudBlockBlob)
+        {
+            EnsureArg.IsNotNull(cloudBlockBlob, nameof(cloudBlockBlob));
+            EnsureArg.Is(Uri.Compare(_cloudBlob.Uri, cloudBlockBlob.Uri, UriComponents.AbsoluteUri, UriFormat.Unescaped, StringComparison.OrdinalIgnoreCase), 0);
+
+            _cloudBlob = cloudBlockBlob;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Azure/ExportDestinationClient/StorageExceptionParser.cs
+++ b/src/Microsoft.Health.Fhir.Azure/ExportDestinationClient/StorageExceptionParser.cs
@@ -1,0 +1,43 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Net;
+using EnsureThat;
+using Microsoft.Azure.Storage;
+
+namespace Microsoft.Health.Fhir.Azure.ExportDestinationClient
+{
+    public static class StorageExceptionParser
+    {
+        /// <summary>
+        /// Attempts to return a HttpStatusCode that represents the information present in the
+        /// <see cref="StorageException"/> object. If there is no information, returns a <see cref="HttpStatusCode.InternalServerError"/>.
+        /// </summary>
+        /// <param name="storageException"><see cref="StorageException"/> object that needs to be parsed.</param>
+        /// <returns>A corresponding <see cref="HttpStatusCode"/></returns>
+        public static HttpStatusCode ParseStorageException(StorageException storageException)
+        {
+            EnsureArg.IsNotNull(storageException, nameof(storageException));
+
+            // Let's check whether there is a valid http status code that we can return.
+            if (storageException.RequestInformation != null)
+            {
+                if (Enum.IsDefined(typeof(HttpStatusCode), storageException.RequestInformation.HttpStatusCode))
+                {
+                    return (HttpStatusCode)storageException.RequestInformation.HttpStatusCode;
+                }
+            }
+
+            // We don't have a valid status code. Let's look at the message to try to get more information.
+            if (storageException.Message.Contains("No such host is known", StringComparison.OrdinalIgnoreCase))
+            {
+                return HttpStatusCode.BadRequest;
+            }
+
+            return HttpStatusCode.InternalServerError;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Azure/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Azure/Resources.Designer.cs
@@ -70,6 +70,15 @@ namespace Microsoft.Health.Fhir.Azure {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unable to get an authorized client to export destination..
+        /// </summary>
+        internal static string CannotGetAuthorizedClient {
+            get {
+                return ResourceManager.GetString("CannotGetAuthorizedClient", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The destination client is not connected to the destination end point..
         /// </summary>
         internal static string DestinationClientNotConnected {

--- a/src/Microsoft.Health.Fhir.Azure/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Azure/Resources.resx
@@ -120,6 +120,9 @@
   <data name="CannotGetAccessToken" xml:space="preserve">
     <value>Unable to get access token for storage account for export.</value>
   </data>
+  <data name="CannotGetAuthorizedClient" xml:space="preserve">
+    <value>Unable to get an authorized client to export destination.</value>
+  </data>
   <data name="DestinationClientNotConnected" xml:space="preserve">
     <value>The destination client is not connected to the destination end point.</value>
   </data>


### PR DESCRIPTION
## Description
When exporting large amounts of data, we can run into an issue when the current auth token for the export client can expire. This change adds a retry mechanism where we attempt to get a new auth token and then continue export with the newly authorized export client

## Related issues
Addresses [issue [AB#72260](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/72260)].

## Testing
Existing tests, some UTs. Manually tested by expiring the access key of a test storage account (while export was running) and validated that a new token was retrieved to complete export.
