### PR TITLE
Fixes SupportedSearchParameterDefinitionManager to filter by IsSupported

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Definition/SupportedSearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Definition/SupportedSearchParameterDefinitionManager.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         public bool TryGetSearchParameter(string resourceType, string name, out SearchParameterInfo searchParameter)
         {
             searchParameter = null;
-            if (_inner.TryGetSearchParameter(resourceType, name, out var parameter) && parameter.IsSearchable)
+            if (_inner.TryGetSearchParameter(resourceType, name, out var parameter) && parameter.IsSupported)
             {
                 searchParameter = parameter;
 


### PR DESCRIPTION
## Description
- Fixes `SupportedSearchParameterDefinitionManger.TryGetSearchParameter()` to filter by `IsSupported` instead of `IsSearchable`

## Related issues
Addresses #1005 and [#AB73881](https://microsofthealth.visualstudio.com/Health/_workitems/edit/73881).

## Testing
Tests to be done in [#AB73991](https://microsofthealth.visualstudio.com/Health/_workitems/edit/73991)
