### PR TITLE
Removes double registration of SecurityProvider and XmlFormatter refs…

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/FeatureFlags/XmlFormatter/XmlFormatterFeatureModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/FeatureFlags/XmlFormatter/XmlFormatterFeatureModule.cs
@@ -45,11 +45,6 @@ namespace Microsoft.Health.Fhir.Api.Modules.FeatureFlags.XmlFormatter
                     .Singleton()
                     .AsSelf()
                     .AsService<TextOutputFormatter>();
-
-                services.Add<XmlFormatterConfiguration>()
-                    .Singleton()
-                    .AsSelf()
-                    .AsImplementedInterfaces();
             }
         }
     }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs
@@ -134,11 +134,6 @@ namespace Microsoft.Health.Fhir.Api.Modules
                 .AsSelf()
                 .AsImplementedInterfaces();
 
-            services.Add<SecurityProvider>()
-                .Singleton()
-                .AsSelf()
-                .AsService<IProvideCapability>();
-
             services.TypesInSameAssembly(KnownAssemblies.All)
                 .AssignableTo<IProvideCapability>()
                 .Transient()


### PR DESCRIPTION
## Description
Removes the double registration of SecurityProvider and XmlConfiguration

## Related issues
Addresses #1000

## Testing
Manually verified
