### PR TITLE
Role names to match new RBAC changes

### DIFF
--- a/docs/DefaultDeployment.md
+++ b/docs/DefaultDeployment.md
@@ -27,10 +27,10 @@ Register an AAD Application for the FHIR server API:
 
 ```PowerShell
 $fhirServiceName = "myfhirservice"
-$apiAppReg = New-FhirServerApiApplicationRegistration -FhirServiceName $fhirServiceName -AppRoles admin,nurse,patient
+$apiAppReg = New-FhirServerApiApplicationRegistration -FhirServiceName $fhirServiceName -AppRoles globalAdmin
 ```
 
-The `-AppRoles` defines a set of roles that can be granted to users or service principals (service accounts) interacting with the FHIR server API. Configuration settings for the FHIR server will determine which privileges (Read, Write, etc.) that are assosiated with each role. 
+The `-AppRoles` defines a set of roles that can be granted to users or service principals (service accounts) interacting with the FHIR server API. Configuration settings for the FHIR server will determine which privileges (Read, Write, etc.) that are assosiated with each role. The allowed roles are enumerated in [roles.json](../src/Microsoft.Health.Fhir.Shared.Web/roles.json).
 
 To access the FHIR server from a client, you will also need a client AAD Application registration with a client secret. This client AAD Application registration will need to have appropriate application permissions and reply URLs configured. Here is how to register a client AAD Application for use with [Postman](https://getpostman.com):
 
@@ -41,13 +41,13 @@ $clientAppReg = New-FhirServerClientApplicationRegistration -ApiAppId $apiAppReg
 If you would like a client application to be able to act as a service account, you can assign roles to the client application:
 
 ```PowerShell
-Set-FhirServerClientAppRoleAssignments -AppId $clientAppReg.AppId -ApiAppId $apiAppReg.AppId -AppRoles admin,patient
+Set-FhirServerClientAppRoleAssignments -AppId $clientAppReg.AppId -ApiAppId $apiAppReg.AppId -AppRoles globalAdmin
 ```
 
 To assign roles to a specific user in Azure Active Directory:
 
 ```PowerShell
-Set-FhirServerUserAppRoleAssignments -UserPrincipalName myuser@mydomain.com -ApiAppId $apiAppReg.AppId -AppRoles admin,nurse
+Set-FhirServerUserAppRoleAssignments -UserPrincipalName myuser@mydomain.com -ApiAppId $apiAppReg.AppId -AppRoles globalAdmin
 ```
 
 ## Deploying the FHIR Server Template
@@ -85,7 +85,7 @@ New-AzResourceGroupDeployment `
 -ResourceGroupName $rg.ResourceGroupName -serviceName $fhirServiceName
 ```
 
-The default deployment will have a single role (`admin`) defined. To define more roles when deploying the server, see [details on specifying roles](Roles.md).
+The default deployment will have a number of roles as defined in the [roles.json](../src/Microsoft.Health.Fhir.Shared.Web/roles.json) file. To define more roles when deploying the server, see [details on specifying roles](Roles.md).
 
 You can use [Postman to test the FHIR server](PostmanTesting.md). 
 

--- a/docs/PortalAppRegistration.md
+++ b/docs/PortalAppRegistration.md
@@ -9,7 +9,7 @@ This document explains how to create these application registrations using the A
 Please consult the Azure Active Directory Documentation for details on the steps below:
 
 1. [Register an AAD Application](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-v1-add-azure-ad-app)
-2. [Add application roles to the application](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-add-app-roles-in-azure-ad-apps). You should add at least one role, say `admin`.
+2. [Add application roles to the application](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-add-app-roles-in-azure-ad-apps). You should add at least one role, say `globalAdmin`.
 
 Make a note of the application id and/or the identifier URI of the of the API application. This will be used as the `audience` when deploying the FHIR server.  
 

--- a/samples/scripts/PowerShell/FhirServer/Public/New-FhirServerApiApplicationRegistration.ps1
+++ b/samples/scripts/PowerShell/FhirServer/Public/New-FhirServerApiApplicationRegistration.ps1
@@ -6,9 +6,9 @@ function New-FhirServerApiApplicationRegistration {
     Create a new AAD Application registration for a FHIR server instance. 
     A FhirServiceName or FhirServiceAudience must be supplied.
     .EXAMPLE
-    New-FhirServerApiApplicationRegistration -FhirServiceName "myfhiservice" -AppRoles admin,nurse
+    New-FhirServerApiApplicationRegistration -FhirServiceName "myfhiservice" -AppRoles globalReader,globalExporter
     .EXAMPLE
-    New-FhirServerApiApplicationRegistration -FhirServiceAudience "https://myfhirservice.azurewebsites.net" -AppRoles admin,nurse
+    New-FhirServerApiApplicationRegistration -FhirServiceAudience "https://myfhirservice.azurewebsites.net" -AppRoles globalReader,globalExporter
     .PARAMETER FhirServiceName
     Name of the FHIR service instance. 
     .PARAMETER FhirServiceAudience

--- a/samples/scripts/PowerShell/FhirServer/Public/Set-FhirServerApiApplicationRoles.ps1
+++ b/samples/scripts/PowerShell/FhirServer/Public/Set-FhirServerApiApplicationRoles.ps1
@@ -5,7 +5,7 @@ function Set-FhirServerApiApplicationRoles {
     .DESCRIPTION
     Configures (create/update) the roles of the API Application registration, specifically, it populates the AppRoles field of the application manifest.
     .EXAMPLE
-    Set-FhirServerApiApplicationRoles -AppId <ID of API App> -AppRoles admin,nurse,patient
+    Set-FhirServerApiApplicationRoles -AppId <ID of API App> -AppRoles globalReader,globalExporter
     .PARAMETER ApiAppId
     ApiId for the API application
     .PARAMETER AppRoles

--- a/samples/scripts/PowerShell/FhirServer/Public/Set-FhirServerClientAppRoleAssignments.ps1
+++ b/samples/scripts/PowerShell/FhirServer/Public/Set-FhirServerClientAppRoleAssignments.ps1
@@ -5,7 +5,7 @@ function Set-FhirServerClientAppRoleAssignments {
     .DESCRIPTION
     Set AppRoles for a given client application. Requires Azure AD admin privileges.
     .EXAMPLE
-    Set-FhirServerClientAppRoleAssignments -AppId <Client App Id> -ApiAppId <Resource Api Id> -AppRoles admin,nurse
+    Set-FhirServerClientAppRoleAssignments -AppId <Client App Id> -ApiAppId <Resource Api Id> -AppRoles globalReader,globalExporter
     .PARAMETER AppId
     The AppId of the of the client application
     .PARAMETER ApiAppId

--- a/samples/scripts/PowerShell/FhirServer/Public/Set-FhirServerUserAppRoleAssignments.ps1
+++ b/samples/scripts/PowerShell/FhirServer/Public/Set-FhirServerUserAppRoleAssignments.ps1
@@ -5,7 +5,7 @@ function Set-FhirServerUserAppRoleAssignments {
     .DESCRIPTION
     Set AppRoles for a given user. Requires Azure AD admin privileges.
     .EXAMPLE
-    Set-FhirServerUserAppRoleAssignments -UserPrincipalName <User Principal Name> -ApiAppId <Resource Api Id> -AppRoles admin,nurse
+    Set-FhirServerUserAppRoleAssignments -UserPrincipalName <User Principal Name> -ApiAppId <Resource Api Id> -AppRoles globalReader,globalExporter
     .PARAMETER UserPrincipalName
     The user principal name (e.g. myalias@contoso.com) of the of the user
     .PARAMETER ApiAppId


### PR DESCRIPTION
## Description
Updates documentation and examples so that role names match new pre-defined roles, e.g. `admin` -> `globalAdmin`

## Testing
Manual review
