### PR TITLE
Detect change in export location

### DIFF
--- a/src/Microsoft.Health.Fhir.Azure.UnitTests/ExportDestinationClient/AzureExportDestinationClientTests.cs
+++ b/src/Microsoft.Health.Fhir.Azure.UnitTests/ExportDestinationClient/AzureExportDestinationClientTests.cs
@@ -8,7 +8,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Storage.Blob;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Azure.ExportDestinationClient;
+using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export.ExportDestinationClient;
 using NSubstitute;
 using Xunit;
@@ -18,6 +20,7 @@ namespace Microsoft.Health.Fhir.Azure.UnitTests.ExportDestinationClient
     public class AzureExportDestinationClientTests
     {
         private IExportClientInitializer<CloudBlobClient> _exportClientInitializer;
+        private ExportJobConfiguration _exportJobConfiguration;
         private ILogger<AzureExportDestinationClient> _logger;
 
         private AzureExportDestinationClient _exportDestinationClient;
@@ -27,7 +30,11 @@ namespace Microsoft.Health.Fhir.Azure.UnitTests.ExportDestinationClient
             _exportClientInitializer = Substitute.For<IExportClientInitializer<CloudBlobClient>>();
             _logger = Substitute.For<ILogger<AzureExportDestinationClient>>();
 
-            _exportDestinationClient = new AzureExportDestinationClient(_exportClientInitializer, _logger);
+            _exportJobConfiguration = new ExportJobConfiguration();
+            IOptions<ExportJobConfiguration> optionsExportConfig = Substitute.For<IOptions<ExportJobConfiguration>>();
+            optionsExportConfig.Value.Returns(_exportJobConfiguration);
+
+            _exportDestinationClient = new AzureExportDestinationClient(_exportClientInitializer, optionsExportConfig, _logger);
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Azure.UnitTests/ExportDestinationClient/AzureExportDestinationClientTests.cs
+++ b/src/Microsoft.Health.Fhir.Azure.UnitTests/ExportDestinationClient/AzureExportDestinationClientTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Health.Fhir.Azure.UnitTests.ExportDestinationClient
             string message = "Can't initialize client";
             HttpStatusCode statusCode = HttpStatusCode.BadRequest;
 
-            _exportClientInitializer.GetAuthorizedClientAsync(Arg.Any<CancellationToken>()).Returns<CloudBlobClient>(x => throw new ExportClientInitializerException(message, statusCode));
+            _exportClientInitializer.GetAuthorizedClientAsync(Arg.Any<ExportJobConfiguration>(), Arg.Any<CancellationToken>()).Returns<CloudBlobClient>(x => throw new ExportClientInitializerException(message, statusCode));
 
             var exception = await Assert.ThrowsAsync<DestinationConnectionException>(() => _exportDestinationClient.ConnectAsync(CancellationToken.None));
 

--- a/src/Microsoft.Health.Fhir.Azure/ExportDestinationClient/AzureAccessTokenClientInitializer.cs
+++ b/src/Microsoft.Health.Fhir.Azure/ExportDestinationClient/AzureAccessTokenClientInitializer.cs
@@ -39,13 +39,18 @@ namespace Microsoft.Health.Fhir.Azure.ExportDestinationClient
 
         public async Task<CloudBlobClient> GetAuthorizedClientAsync(CancellationToken cancellationToken)
         {
+            return await GetAuthorizedClientAsync(_exportJobConfiguration, cancellationToken);
+        }
+
+        public async Task<CloudBlobClient> GetAuthorizedClientAsync(ExportJobConfiguration exportJobConfiguration, CancellationToken cancellationToken)
+        {
             // Get storage uri from config
-            if (string.IsNullOrWhiteSpace(_exportJobConfiguration.StorageAccountUri))
+            if (string.IsNullOrWhiteSpace(exportJobConfiguration.StorageAccountUri))
             {
                 throw new ExportClientInitializerException(Resources.InvalidStorageUri, HttpStatusCode.BadRequest);
             }
 
-            if (!Uri.TryCreate(_exportJobConfiguration.StorageAccountUri, UriKind.Absolute, out Uri storageAccountUri))
+            if (!Uri.TryCreate(exportJobConfiguration.StorageAccountUri, UriKind.Absolute, out Uri storageAccountUri))
             {
                 throw new ExportClientInitializerException(Resources.InvalidStorageUri, HttpStatusCode.BadRequest);
             }

--- a/src/Microsoft.Health.Fhir.Azure/ExportDestinationClient/AzureConnectionStringClientInitializer.cs
+++ b/src/Microsoft.Health.Fhir.Azure/ExportDestinationClient/AzureConnectionStringClientInitializer.cs
@@ -33,12 +33,17 @@ namespace Microsoft.Health.Fhir.Azure.ExportDestinationClient
 
         public Task<CloudBlobClient> GetAuthorizedClientAsync(CancellationToken cancellationToken)
         {
-            if (string.IsNullOrWhiteSpace(_exportJobConfiguration.StorageAccountConnection))
+            return GetAuthorizedClientAsync(_exportJobConfiguration, cancellationToken);
+        }
+
+        public Task<CloudBlobClient> GetAuthorizedClientAsync(ExportJobConfiguration exportJobConfiguration, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(exportJobConfiguration.StorageAccountConnection))
             {
                 throw new ExportClientInitializerException(Resources.InvalidConnectionSettings, HttpStatusCode.BadRequest);
             }
 
-            if (!CloudStorageAccount.TryParse(_exportJobConfiguration.StorageAccountConnection, out CloudStorageAccount cloudAccount))
+            if (!CloudStorageAccount.TryParse(exportJobConfiguration.StorageAccountConnection, out CloudStorageAccount cloudAccount))
             {
                 throw new ExportClientInitializerException(Resources.InvalidConnectionSettings, HttpStatusCode.BadRequest);
             }

--- a/src/Microsoft.Health.Fhir.Azure/ExportDestinationClient/AzureExportDestinationClient.cs
+++ b/src/Microsoft.Health.Fhir.Azure/ExportDestinationClient/AzureExportDestinationClient.cs
@@ -15,6 +15,8 @@ using EnsureThat;
 using Microsoft.Azure.Storage;
 using Microsoft.Azure.Storage.Blob;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export.ExportDestinationClient;
 using Polly;
 
@@ -29,24 +31,33 @@ namespace Microsoft.Health.Fhir.Azure.ExportDestinationClient
         private Dictionary<(Uri FileUri, uint PartId), Stream> _streamMappings = new Dictionary<(Uri FileUri, uint PartId), Stream>();
 
         private readonly IExportClientInitializer<CloudBlobClient> _exportClientInitializer;
+        private readonly ExportJobConfiguration _exportJobConfiguration;
         private readonly ILogger _logger;
 
         public AzureExportDestinationClient(
             IExportClientInitializer<CloudBlobClient> exportClientInitializer,
+            IOptions<ExportJobConfiguration> exportJobConfiguration,
             ILogger<AzureExportDestinationClient> logger)
         {
             EnsureArg.IsNotNull(exportClientInitializer, nameof(exportClientInitializer));
+            EnsureArg.IsNotNull(exportJobConfiguration?.Value, nameof(exportJobConfiguration));
             EnsureArg.IsNotNull(logger, nameof(logger));
 
             _exportClientInitializer = exportClientInitializer;
+            _exportJobConfiguration = exportJobConfiguration.Value;
             _logger = logger;
         }
 
         public async Task ConnectAsync(CancellationToken cancellationToken, string containerId = null)
         {
+            await ConnectAsync(_exportJobConfiguration, cancellationToken, containerId);
+        }
+
+        public async Task ConnectAsync(ExportJobConfiguration exportJobConfiguration, CancellationToken cancellationToken, string containerId = null)
+        {
             try
             {
-                _blobClient = await _exportClientInitializer.GetAuthorizedClientAsync(cancellationToken);
+                _blobClient = await _exportClientInitializer.GetAuthorizedClientAsync(exportJobConfiguration, cancellationToken);
             }
             catch (ExportClientInitializerException ece)
             {
@@ -117,6 +128,11 @@ namespace Microsoft.Health.Fhir.Azure.ExportDestinationClient
 
         public async Task CommitAsync(CancellationToken cancellationToken)
         {
+            await CommitAsync(_exportJobConfiguration, cancellationToken);
+        }
+
+        public async Task CommitAsync(ExportJobConfiguration exportJobConfiguration, CancellationToken cancellationToken)
+        {
             CheckIfClientIsConnected();
 
             try
@@ -128,7 +144,7 @@ namespace Microsoft.Health.Fhir.Azure.ExportDestinationClient
                         onRetryAsync: async (exception, retryCount) =>
                         {
                             _logger.LogWarning(exception, "Error while uploading blobs.");
-                            await RefreshClientAsync(cancellationToken);
+                            await RefreshClientAsync(exportJobConfiguration, cancellationToken);
                         })
                     .ExecuteAsync(() => UploadBlobHelperAsync(cancellationToken));
             }
@@ -151,7 +167,7 @@ namespace Microsoft.Health.Fhir.Azure.ExportDestinationClient
                         onRetryAsync: async (exception, retryCount) =>
                         {
                             _logger.LogWarning(exception, "Error while committing block list.");
-                            await RefreshClientAsync(cancellationToken);
+                            await RefreshClientAsync(exportJobConfiguration, cancellationToken);
                         })
                     .ExecuteAsync(() => UploadBlockListHelperAsync(cancellationToken));
             }
@@ -252,12 +268,12 @@ namespace Microsoft.Health.Fhir.Azure.ExportDestinationClient
         /// Also updates the existing blob container and CloudBlockBlob objects so that they will
         /// use the new CloudBlobClient.
         /// </summary>
-        private async Task RefreshClientAsync(CancellationToken cancellationToken)
+        private async Task RefreshClientAsync(ExportJobConfiguration exportJobConfiguration, CancellationToken cancellationToken)
         {
             CloudBlobClient refreshedClient;
             try
             {
-                refreshedClient = await _exportClientInitializer.GetAuthorizedClientAsync(cancellationToken);
+                refreshedClient = await _exportClientInitializer.GetAuthorizedClientAsync(exportJobConfiguration, cancellationToken);
             }
             catch (ExportClientInitializerException ex)
             {

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportJobTaskTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportJobTaskTests.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
                 "Patient",
                 "hash",
                 since: Core.Models.PartialDateTime.MinValue,
-                storageAccountConnectionHash: Microsoft.Health.Core.Extensions.StringExtensions.ComputeHash(_exportJobConfiguration.StorageAccountConnection),
+                storageAccountConnectionHash: string.Empty,
                 storageAccountUri: _exportJobConfiguration.StorageAccountUri);
 
             SetupExportJobRecordAndOperationDataStore(exportJobRecordWithSince);
@@ -166,7 +166,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
                 "Patient",
                 "hash",
                 since: PartialDateTime.MinValue,
-                storageAccountConnectionHash: Microsoft.Health.Core.Extensions.StringExtensions.ComputeHash(_exportJobConfiguration.StorageAccountConnection),
+                storageAccountConnectionHash: string.Empty,
                 storageAccountUri: _exportJobConfiguration.StorageAccountUri);
             SetupExportJobRecordAndOperationDataStore(exportJobRecordWithSince);
 
@@ -256,7 +256,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
                 "Patient",
                 "hash",
                 since: PartialDateTime.MinValue,
-                storageAccountConnectionHash: Microsoft.Health.Core.Extensions.StringExtensions.ComputeHash(_exportJobConfiguration.StorageAccountConnection),
+                storageAccountConnectionHash: string.Empty,
                 storageAccountUri: _exportJobConfiguration.StorageAccountUri);
             SetupExportJobRecordAndOperationDataStore(exportJobRecordWithSince);
 
@@ -662,7 +662,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
                 new Uri("https://localhost/ExportJob/"),
                 "Patient",
                 "hash",
-                storageAccountConnectionHash: Microsoft.Health.Core.Extensions.StringExtensions.ComputeHash(_exportJobConfiguration.StorageAccountConnection),
+                storageAccountConnectionHash: string.Empty,
                 storageAccountUri: _exportJobConfiguration.StorageAccountUri);
 
             _fhirOperationDataStore.UpdateExportJobAsync(_exportJobRecord, _weakETag, _cancellationToken).Returns(x =>

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportJobTaskTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportJobTaskTests.cs
@@ -13,7 +13,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
-using Microsoft.Health.Core;
 using Microsoft.Health.Core.Internal;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features.Operations;
@@ -97,10 +96,12 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
             _exportJobConfiguration.MaximumNumberOfResourcesPerQuery = 1;
             var exportJobRecordWithSince = new ExportJobRecord(
-               new Uri("https://localhost/ExportJob/"),
-               "Patient",
-               "hash",
-               since: Core.Models.PartialDateTime.MinValue);
+                new Uri("https://localhost/ExportJob/"),
+                "Patient",
+                "hash",
+                since: Core.Models.PartialDateTime.MinValue,
+                storageAccountConnectionHash: ExportJobConfiguration.HashStorageAccountConnection(_exportJobConfiguration.StorageAccountConnection),
+                storageAccountUri: _exportJobConfiguration.StorageAccountUri);
 
             SetupExportJobRecordAndOperationDataStore(exportJobRecordWithSince);
 
@@ -161,10 +162,12 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
             _exportJobConfiguration.MaximumNumberOfResourcesPerQuery = 1;
             var exportJobRecordWithSince = new ExportJobRecord(
-               new Uri("https://localhost/ExportJob/"),
-               "Patient",
-               "hash",
-               since: PartialDateTime.MinValue);
+                new Uri("https://localhost/ExportJob/"),
+                "Patient",
+                "hash",
+                since: PartialDateTime.MinValue,
+                storageAccountConnectionHash: ExportJobConfiguration.HashStorageAccountConnection(_exportJobConfiguration.StorageAccountConnection),
+                storageAccountUri: _exportJobConfiguration.StorageAccountUri);
             SetupExportJobRecordAndOperationDataStore(exportJobRecordWithSince);
 
             // First search returns a search result with continuation token.
@@ -249,10 +252,12 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
             _exportJobConfiguration.MaximumNumberOfResourcesPerQuery = 1;
             var exportJobRecordWithSince = new ExportJobRecord(
-               new Uri("https://localhost/ExportJob/"),
-               "Patient",
-               "hash",
-               since: PartialDateTime.MinValue);
+                new Uri("https://localhost/ExportJob/"),
+                "Patient",
+                "hash",
+                since: PartialDateTime.MinValue,
+                storageAccountConnectionHash: ExportJobConfiguration.HashStorageAccountConnection(_exportJobConfiguration.StorageAccountConnection),
+                storageAccountUri: _exportJobConfiguration.StorageAccountUri);
             SetupExportJobRecordAndOperationDataStore(exportJobRecordWithSince);
 
             // First search returns a search result with continuation token.
@@ -483,7 +488,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
             // Setup export destination client.
             string connectionFailure = "failedToConnectToDestination";
             IExportDestinationClient mockExportDestinationClient = Substitute.For<IExportDestinationClient>();
-            mockExportDestinationClient.ConnectAsync(Arg.Any<CancellationToken>(), Arg.Any<string>())
+            mockExportDestinationClient.ConnectAsync(Arg.Any<ExportJobConfiguration>(), Arg.Any<CancellationToken>(), Arg.Any<string>())
                 .Returns<Task>(x => throw new DestinationConnectionException(connectionFailure, HttpStatusCode.BadRequest));
 
             var exportJobTask = new ExportJobTask(
@@ -587,7 +592,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
             _exportJobRecord = exportJobRecord ?? new ExportJobRecord(
                 new Uri("https://localhost/ExportJob/"),
                 "Patient",
-                "hash");
+                "hash",
+                storageAccountConnectionHash: ExportJobConfiguration.HashStorageAccountConnection(_exportJobConfiguration.StorageAccountConnection),
+                storageAccountUri: _exportJobConfiguration.StorageAccountUri);
 
             _fhirOperationDataStore.UpdateExportJobAsync(_exportJobRecord, _weakETag, _cancellationToken).Returns(x =>
             {

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/InMemoryExportDestinationClient.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/InMemoryExportDestinationClient.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
+using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export.ExportDestinationClient;
 using Task = System.Threading.Tasks.Task;
 
@@ -21,6 +22,11 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
         private Dictionary<(Uri FileUri, uint PartId), Stream> _streamMappings = new Dictionary<(Uri FileUri, uint PartId), Stream>();
 
         public async Task ConnectAsync(CancellationToken cancellationToken, string containerId = null)
+        {
+            await Task.CompletedTask;
+        }
+
+        public async Task ConnectAsync(ExportJobConfiguration exportJobConfiguration, CancellationToken cancellationToken, string containerId = null)
         {
             await Task.CompletedTask;
         }
@@ -74,6 +80,11 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
             // Now that all of the parts are committed, remove all stream mappings.
             _streamMappings.Clear();
+        }
+
+        public async Task CommitAsync(ExportJobConfiguration exportJobConfiguration, CancellationToken cancellationToken)
+        {
+            await CommitAsync(cancellationToken);
         }
 
         public Task OpenFileAsync(Uri fileUri, CancellationToken cancellationToken)

--- a/src/Microsoft.Health.Fhir.Core/Configs/ExportJobConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/ExportJobConfiguration.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Security.Cryptography;
 
 namespace Microsoft.Health.Fhir.Core.Configs
 {
@@ -51,9 +52,15 @@ namespace Microsoft.Health.Fhir.Core.Configs
                 return string.Empty;
             }
 
-            return System.Text.Encoding.UTF8.GetString(
-                        System.Security.Cryptography.SHA512.Create().ComputeHash(
+            SHA512 hasher = System.Security.Cryptography.SHA512.Create();
+
+            string hash = System.Text.Encoding.UTF8.GetString(
+                        hasher.ComputeHash(
                             System.Text.Encoding.UTF8.GetBytes(connection)));
+
+            hasher.Dispose();
+
+            return hash;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Configs/ExportJobConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/ExportJobConfiguration.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Health.Fhir.Core.Configs
         /// Determines the storage account connection that will be used to export data to.
         /// Should be a connection string to the required storage account.
         /// </summary>
-        public string StorageAccountConnection { get; set; }
+        public string StorageAccountConnection { get; set; } = string.Empty;
 
         /// <summary>
         /// Determines the storage account connection that will be used to export data to.
@@ -28,7 +28,7 @@ namespace Microsoft.Health.Fhir.Core.Configs
             "Usage",
             "CA1056:Uri properties should not be strings",
             Justification = "Set from an environment variable.")]
-        public string StorageAccountUri { get; set; }
+        public string StorageAccountUri { get; set; } = string.Empty;
 
         public ushort MaximumNumberOfConcurrentJobsAllowed { get; set; } = 1;
 

--- a/src/Microsoft.Health.Fhir.Core/Configs/ExportJobConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/ExportJobConfiguration.cs
@@ -43,5 +43,17 @@ namespace Microsoft.Health.Fhir.Core.Configs
         /// Number of pages to be iterated before committing the export progress.
         /// </summary>
         public uint NumberOfPagesPerCommit { get; set; } = 10;
+
+        public static string HashStorageAccountConnection(string connection)
+        {
+            if (string.IsNullOrEmpty(connection))
+            {
+                return string.Empty;
+            }
+
+            return System.Text.Encoding.UTF8.GetString(
+                        System.Security.Cryptography.SHA512.Create().ComputeHash(
+                            System.Text.Encoding.UTF8.GetBytes(connection)));
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Configs/ExportJobConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/ExportJobConfiguration.cs
@@ -4,7 +4,6 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Security.Cryptography;
 
 namespace Microsoft.Health.Fhir.Core.Configs
 {
@@ -25,9 +24,11 @@ namespace Microsoft.Health.Fhir.Core.Configs
         /// Determines the storage account connection that will be used to export data to.
         /// Should be a uri pointing to the required storage account.
         /// </summary>
-#pragma warning disable CA1056 // Uri properties should not be strings
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Usage",
+            "CA1056:Uri properties should not be strings",
+            Justification = "Set from an environment variable.")]
         public string StorageAccountUri { get; set; }
-#pragma warning restore CA1056 // Uri properties should not be strings
 
         public ushort MaximumNumberOfConcurrentJobsAllowed { get; set; } = 1;
 
@@ -44,23 +45,5 @@ namespace Microsoft.Health.Fhir.Core.Configs
         /// Number of pages to be iterated before committing the export progress.
         /// </summary>
         public uint NumberOfPagesPerCommit { get; set; } = 10;
-
-        public static string HashStorageAccountConnection(string connection)
-        {
-            if (string.IsNullOrEmpty(connection))
-            {
-                return string.Empty;
-            }
-
-            SHA512 hasher = System.Security.Cryptography.SHA512.Create();
-
-            string hash = System.Text.Encoding.UTF8.GetString(
-                        hasher.ComputeHash(
-                            System.Text.Encoding.UTF8.GetBytes(connection)));
-
-            hasher.Dispose();
-
-            return hash;
-        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
@@ -67,7 +67,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
             string hash = JsonConvert.SerializeObject(hashObject).ComputeHash();
 
-            string storageAccountConnectionHash = Microsoft.Health.Core.Extensions.StringExtensions.ComputeHash(_exportJobConfiguration.StorageAccountConnection);
+            string storageAccountConnectionHash = string.IsNullOrEmpty(_exportJobConfiguration.StorageAccountConnection) ?
+                string.Empty :
+                Microsoft.Health.Core.Extensions.StringExtensions.ComputeHash(_exportJobConfiguration.StorageAccountConnection);
 
             // Check to see if a matching job exists or not. If a matching job exists, we will return that instead.
             // Otherwise, we will create a new export job. This will be a best effort since the likelihood of this happen should be small.

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
@@ -10,7 +10,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using MediatR;
+using Microsoft.Extensions.Options;
 using Microsoft.Health.Core.Extensions;
+using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export.Models;
 using Microsoft.Health.Fhir.Core.Features.Security;
@@ -25,16 +27,23 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
         private readonly IClaimsExtractor _claimsExtractor;
         private readonly IFhirOperationDataStore _fhirOperationDataStore;
         private readonly IFhirAuthorizationService _authorizationService;
+        private readonly ExportJobConfiguration _exportJobConfiguration;
 
-        public CreateExportRequestHandler(IClaimsExtractor claimsExtractor, IFhirOperationDataStore fhirOperationDataStore, IFhirAuthorizationService authorizationService)
+        public CreateExportRequestHandler(
+            IClaimsExtractor claimsExtractor,
+            IFhirOperationDataStore fhirOperationDataStore,
+            IFhirAuthorizationService authorizationService,
+            IOptions<ExportJobConfiguration> exportJobConfiguration)
         {
             EnsureArg.IsNotNull(claimsExtractor, nameof(claimsExtractor));
             EnsureArg.IsNotNull(fhirOperationDataStore, nameof(fhirOperationDataStore));
             EnsureArg.IsNotNull(authorizationService, nameof(authorizationService));
+            EnsureArg.IsNotNull(exportJobConfiguration?.Value, nameof(exportJobConfiguration));
 
             _claimsExtractor = claimsExtractor;
             _fhirOperationDataStore = fhirOperationDataStore;
             _authorizationService = authorizationService;
+            _exportJobConfiguration = exportJobConfiguration.Value;
         }
 
         public async Task<CreateExportResponse> Handle(CreateExportRequest request, CancellationToken cancellationToken)
@@ -58,13 +67,17 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
             string hash = JsonConvert.SerializeObject(hashObject).ComputeHash();
 
+            string storageAccountConnectionHash = System.Text.Encoding.UTF8.GetString(
+                System.Security.Cryptography.SHA512.Create().ComputeHash(
+                    System.Text.Encoding.UTF8.GetBytes(_exportJobConfiguration.StorageAccountConnection)));
+
             // Check to see if a matching job exists or not. If a matching job exists, we will return that instead.
             // Otherwise, we will create a new export job. This will be a best effort since the likelihood of this happen should be small.
             ExportJobOutcome outcome = await _fhirOperationDataStore.GetExportJobByHashAsync(hash, cancellationToken);
 
             if (outcome == null)
             {
-                var jobRecord = new ExportJobRecord(request.RequestUri, request.ResourceType, hash, requestorClaims, request.Since);
+                var jobRecord = new ExportJobRecord(request.RequestUri, request.ResourceType, hash, requestorClaims, request.Since, storageAccountConnectionHash, _exportJobConfiguration.StorageAccountUri);
 
                 outcome = await _fhirOperationDataStore.CreateExportJobAsync(jobRecord, cancellationToken);
             }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
@@ -67,9 +67,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
             string hash = JsonConvert.SerializeObject(hashObject).ComputeHash();
 
-            string storageAccountConnectionHash = System.Text.Encoding.UTF8.GetString(
-                System.Security.Cryptography.SHA512.Create().ComputeHash(
-                    System.Text.Encoding.UTF8.GetBytes(_exportJobConfiguration.StorageAccountConnection)));
+            string storageAccountConnectionHash = ExportJobConfiguration.HashStorageAccountConnection(_exportJobConfiguration.StorageAccountConnection);
 
             // Check to see if a matching job exists or not. If a matching job exists, we will return that instead.
             // Otherwise, we will create a new export job. This will be a best effort since the likelihood of this happen should be small.

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
             string hash = JsonConvert.SerializeObject(hashObject).ComputeHash();
 
-            string storageAccountConnectionHash = ExportJobConfiguration.HashStorageAccountConnection(_exportJobConfiguration.StorageAccountConnection);
+            string storageAccountConnectionHash = Microsoft.Health.Core.Extensions.StringExtensions.ComputeHash(_exportJobConfiguration.StorageAccountConnection);
 
             // Check to see if a matching job exists or not. If a matching job exists, we will return that instead.
             // Otherwise, we will create a new export job. This will be a best effort since the likelihood of this happen should be small.

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportDestinationClient/IExportClientInitializer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportDestinationClient/IExportClientInitializer.cs
@@ -5,6 +5,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Health.Fhir.Core.Configs;
 
 namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.ExportDestinationClient
 {
@@ -17,5 +18,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.ExportDestinatio
         /// <returns>A client of type T</returns>
         /// <exception cref="ExportClientInitializerException">Thrown when unable to initialize client.</exception>
         Task<T> GetAuthorizedClientAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Used to get a client that is authorized to talk to an export destination specified by the given configuration.
+        /// </summary>
+        /// <param name="exportJobConfiguration">Configuration of the export job.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A client of type T</returns>
+        /// <exception cref="ExportClientInitializerException">Thrown when unable to initialize client.</exception>
+        Task<T> GetAuthorizedClientAsync(ExportJobConfiguration exportJobConfiguration, CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportDestinationClient/IExportDestinationClient.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportDestinationClient/IExportDestinationClient.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Health.Fhir.Core.Configs;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.ExportDestinationClient
@@ -23,6 +24,16 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.ExportDestinatio
         /// <returns>A <see cref="Task"/> representing connection operation.</returns>
         /// <exception cref="DestinationConnectionException">Thrown when we can't connect to the destination.</exception>
         Task ConnectAsync(CancellationToken cancellationToken, string containerId = null);
+
+        /// <summary>
+        /// Connects to a destination specified by the given configuration. Must be used in tandom with the CommitAsync that takes an ExportJobConfiguration.
+        /// </summary>
+        /// <param name="exportJobConfiguration">The job configuration to use for this call.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <param name="containerId">The id of the container to use for exporting data. We will use the default/root container if not provided.</param>
+        /// <returns>A <see cref="Task"/> representing connection operation.</returns>
+        /// <exception cref="DestinationConnectionException">Thrown when we can't connect to the destination.</exception>
+        Task ConnectAsync(ExportJobConfiguration exportJobConfiguration, CancellationToken cancellationToken, string containerId = null);
 
         /// <summary>
         /// Creates a new file in the destination.
@@ -43,11 +54,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.ExportDestinatio
         Task WriteFilePartAsync(Uri fileUri, uint partId, byte[] bytes, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Commits the written parts of the file.
+        /// Commits the written parts of the file to a specified location.  Must be used in tandom with the ConnectAsync that takes an ExportJobConfiguration.
         /// </summary>
+        /// <param name="exportJobConfiguration">The job configuration to use for this call.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous commit operation.</returns>
-        Task CommitAsync(CancellationToken cancellationToken);
+        Task CommitAsync(ExportJobConfiguration exportJobConfiguration, CancellationToken cancellationToken);
 
         /// <summary>
         /// Opens an existing file from the destination.

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportDestinationClient/IExportDestinationClient.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportDestinationClient/IExportDestinationClient.cs
@@ -54,6 +54,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.ExportDestinatio
         Task WriteFilePartAsync(Uri fileUri, uint partId, byte[] bytes, CancellationToken cancellationToken);
 
         /// <summary>
+        /// Commits the written parts of the file.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous commit operation.</returns>
+        Task CommitAsync(CancellationToken cancellationToken);
+
+        /// <summary>
         /// Commits the written parts of the file to a specified location.  Must be used in tandom with the ConnectAsync that takes an ExportJobConfiguration.
         /// </summary>
         /// <param name="exportJobConfiguration">The job configuration to use for this call.</param>

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -74,11 +74,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
             {
                 ExportJobConfiguration exportJobConfiguration = _exportJobConfiguration;
 
-                string connectionHash = string.Empty;
-                if (!string.IsNullOrEmpty(_exportJobConfiguration.StorageAccountConnection))
-                {
-                    connectionHash = Microsoft.Health.Core.Extensions.StringExtensions.ComputeHash(_exportJobConfiguration.StorageAccountConnection);
-                }
+                string connectionHash = Microsoft.Health.Core.Extensions.StringExtensions.ComputeHash(_exportJobConfiguration.StorageAccountConnection);
 
                 if (string.IsNullOrEmpty(exportJobRecord.StorageAccountUri) && string.IsNullOrEmpty(_exportJobConfiguration.StorageAccountUri))
                 {

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -77,9 +77,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                 string connectionHash = string.Empty;
                 if (!string.IsNullOrEmpty(_exportJobConfiguration.StorageAccountConnection))
                 {
-                    connectionHash = System.Text.Encoding.UTF8.GetString(
-                        System.Security.Cryptography.SHA512.Create().ComputeHash(
-                            System.Text.Encoding.UTF8.GetBytes(_exportJobConfiguration.StorageAccountConnection)));
+                    connectionHash = ExportJobConfiguration.HashStorageAccountConnection(_exportJobConfiguration.StorageAccountConnection);
                 }
 
                 if (string.IsNullOrEmpty(exportJobRecord.StorageAccountUri) && string.IsNullOrEmpty(_exportJobConfiguration.StorageAccountUri))

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -72,8 +72,35 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
             try
             {
+                ExportJobConfiguration exportJobConfiguration = _exportJobConfiguration;
+
+                string connectionHash = string.Empty;
+                if (!string.IsNullOrEmpty(_exportJobConfiguration.StorageAccountConnection))
+                {
+                    connectionHash = System.Text.Encoding.UTF8.GetString(
+                        System.Security.Cryptography.SHA512.Create().ComputeHash(
+                            System.Text.Encoding.UTF8.GetBytes(_exportJobConfiguration.StorageAccountConnection)));
+                }
+
+                if (string.IsNullOrEmpty(exportJobRecord.StorageAccountUri) && string.IsNullOrEmpty(_exportJobConfiguration.StorageAccountUri))
+                {
+                    if (!string.Equals(exportJobRecord.StorageAccountConnectionHash, connectionHash, StringComparison.Ordinal))
+                    {
+                        throw new DestinationConnectionException("Storage account connection string was updated during an export job.", HttpStatusCode.BadRequest);
+                    }
+                }
+                else
+                {
+                    if (!string.Equals(exportJobRecord.StorageAccountUri, _exportJobConfiguration.StorageAccountUri, StringComparison.Ordinal))
+                    {
+                        exportJobConfiguration = new ExportJobConfiguration();
+                        exportJobConfiguration.Enabled = _exportJobConfiguration.Enabled;
+                        exportJobConfiguration.StorageAccountUri = exportJobRecord.StorageAccountUri;
+                    }
+                }
+
                 // Connect to export destination using appropriate client.
-                await _exportDestinationClient.ConnectAsync(cancellationToken, _exportJobRecord.Id);
+                await _exportDestinationClient.ConnectAsync(exportJobConfiguration, cancellationToken, _exportJobRecord.Id);
 
                 // If we are resuming a job, we can detect that by checking the progress info from the job record.
                 // If it is null, then we know we are processing a new job.
@@ -139,7 +166,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                     if (progress.Page % _exportJobConfiguration.NumberOfPagesPerCommit == 0)
                     {
                         // Commit the changes.
-                        await _exportDestinationClient.CommitAsync(cancellationToken);
+                        await _exportDestinationClient.CommitAsync(exportJobConfiguration, cancellationToken);
 
                         // Update the job record.
                         await UpdateJobRecordAsync(cancellationToken);
@@ -149,7 +176,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                 }
 
                 // Commit one last time for any pending changes.
-                await _exportDestinationClient.CommitAsync(cancellationToken);
+                await _exportDestinationClient.CommitAsync(exportJobConfiguration, cancellationToken);
 
                 await CompleteJobAsync(OperationStatus.Completed, cancellationToken);
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -74,9 +74,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
             {
                 ExportJobConfiguration exportJobConfiguration = _exportJobConfiguration;
 
-                string connectionHash = Microsoft.Health.Core.Extensions.StringExtensions.ComputeHash(_exportJobConfiguration.StorageAccountConnection);
+                string connectionHash = string.IsNullOrEmpty(_exportJobConfiguration.StorageAccountConnection) ?
+                    string.Empty :
+                    Microsoft.Health.Core.Extensions.StringExtensions.ComputeHash(_exportJobConfiguration.StorageAccountConnection);
 
-                if (string.IsNullOrEmpty(exportJobRecord.StorageAccountUri) && string.IsNullOrEmpty(_exportJobConfiguration.StorageAccountUri))
+                if (string.IsNullOrEmpty(exportJobRecord.StorageAccountUri))
                 {
                     if (!string.Equals(exportJobRecord.StorageAccountConnectionHash, connectionHash, StringComparison.Ordinal))
                     {
@@ -85,12 +87,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                 }
                 else
                 {
-                    if (!string.Equals(exportJobRecord.StorageAccountUri, _exportJobConfiguration.StorageAccountUri, StringComparison.Ordinal))
-                    {
-                        exportJobConfiguration = new ExportJobConfiguration();
-                        exportJobConfiguration.Enabled = _exportJobConfiguration.Enabled;
-                        exportJobConfiguration.StorageAccountUri = exportJobRecord.StorageAccountUri;
-                    }
+                    exportJobConfiguration = new ExportJobConfiguration();
+                    exportJobConfiguration.Enabled = _exportJobConfiguration.Enabled;
+                    exportJobConfiguration.StorageAccountUri = exportJobRecord.StorageAccountUri;
                 }
 
                 // Connect to export destination using appropriate client.

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                 string connectionHash = string.Empty;
                 if (!string.IsNullOrEmpty(_exportJobConfiguration.StorageAccountConnection))
                 {
-                    connectionHash = ExportJobConfiguration.HashStorageAccountConnection(_exportJobConfiguration.StorageAccountConnection);
+                    connectionHash = Microsoft.Health.Core.Extensions.StringExtensions.ComputeHash(_exportJobConfiguration.StorageAccountConnection);
                 }
 
                 if (string.IsNullOrEmpty(exportJobRecord.StorageAccountUri) && string.IsNullOrEmpty(_exportJobConfiguration.StorageAccountUri))

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobRecord.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobRecord.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
     /// </summary>
     public class ExportJobRecord
     {
-        public ExportJobRecord(Uri requestUri, string resourceType, string hash, IReadOnlyCollection<KeyValuePair<string, string>> requestorClaims = null, PartialDateTime since = null)
+        public ExportJobRecord(Uri requestUri, string resourceType, string hash, IReadOnlyCollection<KeyValuePair<string, string>> requestorClaims = null, PartialDateTime since = null, string storageAccountConnectionHash = null, string storageAccountUri = null)
         {
             EnsureArg.IsNotNull(requestUri, nameof(requestUri));
             EnsureArg.IsNotNullOrWhiteSpace(hash, nameof(hash));
@@ -27,6 +27,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
             ResourceType = resourceType;
             RequestorClaims = requestorClaims;
             Since = since;
+            StorageAccountConnectionHash = storageAccountConnectionHash;
+            StorageAccountUri = storageAccountUri;
 
             // Default values
             SchemaVersion = 1;
@@ -88,5 +90,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
 
         [JsonProperty(JobRecordProperties.Since)]
         public PartialDateTime Since { get; private set; }
+
+        [JsonProperty(JobRecordProperties.StorageAccountConnectionHash)]
+        public string StorageAccountConnectionHash { get; private set; }
+
+#pragma warning disable CA1056 // Uri properties should not be strings
+        [JsonProperty(JobRecordProperties.StorageAccountUri)]
+        public string StorageAccountUri { get; private set; }
+#pragma warning restore CA1056 // Uri properties should not be strings
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobRecord.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobRecord.cs
@@ -94,9 +94,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
         [JsonProperty(JobRecordProperties.StorageAccountConnectionHash)]
         public string StorageAccountConnectionHash { get; private set; }
 
-#pragma warning disable CA1056 // Uri properties should not be strings
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Usage",
+            "CA1056:Uri properties should not be strings",
+            Justification = "Set from an ExportJobConfiguration where the value is a string and is never used as a URI.")]
         [JsonProperty(JobRecordProperties.StorageAccountUri)]
         public string StorageAccountUri { get; private set; }
-#pragma warning restore CA1056 // Uri properties should not be strings
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
@@ -68,5 +68,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations
         public const string Input = "input";
 
         public const string FailureCount = "failureCount";
+
+        public const string StorageAccountConnectionHash = "storageAccountConnectionHash";
+
+        public const string StorageAccountUri = "storageAccountUri";
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Export/CreateExportRequestHandlerTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Export/CreateExportRequestHandlerTests.cs
@@ -7,6 +7,8 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export;
 using Microsoft.Health.Fhir.Core.Features.Security;
@@ -15,6 +17,7 @@ using Microsoft.Health.Fhir.Core.Messages.Export;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.Integration.Persistence;
+using NSubstitute;
 using Xunit;
 
 namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Export
@@ -32,6 +35,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Export
         private readonly IFhirStorageTestHelper _fhirStorageTestHelper;
 
         private CreateExportRequestHandler _createExportRequestHandler;
+        private ExportJobConfiguration _exportJobConfiguration;
 
         private readonly CancellationToken _cancellationToken = new CancellationTokenSource().Token;
 
@@ -39,7 +43,12 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Export
         {
             _fhirOperationDataStore = fixture.OperationDataStore;
             _fhirStorageTestHelper = fixture.TestHelper;
-            _createExportRequestHandler = new CreateExportRequestHandler(_claimsExtractor, _fhirOperationDataStore, DisabledFhirAuthorizationService.Instance);
+
+            _exportJobConfiguration = new ExportJobConfiguration();
+            IOptions<ExportJobConfiguration> optionsExportConfig = Substitute.For<IOptions<ExportJobConfiguration>>();
+            optionsExportConfig.Value.Returns(_exportJobConfiguration);
+
+            _createExportRequestHandler = new CreateExportRequestHandler(_claimsExtractor, _fhirOperationDataStore, DisabledFhirAuthorizationService.Instance, optionsExportConfig);
         }
 
         public static IEnumerable<object[]> ExportUriForSameJobs


### PR DESCRIPTION
## Description
Detects if the export location has changed since the export job was made. If the job is still able to send data to the old location it will continue, otherwise the job will fail.

## Related issues
[User Story 72598: Snapshot export job record data](https://microsofthealth.visualstudio.com/Health/_workitems/edit/72598)

## Testing
Describe how this change was tested.
