### PR TITLE
Update response code returned for export operations that are not supported

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
@@ -277,7 +277,7 @@ namespace Microsoft.Health.Fhir.Api {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The requested &quot;{0}&quot; operation is not implemented..
+        ///   Looks up a localized string similar to The requested &quot;{0}&quot; operation is not supported..
         /// </summary>
         public static string OperationNotImplemented {
             get {

--- a/src/Microsoft.Health.Fhir.Api/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Api/Resources.resx
@@ -179,7 +179,7 @@
     <comment>{0} is operation name, {1} is failure reason.</comment>
   </data>
   <data name="OperationNotImplemented" xml:space="preserve">
-    <value>The requested "{0}" operation is not implemented.</value>
+    <value>The requested "{0}" operation is not supported.</value>
     <comment>{0} is the operation name</comment>
   </data>
   <data name="PageTitle" xml:space="preserve">

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/OperationOutcomeExceptionFilterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/OperationOutcomeExceptionFilterTests.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
         [Fact]
         public void GivenAnOperationNotImplementedException_WhenExecutingAnAction_ThenTheResponseShouldBeAnOperationOutcome()
         {
-            ValidateOperationOutcome(new OperationNotImplementedException("Not implemented."), HttpStatusCode.NotImplemented);
+            ValidateOperationOutcome(new OperationNotImplementedException("Not implemented."), HttpStatusCode.MethodNotAllowed);
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
                         operationOutcomeResult.StatusCode = ofe.ResponseStatusCode;
                         break;
                     case OperationNotImplementedException _:
-                        operationOutcomeResult.StatusCode = HttpStatusCode.NotImplemented;
+                        operationOutcomeResult.StatusCode = HttpStatusCode.MethodNotAllowed;
                         break;
                     case NotAcceptableException _:
                         operationOutcomeResult.StatusCode = HttpStatusCode.NotAcceptable;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ExportTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ExportTests.cs
@@ -31,13 +31,13 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Theory]
         [InlineData("Patient/$export")]
         [InlineData("Group/id/$export")]
-        public async Task GivenExportIsEnabled_WhenRequestingExportForResourceWithCorrectHeaders_ThenServerShouldReturnNotImplemented(string path)
+        public async Task GivenExportIsEnabled_WhenRequestingExportForResourceWithCorrectHeaders_ThenServerShouldReturnMethodNotAllowed(string path)
         {
             HttpRequestMessage request = GenerateExportRequest(path);
 
             HttpResponseMessage response = await _client.SendAsync(request);
 
-            Assert.Equal(HttpStatusCode.NotImplemented, response.StatusCode);
+            Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
         }
 
         [Fact]


### PR DESCRIPTION
## Description
Currently we are returning 501 (HttpStatusCode.NotImplemented) for export by resource type. We should be returning (405) HttpStatusCode.MethodNotAllowed instead.

## Related issues
Addresses [issue [AB#72888](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/72888)].

## Testing
UTs, E2E tests and manual testing.
