### PR TITLE
Update release pipeline to get storage account details

### DIFF
--- a/build/jobs/run-tests.yml
+++ b/build/jobs/run-tests.yml
@@ -97,6 +97,14 @@ jobs:
             Write-Host "##vso[task.setvariable variable=$($environmentVariableName)]$($secretValue.SecretValueText)"
         }
 
+        $storageAccounts = Get-AzStorageAccount -ResourceGroupName $DeploymentEnvironmentName
+        foreach ($storageAccount in $storageAccounts) {
+            $accKey = Get-AzStorageAccountKey -ResourceGroupName $DeploymentEnvironmentName -Name $storageAccount.StorageAccountName | Where-Object {$_.KeyName -eq "key1"}
+
+            $storageSecretName = "$($storageAccount.StorageAccountName)_secret"
+            Write-Host "##vso[task.setvariable variable=$($storageSecretName)]$($accKey.Value)"
+        }
+
         Write-Host "##vso[task.setvariable variable=Resource]$(TestEnvironmentUrl)"
         
         # Do not know if this is needed...

--- a/build/jobs/run-tests.yml
+++ b/build/jobs/run-tests.yml
@@ -97,9 +97,9 @@ jobs:
             Write-Host "##vso[task.setvariable variable=$($environmentVariableName)]$($secretValue.SecretValueText)"
         }
 
-        $storageAccounts = Get-AzStorageAccount -ResourceGroupName $DeploymentEnvironmentName
+        $storageAccounts = Get-AzStorageAccount -ResourceGroupName $(DeploymentEnvironmentName)
         foreach ($storageAccount in $storageAccounts) {
-            $accKey = Get-AzStorageAccountKey -ResourceGroupName $DeploymentEnvironmentName -Name $storageAccount.StorageAccountName | Where-Object {$_.KeyName -eq "key1"}
+            $accKey = Get-AzStorageAccountKey -ResourceGroupName $(DeploymentEnvironmentName) -Name $storageAccount.StorageAccountName | Where-Object {$_.KeyName -eq "key1"}
 
             $storageSecretName = "$($storageAccount.StorageAccountName)_secret"
             Write-Host "##vso[task.setvariable variable=$($storageSecretName)]$($accKey.Value)"

--- a/release/scripts/PowerShell/FhirServerRelease/Public/Add-AadTestAuthEnvironment.ps1
+++ b/release/scripts/PowerShell/FhirServerRelease/Public/Add-AadTestAuthEnvironment.ps1
@@ -111,7 +111,7 @@ function Add-AadTestAuthEnvironment {
 
     Write-Host "Getting storage accounts in resource group"
     $storageAccounts = Get-AzStorageAccount -ResourceGroupName $ResourceGroupName
-    foreacH ($storageAccount in $storageAccounts) {
+    foreach ($storageAccount in $storageAccounts) {
         $accKey = Get-AzStorageAccountKey -ResourceGroupName $ResourceGroupName -Name $storageAccount.StorageAccountName | Where-Object {$_.KeyName -eq "key1"}
         $accKeySecureString = ConvertTo-SecureString -String $accKey.Value -AsPlainText -Force
 

--- a/release/scripts/PowerShell/FhirServerRelease/Public/Add-AadTestAuthEnvironment.ps1
+++ b/release/scripts/PowerShell/FhirServerRelease/Public/Add-AadTestAuthEnvironment.ps1
@@ -109,15 +109,6 @@ function Add-AadTestAuthEnvironment {
         $application = Get-AzureAdApplicationByIdentifierUri $fhirServiceAudience
     }
 
-    Write-Host "Getting storage accounts in resource group"
-    $storageAccounts = Get-AzStorageAccount -ResourceGroupName $ResourceGroupName
-    foreach ($storageAccount in $storageAccounts) {
-        $accKey = Get-AzStorageAccountKey -ResourceGroupName $ResourceGroupName -Name $storageAccount.StorageAccountName | Where-Object {$_.KeyName -eq "key1"}
-        $accKeySecureString = ConvertTo-SecureString -String $accKey.Value -AsPlainText -Force
-
-        Set-AzKeyVaultSecret -VaultName $KeyVaultName -Name "$($storageAccount.StorageAccountName)--secret" -SecretValue $accKeySecureString | Out-Null
-    }
-
     Write-Host "Setting roles on API Application"
     $appRoles = ($testAuthEnvironment.users.roles + $testAuthEnvironment.clientApplications.roles) | Select-Object -Unique
     Set-FhirServerApiApplicationRoles -ApiAppId $application.AppId -AppRoles $appRoles | Out-Null


### PR DESCRIPTION
## Description
Update release pipeline to get storage account details. We deploy storage accounts as part of our PR environment. We will be using these storage accounts to export data to. Since we also need to validate the exported data, we need access to the storage account from within the test code. We will use the existing keyvault to store the required storage account details.

## Related issues
Addresses [issue [AB#73559](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/73559)].

## Testing
Describe how this change was tested.
