### PR TITLE
Removes calls that use Instance.ToPoco

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/Search/ResourceWrapperTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/Search/ResourceWrapperTests.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Storage
                 var wrapper = new ResourceWrapper(typedElement, _rawResourceFactory.Create(typedElement), new ResourceRequest(HttpMethod.Post, "http://fhir"), false, null, null, null);
                 var resource = Deserializers.ResourceDeserializer.Deserialize(wrapper);
 
-                var poco = resource.Instance.ToPoco<Observation>();
+                var poco = resource.ToPoco<Observation>();
 
                 Assert.Equal(observation.VersionId, poco.Meta.VersionId);
                 Assert.Equal(lastModified, poco.Meta.LastUpdated);

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Create/CreateResourceHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Create/CreateResourceHandler.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Create
                 throw new UnauthorizedFhirActionException();
             }
 
-            var resource = message.Resource.Instance.ToPoco<Resource>();
+            var resource = message.Resource.ToPoco<Resource>();
 
             // If an Id is supplied on create it should be removed/ignored
             resource.Id = null;

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Upsert/UpsertResourceHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Upsert/UpsertResourceHandler.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Upsert
                 throw new UnauthorizedFhirActionException();
             }
 
-            Resource resource = message.Resource.Instance.ToPoco<Resource>();
+            Resource resource = message.Resource.ToPoco<Resource>();
 
             if (await ConformanceProvider.Value.RequireETag(resource.TypeName, cancellationToken) && message.WeakETag == null)
             {

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/BundleFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/BundleFactory.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                 return new Bundle.EntryComponent
                 {
                     FullUrlElement = new FhirUri(_urlResolver.ResolveResourceUrl(resource)),
-                    Resource = resource.Instance.ToPoco<Resource>(),
+                    Resource = resource.ToPoco<Resource>(),
                     Search = new Bundle.SearchComponent
                     {
                         Mode = r.SearchEntryMode == SearchEntryMode.Match ? Bundle.SearchEntryMode.Match : Bundle.SearchEntryMode.Include,
@@ -64,7 +64,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                 return new Bundle.EntryComponent
                 {
                     FullUrlElement = new FhirUri(_urlResolver.ResolveResourceUrl(resource, true)),
-                    Resource = resource.Instance.ToPoco<Resource>(),
+                    Resource = resource.ToPoco<Resource>(),
                     Request = new Bundle.RequestComponent
                     {
                         Method = hasVerb ? (Bundle.HTTPVerb?)httpVerb : null,

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             Assert.NotNull(getResult);
             Assert.Equal(saveResult.Id, getResult.Id);
 
-            var observation = getResult.Instance.ToPoco<Observation>();
+            var observation = getResult.ToPoco<Observation>();
             Assert.NotNull(observation);
             Assert.NotNull(observation.Value);
 
@@ -253,7 +253,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         {
             var saveResult = await Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight"));
 
-            var newResourceValues = Samples.GetJsonSample("WeightInGrams").Instance.ToPoco<Resource>();
+            var newResourceValues = Samples.GetJsonSample("WeightInGrams").ToPoco<Resource>();
             newResourceValues.Id = saveResult.Resource.Id;
 
             var list = new List<Task<SaveOutcome>>();
@@ -278,7 +278,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 Assert.Equal(SaveOutcomeType.Updated, item.Result.Outcome);
             }
 
-            var allObservations = list.Select(x => ((Quantity)x.Result.Resource.Instance.ToPoco<Observation>().Value).Value.GetValueOrDefault()).Distinct();
+            var allObservations = list.Select(x => ((Quantity)x.Result.Resource.ToPoco<Observation>().Value).Value.GetValueOrDefault()).Distinct();
             Assert.Equal(itemsToCreate, allObservations.Count());
         }
 


### PR DESCRIPTION
## Description
Should use `[ResourceElement].ToPoco` instead of `[ResourceElement].Instance.ToPoco`.
There is caching built-in when using the call off ResourceElement directly
