### PR TITLE
Updates error for invalid or unsupported _total parameter value

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Health.Fhir.Core {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Resources {
+    public class Resources {
         
         private static global::System.Resources.ResourceManager resourceMan;
         
@@ -433,7 +433,7 @@ namespace Microsoft.Health.Fhir.Core {
         /// <summary>
         ///   Looks up a localized string similar to The &apos;_total&apos; parameter value &apos;{0}&apos; is invalid. The supported values are: {1}..
         /// </summary>
-        internal static string InvalidTotalParameter {
+        public static string InvalidTotalParameter {
             get {
                 return ResourceManager.GetString("InvalidTotalParameter", resourceCulture);
             }
@@ -847,7 +847,7 @@ namespace Microsoft.Health.Fhir.Core {
         /// <summary>
         ///   Looks up a localized string similar to The &apos;_total&apos; parameter value &apos;{0}&apos; is not supported. The supported values are: {1}..
         /// </summary>
-        internal static string UnsupportedTotalParameter {
+        public static string UnsupportedTotalParameter {
             get {
                 return ResourceManager.GetString("UnsupportedTotalParameter", resourceCulture);
             }

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Health.Fhir.Core {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -431,6 +431,15 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The &apos;_total&apos; parameter value &apos;{0}&apos; is invalid. The supported values are: {1}..
+        /// </summary>
+        internal static string InvalidTotalParameter {
+            get {
+                return ResourceManager.GetString("InvalidTotalParameter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid value for :missing modifier. Valid values are: true, false..
         /// </summary>
         internal static string InvalidValueTypeForMissingModifier {
@@ -836,7 +845,7 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The requested &quot;_total&quot; parameter is not supported..
+        ///   Looks up a localized string similar to The &apos;_total&apos; parameter value &apos;{0}&apos; is not supported. The supported values are: {1}..
         /// </summary>
         internal static string UnsupportedTotalParameter {
             get {

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -251,6 +251,10 @@
   <data name="InvalidSearchCountSpecified" xml:space="preserve">
     <value>The count must be greater than zero.</value>
   </data>
+  <data name="InvalidTotalParameter" xml:space="preserve">
+    <value>The '_total' parameter value '{0}' is invalid. The supported values are: {1}.</value>
+    <comment>{0}: the invalid _total parameter value. {1}: the supported _total parameter values.</comment>
+  </data>
   <data name="InvalidValueTypeForMissingModifier" xml:space="preserve">
     <value>Invalid value for :missing modifier. Valid values are: true, false.</value>
   </data>
@@ -392,7 +396,8 @@
     <value>Unsupported configuration found.</value>
   </data>
   <data name="UnsupportedTotalParameter" xml:space="preserve">
-    <value>The requested "_total" parameter is not supported.</value>
+    <value>The '_total' parameter value '{0}' is not supported. The supported values are: {1}.</value>
+    <comment>{0}: the unsupported _total parameter value. {1}: the supported _total parameter values.</comment>
   </data>
   <data name="UpdateRequestsRequireId" xml:space="preserve">
     <value>Resource id is required for updates.</value>

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using EnsureThat;
@@ -92,19 +93,21 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                 }
                 else if (string.Compare(query.Item1, KnownQueryParameterNames.Total, StringComparison.OrdinalIgnoreCase) == 0)
                 {
+                    // Estimate is not yet supported.
+                    var supportedTotalTypes = new string($"'{TotalType.Accurate}', '{TotalType.None}'").ToLower(CultureInfo.CurrentCulture);
+
                     if (Enum.TryParse<TotalType>(query.Item2, true, out var totalType))
                     {
-                        // Estimate is not yet supported.
                         if (totalType == TotalType.Estimate)
                         {
-                            throw new SearchOperationNotSupportedException(Core.Resources.UnsupportedTotalParameter);
+                            throw new SearchOperationNotSupportedException(string.Format(Core.Resources.UnsupportedTotalParameter, query.Item2, supportedTotalTypes));
                         }
 
                         searchOptions.IncludeTotal = totalType;
                     }
                     else
                     {
-                        throw new BadRequestException(Core.Resources.UnsupportedTotalParameter);
+                        throw new BadRequestException(string.Format(Core.Resources.InvalidTotalParameter, query.Item2, supportedTotalTypes));
                     }
                 }
                 else


### PR DESCRIPTION
## Description

Previously, when an unsupported or invalid `_total` parameter value was provided, the error message that was returned was:

`"The requested \"_total\" parameter is not supported."`

This PR updates the error message to be:

`"The '_total' parameter value 'estimate' is unsupported. The supported values are: 'accurate', 'none'."` (in the case of an unsupported value)

`"The '_total' parameter value 'x' is invalid. The supported values are: 'accurate', 'none'."` (in the case of an invalid value)

![total-error-messages](https://user-images.githubusercontent.com/54082711/78185970-c7517000-7420-11ea-9748-f0a5b2d183e5.gif)

## Related issues
Addresses [73289](https://microsofthealth.visualstudio.com/Health/_workitems/edit/73289).

## Testing

Updates existing E2E tests to validate error message.