### PR TITLE
CosmosDbStatusRegistry should retry if no records are found

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/Registry/SearchParameterStatusManagerTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/Registry/SearchParameterStatusManagerTests.cs
@@ -147,13 +147,13 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Registry
         }
 
         [Fact]
-        public async Task GivenASPStatusManager_WhenInitializing_ThenRegistryShouldGetNewlyFoundParameters()
+        public async Task GivenASPStatusManager_WhenInitializing_ThenRegistryShouldNotUpdateNewlyFoundParameters()
         {
             await _manager.EnsureInitialized();
 
             await _searchParameterRegistry
-                .Received()
-                .UpdateStatuses(Arg.Is<IEnumerable<ResourceSearchParameterStatus>>(x => x.Single().Uri == _queryParameter.Url));
+                .DidNotReceive()
+                .UpdateStatuses(Arg.Any<IEnumerable<ResourceSearchParameterStatus>>());
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
@@ -44,7 +44,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
         public async Task EnsureInitialized()
         {
             var updated = new List<SearchParameterInfo>();
-            var newParameters = new List<ResourceSearchParameterStatus>();
 
             var parameters = (await _searchParameterRegistry.GetSearchParameterStatuses())
                 .ToDictionary(x => x.Uri);
@@ -79,13 +78,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
                 }
                 else
                 {
-                    newParameters.Add(new ResourceSearchParameterStatus
-                    {
-                        Uri = p.Url,
-                        LastUpdated = Clock.UtcNow,
-                        Status = SearchParameterStatus.Supported,
-                    });
-
                     p.IsSearchable = false;
 
                     // Check if this parameter is now supported.
@@ -95,11 +87,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
 
                     updated.Add(p);
                 }
-            }
-
-            if (newParameters.Any())
-            {
-                await _searchParameterRegistry.UpdateStatuses(newParameters);
             }
 
             await _mediator.Publish(new SearchParametersUpdated(updated));


### PR DESCRIPTION
## Description
This addresses a concurrency issue when initializing the SearchParameterRegistry. 
The issue occurs when there are multiple front-ends. The first node uses a global lock to write the initial status of the registry which works as intended, however the second node which fails to attain the lock continues, when it initializes the SearchParameterStatusManager it finds no entries and assumes all parameters are new. It then writes these to the database, which overwrites the correct entries from the initializer.

Changes to handle this are:
- CosmosDbStatusRegistry should retry if no records are found
- Changes SearchParameterStatusManager to not write new results to registry

## Related issues
Addresses #1040 .

