### PR TITLE
Fixed continuous loop in ExportJobWorker when exception is thrown

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobWorker.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobWorker.cs
@@ -96,6 +96,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                 {
                     // Cancellation requested
                     _logger.LogInformation("ExportJobWorker: Cancellation requested.");
+                    break;
                 }
             }
         }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobWorker.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobWorker.cs
@@ -95,10 +95,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
                     // Cancellation requested
-                    _logger.LogInformation("ExportJobWorker: Cancellation requested.");
                     break;
                 }
             }
+
+            _logger.LogInformation("ExportJobWorker: Cancellation requested.");
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobWorker.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobWorker.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
         private readonly Func<IExportJobTask> _exportJobTaskFactory;
         private readonly ILogger _logger;
 
-        private readonly TimeSpan _maximumDelay = TimeSpan.FromSeconds(3600);
+        private const int MaximumDelayInSeconds = 3600;
 
         public ExportJobWorker(Func<IScoped<IFhirOperationDataStore>> fhirOperationDataStoreFactory, IOptions<ExportJobConfiguration> exportJobConfiguration, Func<IExportJobTask> exportJobTaskFactory, ILogger<ExportJobWorker> logger)
         {
@@ -82,9 +82,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
                     // Since acquiring jobs failed let us introduce a delay before we retry. We don't want to increase the delay between polls to more than an hour.
                     delayBeforeNextPoll *= 2;
-                    if (delayBeforeNextPoll > _maximumDelay)
+                    if (delayBeforeNextPoll.TotalSeconds > MaximumDelayInSeconds)
                     {
-                        delayBeforeNextPoll = _maximumDelay;
+                        delayBeforeNextPoll = TimeSpan.FromSeconds(MaximumDelayInSeconds);
                     }
                 }
 


### PR DESCRIPTION
## Description
In the ExportJobWorker we don't respect the time delay when an exception is thrown within the `ExecuteAsync` loop. This causes us to continuously retry.

This code fixes that. It also introduces a mechanism of increasing the delay between retries as long as we encounter exceptions within the execute loop.

## Related issues
Addresses [issue #999].

## Testing
Added UTs.
