### PR TITLE
Add E2E export data validation test

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobResult.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobResult.cs
@@ -30,19 +30,24 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
             Error = errors;
         }
 
+        [JsonConstructor]
+        private ExportJobResult()
+        {
+        }
+
         [JsonProperty("transactionTime")]
-        public DateTimeOffset TransactionTime { get; }
+        public DateTimeOffset TransactionTime { get; private set; }
 
         [JsonProperty("request")]
-        public Uri RequestUri { get; }
+        public Uri RequestUri { get; private set; }
 
         [JsonProperty("requiresAccessToken")]
-        public bool RequiresAccessToken { get; }
+        public bool RequiresAccessToken { get; private set; }
 
         [JsonProperty("output")]
-        public IList<ExportOutputResponse> Output { get; }
+        public IList<ExportOutputResponse> Output { get; private set; }
 
         [JsonProperty("error")]
-        public IList<ExportOutputResponse> Error { get; }
+        public IList<ExportOutputResponse> Error { get; private set; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Tests.Common/Categories.cs
+++ b/src/Microsoft.Health.Fhir.Tests.Common/Categories.cs
@@ -24,5 +24,7 @@ namespace Microsoft.Health.Fhir.Tests.Common
         public const string Validate = "Validate";
 
         public const string Xml = "Xml";
+
+        public const string ExportDataValidation = "ExportDataValidation";
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E.Common/FhirClient.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E.Common/FhirClient.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -298,9 +297,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Common
 
         public async Task<HttpResponseMessage> CheckExportAsync(Uri contentLocation)
         {
-            // We have to remove the host component becase our HttpClient is already setup with the base address of the server.
-            Uri relativeUri = contentLocation.MakeRelativeUri(HttpClient.BaseAddress);
-            var message = new HttpRequestMessage(HttpMethod.Get, relativeUri);
+            var message = new HttpRequestMessage(HttpMethod.Get, contentLocation);
 
             HttpResponseMessage response = await HttpClient.SendAsync(message);
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Microsoft.Health.Fhir.Shared.Tests.E2E.projitems
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Microsoft.Health.Fhir.Shared.Tests.E2E.projitems
@@ -23,6 +23,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rest\ConditionalCreateTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\ConditionalUpdateTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\CorsTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rest\ExportDataValidationTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\ObservationResolveReferenceTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\CreateTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\DeleteTests.cs" />

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ExportDataValidationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ExportDataValidationTests.cs
@@ -1,0 +1,214 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Azure.Storage;
+using Microsoft.Azure.Storage.Auth;
+using Microsoft.Azure.Storage.Blob;
+using Microsoft.Health.Fhir.Core.Features.Operations.Export.Models;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Microsoft.Health.Fhir.Tests.E2E.Rest;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using FhirClient = Microsoft.Health.Fhir.Tests.E2E.Common.FhirClient;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
+{
+    [Trait(Traits.Category, Categories.ExportDataValidation)]
+    [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.Json)]
+    public class ExportDataValidationTests : IClassFixture<HttpIntegrationTestFixture>
+    {
+        private readonly FhirClient _fhirClient;
+
+        public ExportDataValidationTests(HttpIntegrationTestFixture fixture)
+        {
+            _fhirClient = fixture.FhirClient;
+        }
+
+        [Fact]
+        public async Task GivenFhirServer_WhenDataIsExported_ThenExportedDataIsSameAsDataInFhirServer()
+        {
+            // Trigger export request and check for export status
+            Uri contentLocation = await _fhirClient.ExportAsync();
+            IList<Uri> blobUris = await CheckExportStatus(contentLocation);
+
+            // Download exported data from storage account
+            Dictionary<string, string> dataFromExport = await DownloadBlobAndParse(blobUris);
+
+            // Download all resources from fhir server
+            Dictionary<string, string> dataFromFhirServer = await GetResourcesFromFhirServer(new Uri("/"));
+
+            // Assert both data are equal
+            Assert.True(ValidateDataFromBothSources(dataFromFhirServer, dataFromExport));
+        }
+
+        private bool ValidateDataFromBothSources(Dictionary<string, string> dataFromServer, Dictionary<string, string> dataFromStorageAccount)
+        {
+            bool result = true;
+            if (dataFromStorageAccount.Count != dataFromServer.Count)
+            {
+                Console.WriteLine($"Count differs. Exported data count: {dataFromStorageAccount.Count} Fhir Server Count: {dataFromServer.Count}");
+                return false;
+            }
+
+            int wrongCount = 0;
+            foreach (var kvp in dataFromServer)
+            {
+                if (!dataFromStorageAccount.ContainsKey(kvp.Key))
+                {
+                    Console.WriteLine($"Missing resource from exported data: {kvp.Key}");
+                    result = false;
+                    wrongCount++;
+                    continue;
+                }
+
+                string exportEntry = dataFromStorageAccount[kvp.Key];
+                string serverEntry = kvp.Value;
+                if (serverEntry.Equals(exportEntry))
+                {
+                    Console.WriteLine($"Exported resource does not match server resource: {kvp.Key}");
+                    result = false;
+                    wrongCount++;
+                    continue;
+                }
+            }
+
+            Console.WriteLine($"Missing or wrong match count: {wrongCount}");
+            return result;
+        }
+
+        // Check export status and return output once we get 200
+        private async Task<IList<Uri>> CheckExportStatus(Uri contentLocation)
+        {
+            HttpStatusCode resultCode = HttpStatusCode.Accepted;
+            HttpResponseMessage response = null;
+            while (resultCode == HttpStatusCode.Accepted)
+            {
+                await Task.Delay(5000);
+
+                response = await _fhirClient.CheckExportAsync(contentLocation);
+
+                resultCode = response.StatusCode;
+            }
+
+            if (resultCode != HttpStatusCode.OK)
+            {
+                throw new Exception($"Export request failed with status code {resultCode}");
+            }
+
+            // we have got the result. deserialize into output response
+            var contentString = await response.Content.ReadAsStringAsync();
+
+            ExportJobResult exportJobResult = JsonConvert.DeserializeObject<ExportJobResult>(contentString);
+            return exportJobResult.Output.Select(x => x.FileUri).ToList();
+        }
+
+        private async Task<Dictionary<string, string>> DownloadBlobAndParse(IList<Uri> blobUri)
+        {
+            if (blobUri == null || blobUri.Count == 0)
+            {
+                return new Dictionary<string, string>();
+            }
+
+            // Extract storage account name from blob uri in order to get corresponding access token.
+            var sampleUri = blobUri[0];
+            string storageAccountName = sampleUri.Host.Split('.')[0];
+
+            string storageSecret = Environment.GetEnvironmentVariable(storageAccountName + "_secret");
+            if (string.IsNullOrWhiteSpace(storageSecret))
+            {
+                return new Dictionary<string, string>();
+            }
+
+            StorageCredentials storageCredentials = new StorageCredentials(storageAccountName, storageSecret);
+            var cloudAccount = new CloudStorageAccount (storageCredentials, useHttps: true);
+            CloudBlobClient blobClient = cloudAccount.CreateCloudBlobClient();
+            Dictionary<string, string> resourceIdToResourceMapping = new Dictionary<string, string>();
+
+            foreach (var uri in blobUri)
+            {
+                var blob = new CloudBlockBlob(uri, blobClient);
+                string allData = await blob.DownloadTextAsync();
+
+                var splitData = allData.Split("\n");
+
+                foreach (var entry in splitData)
+                {
+                    if (string.IsNullOrWhiteSpace(entry))
+                    {
+                        continue;
+                    }
+
+                    JObject resource = JObject.Parse(entry);
+                    resourceIdToResourceMapping.Add(resource["id"].ToString(), entry);
+                }
+            }
+
+            // Delete the container since we have downloaded the data.
+            string containerId = blobUri[0].PathAndQuery.Split('/')[1];
+            CloudBlobContainer container = blobClient.GetContainerReference(containerId);
+            await container.DeleteIfExistsAsync();
+
+            return resourceIdToResourceMapping;
+        }
+
+        private async Task<Dictionary<string, string>> GetResourcesFromFhirServer(Uri requestUri)
+        {
+            Dictionary<string, string> resourceIdToResourceMapping = new Dictionary<string, string>();
+
+            while (requestUri != null)
+            {
+                HttpRequestMessage request = new HttpRequestMessage()
+                {
+                    RequestUri = requestUri,
+                    Method = HttpMethod.Get,
+                };
+
+                HttpResponseMessage response = await _fhirClient.HttpClient.SendAsync(request);
+
+                var responseString = await response.Content.ReadAsStringAsync();
+
+                JObject result = JObject.Parse(responseString);
+
+                JArray entries = (JArray)result["entry"];
+                foreach (var entry in entries)
+                {
+                    string id = entry["resource"]["id"].ToString();
+                    string resource = entry["resource"].ToString().Trim();
+
+                    resourceIdToResourceMapping.Add(id, resource);
+                }
+
+                // Look at whether a continutation token has been returned.
+                // We will always have self link. We are looking for the "next" link
+                JArray links = (JArray)result["link"];
+                string nextUri = null;
+                if (links != null && links.Count > 1)
+                {
+                    foreach (var link in links)
+                    {
+                        if (link["relation"].ToString() == "next")
+                        {
+                            nextUri = link["url"].ToString();
+                            break;
+                        }
+                    }
+                }
+
+                requestUri = nextUri == null ? null : new Uri(nextUri);
+            }
+
+            return resourceIdToResourceMapping;
+        }
+    }
+}

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ExportDataValidationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ExportDataValidationTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
             Dictionary<string, string> dataFromExport = await DownloadBlobAndParse(blobUris);
 
             // Download all resources from fhir server
-            Dictionary<string, string> dataFromFhirServer = await GetResourcesFromFhirServer(new Uri("/"));
+            Dictionary<string, string> dataFromFhirServer = await GetResourcesFromFhirServer(_fhirClient.HttpClient.BaseAddress);
 
             // Assert both data are equal
             Assert.True(ValidateDataFromBothSources(dataFromFhirServer, dataFromExport));

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/InProcTestFhirServer.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/InProcTestFhirServer.cs
@@ -43,6 +43,9 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             configuration["TestAuthEnvironment:FilePath"] = "testauthenvironment.json";
             configuration["FhirServer:Security:Authentication:Authority"] = "https://inprochost";
 
+            // For local development we will use the Azure Storage Emulator for export.
+            configuration["FhirServer:Operations:Export:StorageAccountConnection"] = "UseDevelopmentStorage=true";
+
             var builder = WebHost.CreateDefaultBuilder()
                 .UseContentRoot(Path.GetDirectoryName(startupType.Assembly.Location))
                 .ConfigureAppConfiguration(configurationBuilder =>


### PR DESCRIPTION
## Description
Add an e2e test that exports data to a storage account and validates that the exported data is as expected. When running the test locally, it uses the Azure Storage Emulator to export data to.

## Related issues
Addresses [issue [AB#72263](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/72263)].

## Testing
Test passes locally.
