### PR TITLE
Turn on bundle totals for Crucible tests

### DIFF
--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -50,6 +50,7 @@ jobs:
         $additionalProperties["SqlServer__DeleteAllDataOnStartup"] = "false"
         $additionalProperties["SqlServer__AllowDatabaseCreation"] = "true"
         $additionalProperties["ASPNETCORE_FORWARDEDHEADERS_ENABLED"] = "true"
+        $additionalProperties["FhirServer__CoreFeatures__IncludeTotalInBundle"] = "Accurate"
 
         $templateParameters = @{
             fhirVersion = "${{ parameters.version }}"


### PR DESCRIPTION
## Description
Adds a setting to PR deployments that turns on default bundle totals, this should make Crucible results much greener 🍏 
