### PR TITLE
Add R5 to ARM templates

### DIFF
--- a/samples/templates/default-azuredeploy-sql.json
+++ b/samples/templates/default-azuredeploy-sql.json
@@ -110,6 +110,13 @@
                 "description": "The password for the sql admin user if using SQL server."
             }
         },
+        "sqlLocation": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().location]",
+            "metadata": {
+                "description": "An override location for the sql server database."
+            }
+        },
         "fhirVersion": {
             "type": "string",
             "defaultValue": "R4",
@@ -245,7 +252,7 @@
             "name": "[variables('serviceName')]",
             "type": "Microsoft.Sql/servers",
             "apiVersion": "2015-05-01-preview",
-            "location": "[resourceGroup().location]",
+            "location": "[parameters('sqlLocation')]",
             "tags": {
                 "FhirServerSolution": "[parameters('solutionType')]"
             },
@@ -260,7 +267,7 @@
                     "dependsOn": [
                         "[variables('serviceName')]"
                     ],
-                    "location": "[resourceGroup().location]",
+                    "location": "[parameters('sqlLocation')]",
                     "tags": {
                         "FhirServerSolution": "[parameters('solutionType')]"
                     },

--- a/samples/templates/default-azuredeploy-sql.json
+++ b/samples/templates/default-azuredeploy-sql.json
@@ -115,7 +115,8 @@
             "defaultValue": "R4",
             "allowedValues": [
                 "Stu3",
-                "R4"
+                "R4",
+                "R5"
             ],
             "metadata": {
                 "description": "Only applies when MsdeployPackageUrl is not specified."

--- a/samples/templates/default-azuredeploy.json
+++ b/samples/templates/default-azuredeploy.json
@@ -118,7 +118,8 @@
             "defaultValue": "R4",
             "allowedValues": [
                 "Stu3",
-                "R4"
+                "R4",
+                "R5"
             ],
             "metadata": {
                 "description": "Only applies when MsdeployPackageUrl is not specified."

--- a/test/Microsoft.Health.Fhir.R5.Tests.E2E/Microsoft.Health.Fhir.R5.Tests.E2E.csproj
+++ b/test/Microsoft.Health.Fhir.R5.Tests.E2E/Microsoft.Health.Fhir.R5.Tests.E2E.csproj
@@ -51,7 +51,6 @@
   <Import Project="..\Microsoft.Health.Fhir.Shared.Tests.E2E\Microsoft.Health.Fhir.Shared.Tests.E2E.projitems" Label="Shared" />
   <Import Project="..\..\src\Microsoft.Health.Fhir.Shared.Tests\Microsoft.Health.Fhir.Shared.Tests.projitems" Label="Shared" />
   <Import Project="..\Microsoft.Health.Fhir.Shared.Tests.E2E.Common\Microsoft.Health.Fhir.Shared.Tests.E2E.Common.projitems" Label="Shared" />
-  <Import Project="..\Microsoft.Health.Fhir.Shared.Tests.Crucible\Microsoft.Health.Fhir.Shared.Tests.Crucible.projitems" Label="Shared" />
 
   <Target Name="VerifyExactSdkVersion" BeforeTargets="Build">
 


### PR DESCRIPTION
## Description
Adds R5 to the default-azuredeploy ARM templates.
Adds an option to override the SQL database location in default-azuredeploy-sql.

## Related issues
Addresses [issue #862].

## Testing
Deployed test environments using both templates.
