### PR TITLE
CI pipeline - Clear old data from storage accounts after e2e tests

### DIFF
--- a/build/ci-pipeline.yml
+++ b/build/ci-pipeline.yml
@@ -145,6 +145,7 @@ stages:
 
 - stage: cleanStorageAccounts
   displayName: 'Clean Storage Accounts'
+  dependsOn: []
   jobs:
     - template: ./jobs/clean-storage-accounts.yml
       parameters:

--- a/build/ci-pipeline.yml
+++ b/build/ci-pipeline.yml
@@ -143,6 +143,13 @@ stages:
       version: R5
       keyVaultName: $(DeploymentEnvironmentNameR5)
 
+- stage: cleanStorageAccounts
+  displayName: 'Clean Storage Accounts'
+  jobs:
+    - template: ./jobs/clean-storage-accounts.yml
+      parameters:
+        environmentName: $(DeploymentEnvironmentName)
+
 - stage: securityScan
   displayName: Security Scan
   dependsOn: []

--- a/build/ci-pipeline.yml
+++ b/build/ci-pipeline.yml
@@ -147,9 +147,9 @@ stages:
   displayName: 'Clean Storage Accounts'
   dependsOn: []
   jobs:
-    - template: ./jobs/clean-storage-accounts.yml
-      parameters:
-        environmentName: $(DeploymentEnvironmentName)
+  - template: ./jobs/clean-storage-accounts.yml
+    parameters:
+      environmentName: $(DeploymentEnvironmentName)
 
 - stage: securityScan
   displayName: Security Scan

--- a/build/jobs/clean-storage-accounts.yml
+++ b/build/jobs/clean-storage-accounts.yml
@@ -1,0 +1,28 @@
+parameters:
+- name: environmentName
+  type: string
+
+jobs:
+- task: AzurePowerShell@4
+    displayName: 'Clean storage account'
+    continueOnError: true
+    inputs:
+      azureSubscription: $(ConnectedServiceName)
+      azurePowerShellVersion: latestVersion
+      ScriptType: inlineScript
+      Inline: |
+
+        $currentUtcTime = [DateTime]::UtcNow
+
+        $storageAccounts = Get-AzStorageAccount -ResourceGroupName ${{ parameters.environmentName }}
+        foreach ($storageAccount in $storageAccounts) {
+
+            $storageContainers = Get-AzStorageContainer -Name * -Context $storageAccount.Context
+            foreach ($container in $storageContainers) {
+                $ageDiff = $currentUtcTime - $container.CloudBlobContainer.Properties.LastModified.UtcDateTime
+                if($ageDiff.TotalDays -ge 1) {
+                    Write-Host "Deleting container $($container.Name)"
+                    $container.CloudBlobContainer.Delete()
+                }
+            }
+        }

--- a/build/jobs/clean-storage-accounts.yml
+++ b/build/jobs/clean-storage-accounts.yml
@@ -3,12 +3,12 @@ parameters:
   type: string
 
 jobs:
-- job: "Clean Storage Accounts"
+- job: "cleanStorageAccounts"
   pool:
     vmImage: $(WindowsVmImage)
   steps:
   - task: AzurePowerShell@4
-    displayName: 'Clean storage accounts'
+    displayName: 'Clean Storage Accounts'
     continueOnError: true
     inputs:
       azureSubscription: $(ConnectedServiceName)

--- a/build/jobs/clean-storage-accounts.yml
+++ b/build/jobs/clean-storage-accounts.yml
@@ -2,7 +2,7 @@ parameters:
 - name: environmentName
   type: string
 
-jobs:
+steps:
 - task: AzurePowerShell@4
   displayName: 'Clean storage account'
   continueOnError: true

--- a/build/jobs/clean-storage-accounts.yml
+++ b/build/jobs/clean-storage-accounts.yml
@@ -2,26 +2,30 @@ parameters:
 - name: environmentName
   type: string
 
-steps:
-- task: AzurePowerShell@4
-  displayName: 'Clean storage account'
-  continueOnError: true
-  inputs:
-    azureSubscription: $(ConnectedServiceName)
-    azurePowerShellVersion: latestVersion
-    ScriptType: inlineScript
-    Inline: |
-      $currentUtcTime = [DateTime]::UtcNow
+jobs:
+- job: "Clean Storage Accounts"
+  pool:
+    vmImage: $(WindowsVmImage)
+  steps:
+  - task: AzurePowerShell@4
+    displayName: 'Clean storage accounts'
+    continueOnError: true
+    inputs:
+      azureSubscription: $(ConnectedServiceName)
+      azurePowerShellVersion: latestVersion
+      ScriptType: inlineScript
+      Inline: |
+        $currentUtcTime = [DateTime]::UtcNow
 
-      $storageAccounts = Get-AzStorageAccount -ResourceGroupName ${{ parameters.environmentName }}
-      foreach ($storageAccount in $storageAccounts) {
+        $storageAccounts = Get-AzStorageAccount -ResourceGroupName ${{ parameters.environmentName }}
+        foreach ($storageAccount in $storageAccounts) {
 
-          $storageContainers = Get-AzStorageContainer -Name * -Context $storageAccount.Context
-          foreach ($container in $storageContainers) {
-              $ageDiff = $currentUtcTime - $container.CloudBlobContainer.Properties.LastModified.UtcDateTime
-              if($ageDiff.TotalDays -ge 1) {
-                  Write-Host "Deleting container $($container.Name)"
-                  $container.CloudBlobContainer.Delete()
-              }
-          }
-      }
+            $storageContainers = Get-AzStorageContainer -Name * -Context $storageAccount.Context
+            foreach ($container in $storageContainers) {
+                $ageDiff = $currentUtcTime - $container.CloudBlobContainer.Properties.LastModified.UtcDateTime
+                if($ageDiff.TotalDays -ge 1) {
+                    Write-Host "Deleting container $($container.Name)"
+                    $container.CloudBlobContainer.Delete()
+                }
+            }
+        }

--- a/build/jobs/clean-storage-accounts.yml
+++ b/build/jobs/clean-storage-accounts.yml
@@ -4,25 +4,24 @@ parameters:
 
 jobs:
 - task: AzurePowerShell@4
-    displayName: 'Clean storage account'
-    continueOnError: true
-    inputs:
-      azureSubscription: $(ConnectedServiceName)
-      azurePowerShellVersion: latestVersion
-      ScriptType: inlineScript
-      Inline: |
+  displayName: 'Clean storage account'
+  continueOnError: true
+  inputs:
+    azureSubscription: $(ConnectedServiceName)
+    azurePowerShellVersion: latestVersion
+    ScriptType: inlineScript
+    Inline: |
+      $currentUtcTime = [DateTime]::UtcNow
 
-        $currentUtcTime = [DateTime]::UtcNow
+      $storageAccounts = Get-AzStorageAccount -ResourceGroupName ${{ parameters.environmentName }}
+      foreach ($storageAccount in $storageAccounts) {
 
-        $storageAccounts = Get-AzStorageAccount -ResourceGroupName ${{ parameters.environmentName }}
-        foreach ($storageAccount in $storageAccounts) {
-
-            $storageContainers = Get-AzStorageContainer -Name * -Context $storageAccount.Context
-            foreach ($container in $storageContainers) {
-                $ageDiff = $currentUtcTime - $container.CloudBlobContainer.Properties.LastModified.UtcDateTime
-                if($ageDiff.TotalDays -ge 1) {
-                    Write-Host "Deleting container $($container.Name)"
-                    $container.CloudBlobContainer.Delete()
-                }
-            }
-        }
+          $storageContainers = Get-AzStorageContainer -Name * -Context $storageAccount.Context
+          foreach ($container in $storageContainers) {
+              $ageDiff = $currentUtcTime - $container.CloudBlobContainer.Properties.LastModified.UtcDateTime
+              if($ageDiff.TotalDays -ge 1) {
+                  Write-Host "Deleting container $($container.Name)"
+                  $container.CloudBlobContainer.Delete()
+              }
+          }
+      }


### PR DESCRIPTION
## Description
The Export E2E tests create some containers in the storage accounts. Since the storage accounts for CI are persistent, we need a mechanism to clear the old data from the storage accounts from time to time. This change adds a step to the CI pipeline that takes care of removing containers older than one day.

## Related issues
Addresses [issue [AB#74093](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/74093)].

## Testing
Describe how this change was tested.
