### PR TITLE
Provision resource group after build succeeds

### DIFF
--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -37,7 +37,8 @@ stages:
 
 - stage: provisionEnvironment
   displayName: Provision Environment
-  dependsOn: []
+  dependsOn:
+  - DockerBuild
   jobs:
   - job: provision
     steps:


### PR DESCRIPTION
## Description
Changes dependencies to provision RG after build succeeds. 
This should avoid many empty resource groups where no builds ever completed
