### PR TITLE
Adds CosmosDb SearchParameterRegistry

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/Registry/SearchParameterStatusManagerTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/Registry/SearchParameterStatusManagerTests.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
 using Microsoft.Health.Fhir.Core.Features.Definition;
+using Microsoft.Health.Fhir.Core.Features.Search.Parameters;
 using Microsoft.Health.Fhir.Core.Features.Search.Registry;
 using Microsoft.Health.Fhir.Core.Messages.Search;
 using Microsoft.Health.Fhir.Core.Models;
@@ -33,16 +34,19 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Registry
         private readonly IMediator _mediator;
         private readonly SearchParameterInfo[] _searchParameterInfos;
         private readonly SearchParameterInfo _queryParameter;
+        private readonly ISearchParameterSupportResolver _searchParameterSupportResolver;
 
         public SearchParameterStatusManagerTests()
         {
             _searchParameterRegistry = Substitute.For<ISearchParameterRegistry>();
             _searchParameterDefinitionManager = Substitute.For<ISearchParameterDefinitionManager>();
+            _searchParameterSupportResolver = Substitute.For<ISearchParameterSupportResolver>();
             _mediator = Substitute.For<IMediator>();
 
             _manager = new SearchParameterStatusManager(
                 _searchParameterRegistry,
                 _searchParameterDefinitionManager,
+                _searchParameterSupportResolver,
                 _mediator);
 
             _searchParameterRegistry.GetSearchParameterStatuses()
@@ -89,6 +93,14 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Registry
 
             _searchParameterDefinitionManager.GetSearchParameter(new Uri(ResourceQuery))
                 .Returns(_queryParameter);
+
+            _searchParameterSupportResolver
+                .IsSearchParameterSupported(Arg.Any<SearchParameterInfo>())
+                .Returns(false);
+
+            _searchParameterSupportResolver
+                .IsSearchParameterSupported(Arg.Is(_searchParameterInfos[4]))
+                .Returns(true);
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/SystemConformanceProvider.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/SystemConformanceProvider.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
 
         public SystemConformanceProvider(
             IModelInfoProvider modelInfoProvider,
-            SearchableSearchParameterDefinitionManagerResolver searchParameterDefinitionManagerResolver,
+            ISearchParameterDefinitionManager.SearchableSearchParameterDefinitionManagerResolver searchParameterDefinitionManagerResolver,
             Func<IScoped<IEnumerable<IProvideCapability>>> capabilityProviders)
         {
             EnsureArg.IsNotNull(modelInfoProvider, nameof(modelInfoProvider));

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/ISearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/ISearchParameterDefinitionManager.cs
@@ -10,15 +10,15 @@ using Microsoft.Health.Fhir.ValueSets;
 
 namespace Microsoft.Health.Fhir.Core.Features.Definition
 {
-    public delegate ISearchParameterDefinitionManager SearchableSearchParameterDefinitionManagerResolver();
-
-    public delegate ISearchParameterDefinitionManager SupportedSearchParameterDefinitionManagerResolver();
-
     /// <summary>
     /// Provides mechanism to access search parameter definition.
     /// </summary>
     public interface ISearchParameterDefinitionManager
     {
+        public delegate ISearchParameterDefinitionManager SearchableSearchParameterDefinitionManagerResolver();
+
+        public delegate ISearchParameterDefinitionManager SupportedSearchParameterDefinitionManagerResolver();
+
         /// <summary>
         /// Gets the list of all search parameters.
         /// </summary>

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/ISearchParameterSupportResolver.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/ISearchParameterSupportResolver.cs
@@ -1,0 +1,17 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Fhir.Core.Models;
+
+namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
+{
+    public interface ISearchParameterSupportResolver
+    {
+        /// <summary>
+        /// Determines if the given search parameter is able to be indexed
+        /// </summary>
+        bool IsSearchParameterSupported(SearchParameterInfo info);
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/FilebasedSearchParameterRegistry.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/FilebasedSearchParameterRegistry.cs
@@ -37,6 +37,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
             _unsupportedParamsEmbeddedResourceName = unsupportedParamsEmbeddedResourceName;
         }
 
+        public delegate ISearchParameterRegistry Resolver();
+
         public Task<IReadOnlyCollection<ResourceSearchParameterStatus>> GetSearchParameterStatuses()
         {
             if (_statusResults == null)

--- a/src/Microsoft.Health.Fhir.Core/Models/SearchParameterInfo.cs
+++ b/src/Microsoft.Health.Fhir.Core/Models/SearchParameterInfo.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Health.Fhir.Core.Models
             IReadOnlyList<SearchParameterComponentInfo> components = null,
             string expression = null,
             IReadOnlyCollection<string> targetResourceTypes = null,
+            IReadOnlyCollection<string> baseResourceTypes = null,
             string description = null)
             : this(
                 name,
@@ -29,6 +30,7 @@ namespace Microsoft.Health.Fhir.Core.Models
                 components,
                 expression,
                 targetResourceTypes,
+                baseResourceTypes,
                 description)
         {
         }
@@ -40,6 +42,7 @@ namespace Microsoft.Health.Fhir.Core.Models
             IReadOnlyList<SearchParameterComponentInfo> components = null,
             string expression = null,
             IReadOnlyCollection<string> targetResourceTypes = null,
+            IReadOnlyCollection<string> baseResourceTypes = null,
             string description = null)
             : this(name)
         {
@@ -48,6 +51,7 @@ namespace Microsoft.Health.Fhir.Core.Models
             Component = components;
             Expression = expression;
             TargetResourceTypes = targetResourceTypes;
+            BaseResourceTypes = baseResourceTypes;
             Description = description;
         }
 
@@ -67,6 +71,8 @@ namespace Microsoft.Health.Fhir.Core.Models
         public string Expression { get; }
 
         public IReadOnlyCollection<string> TargetResourceTypes { get; } = Array.Empty<string>();
+
+        public IReadOnlyCollection<string> BaseResourceTypes { get; } = Array.Empty<string>();
 
         public Uri Url { get; }
 

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/Registry/CosmosDbStatusRegistryInitializerTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/Registry/CosmosDbStatusRegistryInitializerTests.cs
@@ -1,0 +1,94 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Documents;
+using Microsoft.Azure.Documents.Client;
+using Microsoft.Azure.Documents.Linq;
+using Microsoft.Health.Core;
+using Microsoft.Health.CosmosDb.Features.Storage;
+using Microsoft.Health.Fhir.Core.Features.Search.Registry;
+using Microsoft.Health.Fhir.CosmosDb.Features.Storage.Registry;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Storage.Registry
+{
+    public class CosmosDbStatusRegistryInitializerTests
+    {
+        private readonly CosmosDbStatusRegistryInitializer _initializer;
+        private readonly ICosmosDocumentQueryFactory _cosmosDocumentQueryFactory;
+        private readonly Uri _testParameterUri;
+
+        public CosmosDbStatusRegistryInitializerTests()
+        {
+            ISearchParameterRegistry searchParameterRegistry = Substitute.For<ISearchParameterRegistry>();
+            _cosmosDocumentQueryFactory = Substitute.For<ICosmosDocumentQueryFactory>();
+
+            _initializer = new CosmosDbStatusRegistryInitializer(
+                () => searchParameterRegistry,
+                _cosmosDocumentQueryFactory);
+
+            _testParameterUri = new Uri("/test", UriKind.Relative);
+            searchParameterRegistry
+                .GetSearchParameterStatuses()
+                .Returns(new[]
+                {
+                    new ResourceSearchParameterStatus
+                    {
+                      Uri = _testParameterUri,
+                      Status = SearchParameterStatus.Enabled,
+                      LastUpdated = Clock.UtcNow,
+                      IsPartiallySupported = false,
+                    },
+                });
+        }
+
+        [Fact]
+        public async Task GivenARegistryInitializer_WhenDatabaseIsNew_SearchParametersShouldBeUpserted()
+        {
+            IDocumentQuery<dynamic> documentQuery = Substitute.For<IDocumentQuery<dynamic>>();
+            _cosmosDocumentQueryFactory.Create<dynamic>(Arg.Any<IDocumentClient>(), Arg.Any<CosmosQueryContext>())
+                .Returns(documentQuery);
+
+            documentQuery
+                .ExecuteNextAsync()
+                .Returns(new FeedResponse<dynamic>(new dynamic[0]));
+
+            IDocumentClient documentClient = Substitute.For<IDocumentClient>();
+            var relativeCollectionUri = new Uri("/collection1", UriKind.Relative);
+
+            await _initializer.ExecuteAsync(documentClient, new DocumentCollection(), relativeCollectionUri);
+
+            await documentClient.Received().UpsertDocumentAsync(
+                relativeCollectionUri,
+                Arg.Is<SearchParameterStatusWrapper>(x => x.Uri == _testParameterUri));
+        }
+
+        [Fact]
+        public async Task GivenARegistryInitializer_WhenDatabaseIsExisting_NothingNeedsToBeDone()
+        {
+            IDocumentQuery<dynamic> documentQuery = Substitute.For<IDocumentQuery<dynamic>>();
+            _cosmosDocumentQueryFactory.Create<dynamic>(Arg.Any<IDocumentClient>(), Arg.Any<CosmosQueryContext>())
+                .Returns(documentQuery);
+
+            documentQuery
+                .ExecuteNextAsync()
+                .Returns(new FeedResponse<dynamic>(new dynamic[] { new SearchParameterStatusWrapper() }));
+
+            IDocumentClient documentClient = Substitute.For<IDocumentClient>();
+            var relativeCollectionUri = new Uri("/collection1", UriKind.Relative);
+
+            await _initializer.ExecuteAsync(documentClient, new DocumentCollection(), relativeCollectionUri);
+
+            await documentClient.DidNotReceive().UpsertDocumentAsync(
+                relativeCollectionUri,
+                Arg.Any<SearchParameterStatusWrapper>());
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Registry/CosmosDbStatusRegistry.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Registry/CosmosDbStatusRegistry.cs
@@ -1,0 +1,85 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using EnsureThat;
+using Microsoft.Azure.Documents;
+using Microsoft.Azure.Documents.Client;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.CosmosDb.Configs;
+using Microsoft.Health.CosmosDb.Features.Storage;
+using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Health.Fhir.Core.Features.Search.Registry;
+
+namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Registry
+{
+    public class CosmosDbStatusRegistry : ISearchParameterRegistry
+    {
+        private readonly Func<IScoped<IDocumentClient>> _documentClientFactory;
+        private readonly ICosmosDocumentQueryFactory _queryFactory;
+
+        public CosmosDbStatusRegistry(
+            Func<IScoped<IDocumentClient>> documentClientFactory,
+            CosmosDataStoreConfiguration cosmosDataStoreConfiguration,
+            ICosmosDocumentQueryFactory queryFactory,
+            IOptionsMonitor<CosmosCollectionConfiguration> namedCosmosCollectionConfigurationAccessor)
+        {
+            EnsureArg.IsNotNull(documentClientFactory, nameof(documentClientFactory));
+            EnsureArg.IsNotNull(cosmosDataStoreConfiguration, nameof(cosmosDataStoreConfiguration));
+            EnsureArg.IsNotNull(queryFactory, nameof(queryFactory));
+            EnsureArg.IsNotNull(namedCosmosCollectionConfigurationAccessor, nameof(namedCosmosCollectionConfigurationAccessor));
+
+            _documentClientFactory = documentClientFactory;
+            _queryFactory = queryFactory;
+
+            CosmosCollectionConfiguration collectionConfiguration = namedCosmosCollectionConfigurationAccessor.Get(Constants.CollectionConfigurationName);
+            CollectionUri = cosmosDataStoreConfiguration.GetRelativeCollectionUri(collectionConfiguration.CollectionId);
+        }
+
+        public Uri CollectionUri { get; set; }
+
+        public async Task<IReadOnlyCollection<ResourceSearchParameterStatus>> GetSearchParameterStatuses()
+        {
+            var parameterStatus = new List<ResourceSearchParameterStatus>();
+            using var clientScope = _documentClientFactory.Invoke();
+
+            var query = _queryFactory.Create<SearchParameterStatusWrapper>(
+                    clientScope.Value,
+                    new CosmosQueryContext(
+                        CollectionUri,
+                        new SqlQuerySpec("select * from c"),
+                        new FeedOptions
+                        {
+                            PartitionKey =
+                                new PartitionKey(SearchParameterStatusWrapper.SearchParameterStatusPartitionKey),
+                        }));
+
+            do
+            {
+                FeedResponse<SearchParameterStatusWrapper> results = await query.ExecuteNextAsync<SearchParameterStatusWrapper>();
+                parameterStatus.AddRange(results
+                    .Select(x => x.ToSearchParameterStatus()));
+            }
+            while (query.HasMoreResults);
+
+            return parameterStatus;
+        }
+
+        public async Task UpdateStatuses(IEnumerable<ResourceSearchParameterStatus> statuses)
+        {
+            EnsureArg.IsNotNull(statuses, nameof(statuses));
+
+            using var clientScope = _documentClientFactory.Invoke();
+
+            foreach (var status in statuses.Select(x => x.ToSearchParameterStatusWrapper()))
+            {
+                await clientScope.Value.UpsertDocumentAsync(CollectionUri, status);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Registry/CosmosDbStatusRegistryInitializer.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Registry/CosmosDbStatusRegistryInitializer.cs
@@ -1,0 +1,59 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using EnsureThat;
+using Microsoft.Azure.Documents;
+using Microsoft.Health.CosmosDb.Features.Storage;
+using Microsoft.Health.Fhir.Core.Features.Search.Registry;
+using Microsoft.Health.Fhir.CosmosDb.Features.Storage.Versioning;
+
+namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Registry
+{
+    public class CosmosDbStatusRegistryInitializer : IFhirCollectionUpdater
+    {
+        private readonly ISearchParameterRegistry _filebasedRegistry;
+        private readonly ICosmosDocumentQueryFactory _queryFactory;
+
+        public CosmosDbStatusRegistryInitializer(
+            FilebasedSearchParameterRegistry.Resolver filebasedRegistry,
+            ICosmosDocumentQueryFactory queryFactory)
+        {
+            EnsureArg.IsNotNull(filebasedRegistry, nameof(filebasedRegistry));
+            EnsureArg.IsNotNull(queryFactory, nameof(queryFactory));
+
+            _filebasedRegistry = filebasedRegistry.Invoke();
+            _queryFactory = queryFactory;
+        }
+
+        public async Task ExecuteAsync(IDocumentClient client, DocumentCollection collection, Uri relativeCollectionUri)
+        {
+            EnsureArg.IsNotNull(client, nameof(client));
+            EnsureArg.IsNotNull(collection, nameof(collection));
+            EnsureArg.IsNotNull(relativeCollectionUri, nameof(relativeCollectionUri));
+
+            // Detect if registry has been initialized
+            var query = _queryFactory.Create<dynamic>(
+                client,
+                new CosmosQueryContext(
+                    relativeCollectionUri,
+                    new SqlQuerySpec($"SELECT TOP 1 * FROM c where c.{KnownDocumentProperties.PartitionKey} = '{SearchParameterStatusWrapper.SearchParameterStatusPartitionKey}'")));
+
+            var results = await query.ExecuteNextAsync();
+
+            if (!results.Any())
+            {
+                var statuses = await _filebasedRegistry.GetSearchParameterStatuses();
+
+                foreach (SearchParameterStatusWrapper status in statuses.Select(x => x.ToSearchParameterStatusWrapper()))
+                {
+                    await client.UpsertDocumentAsync(relativeCollectionUri, status);
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Registry/SearchParameterStatusExtensions.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Registry/SearchParameterStatusExtensions.cs
@@ -1,0 +1,34 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Fhir.Core.Features.Search.Registry;
+
+namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Registry
+{
+    internal static class SearchParameterStatusExtensions
+    {
+        public static SearchParameterStatusWrapper ToSearchParameterStatusWrapper(this ResourceSearchParameterStatus status)
+        {
+            return new SearchParameterStatusWrapper
+            {
+                Uri = status.Uri,
+                Status = status.Status,
+                LastUpdated = status.LastUpdated,
+                IsPartiallySupported = status.IsPartiallySupported ? true : (bool?)null,
+            };
+        }
+
+        public static ResourceSearchParameterStatus ToSearchParameterStatus(this SearchParameterStatusWrapper wrapper)
+        {
+            return new ResourceSearchParameterStatus
+            {
+                Uri = wrapper.Uri,
+                Status = wrapper.Status,
+                LastUpdated = wrapper.LastUpdated,
+                IsPartiallySupported = wrapper.IsPartiallySupported.GetValueOrDefault(),
+            };
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Registry/SearchParameterStatusWrapper.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Registry/SearchParameterStatusWrapper.cs
@@ -1,0 +1,44 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Text;
+using EnsureThat;
+using Microsoft.Health.Core.Extensions;
+using Microsoft.Health.CosmosDb.Features.Storage;
+using Microsoft.Health.Fhir.Core.Features.Search.Registry;
+using Newtonsoft.Json;
+
+namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Registry
+{
+    internal class SearchParameterStatusWrapper : SystemData
+    {
+        private Uri _uri;
+        public const string SearchParameterStatusPartitionKey = "__searchparameterstatus__";
+
+        [JsonProperty("uri")]
+        public Uri Uri
+        {
+            get => _uri;
+            set
+            {
+                _uri = value;
+                Id = value?.ToString().ComputeHash();
+            }
+        }
+
+        [JsonProperty("status")]
+        public SearchParameterStatus Status { get; set; }
+
+        [JsonProperty("isPartiallySupported")]
+        public bool? IsPartiallySupported { get; set; }
+
+        [JsonProperty("lastUpdated")]
+        public DateTimeOffset LastUpdated { get; set; }
+
+        [JsonProperty(KnownDocumentProperties.PartitionKey)]
+        public string PartitionKey { get; } = SearchParameterStatusPartitionKey;
+    }
+}

--- a/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
@@ -12,6 +12,7 @@ using Microsoft.Health.CosmosDb.Features.Storage;
 using Microsoft.Health.CosmosDb.Features.Storage.StoredProcedures;
 using Microsoft.Health.CosmosDb.Features.Storage.Versioning;
 using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Health.Fhir.Core.Features.Search.Registry;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Core.Registration;
 using Microsoft.Health.Fhir.CosmosDb;
@@ -20,6 +21,7 @@ using Microsoft.Health.Fhir.CosmosDb.Features.Search;
 using Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries;
 using Microsoft.Health.Fhir.CosmosDb.Features.Storage;
 using Microsoft.Health.Fhir.CosmosDb.Features.Storage.Operations;
+using Microsoft.Health.Fhir.CosmosDb.Features.Storage.Registry;
 using Microsoft.Health.Fhir.CosmosDb.Features.Storage.StoredProcedures;
 using Microsoft.Health.Fhir.CosmosDb.Features.Storage.Versioning;
 
@@ -101,11 +103,15 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AsService<ICollectionInitializer>();
 
             services.Add<FhirCollectionSettingsUpdater>()
-                .Singleton()
+                .Transient()
                 .AsService<IFhirCollectionUpdater>();
 
             services.Add<FhirStoredProcedureInstaller>()
-                .Singleton()
+                .Transient()
+                .AsService<IFhirCollectionUpdater>();
+
+            services.Add<CosmosDbStatusRegistryInitializer>()
+                .Transient()
                 .AsService<IFhirCollectionUpdater>();
 
             services.TypesInSameAssemblyAs<IFhirStoredProcedure>()
@@ -131,6 +137,11 @@ namespace Microsoft.Extensions.DependencyInjection
                 .Singleton()
                 .AsSelf()
                 .AsImplementedInterfaces();
+
+            services.Add<CosmosDbStatusRegistry>()
+                .Singleton()
+                .AsSelf()
+                .ReplaceService<ISearchParameterRegistry>();
 
             return fhirServerBuilder;
         }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchConverterForAllSearchTypes.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchConverterForAllSearchTypes.cs
@@ -10,6 +10,7 @@ using Hl7.FhirPath.Expressions;
 using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Features.Search.Converters;
+using Microsoft.Health.Fhir.Core.Features.Search.Parameters;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.ValueSets;
 using Newtonsoft.Json;
@@ -57,7 +58,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
                 foreach (var result in converters.Where(x => x.hasConverter || !parameterInfo.IsPartiallySupported))
                 {
-                    var found = _fixtureData.Manager.TryGetConverter(result.result.ClassMapping.NativeType, SearchIndexer.GetSearchValueTypeForSearchParamType(result.result.SearchParamType), out var converter);
+                    var found = SearchParameterFixtureData.Manager.TryGetConverter(result.result.ClassMapping.NativeType, SearchIndexer.GetSearchValueTypeForSearchParamType(result.result.SearchParamType), out var converter);
 
                     var converterText = found ? converter.GetType().Name : "None";
                     string searchTermMapping = $"Search term '{parameterName}' ({result.result.SearchParamType}) mapped to '{result.result.ClassMapping.NativeType.Name}', converter: {converterText}";
@@ -129,11 +130,11 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             string resourceType,
             SearchParameterInfo parameterInfo)
         {
-            var parsed = _fixtureData.Compiler.Parse(parameterInfo.Expression);
+            var parsed = SearchParameterFixtureData.Compiler.Parse(parameterInfo.Expression);
 
             (SearchParamType Type, Expression, Uri DefinitionUrl)[] componentExpressions = parameterInfo.Component
                 .Select(x => (_fixtureData.SearchDefinitionManager.UrlLookup[x.DefinitionUrl].Type,
-                    _fixtureData.Compiler.Parse(x.Expression),
+                    SearchParameterFixtureData.Compiler.Parse(x.Expression),
                     x.DefinitionUrl))
                 .ToArray();
 
@@ -145,7 +146,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             var converters = results
                 .Select(result => (
                     result,
-                    hasConverter: _fixtureData.Manager.TryGetConverter(
+                    hasConverter: SearchParameterFixtureData.Manager.TryGetConverter(
                         result.ClassMapping.NativeType,
                         SearchIndexer.GetSearchValueTypeForSearchParamType(result.SearchParamType),
                         out IFhirElementToSearchValueTypeConverter converter),

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterSupportResolverTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterSupportResolverTests.cs
@@ -1,0 +1,77 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.Health.Fhir.Core.Features.Search.Parameters;
+using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.ValueSets;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
+{
+    public class SearchParameterSupportResolverTests : IClassFixture<SearchParameterFixtureData>
+    {
+        private readonly ITestOutputHelper _outputHelper;
+        private readonly SearchParameterFixtureData _fixtureData;
+        private SearchParameterSupportResolver _resolver;
+
+        public SearchParameterSupportResolverTests(ITestOutputHelper outputHelper, SearchParameterFixtureData fixtureData)
+        {
+            _outputHelper = outputHelper;
+            _fixtureData = fixtureData;
+
+            _resolver = new SearchParameterSupportResolver(_fixtureData.SearchDefinitionManager, SearchParameterFixtureData.Manager);
+        }
+
+        [Fact]
+        public void GivenASupportedSearchParameter_WhenResolvingSupport_ThenTrueIsReturned()
+        {
+            var sp = new SearchParameterInfo(
+                "Condition-abatement-age",
+                SearchParamType.Quantity,
+                new Uri("http://hl7.org/fhir/SearchParameter/Condition-abatement-age"),
+                expression: "Condition.abatement.as(Range)",
+                baseResourceTypes: new[] { "Condition" });
+
+            bool supported = _resolver.IsSearchParameterSupported(sp);
+
+            Assert.True(supported);
+        }
+
+        [Fact]
+        public void GivenAnUnsupportedSearchParameter_WhenResolvingSupport_ThenFalseIsReturned()
+        {
+            var sp = new SearchParameterInfo(
+                "Condition-abatement-age",
+                SearchParamType.Uri,
+                new Uri("http://hl7.org/fhir/SearchParameter/Condition-abatement-age"),
+                expression: "Condition.abatement.as(Range)",
+                baseResourceTypes: new[] { "Condition" });
+
+            // Can not convert Range => Uri
+            bool supported = _resolver.IsSearchParameterSupported(sp);
+
+            Assert.False(supported);
+        }
+
+        [Fact]
+        public void GivenAPartiallySupportedSearchParameter_WhenResolvingSupport_ThenFalseIsReturned()
+        {
+            var sp = new SearchParameterInfo(
+                "Condition-abatement-age",
+                SearchParamType.Quantity,
+                new Uri("http://hl7.org/fhir/SearchParameter/Condition-abatement-age"),
+                expression: "Condition.asserter | Condition.abatement.as(Range)",
+                baseResourceTypes: new[] { "Condition" });
+
+            // Condition.asserter cannot be translated to Quantity
+            // Condition.abatement.as(Range) CAN be translated to Quantity
+            bool supported = _resolver.IsSearchParameterSupported(sp);
+
+            Assert.False(supported);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
@@ -14,11 +14,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Compartment\SearchCompartmentHandlerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Conformance\ConformanceBuilderTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\LightweightReferenceToElementResolverTests.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchParameters\PropertyMappingExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchParameters\SearchConverterForAllSearchTypes.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchParameters\SearchParameterFixtureData.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchParameters\SearchParameterToTypeResolver.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchParameters\SearchParameterTypeResult.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchParameters\SearchParameterSupportResolverTests.cs" />
     <Compile Include="..\Microsoft.Health.Fhir.Shared.Core.UnitTests\Features\Conformance\ProfileReferenceConverterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Conformance\DefaultOptionHashSetJsonConverterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Conformance\EnumLiteralJsonConverterTests.cs" />

--- a/src/Microsoft.Health.Fhir.Shared.Core/Extensions/ModelExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Extensions/ModelExtensions.cs
@@ -94,6 +94,7 @@ namespace Microsoft.Health.Fhir.Core.Extensions
                 searchParam.Component?.Select(x => new SearchParameterComponentInfo(x.GetComponentDefinitionUri(), x.Expression)).ToArray(),
                 searchParam.Expression,
                 searchParam.Target?.Select(x => x?.ToString()).ToArray(),
+                searchParam.Base?.Select(x => x?.ToString()).ToArray(),
                 searchParam.Description?.Value);
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Expressions/Parsers/ExpressionParser.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Expressions/Parsers/ExpressionParser.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
         /// <param name="searchParameterDefinitionManagerResolver">The search parameter definition manager.</param>
         /// <param name="searchParameterExpressionParser">The parser used to parse the search value into a search expression.</param>
         public ExpressionParser(
-            SearchableSearchParameterDefinitionManagerResolver searchParameterDefinitionManagerResolver,
+            ISearchParameterDefinitionManager.SearchableSearchParameterDefinitionManagerResolver searchParameterDefinitionManagerResolver,
             ISearchParameterExpressionParser searchParameterExpressionParser)
         {
             EnsureArg.IsNotNull(searchParameterDefinitionManagerResolver, nameof(searchParameterDefinitionManagerResolver));

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Expressions/Parsers/SearchParameterExpressionParser.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Expressions/Parsers/SearchParameterExpressionParser.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
         private readonly Dictionary<SearchParamType, Func<string, ISearchValue>> _parserDictionary;
 
         public SearchParameterExpressionParser(
-            SearchableSearchParameterDefinitionManagerResolver searchParameterDefinitionManagerResolver,
+            ISearchParameterDefinitionManager.SearchableSearchParameterDefinitionManagerResolver searchParameterDefinitionManagerResolver,
             IReferenceSearchValueParser referenceSearchValueParser)
         {
             EnsureArg.IsNotNull(searchParameterDefinitionManagerResolver, nameof(searchParameterDefinitionManagerResolver));

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Parameters/PropertyMappingExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Parameters/PropertyMappingExtensions.cs
@@ -6,9 +6,9 @@
 using System;
 using Hl7.Fhir.Introspection;
 
-namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
+namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
 {
-    public static class PropertyMappingExtensions
+    internal static class PropertyMappingExtensions
     {
         public static Type GetElementType(this PropertyMapping mapping)
         {

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Parameters/SearchParameterSupportResolver.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Parameters/SearchParameterSupportResolver.cs
@@ -1,0 +1,81 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EnsureThat;
+using Hl7.FhirPath;
+using Hl7.FhirPath.Expressions;
+using Microsoft.Health.Fhir.Core.Features.Definition;
+using Microsoft.Health.Fhir.Core.Features.Search.Converters;
+using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.ValueSets;
+
+namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
+{
+    public class SearchParameterSupportResolver : ISearchParameterSupportResolver
+    {
+        private readonly ISearchParameterDefinitionManager _definitionManager;
+        private readonly IFhirElementToSearchValueTypeConverterManager _searchValueTypeConverterManager;
+        private static readonly FhirPathCompiler _compiler = new FhirPathCompiler();
+
+        public SearchParameterSupportResolver(
+            ISearchParameterDefinitionManager definitionManager,
+            IFhirElementToSearchValueTypeConverterManager searchValueTypeConverterManager)
+        {
+            EnsureArg.IsNotNull(definitionManager, nameof(definitionManager));
+            EnsureArg.IsNotNull(searchValueTypeConverterManager, nameof(searchValueTypeConverterManager));
+
+            _definitionManager = definitionManager;
+            _searchValueTypeConverterManager = searchValueTypeConverterManager;
+        }
+
+        public bool IsSearchParameterSupported(SearchParameterInfo parameterInfo)
+        {
+            EnsureArg.IsNotNull(parameterInfo, nameof(parameterInfo));
+
+            Expression parsed = _compiler.Parse(parameterInfo.Expression);
+
+            (SearchParamType Type, Expression, Uri DefinitionUrl)[] componentExpressions = parameterInfo.Component
+                ?.Select(x => (_definitionManager.GetSearchParameter(x.DefinitionUrl).Type,
+                    _compiler.Parse(x.Expression),
+                    x.DefinitionUrl))
+                .ToArray();
+
+            if (parameterInfo.TargetResourceTypes?.Any() != true && parameterInfo.BaseResourceTypes?.Any() != true)
+            {
+                throw new NotSupportedException("No target resources defined.");
+            }
+
+            IEnumerable<string> resourceTypes = (parameterInfo.TargetResourceTypes ?? Enumerable.Empty<string>()).Concat(parameterInfo.BaseResourceTypes ?? Enumerable.Empty<string>());
+
+            foreach (var resource in resourceTypes)
+            {
+                SearchParameterTypeResult[] results = SearchParameterToTypeResolver.Resolve(
+                    resource,
+                    (parameterInfo.Type, parsed, parameterInfo.Url),
+                    componentExpressions).ToArray();
+
+                var converters = results
+                    .Select(result => (
+                        result,
+                        hasConverter: _searchValueTypeConverterManager.TryGetConverter(
+                            result.ClassMapping.NativeType,
+                            SearchIndexer.GetSearchValueTypeForSearchParamType(result.SearchParamType),
+                            out IFhirElementToSearchValueTypeConverter converter),
+                        converter))
+                    .ToArray();
+
+                if (!converters.All(x => x.hasConverter))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Parameters/SearchParameterToTypeResolver.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Parameters/SearchParameterToTypeResolver.cs
@@ -6,20 +6,25 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using Hl7.Fhir.Introspection;
 using Hl7.Fhir.Model;
 using Hl7.FhirPath.Expressions;
 using Microsoft.Health.Fhir.Core.Models;
-using EnumerableReturnType = System.Collections.Generic.IEnumerable<Microsoft.Health.Fhir.Core.UnitTests.Features.Search.SearchParameterTypeResult>;
+using EnumerableReturnType = System.Collections.Generic.IEnumerable<Microsoft.Health.Fhir.Core.Features.Search.Parameters.SearchParameterTypeResult>;
 using Expression = Hl7.FhirPath.Expressions.Expression;
 using Range = Hl7.Fhir.Model.Range;
 using SearchParamType = Microsoft.Health.Fhir.ValueSets.SearchParamType;
 
-namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
+namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
 {
-    public static class SearchParameterToTypeResolver
+    /// <summary>
+    /// Resolves the POCO types from a FHIR Path query
+    /// </summary>
+    [SuppressMessage("Design", "CA1801", Justification = "Visitor overloads are resolved dynamically so method signature should remain the same.")]
+    internal static class SearchParameterToTypeResolver
     {
         private static readonly ModelInspector ModelInspector = new ModelInspector();
 

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Parameters/SearchParameterTypeResult.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Parameters/SearchParameterTypeResult.cs
@@ -7,9 +7,9 @@ using System;
 using Hl7.Fhir.Introspection;
 using Microsoft.Health.Fhir.ValueSets;
 
-namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
+namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
 {
-    public class SearchParameterTypeResult
+    internal class SearchParameterTypeResult
     {
         public SearchParameterTypeResult(ClassMapping classMapping, SearchParamType searchParamType, string path, Uri definition)
         {

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchIndexer.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchIndexer.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
         /// <param name="referenceToElementResolver">Used for parsing reference strings</param>
         /// <param name="logger">The logger.</param>
         public SearchIndexer(
-            SupportedSearchParameterDefinitionManagerResolver searchParameterDefinitionManagerResolver,
+            ISearchParameterDefinitionManager.SupportedSearchParameterDefinitionManagerResolver searchParameterDefinitionManagerResolver,
             IFhirElementToSearchValueTypeConverterManager fhirElementTypeConverterManager,
             IReferenceToElementResolver referenceToElementResolver,
             ILogger<SearchIndexer> logger)

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
 
         public SearchOptionsFactory(
             IExpressionParser expressionParser,
-            SearchableSearchParameterDefinitionManagerResolver searchParameterDefinitionManagerResolver,
+            ISearchParameterDefinitionManager.SearchableSearchParameterDefinitionManagerResolver searchParameterDefinitionManagerResolver,
             ILogger<SearchOptionsFactory> logger)
         {
             EnsureArg.IsNotNull(expressionParser, nameof(expressionParser));

--- a/src/Microsoft.Health.Fhir.Shared.Core/Microsoft.Health.Fhir.Shared.Core.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Microsoft.Health.Fhir.Shared.Core.projitems
@@ -73,6 +73,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\Expressions\Parsers\ISearchParameterExpressionParser.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\Expressions\Parsers\SearchParameterExpressionParser.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\Expressions\Parsers\SearchValueExpressionBuilderHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Search\Parameters\PropertyMappingExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Search\Parameters\SearchParameterSupportResolver.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Search\Parameters\SearchParameterToTypeResolver.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Search\Parameters\SearchParameterTypeResult.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchIndexer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchOptionsFactory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchResourceHandler.cs" />

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/StringOverflowRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/StringOverflowRewriter.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
     {
         private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager;
 
-        public StringOverflowRewriter(SupportedSearchParameterDefinitionManagerResolver searchParameterDefinitionManagerResolver)
+        public StringOverflowRewriter(ISearchParameterDefinitionManager.SupportedSearchParameterDefinitionManagerResolver searchParameterDefinitionManagerResolver)
             : base(new Scout(searchParameterDefinitionManagerResolver()))
         {
             EnsureArg.IsNotNull(searchParameterDefinitionManagerResolver, nameof(searchParameterDefinitionManagerResolver));

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SearchParameterToSearchValueTypeMap.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SearchParameterToSearchValueTypeMap.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
         private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager;
         private readonly ConcurrentDictionary<SearchParameterInfo, Type> _map = new ConcurrentDictionary<SearchParameterInfo, Type>();
 
-        public SearchParameterToSearchValueTypeMap(SupportedSearchParameterDefinitionManagerResolver searchParameterDefinitionManagerResolver)
+        public SearchParameterToSearchValueTypeMap(ISearchParameterDefinitionManager.SupportedSearchParameterDefinitionManagerResolver searchParameterDefinitionManagerResolver)
         {
             EnsureArg.IsNotNull(searchParameterDefinitionManagerResolver, nameof(searchParameterDefinitionManagerResolver));
             _searchParameterDefinitionManager = searchParameterDefinitionManagerResolver();

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
         public SqlServerFhirModel(
             SqlServerDataStoreConfiguration configuration,
             SchemaInformation schemaInformation,
-            SupportedSearchParameterDefinitionManagerResolver searchParameterDefinitionManagerResolver,
+            ISearchParameterDefinitionManager.SupportedSearchParameterDefinitionManagerResolver searchParameterDefinitionManagerResolver,
             IOptions<SecurityConfiguration> securityConfiguration,
             ILogger<SqlServerFhirModel> logger)
             : base(configuration, schemaInformation, logger)


### PR DESCRIPTION
## Description
Adds storage of the status of a search parameter into cosmosDb

## Related issues
Addresses [AB#73171](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/73171).

## Testing
Adds unit tests for new components