### PR TITLE
Adds SQL search parameter registry

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/Registry/SearchParameterStatusManagerTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/Registry/SearchParameterStatusManagerTests.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Registry
 
             await _searchParameterRegistry
                 .Received()
-                .UpdateStatuses(Arg.Is<IEnumerable<ResourceSearchParameterStatus>>(x => x.Single().Uri == _queryParameter.Url));
+                .UpsertStatuses(Arg.Is<IEnumerable<ResourceSearchParameterStatus>>(x => x.Single().Uri == _queryParameter.Url));
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Exceptions/FhirTransactionFailedException.cs
+++ b/src/Microsoft.Health.Fhir.Core/Exceptions/FhirTransactionFailedException.cs
@@ -6,10 +6,9 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net;
-using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Models;
 
-namespace Microsoft.Health.Fhir.Api.Features.Bundle
+namespace Microsoft.Health.Fhir.Core.Exceptions
 {
     public class FhirTransactionFailedException : FhirException
     {

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/FilebasedSearchParameterRegistry.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/FilebasedSearchParameterRegistry.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -81,7 +80,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
             return Task.FromResult<IReadOnlyCollection<ResourceSearchParameterStatus>>(_statusResults);
         }
 
-        public Task UpdateStatuses(IEnumerable<ResourceSearchParameterStatus> statuses)
+        public Task UpsertStatuses(IEnumerable<ResourceSearchParameterStatus> statuses)
         {
             // File based registry does not persist runtime updates
             return Task.CompletedTask;

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/ISearchParameterRegistry.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/ISearchParameterRegistry.cs
@@ -12,6 +12,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
     {
         Task<IReadOnlyCollection<ResourceSearchParameterStatus>> GetSearchParameterStatuses();
 
-        Task UpdateStatuses(IEnumerable<ResourceSearchParameterStatus> statuses);
+        Task UpsertStatuses(IEnumerable<ResourceSearchParameterStatus> statuses);
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
 
             if (newParameters.Any())
             {
-                await _searchParameterRegistry.UpdateStatuses(newParameters);
+                await _searchParameterRegistry.UpsertStatuses(newParameters);
             }
 
             await _mediator.Publish(new SearchParametersUpdated(updated));

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Registry/CosmosDbStatusRegistry.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Registry/CosmosDbStatusRegistry.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Registry
             return parameterStatus;
         }
 
-        public async Task UpdateStatuses(IEnumerable<ResourceSearchParameterStatus> statuses)
+        public async Task UpsertStatuses(IEnumerable<ResourceSearchParameterStatus> statuses)
         {
             EnsureArg.IsNotNull(statuses, nameof(statuses));
 

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Bundle/FhirTransactionFailedExceptionTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Bundle/FhirTransactionFailedExceptionTests.cs
@@ -6,7 +6,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using Microsoft.Health.Fhir.Api.Features.Bundle;
+using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Models;
 using Xunit;
 

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/TransactionExceptionHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/TransactionExceptionHandlerTests.cs
@@ -6,8 +6,8 @@
 using System.Collections.Generic;
 using System.Net;
 using Hl7.Fhir.Model;
-using Microsoft.Health.Fhir.Api.Features.Bundle;
 using Microsoft.Health.Fhir.Api.Features.Resources.Bundle;
+using Microsoft.Health.Fhir.Core.Exceptions;
 using Xunit;
 
 namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
@@ -24,7 +24,6 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
-using Microsoft.Health.Abstractions.Exceptions;
 using Microsoft.Health.Abstractions.Features.Transactions;
 using Microsoft.Health.Fhir.Api.Configs;
 using Microsoft.Health.Fhir.Api.Features.Audit;

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/TransactionExceptionHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/TransactionExceptionHandler.cs
@@ -6,7 +6,7 @@
 using System.Collections.Generic;
 using System.Net;
 using Hl7.Fhir.Model;
-using Microsoft.Health.Fhir.Api.Features.Bundle;
+using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/3.diff.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/3.diff.sql
@@ -13,7 +13,7 @@ CREATE TABLE dbo.SearchParamRegistry
 (
     Uri varchar(128) COLLATE Latin1_General_100_CS_AS NOT NULL,
     Status varchar(10) NOT NULL,
-    LastUpdated datetimeoffset(7) NULL, -- TODO: Should this just be datetime? What level of precision is needed?
+    LastUpdated datetimeoffset(7) NULL,
     IsPartiallySupported bit NOT NULL
 )
 
@@ -66,7 +66,7 @@ AS
     SET TRANSACTION ISOLATION LEVEL SERIALIZABLE
     BEGIN TRANSACTION
 
-    DECLARE @lastUpdated datetime2(7) = SYSUTCDATETIME()
+    DECLARE @lastUpdated datetimeoffset(7) = SYSDATETIMEOFFSET()
 
     -- Acquire and hold an exclusive table lock for the entire transaction to prevent parameters from being added or modified during upsertion.
     UPDATE dbo.SearchParamRegistry
@@ -121,7 +121,7 @@ AS
     SET XACT_ABORT ON
     BEGIN TRANSACTION
 
-    DECLARE @lastUpdated datetime2(7) = SYSUTCDATETIME()
+    DECLARE @lastUpdated datetimeoffset(7) = SYSDATETIMEOFFSET()
     
     INSERT INTO dbo.SearchParamRegistry
         (Uri, Status, LastUpdated, IsPartiallySupported)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/3.diff.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/3.diff.sql
@@ -37,6 +37,30 @@ GO
 
 --
 -- STORED PROCEDURE
+--     Updates the status of a search parameter.
+--
+-- DESCRIPTION
+--     Given an identifying URI, sets the status of a search parameter.
+--
+-- PARAMETERS
+--     @uri
+--         * The search parameter's identifying URI
+--     @status
+--         * The new status of the search parameter
+--
+CREATE PROCEDURE dbo.UpdateSearchParamStatus
+    @uri varchar(128),
+    @status varchar(10)
+AS
+    SET NOCOUNT ON
+    
+    UPDATE dbo.SearchParamRegistry
+    SET Status = @status
+    WHERE Uri = @uri
+GO
+
+--
+-- STORED PROCEDURE
 --     Inserts a search parameter and its status into the search parameter registry.
 --
 -- DESCRIPTION
@@ -69,4 +93,3 @@ AS
 
     COMMIT TRANSACTION
 GO
-

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/3.diff.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/3.diff.sql
@@ -69,7 +69,6 @@ AS
     DECLARE @lastUpdated datetime2(7) = SYSUTCDATETIME()
 
     -- Acquire and hold an exclusive table lock for the entire transaction to prevent parameters from being added or modified during upsertion.
-    -- TODO: should this be an update lock?
     UPDATE dbo.SearchParamRegistry
     WITH (TABLOCKX)
     SET Status = sps.Status, LastUpdated = @lastUpdated, IsPartiallySupported = sps.IsPartiallySupported

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/3.diff.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/3.diff.sql
@@ -115,7 +115,7 @@ AS
     INSERT INTO dbo.SearchParamRegistry
         (Uri, Status, LastUpdated, IsPartiallySupported)
     SELECT sps.Uri, sps.Status, @lastUpdated, sps.IsPartiallySupported
-    FROM searchParamStatuses AS sps
+    FROM @searchParamStatuses AS sps
 
     COMMIT TRANSACTION
 GO

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/3.diff.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/3.diff.sql
@@ -1,0 +1,40 @@
+/*************************************************************
+    Search Parameter Registry
+**************************************************************/
+-- TODO: Update table and indices one usage of table is fully understood
+CREATE TABLE dbo.SearchParameterRegistry
+(
+    SearchParamId smallint NOT NULL,
+    ResourceTypeId smallint NOT NULL, -- TODO: Should we be storing the uri instead?
+    Status varchar(10) NOT NULL, -- TODO: Can/should this be stored as an enum or number instead of a string?
+    LastUpdated datetimeoffset(7) NULL -- TODO: Should this just be datetime? What level of precision is needed?
+)
+
+CREATE UNIQUE CLUSTERED INDEX IXC_SearchParameterRegistry ON dbo.SearchParameterRegistry
+(
+    SearchParamId
+)
+
+CREATE UNIQUE NONCLUSTERED INDEX IX_SearchParameterRegistry_ResourceTypeId ON dbo.SearchParameterRegistry
+(
+    ResourceTypeId
+)
+
+GO
+
+--
+-- STORED PROCEDURE
+--     Gets all the search parameters and their statuses.
+--
+-- DESCRIPTION
+--     Retrieves and returns the contents of the search parameter registry.
+--
+-- RETURN VALUE
+--     The search parameters and their statuses.
+--
+CREATE PROCEDURE dbo.GetSearchParameterStatuses
+AS
+    SET NOCOUNT ON
+    
+    SELECT * FROM dbo.SearchParameterRegistry
+GO

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/3.diff.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/3.diff.sql
@@ -76,23 +76,34 @@ GO
 
 --
 -- STORED PROCEDURE
+--     Counts the number of search parameters.
+--
+-- DESCRIPTION
+--     Retrieves and returns the number of rows in the search parameter registry.
+--
+-- RETURN VALUE
+--     The number of search parameters in the registry.
+--
+CREATE PROCEDURE dbo.GetSearchParamRegistryCount
+AS
+    SET NOCOUNT ON
+    
+    SELECT COUNT(*) FROM dbo.SearchParamRegistry
+GO
+
+--
+-- STORED PROCEDURE
 --     Inserts a search parameter and its status into the search parameter registry.
 --
 -- DESCRIPTION
 --     Adds a row to the search parameter registry.
 --
 -- PARAMETERS
---     @uri
---         * The search parameter's identifying URI
---     @status
---         * The status of the search parameter
---     @isPartiallySupported
---         * True if the parameter resolves to more than one type (FhirString, FhirUri, etc) but not all types can be indexed
+--     @searchParamStatuses
+--         * The updated search parameter statuses
 --
 CREATE PROCEDURE dbo.InsertIntoSearchParamRegistry
-    @uri varchar(128),
-    @status varchar(10),
-    @isPartiallySupported bit
+    @searchParamStatuses dbo.SearchParamRegistryTableType_1 READONLY
 AS
     SET NOCOUNT ON
 
@@ -103,8 +114,8 @@ AS
     
     INSERT INTO dbo.SearchParamRegistry
         (Uri, Status, LastUpdated, IsPartiallySupported)
-    VALUES
-        (@uri, @status, @lastUpdated, @isPartiallySupported)
+    SELECT sps.Uri, sps.Status, @lastUpdated, sps.IsPartiallySupported
+    FROM searchParamStatuses AS sps
 
     COMMIT TRANSACTION
 GO

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/3.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/3.sql
@@ -1,0 +1,2031 @@
+-- NOTE: This script DROPS AND RECREATES all database objects.
+-- Style guide: please see: https://github.com/ktaranov/sqlserver-kit/blob/master/SQL%20Server%20Name%20Convention%20and%20T-SQL%20Programming%20Style.md
+
+
+/*************************************************************
+    Drop existing objects
+**************************************************************/
+
+DECLARE @sql nvarchar(max) =''
+
+SELECT @sql = @sql + 'DROP PROCEDURE ' + name + '; '
+FROM sys.procedures
+
+SELECT @sql = @sql + 'DROP TABLE ' + name + '; '
+FROM sys.tables
+
+SELECT @sql = @sql + 'DROP TYPE ' + name + '; '
+FROM sys.table_types
+
+SELECT @sql = @sql + 'DROP SEQUENCE ' + name + '; '
+FROM sys.sequences
+
+EXEC(@sql)
+
+GO
+
+/*************************************************************
+    Configure database
+**************************************************************/
+
+-- Enable RCSI
+IF ((SELECT is_read_committed_snapshot_on FROM sys.databases WHERE database_id = DB_ID()) = 0) BEGIN
+    ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT ON
+END
+
+-- Avoid blocking queries when statistics need to be rebuilt
+IF ((SELECT is_auto_update_stats_async_on FROM sys.databases WHERE database_id = DB_ID()) = 0) BEGIN
+    ALTER DATABASE CURRENT SET AUTO_UPDATE_STATISTICS_ASYNC ON
+END
+
+-- Use ANSI behavior for null values
+IF ((SELECT is_ansi_nulls_on FROM sys.databases WHERE database_id = DB_ID()) = 0) BEGIN
+    ALTER DATABASE CURRENT SET ANSI_NULLS ON
+END
+
+GO
+
+/*************************************************************
+    Schema bootstrap
+**************************************************************/
+
+CREATE TABLE dbo.SchemaVersion
+(
+    Version int PRIMARY KEY,
+    Status varchar(10)
+)
+
+INSERT INTO dbo.SchemaVersion
+VALUES
+    (3, 'started')
+
+GO
+
+--
+--  STORED PROCEDURE
+--      SelectCurrentSchemaVersion
+--
+--  DESCRIPTION
+--      Selects the current completed schema version
+--
+--  RETURNS
+--      The current version as a result set
+--
+CREATE PROCEDURE dbo.SelectCurrentSchemaVersion
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    SELECT MAX(Version)
+    FROM SchemaVersion
+    WHERE Status = 'complete'
+END
+GO
+
+--
+--  STORED PROCEDURE
+--      UpsertSchemaVersion
+--
+--  DESCRIPTION
+--      Creates or updates a new schema version entry
+--
+--  PARAMETERS
+--      @version
+--          * The version number
+--      @status
+--          * The status of the version
+--
+CREATE PROCEDURE dbo.UpsertSchemaVersion
+    @version int,
+    @status varchar(10)
+AS
+    SET NOCOUNT ON
+
+    IF EXISTS(SELECT *
+        FROM dbo.SchemaVersion
+        WHERE Version = @version)
+    BEGIN
+        UPDATE dbo.SchemaVersion
+        SET Status = @status
+        WHERE Version = @version
+    END
+    ELSE
+    BEGIN
+        INSERT INTO dbo.SchemaVersion
+            (Version, Status)
+        VALUES
+            (@version, @status)
+    END
+GO
+
+
+/*************************************************************
+    Model tables
+**************************************************************/
+
+CREATE TABLE dbo.SearchParam
+(
+    SearchParamId smallint IDENTITY(1,1) NOT NULL,
+    Uri varchar(128) COLLATE Latin1_General_100_CS_AS NOT NULL
+)
+
+CREATE UNIQUE CLUSTERED INDEX IXC_SearchParam ON dbo.SearchParam
+(
+    Uri
+)
+
+CREATE TABLE dbo.ResourceType
+(
+    ResourceTypeId smallint IDENTITY(1,1) NOT NULL,
+    Name nvarchar(50) COLLATE Latin1_General_100_CS_AS  NOT NULL
+)
+
+CREATE UNIQUE CLUSTERED INDEX IXC_ResourceType on dbo.ResourceType
+(
+    Name
+)
+
+-- Create System and QuantityCode tables
+
+CREATE TABLE dbo.System
+(
+    SystemId int IDENTITY(1,1) NOT NULL,
+    Value nvarchar(256) NOT NULL,
+)
+
+CREATE UNIQUE CLUSTERED INDEX IXC_System ON dbo.System
+(
+    Value
+)
+
+CREATE TABLE dbo.QuantityCode
+(
+    QuantityCodeId int IDENTITY(1,1) NOT NULL,
+    Value nvarchar(256) COLLATE Latin1_General_100_CS_AS NOT NULL
+)
+
+CREATE UNIQUE CLUSTERED INDEX IXC_QuantityCode on dbo.QuantityCode
+(
+    Value
+)
+
+/*************************************************************
+    Resource table
+**************************************************************/
+
+CREATE TABLE dbo.Resource
+(
+    ResourceTypeId smallint NOT NULL,
+    ResourceId varchar(64) COLLATE Latin1_General_100_CS_AS NOT NULL,
+    Version int NOT NULL,
+    IsHistory bit NOT NULL,
+    ResourceSurrogateId bigint NOT NULL,
+    IsDeleted bit NOT NULL,
+    RequestMethod varchar(10) NULL,
+    RawResource varbinary(max) NOT NULL
+)
+
+CREATE UNIQUE CLUSTERED INDEX IXC_Resource ON dbo.Resource
+(
+    ResourceSurrogateId
+)
+
+CREATE UNIQUE NONCLUSTERED INDEX IX_Resource_ResourceTypeId_ResourceId_Version ON dbo.Resource
+(
+    ResourceTypeId,
+    ResourceId,
+    Version
+)
+
+CREATE UNIQUE NONCLUSTERED INDEX IX_Resource_ResourceTypeId_ResourceId ON dbo.Resource
+(
+    ResourceTypeId,
+    ResourceId
+)
+INCLUDE -- We want the query in UpsertResource, which is done with UPDLOCK AND HOLDLOCK, to not require a key lookup
+(
+    Version,
+    IsDeleted
+)
+WHERE IsHistory = 0
+
+CREATE UNIQUE NONCLUSTERED INDEX IX_Resource_ResourceTypeId_ResourceSurrgateId ON dbo.Resource
+(
+    ResourceTypeId,
+    ResourceSurrogateId
+)
+WHERE IsHistory = 0 AND IsDeleted = 0
+
+/*************************************************************
+    Capture claims on write
+**************************************************************/
+
+CREATE TABLE dbo.ClaimType
+(
+    ClaimTypeId tinyint IDENTITY(1,1) NOT NULL,
+    Name varchar(128) COLLATE Latin1_General_100_CS_AS NOT NULL
+)
+
+CREATE UNIQUE CLUSTERED INDEX IXC_Claim on dbo.ClaimType
+(
+    Name
+)
+
+CREATE TYPE dbo.ResourceWriteClaimTableType_1 AS TABLE
+(
+    ClaimTypeId tinyint NOT NULL,
+    ClaimValue nvarchar(128) NOT NULL
+)
+
+CREATE TABLE dbo.ResourceWriteClaim
+(
+    ResourceSurrogateId bigint NOT NULL,
+    ClaimTypeId tinyint NOT NULL,
+    ClaimValue nvarchar(128) NOT NULL,
+) WITH (DATA_COMPRESSION = PAGE)
+
+CREATE CLUSTERED INDEX IXC_ResourceWriteClaim on dbo.ResourceWriteClaim
+(
+    ResourceSurrogateId,
+    ClaimTypeId
+)
+
+/*************************************************************
+    Compartments
+**************************************************************/
+
+CREATE TABLE dbo.CompartmentType
+(
+    CompartmentTypeId tinyint IDENTITY(1,1) NOT NULL,
+    Name varchar(128) COLLATE Latin1_General_100_CS_AS NOT NULL
+)
+
+CREATE UNIQUE CLUSTERED INDEX IXC_CompartmentType on dbo.CompartmentType
+(
+    Name
+)
+
+CREATE TYPE dbo.CompartmentAssignmentTableType_1 AS TABLE
+(
+    CompartmentTypeId tinyint NOT NULL,
+    ReferenceResourceId varchar(64) COLLATE Latin1_General_100_CS_AS NOT NULL
+)
+
+CREATE TABLE dbo.CompartmentAssignment
+(
+    ResourceTypeId smallint NOT NULL,
+    ResourceSurrogateId bigint NOT NULL,
+    CompartmentTypeId tinyint NOT NULL,
+    ReferenceResourceId varchar(64) COLLATE Latin1_General_100_CS_AS NOT NULL,
+    IsHistory bit NOT NULL,
+) WITH (DATA_COMPRESSION = PAGE)
+
+CREATE CLUSTERED INDEX IXC_CompartmentAssignment
+ON dbo.CompartmentAssignment
+(
+    ResourceSurrogateId,
+    CompartmentTypeId,
+    ReferenceResourceId
+)
+
+CREATE NONCLUSTERED INDEX IX_CompartmentAssignment_CompartmentTypeId_ReferenceResourceId
+ON dbo.CompartmentAssignment
+(
+    CompartmentTypeId,
+    ReferenceResourceId
+)
+INCLUDE
+(
+    ResourceTypeId
+)
+WHERE IsHistory = 0
+WITH (DATA_COMPRESSION = PAGE)
+
+GO
+
+/*************************************************************
+    Reference Search Param
+**************************************************************/
+
+CREATE TYPE dbo.ReferenceSearchParamTableType_1 AS TABLE
+(
+    SearchParamId smallint NOT NULL,
+    BaseUri varchar(128) COLLATE Latin1_General_100_CS_AS NULL,
+    ReferenceResourceTypeId smallint NOT NULL,
+    ReferenceResourceId varchar(64) COLLATE Latin1_General_100_CS_AS NOT NULL,
+    ReferenceResourceVersion int NULL
+)
+
+CREATE TABLE dbo.ReferenceSearchParam
+(
+    ResourceTypeId smallint NOT NULL,
+    ResourceSurrogateId bigint NOT NULL,
+    SearchParamId smallint NOT NULL,
+    BaseUri varchar(128) COLLATE Latin1_General_100_CS_AS NULL,
+    ReferenceResourceTypeId smallint NOT NULL,
+    ReferenceResourceId varchar(64) COLLATE Latin1_General_100_CS_AS NOT NULL,
+    ReferenceResourceVersion int NULL,
+    IsHistory bit NOT NULL,
+) WITH (DATA_COMPRESSION = PAGE)
+
+CREATE CLUSTERED INDEX IXC_ReferenceSearchParam
+ON dbo.ReferenceSearchParam
+(
+    ResourceSurrogateId,
+    SearchParamId
+)
+
+CREATE NONCLUSTERED INDEX IX_ReferenceSearchParam_SearchParamId_ReferenceResourceTypeId_ReferenceResourceId_BaseUri_ReferenceResourceVersion
+ON dbo.ReferenceSearchParam
+(
+    SearchParamId,
+    ReferenceResourceId,
+    ReferenceResourceTypeId,
+    BaseUri
+)
+INCLUDE
+(
+    ResourceTypeId,
+    ReferenceResourceVersion
+)
+WHERE IsHistory = 0
+WITH (DATA_COMPRESSION = PAGE)
+
+GO
+
+/*************************************************************
+    Token Search Param
+**************************************************************/
+
+CREATE TYPE dbo.TokenSearchParamTableType_1 AS TABLE
+(
+    SearchParamId smallint NOT NULL,
+    SystemId int NULL,
+    Code varchar(128) COLLATE Latin1_General_100_CS_AS NOT NULL
+)
+
+CREATE TABLE dbo.TokenSearchParam
+(
+    ResourceTypeId smallint NOT NULL,
+    ResourceSurrogateId bigint NOT NULL,
+    SearchParamId smallint NOT NULL,
+    SystemId int NULL,
+    Code varchar(128) COLLATE Latin1_General_100_CS_AS NOT NULL,
+    IsHistory bit NOT NULL,
+) WITH (DATA_COMPRESSION = PAGE)
+
+CREATE CLUSTERED INDEX IXC_TokenSearchParam
+ON dbo.TokenSearchParam
+(
+    ResourceSurrogateId,
+    SearchParamId
+)
+
+CREATE NONCLUSTERED INDEX IX_TokenSeachParam_SearchParamId_Code_SystemId
+ON dbo.TokenSearchParam
+(
+    SearchParamId,
+    Code,
+    SystemId
+)
+INCLUDE
+(
+    ResourceTypeId
+)
+WHERE IsHistory = 0
+WITH (DATA_COMPRESSION = PAGE)
+
+GO
+
+/*************************************************************
+    Token Text
+**************************************************************/
+
+CREATE TYPE dbo.TokenTextTableType_1 AS TABLE
+(
+    SearchParamId smallint NOT NULL,
+    Text nvarchar(400) COLLATE Latin1_General_CI_AI NOT NULL
+)
+
+CREATE TABLE dbo.TokenText
+(
+    ResourceTypeId smallint NOT NULL,
+    ResourceSurrogateId bigint NOT NULL,
+    SearchParamId smallint NOT NULL,
+    Text nvarchar(400) COLLATE Latin1_General_CI_AI NOT NULL,
+    IsHistory bit NOT NULL
+) WITH (DATA_COMPRESSION = PAGE)
+
+CREATE CLUSTERED INDEX IXC_TokenText
+ON dbo.TokenText
+(
+    ResourceSurrogateId,
+    SearchParamId
+)
+
+CREATE NONCLUSTERED INDEX IX_TokenText_SearchParamId_Text
+ON dbo.TokenText
+(
+    SearchParamId,
+    Text
+)
+INCLUDE
+(
+    ResourceTypeId
+)
+WHERE IsHistory = 0
+WITH (DATA_COMPRESSION = PAGE)
+
+GO
+
+/*************************************************************
+    String Search Param
+**************************************************************/
+
+CREATE TYPE dbo.StringSearchParamTableType_1 AS TABLE
+(
+    SearchParamId smallint NOT NULL,
+    Text nvarchar(256) COLLATE Latin1_General_100_CI_AI_SC NOT NULL,
+    TextOverflow nvarchar(max) COLLATE Latin1_General_100_CI_AI_SC NULL
+)
+
+CREATE TABLE dbo.StringSearchParam
+(
+    ResourceTypeId smallint NOT NULL,
+    ResourceSurrogateId bigint NOT NULL,
+    SearchParamId smallint NOT NULL,
+    Text nvarchar(256) COLLATE Latin1_General_100_CI_AI_SC NOT NULL,
+    TextOverflow nvarchar(max) COLLATE Latin1_General_100_CI_AI_SC NULL,
+    IsHistory bit NOT NULL
+) WITH (DATA_COMPRESSION = PAGE)
+
+CREATE CLUSTERED INDEX IXC_StringSearchParam
+ON dbo.StringSearchParam
+(
+    ResourceSurrogateId,
+    SearchParamId
+)
+
+CREATE NONCLUSTERED INDEX IX_StringSearchParam_SearchParamId_Text
+ON dbo.StringSearchParam
+(
+    SearchParamId,
+    Text
+)
+INCLUDE
+(
+    ResourceTypeId,
+    TextOverflow -- workaround for https://support.microsoft.com/en-gb/help/3051225/a-filtered-index-that-you-create-together-with-the-is-null-predicate-i
+)
+WHERE IsHistory = 0 AND TextOverflow IS NULL
+WITH (DATA_COMPRESSION = PAGE)
+
+CREATE NONCLUSTERED INDEX IX_StringSearchParam_SearchParamId_TextWithOverflow
+ON dbo.StringSearchParam
+(
+    SearchParamId,
+    Text
+)
+INCLUDE
+(
+    ResourceTypeId
+)
+WHERE IsHistory = 0 AND TextOverflow IS NOT NULL
+WITH (DATA_COMPRESSION = PAGE)
+
+GO
+
+/*************************************************************
+    URI Search Param
+**************************************************************/
+
+CREATE TYPE dbo.UriSearchParamTableType_1 AS TABLE
+(
+    SearchParamId smallint NOT NULL,
+    Uri varchar(256) COLLATE Latin1_General_100_CS_AS NOT NULL
+)
+
+CREATE TABLE dbo.UriSearchParam
+(
+    ResourceTypeId smallint NOT NULL,
+    ResourceSurrogateId bigint NOT NULL,
+    SearchParamId smallint NOT NULL,
+    Uri varchar(256) COLLATE Latin1_General_100_CS_AS NOT NULL,
+    IsHistory bit NOT NULL
+) WITH (DATA_COMPRESSION = PAGE)
+
+CREATE CLUSTERED INDEX IXC_UriSearchParam
+ON dbo.UriSearchParam
+(
+    ResourceSurrogateId,
+    SearchParamId
+)
+
+CREATE NONCLUSTERED INDEX IX_UriSearchParam_SearchParamId_Uri
+ON dbo.UriSearchParam
+(
+    SearchParamId,
+    Uri
+)
+INCLUDE
+(
+    ResourceTypeId
+)
+WHERE IsHistory = 0
+WITH (DATA_COMPRESSION = PAGE)
+
+GO
+
+
+/*************************************************************
+    Number Search Param
+**************************************************************/
+
+-- We support the underlying value being a range, though we expect the vast majority of entries to be a single value.
+-- Either:
+--  (1) SingleValue is not null and LowValue and HighValue are both null, or
+--  (2) SingleValue is null and LowValue and HighValue are both not null
+-- We make use of filtered nonclustered indexes to keep queries over the ranges limited to those rows that actually have ranges
+
+CREATE TYPE dbo.NumberSearchParamTableType_1 AS TABLE
+(
+    SearchParamId smallint NOT NULL,
+    SingleValue decimal(18,6) NULL,
+    LowValue decimal(18,6) NULL,
+    HighValue decimal(18,6) NULL
+)
+
+CREATE TABLE dbo.NumberSearchParam
+(
+    ResourceTypeId smallint NOT NULL,
+    ResourceSurrogateId bigint NOT NULL,
+    SearchParamId smallint NOT NULL,
+    SingleValue decimal(18,6) NULL,
+    LowValue decimal(18,6) SPARSE NULL,
+    HighValue decimal(18,6) SPARSE NULL,
+    IsHistory bit NOT NULL
+)
+
+CREATE CLUSTERED INDEX IXC_NumberSearchParam
+ON dbo.NumberSearchParam
+(
+    ResourceSurrogateId,
+    SearchParamId
+)
+
+CREATE NONCLUSTERED INDEX IX_NumberSearchParam_SearchParamId_SingleValue
+ON dbo.NumberSearchParam
+(
+    SearchParamId,
+    SingleValue
+)
+INCLUDE
+(
+    ResourceTypeId
+)
+WHERE IsHistory = 0 AND SingleValue IS NOT NULL
+
+CREATE NONCLUSTERED INDEX IX_NumberSearchParam_SearchParamId_LowValue_HighValue
+ON dbo.NumberSearchParam
+(
+    SearchParamId,
+    LowValue,
+    HighValue
+)
+INCLUDE
+(
+    ResourceTypeId
+)
+WHERE IsHistory = 0 AND LowValue IS NOT NULL
+
+CREATE NONCLUSTERED INDEX IX_NumberSearchParam_SearchParamId_HighValue_LowValue
+ON dbo.NumberSearchParam
+(
+    SearchParamId,
+    HighValue,
+    LowValue
+)
+INCLUDE
+(
+    ResourceTypeId
+)
+WHERE IsHistory = 0 AND LowValue IS NOT NULL
+
+GO
+
+/*************************************************************
+    Quantity Search Param
+**************************************************************/
+
+-- See comment above for number search params for how we store ranges
+
+CREATE TYPE dbo.QuantitySearchParamTableType_1 AS TABLE
+(
+    SearchParamId smallint NOT NULL,
+    SystemId int NULL,
+    QuantityCodeId int NULL,
+    SingleValue decimal(18,6) NULL,
+    LowValue decimal(18,6) NULL,
+    HighValue decimal(18,6) NULL
+)
+
+CREATE TABLE dbo.QuantitySearchParam
+(
+    ResourceTypeId smallint NOT NULL,
+    ResourceSurrogateId bigint NOT NULL,
+    SearchParamId smallint NOT NULL,
+    SystemId int NULL,
+    QuantityCodeId int NULL,
+    SingleValue decimal(18,6) NULL,
+    LowValue decimal(18,6) SPARSE NULL,
+    HighValue decimal(18,6) SPARSE NULL,
+    IsHistory bit NOT NULL
+)
+
+CREATE CLUSTERED INDEX IXC_QuantitySearchParam
+ON dbo.QuantitySearchParam
+(
+    ResourceSurrogateId,
+    SearchParamId
+)
+
+CREATE NONCLUSTERED INDEX IX_QuantitySearchParam_SearchParamId_QuantityCodeId_SingleValue
+ON dbo.QuantitySearchParam
+(
+    SearchParamId,
+    QuantityCodeId,
+    SingleValue
+)
+INCLUDE
+(
+    ResourceTypeId,
+    SystemId
+)
+WHERE IsHistory = 0 AND SingleValue IS NOT NULL
+
+CREATE NONCLUSTERED INDEX IX_QuantitySearchParam_SearchParamId_QuantityCodeId_LowValue_HighValue
+ON dbo.QuantitySearchParam
+(
+    SearchParamId,
+    QuantityCodeId,
+    LowValue,
+    HighValue
+)
+INCLUDE
+(
+    ResourceTypeId,
+    SystemId
+)
+WHERE IsHistory = 0 AND LowValue IS NOT NULL
+
+CREATE NONCLUSTERED INDEX IX_QuantitySearchParam_SearchParamId_QuantityCodeId_HighValue_LowValue
+ON dbo.QuantitySearchParam
+(
+    SearchParamId,
+    QuantityCodeId,
+    HighValue,
+    LowValue
+)
+INCLUDE
+(
+    ResourceTypeId,
+    SystemId
+)
+WHERE IsHistory = 0 AND LowValue IS NOT NULL
+
+GO
+
+/*************************************************************
+    Date Search Param
+**************************************************************/
+
+CREATE TYPE dbo.DateTimeSearchParamTableType_1 AS TABLE
+(
+    SearchParamId smallint NOT NULL,
+    StartDateTime datetimeoffset(7) NOT NULL,
+    EndDateTime datetimeoffset(7) NOT NULL,
+    IsLongerThanADay bit NOT NULL
+)
+
+CREATE TABLE dbo.DateTimeSearchParam
+(
+    ResourceTypeId smallint NOT NULL,
+    ResourceSurrogateId bigint NOT NULL,
+    SearchParamId smallint NOT NULL,
+    StartDateTime datetime2(7) NOT NULL,
+    EndDateTime datetime2(7) NOT NULL,
+    IsLongerThanADay bit NOT NULL,
+    IsHistory bit NOT NULL
+)
+
+CREATE CLUSTERED INDEX IXC_DateTimeSearchParam
+ON dbo.DateTimeSearchParam
+(
+    ResourceSurrogateId,
+    SearchParamId
+)
+
+CREATE NONCLUSTERED INDEX IX_DateTimeSearchParam_SearchParamId_StartDateTime_EndDateTime
+ON dbo.DateTimeSearchParam
+(
+    SearchParamId,
+    StartDateTime,
+    EndDateTime
+)
+INCLUDE
+(
+    ResourceTypeId,
+    IsLongerThanADay
+)
+WHERE IsHistory = 0
+
+CREATE NONCLUSTERED INDEX IX_DateTimeSearchParam_SearchParamId_EndDateTime_StartDateTime
+ON dbo.DateTimeSearchParam
+(
+    SearchParamId,
+    EndDateTime,
+    StartDateTime
+)
+INCLUDE
+(
+    ResourceTypeId,
+    IsLongerThanADay
+)
+WHERE IsHistory = 0
+
+
+CREATE NONCLUSTERED INDEX IX_DateTimeSearchParam_SearchParamId_StartDateTime_EndDateTime_Long
+ON dbo.DateTimeSearchParam
+(
+    SearchParamId,
+    StartDateTime,
+    EndDateTime
+)
+INCLUDE
+(
+    ResourceTypeId
+)
+WHERE IsHistory = 0 AND IsLongerThanADay = 1
+
+CREATE NONCLUSTERED INDEX IX_DateTimeSearchParam_SearchParamId_EndDateTime_StartDateTime_Long
+ON dbo.DateTimeSearchParam
+(
+    SearchParamId,
+    EndDateTime,
+    StartDateTime
+)
+INCLUDE
+(
+    ResourceTypeId
+)
+WHERE IsHistory = 0 AND IsLongerThanADay = 1
+
+GO
+
+/*************************************************************
+    Reference$Token Composite Search Param
+**************************************************************/
+
+CREATE TYPE dbo.ReferenceTokenCompositeSearchParamTableType_1 AS TABLE
+(
+    SearchParamId smallint NOT NULL,
+    BaseUri1 varchar(128) COLLATE Latin1_General_100_CS_AS NULL,
+    ReferenceResourceTypeId1 smallint NOT NULL,
+    ReferenceResourceId1 varchar(64) COLLATE Latin1_General_100_CS_AS NOT NULL,
+    ReferenceResourceVersion1 int NULL,
+    SystemId2 int NULL,
+    Code2 varchar(128) COLLATE Latin1_General_100_CS_AS NOT NULL
+)
+
+CREATE TABLE dbo.ReferenceTokenCompositeSearchParam
+(
+    ResourceTypeId smallint NOT NULL,
+    ResourceSurrogateId bigint NOT NULL,
+    SearchParamId smallint NOT NULL,
+    BaseUri1 varchar(128) COLLATE Latin1_General_100_CS_AS NULL,
+    ReferenceResourceTypeId1 smallint NOT NULL,
+    ReferenceResourceId1 varchar(64) COLLATE Latin1_General_100_CS_AS NOT NULL,
+    ReferenceResourceVersion1 int NULL,
+    SystemId2 int NULL,
+    Code2 varchar(128) COLLATE Latin1_General_100_CS_AS NOT NULL,
+    IsHistory bit NOT NULL,
+) WITH (DATA_COMPRESSION = PAGE)
+
+CREATE CLUSTERED INDEX IXC_ReferenceTokenCompositeSearchParam
+ON dbo.ReferenceTokenCompositeSearchParam
+(
+    ResourceSurrogateId,
+    SearchParamId
+)
+
+CREATE NONCLUSTERED INDEX IX_ReferenceTokenCompositeSearchParam_ReferenceResourceId1_Code2
+ON dbo.ReferenceTokenCompositeSearchParam
+(
+    SearchParamId,
+    ReferenceResourceId1,
+    Code2
+)
+INCLUDE
+(
+    ResourceTypeId,
+    ReferenceResourceTypeId1,
+    BaseUri1,
+    SystemId2
+)
+WHERE IsHistory = 0
+WITH (DATA_COMPRESSION = PAGE)
+
+
+CREATE NONCLUSTERED INDEX IX_ReferenceSearchParam_SearchParamId_ResourceTypeId_ReferenceResourceTypeId_ReferenceResourceId
+ON dbo.ReferenceSearchParam
+(
+	SearchParamId,
+	ResourceTypeId,
+	ReferenceResourceTypeId,
+	ReferenceResourceId
+)
+INCLUDE
+(
+    ReferenceResourceVersion,
+	BaseUri
+)
+WHERE IsHistory = 0
+
+GO
+
+/*************************************************************
+    Token$Token Composite Search Param
+**************************************************************/
+
+CREATE TYPE dbo.TokenTokenCompositeSearchParamTableType_1 AS TABLE
+(
+    SearchParamId smallint NOT NULL,
+    SystemId1 int NULL,
+    Code1 varchar(128) COLLATE Latin1_General_100_CS_AS NOT NULL,
+    SystemId2 int NULL,
+    Code2 varchar(128) COLLATE Latin1_General_100_CS_AS NOT NULL
+)
+
+CREATE TABLE dbo.TokenTokenCompositeSearchParam
+(
+    ResourceTypeId smallint NOT NULL,
+    ResourceSurrogateId bigint NOT NULL,
+    SearchParamId smallint NOT NULL,
+    SystemId1 int NULL,
+    Code1 varchar(128) COLLATE Latin1_General_100_CS_AS NOT NULL,
+    SystemId2 int NULL,
+    Code2 varchar(128) COLLATE Latin1_General_100_CS_AS NOT NULL,
+    IsHistory bit NOT NULL
+) WITH (DATA_COMPRESSION = PAGE)
+
+CREATE CLUSTERED INDEX IXC_TokenTokenCompositeSearchParam
+ON dbo.TokenTokenCompositeSearchParam
+(
+    ResourceSurrogateId,
+    SearchParamId
+)
+
+CREATE NONCLUSTERED INDEX IX_TokenTokenCompositeSearchParam_Code1_Code2
+ON dbo.TokenTokenCompositeSearchParam
+(
+    SearchParamId,
+    Code1,
+    Code2
+)
+INCLUDE
+(
+    ResourceTypeId,
+    SystemId1,
+    SystemId2
+)
+WHERE IsHistory = 0
+WITH (DATA_COMPRESSION = PAGE)
+
+GO
+
+/*************************************************************
+    Token$DateTime Composite Search Param
+**************************************************************/
+
+CREATE TYPE dbo.TokenDateTimeCompositeSearchParamTableType_1 AS TABLE
+(
+    SearchParamId smallint NOT NULL,
+    SystemId1 int NULL,
+    Code1 varchar(128) COLLATE Latin1_General_100_CS_AS NOT NULL,
+    StartDateTime2 datetimeoffset(7) NOT NULL,
+    EndDateTime2 datetimeoffset(7) NOT NULL,
+    IsLongerThanADay2 bit NOT NULL
+)
+
+CREATE TABLE dbo.TokenDateTimeCompositeSearchParam
+(
+    ResourceTypeId smallint NOT NULL,
+    ResourceSurrogateId bigint NOT NULL,
+    SearchParamId smallint NOT NULL,
+    SystemId1 int NULL,
+    Code1 varchar(128) COLLATE Latin1_General_100_CS_AS NOT NULL,
+    StartDateTime2 datetime2(7) NOT NULL,
+    EndDateTime2 datetime2(7) NOT NULL,
+    IsLongerThanADay2 bit NOT NULL,
+    IsHistory bit NOT NULL,
+) WITH (DATA_COMPRESSION = PAGE)
+
+CREATE CLUSTERED INDEX IXC_TokenDateTimeCompositeSearchParam
+ON dbo.TokenDateTimeCompositeSearchParam
+(
+    ResourceSurrogateId,
+    SearchParamId
+)
+
+CREATE NONCLUSTERED INDEX IX_TokenDateTimeCompositeSearchParam_Code1_StartDateTime2_EndDateTime2
+ON dbo.TokenDateTimeCompositeSearchParam
+(
+    SearchParamId,
+    Code1,
+    StartDateTime2,
+    EndDateTime2
+)
+INCLUDE
+(
+    ResourceTypeId,
+    SystemId1,
+    IsLongerThanADay2
+)
+
+WHERE IsHistory = 0
+WITH (DATA_COMPRESSION = PAGE)
+
+CREATE NONCLUSTERED INDEX IX_TokenDateTimeCompositeSearchParam_Code1_EndDateTime2_StartDateTime2
+ON dbo.TokenDateTimeCompositeSearchParam
+(
+    SearchParamId,
+    Code1,
+    EndDateTime2,
+    StartDateTime2
+)
+INCLUDE
+(
+    ResourceTypeId,
+    SystemId1,
+    IsLongerThanADay2
+)
+WHERE IsHistory = 0
+WITH (DATA_COMPRESSION = PAGE)
+
+CREATE NONCLUSTERED INDEX IX_TokenDateTimeCompositeSearchParam_Code1_StartDateTime2_EndDateTime2_Long
+ON dbo.TokenDateTimeCompositeSearchParam
+(
+    SearchParamId,
+    Code1,
+    StartDateTime2,
+    EndDateTime2
+)
+INCLUDE
+(
+    ResourceTypeId,
+    SystemId1
+)
+
+WHERE IsHistory = 0 AND IsLongerThanADay2 = 1
+WITH (DATA_COMPRESSION = PAGE)
+
+CREATE NONCLUSTERED INDEX IX_TokenDateTimeCompositeSearchParam_Code1_EndDateTime2_StartDateTime2_Long
+ON dbo.TokenDateTimeCompositeSearchParam
+(
+    SearchParamId,
+    Code1,
+    EndDateTime2,
+    StartDateTime2
+)
+INCLUDE
+(
+    ResourceTypeId,
+    SystemId1
+)
+WHERE IsHistory = 0 AND IsLongerThanADay2 = 1
+WITH (DATA_COMPRESSION = PAGE)
+
+GO
+
+/*************************************************************
+    Token$Quantity Composite Search Param
+**************************************************************/
+
+CREATE TYPE dbo.TokenQuantityCompositeSearchParamTableType_1 AS TABLE
+(
+    SearchParamId smallint NOT NULL,
+    SystemId1 int NULL,
+    Code1 varchar(128) COLLATE Latin1_General_100_CS_AS NOT NULL,
+    SystemId2 int NULL,
+    QuantityCodeId2 int NULL,
+    SingleValue2 decimal(18,6) NULL,
+    LowValue2 decimal(18,6) NULL,
+    HighValue2 decimal(18,6) NULL
+)
+
+CREATE TABLE dbo.TokenQuantityCompositeSearchParam
+(
+    ResourceTypeId smallint NOT NULL,
+    ResourceSurrogateId bigint NOT NULL,
+    SearchParamId smallint NOT NULL,
+    SystemId1 int NULL,
+    Code1 varchar(128) COLLATE Latin1_General_100_CS_AS NOT NULL,
+    SystemId2 int NULL,
+    QuantityCodeId2 int NULL,
+    SingleValue2 decimal(18,6) NULL,
+    LowValue2 decimal(18,6) NULL,
+    HighValue2 decimal(18,6) NULL,
+    IsHistory bit NOT NULL,
+) WITH (DATA_COMPRESSION = PAGE)
+
+CREATE CLUSTERED INDEX IXC_TokenQuantityCompositeSearchParam
+ON dbo.TokenQuantityCompositeSearchParam
+(
+    ResourceSurrogateId,
+    SearchParamId
+)
+
+CREATE NONCLUSTERED INDEX IX_TokenQuantityCompositeSearchParam_SearchParamId_Code1_QuantityCodeId2_SingleValue2
+ON dbo.TokenQuantityCompositeSearchParam
+(
+    SearchParamId,
+    Code1,
+    SingleValue2
+)
+INCLUDE
+(
+    ResourceTypeId,
+    QuantityCodeId2,
+    SystemId1,
+    SystemId2
+)
+WHERE IsHistory = 0 AND SingleValue2 IS NOT NULL
+WITH (DATA_COMPRESSION = PAGE)
+
+CREATE NONCLUSTERED INDEX IX_TokenQuantityCompositeSearchParam_SearchParamId_Code1_QuantityCodeId2_LowValue2_HighValue2
+ON dbo.TokenQuantityCompositeSearchParam
+(
+    SearchParamId,
+    Code1,
+    LowValue2,
+    HighValue2
+)
+INCLUDE
+(
+    ResourceTypeId,
+    QuantityCodeId2,
+    SystemId1,
+    SystemId2
+)
+WHERE IsHistory = 0 AND LowValue2 IS NOT NULL
+WITH (DATA_COMPRESSION = PAGE)
+
+CREATE NONCLUSTERED INDEX IX_TokenQuantityCompositeSearchParam_SearchParamId_Code1_QuantityCodeId2_HighValue2_LowValue2
+ON dbo.TokenQuantityCompositeSearchParam
+(
+    SearchParamId,
+    Code1,
+    HighValue2,
+    LowValue2
+)
+INCLUDE
+(
+    ResourceTypeId,
+    QuantityCodeId2,
+    SystemId1,
+    SystemId2
+)
+WHERE IsHistory = 0 AND LowValue2 IS NOT NULL
+WITH (DATA_COMPRESSION = PAGE)
+
+GO
+
+/*************************************************************
+    Token$String Composite Search Param
+**************************************************************/
+
+CREATE TYPE dbo.TokenStringCompositeSearchParamTableType_1 AS TABLE
+(
+    SearchParamId smallint NOT NULL,
+    SystemId1 int NULL,
+    Code1 varchar(128) COLLATE Latin1_General_100_CS_AS NOT NULL,
+    Text2 nvarchar(256) COLLATE Latin1_General_100_CI_AI_SC NOT NULL,
+    TextOverflow2 nvarchar(max) COLLATE Latin1_General_100_CI_AI_SC NULL
+)
+
+CREATE TABLE dbo.TokenStringCompositeSearchParam
+(
+    ResourceTypeId smallint NOT NULL,
+    ResourceSurrogateId bigint NOT NULL,
+    SearchParamId smallint NOT NULL,
+    SystemId1 int NULL,
+    Code1 varchar(128) COLLATE Latin1_General_100_CS_AS NOT NULL,
+    Text2 nvarchar(256) COLLATE Latin1_General_CI_AI NOT NULL,
+    TextOverflow2 nvarchar(max) COLLATE Latin1_General_CI_AI NULL,
+    IsHistory bit NOT NULL,
+) WITH (DATA_COMPRESSION = PAGE)
+
+CREATE CLUSTERED INDEX IXC_TokenStringCompositeSearchParam
+ON dbo.TokenStringCompositeSearchParam
+(
+    ResourceSurrogateId,
+    SearchParamId
+)
+
+CREATE NONCLUSTERED INDEX IX_TokenStringCompositeSearchParam_SearchParamId_Code1_Text2
+ON dbo.TokenStringCompositeSearchParam
+(
+    SearchParamId,
+    Code1,
+    Text2
+)
+INCLUDE
+(
+    ResourceTypeId,
+    SystemId1,
+    TextOverflow2 -- workaround for https://support.microsoft.com/en-gb/help/3051225/a-filtered-index-that-you-create-together-with-the-is-null-predicate-i
+)
+WHERE IsHistory = 0 AND TextOverflow2 IS NULL
+WITH (DATA_COMPRESSION = PAGE)
+
+CREATE NONCLUSTERED INDEX IX_TokenStringCompositeSearchParam_SearchParamId_Code1_Text2WithOverflow
+ON dbo.TokenStringCompositeSearchParam
+(
+    SearchParamId,
+    Code1,
+    Text2
+)
+INCLUDE
+(
+    ResourceTypeId,
+    SystemId1
+)
+WHERE IsHistory = 0 AND TextOverflow2 IS NOT NULL
+WITH (DATA_COMPRESSION = PAGE)
+
+GO
+
+
+/*************************************************************
+    Token$Number$Number Composite Search Param
+**************************************************************/
+
+-- See number search param for how we deal with null. We apply a similar pattern here,
+-- except that we pass in a HasRange bit though the TVP. The alternative would have
+-- for a computed column, but a computed column cannot be used in as a index filter
+-- (even if it is a persisted computed column).
+
+
+CREATE TYPE dbo.TokenNumberNumberCompositeSearchParamTableType_1 AS TABLE
+(
+    SearchParamId smallint NOT NULL,
+    SystemId1 int NULL,
+    Code1 varchar(128) COLLATE Latin1_General_100_CS_AS NOT NULL,
+    SingleValue2 decimal(18,6) NULL,
+    LowValue2 decimal(18,6) NULL,
+    HighValue2 decimal(18,6) NULL,
+    SingleValue3 decimal(18,6) NULL,
+    LowValue3 decimal(18,6) NULL,
+    HighValue3 decimal(18,6) NULL,
+    HasRange bit NOT NULL
+)
+
+CREATE TABLE dbo.TokenNumberNumberCompositeSearchParam
+(
+    ResourceTypeId smallint NOT NULL,
+    ResourceSurrogateId bigint NOT NULL,
+    SearchParamId smallint NOT NULL,
+    SystemId1 int NULL,
+    Code1 varchar(128) COLLATE Latin1_General_100_CS_AS NOT NULL,
+    SingleValue2 decimal(18,6) NULL,
+    LowValue2 decimal(18,6) NULL,
+    HighValue2 decimal(18,6) NULL,
+    SingleValue3 decimal(18,6) NULL,
+    LowValue3 decimal(18,6) NULL,
+    HighValue3 decimal(18,6) NULL,
+    HasRange bit NOT NULL,
+    IsHistory bit NOT NULL,
+) WITH (DATA_COMPRESSION = PAGE)
+
+CREATE CLUSTERED INDEX IXC_TokenNumberNumberCompositeSearchParam
+ON dbo.TokenNumberNumberCompositeSearchParam
+(
+    ResourceSurrogateId,
+    SearchParamId
+)
+
+CREATE NONCLUSTERED INDEX IX_TokenNumberNumberCompositeSearchParam_SearchParamId_Code1_Text2
+ON dbo.TokenNumberNumberCompositeSearchParam
+(
+    SearchParamId,
+    Code1,
+    SingleValue2,
+    SingleValue3
+)
+INCLUDE
+(
+    ResourceTypeId,
+    SystemId1
+)
+WHERE IsHistory = 0 AND HasRange = 0
+WITH (DATA_COMPRESSION = PAGE)
+
+CREATE NONCLUSTERED INDEX IX_TokenNumberNumberCompositeSearchParam_SearchParamId_Code1_LowValue2_HighValue2_LowValue3_HighValue3
+ON dbo.TokenNumberNumberCompositeSearchParam
+(
+    SearchParamId,
+    Code1,
+    LowValue2,
+    HighValue2,
+    LowValue3,
+    HighValue3
+)
+INCLUDE
+(
+    ResourceTypeId,
+    SystemId1
+)
+WHERE IsHistory = 0 AND HasRange = 1
+WITH (DATA_COMPRESSION = PAGE)
+
+GO
+
+/*************************************************************
+    Sequence for generating unique 12.5ns "tick" components that are added
+    to a base ID based on the timestamp to form a unique resource surrogate ID
+**************************************************************/
+
+CREATE SEQUENCE dbo.ResourceSurrogateIdUniquifierSequence
+        AS int
+        START WITH 0
+        INCREMENT BY 1
+        MINVALUE 0
+        MAXVALUE 79999
+        CYCLE
+        CACHE 1000000
+GO
+
+/*************************************************************
+    Stored procedures for creating and deleting
+**************************************************************/
+
+--
+-- STORED PROCEDURE
+--     UpsertResource
+--
+-- DESCRIPTION
+--     Creates or updates (including marking deleted) a FHIR resource
+--
+-- PARAMETERS
+--     @baseResourceSurrogateId
+--         * A bigint to which a value between [0, 80000) is added, forming a unique ResourceSurrogateId.
+--         * This value should be the current UTC datetime, truncated to millisecond precision, with its 100ns ticks component bitshifted left by 3.
+--     @resourceTypeId
+--         * The ID of the resource type (See ResourceType table)
+--     @resourceid
+--         * The resource ID (must be the same as the in the resource itself)
+--     @allowCreate
+--         * If false, an error is thrown if the resource does not already exist
+--     @isDeleted
+--         * Whether this resource marks the resource as deleted
+--     @updatedDateTime
+--         * The last modified time in the resource
+--     @keepHistory
+--         * Whether the existing version of the resource should be preserved
+--     @requestMethod
+--         * The HTTP method/verb used for the request
+--     @rawResource
+--         * A compressed UTF16-encoded JSON document
+--     @resourceWriteClaims
+--         * Claims on the principal that performed the write
+--     @compartmentAssignments
+--         * Compartments that the resource is part of
+--     @referenceSearchParams
+--         * Extracted reference search params
+--     @tokenSearchParams
+--         * Extracted token search params
+--     @tokenTextSearchParams
+--         * The text representation of extracted token search params
+--     @stringSearchParams
+--         * Extracted string search params
+--     @numberSearchParams
+--         * Extracted number search params
+--     @quantitySearchParams
+--         * Extracted quantity search params
+--     @uriSearchParams
+--         * Extracted URI search params
+--     @dateTimeSearchParms
+--         * Extracted datetime search params
+--     @referenceTokenCompositeSearchParams
+--         * Extracted reference$token search params
+--     @tokenTokenCompositeSearchParams
+--         * Extracted token$token tokensearch params
+--     @tokenDateTimeCompositeSearchParams
+--         * Extracted token$datetime search params
+--     @tokenQuantityCompositeSearchParams
+--         * Extracted token$quantity search params
+--     @tokenStringCompositeSearchParams
+--         * Extracted token$string search params
+--     @tokenNumberNumberCompositeSearchParams
+--         * Extracted token$number$number search params
+--
+-- RETURN VALUE
+--         The version of the resource as a result set. Will be empty if no insertion was done.
+--
+CREATE PROCEDURE dbo.UpsertResource
+    @baseResourceSurrogateId bigint,
+    @resourceTypeId smallint,
+    @resourceId varchar(64),
+    @eTag int = NULL,
+    @allowCreate bit,
+    @isDeleted bit,
+    @keepHistory bit,
+    @requestMethod varchar(10),
+    @rawResource varbinary(max),
+    @resourceWriteClaims dbo.ResourceWriteClaimTableType_1 READONLY,
+    @compartmentAssignments dbo.CompartmentAssignmentTableType_1 READONLY,
+    @referenceSearchParams dbo.ReferenceSearchParamTableType_1 READONLY,
+    @tokenSearchParams dbo.TokenSearchParamTableType_1 READONLY,
+    @tokenTextSearchParams dbo.TokenTextTableType_1 READONLY,
+    @stringSearchParams dbo.StringSearchParamTableType_1 READONLY,
+    @numberSearchParams dbo.NumberSearchParamTableType_1 READONLY,
+    @quantitySearchParams dbo.QuantitySearchParamTableType_1 READONLY,
+    @uriSearchParams dbo.UriSearchParamTableType_1 READONLY,
+    @dateTimeSearchParms dbo.DateTimeSearchParamTableType_1 READONLY,
+    @referenceTokenCompositeSearchParams dbo.ReferenceTokenCompositeSearchParamTableType_1 READONLY,
+    @tokenTokenCompositeSearchParams dbo.TokenTokenCompositeSearchParamTableType_1 READONLY,
+    @tokenDateTimeCompositeSearchParams dbo.TokenDateTimeCompositeSearchParamTableType_1 READONLY,
+    @tokenQuantityCompositeSearchParams dbo.TokenQuantityCompositeSearchParamTableType_1 READONLY,
+    @tokenStringCompositeSearchParams dbo.TokenStringCompositeSearchParamTableType_1 READONLY,
+    @tokenNumberNumberCompositeSearchParams dbo.TokenNumberNumberCompositeSearchParamTableType_1 READONLY
+AS
+    SET NOCOUNT ON
+
+    SET XACT_ABORT ON
+    BEGIN TRANSACTION
+
+    -- variables for the existing version of the resource that will be replaced
+    DECLARE @previousResourceSurrogateId bigint
+    DECLARE @previousVersion bigint
+    DECLARE @previousIsDeleted bit
+
+    -- This should place a range lock on a row in the IX_Resource_ResourceTypeId_ResourceId nonclustered filtered index
+    SELECT @previousResourceSurrogateId = ResourceSurrogateId, @previousVersion = Version, @previousIsDeleted = IsDeleted
+    FROM dbo.Resource WITH (UPDLOCK, HOLDLOCK)
+    WHERE ResourceTypeId = @resourceTypeId AND ResourceId = @resourceId AND IsHistory = 0
+
+    IF (@etag IS NOT NULL AND @etag <> @previousVersion) BEGIN
+        THROW 50412, 'Precondition failed', 1;
+    END
+
+    DECLARE @version int -- the version of the resource being written
+
+    IF (@previousResourceSurrogateId IS NULL) BEGIN
+        -- There is no previous version of this resource
+
+        IF (@isDeleted = 1) BEGIN
+            -- Don't bother marking the resource as deleted since it already does not exist.
+            COMMIT TRANSACTION
+            RETURN
+        END
+
+        IF (@etag IS NOT NULL) BEGIN
+        -- You can't update a resource with a specified version if the resource does not exist
+            THROW 50404, 'Resource with specified version not found', 1;
+        END
+
+        IF (@allowCreate = 0) BEGIN
+            THROW 50405, 'Resource does not exist and create is not allowed', 1;
+        END
+
+        SET @version = 1
+    END
+    ELSE BEGIN
+        -- There is a previous version
+
+        IF (@isDeleted = 1 AND @previousIsDeleted = 1) BEGIN
+            -- Already deleted - don't create a new version
+            COMMIT TRANSACTION
+            RETURN
+        END
+
+        SET @version = @previousVersion + 1
+
+        IF (@keepHistory = 1) BEGIN
+
+            -- Set the existing resource as history
+            UPDATE dbo.Resource
+            SET IsHistory = 1
+            WHERE ResourceSurrogateId = @previousResourceSurrogateId
+
+            -- Set the indexes for this resource as history.
+            -- Note there is no IsHistory column on ResourceWriteClaim since we do not query it.
+
+            UPDATE dbo.CompartmentAssignment
+            SET IsHistory = 1
+            WHERE ResourceSurrogateId = @previousResourceSurrogateId
+
+            UPDATE dbo.ReferenceSearchParam
+            SET IsHistory = 1
+            WHERE ResourceSurrogateId = @previousResourceSurrogateId
+
+            UPDATE dbo.TokenSearchParam
+            SET IsHistory = 1
+            WHERE ResourceSurrogateId = @previousResourceSurrogateId
+
+            UPDATE dbo.TokenText
+            SET IsHistory = 1
+            WHERE ResourceSurrogateId = @previousResourceSurrogateId
+
+            UPDATE dbo.StringSearchParam
+            SET IsHistory = 1
+            WHERE ResourceSurrogateId = @previousResourceSurrogateId
+
+            UPDATE dbo.UriSearchParam
+            SET IsHistory = 1
+            WHERE ResourceSurrogateId = @previousResourceSurrogateId
+
+            UPDATE dbo.NumberSearchParam
+            SET IsHistory = 1
+            WHERE ResourceSurrogateId = @previousResourceSurrogateId
+
+            UPDATE dbo.QuantitySearchParam
+            SET IsHistory = 1
+            WHERE ResourceSurrogateId = @previousResourceSurrogateId
+
+            UPDATE dbo.DateTimeSearchParam
+            SET IsHistory = 1
+            WHERE ResourceSurrogateId = @previousResourceSurrogateId
+
+            UPDATE dbo.ReferenceTokenCompositeSearchParam
+            SET IsHistory = 1
+            WHERE ResourceSurrogateId = @previousResourceSurrogateId
+
+            UPDATE dbo.TokenTokenCompositeSearchParam
+            SET IsHistory = 1
+            WHERE ResourceSurrogateId = @previousResourceSurrogateId
+
+            UPDATE dbo.TokenDateTimeCompositeSearchParam
+            SET IsHistory = 1
+            WHERE ResourceSurrogateId = @previousResourceSurrogateId
+
+            UPDATE dbo.TokenQuantityCompositeSearchParam
+            SET IsHistory = 1
+            WHERE ResourceSurrogateId = @previousResourceSurrogateId
+
+            UPDATE dbo.TokenStringCompositeSearchParam
+            SET IsHistory = 1
+            WHERE ResourceSurrogateId = @previousResourceSurrogateId
+
+            UPDATE dbo.TokenNumberNumberCompositeSearchParam
+            SET IsHistory = 1
+            WHERE ResourceSurrogateId = @previousResourceSurrogateId
+
+        END
+        ELSE BEGIN
+
+            -- Not keeping history. Delete the current resource and all associated indexes.
+
+            DELETE FROM dbo.Resource
+            WHERE ResourceSurrogateId = @previousResourceSurrogateId
+
+            DELETE FROM dbo.ResourceWriteClaim
+            WHERE ResourceSurrogateId = @previousResourceSurrogateId
+
+            DELETE FROM dbo.CompartmentAssignment
+            WHERE ResourceSurrogateId = @previousResourceSurrogateId
+
+            DELETE FROM dbo.ReferenceSearchParam
+            WHERE ResourceSurrogateId = @previousResourceSurrogateId
+
+            DELETE FROM dbo.TokenSearchParam
+            WHERE ResourceSurrogateId = @previousResourceSurrogateId
+
+            DELETE FROM dbo.TokenText
+            WHERE ResourceSurrogateId = @previousResourceSurrogateId
+
+            DELETE FROM dbo.StringSearchParam
+            WHERE ResourceSurrogateId = @previousResourceSurrogateId
+
+            DELETE FROM dbo.UriSearchParam
+            WHERE ResourceSurrogateId = @previousResourceSurrogateId
+
+            DELETE FROM dbo.NumberSearchParam
+            WHERE ResourceSurrogateId = @previousResourceSurrogateId
+
+            DELETE FROM dbo.QuantitySearchParam
+            WHERE ResourceSurrogateId = @previousResourceSurrogateId
+
+            DELETE FROM dbo.DateTimeSearchParam
+            WHERE ResourceSurrogateId = @previousResourceSurrogateId
+
+            DELETE FROM dbo.ReferenceTokenCompositeSearchParam
+            WHERE ResourceSurrogateId = @previousResourceSurrogateId
+
+            DELETE FROM dbo.TokenTokenCompositeSearchParam
+            WHERE ResourceSurrogateId = @previousResourceSurrogateId
+
+            DELETE FROM dbo.TokenDateTimeCompositeSearchParam
+            WHERE ResourceSurrogateId = @previousResourceSurrogateId
+
+            DELETE FROM dbo.TokenQuantityCompositeSearchParam
+            WHERE ResourceSurrogateId = @previousResourceSurrogateId
+
+            DELETE FROM dbo.TokenStringCompositeSearchParam
+            WHERE ResourceSurrogateId = @previousResourceSurrogateId
+
+            DELETE FROM dbo.TokenNumberNumberCompositeSearchParam
+            WHERE ResourceSurrogateId = @previousResourceSurrogateId
+
+        END
+    END
+
+    DECLARE @resourceSurrogateId bigint = @baseResourceSurrogateId + (NEXT VALUE FOR ResourceSurrogateIdUniquifierSequence)
+
+    INSERT INTO dbo.Resource
+        (ResourceTypeId, ResourceId, Version, IsHistory, ResourceSurrogateId, IsDeleted, RequestMethod, RawResource)
+    VALUES
+        (@resourceTypeId, @resourceId, @version, 0, @resourceSurrogateId, @isDeleted, @requestMethod, @rawResource)
+
+    INSERT INTO dbo.ResourceWriteClaim
+        (ResourceSurrogateId, ClaimTypeId, ClaimValue)
+    SELECT @resourceSurrogateId, ClaimTypeId, ClaimValue
+    FROM @resourceWriteClaims
+
+    INSERT INTO dbo.CompartmentAssignment
+        (ResourceTypeId, ResourceSurrogateId, CompartmentTypeId, ReferenceResourceId, IsHistory)
+    SELECT DISTINCT @resourceTypeId, @resourceSurrogateId, CompartmentTypeId, ReferenceResourceId, 0
+    FROM @compartmentAssignments
+
+    INSERT INTO dbo.ReferenceSearchParam
+        (ResourceTypeId, ResourceSurrogateId, SearchParamId, BaseUri, ReferenceResourceTypeId, ReferenceResourceId, ReferenceResourceVersion, IsHistory)
+    SELECT DISTINCT @resourceTypeId, @resourceSurrogateId, SearchParamId, BaseUri, ReferenceResourceTypeId, ReferenceResourceId, ReferenceResourceVersion, 0
+    FROM @referenceSearchParams
+
+    INSERT INTO dbo.TokenSearchParam
+        (ResourceTypeId, ResourceSurrogateId, SearchParamId, SystemId, Code, IsHistory)
+    SELECT DISTINCT @resourceTypeId, @resourceSurrogateId, SearchParamId, SystemId, Code, 0
+    FROM @tokenSearchParams
+
+    INSERT INTO dbo.TokenText
+        (ResourceTypeId, ResourceSurrogateId, SearchParamId, Text, IsHistory)
+    SELECT DISTINCT @resourceTypeId, @resourceSurrogateId, SearchParamId, Text, 0
+    FROM @tokenTextSearchParams
+
+    INSERT INTO dbo.StringSearchParam
+        (ResourceTypeId, ResourceSurrogateId, SearchParamId, Text, TextOverflow, IsHistory)
+    SELECT DISTINCT @resourceTypeId, @resourceSurrogateId, SearchParamId, Text, TextOverflow, 0
+    FROM @stringSearchParams
+
+    INSERT INTO dbo.UriSearchParam
+        (ResourceTypeId, ResourceSurrogateId, SearchParamId, Uri, IsHistory)
+    SELECT DISTINCT @resourceTypeId, @resourceSurrogateId, SearchParamId, Uri, 0
+    FROM @uriSearchParams
+
+    INSERT INTO dbo.NumberSearchParam
+        (ResourceTypeId, ResourceSurrogateId, SearchParamId, SingleValue, LowValue, HighValue, IsHistory)
+    SELECT DISTINCT @resourceTypeId, @resourceSurrogateId, SearchParamId, SingleValue, LowValue, HighValue, 0
+    FROM @numberSearchParams
+
+    INSERT INTO dbo.QuantitySearchParam
+        (ResourceTypeId, ResourceSurrogateId, SearchParamId, SystemId, QuantityCodeId, SingleValue, LowValue, HighValue, IsHistory)
+    SELECT DISTINCT @resourceTypeId, @resourceSurrogateId, SearchParamId, SystemId, QuantityCodeId, SingleValue, LowValue, HighValue, 0
+    FROM @quantitySearchParams
+
+    INSERT INTO dbo.DateTimeSearchParam
+        (ResourceTypeId, ResourceSurrogateId, SearchParamId, StartDateTime, EndDateTime, IsLongerThanADay, IsHistory)
+    SELECT DISTINCT @resourceTypeId, @resourceSurrogateId, SearchParamId, StartDateTime, EndDateTime, IsLongerThanADay, 0
+    FROM @dateTimeSearchParms
+
+    INSERT INTO dbo.ReferenceTokenCompositeSearchParam
+        (ResourceTypeId, ResourceSurrogateId, SearchParamId, BaseUri1, ReferenceResourceTypeId1, ReferenceResourceId1, ReferenceResourceVersion1, SystemId2, Code2, IsHistory)
+    SELECT DISTINCT @resourceTypeId, @resourceSurrogateId, SearchParamId, BaseUri1, ReferenceResourceTypeId1, ReferenceResourceId1, ReferenceResourceVersion1, SystemId2, Code2, 0
+    FROM @referenceTokenCompositeSearchParams
+
+    INSERT INTO dbo.TokenTokenCompositeSearchParam
+        (ResourceTypeId, ResourceSurrogateId, SearchParamId, SystemId1, Code1, SystemId2, Code2, IsHistory)
+    SELECT DISTINCT @resourceTypeId, @resourceSurrogateId, SearchParamId, SystemId1, Code1, SystemId2, Code2, 0
+    FROM @tokenTokenCompositeSearchParams
+
+    INSERT INTO dbo.TokenDateTimeCompositeSearchParam
+        (ResourceTypeId, ResourceSurrogateId, SearchParamId, SystemId1, Code1, StartDateTime2, EndDateTime2, IsLongerThanADay2, IsHistory)
+    SELECT DISTINCT @resourceTypeId, @resourceSurrogateId, SearchParamId, SystemId1, Code1, StartDateTime2, EndDateTime2, IsLongerThanADay2, 0
+    FROM @tokenDateTimeCompositeSearchParams
+
+    INSERT INTO dbo.TokenQuantityCompositeSearchParam
+        (ResourceTypeId, ResourceSurrogateId, SearchParamId, SystemId1, Code1, SingleValue2, SystemId2, QuantityCodeId2, LowValue2, HighValue2, IsHistory)
+    SELECT DISTINCT @resourceTypeId, @resourceSurrogateId, SearchParamId, SystemId1, Code1, SingleValue2, SystemId2, QuantityCodeId2, LowValue2, HighValue2, 0
+    FROM @tokenQuantityCompositeSearchParams
+
+    INSERT INTO dbo.TokenStringCompositeSearchParam
+        (ResourceTypeId, ResourceSurrogateId, SearchParamId, SystemId1, Code1, Text2, TextOverflow2, IsHistory)
+    SELECT DISTINCT @resourceTypeId, @resourceSurrogateId, SearchParamId, SystemId1, Code1, Text2, TextOverflow2, 0
+    FROM @tokenStringCompositeSearchParams
+
+    INSERT INTO dbo.TokenNumberNumberCompositeSearchParam
+        (ResourceTypeId, ResourceSurrogateId, SearchParamId, SystemId1, Code1, SingleValue2, LowValue2, HighValue2, SingleValue3, LowValue3, HighValue3, HasRange, IsHistory)
+    SELECT DISTINCT @resourceTypeId, @resourceSurrogateId, SearchParamId, SystemId1, Code1, SingleValue2, LowValue2, HighValue2, SingleValue3, LowValue3, HighValue3, HasRange, 0
+    FROM @tokenNumberNumberCompositeSearchParams
+
+    SELECT @version
+
+    COMMIT TRANSACTION
+GO
+
+--
+-- STORED PROCEDURE
+--     ReadResource
+--
+-- DESCRIPTION
+--     Reads a single resource, optionally a specific version of the resource.
+--
+-- PARAMETERS
+--     @resourceTypeId
+--         * The ID of the resource type (See ResourceType table)
+--     @resourceId
+--         * The resource ID
+--     @version
+--         * A specific version of the resource. If null, returns the latest version.
+-- RETURN VALUE
+--         A result set with 0 or 1 rows.
+--
+CREATE PROCEDURE dbo.ReadResource
+    @resourceTypeId smallint,
+    @resourceId varchar(64),
+    @version int = NULL
+AS
+    SET NOCOUNT ON
+
+    IF (@version IS NULL) BEGIN
+        SELECT ResourceSurrogateId, Version, IsDeleted, IsHistory, RawResource
+        FROM dbo.Resource
+        WHERE ResourceTypeId = @resourceTypeId AND ResourceId = @resourceId AND IsHistory = 0
+    END
+    ELSE BEGIN
+        SELECT ResourceSurrogateId, Version, IsDeleted, IsHistory, RawResource
+        FROM dbo.Resource
+        WHERE ResourceTypeId = @resourceTypeId AND ResourceId = @resourceId AND Version = @version
+    END
+GO
+
+--
+-- STORED PROCEDURE
+--     Reads a single resource
+--
+-- DESCRIPTION
+--     Permanently deletes all data related to a resource.
+--     Data remains recoverable from the transaction log, however.
+--
+-- PARAMETERS
+--     @resourceTypeId
+--         * The ID of the resource type (See ResourceType table)
+--     @resourceId
+--         * The resource ID (must be the same as in the resource itself)
+--
+CREATE PROCEDURE dbo.HardDeleteResource
+    @resourceTypeId smallint,
+    @resourceId varchar(64)
+AS
+    SET NOCOUNT ON
+
+    SET XACT_ABORT ON
+    BEGIN TRANSACTION
+
+    DECLARE @resourceSurrogateIds TABLE(ResourceSurrogateId bigint NOT NULL)
+
+    DELETE FROM dbo.Resource
+    OUTPUT deleted.ResourceSurrogateId
+    INTO @resourceSurrogateIds
+    WHERE ResourceTypeId = @resourceTypeId AND ResourceId = @resourceId
+
+    DELETE FROM dbo.ResourceWriteClaim
+    WHERE ResourceSurrogateId IN (SELECT ResourceSurrogateId FROM @resourceSurrogateIds)
+
+    DELETE FROM dbo.CompartmentAssignment
+    WHERE ResourceSurrogateId IN (SELECT ResourceSurrogateId FROM @resourceSurrogateIds)
+
+    DELETE FROM dbo.ReferenceSearchParam
+    WHERE ResourceSurrogateId IN (SELECT ResourceSurrogateId FROM @resourceSurrogateIds)
+
+    DELETE FROM dbo.TokenSearchParam
+    WHERE ResourceSurrogateId IN (SELECT ResourceSurrogateId FROM @resourceSurrogateIds)
+
+    DELETE FROM dbo.TokenText
+    WHERE ResourceSurrogateId IN (SELECT ResourceSurrogateId FROM @resourceSurrogateIds)
+
+    DELETE FROM dbo.StringSearchParam
+    WHERE ResourceSurrogateId IN (SELECT ResourceSurrogateId FROM @resourceSurrogateIds)
+
+    DELETE FROM dbo.UriSearchParam
+    WHERE ResourceSurrogateId IN (SELECT ResourceSurrogateId FROM @resourceSurrogateIds)
+
+    DELETE FROM dbo.NumberSearchParam
+    WHERE ResourceSurrogateId IN (SELECT ResourceSurrogateId FROM @resourceSurrogateIds)
+
+    DELETE FROM dbo.QuantitySearchParam
+    WHERE ResourceSurrogateId IN (SELECT ResourceSurrogateId FROM @resourceSurrogateIds)
+
+    DELETE FROM dbo.DateTimeSearchParam
+    WHERE ResourceSurrogateId IN (SELECT ResourceSurrogateId FROM @resourceSurrogateIds)
+
+    DELETE FROM dbo.ReferenceTokenCompositeSearchParam
+    WHERE ResourceSurrogateId IN (SELECT ResourceSurrogateId FROM @resourceSurrogateIds)
+
+    DELETE FROM dbo.TokenTokenCompositeSearchParam
+    WHERE ResourceSurrogateId IN (SELECT ResourceSurrogateId FROM @resourceSurrogateIds)
+
+    DELETE FROM dbo.TokenDateTimeCompositeSearchParam
+    WHERE ResourceSurrogateId IN (SELECT ResourceSurrogateId FROM @resourceSurrogateIds)
+
+    DELETE FROM dbo.TokenQuantityCompositeSearchParam
+    WHERE ResourceSurrogateId IN (SELECT ResourceSurrogateId FROM @resourceSurrogateIds)
+
+    DELETE FROM dbo.TokenStringCompositeSearchParam
+    WHERE ResourceSurrogateId IN (SELECT ResourceSurrogateId FROM @resourceSurrogateIds)
+
+    DELETE FROM dbo.TokenNumberNumberCompositeSearchParam
+    WHERE ResourceSurrogateId IN (SELECT ResourceSurrogateId FROM @resourceSurrogateIds)
+
+    COMMIT TRANSACTION
+GO
+
+/*************************************************************
+    Export Job
+**************************************************************/
+CREATE TABLE dbo.ExportJob
+(
+    Id varchar(64) COLLATE Latin1_General_100_CS_AS NOT NULL,
+    Hash varchar(64) COLLATE Latin1_General_100_CS_AS NOT NULL,
+    Status varchar(10) NOT NULL,
+    HeartbeatDateTime datetime2(7) NULL,
+    RawJobRecord varchar(max) NOT NULL,
+    JobVersion rowversion NOT NULL
+)
+
+CREATE UNIQUE CLUSTERED INDEX IXC_ExportJob ON dbo.ExportJob
+(
+    Id
+)
+
+CREATE UNIQUE NONCLUSTERED INDEX IX_ExportJob_Hash_Status_HeartbeatDateTime ON dbo.ExportJob
+(
+    Hash,
+    Status,
+    HeartbeatDateTime
+)
+
+GO
+
+/*************************************************************
+    Stored procedures for exporting
+**************************************************************/
+--
+-- STORED PROCEDURE
+--     Creates an export job.
+--
+-- DESCRIPTION
+--     Creates a new row to the ExportJob table, adding a new job to the queue of jobs to be processed.
+--
+-- PARAMETERS
+--     @id
+--         * The ID of the export job record
+--     @hash
+--         * The SHA256 hash of the export job record ID
+--     @status
+--         * The status of the export job
+--     @rawJobRecord
+--         * A JSON document
+--
+-- RETURN VALUE
+--     The row version of the created export job.
+--
+CREATE PROCEDURE dbo.CreateExportJob
+    @id varchar(64),
+    @hash varchar(64),
+    @status varchar(10),
+    @rawJobRecord varchar(max)
+AS
+    SET NOCOUNT ON
+
+    SET XACT_ABORT ON
+    BEGIN TRANSACTION
+
+    DECLARE @heartbeatDateTime datetime2(7) = SYSUTCDATETIME()
+
+    INSERT INTO dbo.ExportJob
+        (Id, Hash, Status, HeartbeatDateTime, RawJobRecord)
+    VALUES
+        (@id, @hash, @status, @heartbeatDateTime, @rawJobRecord)
+  
+    SELECT CAST(MIN_ACTIVE_ROWVERSION() AS INT)
+
+    COMMIT TRANSACTION
+GO
+
+--
+-- STORED PROCEDURE
+--     Gets an export job given its ID.
+--
+-- DESCRIPTION
+--     Retrieves the export job record from the ExportJob table that has the matching ID.
+--
+-- PARAMETERS
+--     @id
+--         * The ID of the export job record to retrieve
+--
+-- RETURN VALUE
+--     The matching export job.
+--
+CREATE PROCEDURE dbo.GetExportJobById
+    @id varchar(64)
+AS
+    SET NOCOUNT ON
+
+    SELECT RawJobRecord, JobVersion
+    FROM dbo.ExportJob
+    WHERE Id = @id
+GO
+
+--
+-- STORED PROCEDURE
+--     Gets an export job given the hash of its ID.
+--
+-- DESCRIPTION
+--     Retrieves the export job record from the ExportJob table that has the matching hash.
+--
+-- PARAMETERS
+--     @hash
+--         * The SHA256 hash of the export job record ID
+--
+-- RETURN VALUE
+--     The matching export job.
+--
+CREATE PROCEDURE dbo.GetExportJobByHash
+    @hash varchar(64)
+AS
+    SET NOCOUNT ON
+
+    SELECT TOP(1) RawJobRecord, JobVersion
+    FROM dbo.ExportJob
+    WHERE Hash = @hash AND (Status = 'Queued' OR Status = 'Running')
+    ORDER BY HeartbeatDateTime ASC
+GO
+
+--
+-- STORED PROCEDURE
+--     Updates an export job.
+--
+-- DESCRIPTION
+--     Modifies an existing job in the ExportJob table.
+--
+-- PARAMETERS
+--     @id
+--         * The ID of the export job record
+--     @status
+--         * The status of the export job
+--     @rawJobRecord
+--         * A JSON document
+--     @jobVersion
+--         * The version of the job to update must match this
+--
+-- RETURN VALUE
+--     The row version of the updated export job.
+--
+CREATE PROCEDURE dbo.UpdateExportJob
+    @id varchar(64),
+    @status varchar(10),
+    @rawJobRecord varchar(max),
+    @jobVersion binary(8)
+AS
+    SET NOCOUNT ON
+
+    SET XACT_ABORT ON
+    BEGIN TRANSACTION
+
+    DECLARE @currentJobVersion binary(8)
+
+    -- Acquire and hold an update lock on a row in the ExportJob table for the entire transaction.
+    -- This ensures the version check and update occur atomically.
+    SELECT @currentJobVersion = JobVersion
+    FROM dbo.ExportJob WITH (UPDLOCK, HOLDLOCK)
+    WHERE Id = @id
+
+    IF (@currentJobVersion IS NULL) BEGIN
+        THROW 50404, 'Export job record not found', 1;
+    END
+
+    IF (@jobVersion <> @currentJobVersion) BEGIN
+        THROW 50412, 'Precondition failed', 1;
+    END
+
+    -- We will timestamp the jobs when we update them to track stale jobs.
+    DECLARE @heartbeatDateTime datetime2(7) = SYSUTCDATETIME()
+
+    UPDATE dbo.ExportJob
+    SET Status = @status, HeartbeatDateTime = @heartbeatDateTime, RawJobRecord = @rawJobRecord
+    WHERE Id = @id
+  
+    SELECT MIN_ACTIVE_ROWVERSION()
+
+    COMMIT TRANSACTION
+GO
+
+--
+-- STORED PROCEDURE
+--     Acquires export jobs.
+--
+-- DESCRIPTION
+--     Timestamps the available export jobs and sets their statuses to running.
+--
+-- PARAMETERS
+--     @jobHeartbeatTimeoutThresholdInSeconds
+--         * The number of seconds that must pass before an export job is considered stale
+--     @maximumNumberOfConcurrentJobsAllowed
+--         * The maximum number of running jobs we can have at once
+--
+-- RETURN VALUE
+--     The updated jobs that are now running.
+--
+CREATE PROCEDURE dbo.AcquireExportJobs
+    @jobHeartbeatTimeoutThresholdInSeconds bigint,
+    @maximumNumberOfConcurrentJobsAllowed int
+AS
+    SET NOCOUNT ON
+    SET XACT_ABORT ON
+
+    SET TRANSACTION ISOLATION LEVEL SERIALIZABLE
+    BEGIN TRANSACTION
+
+    -- We will consider a job to be stale if its timestamp is smaller than or equal to this.
+    DECLARE @expirationDateTime dateTime2(7)
+    SELECT @expirationDateTime = DATEADD(second, -@jobHeartbeatTimeoutThresholdInSeconds, SYSUTCDATETIME())
+
+    -- Get the number of jobs that are running and not stale.
+    -- Acquire and hold an exclusive table lock for the entire transaction to prevent jobs from being created, updated or deleted during acquisitions.
+    DECLARE @numberOfRunningJobs int
+    SELECT @numberOfRunningJobs = COUNT(*) FROM dbo.ExportJob WITH (TABLOCKX) WHERE Status = 'Running' AND HeartbeatDateTime > @expirationDateTime
+
+    -- Determine how many available jobs we can pick up.
+    DECLARE @limit int = @maximumNumberOfConcurrentJobsAllowed - @numberOfRunningJobs;
+
+    DECLARE @availableJobs TABLE (Id varchar(64) COLLATE Latin1_General_100_CS_AS NOT NULL, JobVersion binary(8) NOT NULL)
+
+    -- Get the available jobs, which are export jobs that are queued or stale.
+    -- Older jobs will be prioritized over newer ones.
+    INSERT INTO @availableJobs
+    SELECT TOP(@limit) Id, JobVersion
+    FROM dbo.ExportJob
+    WHERE (Status = 'Queued' OR (Status = 'Running' AND HeartbeatDateTime <= @expirationDateTime))
+    ORDER BY HeartbeatDateTime
+
+    DECLARE @heartbeatDateTime datetime2(7) = SYSUTCDATETIME()
+
+    -- Update each available job's status to running both in the export table's status column and in the raw export job record JSON.
+    UPDATE dbo.ExportJob
+    SET Status = 'Running', HeartbeatDateTime = @heartbeatDateTime, RawJobRecord = JSON_MODIFY(RawJobRecord,'$.status', 'Running')
+    OUTPUT inserted.RawJobRecord, inserted.JobVersion
+    FROM dbo.ExportJob job INNER JOIN @availableJobs availableJob ON job.Id = availableJob.Id AND job.JobVersion = availableJob.JobVersion
+   
+    COMMIT TRANSACTION
+GO
+
+/*************************************************************
+    Search Parameter Registry
+**************************************************************/
+-- TODO: Update table and indices one usage of table is fully understood
+CREATE TABLE dbo.SearchParameterRegistry
+(
+    SearchParamId smallint NOT NULL,
+    ResourceTypeId smallint NOT NULL, -- TODO: Should we be storing the uri instead?
+    Status varchar(10) NOT NULL, -- TODO: Can/should this be stored as an enum or number instead of a string?
+    LastUpdated datetimeoffset(7) NULL -- TODO: Should this just be datetime? What level of precision is needed?
+)
+
+CREATE UNIQUE CLUSTERED INDEX IXC_SearchParameterRegistry ON dbo.SearchParameterRegistry
+(
+    SearchParamId
+)
+
+CREATE UNIQUE NONCLUSTERED INDEX IX_SearchParameterRegistry_ResourceTypeId ON dbo.SearchParameterRegistry
+(
+    ResourceTypeId
+)
+
+GO
+
+--
+-- STORED PROCEDURE
+--     Gets all the search parameters and their statuses.
+--
+-- DESCRIPTION
+--     Retrieves and returns the contents of the search parameter registry.
+--
+-- RETURN VALUE
+--     The search parameters and their statuses.
+--
+CREATE PROCEDURE dbo.GetSearchParameterStatuses
+AS
+    SET NOCOUNT ON
+    
+    SELECT * FROM dbo.SearchParameterRegistry
+GO

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/3.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/3.sql
@@ -2060,7 +2060,6 @@ AS
     DECLARE @lastUpdated datetime2(7) = SYSUTCDATETIME()
 
     -- Acquire and hold an exclusive table lock for the entire transaction to prevent parameters from being added or modified during upsertion.
-    -- TODO: should this be an update lock?
     UPDATE dbo.SearchParamRegistry
     WITH (TABLOCKX)
     SET Status = sps.Status, LastUpdated = @lastUpdated, IsPartiallySupported = sps.IsPartiallySupported

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/3.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/3.sql
@@ -2067,23 +2067,34 @@ GO
 
 --
 -- STORED PROCEDURE
+--     Counts the number of search parameters.
+--
+-- DESCRIPTION
+--     Retrieves and returns the number of rows in the search parameter registry.
+--
+-- RETURN VALUE
+--     The number of search parameters in the registry.
+--
+CREATE PROCEDURE dbo.GetSearchParamRegistryCount
+AS
+    SET NOCOUNT ON
+    
+    SELECT COUNT(*) FROM dbo.SearchParamRegistry
+GO
+
+--
+-- STORED PROCEDURE
 --     Inserts a search parameter and its status into the search parameter registry.
 --
 -- DESCRIPTION
 --     Adds a row to the search parameter registry.
 --
 -- PARAMETERS
---     @uri
---         * The search parameter's identifying URI
---     @status
---         * The status of the search parameter
---     @isPartiallySupported
---         * True if the parameter resolves to more than one type (FhirString, FhirUri, etc) but not all types can be indexed
+--     @searchParamStatuses
+--         * The updated search parameter statuses
 --
 CREATE PROCEDURE dbo.InsertIntoSearchParamRegistry
-    @uri varchar(128),
-    @status varchar(10),
-    @isPartiallySupported bit
+    @searchParamStatuses dbo.SearchParamRegistryTableType_1 READONLY
 AS
     SET NOCOUNT ON
 
@@ -2094,8 +2105,8 @@ AS
     
     INSERT INTO dbo.SearchParamRegistry
         (Uri, Status, LastUpdated, IsPartiallySupported)
-    VALUES
-        (@uri, @status, @lastUpdated, @isPartiallySupported)
+    SELECT sps.Uri, sps.Status, @lastUpdated, sps.IsPartiallySupported
+    FROM searchParamStatuses AS sps
 
     COMMIT TRANSACTION
 GO

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/3.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/3.sql
@@ -1993,22 +1993,18 @@ GO
     Search Parameter Registry
 **************************************************************/
 -- TODO: Update table and indices one usage of table is fully understood
-CREATE TABLE dbo.SearchParameterRegistry
+-- TODO: Comments for table?
+CREATE TABLE dbo.SearchParamRegistry
 (
-    SearchParamId smallint NOT NULL,
-    ResourceTypeId smallint NOT NULL, -- TODO: Should we be storing the uri instead?
-    Status varchar(10) NOT NULL, -- TODO: Can/should this be stored as an enum or number instead of a string?
-    LastUpdated datetimeoffset(7) NULL -- TODO: Should this just be datetime? What level of precision is needed?
+    Uri varchar(128) COLLATE Latin1_General_100_CS_AS NOT NULL,
+    Status varchar(10) NOT NULL,
+    LastUpdated datetimeoffset(7) NULL, -- TODO: Should this just be datetime? What level of precision is needed?
+    IsPartiallySupported bit NOT NULL
 )
 
-CREATE UNIQUE CLUSTERED INDEX IXC_SearchParameterRegistry ON dbo.SearchParameterRegistry
+CREATE UNIQUE CLUSTERED INDEX IXC_SearchParamRegistry ON dbo.SearchParamRegistry
 (
-    SearchParamId
-)
-
-CREATE UNIQUE NONCLUSTERED INDEX IX_SearchParameterRegistry_ResourceTypeId ON dbo.SearchParameterRegistry
-(
-    ResourceTypeId
+    Uri
 )
 
 GO
@@ -2023,9 +2019,44 @@ GO
 -- RETURN VALUE
 --     The search parameters and their statuses.
 --
-CREATE PROCEDURE dbo.GetSearchParameterStatuses
+CREATE PROCEDURE dbo.GetSearchParamStatuses
 AS
     SET NOCOUNT ON
     
-    SELECT * FROM dbo.SearchParameterRegistry
+    SELECT * FROM dbo.SearchParamRegistry
+GO
+
+--
+-- STORED PROCEDURE
+--     Inserts a search parameter and its status into the search parameter registry.
+--
+-- DESCRIPTION
+--     Adds a row to the search parameter registry.
+--
+-- PARAMETERS
+--     @uri
+--         * The search parameter's identifying URI
+--     @status
+--         * The status of the search parameter
+--     @isPartiallySupported
+--         * True if the parameter resolves to more than one type (FhirString, FhirUri, etc) but not all types can be indexed
+--
+CREATE PROCEDURE dbo.InsertIntoSearchParamRegistry
+    @uri varchar(128),
+    @status varchar(10),
+    @isPartiallySupported bit
+AS
+    SET NOCOUNT ON
+
+    SET XACT_ABORT ON
+    BEGIN TRANSACTION
+
+    DECLARE @lastUpdated datetime2(7) = SYSUTCDATETIME()
+    
+    INSERT INTO dbo.SearchParamRegistry
+        (Uri, Status, LastUpdated, IsPartiallySupported)
+    VALUES
+        (@uri, @status, @lastUpdated, @isPartiallySupported)
+
+    COMMIT TRANSACTION
 GO

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/3.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/3.sql
@@ -2038,29 +2038,41 @@ GO
 
 --
 -- STORED PROCEDURE
---     Updates the status of a search parameter.
+--     Given a table of search parameters, upserts the registry.
 --
 -- DESCRIPTION
---     Given an identifying URI, sets the status of a search parameter.
+--     If a parameter with a matching URI already exists in the registry, it is updated.
+--     If not, a new entry is created.
 --
 -- PARAMETERS
 --     @searchParamStatuses
---         * The updated search parameter statuses
+--         * The updated or new search parameter statuses
 --
-CREATE PROCEDURE dbo.UpdateSearchParamStatus
+CREATE PROCEDURE dbo.UpsertSearchParamStatus
     @searchParamStatuses dbo.SearchParamRegistryTableType_1 READONLY
 AS
     SET NOCOUNT ON
-
     SET XACT_ABORT ON
+
+    SET TRANSACTION ISOLATION LEVEL SERIALIZABLE
     BEGIN TRANSACTION
 
     DECLARE @lastUpdated datetime2(7) = SYSUTCDATETIME()
 
+    -- Acquire and hold an exclusive table lock for the entire transaction to prevent parameters from being added or modified during upsertion.
+    -- TODO: should this be an update lock?
     UPDATE dbo.SearchParamRegistry
-    SET Status = sps.Status, LastUpdated = @lastUpdated
+    WITH (TABLOCKX)
+    SET Status = sps.Status, LastUpdated = @lastUpdated, IsPartiallySupported = sps.IsPartiallySupported
     FROM dbo.SearchParamRegistry INNER JOIN @searchParamStatuses as sps
     ON dbo.SearchParamRegistry.Uri = sps.Uri
+
+    INSERT INTO dbo.SearchParamRegistry
+        (Uri, Status, LastUpdated, IsPartiallySupported)
+    SELECT sps.Uri, sps.Status, @lastUpdated, sps.IsPartiallySupported
+    FROM @searchParamStatuses AS sps
+    WHERE sps.Uri NOT IN
+        (SELECT Uri FROM dbo.SearchParamRegistry) 
 
     COMMIT TRANSACTION
 GO

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/3.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/3.sql
@@ -2106,7 +2106,7 @@ AS
     INSERT INTO dbo.SearchParamRegistry
         (Uri, Status, LastUpdated, IsPartiallySupported)
     SELECT sps.Uri, sps.Status, @lastUpdated, sps.IsPartiallySupported
-    FROM searchParamStatuses AS sps
+    FROM @searchParamStatuses AS sps
 
     COMMIT TRANSACTION
 GO

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/3.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/3.sql
@@ -2028,6 +2028,30 @@ GO
 
 --
 -- STORED PROCEDURE
+--     Updates the status of a search parameter.
+--
+-- DESCRIPTION
+--     Given an identifying URI, sets the status of a search parameter.
+--
+-- PARAMETERS
+--     @uri
+--         * The search parameter's identifying URI
+--     @status
+--         * The new status of the search parameter
+--
+CREATE PROCEDURE dbo.UpdateSearchParamStatus
+    @uri varchar(128),
+    @status varchar(10)
+AS
+    SET NOCOUNT ON
+    
+    UPDATE dbo.SearchParamRegistry
+    SET Status = @status
+    WHERE Uri = @uri
+GO
+
+--
+-- STORED PROCEDURE
 --     Inserts a search parameter and its status into the search parameter registry.
 --
 -- DESCRIPTION

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/3.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/3.sql
@@ -1992,8 +1992,14 @@ GO
 /*************************************************************
     Search Parameter Registry
 **************************************************************/
--- TODO: Update table and indices one usage of table is fully understood
--- TODO: Comments for table?
+
+CREATE TYPE dbo.SearchParamRegistryTableType_1 AS TABLE
+(
+    Uri varchar(128) COLLATE Latin1_General_100_CS_AS NOT NULL,
+    Status varchar(10) NOT NULL,
+    IsPartiallySupported bit NOT NULL
+)
+
 CREATE TABLE dbo.SearchParamRegistry
 (
     Uri varchar(128) COLLATE Latin1_General_100_CS_AS NOT NULL,
@@ -2002,13 +2008,17 @@ CREATE TABLE dbo.SearchParamRegistry
     IsPartiallySupported bit NOT NULL
 )
 
-CREATE UNIQUE CLUSTERED INDEX IXC_SearchParamRegistry ON dbo.SearchParamRegistry
+CREATE UNIQUE CLUSTERED INDEX IXC_SearchParamRegistry
+ON dbo.SearchParamRegistry
 (
     Uri
 )
 
 GO
 
+/*************************************************************
+    Stored procedures for the search parameter registry
+**************************************************************/
 --
 -- STORED PROCEDURE
 --     Gets all the search parameters and their statuses.
@@ -2034,20 +2044,25 @@ GO
 --     Given an identifying URI, sets the status of a search parameter.
 --
 -- PARAMETERS
---     @uri
---         * The search parameter's identifying URI
---     @status
---         * The new status of the search parameter
+--     @searchParamStatuses
+--         * The updated search parameter statuses
 --
 CREATE PROCEDURE dbo.UpdateSearchParamStatus
-    @uri varchar(128),
-    @status varchar(10)
+    @searchParamStatuses dbo.SearchParamRegistryTableType_1 READONLY
 AS
     SET NOCOUNT ON
-    
+
+    SET XACT_ABORT ON
+    BEGIN TRANSACTION
+
+    DECLARE @lastUpdated datetime2(7) = SYSUTCDATETIME()
+
     UPDATE dbo.SearchParamRegistry
-    SET Status = @status
-    WHERE Uri = @uri
+    SET Status = sps.Status, LastUpdated = @lastUpdated
+    FROM dbo.SearchParamRegistry INNER JOIN @searchParamStatuses as sps
+    ON dbo.SearchParamRegistry.Uri = sps.Uri
+
+    COMMIT TRANSACTION
 GO
 
 --

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/3.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/3.sql
@@ -2004,7 +2004,7 @@ CREATE TABLE dbo.SearchParamRegistry
 (
     Uri varchar(128) COLLATE Latin1_General_100_CS_AS NOT NULL,
     Status varchar(10) NOT NULL,
-    LastUpdated datetimeoffset(7) NULL, -- TODO: Should this just be datetime? What level of precision is needed?
+    LastUpdated datetimeoffset(7) NULL,
     IsPartiallySupported bit NOT NULL
 )
 
@@ -2057,7 +2057,7 @@ AS
     SET TRANSACTION ISOLATION LEVEL SERIALIZABLE
     BEGIN TRANSACTION
 
-    DECLARE @lastUpdated datetime2(7) = SYSUTCDATETIME()
+    DECLARE @lastUpdated datetimeoffset(7) = SYSDATETIMEOFFSET()
 
     -- Acquire and hold an exclusive table lock for the entire transaction to prevent parameters from being added or modified during upsertion.
     UPDATE dbo.SearchParamRegistry
@@ -2112,7 +2112,7 @@ AS
     SET XACT_ABORT ON
     BEGIN TRANSACTION
 
-    DECLARE @lastUpdated datetime2(7) = SYSUTCDATETIME()
+    DECLARE @lastUpdated datetimeoffset(7) = SYSDATETIMEOFFSET()
     
     INSERT INTO dbo.SearchParamRegistry
         (Uri, Status, LastUpdated, IsPartiallySupported)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/VLatest.Generated.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/VLatest.Generated.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
         internal readonly static CreateExportJobProcedure CreateExportJob = new CreateExportJobProcedure();
         internal readonly static GetExportJobByHashProcedure GetExportJobByHash = new GetExportJobByHashProcedure();
         internal readonly static GetExportJobByIdProcedure GetExportJobById = new GetExportJobByIdProcedure();
+        internal readonly static GetSearchParamRegistryCountProcedure GetSearchParamRegistryCount = new GetSearchParamRegistryCountProcedure();
         internal readonly static GetSearchParamStatusesProcedure GetSearchParamStatuses = new GetSearchParamStatusesProcedure();
         internal readonly static HardDeleteResourceProcedure HardDeleteResource = new HardDeleteResourceProcedure();
         internal readonly static InsertIntoSearchParamRegistryProcedure InsertIntoSearchParamRegistry = new InsertIntoSearchParamRegistryProcedure();
@@ -479,6 +480,19 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             }
         }
 
+        internal class GetSearchParamRegistryCountProcedure : StoredProcedure
+        {
+            internal GetSearchParamRegistryCountProcedure(): base("dbo.GetSearchParamRegistryCount")
+            {
+            }
+
+            public void PopulateCommand(global::System.Data.SqlClient.SqlCommand command)
+            {
+                command.CommandType = global::System.Data.CommandType.StoredProcedure;
+                command.CommandText = "dbo.GetSearchParamRegistryCount";
+            }
+        }
+
         internal class GetSearchParamStatusesProcedure : StoredProcedure
         {
             internal GetSearchParamStatusesProcedure(): base("dbo.GetSearchParamStatuses")
@@ -515,16 +529,44 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             {
             }
 
-            private readonly ParameterDefinition<System.String> _uri = new ParameterDefinition<System.String>("@uri", global::System.Data.SqlDbType.VarChar, false, 128);
-            private readonly ParameterDefinition<System.String> _status = new ParameterDefinition<System.String>("@status", global::System.Data.SqlDbType.VarChar, false, 10);
-            private readonly ParameterDefinition<System.Boolean> _isPartiallySupported = new ParameterDefinition<System.Boolean>("@isPartiallySupported", global::System.Data.SqlDbType.Bit, false);
-            public void PopulateCommand(global::System.Data.SqlClient.SqlCommand command, System.String uri, System.String status, System.Boolean isPartiallySupported)
+            private readonly SearchParamRegistryTableTypeTableValuedParameterDefinition _searchParamStatuses = new SearchParamRegistryTableTypeTableValuedParameterDefinition("@searchParamStatuses");
+            public void PopulateCommand(global::System.Data.SqlClient.SqlCommand command, global::System.Collections.Generic.IEnumerable<SearchParamRegistryTableTypeRow> searchParamStatuses)
             {
                 command.CommandType = global::System.Data.CommandType.StoredProcedure;
                 command.CommandText = "dbo.InsertIntoSearchParamRegistry";
-                _uri.AddParameter(command.Parameters, uri);
-                _status.AddParameter(command.Parameters, status);
-                _isPartiallySupported.AddParameter(command.Parameters, isPartiallySupported);
+                _searchParamStatuses.AddParameter(command.Parameters, searchParamStatuses);
+            }
+
+            public void PopulateCommand(global::System.Data.SqlClient.SqlCommand command, InsertIntoSearchParamRegistryTableValuedParameters tableValuedParameters)
+            {
+                PopulateCommand(command, searchParamStatuses: tableValuedParameters.SearchParamStatuses);
+            }
+        }
+
+        internal class InsertIntoSearchParamRegistryTvpGenerator<TInput> : IStoredProcedureTableValuedParametersGenerator<TInput, InsertIntoSearchParamRegistryTableValuedParameters>
+        {
+            public InsertIntoSearchParamRegistryTvpGenerator(ITableValuedParameterRowGenerator<TInput, SearchParamRegistryTableTypeRow> SearchParamRegistryTableTypeRowGenerator)
+            {
+                this.SearchParamRegistryTableTypeRowGenerator = SearchParamRegistryTableTypeRowGenerator;
+            }
+
+            private readonly ITableValuedParameterRowGenerator<TInput, SearchParamRegistryTableTypeRow> SearchParamRegistryTableTypeRowGenerator;
+            public InsertIntoSearchParamRegistryTableValuedParameters Generate(TInput input)
+            {
+                return new InsertIntoSearchParamRegistryTableValuedParameters(SearchParamRegistryTableTypeRowGenerator.GenerateRows(input));
+            }
+        }
+
+        internal struct InsertIntoSearchParamRegistryTableValuedParameters
+        {
+            internal InsertIntoSearchParamRegistryTableValuedParameters(global::System.Collections.Generic.IEnumerable<SearchParamRegistryTableTypeRow> SearchParamStatuses)
+            {
+                this.SearchParamStatuses = SearchParamStatuses;
+            }
+
+            internal global::System.Collections.Generic.IEnumerable<SearchParamRegistryTableTypeRow> SearchParamStatuses
+            {
+                get;
             }
         }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/VLatest.Generated.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/VLatest.Generated.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
         internal readonly static ResourceWriteClaimTable ResourceWriteClaim = new ResourceWriteClaimTable();
         internal readonly static SchemaVersionTable SchemaVersion = new SchemaVersionTable();
         internal readonly static SearchParamTable SearchParam = new SearchParamTable();
+        internal readonly static SearchParameterRegistryTable SearchParameterRegistry = new SearchParameterRegistryTable();
         internal readonly static StringSearchParamTable StringSearchParam = new StringSearchParamTable();
         internal readonly static SystemTable System = new SystemTable();
         internal readonly static TokenDateTimeCompositeSearchParamTable TokenDateTimeCompositeSearchParam = new TokenDateTimeCompositeSearchParamTable();
@@ -41,6 +42,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
         internal readonly static CreateExportJobProcedure CreateExportJob = new CreateExportJobProcedure();
         internal readonly static GetExportJobByHashProcedure GetExportJobByHash = new GetExportJobByHashProcedure();
         internal readonly static GetExportJobByIdProcedure GetExportJobById = new GetExportJobByIdProcedure();
+        internal readonly static GetSearchParameterStatusesProcedure GetSearchParameterStatuses = new GetSearchParameterStatusesProcedure();
         internal readonly static HardDeleteResourceProcedure HardDeleteResource = new HardDeleteResourceProcedure();
         internal readonly static ReadResourceProcedure ReadResource = new ReadResourceProcedure();
         internal readonly static SelectCurrentSchemaVersionProcedure SelectCurrentSchemaVersion = new SelectCurrentSchemaVersionProcedure();
@@ -240,6 +242,18 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
 
             internal readonly SmallIntColumn SearchParamId = new SmallIntColumn("SearchParamId");
             internal readonly VarCharColumn Uri = new VarCharColumn("Uri", 128, "Latin1_General_100_CS_AS");
+        }
+
+        internal class SearchParameterRegistryTable : Table
+        {
+            internal SearchParameterRegistryTable(): base("dbo.SearchParameterRegistry")
+            {
+            }
+
+            internal readonly SmallIntColumn SearchParamId = new SmallIntColumn("SearchParamId");
+            internal readonly SmallIntColumn ResourceTypeId = new SmallIntColumn("ResourceTypeId");
+            internal readonly VarCharColumn Status = new VarCharColumn("Status", 10);
+            internal readonly NullableDateTimeOffsetColumn LastUpdated = new NullableDateTimeOffsetColumn("LastUpdated", 7);
         }
 
         internal class StringSearchParamTable : Table
@@ -460,6 +474,19 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
                 command.CommandType = global::System.Data.CommandType.StoredProcedure;
                 command.CommandText = "dbo.GetExportJobById";
                 _id.AddParameter(command.Parameters, id);
+            }
+        }
+
+        internal class GetSearchParameterStatusesProcedure : StoredProcedure
+        {
+            internal GetSearchParameterStatusesProcedure(): base("dbo.GetSearchParameterStatuses")
+            {
+            }
+
+            public void PopulateCommand(global::System.Data.SqlClient.SqlCommand command)
+            {
+                command.CommandType = global::System.Data.CommandType.StoredProcedure;
+                command.CommandText = "dbo.GetSearchParameterStatuses";
             }
         }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/VLatest.Generated.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/VLatest.Generated.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
         internal readonly static ReadResourceProcedure ReadResource = new ReadResourceProcedure();
         internal readonly static SelectCurrentSchemaVersionProcedure SelectCurrentSchemaVersion = new SelectCurrentSchemaVersionProcedure();
         internal readonly static UpdateExportJobProcedure UpdateExportJob = new UpdateExportJobProcedure();
+        internal readonly static UpdateSearchParamStatusProcedure UpdateSearchParamStatus = new UpdateSearchParamStatusProcedure();
         internal readonly static UpsertResourceProcedure UpsertResource = new UpsertResourceProcedure();
         internal readonly static UpsertSchemaVersionProcedure UpsertSchemaVersion = new UpsertSchemaVersionProcedure();
         internal class ClaimTypeTable : Table
@@ -577,6 +578,23 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
                 _status.AddParameter(command.Parameters, status);
                 _rawJobRecord.AddParameter(command.Parameters, rawJobRecord);
                 _jobVersion.AddParameter(command.Parameters, jobVersion);
+            }
+        }
+
+        internal class UpdateSearchParamStatusProcedure : StoredProcedure
+        {
+            internal UpdateSearchParamStatusProcedure(): base("dbo.UpdateSearchParamStatus")
+            {
+            }
+
+            private readonly ParameterDefinition<System.String> _uri = new ParameterDefinition<System.String>("@uri", global::System.Data.SqlDbType.VarChar, false, 128);
+            private readonly ParameterDefinition<System.String> _status = new ParameterDefinition<System.String>("@status", global::System.Data.SqlDbType.VarChar, false, 10);
+            public void PopulateCommand(global::System.Data.SqlClient.SqlCommand command, System.String uri, System.String status)
+            {
+                command.CommandType = global::System.Data.CommandType.StoredProcedure;
+                command.CommandText = "dbo.UpdateSearchParamStatus";
+                _uri.AddParameter(command.Parameters, uri);
+                _status.AddParameter(command.Parameters, status);
             }
         }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/VLatest.Generated.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/VLatest.Generated.cs
@@ -587,14 +587,44 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             {
             }
 
-            private readonly ParameterDefinition<System.String> _uri = new ParameterDefinition<System.String>("@uri", global::System.Data.SqlDbType.VarChar, false, 128);
-            private readonly ParameterDefinition<System.String> _status = new ParameterDefinition<System.String>("@status", global::System.Data.SqlDbType.VarChar, false, 10);
-            public void PopulateCommand(global::System.Data.SqlClient.SqlCommand command, System.String uri, System.String status)
+            private readonly SearchParamRegistryTableTypeTableValuedParameterDefinition _searchParamStatuses = new SearchParamRegistryTableTypeTableValuedParameterDefinition("@searchParamStatuses");
+            public void PopulateCommand(global::System.Data.SqlClient.SqlCommand command, global::System.Collections.Generic.IEnumerable<SearchParamRegistryTableTypeRow> searchParamStatuses)
             {
                 command.CommandType = global::System.Data.CommandType.StoredProcedure;
                 command.CommandText = "dbo.UpdateSearchParamStatus";
-                _uri.AddParameter(command.Parameters, uri);
-                _status.AddParameter(command.Parameters, status);
+                _searchParamStatuses.AddParameter(command.Parameters, searchParamStatuses);
+            }
+
+            public void PopulateCommand(global::System.Data.SqlClient.SqlCommand command, UpdateSearchParamStatusTableValuedParameters tableValuedParameters)
+            {
+                PopulateCommand(command, searchParamStatuses: tableValuedParameters.SearchParamStatuses);
+            }
+        }
+
+        internal class UpdateSearchParamStatusTvpGenerator<TInput> : IStoredProcedureTableValuedParametersGenerator<TInput, UpdateSearchParamStatusTableValuedParameters>
+        {
+            public UpdateSearchParamStatusTvpGenerator(ITableValuedParameterRowGenerator<TInput, SearchParamRegistryTableTypeRow> SearchParamRegistryTableTypeRowGenerator)
+            {
+                this.SearchParamRegistryTableTypeRowGenerator = SearchParamRegistryTableTypeRowGenerator;
+            }
+
+            private readonly ITableValuedParameterRowGenerator<TInput, SearchParamRegistryTableTypeRow> SearchParamRegistryTableTypeRowGenerator;
+            public UpdateSearchParamStatusTableValuedParameters Generate(TInput input)
+            {
+                return new UpdateSearchParamStatusTableValuedParameters(SearchParamRegistryTableTypeRowGenerator.GenerateRows(input));
+            }
+        }
+
+        internal struct UpdateSearchParamStatusTableValuedParameters
+        {
+            internal UpdateSearchParamStatusTableValuedParameters(global::System.Collections.Generic.IEnumerable<SearchParamRegistryTableTypeRow> SearchParamStatuses)
+            {
+                this.SearchParamStatuses = SearchParamStatuses;
+            }
+
+            internal global::System.Collections.Generic.IEnumerable<SearchParamRegistryTableTypeRow> SearchParamStatuses
+            {
+                get;
             }
         }
 
@@ -1198,6 +1228,49 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             }
 
             internal System.String ClaimValue
+            {
+                get;
+            }
+        }
+
+        private class SearchParamRegistryTableTypeTableValuedParameterDefinition : TableValuedParameterDefinition<SearchParamRegistryTableTypeRow>
+        {
+            internal SearchParamRegistryTableTypeTableValuedParameterDefinition(System.String parameterName): base(parameterName, "dbo.SearchParamRegistryTableType_1")
+            {
+            }
+
+            internal readonly VarCharColumn Uri = new VarCharColumn("Uri", 128, "Latin1_General_100_CS_AS");
+            internal readonly VarCharColumn Status = new VarCharColumn("Status", 10);
+            internal readonly BitColumn IsPartiallySupported = new BitColumn("IsPartiallySupported");
+            protected override global::System.Collections.Generic.IEnumerable<Column> Columns => new Column[]{Uri, Status, IsPartiallySupported};
+            protected override void FillSqlDataRecord(global::Microsoft.SqlServer.Server.SqlDataRecord record, SearchParamRegistryTableTypeRow rowData)
+            {
+                Uri.Set(record, 0, rowData.Uri);
+                Status.Set(record, 1, rowData.Status);
+                IsPartiallySupported.Set(record, 2, rowData.IsPartiallySupported);
+            }
+        }
+
+        internal struct SearchParamRegistryTableTypeRow
+        {
+            internal SearchParamRegistryTableTypeRow(System.String Uri, System.String Status, System.Boolean IsPartiallySupported)
+            {
+                this.Uri = Uri;
+                this.Status = Status;
+                this.IsPartiallySupported = IsPartiallySupported;
+            }
+
+            internal System.String Uri
+            {
+                get;
+            }
+
+            internal System.String Status
+            {
+                get;
+            }
+
+            internal System.Boolean IsPartiallySupported
             {
                 get;
             }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/VLatest.Generated.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/VLatest.Generated.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
         internal readonly static ResourceWriteClaimTable ResourceWriteClaim = new ResourceWriteClaimTable();
         internal readonly static SchemaVersionTable SchemaVersion = new SchemaVersionTable();
         internal readonly static SearchParamTable SearchParam = new SearchParamTable();
-        internal readonly static SearchParameterRegistryTable SearchParameterRegistry = new SearchParameterRegistryTable();
+        internal readonly static SearchParamRegistryTable SearchParamRegistry = new SearchParamRegistryTable();
         internal readonly static StringSearchParamTable StringSearchParam = new StringSearchParamTable();
         internal readonly static SystemTable System = new SystemTable();
         internal readonly static TokenDateTimeCompositeSearchParamTable TokenDateTimeCompositeSearchParam = new TokenDateTimeCompositeSearchParamTable();
@@ -42,8 +42,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
         internal readonly static CreateExportJobProcedure CreateExportJob = new CreateExportJobProcedure();
         internal readonly static GetExportJobByHashProcedure GetExportJobByHash = new GetExportJobByHashProcedure();
         internal readonly static GetExportJobByIdProcedure GetExportJobById = new GetExportJobByIdProcedure();
-        internal readonly static GetSearchParameterStatusesProcedure GetSearchParameterStatuses = new GetSearchParameterStatusesProcedure();
+        internal readonly static GetSearchParamStatusesProcedure GetSearchParamStatuses = new GetSearchParamStatusesProcedure();
         internal readonly static HardDeleteResourceProcedure HardDeleteResource = new HardDeleteResourceProcedure();
+        internal readonly static InsertIntoSearchParamRegistryProcedure InsertIntoSearchParamRegistry = new InsertIntoSearchParamRegistryProcedure();
         internal readonly static ReadResourceProcedure ReadResource = new ReadResourceProcedure();
         internal readonly static SelectCurrentSchemaVersionProcedure SelectCurrentSchemaVersion = new SelectCurrentSchemaVersionProcedure();
         internal readonly static UpdateExportJobProcedure UpdateExportJob = new UpdateExportJobProcedure();
@@ -244,16 +245,16 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly VarCharColumn Uri = new VarCharColumn("Uri", 128, "Latin1_General_100_CS_AS");
         }
 
-        internal class SearchParameterRegistryTable : Table
+        internal class SearchParamRegistryTable : Table
         {
-            internal SearchParameterRegistryTable(): base("dbo.SearchParameterRegistry")
+            internal SearchParamRegistryTable(): base("dbo.SearchParamRegistry")
             {
             }
 
-            internal readonly SmallIntColumn SearchParamId = new SmallIntColumn("SearchParamId");
-            internal readonly SmallIntColumn ResourceTypeId = new SmallIntColumn("ResourceTypeId");
+            internal readonly VarCharColumn Uri = new VarCharColumn("Uri", 128, "Latin1_General_100_CS_AS");
             internal readonly VarCharColumn Status = new VarCharColumn("Status", 10);
             internal readonly NullableDateTimeOffsetColumn LastUpdated = new NullableDateTimeOffsetColumn("LastUpdated", 7);
+            internal readonly BitColumn IsPartiallySupported = new BitColumn("IsPartiallySupported");
         }
 
         internal class StringSearchParamTable : Table
@@ -477,16 +478,16 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             }
         }
 
-        internal class GetSearchParameterStatusesProcedure : StoredProcedure
+        internal class GetSearchParamStatusesProcedure : StoredProcedure
         {
-            internal GetSearchParameterStatusesProcedure(): base("dbo.GetSearchParameterStatuses")
+            internal GetSearchParamStatusesProcedure(): base("dbo.GetSearchParamStatuses")
             {
             }
 
             public void PopulateCommand(global::System.Data.SqlClient.SqlCommand command)
             {
                 command.CommandType = global::System.Data.CommandType.StoredProcedure;
-                command.CommandText = "dbo.GetSearchParameterStatuses";
+                command.CommandText = "dbo.GetSearchParamStatuses";
             }
         }
 
@@ -504,6 +505,25 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
                 command.CommandText = "dbo.HardDeleteResource";
                 _resourceTypeId.AddParameter(command.Parameters, resourceTypeId);
                 _resourceId.AddParameter(command.Parameters, resourceId);
+            }
+        }
+
+        internal class InsertIntoSearchParamRegistryProcedure : StoredProcedure
+        {
+            internal InsertIntoSearchParamRegistryProcedure(): base("dbo.InsertIntoSearchParamRegistry")
+            {
+            }
+
+            private readonly ParameterDefinition<System.String> _uri = new ParameterDefinition<System.String>("@uri", global::System.Data.SqlDbType.VarChar, false, 128);
+            private readonly ParameterDefinition<System.String> _status = new ParameterDefinition<System.String>("@status", global::System.Data.SqlDbType.VarChar, false, 10);
+            private readonly ParameterDefinition<System.Boolean> _isPartiallySupported = new ParameterDefinition<System.Boolean>("@isPartiallySupported", global::System.Data.SqlDbType.Bit, false);
+            public void PopulateCommand(global::System.Data.SqlClient.SqlCommand command, System.String uri, System.String status, System.Boolean isPartiallySupported)
+            {
+                command.CommandType = global::System.Data.CommandType.StoredProcedure;
+                command.CommandText = "dbo.InsertIntoSearchParamRegistry";
+                _uri.AddParameter(command.Parameters, uri);
+                _status.AddParameter(command.Parameters, status);
+                _isPartiallySupported.AddParameter(command.Parameters, isPartiallySupported);
             }
         }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/VLatest.Generated.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/VLatest.Generated.cs
@@ -49,9 +49,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
         internal readonly static ReadResourceProcedure ReadResource = new ReadResourceProcedure();
         internal readonly static SelectCurrentSchemaVersionProcedure SelectCurrentSchemaVersion = new SelectCurrentSchemaVersionProcedure();
         internal readonly static UpdateExportJobProcedure UpdateExportJob = new UpdateExportJobProcedure();
-        internal readonly static UpdateSearchParamStatusProcedure UpdateSearchParamStatus = new UpdateSearchParamStatusProcedure();
         internal readonly static UpsertResourceProcedure UpsertResource = new UpsertResourceProcedure();
         internal readonly static UpsertSchemaVersionProcedure UpsertSchemaVersion = new UpsertSchemaVersionProcedure();
+        internal readonly static UpsertSearchParamStatusProcedure UpsertSearchParamStatus = new UpsertSearchParamStatusProcedure();
         internal class ClaimTypeTable : Table
         {
             internal ClaimTypeTable(): base("dbo.ClaimType")
@@ -623,53 +623,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             }
         }
 
-        internal class UpdateSearchParamStatusProcedure : StoredProcedure
-        {
-            internal UpdateSearchParamStatusProcedure(): base("dbo.UpdateSearchParamStatus")
-            {
-            }
-
-            private readonly SearchParamRegistryTableTypeTableValuedParameterDefinition _searchParamStatuses = new SearchParamRegistryTableTypeTableValuedParameterDefinition("@searchParamStatuses");
-            public void PopulateCommand(global::System.Data.SqlClient.SqlCommand command, global::System.Collections.Generic.IEnumerable<SearchParamRegistryTableTypeRow> searchParamStatuses)
-            {
-                command.CommandType = global::System.Data.CommandType.StoredProcedure;
-                command.CommandText = "dbo.UpdateSearchParamStatus";
-                _searchParamStatuses.AddParameter(command.Parameters, searchParamStatuses);
-            }
-
-            public void PopulateCommand(global::System.Data.SqlClient.SqlCommand command, UpdateSearchParamStatusTableValuedParameters tableValuedParameters)
-            {
-                PopulateCommand(command, searchParamStatuses: tableValuedParameters.SearchParamStatuses);
-            }
-        }
-
-        internal class UpdateSearchParamStatusTvpGenerator<TInput> : IStoredProcedureTableValuedParametersGenerator<TInput, UpdateSearchParamStatusTableValuedParameters>
-        {
-            public UpdateSearchParamStatusTvpGenerator(ITableValuedParameterRowGenerator<TInput, SearchParamRegistryTableTypeRow> SearchParamRegistryTableTypeRowGenerator)
-            {
-                this.SearchParamRegistryTableTypeRowGenerator = SearchParamRegistryTableTypeRowGenerator;
-            }
-
-            private readonly ITableValuedParameterRowGenerator<TInput, SearchParamRegistryTableTypeRow> SearchParamRegistryTableTypeRowGenerator;
-            public UpdateSearchParamStatusTableValuedParameters Generate(TInput input)
-            {
-                return new UpdateSearchParamStatusTableValuedParameters(SearchParamRegistryTableTypeRowGenerator.GenerateRows(input));
-            }
-        }
-
-        internal struct UpdateSearchParamStatusTableValuedParameters
-        {
-            internal UpdateSearchParamStatusTableValuedParameters(global::System.Collections.Generic.IEnumerable<SearchParamRegistryTableTypeRow> SearchParamStatuses)
-            {
-                this.SearchParamStatuses = SearchParamStatuses;
-            }
-
-            internal global::System.Collections.Generic.IEnumerable<SearchParamRegistryTableTypeRow> SearchParamStatuses
-            {
-                get;
-            }
-        }
-
         internal class UpsertResourceProcedure : StoredProcedure
         {
             internal UpsertResourceProcedure(): base("dbo.UpsertResource")
@@ -899,6 +852,53 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
                 command.CommandText = "dbo.UpsertSchemaVersion";
                 _version.AddParameter(command.Parameters, version);
                 _status.AddParameter(command.Parameters, status);
+            }
+        }
+
+        internal class UpsertSearchParamStatusProcedure : StoredProcedure
+        {
+            internal UpsertSearchParamStatusProcedure(): base("dbo.UpsertSearchParamStatus")
+            {
+            }
+
+            private readonly SearchParamRegistryTableTypeTableValuedParameterDefinition _searchParamStatuses = new SearchParamRegistryTableTypeTableValuedParameterDefinition("@searchParamStatuses");
+            public void PopulateCommand(global::System.Data.SqlClient.SqlCommand command, global::System.Collections.Generic.IEnumerable<SearchParamRegistryTableTypeRow> searchParamStatuses)
+            {
+                command.CommandType = global::System.Data.CommandType.StoredProcedure;
+                command.CommandText = "dbo.UpsertSearchParamStatus";
+                _searchParamStatuses.AddParameter(command.Parameters, searchParamStatuses);
+            }
+
+            public void PopulateCommand(global::System.Data.SqlClient.SqlCommand command, UpsertSearchParamStatusTableValuedParameters tableValuedParameters)
+            {
+                PopulateCommand(command, searchParamStatuses: tableValuedParameters.SearchParamStatuses);
+            }
+        }
+
+        internal class UpsertSearchParamStatusTvpGenerator<TInput> : IStoredProcedureTableValuedParametersGenerator<TInput, UpsertSearchParamStatusTableValuedParameters>
+        {
+            public UpsertSearchParamStatusTvpGenerator(ITableValuedParameterRowGenerator<TInput, SearchParamRegistryTableTypeRow> SearchParamRegistryTableTypeRowGenerator)
+            {
+                this.SearchParamRegistryTableTypeRowGenerator = SearchParamRegistryTableTypeRowGenerator;
+            }
+
+            private readonly ITableValuedParameterRowGenerator<TInput, SearchParamRegistryTableTypeRow> SearchParamRegistryTableTypeRowGenerator;
+            public UpsertSearchParamStatusTableValuedParameters Generate(TInput input)
+            {
+                return new UpsertSearchParamStatusTableValuedParameters(SearchParamRegistryTableTypeRowGenerator.GenerateRows(input));
+            }
+        }
+
+        internal struct UpsertSearchParamStatusTableValuedParameters
+        {
+            internal UpsertSearchParamStatusTableValuedParameters(global::System.Collections.Generic.IEnumerable<SearchParamRegistryTableTypeRow> SearchParamStatuses)
+            {
+                this.SearchParamStatuses = SearchParamStatuses;
+            }
+
+            internal global::System.Collections.Generic.IEnumerable<SearchParamRegistryTableTypeRow> SearchParamStatuses
+            {
+                get;
             }
         }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaVersion.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaVersion.cs
@@ -12,5 +12,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema
     {
         V1 = 1,
         V2 = 2,
+        V3 = 3,
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaVersionConstants.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaVersionConstants.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema
 {
     public static class SchemaVersionConstants
     {
-        public const int Max = (int)SchemaVersion.V2;
+        public const int Max = (int)SchemaVersion.V3;
         public const int Min = (int)SchemaVersion.V1;
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerStatusRegistry.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerStatusRegistry.cs
@@ -51,7 +51,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry
                 {
                     while (await sqlDataReader.ReadAsync())
                     {
-                        // TODO: Fix data types, avoid weird conversions.
                         (string uri, string stringStatus, DateTimeOffset? lastUpdated, bool isPartiallySupported) = sqlDataReader.ReadRow(
                             VLatest.SearchParamRegistry.Uri,
                             VLatest.SearchParamRegistry.Status,

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerStatusRegistry.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerStatusRegistry.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry
             using (SqlConnectionWrapper sqlConnectionWrapper = _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapper(true))
             using (SqlCommand sqlCommand = sqlConnectionWrapper.CreateSqlCommand())
             {
-                VLatest.GetSearchParameterStatuses.PopulateCommand(sqlCommand);
+                VLatest.GetSearchParamStatuses.PopulateCommand(sqlCommand);
 
                 var parameterStatuses = new List<ResourceSearchParameterStatus>();
 
@@ -42,19 +42,19 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry
                     while (await sqlDataReader.ReadAsync())
                     {
                         // TODO: Fix data types, avoid weird conversions.
-                        (int uri, string stringStatus, DateTimeOffset? lastUpdated) = sqlDataReader.ReadRow(
-                            VLatest.SearchParameterRegistry.ResourceTypeId,
-                            VLatest.SearchParameterRegistry.Status,
-                            VLatest.SearchParameterRegistry.LastUpdated);
+                        (string uri, string stringStatus, DateTimeOffset? lastUpdated, bool isPartiallySupported) = sqlDataReader.ReadRow(
+                            VLatest.SearchParamRegistry.Uri,
+                            VLatest.SearchParamRegistry.Status,
+                            VLatest.SearchParamRegistry.LastUpdated,
+                            VLatest.SearchParamRegistry.IsPartiallySupported);
 
                         var status = Enum.Parse<SearchParameterStatus>(stringStatus, true);
 
                         var resourceSearchParameterStatus = new ResourceSearchParameterStatus()
                         {
-                            Uri = new Uri(uri.ToString()),
+                            Uri = new Uri(uri),
                             Status = status,
-                            IsPartiallySupported = status == SearchParameterStatus.Supported &&
-                                                   status != SearchParameterStatus.Enabled,
+                            IsPartiallySupported = isPartiallySupported,
                             LastUpdated = (DateTimeOffset)lastUpdated,
                         };
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerStatusRegistry.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerStatusRegistry.cs
@@ -1,0 +1,36 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using EnsureThat;
+using Microsoft.Health.Fhir.Core.Features.Search.Registry;
+using Microsoft.Health.SqlServer.Features.Client;
+
+namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry
+{
+    public class SqlServerStatusRegistry : ISearchParameterRegistry
+    {
+        private readonly SqlConnectionWrapperFactory _sqlConnectionWrapperFactory;
+
+        public SqlServerStatusRegistry(SqlConnectionWrapperFactory sqlConnectionWrapperFactory)
+        {
+            EnsureArg.IsNotNull(sqlConnectionWrapperFactory, nameof(sqlConnectionWrapperFactory));
+
+            _sqlConnectionWrapperFactory = sqlConnectionWrapperFactory;
+        }
+
+        public Task<IReadOnlyCollection<ResourceSearchParameterStatus>> GetSearchParameterStatuses()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task UpdateStatuses(IEnumerable<ResourceSearchParameterStatus> statuses)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerStatusRegistry.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerStatusRegistry.cs
@@ -5,10 +5,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Data;
+using System.Data.SqlClient;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Health.Fhir.Core.Features.Search.Registry;
+using Microsoft.Health.Fhir.SqlServer.Features.Schema.Model;
 using Microsoft.Health.SqlServer.Features.Client;
+using Microsoft.Health.SqlServer.Features.Storage;
 
 namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry
 {
@@ -23,9 +27,43 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry
             _sqlConnectionWrapperFactory = sqlConnectionWrapperFactory;
         }
 
-        public Task<IReadOnlyCollection<ResourceSearchParameterStatus>> GetSearchParameterStatuses()
+        public async Task<IReadOnlyCollection<ResourceSearchParameterStatus>> GetSearchParameterStatuses()
         {
-            throw new NotImplementedException();
+            using (SqlConnectionWrapper sqlConnectionWrapper = _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapper(true))
+            using (SqlCommand sqlCommand = sqlConnectionWrapper.CreateSqlCommand())
+            {
+                VLatest.GetSearchParameterStatuses.PopulateCommand(sqlCommand);
+
+                var parameterStatuses = new List<ResourceSearchParameterStatus>();
+
+                // TODO: Pass in cancellation token?
+                using (SqlDataReader sqlDataReader = await sqlCommand.ExecuteReaderAsync(CommandBehavior.SequentialAccess))
+                {
+                    while (await sqlDataReader.ReadAsync())
+                    {
+                        // TODO: Fix data types, avoid weird conversions.
+                        (int uri, string stringStatus, DateTimeOffset? lastUpdated) = sqlDataReader.ReadRow(
+                            VLatest.SearchParameterRegistry.ResourceTypeId,
+                            VLatest.SearchParameterRegistry.Status,
+                            VLatest.SearchParameterRegistry.LastUpdated);
+
+                        var status = Enum.Parse<SearchParameterStatus>(stringStatus, true);
+
+                        var resourceSearchParameterStatus = new ResourceSearchParameterStatus()
+                        {
+                            Uri = new Uri(uri.ToString()),
+                            Status = status,
+                            IsPartiallySupported = status == SearchParameterStatus.Supported &&
+                                                   status != SearchParameterStatus.Enabled,
+                            LastUpdated = (DateTimeOffset)lastUpdated,
+                        };
+
+                        parameterStatuses.Add(resourceSearchParameterStatus);
+                    }
+                }
+
+                return parameterStatuses;
+            }
         }
 
         public Task UpdateStatuses(IEnumerable<ResourceSearchParameterStatus> statuses)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerStatusRegistry.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerStatusRegistry.cs
@@ -20,12 +20,12 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry
     internal class SqlServerStatusRegistry : ISearchParameterRegistry
     {
         private readonly SqlConnectionWrapperFactory _sqlConnectionWrapperFactory;
-        private readonly VLatest.UpdateSearchParamStatusTvpGenerator<List<ResourceSearchParameterStatus>> _updateSearchParamRegistryTvpGenerator;
+        private readonly VLatest.UpsertSearchParamStatusTvpGenerator<List<ResourceSearchParameterStatus>> _updateSearchParamRegistryTvpGenerator;
         private readonly VLatest.InsertIntoSearchParamRegistryTvpGenerator<List<ResourceSearchParameterStatus>> _insertSearchParamRegistryTvpGenerator;
 
         public SqlServerStatusRegistry(
             SqlConnectionWrapperFactory sqlConnectionWrapperFactory,
-            VLatest.UpdateSearchParamStatusTvpGenerator<List<ResourceSearchParameterStatus>> updateSearchParamRegistryTvpGenerator,
+            VLatest.UpsertSearchParamStatusTvpGenerator<List<ResourceSearchParameterStatus>> updateSearchParamRegistryTvpGenerator,
             VLatest.InsertIntoSearchParamRegistryTvpGenerator<List<ResourceSearchParameterStatus>> insertSearchParamRegistryTvpGenerator)
         {
             EnsureArg.IsNotNull(sqlConnectionWrapperFactory, nameof(sqlConnectionWrapperFactory));
@@ -76,20 +76,20 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry
             }
         }
 
-        public async Task UpdateStatuses(IEnumerable<ResourceSearchParameterStatus> statuses)
+        public async Task UpsertStatuses(IEnumerable<ResourceSearchParameterStatus> statuses)
         {
             EnsureArg.IsNotNull(statuses, nameof(statuses));
 
             using (SqlConnectionWrapper sqlConnectionWrapper = _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapper(true))
             using (SqlCommand sqlCommand = sqlConnectionWrapper.CreateSqlCommand())
             {
-                VLatest.UpdateSearchParamStatus.PopulateCommand(sqlCommand, _updateSearchParamRegistryTvpGenerator.Generate(statuses.ToList()));
+                VLatest.UpsertSearchParamStatus.PopulateCommand(sqlCommand, _updateSearchParamRegistryTvpGenerator.Generate(statuses.ToList()));
 
                 await sqlCommand.ExecuteScalarAsync();
             }
         }
 
-        public async Task<bool> GetIsSearchParameterRegistryEmpty()
+        internal async Task<bool> GetIsSearchParameterRegistryEmpty()
         {
             using (SqlConnectionWrapper sqlConnectionWrapper = _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapper(true))
             using (SqlCommand sqlCommand = sqlConnectionWrapper.CreateSqlCommand())
@@ -100,7 +100,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry
             }
         }
 
-        public async Task BulkInsert(List<ResourceSearchParameterStatus> statuses)
+        internal async Task BulkInsert(List<ResourceSearchParameterStatus> statuses)
         {
             EnsureArg.IsNotNull(statuses, nameof(statuses));
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerStatusRegistryInitializer.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerStatusRegistryInitializer.cs
@@ -3,62 +3,37 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.Data.SqlClient;
+using System.Collections.Generic;
 using EnsureThat;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Features.Search.Registry;
-using Microsoft.Health.Fhir.SqlServer.Features.Schema.Model;
-using Microsoft.Health.SqlServer.Configs;
 
 namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry
 {
-    public class SqlServerStatusRegistryInitializer : IStartable
+    internal class SqlServerStatusRegistryInitializer : IStartable
     {
         private readonly ISearchParameterRegistry _filebasedRegistry;
-        private readonly SqlServerDataStoreConfiguration _sqlServerDataStoreConfiguration;
+        private readonly SqlServerStatusRegistry _sqlServerStatusRegistry;
 
-        public SqlServerStatusRegistryInitializer(FilebasedSearchParameterRegistry.Resolver filebasedRegistry, SqlServerDataStoreConfiguration sqlServerDataStoreConfiguration)
+        public SqlServerStatusRegistryInitializer(
+            FilebasedSearchParameterRegistry.Resolver filebasedRegistry,
+            SqlServerStatusRegistry sqlServerStatusRegistry)
         {
             EnsureArg.IsNotNull(filebasedRegistry, nameof(filebasedRegistry));
-            EnsureArg.IsNotNull(sqlServerDataStoreConfiguration, nameof(sqlServerDataStoreConfiguration));
+            EnsureArg.IsNotNull(sqlServerStatusRegistry, nameof(sqlServerStatusRegistry));
 
             _filebasedRegistry = filebasedRegistry.Invoke();
-            _sqlServerDataStoreConfiguration = sqlServerDataStoreConfiguration;
+            _sqlServerStatusRegistry = sqlServerStatusRegistry;
         }
 
         public async void Start() // TODO: Should a start method be async?
         {
-            using (var sqlConnection = new SqlConnection(_sqlServerDataStoreConfiguration.ConnectionString))
+            if (await _sqlServerStatusRegistry.GetIsSearchParameterRegistryEmpty())
             {
-                sqlConnection.Open();
-                int rowCount = 0;
-                using (SqlCommand command = sqlConnection.CreateCommand())
-                {
-                    command.CommandText = "SELECT COUNT(*) FROM dbo.SearchParamRegistry";
-                    rowCount = (int)await command.ExecuteScalarAsync();
-                }
+                IReadOnlyCollection<ResourceSearchParameterStatus> readonlyStatuses = await _filebasedRegistry.GetSearchParameterStatuses();
+                var statuses = new List<ResourceSearchParameterStatus>(readonlyStatuses);
 
-                if (rowCount == 0)
-                {
-                    var statuses = await _filebasedRegistry.GetSearchParameterStatuses();
-
-                    using (SqlCommand command = sqlConnection.CreateCommand())
-                    {
-                        foreach (ResourceSearchParameterStatus status in statuses)
-                        {
-                            VLatest.InsertIntoSearchParamRegistry.PopulateCommand(
-                                command,
-                                status.Uri.ToString(),
-                                status.Status.ToString(),
-                                status.IsPartiallySupported);
-
-                            await command.ExecuteScalarAsync();
-
-                            // Clear the parameters for the next loop.
-                            command.Parameters.Clear();
-                        }
-                    }
-                }
+                await _sqlServerStatusRegistry.BulkInsert(statuses);
             }
         }
     }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerStatusRegistryInitializer.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerStatusRegistryInitializer.cs
@@ -1,0 +1,53 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Data.SqlClient;
+using EnsureThat;
+using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Health.Fhir.Core.Features.Search.Registry;
+using Microsoft.Health.SqlServer.Configs;
+
+namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry
+{
+    public class SqlServerStatusRegistryInitializer : IStartable
+    {
+        private readonly ISearchParameterRegistry _filebasedRegistry;
+        private readonly SqlServerDataStoreConfiguration _sqlServerDataStoreConfiguration;
+
+        public SqlServerStatusRegistryInitializer(FilebasedSearchParameterRegistry.Resolver filebasedRegistry, SqlServerDataStoreConfiguration sqlServerDataStoreConfiguration)
+        {
+            EnsureArg.IsNotNull(filebasedRegistry, nameof(filebasedRegistry));
+            EnsureArg.IsNotNull(sqlServerDataStoreConfiguration, nameof(sqlServerDataStoreConfiguration));
+
+            _filebasedRegistry = filebasedRegistry.Invoke();
+            _sqlServerDataStoreConfiguration = sqlServerDataStoreConfiguration;
+        }
+
+        public async void Start() // TODO: Should a start method be async?
+        {
+            using (var sqlConnection = new SqlConnection(_sqlServerDataStoreConfiguration.ConnectionString))
+            {
+                sqlConnection.Open();
+                int rowCount = 0;
+                using (SqlCommand command = sqlConnection.CreateCommand())
+                {
+                    command.CommandText = "SELECT COUNT(*) FROM dbo.SearchParameterRegistry";
+                    rowCount = (int)await command.ExecuteScalarAsync();
+                }
+
+                if (rowCount == 0)
+                {
+                    var statuses = await _filebasedRegistry.GetSearchParameterStatuses();
+
+                    foreach (ResourceSearchParameterStatus status in statuses)
+                    {
+                        // TODO: Load into registry
+                        //// Cosmos implementation: await client.UpsertDocumentAsync(relativeCollectionUri, status);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerStatusRegistryInitializer.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerStatusRegistryInitializer.cs
@@ -3,14 +3,12 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
 using System.Data.SqlClient;
 using EnsureThat;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Features.Search.Registry;
 using Microsoft.Health.Fhir.SqlServer.Features.Schema.Model;
 using Microsoft.Health.SqlServer.Configs;
-using Newtonsoft.Json;
 
 namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry
 {

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerStatusRegistryInitializer.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerStatusRegistryInitializer.cs
@@ -4,8 +4,12 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Net;
+using System.Transactions;
 using EnsureThat;
+using Microsoft.Health.Abstractions.Features.Transactions;
 using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Features.Search.Registry;
 
 namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry
@@ -14,26 +18,44 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry
     {
         private readonly ISearchParameterRegistry _filebasedRegistry;
         private readonly SqlServerStatusRegistry _sqlServerStatusRegistry;
+        private readonly ITransactionHandler _transactionHandler;
 
         public SqlServerStatusRegistryInitializer(
             FilebasedSearchParameterRegistry.Resolver filebasedRegistry,
-            SqlServerStatusRegistry sqlServerStatusRegistry)
+            SqlServerStatusRegistry sqlServerStatusRegistry,
+            ITransactionHandler transactionHandler)
         {
             EnsureArg.IsNotNull(filebasedRegistry, nameof(filebasedRegistry));
             EnsureArg.IsNotNull(sqlServerStatusRegistry, nameof(sqlServerStatusRegistry));
+            EnsureArg.IsNotNull(transactionHandler, nameof(transactionHandler));
 
             _filebasedRegistry = filebasedRegistry.Invoke();
             _sqlServerStatusRegistry = sqlServerStatusRegistry;
+            _transactionHandler = transactionHandler;
         }
 
-        public async void Start() // TODO: Should a start method be async?
+        public async void Start()
         {
-            if (await _sqlServerStatusRegistry.GetIsSearchParameterRegistryEmpty())
+            try
             {
-                IReadOnlyCollection<ResourceSearchParameterStatus> readonlyStatuses = await _filebasedRegistry.GetSearchParameterStatuses();
-                var statuses = new List<ResourceSearchParameterStatus>(readonlyStatuses);
+                // Wrap the SQL calls in a transaction to ensure the read and insert operations are atomic.
+                using (var transaction = _transactionHandler.BeginTransaction())
+                {
+                    if (await _sqlServerStatusRegistry.GetIsSearchParameterRegistryEmpty())
+                    {
+                        // The registry has yet to be initialized, so get the search parameter statuses from file and add them to the registry.
+                        IReadOnlyCollection<ResourceSearchParameterStatus> readonlyStatuses = await _filebasedRegistry.GetSearchParameterStatuses();
+                        var statuses = new List<ResourceSearchParameterStatus>(readonlyStatuses);
 
-                await _sqlServerStatusRegistry.BulkInsert(statuses);
+                        await _sqlServerStatusRegistry.BulkInsert(statuses);
+                    }
+
+                    transaction.Complete();
+                }
+            }
+            catch (TransactionAbortedException)
+            {
+                throw new FhirTransactionFailedException(Resources.SearchParameterInitializationTransactionFailedError, HttpStatusCode.BadRequest);
             }
         }
     }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/TvpRowGeneration/SearchParameterRegistryRowGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/TvpRowGeneration/SearchParameterRegistryRowGenerator.cs
@@ -1,0 +1,25 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Health.Fhir.Core.Features.Search.Registry;
+using Microsoft.Health.Fhir.SqlServer.Features.Schema.Model;
+using Microsoft.Health.SqlServer.Features.Schema.Model;
+
+namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.TvpRowGeneration
+{
+    internal class SearchParameterRegistryRowGenerator : ITableValuedParameterRowGenerator<List<ResourceSearchParameterStatus>, VLatest.SearchParamRegistryTableTypeRow>
+    {
+        public SearchParameterRegistryRowGenerator()
+        {
+        }
+
+        public IEnumerable<VLatest.SearchParamRegistryTableTypeRow> GenerateRows(List<ResourceSearchParameterStatus> searchParameterStatus)
+        {
+            return searchParameterStatus.Select(status => new VLatest.SearchParamRegistryTableTypeRow(status.Uri.ToString(), status.Status.ToString(), status.IsPartiallySupported)).ToList();
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer/Microsoft.Health.Fhir.SqlServer.csproj
+++ b/src/Microsoft.Health.Fhir.SqlServer/Microsoft.Health.Fhir.SqlServer.csproj
@@ -8,14 +8,18 @@
     <None Remove="Features\Schema\Migrations\1.sql" />
     <None Remove="Features\Schema\Migrations\2.diff.sql" />
     <None Remove="Features\Schema\Migrations\2.sql" />
+    <None Remove="Features\Schema\Migrations\3.diff.sql" />
+    <None Remove="Features\Schema\Migrations\3.sql" />
     <EmbeddedResource Include="Features\Schema\Migrations\1.sql" />
+    <EmbeddedResource Include="Features\Schema\Migrations\3.diff.sql" />
+    <EmbeddedResource Include="Features\Schema\Migrations\3.sql" />
     <EmbeddedResource Include="Features\Schema\Migrations\2.diff.sql" />
     <EmbeddedResource Include="Features\Schema\Migrations\2.sql" />
-    <GenerateFilesInputs Include="Features\Schema\Migrations\2.sql" />
+    <GenerateFilesInputs Include="Features\Schema\Migrations\3.sql" />
     <Generated Include="Features\Schema\Model\VLatest.Generated.cs">
       <Generator>SqlModelGenerator</Generator>
       <Namespace>Microsoft.Health.Fhir.SqlServer.Features.Schema.Model</Namespace>
-      <Args>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\Features\Schema\Migrations\2.sql'))</Args>
+      <Args>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\Features\Schema\Migrations\3.sql'))</Args>
     </Generated>
   </ItemGroup>
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
@@ -12,6 +12,7 @@ using Microsoft.Health.Fhir.SqlServer.Features.Schema;
 using Microsoft.Health.Fhir.SqlServer.Features.Search;
 using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors;
 using Microsoft.Health.Fhir.SqlServer.Features.Storage;
+using Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry;
 using Microsoft.Health.SqlServer.Api.Registration;
 using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Features.Schema;
@@ -30,7 +31,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSqlServerBase<SchemaVersion>(configureAction);
             services.AddSqlServerApi();
 
-            services.Add(provider => new SchemaInformation((int)SchemaVersion.V1, (int)SchemaVersion.V2))
+            services.Add(provider => new SchemaInformation((int)SchemaVersion.V1, (int)SchemaVersion.V3))
                 .Singleton()
                 .AsSelf()
                 .AsImplementedInterfaces();
@@ -57,6 +58,12 @@ namespace Microsoft.Extensions.DependencyInjection
                 .Scoped()
                 .AsSelf()
                 .AsImplementedInterfaces();
+
+            // TODO: Service shouldn't be registered as IStartable?
+            services.Add<SqlServerStatusRegistryInitializer>()
+                .Singleton()
+                .AsSelf()
+                .AsService<IStartable>();
 
             AddSqlServerTableRowParameterGenerators(services);
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
@@ -15,8 +15,10 @@ using Microsoft.Health.Fhir.SqlServer.Features.Storage;
 using Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry;
 using Microsoft.Health.SqlServer.Api.Registration;
 using Microsoft.Health.SqlServer.Configs;
+using Microsoft.Health.SqlServer.Features.Client;
 using Microsoft.Health.SqlServer.Features.Schema;
 using Microsoft.Health.SqlServer.Features.Schema.Model;
+using Microsoft.Health.SqlServer.Features.Storage;
 using Microsoft.Health.SqlServer.Registration;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -32,6 +34,21 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSqlServerApi();
 
             services.Add(provider => new SchemaInformation((int)SchemaVersion.V1, (int)SchemaVersion.V3))
+                .Singleton()
+                .AsSelf()
+                .AsImplementedInterfaces();
+
+            services.Add<SqlServerStatusRegistry>()
+                .Singleton()
+                .AsSelf()
+                .AsImplementedInterfaces();
+
+            services.Add<SqlConnectionWrapperFactory>()
+                .Singleton()
+                .AsSelf()
+                .AsImplementedInterfaces();
+
+            services.Add<SqlTransactionHandler>()
                 .Singleton()
                 .AsSelf()
                 .AsImplementedInterfaces();
@@ -59,13 +76,13 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AsSelf()
                 .AsImplementedInterfaces();
 
-            // TODO: Service shouldn't be registered as IStartable?
-            services.Add<SqlServerStatusRegistryInitializer>()
-                .Singleton()
-                .AsSelf()
-                .AsService<IStartable>();
-
             AddSqlServerTableRowParameterGenerators(services);
+
+            services.Add<SqlServerStatusRegistryInitializer>()
+                .Transient()
+                .AsImplementedInterfaces();
+            ////.Singleton()
+            ////;
 
             services.Add<NormalizedSearchParameterQueryGeneratorFactory>()
                 .Singleton()

--- a/src/Microsoft.Health.Fhir.SqlServer/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
@@ -81,8 +81,6 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Add<SqlServerStatusRegistryInitializer>()
                 .Transient()
                 .AsImplementedInterfaces();
-            ////.Singleton()
-            ////;
 
             services.Add<NormalizedSearchParameterQueryGeneratorFactory>()
                 .Singleton()

--- a/src/Microsoft.Health.Fhir.SqlServer/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Resources.Designer.cs
@@ -70,6 +70,15 @@ namespace Microsoft.Health.Fhir.SqlServer {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Transaction was failed while initializing the search parameter registry..
+        /// </summary>
+        internal static string SearchParameterInitializationTransactionFailedError {
+            get {
+                return ResourceManager.GetString("SearchParameterInitializationTransactionFailedError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to There was an internal server error while processing the transaction..
         /// </summary>
         internal static string TransactionProcessingException {

--- a/src/Microsoft.Health.Fhir.SqlServer/Resources.resx
+++ b/src/Microsoft.Health.Fhir.SqlServer/Resources.resx
@@ -120,6 +120,9 @@
   <data name="InvalidContinuationToken" xml:space="preserve">
     <value>The provided continuation token is not valid.</value>
   </data>
+  <data name="SearchParameterInitializationTransactionFailedError" xml:space="preserve">
+    <value>Transaction was failed while initializing the search parameter registry.</value>
+  </data>
   <data name="TransactionProcessingException" xml:space="preserve">
     <value>There was an internal server error while processing the transaction.</value>
   </data>


### PR DESCRIPTION
## Description
- Adds a new table in SQL for tracking search parameter statuses
- Implements stored procedures for getting, upserting and initializing status information in the registry
- Adds a search parameter initializer

![image](https://user-images.githubusercontent.com/54082711/82064918-3eb22a80-9682-11ea-8aa7-efc773e5b232.png)

## Related issues
Addresses [#AB73584](https://microsofthealth.visualstudio.com/Health/_workitems/edit/73584) and [#AB72774](https://microsofthealth.visualstudio.com/Health/_workitems/edit/72774).

## Testing
Status registry integration tests to be done in [#AB74003](https://microsofthealth.visualstudio.com/Health/_workitems/edit/74003)
