### PR TITLE
Returns error on invalid date time parameter

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/SearchValues/DateTimeSearchValueTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/SearchValues/DateTimeSearchValueTests.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.SearchValues
         public void GivenAPartialStartDateTime_WhenInitialized_ThenCorrectStartDateTimeShouldBeAssigned(string input, string start)
         {
             PartialDateTime inputDateTime = PartialDateTime.Parse(input);
-            PartialDateTime endDateTime = new PartialDateTime(2018);
+            PartialDateTime endDateTime = PartialDateTime.Parse("2018");
 
             DateTimeOffset expectedStartDateTime = DateTimeOffset.Parse(start);
 
@@ -97,7 +97,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.SearchValues
         public void GivenAPartialEndDateTime_WhenInitialized_ThenCorrectEndDateTimeShouldBeAssigned(string input, string start)
         {
             PartialDateTime inputDateTime = PartialDateTime.Parse(input);
-            PartialDateTime startDateTime = new PartialDateTime(2000);
+            PartialDateTime startDateTime = PartialDateTime.Parse("2000");
 
             DateTimeOffset expectedEndDateTime = DateTimeOffset.Parse(start);
 

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Models/PartialDateTimeTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Models/PartialDateTimeTests.cs
@@ -86,6 +86,24 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Models
         }
 
         [Theory]
+        [InlineData("2013-05-18T23:09+1:00")]
+        [InlineData("2013-05-18T23:09-4:30")]
+        [InlineData("2013-05-18T23:09+01:300")]
+        [InlineData("2013-05-18T23:09+01:77")]
+        [InlineData("2013-05-18T23:09+1")]
+        [InlineData("2013-05-18T23:09-7")]
+        [InlineData("2013-05-18T23:09-07")]
+        [InlineData("2013-05-18T23:09+Z")]
+        [InlineData("2013-05-18T23:09-Z")]
+        [InlineData("2013-05-18T23:09ZZ")]
+        [InlineData("2013-05-18T23:09-99:00")]
+        [InlineData("2013-05-18T23:09-789")]
+        public void GivenInvalidUtcOffset_WhenParsingPartialDateTime_ThenExceptionShouldBeThrown(string inputString)
+        {
+            Assert.Throws<FormatException>(() => PartialDateTime.Parse(inputString));
+        }
+
+        [Theory]
         [InlineData("0000-05-18T23:57:09.931094+01:00")] // Year cannot be less than 1.
         [InlineData("10000-05-18T23:57:09.931094+01:00")] // Year cannot be greater than 9999.
         [InlineData("2013-00-18T23:57:09.931094+01:00")] // Month cannot be less than 1.
@@ -111,6 +129,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Models
             yield return new object[] { "1999", 1999, null, null, null, null, null, null, null };
             yield return new object[] { "1999-10", 1999, 10, null, null, null, null, null, null };
             yield return new object[] { "1999-10-01", 1999, 10, 1, null, null, null, null, null };
+            yield return new object[] { "1999-10-18T12:35", 1999, 10, 18, 12, 35, null, null, 0 };
             yield return new object[] { "1999-10-18T12:35+01:00", 1999, 10, 18, 12, 35, null, null, 60 };
             yield return new object[] { "1999-10-18T12:35:55-02:30", 1999, 10, 18, 12, 35, 55, null, -150 };
             yield return new object[] { "1999-10-18T12:35:55Z", 1999, 10, 18, 12, 35, 55, null, 0 };

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Models/PartialDateTimeTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Models/PartialDateTimeTests.cs
@@ -27,33 +27,33 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Models
         [InlineData("05-18T23:57")]
         [InlineData("05-18T23:57:09")]
         [InlineData("05-18T23:57:09.931094")]
-        [InlineData("05-18T23:57%2B01:00")]
-        [InlineData("05-18T23:57:09%2B01:00")]
-        [InlineData("05-18T23:57:09.931094%2B01:00")]
+        [InlineData("05-18T23:57+01:00")]
+        [InlineData("05-18T23:57:09+01:00")]
+        [InlineData("05-18T23:57:09.931094+01:00")]
         [InlineData("2013-05T23:57")] // Month/date needs to be specified.
         [InlineData("2013-05T23:57:09")]
         [InlineData("2013-05T23:57:09.931094")]
-        [InlineData("2013-05T23:57%2B01:00")]
-        [InlineData("2013-05T23:57:09%2B01:00")]
-        [InlineData("2013-05T23:57:09.931094%2B01:00")]
+        [InlineData("2013-05T23:57+01:00")]
+        [InlineData("2013-05T23:57:09+01:00")]
+        [InlineData("2013-05T23:57:09.931094+01:00")]
         [InlineData("2013T23:57")] // Month and date need to be specified.
         [InlineData("2013T23:57:09")]
         [InlineData("2013T23:57:09.931094")]
-        [InlineData("2013T23:57%2B01:00")]
-        [InlineData("2013T23:57:09%2B01:00")]
-        [InlineData("2013T23:57:09.931094%2B01:00")]
+        [InlineData("2013T23:57+01:00")]
+        [InlineData("2013T23:57:09+01:00")]
+        [InlineData("2013T23:57:09.931094+01:00")]
         [InlineData("T23:57")] // Year, month and date need to be specified.
         [InlineData("T23:57:09")]
         [InlineData("T23:57:09.931094")]
-        [InlineData("T23:57%2B01:00")]
-        [InlineData("T23:57:09%2B01:00")]
-        [InlineData("T23:57:09.931094%2B01:00")]
+        [InlineData("T23:57+01:00")]
+        [InlineData("T23:57:09+01:00")]
+        [InlineData("T23:57:09.931094+01:00")]
         [InlineData("2013-05-18T23:09.931094")] // Hour/minute/second needs to be specified.
-        [InlineData("2013-05-18T23:09.931094%2B01:00")]
+        [InlineData("2013-05-18T23:09.931094+01:00")]
         [InlineData("2013-05-18T09.931094")] // Hour and minute need to be specified.
-        [InlineData("2013-05-18T09.931094%2B01:00")]
+        [InlineData("2013-05-18T09.931094+01:00")]
         [InlineData("2013-05-18T.931094")] // Hour, minute and second need to be specified.
-        [InlineData("2013-05-18T.931094%2B01:00")]
+        [InlineData("2013-05-18T.931094+01:00")]
         public void GivenPreviousParamIsNotSpecified_WhenParsingPartialDateTime_ThenExceptionShouldBeThrown(string inputString)
         {
             Exception ex = Assert.Throws<FormatException>(() => PartialDateTime.Parse(inputString));
@@ -63,9 +63,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Models
         }
 
         [Theory]
-        [InlineData("2013%2B01:00")] // Time needs to be specified if UTC offset is specified.
-        [InlineData("2013-05%2B01:00")]
-        [InlineData("2013-05-18%2B01:00")]
+        [InlineData("2013+01:00")] // Time needs to be specified if UTC offset is specified.
+        [InlineData("2013-05+01:00")]
+        [InlineData("2013-05-18+01:00")]
         public void GivenUtcOffsetButNoTime_WhenParsingPartialDateTime_ThenExceptionShouldBeThrown(string inputString)
         {
             Exception ex = Assert.Throws<FormatException>(() => PartialDateTime.Parse(inputString));
@@ -76,7 +76,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Models
 
         [Theory]
         [InlineData("2013-05-18T23")] // Minutes need to be specified if hour is specified.
-        [InlineData("2013-05-18T23%2B01:00")]
+        [InlineData("2013-05-18T23+01:00")]
         public void GivenHourIsSpecifiedWithoutMinutes_WhenParsingPartialDateTime_ThenExceptionShouldBeThrown(string inputString)
         {
             Exception ex = Assert.Throws<FormatException>(() => PartialDateTime.Parse(inputString));
@@ -86,21 +86,21 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Models
         }
 
         [Theory]
-        [InlineData("0000-05-18T23:57:09.931094%2B01:00")] // Year cannot be less than 1.
-        [InlineData("10000-05-18T23:57:09.931094%2B01:00")] // Year cannot be greater than 9999.
-        [InlineData("2013-00-18T23:57:09.931094%2B01:00")] // Month cannot be less than 1.
-        [InlineData("2013-13-18T23:57:09.931094%2B01:00")] // Month cannot be greater than 12.
-        [InlineData("2013-05-00T23:57:09.931094%2B01:00")] // Day cannot be less than 1.
-        [InlineData("2013-05-32T23:57:09.931094%2B01:00")] // Day cannot be greater than 31 in May.
-        [InlineData("2013-02-29T23:57:09.931094%2B01:00")] // Day cannot be greater than 28 in non-leap year.
-        [InlineData("2020-02-30T23:57:09.931094%2B01:00")] // Day cannot be greater than 29 in leap year.
-        [InlineData("2013-05-18T-01:57:09.931094%2B01:00")] // Hour cannot be less than 0.
+        [InlineData("0000-05-18T23:57:09.931094+01:00")] // Year cannot be less than 1.
+        [InlineData("10000-05-18T23:57:09.931094+01:00")] // Year cannot be greater than 9999.
+        [InlineData("2013-00-18T23:57:09.931094+01:00")] // Month cannot be less than 1.
+        [InlineData("2013-13-18T23:57:09.931094+01:00")] // Month cannot be greater than 12.
+        [InlineData("2013-05-00T23:57:09.931094+01:00")] // Day cannot be less than 1.
+        [InlineData("2013-05-32T23:57:09.931094+01:00")] // Day cannot be greater than 31 in May.
+        [InlineData("2013-02-29T23:57:09.931094+01:00")] // Day cannot be greater than 28 in non-leap year.
+        [InlineData("2020-02-30T23:57:09.931094+01:00")] // Day cannot be greater than 29 in leap year.
+        [InlineData("2013-05-18T-01:57:09.931094+01:00")] // Hour cannot be less than 0.
         [InlineData("2013-05-18T24:00:00Z")] // Hour cannot be greater than 23.
-        [InlineData("2013-05-18T23:-01:09.931094%2B01:00")] // Minute cannot be less than 0.
+        [InlineData("2013-05-18T23:-01:09.931094+01:00")] // Minute cannot be less than 0.
         [InlineData("2013-05-18T23:60:00Z")] // Minute cannot be greater than 59.
-        [InlineData("2013-05-18T23:57:-01.931094%2B01:00")] // Second cannot be less than 0.
+        [InlineData("2013-05-18T23:57:-01.931094+01:00")] // Second cannot be less than 0.
         [InlineData("2013-05-18T23:57:60Z")] // Second cannot be greater than 59.
-        [InlineData("2013-05-18T23:57:09.999999999999999999999999%2B01:00")] // Fraction cannot be rounded up to 1 minute.
+        [InlineData("2013-05-18T23:57:09.999999999999999999999999+01:00")] // Fraction cannot be rounded up to 1 minute.
         public void GivenAOutOfRangeParameter_WhenInitializing_ThenExceptionShouldBeThrown(string inputString)
         {
             Assert.Throws<FormatException>(() => PartialDateTime.Parse(inputString));
@@ -111,7 +111,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Models
             yield return new object[] { "1999", 1999, null, null, null, null, null, null, null };
             yield return new object[] { "1999-10", 1999, 10, null, null, null, null, null, null };
             yield return new object[] { "1999-10-01", 1999, 10, 1, null, null, null, null, null };
-            yield return new object[] { "1999-10-18T12:35%2B01:00", 1999, 10, 18, 12, 35, null, null, 60 };
+            yield return new object[] { "1999-10-18T12:35+01:00", 1999, 10, 18, 12, 35, null, null, 60 };
             yield return new object[] { "1999-10-18T12:35:55-02:30", 1999, 10, 18, 12, 35, 55, null, -150 };
             yield return new object[] { "1999-10-18T12:35:55Z", 1999, 10, 18, 12, 35, 55, null, 0 };
             yield return new object[] { "1999-10-18T12:35:55.9991532-02:30", 1999, 10, 18, 12, 35, 55, 0.9991532m, -150 };
@@ -175,7 +175,6 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Models
         [InlineData("")]
         [InlineData("    ")]
         [InlineData("        ")]
-        [InlineData(null)]
         public void GivenAnEmptyStringOrWhiteSpaces_WhenParsing_ThenArgumentExceptionShouldBeThrown(string inputString)
         {
             Assert.Throws<ArgumentException>(() => PartialDateTime.Parse(inputString));
@@ -236,7 +235,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Models
         [Fact]
         public void GivenAPartialDateTimeWithNoMissingComponent_WhenToDateTimeOffsetIsCalled_ThenCorrectDateTimeOffsetIsReturned()
         {
-            var dateTime = PartialDateTime.Parse("2013-10-12T23:01:35.9995555%2B02:00");
+            var dateTime = PartialDateTime.Parse("2013-10-12T23:01:35.9995555+02:00");
 
             var actualOffset = dateTime.ToDateTimeOffset(
                 2,

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Models/PartialDateTimeTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Models/PartialDateTimeTests.cs
@@ -182,7 +182,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Models
             const int fraction = 1234;
             var utcOffset = TimeSpan.FromMinutes(240);
 
-            DateTimeOffset dateTimeOffset = new DateTimeOffset(year, month, day, hour, minute, second, millisecond, utcOffset).AddTicks(fraction);
+            var dateTimeOffset = new DateTimeOffset(year, month, day, hour, minute, second, millisecond, utcOffset).AddTicks(fraction);
 
             var partialDateTime = new PartialDateTime(dateTimeOffset);
 

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Models/PartialDateTimeTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Models/PartialDateTimeTests.cs
@@ -14,172 +14,114 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Models
 {
     public class PartialDateTimeTests : IDisposable
     {
-        private const string ParamNameYear = "year";
-        private const string ParamNameMonth = "month";
-        private const string ParamNameDay = "day";
-        private const string ParamNameHour = "hour";
-        private const string ParamNameMinute = "minute";
-        private const string ParamNameSecond = "second";
-        private const string ParamNameFraction = "fraction";
-        private const string ParamNameUtcOffset = "utcOffset";
-        private const string ParamNameS = "s";
-
-        private const int DefaultYear = 2017;
-        private const int DefaultMonth = 7;
-        private const int DefaultDay = 1;
-        private const int DefaultHour = 10;
-        private const int DefaultMinute = 5;
-        private const int DefaultSecond = 55;
-        private const decimal DefaultFraction = 0.9931094m;
-        private static readonly TimeSpan DefaultUtcOffset = TimeSpan.FromMinutes(60);
-
-        private PartialDateTimeBuilder _builder = new PartialDateTimeBuilder();
-
-        private CultureInfo _originalCulture;
+        private readonly CultureInfo _originalCulture;
 
         public PartialDateTimeTests()
         {
             _originalCulture = Thread.CurrentThread.CurrentCulture;
         }
 
-        public static IEnumerable<object[]> GetParameterPreviousParamNullData()
-        {
-            yield return new object[] { ParamNameDay, null, 15, 20, 30, 30, 0.500230m, 60, ParamNameMonth }; // Day cannot be specified if month is not specified.
-            yield return new object[] { ParamNameHour, null, null, 10, 15, 0, 0.10023m, 0, ParamNameMonth }; // Hour cannot be specified if month is not specified.
-            yield return new object[] { ParamNameHour, 1, null, 10, 15, 0, 0.10023m, 0, ParamNameDay }; // Hour cannot be specified if day is not specified.
-            yield return new object[] { ParamNameMinute, null, null, null, 10, 15, 0.999234m, 30, ParamNameMonth }; // Minute cannot be specified if month is not specified.
-            yield return new object[] { ParamNameMinute, 2, null, null, 10, 15, 0.999234m, 30, ParamNameDay }; // Minute cannot be specified if day is not specified.
-            yield return new object[] { ParamNameMinute, 2, 5, null, 10, 15, 0.999234m, 30, ParamNameHour }; // Minute cannot be specified if hour is not specified.
-            yield return new object[] { ParamNameSecond, null, null, null, null, 10, 0.20035m, 720, ParamNameMonth }; // Second cannot be specified if month is not specified.
-            yield return new object[] { ParamNameSecond, 5, null, null, null, 10, 0.20035m, 720, ParamNameDay }; // Second cannot be specified if day is not specified.
-            yield return new object[] { ParamNameSecond, 5, 3, null, null, 10, 0.20035m, 720, ParamNameHour }; // Second cannot be specified if hour is not specified.
-            yield return new object[] { ParamNameSecond, 5, 3, 23, null, 10, 0.20035m, 720, ParamNameMinute }; // Second cannot be specified if minute is not specified.
-            yield return new object[] { ParamNameFraction, null, null, null, null, null, 0.20035m, 720, ParamNameMonth }; // Fraction cannot be specified if month is not specified.
-            yield return new object[] { ParamNameFraction, 5, null, null, null, null, 0.20035m, 720, ParamNameDay }; // Fraction cannot be specified if day is not specified.
-            yield return new object[] { ParamNameFraction, 5, 3, null, null, null, 0.20035m, 720, ParamNameHour }; // Fraction cannot be specified if hour is not specified.
-            yield return new object[] { ParamNameFraction, 5, 3, 23, null, null, 0.20035m, 720, ParamNameMinute }; // Fraction cannot be specified if minute is not specified.
-            yield return new object[] { ParamNameFraction, 5, 3, 23, 20, null, 0.20035m, 720, ParamNameSecond }; // Fraction cannot be specified if second is not specified.
-        }
-
         [Theory]
-        [MemberData(nameof(GetParameterPreviousParamNullData))]
-        public void GivenPreviousParamIsNull_WhenInitializing_ThenExceptionShouldBeThrown(
-            string paramName,
-            int? month,
-            int? day,
-            int? hour,
-            int? minute,
-            int? second,
-            decimal? fraction,
-            int? utcOffsetInMinutes,
-            string firstNullParamName)
+        [InlineData("05")] // Year needs to be specified.
+        [InlineData("05-18")]
+        [InlineData("05-18T23:57")]
+        [InlineData("05-18T23:57:09")]
+        [InlineData("05-18T23:57:09.931094")]
+        [InlineData("05-18T23:57%2B01:00")]
+        [InlineData("05-18T23:57:09%2B01:00")]
+        [InlineData("05-18T23:57:09.931094%2B01:00")]
+        [InlineData("2013-05T23:57")] // Month/date needs to be specified.
+        [InlineData("2013-05T23:57:09")]
+        [InlineData("2013-05T23:57:09.931094")]
+        [InlineData("2013-05T23:57%2B01:00")]
+        [InlineData("2013-05T23:57:09%2B01:00")]
+        [InlineData("2013-05T23:57:09.931094%2B01:00")]
+        [InlineData("2013T23:57")] // Month and date need to be specified.
+        [InlineData("2013T23:57:09")]
+        [InlineData("2013T23:57:09.931094")]
+        [InlineData("2013T23:57%2B01:00")]
+        [InlineData("2013T23:57:09%2B01:00")]
+        [InlineData("2013T23:57:09.931094%2B01:00")]
+        [InlineData("T23:57")] // Year, month and date need to be specified.
+        [InlineData("T23:57:09")]
+        [InlineData("T23:57:09.931094")]
+        [InlineData("T23:57%2B01:00")]
+        [InlineData("T23:57:09%2B01:00")]
+        [InlineData("T23:57:09.931094%2B01:00")]
+        [InlineData("2013-05-18T23:09.931094")] // Hour/minute/second needs to be specified.
+        [InlineData("2013-05-18T23:09.931094%2B01:00")]
+        [InlineData("2013-05-18T09.931094")] // Hour and minute need to be specified.
+        [InlineData("2013-05-18T09.931094%2B01:00")]
+        [InlineData("2013-05-18T.931094")] // Hour, minute and second need to be specified.
+        [InlineData("2013-05-18T.931094%2B01:00")]
+        public void GivenPreviousParamIsNotSpecified_WhenParsingPartialDateTime_ThenExceptionShouldBeThrown(string inputString)
         {
-            _builder.Month = month;
-            _builder.Day = day;
-            _builder.Hour = hour;
-            _builder.Minute = minute;
-            _builder.Second = second;
-            _builder.Fraction = fraction;
-            _builder.UtcOffset = utcOffsetInMinutes == null ?
-                (TimeSpan?)null :
-                TimeSpan.FromMinutes(utcOffsetInMinutes.Value);
+            Exception ex = Assert.Throws<FormatException>(() => PartialDateTime.Parse(inputString));
 
-            Exception ex = Assert.Throws<ArgumentException>(paramName, () => _builder.ToPartialDateTime());
-
-            string expectedMessage = $"The {paramName} portion of a date cannot be specified if the {firstNullParamName} portion is not specified. (Parameter '{paramName}')";
-
+            string expectedMessage = string.Format(Resources.DateTimeStringIsIncorrectlyFormatted, inputString);
             Assert.Equal(expectedMessage, ex.Message);
         }
 
-        public static IEnumerable<object[]> GetParameterInvalidData()
+        [Theory]
+        [InlineData("2013%2B01:00")] // Time needs to be specified if UTC offset is specified.
+        [InlineData("2013-05%2B01:00")]
+        [InlineData("2013-05-18%2B01:00")]
+        public void GivenUtcOffsetButNoTime_WhenParsingPartialDateTime_ThenExceptionShouldBeThrown(string inputString)
         {
-            yield return new object[] { ParamNameMinute, 10, 30, 23, null, null, null, 60 }; // Minute must be specified if Hour is specified.
-            yield return new object[] { ParamNameUtcOffset, 3, 5, 17, 30, 15, 0.400123m, null }; // UtcOffset must be specified if Hour and Minutes are specified.
+            Exception ex = Assert.Throws<FormatException>(() => PartialDateTime.Parse(inputString));
+
+            string expectedMessage = string.Format(Resources.DateTimeStringIsIncorrectlyFormatted, inputString);
+            Assert.Equal(expectedMessage, ex.Message);
         }
 
         [Theory]
-        [MemberData(nameof(GetParameterInvalidData))]
-        public void GivenAnInvalidParameter_WhenInitializing_ThenExceptionShouldBeThrown(
-            string paramName,
-            int? month,
-            int? day,
-            int? hour,
-            int? minute,
-            int? second,
-            decimal? fraction,
-            int? utcOffsetInMinutes)
+        [InlineData("2013-05-18T23")] // Minutes need to be specified if hour is specified.
+        [InlineData("2013-05-18T23%2B01:00")]
+        public void GivenHourIsSpecifiedWithoutMinutes_WhenParsingPartialDateTime_ThenExceptionShouldBeThrown(string inputString)
         {
-            _builder.Month = month;
-            _builder.Day = day;
-            _builder.Hour = hour;
-            _builder.Minute = minute;
-            _builder.Second = second;
-            _builder.Fraction = fraction;
-            _builder.UtcOffset = utcOffsetInMinutes == null ?
-                (TimeSpan?)null :
-                TimeSpan.FromMinutes(utcOffsetInMinutes.Value);
+            Exception ex = Assert.Throws<FormatException>(() => PartialDateTime.Parse(inputString));
 
-            Assert.Throws<ArgumentException>(paramName, () => _builder.ToPartialDateTime());
-        }
-
-        public static IEnumerable<object[]> GetParameterOutOfRangeData()
-        {
-            yield return new object[] { ParamNameYear, 0, 1, 1, 1, 1, 1, 0m, 60 }; // Year cannot be less than 1.
-            yield return new object[] { ParamNameYear, 10000, 1, 1, 1, 1, 1, 0m, 60 }; // Year cannot be greater than 9999.
-            yield return new object[] { ParamNameMonth, 2017, 0, 1, 1, 1, 1, 0m, 60 }; // Month cannot be less than 1.
-            yield return new object[] { ParamNameMonth, 2017, 13, 1, 1, 1, 1, 0m, 60 }; // Month cannot be greater than 12.
-            yield return new object[] { ParamNameDay, 2017, 1, 0, 1, 1, 1, 0m, 60 }; // Day cannot be less than 1.
-            yield return new object[] { ParamNameDay, 2017, 1, 32, 1, 1, 1, 0m, 60 }; // Day cannot be greater 31 in January.
-            yield return new object[] { ParamNameDay, 2001, 2, 29, 1, 1, 1, 0m, 60 }; // Day cannot be greater than 28 in non-leap year.
-            yield return new object[] { ParamNameDay, 2000, 2, 30, 1, 1, 1, 0m, 60 }; // Day cannot be greater than 29 in leap year.
-            yield return new object[] { ParamNameHour, 2017, 1, 1, -1, 1, 1, 0m, 60 }; // Hour cannot be less than 0.
-            yield return new object[] { ParamNameHour, 2017, 1, 1, 24, 1, 1, 0m, 60 }; // Hour cannot be greater than 23.
-            yield return new object[] { ParamNameMinute, 2017, 1, 1, 1, -1, 1, 0m, 60 }; // Minute cannot be less than 0.
-            yield return new object[] { ParamNameMinute, 2017, 1, 1, 1, 61, 1, 0m, 60 }; // Minute cannot be greater than 59.
-            yield return new object[] { ParamNameSecond, 2017, 1, 1, 1, 1, -1, 0m, 60 }; // Second cannot be less than 0.
-            yield return new object[] { ParamNameSecond, 2017, 1, 1, 1, 1, 61, 0m, 60 }; // Second cannot be greater than 59.
-            yield return new object[] { ParamNameFraction, 2017, 1, 1, 1, 1, 1, -1m, 60 }; // Fraction cannot be less than 0.
-            yield return new object[] { ParamNameFraction, 2017, 1, 1, 1, 1, 1, 1m, 60 }; // Fraction cannot be greater than .
+            string expectedMessage = string.Format(Resources.DateTimeStringIsIncorrectlyFormatted, inputString);
+            Assert.Equal(expectedMessage, ex.Message);
         }
 
         [Theory]
-        [MemberData(nameof(GetParameterOutOfRangeData))]
-        public void GivenAOutOfRangeParameter_WhenInitializing_ThenExceptionShouldBeThrown(
-            string paramName,
-            int year,
-            int month,
-            int day,
-            int hour,
-            int minute,
-            int second,
-            decimal? fraction,
-            int utcOffsetInMinutes)
+        [InlineData("0000-05-18T23:57:09.931094%2B01:00")] // Year cannot be less than 1.
+        [InlineData("10000-05-18T23:57:09.931094%2B01:00")] // Year cannot be greater than 9999.
+        [InlineData("2013-00-18T23:57:09.931094%2B01:00")] // Month cannot be less than 1.
+        [InlineData("2013-13-18T23:57:09.931094%2B01:00")] // Month cannot be greater than 12.
+        [InlineData("2013-05-00T23:57:09.931094%2B01:00")] // Day cannot be less than 1.
+        [InlineData("2013-05-32T23:57:09.931094%2B01:00")] // Day cannot be greater than 31 in May.
+        [InlineData("2013-02-29T23:57:09.931094%2B01:00")] // Day cannot be greater than 28 in non-leap year.
+        [InlineData("2020-02-30T23:57:09.931094%2B01:00")] // Day cannot be greater than 29 in leap year.
+        [InlineData("2013-05-18T-01:57:09.931094%2B01:00")] // Hour cannot be less than 0.
+        [InlineData("2013-05-18T24:00:00Z")] // Hour cannot be greater than 23.
+        [InlineData("2013-05-18T23:-01:09.931094%2B01:00")] // Minute cannot be less than 0.
+        [InlineData("2013-05-18T23:60:00Z")] // Minute cannot be greater than 59.
+        [InlineData("2013-05-18T23:57:-01.931094%2B01:00")] // Second cannot be less than 0.
+        [InlineData("2013-05-18T23:57:60Z")] // Second cannot be greater than 59.
+        [InlineData("2013-05-18T23:57:09.999999999999999999999999%2B01:00")] // Fraction cannot be rounded up to 1 minute.
+        public void GivenAOutOfRangeParameter_WhenInitializing_ThenExceptionShouldBeThrown(string inputString)
         {
-            _builder.Year = year;
-            _builder.Month = month;
-            _builder.Day = day;
-            _builder.Hour = hour;
-            _builder.Minute = minute;
-            _builder.Second = second;
-            _builder.Fraction = fraction;
-            _builder.UtcOffset = TimeSpan.FromMinutes(utcOffsetInMinutes);
-
-            Assert.Throws<ArgumentOutOfRangeException>(paramName, () => _builder.ToPartialDateTime());
+            Assert.Throws<FormatException>(() => PartialDateTime.Parse(inputString));
         }
 
         public static IEnumerable<object[]> GetParameterNullData()
         {
-            yield return new object[] { null, null, null, null, null, null, null };
-            yield return new object[] { 1, null, null, null, null, null, null };
-            yield return new object[] { 3, 5, null, null, null, null, null };
-            yield return new object[] { 6, 1, 12, 35, null, null, 60 };
-            yield return new object[] { 12, 2, 23, 8, 24, null, -150 };
-            yield return new object[] { 1, 3, 5, 2, 15, 0.9991532m, 30 };
+            yield return new object[] { "1999", 1999, null, null, null, null, null, null, null };
+            yield return new object[] { "1999-10", 1999, 10, null, null, null, null, null, null };
+            yield return new object[] { "1999-10-01", 1999, 10, 1, null, null, null, null, null };
+            yield return new object[] { "1999-10-18T12:35%2B01:00", 1999, 10, 18, 12, 35, null, null, 60 };
+            yield return new object[] { "1999-10-18T12:35:55-02:30", 1999, 10, 18, 12, 35, 55, null, -150 };
+            yield return new object[] { "1999-10-18T12:35:55Z", 1999, 10, 18, 12, 35, 55, null, 0 };
+            yield return new object[] { "1999-10-18T12:35:55.9991532-02:30", 1999, 10, 18, 12, 35, 55, 0.9991532m, -150 };
         }
 
         [Theory]
         [MemberData(nameof(GetParameterNullData))]
         public void GivenANullParameter_WhenInitialized_ThenCorrectPartialDateTimeShouldBeCreated(
+            string inputString,
+            int year,
             int? month,
             int? day,
             int? hour,
@@ -188,22 +130,11 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Models
             decimal? fraction,
             int? utcOffsetInMinutes)
         {
-            _builder.Month = month;
-            _builder.Day = day;
-            _builder.Hour = hour;
-            _builder.Minute = minute;
-            _builder.Second = second;
-            _builder.Fraction = fraction;
+            TimeSpan? utcOffset = utcOffsetInMinutes == null ? (TimeSpan?)null : TimeSpan.FromMinutes(utcOffsetInMinutes.Value);
 
-            TimeSpan? utcOffset = utcOffsetInMinutes == null ?
-                (TimeSpan?)null :
-                TimeSpan.FromMinutes(utcOffsetInMinutes.Value);
+            var dateTime = PartialDateTime.Parse(inputString);
 
-            _builder.UtcOffset = utcOffset;
-
-            PartialDateTime dateTime = _builder.ToPartialDateTime();
-
-            Assert.Equal(DefaultYear, dateTime.Year);
+            Assert.Equal(year, dateTime.Year);
             Assert.Equal(month, dateTime.Month);
             Assert.Equal(day, dateTime.Day);
             Assert.Equal(hour, dateTime.Hour);
@@ -214,7 +145,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Models
         }
 
         [Fact]
-        public void GivenADateImtOffset_WhenInitialized_ThenCorrectPartialDateTimeShouldBeCreated()
+        public void GivenADateTimeOffset_WhenInitialized_ThenCorrectPartialDateTimeShouldBeCreated()
         {
             const int year = 2018;
             const int month = 5;
@@ -224,19 +155,11 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Models
             const int second = 59;
             const int millisecond = 153;
             const int fraction = 1234;
-            TimeSpan utcOffset = TimeSpan.FromMinutes(240);
+            var utcOffset = TimeSpan.FromMinutes(240);
 
-            var dateTimeOffset = new DateTimeOffset(
-                year,
-                month,
-                day,
-                hour,
-                minute,
-                second,
-                millisecond,
-                utcOffset).AddTicks(fraction);
+            DateTimeOffset dateTimeOffset = new DateTimeOffset(year, month, day, hour, minute, second, millisecond, utcOffset).AddTicks(fraction);
 
-            PartialDateTime partialDateTime = new PartialDateTime(dateTimeOffset);
+            var partialDateTime = new PartialDateTime(dateTimeOffset);
 
             Assert.Equal(year, partialDateTime.Year);
             Assert.Equal(month, partialDateTime.Month);
@@ -248,31 +171,33 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Models
             Assert.Equal(utcOffset, partialDateTime.UtcOffset);
         }
 
-        [Fact]
-        public void GivenANullString_WhenParsing_ThenExceptionShouldBeThrown()
-        {
-            Assert.Throws<ArgumentNullException>(ParamNameS, () => PartialDateTime.Parse(null));
-        }
-
         [Theory]
         [InlineData("")]
         [InlineData("    ")]
-        public void GivenAnInvalidString_WhenParsing_ThenExceptionShouldBeThrown(string s)
+        [InlineData("        ")]
+        [InlineData(null)]
+        public void GivenAnEmptyStringOrWhiteSpaces_WhenParsing_ThenArgumentExceptionShouldBeThrown(string inputString)
         {
-            Assert.Throws<ArgumentException>(ParamNameS, () => PartialDateTime.Parse(s));
+            Assert.Throws<ArgumentException>(() => PartialDateTime.Parse(inputString));
         }
 
         [Fact]
-        public void GivenAnInvalidFormatString_WhenParsing_ThenExceptionShouldBeThrown()
+        public void GivenANullString_WhenParsing_ThenArgumentExceptionShouldBeThrown()
         {
-            Assert.Throws<FormatException>(() => PartialDateTime.Parse("abc"));
+            Assert.Throws<ArgumentNullException>(() => PartialDateTime.Parse(null));
+        }
+
+        [Theory]
+        [InlineData("****")]
+        [InlineData("!")]
+        [InlineData("abc")]
+        public void GivenAnInvalidString_WhenParsing_ThenFormatExceptionShouldBeThrown(string inputString)
+        {
+            Assert.Throws<FormatException>(() => PartialDateTime.Parse(inputString));
         }
 
         public static IEnumerable<object[]> GetParseData()
         {
-            yield return new object[] { "2017", 2017, null, null, null, null, null, null, null };
-            yield return new object[] { "2017-01", 2017, 1, null, null, null, null, null, null };
-            yield return new object[] { "2019-01-02", 2019, 1, 2, null, null, null, null, null };
             yield return new object[] { "2017-01-07T11:21:12", 2017, 1, 7, 11, 21, 12, null, 0 };
             yield return new object[] { "2017-02-15T13:30:00Z", 2017, 2, 15, 13, 30, 0, null, 0 };
             yield return new object[] { "2018-02-03T05:30:03.0Z", 2018, 2, 3, 5, 30, 3, 0.0m, 0 };
@@ -284,7 +209,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Models
         [Theory]
         [MemberData(nameof(GetParseData))]
         public void GivenAValidString_WhenParsed_ThenCorrectPartialDateTimeShouldBeCreated(
-            string s,
+            string inputString,
             int year,
             int? month,
             int? day,
@@ -292,11 +217,12 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Models
             int? minute,
             int? second,
             decimal? fraction,
-            int? utcOffsetInMinute)
+            int? utcOffsetInMinutes)
         {
-            PartialDateTime dateTime = PartialDateTime.Parse(s);
+            TimeSpan? utcOffset = utcOffsetInMinutes == null ? (TimeSpan?)null : TimeSpan.FromMinutes(utcOffsetInMinutes.Value);
 
-            Assert.NotNull(dateTime);
+            var dateTime = PartialDateTime.Parse(inputString);
+
             Assert.Equal(year, dateTime.Year);
             Assert.Equal(month, dateTime.Month);
             Assert.Equal(day, dateTime.Day);
@@ -304,23 +230,15 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Models
             Assert.Equal(minute, dateTime.Minute);
             Assert.Equal(second, dateTime.Second);
             Assert.Equal(fraction, dateTime.Fraction);
-
-            TimeSpan? utcOffset = null;
-
-            if (utcOffsetInMinute != null)
-            {
-                utcOffset = TimeSpan.FromMinutes(utcOffsetInMinute.Value);
-            }
-
             Assert.Equal(utcOffset, dateTime.UtcOffset);
         }
 
         [Fact]
         public void GivenAPartialDateTimeWithNoMissingComponent_WhenToDateTimeOffsetIsCalled_ThenCorrectDateTimeOffsetIsReturned()
         {
-            PartialDateTime dateTime = _builder.ToPartialDateTime();
+            var dateTime = PartialDateTime.Parse("2013-10-12T23:01:35.9995555%2B02:00");
 
-            DateTimeOffset actualOffset = dateTime.ToDateTimeOffset(
+            var actualOffset = dateTime.ToDateTimeOffset(
                 2,
                 (year, month) => 10,
                 15,
@@ -329,16 +247,16 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Models
                 0.300250m,
                 TimeSpan.FromMinutes(30));
 
-            DateTimeOffset expectedOffset = new DateTimeOffset(
-                DefaultYear,
-                DefaultMonth,
-                DefaultDay,
-                DefaultHour,
-                DefaultMinute,
-                DefaultSecond,
-                DefaultUtcOffset);
+            var expectedOffset = new DateTimeOffset(
+                2013,
+                10,
+                12,
+                23,
+                01,
+                35,
+                TimeSpan.FromMinutes(120));
 
-            expectedOffset = expectedOffset.AddTicks((long)(DefaultFraction * TimeSpan.TicksPerSecond));
+            expectedOffset = expectedOffset.AddTicks((long)(0.9995555m * TimeSpan.TicksPerSecond));
 
             Assert.Equal(expectedOffset, actualOffset);
         }
@@ -346,25 +264,17 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Models
         [Fact]
         public void GivenAPartialDateTimeWithMissingComponents_WhenToDateTimeOffsetIsCalled_ThenCorrectDateTimeOffsetIsReturned()
         {
-            int expectedMonth = 2;
-            int expectedDay = 10;
-            int expectedHour = 15;
-            int expectedMinute = 13;
-            int expectedSecond = 12;
-            decimal expectedFraction = 0.3009953m;
-            TimeSpan expectedUtcOffset = TimeSpan.FromMinutes(30);
+            const int expectedMonth = 2;
+            const int expectedDay = 10;
+            const int expectedHour = 15;
+            const int expectedMinute = 13;
+            const int expectedSecond = 12;
+            const decimal expectedFraction = 0.3009953m;
+            var expectedUtcOffset = TimeSpan.FromMinutes(30);
 
-            _builder.Month = null;
-            _builder.Day = null;
-            _builder.Hour = null;
-            _builder.Minute = null;
-            _builder.Second = null;
-            _builder.Fraction = null;
-            _builder.UtcOffset = null;
+            var dateTime = PartialDateTime.Parse("2013");
 
-            PartialDateTime dateTime = _builder.ToPartialDateTime();
-
-            DateTimeOffset actualOffset = dateTime.ToDateTimeOffset(
+            var actualOffset = dateTime.ToDateTimeOffset(
                 expectedMonth,
                 (year, month) => expectedDay,
                 expectedHour,
@@ -373,8 +283,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Models
                 expectedFraction,
                 expectedUtcOffset);
 
-            DateTimeOffset expectedOffset = new DateTimeOffset(
-                DefaultYear,
+            var expectedOffset = new DateTimeOffset(
+                2013,
                 expectedMonth,
                 expectedDay,
                 expectedHour,
@@ -401,7 +311,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Models
         [InlineData("2018-11-29T18:30:27.911+01:00", "2018-11-29T18:30:27.9110000+01:00")]
         public void GivenAValidPartialDateTime_WhenToStringIsCalled_ThenCorrectStringShouldBeReturned(string input, string expected)
         {
-            PartialDateTime dateTime = PartialDateTime.Parse(input);
+            var dateTime = PartialDateTime.Parse(input);
 
             Assert.NotNull(dateTime);
             Assert.Equal(expected, dateTime.ToString());
@@ -411,62 +321,18 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Models
         [InlineData("de-DE", "2018-11-29T18:30:27.911+01:00", "2018-11-29T18:30:27,9110000+01:00")]
         [InlineData("en-GB", "2018-11-29T18:30:27.911+01:00", "2018-11-29T18:30:27.9110000+01:00")]
         [InlineData("en-US", "2018-11-29T18:30:27.911+01:00", "2018-11-29T18:30:27.9110000+01:00")]
-        public void GivenACulture_WhenToStringisCalled_ThenCorrectStringShouldBeReturned(string culture, string input, string expected)
+        public void GivenACulture_WhenToStringIsCalled_ThenCorrectStringShouldBeReturned(string culture, string inputString, string expectedString)
         {
-            System.Threading.Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo(culture);
-            PartialDateTime dateTime = PartialDateTime.Parse(input);
+            System.Threading.Thread.CurrentThread.CurrentCulture = new CultureInfo(culture);
+            var dateTime = PartialDateTime.Parse(inputString);
 
             Assert.NotNull(dateTime);
-            Assert.Equal(expected, dateTime.ToString());
+            Assert.Equal(expectedString, dateTime.ToString());
         }
 
         public void Dispose()
         {
             Thread.CurrentThread.CurrentCulture = _originalCulture;
-        }
-
-        private class PartialDateTimeBuilder
-        {
-            public PartialDateTimeBuilder()
-            {
-                Year = DefaultYear;
-                Month = DefaultMonth;
-                Day = DefaultDay;
-                Hour = DefaultHour;
-                Minute = DefaultMinute;
-                Second = DefaultSecond;
-                Fraction = DefaultFraction;
-                UtcOffset = DefaultUtcOffset;
-            }
-
-            public int Year { get; set; }
-
-            public int? Month { get; set; }
-
-            public int? Day { get; set; }
-
-            public int? Hour { get; set; }
-
-            public int? Minute { get; set; }
-
-            public int? Second { get; set; }
-
-            public decimal? Fraction { get; set; }
-
-            public TimeSpan? UtcOffset { get; set; }
-
-            public PartialDateTime ToPartialDateTime()
-            {
-                return new PartialDateTime(
-                    Year,
-                    Month,
-                    Day,
-                    Hour,
-                    Minute,
-                    Second,
-                    Fraction,
-                    UtcOffset);
-            }
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Models/PartialDateTimeTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Models/PartialDateTimeTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Models
         [InlineData("2013-05-18T09.931094+01:00")]
         [InlineData("2013-05-18T.931094")] // Hour, minute and second need to be specified.
         [InlineData("2013-05-18T.931094+01:00")]
-        public void GivenPreviousParamIsNotSpecified_WhenParsingPartialDateTime_ThenExceptionShouldBeThrown(string inputString)
+        public void GivenPreviousParamIsNotSpecified_WhenParsingPartialDateTime_ThenFormatExceptionShouldBeThrown(string inputString)
         {
             Exception ex = Assert.Throws<FormatException>(() => PartialDateTime.Parse(inputString));
 
@@ -66,7 +66,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Models
         [InlineData("2013+01:00")] // Time needs to be specified if UTC offset is specified.
         [InlineData("2013-05+01:00")]
         [InlineData("2013-05-18+01:00")]
-        public void GivenUtcOffsetButNoTime_WhenParsingPartialDateTime_ThenExceptionShouldBeThrown(string inputString)
+        public void GivenUtcOffsetButNoTime_WhenParsingPartialDateTime_ThenFormatExceptionShouldBeThrown(string inputString)
         {
             Exception ex = Assert.Throws<FormatException>(() => PartialDateTime.Parse(inputString));
 
@@ -77,7 +77,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Models
         [Theory]
         [InlineData("2013-05-18T23")] // Minutes need to be specified if hour is specified.
         [InlineData("2013-05-18T23+01:00")]
-        public void GivenHourIsSpecifiedWithoutMinutes_WhenParsingPartialDateTime_ThenExceptionShouldBeThrown(string inputString)
+        public void GivenHourIsSpecifiedWithoutMinutes_WhenParsingPartialDateTime_ThenFormatExceptionShouldBeThrown(string inputString)
         {
             Exception ex = Assert.Throws<FormatException>(() => PartialDateTime.Parse(inputString));
 
@@ -98,9 +98,12 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Models
         [InlineData("2013-05-18T23:09ZZ")]
         [InlineData("2013-05-18T23:09-99:00")]
         [InlineData("2013-05-18T23:09-789")]
-        public void GivenInvalidUtcOffset_WhenParsingPartialDateTime_ThenExceptionShouldBeThrown(string inputString)
+        public void GivenInvalidUtcOffset_WhenParsingPartialDateTime_ThenFormatExceptionShouldBeThrown(string inputString)
         {
-            Assert.Throws<FormatException>(() => PartialDateTime.Parse(inputString));
+            Exception ex = Assert.Throws<FormatException>(() => PartialDateTime.Parse(inputString));
+
+            string expectedMessage = string.Format(Resources.DateTimeStringIsIncorrectlyFormatted, inputString);
+            Assert.Equal(expectedMessage, ex.Message);
         }
 
         [Theory]
@@ -119,9 +122,12 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Models
         [InlineData("2013-05-18T23:57:-01.931094+01:00")] // Second cannot be less than 0.
         [InlineData("2013-05-18T23:57:60Z")] // Second cannot be greater than 59.
         [InlineData("2013-05-18T23:57:09.999999999999999999999999+01:00")] // Fraction cannot be rounded up to 1 minute.
-        public void GivenAOutOfRangeParameter_WhenInitializing_ThenExceptionShouldBeThrown(string inputString)
+        public void GivenAOutOfRangeParameter_WhenInitializing_ThenFormatExceptionShouldBeThrown(string inputString)
         {
-            Assert.Throws<FormatException>(() => PartialDateTime.Parse(inputString));
+            Exception ex = Assert.Throws<FormatException>(() => PartialDateTime.Parse(inputString));
+
+            string expectedMessage = string.Format(Resources.DateTimeStringIsIncorrectlyFormatted, inputString);
+            Assert.Equal(expectedMessage, ex.Message);
         }
 
         public static IEnumerable<object[]> GetParameterNullData()
@@ -200,7 +206,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Models
         }
 
         [Fact]
-        public void GivenANullString_WhenParsing_ThenArgumentExceptionShouldBeThrown()
+        public void GivenANullString_WhenParsing_ThenArgumentNullExceptionShouldBeThrown()
         {
             Assert.Throws<ArgumentNullException>(() => PartialDateTime.Parse(null));
         }
@@ -211,7 +217,10 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Models
         [InlineData("abc")]
         public void GivenAnInvalidString_WhenParsing_ThenFormatExceptionShouldBeThrown(string inputString)
         {
-            Assert.Throws<FormatException>(() => PartialDateTime.Parse(inputString));
+            Exception ex = Assert.Throws<FormatException>(() => PartialDateTime.Parse(inputString));
+
+            string expectedMessage = string.Format(Resources.DateTimeStringIsIncorrectlyFormatted, inputString);
+            Assert.Equal(expectedMessage, ex.Message);
         }
 
         public static IEnumerable<object[]> GetParseData()

--- a/src/Microsoft.Health.Fhir.Core/Models/PartialDateTime.cs
+++ b/src/Microsoft.Health.Fhir.Core/Models/PartialDateTime.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using EnsureThat;

--- a/src/Microsoft.Health.Fhir.Core/Models/PartialDateTime.cs
+++ b/src/Microsoft.Health.Fhir.Core/Models/PartialDateTime.cs
@@ -17,8 +17,7 @@ namespace Microsoft.Health.Fhir.Core.Models
     /// </summary>
     public class PartialDateTime
     {
-        public static readonly PartialDateTime MinValue = new PartialDateTime(DateTimeOffset.MinValue);
-        public static readonly PartialDateTime MaxValue = new PartialDateTime(DateTimeOffset.MaxValue);
+        private static readonly string[] _formats = GenerateDateTimeOffsetFormats();
 
         private const string YearCapture = "year";
         private const string MonthCapture = "month";
@@ -30,14 +29,15 @@ namespace Microsoft.Health.Fhir.Core.Models
         private const string TimeZoneCapture = "timeZone";
         private const string InvalidTimeZoneCapture = "invalidTimeZone";
 
-        private static readonly string[] _formats = GenerateDateTimeOffsetFormats();
-
         // This regular expression is used to capture which date time parts are specified by the user and which parts are not.
         // This is required because date time parts left blank are used to indicate a time period.
         // For example, 2000 is equivalent to an interval of [2000-01-01T00:00, 2000-12-31T23:59].
         private static readonly Regex DateTimeRegex = new Regex(
             $@"-?(?<{YearCapture}>[0-9]{{4}})(-(?<{MonthCapture}>[0-9]{{2}}))?(-(?<{DayCapture}>[0-9]{{2}}))?(T(?<{HourCapture}>[0-9]{{2}}))?(:(?<{MinuteCapture}>[0-9]{{2}}))?(:(?<{SecondCapture}>[0-9]{{2}}))?((?<{FractionCapture}>\.[0-9]+))?((?<{TimeZoneCapture}>Z|(\+|-)(([0-9]{{2}}):[0-9]{{2}}))|(?<{InvalidTimeZoneCapture}>Z|(\+|-)(([0-9]{{1}}):[0-9]{{2}})))?",
             RegexOptions.Singleline | RegexOptions.Compiled | RegexOptions.ExplicitCapture);
+
+        public static readonly PartialDateTime MinValue = new PartialDateTime(DateTimeOffset.MinValue);
+        public static readonly PartialDateTime MaxValue = new PartialDateTime(DateTimeOffset.MaxValue);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PartialDateTime"/> class.
@@ -242,20 +242,7 @@ namespace Microsoft.Health.Fhir.Core.Models
                 }
             }
 
-            // TODO: Any prefixes missing? Can I get this list from somewhere?
-            var formatPrefixes = new List<string> { "ab", "ap", "eb", "eq", "\\ge", "\\g\\t", "l\\t", "le", "ne", "\\sa" };
-
-            var formatsWithPrefixes = new List<string>(formats);
-
-            foreach (var format in formats)
-            {
-                foreach (var prefix in formatPrefixes)
-                {
-                    formatsWithPrefixes.Add(prefix + format);
-                }
-            }
-
-            return formatsWithPrefixes.ToArray();
+            return formats.ToArray();
         }
 
         private static decimal GetFractionFromDateTimeOffset(DateTimeOffset parsedDateTimeOffset)

--- a/src/Microsoft.Health.Fhir.Core/Models/PartialDateTime.cs
+++ b/src/Microsoft.Health.Fhir.Core/Models/PartialDateTime.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Health.Fhir.Core.Models
         /// <param name="second">The optional second component.</param>
         /// <param name="fraction">The optional fraction component representing the fraction of second up to 7 digits.</param>
         /// <param name="utcOffset">The optional UTC offset component.</param>
-        public PartialDateTime(
+        private PartialDateTime(
             int year,
             int? month = null,
             int? day = null,

--- a/src/Microsoft.Health.Fhir.Core/Models/PartialDateTime.cs
+++ b/src/Microsoft.Health.Fhir.Core/Models/PartialDateTime.cs
@@ -210,14 +210,10 @@ namespace Microsoft.Health.Fhir.Core.Models
         /// </remarks>
         private static string[] GenerateDateTimeOffsetFormats()
         {
-            var formats = new List<string>();
-
-            var dateFormats = new List<string> { "yyyy", "yyyy-MM", "yyyy-MM-dd" };
-
-            formats.AddRange(dateFormats);
+            var formats = new List<string> { "yyyy", "yyyy-MM", "yyyy-MM-dd" };
 
             // From spec: "the minutes SHALL be present if an hour is present".
-            var dateTimeFormats = new List<string>
+            var timeFormats = new List<string>
             {
                 "yyyy-MM-ddTHH:mm",
                 "yyyy-MM-ddTHH:mm:ss",
@@ -230,15 +226,16 @@ namespace Microsoft.Health.Fhir.Core.Models
                 "yyyy-MM-ddTHH:mm:ss.fffffff",
             };
 
-            formats.AddRange(dateTimeFormats);
+            formats.AddRange(timeFormats);
 
             var timeZoneFormats = new List<string> { "Z", "zzz" };
 
-            foreach (var dateTime in dateTimeFormats)
+            // If the time is specified, the time zone could be specified.
+            foreach (var timeFormat in timeFormats)
             {
                 foreach (var timeZoneFormat in timeZoneFormats)
                 {
-                    formats.Add(dateTime + timeZoneFormat);
+                    formats.Add(timeFormat + timeZoneFormat);
                 }
             }
 

--- a/src/Microsoft.Health.Fhir.Core/Models/PartialDateTime.cs
+++ b/src/Microsoft.Health.Fhir.Core/Models/PartialDateTime.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Health.Fhir.Core.Models
         // This is required because date time parts left blank are used to indicate a time period.
         // For example, 2000 is equivalent to an interval of [2000-01-01T00:00, 2000-12-31T23:59].
         private static readonly Regex DateTimeRegex = new Regex(
-            $@"-?(?<{YearCapture}>[0-9]{{4}})(-(?<{MonthCapture}>[0-9]{{2}}))?(-(?<{DayCapture}>[0-9]{{2}}))?(T(?<{HourCapture}>[0-9]{{2}}))?(:(?<{MinuteCapture}>[0-9]{{2}}))?(:(?<{SecondCapture}>[0-9]{{2}}))?((?<{FractionCapture}>\.[0-9]+))?((?<{TimeZoneCapture}>Z|(\+|-)(([0-9]{{2}}):[0-9]{{2}}))|(?<{InvalidTimeZoneCapture}>Z|(\+|-)(([0-9]{{1}}):[0-9]{{2}})))?",
+            $@"(?<{YearCapture}>\d{{4}})(-(?<{MonthCapture}>\d{{2}}))?(-(?<{DayCapture}>\d{{2}}))?(T(?<{HourCapture}>\d{{2}}))?(:(?<{MinuteCapture}>\d{{2}}))?(:(?<{SecondCapture}>\d{{2}}))?((?<{FractionCapture}>\.\d+))?((?<{TimeZoneCapture}>Z|(\+|-)((\d{{2}}):\d{{2}}))|(?<{InvalidTimeZoneCapture}>Z|(\+|-)((\d):\d{{2}})))?",
             RegexOptions.Singleline | RegexOptions.Compiled | RegexOptions.ExplicitCapture);
 
         public static readonly PartialDateTime MinValue = new PartialDateTime(DateTimeOffset.MinValue);

--- a/src/Microsoft.Health.Fhir.Core/Models/PartialDateTime.cs
+++ b/src/Microsoft.Health.Fhir.Core/Models/PartialDateTime.cs
@@ -59,78 +59,13 @@ namespace Microsoft.Health.Fhir.Core.Models
             decimal? fraction = null,
             TimeSpan? utcOffset = null)
         {
-            // Validate the parameters. Partial date is supported but the value must be specified from left to right.
-            // E.g., If month is not specified, then day, hour, minute and etc. cannot be specified.
-            (string Name, bool HasValue)[] parameters = new[]
-            {
-                (nameof(month), month.HasValue),
-                (nameof(day), day.HasValue),
-                (nameof(hour), hour.HasValue),
-                (nameof(minute), minute.HasValue),
-                (nameof(second), second.HasValue),
-                (nameof(fraction), fraction.HasValue),
-            };
-
-            bool previousParamHasValue = true;
-            string firstParamWithNullValue = null;
-
-            for (int i = 0; i < parameters.Length; i++)
-            {
-                var currentParameter = parameters[i];
-
-                if (currentParameter.HasValue)
-                {
-                    if (!previousParamHasValue)
-                    {
-                        // The current parameter has value but previous one doesn't. This is an invalid state.
-                        throw new ArgumentException(
-                            $"The {currentParameter.Name} portion of a date cannot be specified if the {firstParamWithNullValue} portion is not specified.",
-                            currentParameter.Name);
-                    }
-                }
-
-                if (!currentParameter.HasValue && firstParamWithNullValue == null)
-                {
-                    firstParamWithNullValue = currentParameter.Name;
-                }
-
-                previousParamHasValue = currentParameter.HasValue;
-            }
-
-            if (hour != null)
-            {
-                if (minute == null)
-                {
-                    // If hour is specified, then minutes must be specified.
-                    throw new ArgumentException(
-                        $"The '{nameof(minute)}' portion of a date must be specified if '{nameof(hour)}' is specified.",
-                        nameof(minute));
-                }
-
-                if (utcOffset == null)
-                {
-                    // If hour and minute are specified, then the timezone offset must be specified
-                    // per spec (http://hl7.org/fhir/datatypes.html#dateTime).
-                    // However, in search queries, the time zone information is optional (http://hl7.org/fhir/search.html#date).
-                    // The parsing logic will default to UTC time zone if the time zone information is not specified in the search query.
-                    throw new ArgumentException(
-                        $"The '{nameof(utcOffset)}' portion of a date must be specified if '{nameof(hour)}' and '{nameof(minute)}' are specified.",
-                        nameof(utcOffset));
-                }
-            }
-
-            // Validate the range of each parameter.
-            ValidateRange(year, 1, 9999, nameof(year));
-            ValidateRange(month, 1, 12, nameof(month));
-
             if (month.HasValue)
             {
-                ValidateRange(day, 1, DateTime.DaysInMonth(year, month.Value), nameof(day));
+                if (day != null)
+                {
+                    EnsureArg.IsInRange(day.Value, 1, DateTime.DaysInMonth(year, month.Value), nameof(day));
+                }
             }
-
-            ValidateRange(hour, 0, 23, nameof(hour));
-            ValidateRange(minute, 0, 59, nameof(minute));
-            ValidateRange(second, 0, 59, nameof(second));
 
             if (fraction != null)
             {
@@ -145,14 +80,6 @@ namespace Microsoft.Health.Fhir.Core.Models
             Second = second;
             Fraction = fraction;
             UtcOffset = utcOffset;
-
-            void ValidateRange(int? value, int min, int max, string paramName)
-            {
-                if (value != null)
-                {
-                    EnsureArg.IsInRange(value.Value, min, max, paramName);
-                }
-            }
         }
 
         /// <summary>

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/Search/SearchIndexEntryJObjectGeneratorTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/Search/SearchIndexEntryJObjectGeneratorTests.cs
@@ -156,9 +156,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Storage.Search
         [Fact]
         public void GivenADateTimeSearchValue_WhenGenerated_ThenCorrectJObjectShouldBeCreated()
         {
-            var value = new DateTimeSearchValue(
-                new PartialDateTime(2000),
-                new PartialDateTime(2001));
+            var value = new DateTimeSearchValue(PartialDateTime.Parse("2000"), PartialDateTime.Parse("2001"));
 
             var expectedValues = new[]
             {

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/Parsers/SearchValueExpressionBuilderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/Parsers/SearchValueExpressionBuilderTests.cs
@@ -276,20 +276,20 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
         }
 
         [Theory]
-        [InlineData("eq2018")]
-        [InlineData("eq2018-02")]
-        [InlineData("eq2018-02-01")]
-        [InlineData("eq2018-02-01T10:00")]
-        [InlineData("eq2018-02-01T10:00-07:00")]
-        public void GivenADateWithEqComparator_WhenBuilt_ThenCorrectExpressionShouldBeCreated(string input)
+        [InlineData("2018")]
+        [InlineData("2018-02")]
+        [InlineData("2018-02-01")]
+        [InlineData("2018-02-01T10:00")]
+        [InlineData("2018-02-01T10:00-07:00")]
+        public void GivenADateWithEqComparator_WhenBuilt_ThenCorrectExpressionShouldBeCreated(string dateTimeInput)
         {
-            var partialDateTime = PartialDateTime.Parse(input);
+            var partialDateTime = PartialDateTime.Parse(dateTimeInput);
             var dateTimeSearchValue = new DateTimeSearchValue(partialDateTime);
 
             Validate(
                 CreateSearchParameter(SearchParamType.Date),
                 null,
-                input,
+                "eq" + dateTimeInput,
                 e => ValidateMultiaryExpression(
                     e,
                     MultiaryOperator.And,
@@ -298,20 +298,20 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
         }
 
         [Theory]
-        [InlineData("ne2018")]
-        [InlineData("ne2018-02")]
-        [InlineData("ne2018-02-01")]
-        [InlineData("ne2018-02-01T10:00")]
-        [InlineData("ne2018-02-01T10:00-07:00")]
-        public void GivenADateWithNeComparator_WhenBuilt_ThenCorrectExpressionShouldBeCreated(string input)
+        [InlineData("2018")]
+        [InlineData("2018-02")]
+        [InlineData("2018-02-01")]
+        [InlineData("2018-02-01T10:00")]
+        [InlineData("2018-02-01T10:00-07:00")]
+        public void GivenADateWithNeComparator_WhenBuilt_ThenCorrectExpressionShouldBeCreated(string dateTimeInput)
         {
-            var partialDateTime = PartialDateTime.Parse(input);
+            var partialDateTime = PartialDateTime.Parse(dateTimeInput);
             var dateTimeSearchValue = new DateTimeSearchValue(partialDateTime);
 
             Validate(
                 CreateSearchParameter(SearchParamType.Date),
                 null,
-                input,
+                "ne" + dateTimeInput,
                 e => ValidateMultiaryExpression(
                     e,
                     MultiaryOperator.Or,
@@ -320,45 +320,45 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
         }
 
         [Theory]
-        [InlineData("lt2018", FieldName.DateTimeStart, BinaryOperator.LessThan, true)]
-        [InlineData("lt2018-02", FieldName.DateTimeStart, BinaryOperator.LessThan, true)]
-        [InlineData("lt2018-02-01", FieldName.DateTimeStart, BinaryOperator.LessThan, true)]
-        [InlineData("lt2018-02-01T10:00", FieldName.DateTimeStart, BinaryOperator.LessThan, true)]
-        [InlineData("lt2018-02-01T10:00-07:00", FieldName.DateTimeStart, BinaryOperator.LessThan, true)]
-        [InlineData("gt2018", FieldName.DateTimeEnd, BinaryOperator.GreaterThan, false)]
-        [InlineData("gt2018-02", FieldName.DateTimeEnd, BinaryOperator.GreaterThan, false)]
-        [InlineData("gt2018-02-01", FieldName.DateTimeEnd, BinaryOperator.GreaterThan, false)]
-        [InlineData("gt2018-02-01T10:00", FieldName.DateTimeEnd, BinaryOperator.GreaterThan, false)]
-        [InlineData("gt2018-02-01T10:00-07:00", FieldName.DateTimeEnd, BinaryOperator.GreaterThan, false)]
-        [InlineData("le2018", FieldName.DateTimeStart, BinaryOperator.LessThanOrEqual, false)]
-        [InlineData("le2018-02", FieldName.DateTimeStart, BinaryOperator.LessThanOrEqual, false)]
-        [InlineData("le2018-02-01", FieldName.DateTimeStart, BinaryOperator.LessThanOrEqual, false)]
-        [InlineData("le2018-02-01T10:00", FieldName.DateTimeStart, BinaryOperator.LessThanOrEqual, false)]
-        [InlineData("le2018-02-01T10:00-07:00", FieldName.DateTimeStart, BinaryOperator.LessThanOrEqual, false)]
-        [InlineData("ge2018", FieldName.DateTimeEnd, BinaryOperator.GreaterThanOrEqual, true)]
-        [InlineData("ge2018-02", FieldName.DateTimeEnd, BinaryOperator.GreaterThanOrEqual, true)]
-        [InlineData("ge2018-02-01", FieldName.DateTimeEnd, BinaryOperator.GreaterThanOrEqual, true)]
-        [InlineData("ge2018-02-01T10:00", FieldName.DateTimeEnd, BinaryOperator.GreaterThanOrEqual, true)]
-        [InlineData("ge2018-02-01T10:00-07:00", FieldName.DateTimeEnd, BinaryOperator.GreaterThanOrEqual, true)]
-        [InlineData("sa2018", FieldName.DateTimeStart, BinaryOperator.GreaterThan, false)]
-        [InlineData("sa2018-02", FieldName.DateTimeStart, BinaryOperator.GreaterThan, false)]
-        [InlineData("sa2018-02-01", FieldName.DateTimeStart, BinaryOperator.GreaterThan, false)]
-        [InlineData("sa2018-02-01T10:00", FieldName.DateTimeStart, BinaryOperator.GreaterThan, false)]
-        [InlineData("sa2018-02-01T10:00-07:00", FieldName.DateTimeStart, BinaryOperator.GreaterThan, false)]
-        [InlineData("eb2018", FieldName.DateTimeEnd, BinaryOperator.LessThan, true)]
-        [InlineData("eb2018-02", FieldName.DateTimeEnd, BinaryOperator.LessThan, true)]
-        [InlineData("eb2018-02-01", FieldName.DateTimeEnd, BinaryOperator.LessThan, true)]
-        [InlineData("eb2018-02-01T10:00", FieldName.DateTimeEnd, BinaryOperator.LessThan, true)]
-        [InlineData("eb2018-02-01T10:00-07:00", FieldName.DateTimeEnd, BinaryOperator.LessThan, true)]
-        public void GivenADateWithComparatorOfSingleBinaryOperator_WhenBuilt_ThenCorrectExpressionShouldBeCreated(string input, FieldName fieldName, BinaryOperator binaryOperator, bool expectStartTimeValue)
+        [InlineData("lt", "2018", FieldName.DateTimeStart, BinaryOperator.LessThan, true)]
+        [InlineData("lt", "2018-02", FieldName.DateTimeStart, BinaryOperator.LessThan, true)]
+        [InlineData("lt", "2018-02-01", FieldName.DateTimeStart, BinaryOperator.LessThan, true)]
+        [InlineData("lt", "2018-02-01T10:00", FieldName.DateTimeStart, BinaryOperator.LessThan, true)]
+        [InlineData("lt", "2018-02-01T10:00-07:00", FieldName.DateTimeStart, BinaryOperator.LessThan, true)]
+        [InlineData("gt", "2018", FieldName.DateTimeEnd, BinaryOperator.GreaterThan, false)]
+        [InlineData("gt", "2018-02", FieldName.DateTimeEnd, BinaryOperator.GreaterThan, false)]
+        [InlineData("gt", "2018-02-01", FieldName.DateTimeEnd, BinaryOperator.GreaterThan, false)]
+        [InlineData("gt", "2018-02-01T10:00", FieldName.DateTimeEnd, BinaryOperator.GreaterThan, false)]
+        [InlineData("gt", "2018-02-01T10:00-07:00", FieldName.DateTimeEnd, BinaryOperator.GreaterThan, false)]
+        [InlineData("le", "2018", FieldName.DateTimeStart, BinaryOperator.LessThanOrEqual, false)]
+        [InlineData("le", "2018-02", FieldName.DateTimeStart, BinaryOperator.LessThanOrEqual, false)]
+        [InlineData("le", "2018-02-01", FieldName.DateTimeStart, BinaryOperator.LessThanOrEqual, false)]
+        [InlineData("le", "2018-02-01T10:00", FieldName.DateTimeStart, BinaryOperator.LessThanOrEqual, false)]
+        [InlineData("le", "2018-02-01T10:00-07:00", FieldName.DateTimeStart, BinaryOperator.LessThanOrEqual, false)]
+        [InlineData("ge", "2018", FieldName.DateTimeEnd, BinaryOperator.GreaterThanOrEqual, true)]
+        [InlineData("ge", "2018-02", FieldName.DateTimeEnd, BinaryOperator.GreaterThanOrEqual, true)]
+        [InlineData("ge", "2018-02-01", FieldName.DateTimeEnd, BinaryOperator.GreaterThanOrEqual, true)]
+        [InlineData("ge", "2018-02-01T10:00", FieldName.DateTimeEnd, BinaryOperator.GreaterThanOrEqual, true)]
+        [InlineData("ge", "2018-02-01T10:00-07:00", FieldName.DateTimeEnd, BinaryOperator.GreaterThanOrEqual, true)]
+        [InlineData("sa", "2018", FieldName.DateTimeStart, BinaryOperator.GreaterThan, false)]
+        [InlineData("sa", "2018-02", FieldName.DateTimeStart, BinaryOperator.GreaterThan, false)]
+        [InlineData("sa", "2018-02-01", FieldName.DateTimeStart, BinaryOperator.GreaterThan, false)]
+        [InlineData("sa", "2018-02-01T10:00", FieldName.DateTimeStart, BinaryOperator.GreaterThan, false)]
+        [InlineData("sa", "2018-02-01T10:00-07:00", FieldName.DateTimeStart, BinaryOperator.GreaterThan, false)]
+        [InlineData("eb", "2018", FieldName.DateTimeEnd, BinaryOperator.LessThan, true)]
+        [InlineData("eb", "2018-02", FieldName.DateTimeEnd, BinaryOperator.LessThan, true)]
+        [InlineData("eb", "2018-02-01", FieldName.DateTimeEnd, BinaryOperator.LessThan, true)]
+        [InlineData("eb", "2018-02-01T10:00", FieldName.DateTimeEnd, BinaryOperator.LessThan, true)]
+        [InlineData("eb", "2018-02-01T10:00-07:00", FieldName.DateTimeEnd, BinaryOperator.LessThan, true)]
+        public void GivenADateWithComparatorOfSingleBinaryOperator_WhenBuilt_ThenCorrectExpressionShouldBeCreated(string prefix, string dateTimeInput, FieldName fieldName, BinaryOperator binaryOperator, bool expectStartTimeValue)
         {
-            var partialDateTime = PartialDateTime.Parse(input);
+            var partialDateTime = PartialDateTime.Parse(dateTimeInput);
             var dateTimeSearchValue = new DateTimeSearchValue(partialDateTime);
 
             Validate(
                 CreateSearchParameter(SearchParamType.Date),
                 null,
-                input,
+                prefix + dateTimeInput,
                 e => ValidateDateTimeBinaryOperatorExpression(
                     e,
                     fieldName,
@@ -367,27 +367,27 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
         }
 
         [Theory]
-        [InlineData("ap2016", "2015-11-25T12:00:00.0000000+00:00", "2017-02-06T11:59:59.9999999+00:00")]
-        [InlineData("ap2016-02", "2015-11-25T21:36:00.0000000+00:00", "2016-05-07T02:23:59.9999999+00:00")]
-        [InlineData("ap2016-02-01", "2015-11-23T02:24:00.0000000+00:00", "2016-04-11T21:35:59.9999999+00:00")]
-        [InlineData("ap2016-02-01T10:00", "2015-11-23T11:00:06.0000000+00:00", "2016-04-11T09:00:53.9999999+00:00")]
-        [InlineData("ap2016-02-01T10:00-07:00", "2015-11-23T18:42:06.0000000+00:00", "2016-04-11T15:18:53.9999999+00:00")]
-        [InlineData("ap2220", "2240-04-19T09:35:59.9999999+00:00", "2200-09-13T14:24:00.0000000+00:00")]
-        [InlineData("ap2220-02", "2240-04-19T19:11:59.9999999+00:00", "2199-12-12T04:48:00.0000000+00:00")]
-        [InlineData("ap2220-02-01", "2240-04-16T23:59:59.9999999+00:00", "2199-11-17T00:00:00.0000000+00:00")]
-        [InlineData("ap2220-02-01T10:00", "2240-04-17T08:36:05.9999999+00:00", "2199-11-16T11:24:54.0000000+00:00")]
-        [InlineData("ap2220-02-01T10:00-07:00", "2240-04-17T16:18:05.9999999+00:00", "2199-11-16T17:42:54.0000000+00:00")]
-        public void GivenADateWithApComparator_WhenBuilt_ThenCorrectExpressionShouldBeCreated(string input, string expectedStartValue, string expectedEndValue)
+        [InlineData("2016", "2015-11-25T12:00:00.0000000+00:00", "2017-02-06T11:59:59.9999999+00:00")]
+        [InlineData("2016-02", "2015-11-25T21:36:00.0000000+00:00", "2016-05-07T02:23:59.9999999+00:00")]
+        [InlineData("2016-02-01", "2015-11-23T02:24:00.0000000+00:00", "2016-04-11T21:35:59.9999999+00:00")]
+        [InlineData("2016-02-01T10:00", "2015-11-23T11:00:06.0000000+00:00", "2016-04-11T09:00:53.9999999+00:00")]
+        [InlineData("2016-02-01T10:00-07:00", "2015-11-23T18:42:06.0000000+00:00", "2016-04-11T15:18:53.9999999+00:00")]
+        [InlineData("2220", "2240-04-19T09:35:59.9999999+00:00", "2200-09-13T14:24:00.0000000+00:00")]
+        [InlineData("2220-02", "2240-04-19T19:11:59.9999999+00:00", "2199-12-12T04:48:00.0000000+00:00")]
+        [InlineData("2220-02-01", "2240-04-16T23:59:59.9999999+00:00", "2199-11-17T00:00:00.0000000+00:00")]
+        [InlineData("2220-02-01T10:00", "2240-04-17T08:36:05.9999999+00:00", "2199-11-16T11:24:54.0000000+00:00")]
+        [InlineData("2220-02-01T10:00-07:00", "2240-04-17T16:18:05.9999999+00:00", "2199-11-16T17:42:54.0000000+00:00")]
+        public void GivenADateWithApComparator_WhenBuilt_ThenCorrectExpressionShouldBeCreated(string dateTimeInput, string expectedStartValue, string expectedEndValue)
         {
             using (Mock.Property(() => Clock.UtcNowFunc, () => DateTimeOffset.Parse("2018-01-01T00:00Z")))
             {
-                var partialDateTime = PartialDateTime.Parse(input);
+                var partialDateTime = PartialDateTime.Parse(dateTimeInput);
                 var dateTimeSearchValue = new DateTimeSearchValue(partialDateTime);
 
                 Validate(
                     CreateSearchParameter(SearchParamType.Date),
                     null,
-                    input,
+                    "ap" + dateTimeInput,
                     e => ValidateMultiaryExpression(
                         e,
                         MultiaryOperator.And,

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Web;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Search;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
@@ -87,7 +88,9 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 ManagingOrganization = new ResourceReference($"Organization/{organizationResponse.Resource.Id}"),
             });
 
-            string query = $"_include=Location:organization:Organization&_lastUpdated=lt{locationResponse2.Resource.Meta.LastUpdated:o}";
+            // Format the time to fit yyyy-MM-ddTHH:mm:ss.fffffffzzz, and encode its special characters.
+            string lastUpdated = HttpUtility.UrlEncode($"{locationResponse2.Resource.Meta.LastUpdated:o}");
+            string query = $"_include=Location:organization:Organization&_lastUpdated=lt{lastUpdated}";
 
             Bundle bundle = await Client.SearchAsync(ResourceType.Location, query);
 
@@ -191,7 +194,9 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                     Result = new List<ResourceReference> { new ResourceReference($"Observation/{Fixture.TrumanSnomedObservation.Id}") },
                 });
 
-            string query = $"_tag={Fixture.Tag}&_include=DiagnosticReport:patient:Patient&_include=DiagnosticReport:result:Observation&code=429858000&_lastUpdated=lt{Fixture.PatientGroup.Meta.LastUpdated.Value:o}";
+            // Format the time to fit yyyy-MM-ddTHH:mm:ss.fffffffzzz, and encode its special characters.
+            string lastUpdated = HttpUtility.UrlEncode($"{Fixture.PatientGroup.Meta.LastUpdated:o}");
+            string query = $"_tag={Fixture.Tag}&_include=DiagnosticReport:patient:Patient&_include=DiagnosticReport:result:Observation&code=429858000&_lastUpdated=lt{lastUpdated}";
 
             Bundle bundle = await Client.SearchAsync(ResourceType.DiagnosticReport, query);
 


### PR DESCRIPTION
## Description

Previously, the `PartialDateTime` parser would read `datetime` input left to right, accepting the valid parts of the string until an incorrect value was reached (for examples, see #25).

Now, `400 Bad Request` is returned if any part of a `datetime` parameter is incorrectly formatted.

The new parser leverages the [DateTimeOffset.TryParseExact](https://docs.microsoft.com/en-us/dotnet/api/system.datetimeoffset.tryparseexact?view=netcore-3.1) method to parse input `datetime` strings.

With this implementation, we rely on the RegEx much less. However, it still benefits us in two ways:
1. It captures the parts of the `datetime` parameter that were not specified (the `DateTimeOffset` parser will auto-populate any information that is "missing")
2. It ensures that, if specified, the time zone hour is formatted with two digits (the `DateTimeOffset` parser allows `(+|-)h:mm`)

## Demo

A few test cases:

| Birthdate  | Is Valid? | Notes |
| ------------- | ------------- | ------------- |
| 1980-12-30T03:04:05.99Z  |  ✔ |  |
| 1980000000-12-30T03:04:05.99Z |  ❌  | Year must be formatted `yyyy` |
| 1980asdfghj-12-30T03:04:05.99Z |  ❌  | Year must be formatted `yyyy` |
| 1980-25-30T03:04:05.99Z |  ❌  | Month must be in range |
| 1980-12-32T03:04:05.99Z |  ❌  | Date must be in range |
| 1980-12-30T03:04:05.99-02:30 |  ✔  |  |
| 1980-12-30T03:04:05.99-2:30 |  ❌  | Time zone must be formatted `Z\|(+\|-)hh:mm`|
| le1980-12-30T03:04:05.99-02:30 |  ✔  |  |
| lg1980-12-30T03:04:05.99-02:30 |  ❌  | Invalid prefix |

![date-time-formatting2](https://user-images.githubusercontent.com/54082711/76369758-dba6bf00-62f1-11ea-9c23-97dee359353d.gif)

## Related issues

Addresses #25, #911 and [#AB72714](https://microsofthealth.visualstudio.com/Health/_workitems/edit/72714). 

## Testing

- Removes duplicate parsing logic in the `PartialDateTime` constructor that unit tests previously checked
  - These tests now call the `PartialDateTime.Parse` method
- Modifies unit tests in `SearchValueExpressionBuilderTests.cs` to call the `PartialDateTime` parser without binary prefixes, as this parsing occurs at a different layer
- Adds new unit tests
- Updates existing E2E tests where the time zone was not properly URL encoded
