### PR TITLE
Initial commit of Reindex worker infrastructure and configuration

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Operations/Reindex/ReindexJobWorkerBackgroundService.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Operations/Reindex/ReindexJobWorkerBackgroundService.cs
@@ -1,0 +1,41 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Threading;
+using System.Threading.Tasks;
+using EnsureThat;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Fhir.Core.Configs;
+using Microsoft.Health.Fhir.Core.Features.Operations.Reindex;
+
+namespace Microsoft.Health.Fhir.Api.Features.Operations.Reindex
+{
+    /// <summary>
+    /// The background service used to host the <see cref="ReindexJobWorker"/>.
+    /// </summary>
+    public class ReindexJobWorkerBackgroundService : BackgroundService
+    {
+        private readonly ReindexJobWorker _reindexJobWorker;
+        private readonly ReindexJobConfiguration _reindexJobConfiguration;
+
+        public ReindexJobWorkerBackgroundService(ReindexJobWorker reindexJobWorker, IOptions<ReindexJobConfiguration> reindexJobConfiguration)
+        {
+            EnsureArg.IsNotNull(reindexJobWorker, nameof(reindexJobWorker));
+            EnsureArg.IsNotNull(reindexJobConfiguration?.Value, nameof(reindexJobConfiguration));
+
+            _reindexJobWorker = reindexJobWorker;
+            _reindexJobConfiguration = reindexJobConfiguration.Value;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            if (_reindexJobConfiguration.Enabled)
+            {
+                await _reindexJobWorker.ExecuteAsync(stoppingToken);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Api/Features/Operations/Reindex/ReindexJobWorkerBackgroundService.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Operations/Reindex/ReindexJobWorkerBackgroundService.cs
@@ -30,11 +30,11 @@ namespace Microsoft.Health.Fhir.Api.Features.Operations.Reindex
             _reindexJobConfiguration = reindexJobConfiguration.Value;
         }
 
-        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        protected override async Task ExecuteAsync(CancellationToken cancellationToken)
         {
             if (_reindexJobConfiguration.Enabled)
             {
-                await _reindexJobWorker.ExecuteAsync(stoppingToken);
+                await _reindexJobWorker.ExecuteAsync(cancellationToken);
             }
         }
     }

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Reindex/ReindexJobWorkerTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Reindex/ReindexJobWorkerTests.cs
@@ -1,0 +1,115 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Health.Fhir.Core.Configs;
+using Microsoft.Health.Fhir.Core.Features.Operations;
+using Microsoft.Health.Fhir.Core.Features.Operations.Reindex;
+using Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
+{
+    public class ReindexJobWorkerTests
+    {
+        private const ushort DefaultMaximumNumberOfConcurrentJobAllowed = 1;
+        private static readonly TimeSpan DefaultJobHeartbeatTimeoutThreshold = TimeSpan.FromMinutes(10);
+        private static readonly TimeSpan DefaultJobPollingFrequency = TimeSpan.FromMilliseconds(100);
+
+        private readonly IFhirOperationDataStore _fhirOperationDataStore = Substitute.For<IFhirOperationDataStore>();
+        private readonly ReindexJobConfiguration _reindexJobConfiguration = new ReindexJobConfiguration();
+        private readonly Func<IReindexJobTask> _reindexJobTaskFactory = Substitute.For<Func<IReindexJobTask>>();
+        private readonly IReindexJobTask _task = Substitute.For<IReindexJobTask>();
+
+        private readonly ReindexJobWorker _reindexJobWorker;
+
+        private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
+        private readonly CancellationToken _cancellationToken;
+
+        public ReindexJobWorkerTests()
+        {
+            _reindexJobConfiguration.MaximumNumberOfConcurrentJobsAllowed = DefaultMaximumNumberOfConcurrentJobAllowed;
+            _reindexJobConfiguration.JobHeartbeatTimeoutThreshold = DefaultJobHeartbeatTimeoutThreshold;
+            _reindexJobConfiguration.JobPollingFrequency = DefaultJobPollingFrequency;
+
+            _reindexJobTaskFactory().Returns(_task);
+            var scopedOperationDataStore = Substitute.For<IScoped<IFhirOperationDataStore>>();
+            scopedOperationDataStore.Value.Returns(_fhirOperationDataStore);
+
+            _reindexJobWorker = new ReindexJobWorker(
+                () => scopedOperationDataStore,
+                Options.Create(_reindexJobConfiguration),
+                _reindexJobTaskFactory,
+                NullLogger<ReindexJobWorker>.Instance);
+
+            _cancellationToken = _cancellationTokenSource.Token;
+        }
+
+        [Fact]
+        public async Task GivenThereIsNoRunningJob_WhenExecuted_ThenATaskShouldBeCreated()
+        {
+            ReindexJobWrapper job = CreateReindexJobWrapper();
+
+            SetupOperationDataStore(job);
+
+            _cancellationTokenSource.CancelAfter(DefaultJobPollingFrequency);
+
+            await _reindexJobWorker.ExecuteAsync(_cancellationToken);
+
+            _reindexJobTaskFactory().Received(1);
+        }
+
+        [Fact]
+        public async Task GivenTheNumberOfRunningJobEqualsThreshold_WhenExecuted_ThenATaskShouldNotBeCreated()
+        {
+            ReindexJobWrapper job = CreateReindexJobWrapper();
+
+            SetupOperationDataStore(job);
+
+            _task.ExecuteAsync(job.JobRecord, job.ETag, _cancellationToken).Returns(Task.Run(async () => { await Task.Delay(1000); }));
+
+            _cancellationTokenSource.CancelAfter(DefaultJobPollingFrequency * 2);
+
+            await _reindexJobWorker.ExecuteAsync(_cancellationToken);
+
+            _reindexJobTaskFactory.Received(1);
+        }
+
+        private void SetupOperationDataStore(
+            ReindexJobWrapper job,
+            ushort maximumNumberOfConcurrentJobsAllowed = DefaultMaximumNumberOfConcurrentJobAllowed,
+            TimeSpan? jobHeartbeatTimeoutThreshold = null,
+            TimeSpan? jobPollingFrequency = null)
+        {
+            if (jobHeartbeatTimeoutThreshold == null)
+            {
+                jobHeartbeatTimeoutThreshold = DefaultJobHeartbeatTimeoutThreshold;
+            }
+
+            if (jobPollingFrequency == null)
+            {
+                jobPollingFrequency = DefaultJobPollingFrequency;
+            }
+
+            _fhirOperationDataStore.AcquireReindexJobsAsync(
+                maximumNumberOfConcurrentJobsAllowed,
+                jobHeartbeatTimeoutThreshold.Value,
+                _cancellationToken)
+                .Returns(new[] { job });
+        }
+
+        private ReindexJobWrapper CreateReindexJobWrapper()
+        {
+            return new ReindexJobWrapper(new ReindexJobRecord("test"), WeakETag.FromVersionId("0"));
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Configs/OperationsConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/OperationsConfiguration.cs
@@ -8,5 +8,7 @@ namespace Microsoft.Health.Fhir.Core.Configs
     public class OperationsConfiguration
     {
         public ExportJobConfiguration Export { get; set; } = new ExportJobConfiguration();
+
+        public ReindexJobConfiguration Reindex { get; set; } = new ReindexJobConfiguration();
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Configs/ReindexJobConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/ReindexJobConfiguration.cs
@@ -1,0 +1,43 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.Health.Fhir.Core.Configs
+{
+    public class ReindexJobConfiguration
+    {
+        /// <summary>
+        /// Determines whether reindexing feature is enabled or not.
+        /// </summary>
+        public bool Enabled { get; set; } = false;
+
+        /// <summary>
+        /// Controls default number of threads applied to a reindex job is parameter is not specified in the POST
+        /// </summary>
+        public ushort DefaultMaximumThreadsPerReindexJob { get; set; } = 1;
+
+        /// <summary>
+        /// Controls time limit before a job is considered stale and needs to be recovered
+        /// </summary>
+        public TimeSpan JobHeartbeatTimeoutThreshold { get; set; } = TimeSpan.FromMinutes(10);
+
+        /// <summary>
+        /// Controls time between queries checking for reindex jobs
+        /// </summary>
+        public TimeSpan JobPollingFrequency { get; set; } = TimeSpan.FromSeconds(10);
+
+        /// <summary>
+        /// Controls how many resources will be returned in a batch for reindexing
+        /// </summary>
+        public uint MaximumNumberOfResourcesPerQuery { get; set; } = 100;
+
+        /// <summary>
+        /// Controls how many reindex jobs are allowed to be running at one time
+        /// currently fixed at 1
+        /// </summary>
+        public int MaximumNumberOfConcurrentJobsAllowed { get; internal set; } = 1;
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Configs/ReindexJobConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/ReindexJobConfiguration.cs
@@ -38,6 +38,6 @@ namespace Microsoft.Health.Fhir.Core.Configs
         /// Controls how many reindex jobs are allowed to be running at one time
         /// currently fixed at 1
         /// </summary>
-        public int MaximumNumberOfConcurrentJobsAllowed { get; internal set; } = 1;
+        public ushort MaximumNumberOfConcurrentJobsAllowed { get; internal set; } = 1;
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Configs/ReindexJobConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/ReindexJobConfiguration.cs
@@ -14,6 +14,8 @@ namespace Microsoft.Health.Fhir.Core.Configs
         /// </summary>
         public bool Enabled { get; set; } = false;
 
+        public ushort ConsecutiveFailuresThreshold { get; set; } = 5;
+
         /// <summary>
         /// Controls default number of threads applied to a reindex job if parameter is not specified in the POST
         /// </summary>

--- a/src/Microsoft.Health.Fhir.Core/Configs/ReindexJobConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/ReindexJobConfiguration.cs
@@ -32,6 +32,11 @@ namespace Microsoft.Health.Fhir.Core.Configs
         public TimeSpan JobPollingFrequency { get; set; } = TimeSpan.FromSeconds(10);
 
         /// <summary>
+        /// Controls the time between queries of resources to be reindexed
+        /// </summary>
+        public TimeSpan QueryDelayIntervalInMilliseconds { get; set; } = TimeSpan.FromMilliseconds(500);
+
+        /// <summary>
         /// Controls how many resources will be returned in a batch for reindexing
         /// </summary>
         public uint MaximumNumberOfResourcesPerQuery { get; set; } = 100;

--- a/src/Microsoft.Health.Fhir.Core/Configs/ReindexJobConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/ReindexJobConfiguration.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Health.Fhir.Core.Configs
         public bool Enabled { get; set; } = false;
 
         /// <summary>
-        /// Controls default number of threads applied to a reindex job is parameter is not specified in the POST
+        /// Controls default number of threads applied to a reindex job if parameter is not specified in the POST
         /// </summary>
         public ushort DefaultMaximumThreadsPerReindexJob { get; set; } = 1;
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/IFhirOperationDataStore.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/IFhirOperationDataStore.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export.Models;
+using Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 
 namespace Microsoft.Health.Fhir.Core.Features.Operations
@@ -56,5 +57,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>A list of acquired export job.</returns>
         Task<IReadOnlyCollection<ExportJobOutcome>> AcquireExportJobsAsync(ushort maximumNumberOfConcurrentJobsAllowed, TimeSpan jobHeartbeatTimeoutThreshold, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Acquires reindex jobs.
+        /// </summary>
+        /// <param name="maximumNumberOfConcurrentJobsAllowed">The maximum number of concurrent reindex jobs allowed.</param>
+        /// <param name="jobHeartbeatTimeoutThreshold">The job heartbeat timeout threshold.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A list of acquired reindex jobs.</returns>
+        Task<IReadOnlyCollection<ReindexJobWrapper>> AcquireReindexJobsAsync(ushort maximumNumberOfConcurrentJobsAllowed, TimeSpan jobHeartbeatTimeoutThreshold, CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
@@ -64,5 +64,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations
         public const string FailureDetails = "failureDetails";
 
         public const string Since = "since";
+
+        public const string Input = "input";
+
+        public const string FailureCount = "failureCount";
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/IReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/IReindexJobTask.cs
@@ -1,0 +1,24 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
+
+namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
+{
+    public interface IReindexJobTask
+    {
+        /// <summary>
+        /// Executes the reindex job task.
+        /// </summary>
+        /// <param name="reindexJobRecord">The reindex job record.</param>
+        /// <param name="weakETag">The version ETag.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A <see cref="Task"/> representing the reindex job task.</returns>
+        Task ExecuteAsync(ReindexJobRecord reindexJobRecord, WeakETag weakETag, CancellationToken cancellationToken);
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobQueryStatus.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobQueryStatus.cs
@@ -1,0 +1,31 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Newtonsoft.Json;
+
+namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
+{
+    /// <summary>
+    /// Class to hold metadata for an individual reindex job.
+    /// </summary>
+    public class ReindexJobQueryStatus
+    {
+        [JsonProperty(JobRecordProperties.Query)]
+        public string Query { get; private set; }
+
+        [JsonProperty(JobRecordProperties.Status)]
+        public OperationStatus Status { get; set; }
+
+        [JsonProperty(JobRecordProperties.LastModified)]
+        public DateTimeOffset LastModified { get; set; }
+
+        [JsonProperty(JobRecordProperties.Error)]
+        public string Error { get; set; }
+
+        [JsonProperty(JobRecordProperties.FailureCount)]
+        public ushort FailureCount { get; set; }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobQueryStatus.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobQueryStatus.cs
@@ -9,7 +9,7 @@ using Newtonsoft.Json;
 namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
 {
     /// <summary>
-    /// Class to hold metadata for an individual reindex job.
+    /// Class to hold metadata for one query of a reindex job
     /// </summary>
     public class ReindexJobQueryStatus
     {

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobRecord.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobRecord.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
     /// </summary>
     public class ReindexJobRecord
     {
-        public ReindexJobRecord()
+        public ReindexJobRecord(string searchParametersHash)
         {
             // Default values
             SchemaVersion = 1;
@@ -25,6 +25,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
 
             QueuedTime = Clock.UtcNow;
             LastModified = Clock.UtcNow;
+
+            Hash = searchParametersHash;
         }
 
         [JsonProperty(JobRecordProperties.Id)]

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobRecord.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobRecord.cs
@@ -1,0 +1,74 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Health.Core;
+using Microsoft.Health.Fhir.Core.Models;
+using Newtonsoft.Json;
+
+namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
+{
+    /// <summary>
+    /// Class to hold metadata for an individual reindex job.
+    /// </summary>
+    public class ReindexJobRecord
+    {
+        public ReindexJobRecord()
+        {
+            // Default values
+            SchemaVersion = 1;
+            Id = Guid.NewGuid().ToString();
+            Status = OperationStatus.Queued;
+
+            QueuedTime = Clock.UtcNow;
+            LastModified = Clock.UtcNow;
+        }
+
+        [JsonProperty(JobRecordProperties.Id)]
+        public string Id { get; private set; }
+
+        /// <summary>
+        ///  The input should be a Parameters FHIR Resource
+        ///  TODO: We don't want to add a dependency on the FHIR model here
+        ///  but need a method to handle this type
+        /// </summary>
+        [JsonProperty(JobRecordProperties.Input)]
+        public string Input { get; private set; }
+
+        [JsonProperty(JobRecordProperties.QueuedTime)]
+        public DateTimeOffset QueuedTime { get; private set; }
+
+        [JsonProperty(JobRecordProperties.SchemaVersion)]
+        public int SchemaVersion { get; private set; }
+
+        [JsonProperty(JobRecordProperties.Error)]
+        public IList<OperationOutcomeIssue> Error { get; private set; } = new List<OperationOutcomeIssue>();
+
+        [JsonProperty(JobRecordProperties.Status)]
+        public OperationStatus Status { get; set; }
+
+        [JsonProperty(JobRecordProperties.StartTime)]
+        public DateTimeOffset? StartTime { get; set; }
+
+        [JsonProperty(JobRecordProperties.EndTime)]
+        public DateTimeOffset? EndTime { get; set; }
+
+        [JsonProperty(JobRecordProperties.CanceledTime)]
+        public DateTimeOffset? CanceledTime { get; set; }
+
+        [JsonProperty(JobRecordProperties.Progress)]
+        public IList<ReindexJobQueryStatus> Progress { get; private set; } = new List<ReindexJobQueryStatus>();
+
+        [JsonProperty(JobRecordProperties.Hash)]
+        public string Hash { get; private set; }
+
+        [JsonProperty(JobRecordProperties.LastModified)]
+        public DateTimeOffset LastModified { get; set; }
+
+        [JsonProperty(JobRecordProperties.FailureCount)]
+        public ushort FaiureCount { get; set; }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobRecord.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobRecord.cs
@@ -29,6 +29,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
             Hash = searchParametersHash;
         }
 
+        [JsonConstructor]
+        protected ReindexJobRecord()
+        {
+        }
+
         [JsonProperty(JobRecordProperties.Id)]
         public string Id { get; private set; }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobWrapper.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobWrapper.cs
@@ -10,7 +10,7 @@ using Newtonsoft.Json;
 namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
 {
     /// <summary>
-    /// Class to wrap reindex document returneded from persistence layer
+    /// Class to wrap reindex document returned from persistence layer
     /// </summary>
     public class ReindexJobWrapper
     {
@@ -29,7 +29,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
         }
 
         /// <summary>
-        /// Metadata for the export job.
+        /// Metadata for the reindex job.
         /// </summary>
         public ReindexJobRecord JobRecord { get; }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobWrapper.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobWrapper.cs
@@ -1,0 +1,35 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using EnsureThat;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
+
+namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
+{
+    /// <summary>
+    /// Class to wrap reindex document returneded from persistence layer
+    /// </summary>
+    public class ReindexJobWrapper
+    {
+        public ReindexJobWrapper(ReindexJobRecord jobRecord, WeakETag eTag)
+        {
+            EnsureArg.IsNotNull(jobRecord, nameof(jobRecord));
+            EnsureArg.IsNotNull(eTag, nameof(eTag));
+
+            JobRecord = jobRecord;
+            ETag = eTag;
+        }
+
+        /// <summary>
+        /// Metadata for the export job.
+        /// </summary>
+        public ReindexJobRecord JobRecord { get; }
+
+        /// <summary>
+        /// Represents the version of the document in the datastore. Used to resolve conflicts.
+        /// </summary>
+        public WeakETag ETag { get; }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobWrapper.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobWrapper.cs
@@ -5,6 +5,7 @@
 
 using EnsureThat;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Newtonsoft.Json;
 
 namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
 {
@@ -20,6 +21,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
 
             JobRecord = jobRecord;
             ETag = eTag;
+        }
+
+        [JsonConstructor]
+        protected ReindexJobWrapper()
+        {
         }
 
         /// <summary>

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -1,0 +1,113 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using EnsureThat;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Core;
+using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Health.Fhir.Core.Configs;
+using Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Microsoft.Health.Fhir.Core.Features.Search;
+using Microsoft.Health.Fhir.Core.Models;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
+{
+    public class ReindexJobTask : IReindexJobTask
+    {
+        private readonly Func<IScoped<IFhirOperationDataStore>> _fhirOperationDataStoreFactory;
+        private readonly ReindexJobConfiguration _reindexJobConfiguration;
+        private readonly Func<IScoped<ISearchService>> _searchServiceFactory;
+        private readonly ILogger _logger;
+
+        private ReindexJobRecord _reindexJobRecord;
+        private WeakETag _weakETag;
+
+        public ReindexJobTask(
+            Func<IScoped<IFhirOperationDataStore>> fhirOperationDataStoreFactory,
+            IOptions<ReindexJobConfiguration> reindexJobConfiguration,
+            Func<IScoped<ISearchService>> searchServiceFactory,
+            ILogger<ReindexJobTask> logger)
+        {
+            EnsureArg.IsNotNull(fhirOperationDataStoreFactory, nameof(fhirOperationDataStoreFactory));
+            EnsureArg.IsNotNull(reindexJobConfiguration?.Value, nameof(reindexJobConfiguration));
+            EnsureArg.IsNotNull(searchServiceFactory, nameof(searchServiceFactory));
+            EnsureArg.IsNotNull(logger, nameof(logger));
+
+            _fhirOperationDataStoreFactory = fhirOperationDataStoreFactory;
+            _reindexJobConfiguration = reindexJobConfiguration.Value;
+            _searchServiceFactory = searchServiceFactory;
+            _logger = logger;
+        }
+
+        /// <inheritdoc />
+        public async Task ExecuteAsync(ReindexJobRecord reindexJobRecord, WeakETag weakETag, CancellationToken cancellationToken)
+        {
+            EnsureArg.IsNotNull(reindexJobRecord, nameof(reindexJobRecord));
+
+            _reindexJobRecord = reindexJobRecord;
+            _weakETag = weakETag;
+
+            try
+            {
+                // If we are resuming a job, we can detect that by checking the progress info from the job record.
+                // If no queries have been added to the progress then this is a new job
+                if (_reindexJobRecord.Progress?.Count == 0)
+                {
+                    // Build query based on new search params
+                }
+
+                // This is just a shell for now, will be completed in future
+
+                await CompleteJobAsync(OperationStatus.Completed, cancellationToken);
+
+                _logger.LogTrace("Successfully completed the job.");
+            }
+            catch (JobConflictException)
+            {
+                // The export job was updated externally. There might be some additional resources that were exported
+                // but we will not be updating the job record.
+                _logger.LogTrace("The job was updated by another process.");
+            }
+            catch (Exception ex)
+            {
+                // The job has encountered an error it cannot recover from.
+                // Try to update the job to failed state.
+                _logger.LogError(ex, "Encountered an unhandled exception. The job will be marked as failed.");
+
+                _reindexJobRecord.Error.Add(new OperationOutcomeIssue(
+                    OperationOutcomeConstants.IssueSeverity.Error,
+                    OperationOutcomeConstants.IssueType.Exception,
+                    ex.Message));
+                await CompleteJobAsync(OperationStatus.Failed, cancellationToken);
+            }
+        }
+
+        private async Task CompleteJobAsync(OperationStatus completionStatus, CancellationToken cancellationToken)
+        {
+            _reindexJobRecord.Status = completionStatus;
+            _reindexJobRecord.EndTime = Clock.UtcNow;
+
+            await UpdateJobRecordAsync(cancellationToken);
+        }
+
+        private async Task UpdateJobRecordAsync(CancellationToken cancellationToken)
+        {
+            await Task.FromException(new NotImplementedException());
+            return;
+        }
+
+        private async Task ProcessSearchResultsAsync(IEnumerable<SearchResultEntry> searchResults, uint partId, CancellationToken cancellationToken)
+        {
+            await Task.FromException(new NotImplementedException());
+            return;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
         public async Task ExecuteAsync(ReindexJobRecord reindexJobRecord, WeakETag weakETag, CancellationToken cancellationToken)
         {
             EnsureArg.IsNotNull(reindexJobRecord, nameof(reindexJobRecord));
+            EnsureArg.IsNotNull(weakETag, nameof(weakETag));
 
             _reindexJobRecord = reindexJobRecord;
             _weakETag = weakETag;

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -72,8 +72,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             }
             catch (JobConflictException)
             {
-                // The export job was updated externally. There might be some additional resources that were exported
-                // but we will not be updating the job record.
+                // The reindex job was updated externally.
                 _logger.LogTrace("The job was updated by another process.");
             }
             catch (Exception ex)
@@ -102,12 +101,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
         {
             // TODO: Placeholder
             await new Task(() => _reindexJobRecord.LastModified = Clock.UtcNow, cancellationToken);
-            return;
         }
-
-        /* private async Task ProcessSearchResultsAsync(IEnumerable<SearchResultEntry> searchResults, uint partId, CancellationToken cancellationToken)
-        {
-
-        }*/
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -4,7 +4,6 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using EnsureThat;
 using Microsoft.Extensions.Logging;
@@ -100,14 +99,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
 
         private async Task UpdateJobRecordAsync(CancellationToken cancellationToken)
         {
-            await Task.FromException(new NotImplementedException());
+            // TODO: Placeholder
+            await new Task(() => _reindexJobRecord.LastModified = Clock.UtcNow, cancellationToken);
             return;
         }
 
-        private async Task ProcessSearchResultsAsync(IEnumerable<SearchResultEntry> searchResults, uint partId, CancellationToken cancellationToken)
+        /* private async Task ProcessSearchResultsAsync(IEnumerable<SearchResultEntry> searchResults, uint partId, CancellationToken cancellationToken)
         {
-            await Task.FromException(new NotImplementedException());
-            return;
-        }
+
+        }*/
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobWorker.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobWorker.cs
@@ -69,6 +69,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                             }
                         }
                     }
+
+                    await Task.Delay(_reindexJobConfiguration.JobPollingFrequency, cancellationToken);
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
@@ -78,10 +80,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                 {
                     // The job failed.
                     _logger.LogError(ex, "Unhandled exception in the worker.");
-                }
-                finally
-                {
-                    await Task.Delay(_reindexJobConfiguration.JobPollingFrequency, cancellationToken);
                 }
             }
         }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobWorker.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobWorker.cs
@@ -1,0 +1,75 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using EnsureThat;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Health.Fhir.Core.Configs;
+
+namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
+{
+    /// <summary>
+    /// The worker responsible for running the export job tasks.
+    /// </summary>
+    public class ReindexJobWorker
+    {
+        private readonly Func<IScoped<IFhirOperationDataStore>> _fhirOperationDataStoreFactory;
+        private readonly ReindexJobConfiguration _reindexJobConfiguration;
+        private readonly Func<IReindexJobTask> _reindexJobTaskFactory;
+        private readonly ILogger _logger;
+
+        public ReindexJobWorker(Func<IScoped<IFhirOperationDataStore>> fhirOperationDataStoreFactory, IOptions<ReindexJobConfiguration> reindexJobConfiguration, Func<IReindexJobTask> reindexJobTaskFactory, ILogger<ReindexJobWorker> logger)
+        {
+            EnsureArg.IsNotNull(fhirOperationDataStoreFactory, nameof(fhirOperationDataStoreFactory));
+            EnsureArg.IsNotNull(reindexJobConfiguration?.Value, nameof(reindexJobConfiguration));
+            EnsureArg.IsNotNull(reindexJobTaskFactory, nameof(reindexJobTaskFactory));
+            EnsureArg.IsNotNull(logger, nameof(logger));
+
+            _fhirOperationDataStoreFactory = fhirOperationDataStoreFactory;
+            _reindexJobConfiguration = reindexJobConfiguration.Value;
+            _reindexJobTaskFactory = reindexJobTaskFactory;
+            _logger = logger;
+        }
+
+        public async Task ExecuteAsync(CancellationToken cancellationToken)
+        {
+            var runningTasks = new List<Task>();
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    // Remove all completed tasks.
+                    runningTasks.RemoveAll(task => task.IsCompleted);
+
+                    // Get list of available jobs.
+                    if (runningTasks.Count < _reindexJobConfiguration.MaximumNumberOfConcurrentJobsAllowed)
+                    {
+                        using (IScoped<IFhirOperationDataStore> store = _fhirOperationDataStoreFactory())
+                        {
+                            // Query reindex job records
+                        }
+                    }
+
+                    await Task.Delay(_reindexJobConfiguration.JobPollingFrequency, cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    // Cancel requested.
+                }
+                catch (Exception ex)
+                {
+                    // The job failed.
+                    _logger.LogError(ex, "Unhandled exception in the worker.");
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobWorker.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobWorker.cs
@@ -17,7 +17,7 @@ using Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models;
 namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
 {
     /// <summary>
-    /// The worker responsible for running the export job tasks.
+    /// The worker responsible for running the reindex job tasks.
     /// </summary>
     public class ReindexJobWorker
     {
@@ -72,7 +72,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
-                    break; // This will skip the delay in the finally block and terminate the Task
+                    // End the execution of the task
                 }
                 catch (Exception ex)
                 {

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobWorker.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobWorker.cs
@@ -80,6 +80,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                 {
                     // The job failed.
                     _logger.LogError(ex, "Unhandled exception in the worker.");
+                    await Task.Delay(_reindexJobConfiguration.JobPollingFrequency, cancellationToken);
                 }
             }
         }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobWorker.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobWorker.cs
@@ -69,8 +69,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                             }
                         }
                     }
-
-                    await Task.Delay(_reindexJobConfiguration.JobPollingFrequency, cancellationToken);
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
@@ -80,6 +78,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                 {
                     // The job failed.
                     _logger.LogError(ex, "Unhandled exception in the worker.");
+                }
+                finally
+                {
+                    await Task.Delay(_reindexJobConfiguration.JobPollingFrequency, cancellationToken);
                 }
             }
         }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobWorker.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobWorker.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
-                    // Cancel requested.
+                    break; // This will skip the delay in the finally block and terminate the Task
                 }
                 catch (Exception ex)
                 {

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/ISearchIndexer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/ISearchIndexer.cs
@@ -4,7 +4,6 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Collections.Generic;
-using Hl7.Fhir.ElementModel;
 using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Core.Features.Search

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Operations/CosmosFhirOperationDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Operations/CosmosFhirOperationDataStore.cs
@@ -21,6 +21,7 @@ using Microsoft.Health.CosmosDb.Features.Storage;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export.Models;
+using Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.CosmosDb.Features.Storage.Operations.Export;
 using Microsoft.Health.Fhir.CosmosDb.Features.Storage.StoredProcedures.AcquireExportJobs;
@@ -260,6 +261,11 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Operations
                 _logger.LogError(dce, "Failed to acquire export jobs.");
                 throw;
             }
+        }
+
+        public Task<IReadOnlyCollection<ReindexJobWrapper>> AcquireReindexJobsAsync(ushort maximumNumberOfConcurrentJobsAllowed, TimeSpan jobHeartbeatTimeoutThreshold, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/OperationsModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/OperationsModule.cs
@@ -7,6 +7,7 @@ using EnsureThat;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export;
+using Microsoft.Health.Fhir.Core.Features.Operations.Reindex;
 
 namespace Microsoft.Health.Fhir.Api.Modules
 {
@@ -35,6 +36,19 @@ namespace Microsoft.Health.Fhir.Api.Modules
             services.Add<ResourceToNdjsonBytesSerializer>()
                 .Singleton()
                 .AsService<IResourceToByteArraySerializer>();
+
+            services.Add<ReindexJobTask>()
+                .Transient()
+                .AsSelf();
+
+            services.Add<IReindexJobTask>(sp => sp.GetRequiredService<ReindexJobTask>())
+                .Transient()
+                .AsSelf()
+                .AsFactory();
+
+            services.Add<ReindexJobWorker>()
+                .Singleton()
+                .AsSelf();
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
@@ -20,6 +20,7 @@ using Microsoft.Health.Fhir.Api.Features.Audit;
 using Microsoft.Health.Fhir.Api.Features.Context;
 using Microsoft.Health.Fhir.Api.Features.Exceptions;
 using Microsoft.Health.Fhir.Api.Features.Operations.Export;
+using Microsoft.Health.Fhir.Api.Features.Operations.Reindex;
 using Microsoft.Health.Fhir.Api.Features.Routing;
 using Microsoft.Health.Fhir.Core.Features.Cors;
 using Microsoft.Health.Fhir.Core.Registration;
@@ -93,16 +94,17 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
-        /// Adds the export worker background service.
+        /// Adds background worker services.
         /// </summary>
         /// <param name="fhirServerBuilder">The FHIR server builder.</param>
         /// <returns>The builder.</returns>
-        public static IFhirServerBuilder AddExportWorker(
+        public static IFhirServerBuilder AddBackgroundWorkers(
             this IFhirServerBuilder fhirServerBuilder)
         {
             EnsureArg.IsNotNull(fhirServerBuilder, nameof(fhirServerBuilder));
 
             fhirServerBuilder.Services.AddHostedService<ExportJobWorkerBackgroundService>();
+            fhirServerBuilder.Services.AddHostedService<ReindexJobWorkerBackgroundService>();
 
             return fhirServerBuilder;
         }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
@@ -66,6 +66,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton(Options.Options.Create(fhirServerConfiguration.Cors));
             services.AddSingleton(Options.Options.Create(fhirServerConfiguration.Operations));
             services.AddSingleton(Options.Options.Create(fhirServerConfiguration.Operations.Export));
+            services.AddSingleton(Options.Options.Create(fhirServerConfiguration.Operations.Reindex));
             services.AddSingleton(Options.Options.Create(fhirServerConfiguration.Audit));
             services.AddSingleton(Options.Options.Create(fhirServerConfiguration.Bundle));
 

--- a/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Health.Fhir.Web
             services.AddDevelopmentIdentityProvider(Configuration);
 
             Core.Registration.IFhirServerBuilder fhirServerBuilder = services.AddFhirServer(Configuration)
-                .AddExportWorker()
+                .AddBackgroundWorkers()
                 .AddAzureExportDestinationClient()
                 .AddAzureExportClientInitializer(Configuration);
 

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -50,7 +50,7 @@
                 "NumberOfPagesPerCommit": 10
             },
             "Reindexing": {
-                "Enabled": true,
+                "Enabled": false,
                 "ConsecutiveFailuresThreshold": 5,
                 "DefaultMaximumThreadsPerReindexJob": 1,
                 "MaximumNumberOfResourcesPerQuery": 100,

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -48,6 +48,15 @@
                 "JobPollingFrequency": "00:00:10",
                 "MaximumNumberOfResourcesPerQuery": 100,
                 "NumberOfPagesPerCommit": 10
+            },
+            "Reindexing": {
+                "Enabled": true,
+                "ConsecutiveFailuresThreshold": 5,
+                "DefaultMaximumThreadsPerReindexJob": 1,
+                "MaximumNumberOfResourcesPerQuery": 100,
+                "JobHeartbeatTimeoutThreshold": "00:10:00",
+                "JobPollingFrequency": "00:00:10",
+                "QueryDelayIntervalInMilliseconds": 500
             }
         },
         "Audit": {

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirOperationDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirOperationDataStore.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Health.Fhir.Core.Features.Conformance.Serialization;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export.Models;
+using Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.SqlServer.Features.Schema.Model;
 using Microsoft.Health.SqlServer;
@@ -192,6 +193,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
                 return acquiredJobs;
             }
+        }
+
+        public Task<IReadOnlyCollection<ReindexJobWrapper>> AcquireReindexJobsAsync(ushort maximumNumberOfConcurrentJobsAllowed, TimeSpan jobHeartbeatTimeoutThreshold, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
         }
 
         private ExportJobOutcome CreateExportJobOutcome(string rawJobRecord, byte[] rowVersionAsBytes)


### PR DESCRIPTION
## Description
Creates the initial infrastructure for a reindex background worker.  Adds configuration, reindex job document and service registration.

## Related issues
Addresses [issue [AB#73387](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/73387)].

## Testing
Unit testing for checking number of concurrent jobs added
