### PR TITLE
Fixes diagnostics message for resourceType passed as empty

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Formatters/FhirJsonInputFormatterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Formatters/FhirJsonInputFormatterTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Buffers;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Hl7.Fhir.Model;
@@ -94,6 +95,22 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Formatters
 
             Assert.False(result.IsModelSet);
             Assert.Equal(1, modelStateDictionary.ErrorCount);
+        }
+
+        [Fact]
+        public async Task GivenAResourceWithMissingResourceType_WhenParsing_ThenAnErrorShouldBeAddedToModelState()
+        {
+            var modelStateDictionary = new ModelStateDictionary();
+
+            var result = await ReadRequestBody(Samples.GetJson("PatientMissingResourceType"), modelStateDictionary);
+
+            Assert.False(result.IsModelSet);
+            Assert.Equal(1, modelStateDictionary.ErrorCount);
+
+            (_, ModelStateEntry entry) = modelStateDictionary.First();
+
+            Assert.Single(entry.Errors);
+            Assert.Equal(Api.Resources.ParsingError, entry.Errors.First().ErrorMessage);
         }
 
         private static async Task<InputFormatterResult> ReadRequestBody(string sampleJson, ModelStateDictionary modelStateDictionary)

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Formatters/FhirJsonInputFormatter.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Formatters/FhirJsonInputFormatter.cs
@@ -95,7 +95,8 @@ namespace Microsoft.Health.Fhir.Api.Features.Formatters
 
                 if (delayedException != null)
                 {
-                    var errorMessage = string.IsNullOrEmpty(delayedException.Message) ? Api.Resources.ParsingError : delayedException.Message;
+                    // Avoid using the exception's message, since the exception thrown in the HL7 FHIR core library has an incorrect message.
+                    var errorMessage = Api.Resources.ParsingError;
 
                     // Add model state information to return to the client
                     context.ModelState.TryAddModelError(string.Empty, errorMessage);

--- a/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
+++ b/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
@@ -88,6 +88,7 @@
     <None Remove="TestFiles\Normative\Patient-f001.json" />
     <None Remove="TestFiles\Normative\Patient.json" />
     <None Remove="TestFiles\Normative\Patient.xml" />
+    <None Remove="TestFiles\Normative\PatientMissingResourceType.json" />
     <None Remove="TestFiles\Normative\PatientWithMinimalData.json" />
     <None Remove="TestFiles\Normative\Weight.json" />
     <None Remove="TestFiles\Normative\WeightInGrams.json" />
@@ -195,6 +196,7 @@
     <EmbeddedResource Include="TestFiles\Normative\ObservationWithTPMTDiplotype.json" />
     <EmbeddedResource Include="TestFiles\Normative\ObservationWithTPMTHaplotypeOne.json" />
     <EmbeddedResource Include="TestFiles\Normative\Patient-f001.json" />
+    <EmbeddedResource Include="TestFiles\Normative\PatientMissingResourceType.json" />
     <EmbeddedResource Include="TestFiles\Normative\PatientWithMinimalData.json" />
     <EmbeddedResource Include="TestFiles\Normative\Patient.json" />
     <EmbeddedResource Include="TestFiles\Normative\Patient.xml" />

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/PatientMissingResourceType.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/PatientMissingResourceType.json
@@ -1,0 +1,165 @@
+﻿{
+    "resourceType": "",
+    "id": "example",
+    "text": {
+        "status": "generated",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n\t\t\t<table>\n\t\t\t\t<tbody>\n\t\t\t\t\t<tr>\n\t\t\t\t\t\t<td>Name</td>\n\t\t\t\t\t\t<td>Peter James \n              <b>Chalmers</b> (&quot;Jim&quot;)\n            </td>\n\t\t\t\t\t</tr>\n\t\t\t\t\t<tr>\n\t\t\t\t\t\t<td>Address</td>\n\t\t\t\t\t\t<td>534 Erewhon, Pleasantville, Vic, 3999</td>\n\t\t\t\t\t</tr>\n\t\t\t\t\t<tr>\n\t\t\t\t\t\t<td>Contacts</td>\n\t\t\t\t\t\t<td>Home: unknown. Work: (03) 5555 6473</td>\n\t\t\t\t\t</tr>\n\t\t\t\t\t<tr>\n\t\t\t\t\t\t<td>Id</td>\n\t\t\t\t\t\t<td>MRN: 12345 (Acme Healthcare)</td>\n\t\t\t\t\t</tr>\n\t\t\t\t</tbody>\n\t\t\t</table>\n\t\t</div>"
+    },
+    "identifier": [
+        {
+            "use": "usual",
+            "type": {
+                "coding": [
+                    {
+                        "system": "http://hl7.org/fhir/v2/0203",
+                        "code": "MR"
+                    }
+                ]
+            },
+            "system": "urn:oid:1.2.36.146.595.217.0.1",
+            "value": "12345",
+            "period": {
+                "start": "2001-05-06"
+            },
+            "assigner": {
+                "display": "Acme Healthcare"
+            }
+        }
+    ],
+    "active": true,
+    "name": [
+        {
+            "use": "official",
+            "family": "Chalmers",
+            "given": [
+                "Peter",
+                "James"
+            ]
+        },
+        {
+            "use": "usual",
+            "given": [
+                "Jim"
+            ]
+        },
+        {
+            "use": "maiden",
+            "family": "Windsor",
+            "given": [
+                "Peter",
+                "James"
+            ],
+            "period": {
+                "end": "2002"
+            }
+        }
+    ],
+    "telecom": [
+        {
+            "use": "home"
+        },
+        {
+            "system": "phone",
+            "value": "(03) 5555 6473",
+            "use": "work",
+            "rank": 1
+        },
+        {
+            "system": "phone",
+            "value": "(03) 3410 5613",
+            "use": "mobile",
+            "rank": 2
+        },
+        {
+            "system": "phone",
+            "value": "(03) 5555 8834",
+            "use": "old",
+            "period": {
+                "end": "2014"
+            }
+        }
+    ],
+    "gender": "male",
+    "birthDate": "1974-12-25",
+    "_birthDate": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/patient-birthTime",
+                "valueDateTime": "1974-12-25T14:35:45-05:00"
+            }
+        ]
+    },
+    "deceasedBoolean": false,
+    "address": [
+        {
+            "use": "home",
+            "type": "both",
+            "text": "534 Erewhon St PeasantVille, Rainbow, Vic  3999",
+            "line": [
+                "534 Erewhon St"
+            ],
+            "city": "PleasantVille",
+            "district": "Rainbow",
+            "state": "Vic",
+            "postalCode": "3999",
+            "period": {
+                "start": "1974-12-25"
+            }
+        }
+    ],
+    "contact": [
+        {
+            "relationship": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/v2/0131",
+                            "code": "N"
+                        }
+                    ]
+                }
+            ],
+            "name": {
+                "family": "du Marché",
+                "_family": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/humanname-own-prefix",
+                            "valueString": "VV"
+                        }
+                    ]
+                },
+                "given": [
+                    "Bénédicte"
+                ]
+            },
+            "telecom": [
+                {
+                    "system": "phone",
+                    "value": "+33 (237) 998327"
+                }
+            ],
+            "address": {
+                "use": "home",
+                "type": "both",
+                "line": [
+                    "534 Erewhon St"
+                ],
+                "city": "PleasantVille",
+                "district": "Rainbow",
+                "state": "Vic",
+                "postalCode": "3999",
+                "period": {
+                    "start": "1974-12-25"
+                }
+            },
+            "gender": "female",
+            "period": {
+                "start": "2012"
+            }
+        }
+    ],
+    "managingOrganization": {
+        "reference": "Organization/1"
+    }
+}

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ValidateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ValidateTests.cs
@@ -55,9 +55,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Theory]
         [InlineData(
             "Patient/$validate",
-            "{\"resourceType\":\"Patient\",\"name\":\"test, one\"}",
-            "Type checking the data: Since type HumanName is not a primitive, it cannot have a value (at Resource.name[0])")]
-        public async void GivenAValidateRequest_WhenTheResourceIsInvalid_ThenADetailedErrorIsReturned(string path, string payload, string expectedIssue)
+            "{\"resourceType\":\"Patient\",\"name\":\"test, one\"}")]
+        public async void GivenAValidateRequest_WhenTheResourceIsInvalid_ThenADetailedErrorIsReturned(string path, string payload)
         {
             OperationOutcome outcome = await _client.ValidateAsync(path, payload);
 
@@ -66,7 +65,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
                     outcome.Issue[0],
                     OperationOutcome.IssueSeverity.Error,
                     OperationOutcome.IssueType.Invalid,
-                    expectedIssue);
+                    Api.Resources.ParsingError);
         }
 
         [Theory]


### PR DESCRIPTION
## Description
Previously, when a JSON-formatted resource was created with `"resourceType": ""`, the following error message was returned:

`"type (at Cannot locate type information for type '')"`

This is the message attached to the exception thrown in the HL7 FHIR core library.

Now, this returns a general parsing error:

`"Error occurred when parsing model."`

![resouce-type-is-empty](https://user-images.githubusercontent.com/54082711/77692846-9aa2e180-6f64-11ea-9787-f95f59e37b1d.png)

## Related issues
Addresses #876 and [#AB73175](https://microsofthealth.visualstudio.com/Health/_workitems/edit/73175).

## Testing
Adds a new unit test.
