### PR TITLE
Handle null code value in search indexer

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/CodeOfTToTokenSearchValueTypeConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/CodeOfTToTokenSearchValueTypeConverterTests.cs
@@ -20,5 +20,14 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
                 ValidateToken,
                 new Token("http://hl7.org/fhir/resource-types", "Patient"));
         }
+
+        [Fact]
+        public void GivenANullCode_WhenConverted_ThenNullValueReturned()
+        {
+            Test(
+                code => code.Value = null,
+                ValidateNull,
+                new Code<ResourceType>(null));
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Converters/CodeOfTToTokenSearchValueTypeConverter.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Converters/CodeOfTToTokenSearchValueTypeConverter.cs
@@ -31,9 +31,16 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Converters
 
             EnsureArg.IsTrue(type.IsGenericType && type.GetGenericTypeDefinition() == FhirElementType, nameof(value));
 
-            ISystemAndCode systemAndCode = (ISystemAndCode)value;
+            var systemAndCode = value as ISystemAndCode;
 
-            yield return new TokenSearchValue(systemAndCode.System, systemAndCode.Code, null);
+            if (systemAndCode == null || systemAndCode.Code == null)
+            {
+                yield return null;
+            }
+            else
+            {
+                yield return new TokenSearchValue(systemAndCode.System, systemAndCode.Code, null);
+            }
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Converters/CodeOfTToTokenSearchValueTypeConverter.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Converters/CodeOfTToTokenSearchValueTypeConverter.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Converters
 
             var systemAndCode = value as ISystemAndCode;
 
-            if (systemAndCode == null || systemAndCode.Code == null)
+            if (systemAndCode == null || string.IsNullOrEmpty(systemAndCode.Code)
             {
                 yield return null;
             }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Converters/CodeOfTToTokenSearchValueTypeConverter.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Converters/CodeOfTToTokenSearchValueTypeConverter.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Converters
 
             var systemAndCode = value as ISystemAndCode;
 
-            if (systemAndCode == null || string.IsNullOrEmpty(systemAndCode.Code)
+            if (systemAndCode == null || string.IsNullOrEmpty(systemAndCode.Code))
             {
                 yield return null;
             }

--- a/src/Microsoft.Health.Fhir.Shared.Tests/Search/SearchValueValidationHelper.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Tests/Search/SearchValueValidationHelper.cs
@@ -78,6 +78,11 @@ namespace Microsoft.Health.Fhir.Tests.Common.Search
             Assert.Equal(expected.Text, tsv.Text);
         }
 
+        public static void ValidateNull(Code<ResourceType> expected, ISearchValue sv)
+        {
+            Assert.Null(sv);
+        }
+
         public static void ValidateUri(string expected, ISearchValue sv)
         {
             UriSearchValue usv = Assert.IsType<UriSearchValue>(sv);


### PR DESCRIPTION
## Description
Addresses a 500 error that was being thrown by the SearchIndexer for for null coded values

## Related issues
Addresses [AB#72608](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/72608).

## Testing
Added a unit test which repo'd the error.  Then saw it pass when the error was addressed.
