### PR TITLE
Adds another condition for large documents that are rejected from CosmosDb

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosResponseProcessor.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosResponseProcessor.cs
@@ -64,8 +64,12 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
                 {
                     throw new Core.Exceptions.RequestNotValidException(Core.Resources.InvalidContinuationToken);
                 }
-                else if (dce.StatusCode == HttpStatusCode.BadRequest && dce.Message.Contains("Request size is too large", StringComparison.OrdinalIgnoreCase))
+                else if (dce.StatusCode == HttpStatusCode.RequestEntityTooLarge
+                         || (dce.StatusCode == HttpStatusCode.BadRequest && dce.Message.Contains("Request size is too large", StringComparison.OrdinalIgnoreCase)))
                 {
+                    // There are multiple known failures relating to RequestEntityTooLarge.
+                    // 1. When the document size is ~2mb (just under or at the limit) it can make it into the stored proc and fail on create
+                    // 2. Larger documents are rejected by CosmosDb with HttpStatusCode.RequestEntityTooLarge
                     throw new Core.Exceptions.RequestEntityTooLargeException();
                 }
                 else if (dce.StatusCode == HttpStatusCode.Forbidden && dce.GetSubStatusValue() == CosmosDbSubStatusValues.CustomerManagedKeyInaccessible)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/CreateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/CreateTests.cs
@@ -57,14 +57,18 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             DotNetAttributeValidation.Validate(observation, true);
         }
 
-        [Fact]
+        [Theory]
+        [InlineData(2)]
+        [InlineData(5)]
         [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb)]
-        public async Task GivenALargeResource_WhenPostingToHttp_ThenServerShouldRespondWithRequestEntityTooLarge()
+        public async Task GivenALargeResource_WhenPostingToHttp_ThenServerShouldRespondWithRequestEntityTooLarge(int dataSizeMb)
         {
             var poco = Samples.GetDefaultPatient().ToPoco<Patient>();
             StringBuilder largeStringBuilder = new StringBuilder();
 
-            for (int i = 0; i < 1024 * 1024 * 2; i++)
+            // At ~2mb the document makes it into the Upsert Stored Proc and fails on create
+            // At 5mb the request is rejected by CosmosDb with HttpStatusCode.RequestEntityTooLarge
+            for (int i = 0; i < 1024 * 1024 * dataSizeMb; i++)
             {
                 largeStringBuilder.Append('a');
             }


### PR DESCRIPTION
Adds another condition for large documents that are rejected from CosmosDb

## Related issues
#771, #778

## Testing
Adds additional E2E test
