### PR TITLE
Support _since paramter for $export requests

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportJobTaskTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportJobTaskTests.cs
@@ -20,6 +20,7 @@ using Microsoft.Health.Fhir.Core.Features.Operations.Export.ExportDestinationCli
 using Microsoft.Health.Fhir.Core.Features.Operations.Export.Models;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Search;
+using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Core.UnitTests.Extensions;
 using Microsoft.Health.Fhir.Tests.Common;
 using NSubstitute;
@@ -97,7 +98,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
                new Uri("https://localhost/ExportJob/"),
                "Patient",
                "hash",
-               since: Core.Models.PartialDateTime.MinValue.ToString());
+               since: Core.Models.PartialDateTime.MinValue);
 
             SetupExportJobRecordAndOperationDataStore(exportJobRecordWithSince);
 
@@ -161,7 +162,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
                new Uri("https://localhost/ExportJob/"),
                "Patient",
                "hash",
-               since: Core.Models.PartialDateTime.MinValue.ToString());
+               since: PartialDateTime.MinValue);
             SetupExportJobRecordAndOperationDataStore(exportJobRecordWithSince);
 
             // First search returns a search result with continuation token.
@@ -195,7 +196,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
             return arg => arg != null && Tuple.Create("_count", "1").Equals(arg[0]) && Tuple.Create("_lastUpdated", $"le{_exportJobRecord.QueuedTime.ToString("o")}").Equals(arg[1]);
         }
 
-        private Expression<Predicate<IReadOnlyList<Tuple<string, string>>>> CreateQueryParametersExpression(string since)
+        private Expression<Predicate<IReadOnlyList<Tuple<string, string>>>> CreateQueryParametersExpression(PartialDateTime since)
         {
             return arg => arg != null &&
                 Tuple.Create("_count", "1").Equals(arg[0]) &&
@@ -211,7 +212,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
                 Tuple.Create("_lastUpdated", $"le{_exportJobRecord.QueuedTime.ToString("o")}").Equals(arg[2]);
         }
 
-        private Expression<Predicate<IReadOnlyList<Tuple<string, string>>>> CreateQueryParametersExpressionWithContinuationToken(string continuationToken, string since)
+        private Expression<Predicate<IReadOnlyList<Tuple<string, string>>>> CreateQueryParametersExpressionWithContinuationToken(string continuationToken, PartialDateTime since)
         {
             return arg => arg != null &&
                 Tuple.Create("ct", continuationToken).Equals(arg[0]) &&

--- a/src/Microsoft.Health.Fhir.Core/Extensions/ExportMediatorExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Extensions/ExportMediatorExtensions.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using EnsureThat;
 using MediatR;
 using Microsoft.Health.Fhir.Core.Messages.Export;
+using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Core.Extensions
 {
@@ -17,14 +18,15 @@ namespace Microsoft.Health.Fhir.Core.Extensions
         public static async Task<CreateExportResponse> ExportAsync(
             this IMediator mediator,
             Uri requestUri,
+            PartialDateTime since,
             CancellationToken cancellationToken)
         {
             EnsureArg.IsNotNull(mediator, nameof(mediator));
             EnsureArg.IsNotNull(requestUri, nameof(requestUri));
 
-            CreateExportRequest request = new CreateExportRequest(requestUri);
+            var request = new CreateExportRequest(requestUri, since: since);
 
-            var response = await mediator.Send(request, cancellationToken);
+            CreateExportResponse response = await mediator.Send(request, cancellationToken);
             return response;
         }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
             if (outcome == null)
             {
-                var jobRecord = new ExportJobRecord(request.RequestUri, request.ResourceType, hash, requestorClaims, request.Since?.ToString());
+                var jobRecord = new ExportJobRecord(request.RequestUri, request.ResourceType, hash, requestorClaims, request.Since);
 
                 outcome = await _fhirOperationDataStore.CreateExportJobAsync(jobRecord, cancellationToken);
             }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
             if (outcome == null)
             {
-                var jobRecord = new ExportJobRecord(request.RequestUri, request.ResourceType, hash, requestorClaims);
+                var jobRecord = new ExportJobRecord(request.RequestUri, request.ResourceType, hash, requestorClaims, request.Since.ToString());
 
                 outcome = await _fhirOperationDataStore.CreateExportJobAsync(jobRecord, cancellationToken);
             }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
             if (outcome == null)
             {
-                var jobRecord = new ExportJobRecord(request.RequestUri, request.ResourceType, hash, requestorClaims, request.Since.ToString());
+                var jobRecord = new ExportJobRecord(request.RequestUri, request.ResourceType, hash, requestorClaims, request.Since?.ToString());
 
                 outcome = await _fhirOperationDataStore.CreateExportJobAsync(jobRecord, cancellationToken);
             }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
                 // The first item is placeholder for continuation token so that it can be updated efficiently later.
                 Tuple<string, string>[] queryParameters;
-                if (!string.IsNullOrWhiteSpace(_exportJobRecord.Since))
+                if (_exportJobRecord.Since != null)
                 {
                     queryParameters = new Tuple<string, string>[4];
                     queryParameters[3] = Tuple.Create(KnownQueryParameterNames.LastUpdated, $"ge{_exportJobRecord.Since}");

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -87,12 +87,20 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                 uint currentBatchId = progress.Page;
 
                 // The first item is placeholder for continuation token so that it can be updated efficiently later.
-                var queryParameters = new Tuple<string, string>[]
+                Tuple<string, string>[] queryParameters;
+                if (!string.IsNullOrWhiteSpace(_exportJobRecord.Since))
                 {
-                    Tuple.Create(KnownQueryParameterNames.ContinuationToken, progress.ContinuationToken),
-                    Tuple.Create(KnownQueryParameterNames.Count, _exportJobConfiguration.MaximumNumberOfResourcesPerQuery.ToString(CultureInfo.InvariantCulture)),
-                    Tuple.Create(KnownQueryParameterNames.LastUpdated, $"le{_exportJobRecord.QueuedTime.ToString("o", CultureInfo.InvariantCulture)}"),
-                };
+                    queryParameters = new Tuple<string, string>[4];
+                    queryParameters[3] = Tuple.Create(KnownQueryParameterNames.LastUpdated, $"ge{_exportJobRecord.Since}");
+                }
+                else
+                {
+                    queryParameters = new Tuple<string, string>[3];
+                }
+
+                queryParameters[0] = Tuple.Create(KnownQueryParameterNames.ContinuationToken, progress.ContinuationToken);
+                queryParameters[1] = Tuple.Create(KnownQueryParameterNames.Count, _exportJobConfiguration.MaximumNumberOfResourcesPerQuery.ToString(CultureInfo.InvariantCulture));
+                queryParameters[2] = Tuple.Create(KnownQueryParameterNames.LastUpdated, $"le{_exportJobRecord.QueuedTime.ToString("o", CultureInfo.InvariantCulture)}");
 
                 // Process the export if:
                 // 1. There is continuation token, which means there is more resource to be exported.

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobRecord.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobRecord.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
     /// </summary>
     public class ExportJobRecord
     {
-        public ExportJobRecord(Uri requestUri, string resourceType, string hash, IReadOnlyCollection<KeyValuePair<string, string>> requestorClaims = null)
+        public ExportJobRecord(Uri requestUri, string resourceType, string hash, IReadOnlyCollection<KeyValuePair<string, string>> requestorClaims = null, string since = null)
         {
             EnsureArg.IsNotNull(requestUri, nameof(requestUri));
             EnsureArg.IsNotNullOrWhiteSpace(hash, nameof(hash));
@@ -24,6 +24,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
             RequestUri = requestUri;
             ResourceType = resourceType;
             RequestorClaims = requestorClaims;
+            Since = since;
 
             // Default values
             SchemaVersion = 1;
@@ -82,5 +83,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
 
         [JsonProperty(JobRecordProperties.FailureDetails)]
         public ExportJobFailureDetails FailureDetails { get; set; }
+
+        [JsonProperty(JobRecordProperties.Since)]
+        public string Since { get; private set; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobRecord.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobRecord.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using EnsureThat;
+using Microsoft.Health.Fhir.Core.Models;
 using Newtonsoft.Json;
 
 namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
@@ -15,7 +16,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
     /// </summary>
     public class ExportJobRecord
     {
-        public ExportJobRecord(Uri requestUri, string resourceType, string hash, IReadOnlyCollection<KeyValuePair<string, string>> requestorClaims = null, string since = null)
+        public ExportJobRecord(Uri requestUri, string resourceType, string hash, IReadOnlyCollection<KeyValuePair<string, string>> requestorClaims = null, PartialDateTime since = null)
         {
             EnsureArg.IsNotNull(requestUri, nameof(requestUri));
             EnsureArg.IsNotNullOrWhiteSpace(hash, nameof(hash));
@@ -85,6 +86,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
         public ExportJobFailureDetails FailureDetails { get; set; }
 
         [JsonProperty(JobRecordProperties.Since)]
-        public string Since { get; private set; }
+        public PartialDateTime Since { get; private set; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
@@ -62,5 +62,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations
         public const string FailureStatusCode = "failureStatusCode";
 
         public const string FailureDetails = "failureDetails";
+
+        public const string Since = "since";
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Messages/Export/CreateExportRequest.cs
+++ b/src/Microsoft.Health.Fhir.Core/Messages/Export/CreateExportRequest.cs
@@ -6,21 +6,25 @@
 using System;
 using EnsureThat;
 using MediatR;
+using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Core.Messages.Export
 {
     public class CreateExportRequest : IRequest<CreateExportResponse>
     {
-        public CreateExportRequest(Uri requestUri, string resourceType = null)
+        public CreateExportRequest(Uri requestUri, string resourceType = null, PartialDateTime since = null)
         {
             EnsureArg.IsNotNull(requestUri, nameof(requestUri));
 
             RequestUri = requestUri;
             ResourceType = resourceType;
+            Since = since;
         }
 
         public Uri RequestUri { get; }
 
         public string ResourceType { get; }
+
+        public PartialDateTime Since { get; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Models/PartialDateTime.cs
+++ b/src/Microsoft.Health.Fhir.Core/Models/PartialDateTime.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
 using EnsureThat;
+using Newtonsoft.Json;
 
 namespace Microsoft.Health.Fhir.Core.Models
 {
@@ -70,6 +71,11 @@ namespace Microsoft.Health.Fhir.Core.Models
             UtcOffset = utcOffset;
         }
 
+        [JsonConstructor]
+        protected PartialDateTime()
+        {
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="PartialDateTime"/> class.
         /// </summary>
@@ -99,42 +105,50 @@ namespace Microsoft.Health.Fhir.Core.Models
         /// <summary>
         /// The year component.
         /// </summary>
-        public int Year { get; }
+        [JsonProperty("year")]
+        public int Year { get; private set; }
 
         /// <summary>
         /// The optional month component.
         /// </summary>
-        public int? Month { get; }
+        [JsonProperty("month")]
+        public int? Month { get; private set; }
 
         /// <summary>
         /// The optional day component.
         /// </summary>
-        public int? Day { get; }
+        [JsonProperty("day")]
+        public int? Day { get; private set; }
 
         /// <summary>
         /// The optional hour component.
         /// </summary>
-        public int? Hour { get; }
+        [JsonProperty("hour")]
+        public int? Hour { get; private set; }
 
         /// <summary>
         /// The optional minute component.
         /// </summary>
-        public int? Minute { get; }
+        [JsonProperty("minute")]
+        public int? Minute { get; private set; }
 
         /// <summary>
         /// The optional second component.
         /// </summary>
-        public int? Second { get; }
+        [JsonProperty("second")]
+        public int? Second { get; private set; }
 
         /// <summary>
         /// The optional fraction component representing the fraction of second up to 7 digits.
         /// </summary>
-        public decimal? Fraction { get; }
+        [JsonProperty("fraction")]
+        public decimal? Fraction { get; private set; }
 
         /// <summary>
         /// The optional UTC offset.
         /// </summary>
-        public TimeSpan? UtcOffset { get; }
+        [JsonProperty("utcOffset")]
+        public TimeSpan? UtcOffset { get; private set; }
 
         /// <summary>
         /// Parses the string value to an instance of <see cref="PartialDateTime"/>.

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ExportControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ExportControllerTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
         {
             var exportController = GetController(new ExportJobConfiguration() { Enabled = false });
 
-            await Assert.ThrowsAsync<RequestNotValidException>(() => exportController.Export());
+            await Assert.ThrowsAsync<RequestNotValidException>(() => exportController.Export(since: null));
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/ValidateExportRequestFilterAttributeTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/ValidateExportRequestFilterAttributeTests.cs
@@ -13,6 +13,8 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Health.Fhir.Api.Features.Filters;
 using Microsoft.Health.Fhir.Core.Exceptions;
+using Microsoft.Health.Fhir.Core.Features;
+using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Net.Http.Headers;
 using Xunit;
 
@@ -80,7 +82,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
         }
 
         [Fact]
-        public void GivenARequestWithCorrectHeadersAndQueryParam_WhenGettingAnExportOperationRequest_ThenARequestNotValidExceptionShouldBeThrown()
+        public void GivenARequestWithCorrectHeadersAndUnsupportedQueryParam_WhenGettingAnExportOperationRequest_ThenARequestNotValidExceptionShouldBeThrown()
         {
             var context = CreateContext();
             context.HttpContext.Request.Headers.Add(HeaderNames.Accept, CorrectAcceptHeaderValue);
@@ -96,7 +98,23 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
         }
 
         [Fact]
-        public void GiveARequestWithValidAcceptAndPreferHeaderAndNoQueryParams_WhenGettingAnExportOperationRequest_ThenTheResultIsSuccessful()
+        public void GiveARequestWithCorrectHeaderAndSinceQueryParam_WhenGettingAnExportOperationRequest_ThenTheResultIsSuccessful()
+        {
+            var context = CreateContext();
+            context.HttpContext.Request.Headers.Add(HeaderNames.Accept, CorrectAcceptHeaderValue);
+            context.HttpContext.Request.Headers.Add(PreferHeaderName, CorrectPreferHeaderValue);
+
+            var queryParams = new Dictionary<string, StringValues>()
+            {
+                { KnownQueryParameterNames.Since, PartialDateTime.MinValue.ToString() },
+            };
+            context.HttpContext.Request.Query = new QueryCollection(queryParams);
+
+            _filter.OnActionExecuting(context);
+        }
+
+        [Fact]
+        public void GiveARequestWithCorrectHeaderAndNoQueryParams_WhenGettingAnExportOperationRequest_ThenTheResultIsSuccessful()
         {
             var context = CreateContext();
             context.HttpContext.Request.Headers.Add(HeaderNames.Accept, CorrectAcceptHeaderValue);

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/ValidateExportRequestFilterAttributeTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/ValidateExportRequestFilterAttributeTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
         [InlineData("text/xml")]
         [InlineData("application/json")]
         [InlineData("*/*")]
-        public void GiveARequestWithInvalidAcceptHeader_WhenGettingAnExportOperationRequest_ThenARequestNotValidExceptionShouldBeThrown(string acceptHeader)
+        public void GivenARequestWithInvalidAcceptHeader_WhenGettingAnExportOperationRequest_ThenARequestNotValidExceptionShouldBeThrown(string acceptHeader)
         {
             var context = CreateContext();
 
@@ -49,7 +49,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
         }
 
         [Fact]
-        public void GiveARequestWithNoAcceptHeader_WhenGettingAnExportOperationRequest_ThenARequestNotValidExceptionShouldBeThrown()
+        public void GivenARequestWithNoAcceptHeader_WhenGettingAnExportOperationRequest_ThenARequestNotValidExceptionShouldBeThrown()
         {
             var context = CreateContext();
 
@@ -81,8 +81,11 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
             Assert.Throws<RequestNotValidException>(() => _filter.OnActionExecuting(context));
         }
 
-        [Fact]
-        public void GivenARequestWithCorrectHeadersAndUnsupportedQueryParam_WhenGettingAnExportOperationRequest_ThenARequestNotValidExceptionShouldBeThrown()
+        [InlineData("since")]
+        [InlineData("_SINCE")]
+        [InlineData("queryParam")]
+        [Theory]
+        public void GivenARequestWithCorrectHeadersAndUnsupportedQueryParam_WhenGettingAnExportOperationRequest_ThenARequestNotValidExceptionShouldBeThrown(string queryParamName)
         {
             var context = CreateContext();
             context.HttpContext.Request.Headers.Add(HeaderNames.Accept, CorrectAcceptHeaderValue);
@@ -90,7 +93,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
 
             var queryParams = new Dictionary<string, StringValues>()
             {
-                { "queryParam", "paramValue" },
+                { queryParamName, "paramValue" },
             };
             context.HttpContext.Request.Query = new QueryCollection(queryParams);
 
@@ -98,7 +101,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
         }
 
         [Fact]
-        public void GiveARequestWithCorrectHeaderAndSinceQueryParam_WhenGettingAnExportOperationRequest_ThenTheResultIsSuccessful()
+        public void GivenARequestWithCorrectHeaderAndSinceQueryParam_WhenGettingAnExportOperationRequest_ThenTheResultIsSuccessful()
         {
             var context = CreateContext();
             context.HttpContext.Request.Headers.Add(HeaderNames.Accept, CorrectAcceptHeaderValue);
@@ -114,7 +117,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
         }
 
         [Fact]
-        public void GiveARequestWithCorrectHeaderAndNoQueryParams_WhenGettingAnExportOperationRequest_ThenTheResultIsSuccessful()
+        public void GivenARequestWithCorrectHeaderAndNoQueryParams_WhenGettingAnExportOperationRequest_ThenTheResultIsSuccessful()
         {
             var context = CreateContext();
             context.HttpContext.Request.Headers.Add(HeaderNames.Accept, CorrectAcceptHeaderValue);

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ExportController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ExportController.cs
@@ -20,10 +20,12 @@ using Microsoft.Health.Fhir.Api.Features.Routing;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Core.Features;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Routing;
 using Microsoft.Health.Fhir.Core.Messages.Export;
+using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.ValueSets;
 
 namespace Microsoft.Health.Fhir.Api.Controllers
@@ -73,14 +75,14 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         [Route(KnownRoutes.Export)]
         [ServiceFilter(typeof(ValidateExportRequestFilterAttribute))]
         [AuditEventType(AuditEventSubType.Export)]
-        public async Task<IActionResult> Export()
+        public async Task<IActionResult> Export([FromQuery(Name = KnownQueryParameterNames.Since)] PartialDateTime since)
         {
             if (!_exportConfig.Enabled)
             {
                 throw new RequestNotValidException(string.Format(Resources.OperationNotEnabled, OperationsConstants.Export));
             }
 
-            CreateExportResponse response = await _mediator.ExportAsync(_fhirRequestContextAccessor.FhirRequestContext.Uri, HttpContext.RequestAborted);
+            CreateExportResponse response = await _mediator.ExportAsync(_fhirRequestContextAccessor.FhirRequestContext.Uri, since, HttpContext.RequestAborted);
 
             var exportResult = ExportResult.Accepted();
             exportResult.SetContentLocationHeader(_urlResolver, OperationsConstants.Export, response.JobId);


### PR DESCRIPTION
## Description
Added support for _since query parameter for $export requests.

## Related issues
Addresses [issue [AB#68721](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/68721)].

## Testing
UTs, E2E tests and manual testing.
