### PR TITLE
Add interface for FhirClient

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Client/FhirClient.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Client/FhirClient.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using Hl7.Fhir.Model;
@@ -21,7 +22,7 @@ using RestfulCapabilityMode = Hl7.Fhir.Model.CapabilityStatement.RestfulCapabili
 
 namespace Microsoft.Health.Fhir.Client
 {
-    public class FhirClient
+    public class FhirClient : IFhirClient
     {
         private const string SmartOAuthUriExtension = "http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris";
         private const string SmartOAuthUriExtensionToken = "token";
@@ -125,13 +126,13 @@ namespace Microsoft.Health.Fhir.Client
             HttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
         }
 
-        public Task<FhirResponse<T>> CreateAsync<T>(T resource, string conditionalCreateCriteria = null)
+        public Task<FhirResponse<T>> CreateAsync<T>(T resource, string conditionalCreateCriteria = null, CancellationToken cancellationToken = default)
             where T : Resource
         {
-            return CreateAsync(resource.ResourceType.ToString(), resource, conditionalCreateCriteria);
+            return CreateAsync(resource.ResourceType.ToString(), resource, conditionalCreateCriteria, cancellationToken);
         }
 
-        public async Task<FhirResponse<T>> CreateAsync<T>(string uri, T resource, string conditionalCreateCriteria = null)
+        public async Task<FhirResponse<T>> CreateAsync<T>(string uri, T resource, string conditionalCreateCriteria = null, CancellationToken cancellationToken = default)
             where T : Resource
         {
             var message = new HttpRequestMessage(HttpMethod.Post, uri);
@@ -143,51 +144,51 @@ namespace Microsoft.Health.Fhir.Client
                 message.Headers.TryAddWithoutValidation(IfNoneExistHeaderName, conditionalCreateCriteria);
             }
 
-            using HttpResponseMessage response = await HttpClient.SendAsync(message);
+            using HttpResponseMessage response = await HttpClient.SendAsync(message, cancellationToken);
 
             await EnsureSuccessStatusCodeAsync(response);
 
             return await CreateResponseAsync<T>(response);
         }
 
-        public Task<FhirResponse<T>> ReadAsync<T>(ResourceType resourceType, string resourceId)
+        public Task<FhirResponse<T>> ReadAsync<T>(ResourceType resourceType, string resourceId, CancellationToken cancellationToken = default)
             where T : Resource
         {
-            return ReadAsync<T>($"{resourceType}/{resourceId}");
+            return ReadAsync<T>($"{resourceType}/{resourceId}", cancellationToken);
         }
 
-        public async Task<FhirResponse<T>> ReadAsync<T>(string uri)
+        public async Task<FhirResponse<T>> ReadAsync<T>(string uri, CancellationToken cancellationToken = default)
             where T : Resource
         {
             var message = new HttpRequestMessage(HttpMethod.Get, uri);
             message.Headers.Accept.Add(_mediaType);
 
-            HttpResponseMessage response = await HttpClient.SendAsync(message);
+            HttpResponseMessage response = await HttpClient.SendAsync(message, cancellationToken);
 
             await EnsureSuccessStatusCodeAsync(response);
 
             return await CreateResponseAsync<T>(response);
         }
 
-        public Task<FhirResponse<T>> VReadAsync<T>(ResourceType resourceType, string resourceId, string versionId)
+        public Task<FhirResponse<T>> VReadAsync<T>(ResourceType resourceType, string resourceId, string versionId, CancellationToken cancellationToken = default)
             where T : Resource
         {
-            return ReadAsync<T>($"{resourceType}/{resourceId}/_history/{versionId}");
+            return ReadAsync<T>($"{resourceType}/{resourceId}/_history/{versionId}", cancellationToken);
         }
 
-        public Task<FhirResponse<T>> UpdateAsync<T>(T resource, string ifMatchVersion = null)
+        public Task<FhirResponse<T>> UpdateAsync<T>(T resource, string ifMatchVersion = null, CancellationToken cancellationToken = default)
             where T : Resource
         {
-            return UpdateAsync($"{resource.ResourceType}/{resource.Id}", resource, ifMatchVersion);
+            return UpdateAsync($"{resource.ResourceType}/{resource.Id}", resource, ifMatchVersion, cancellationToken);
         }
 
-        public Task<FhirResponse<T>> ConditionalUpdateAsync<T>(T resource, string searchCriteria, string ifMatchVersion = null)
+        public Task<FhirResponse<T>> ConditionalUpdateAsync<T>(T resource, string searchCriteria, string ifMatchVersion = null, CancellationToken cancellationToken = default)
             where T : Resource
         {
-            return UpdateAsync($"{resource.ResourceType}?{searchCriteria}", resource, ifMatchVersion);
+            return UpdateAsync($"{resource.ResourceType}?{searchCriteria}", resource, ifMatchVersion, cancellationToken);
         }
 
-        public async Task<FhirResponse<T>> UpdateAsync<T>(string uri, T resource, string ifMatchVersion = null)
+        public async Task<FhirResponse<T>> UpdateAsync<T>(string uri, T resource, string ifMatchVersion = null, CancellationToken cancellationToken = default)
             where T : Resource
         {
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Put, uri)
@@ -203,38 +204,38 @@ namespace Microsoft.Health.Fhir.Client
                 request.Headers.Add(IfMatchHeaderName, weakETag);
             }
 
-            HttpResponseMessage response = await HttpClient.SendAsync(request);
+            HttpResponseMessage response = await HttpClient.SendAsync(request, cancellationToken);
 
             await EnsureSuccessStatusCodeAsync(response);
 
             return await CreateResponseAsync<T>(response);
         }
 
-        public Task<FhirResponse> DeleteAsync<T>(T resource)
+        public Task<FhirResponse> DeleteAsync<T>(T resource, CancellationToken cancellationToken = default)
             where T : Resource
         {
-            return DeleteAsync($"{resource.ResourceType}/{resource.Id}");
+            return DeleteAsync($"{resource.ResourceType}/{resource.Id}", cancellationToken);
         }
 
-        public async Task<FhirResponse> DeleteAsync(string uri)
+        public async Task<FhirResponse> DeleteAsync(string uri, CancellationToken cancellationToken = default)
         {
             var message = new HttpRequestMessage(HttpMethod.Delete, uri);
             message.Headers.Accept.Add(_mediaType);
 
-            HttpResponseMessage response = await HttpClient.SendAsync(message);
+            HttpResponseMessage response = await HttpClient.SendAsync(message, cancellationToken);
 
             await EnsureSuccessStatusCodeAsync(response);
 
             return new FhirResponse(response);
         }
 
-        public Task<FhirResponse> HardDeleteAsync<T>(T resource)
+        public Task<FhirResponse> HardDeleteAsync<T>(T resource, CancellationToken cancellationToken = default)
             where T : Resource
         {
-            return DeleteAsync($"{resource.ResourceType}/{resource.Id}?hardDelete=true");
+            return DeleteAsync($"{resource.ResourceType}/{resource.Id}?hardDelete=true", cancellationToken);
         }
 
-        public async Task<FhirResponse> PatchAsync(string uri, string content)
+        public async Task<FhirResponse> PatchAsync(string uri, string content, CancellationToken cancellationToken = default)
         {
             var message = new HttpRequestMessage(HttpMethod.Patch, uri)
             {
@@ -242,14 +243,14 @@ namespace Microsoft.Health.Fhir.Client
             };
             message.Headers.Accept.Add(_mediaType);
 
-            HttpResponseMessage response = await HttpClient.SendAsync(message);
+            HttpResponseMessage response = await HttpClient.SendAsync(message, cancellationToken);
 
             await EnsureSuccessStatusCodeAsync(response);
 
             return new FhirResponse(response);
         }
 
-        public Task<FhirResponse<Bundle>> SearchAsync(ResourceType resourceType, string query = null, int? count = null)
+        public Task<FhirResponse<Bundle>> SearchAsync(ResourceType resourceType, string query = null, int? count = null, CancellationToken cancellationToken = default)
         {
             StringBuilder sb = new StringBuilder();
 
@@ -270,58 +271,58 @@ namespace Microsoft.Health.Fhir.Client
                 sb.Append("_count=").Append(count.Value);
             }
 
-            return SearchAsync(sb.ToString());
+            return SearchAsync(sb.ToString(), cancellationToken);
         }
 
-        public async Task<FhirResponse<Bundle>> SearchAsync(string url)
+        public async Task<FhirResponse<Bundle>> SearchAsync(string url, CancellationToken cancellationToken = default)
         {
             var message = new HttpRequestMessage(HttpMethod.Get, url);
             message.Headers.Accept.Add(_mediaType);
 
-            HttpResponseMessage response = await HttpClient.SendAsync(message);
+            HttpResponseMessage response = await HttpClient.SendAsync(message, cancellationToken);
 
             await EnsureSuccessStatusCodeAsync(response);
 
             return await CreateResponseAsync<Bundle>(response);
         }
 
-        public async Task<FhirResponse<Bundle>> SearchPostAsync(string resourceType, params (string key, string value)[] body)
+        public async Task<FhirResponse<Bundle>> SearchPostAsync(string resourceType, CancellationToken cancellationToken = default, params (string key, string value)[] body)
         {
             var message = new HttpRequestMessage(HttpMethod.Post, $"{(string.IsNullOrEmpty(resourceType) ? null : $"{resourceType}/")}_search")
             {
                 Content = new FormUrlEncodedContent(body.ToDictionary(p => p.key, p => p.value)),
             };
-            HttpResponseMessage response = await HttpClient.SendAsync(message);
+            HttpResponseMessage response = await HttpClient.SendAsync(message, cancellationToken);
 
             await EnsureSuccessStatusCodeAsync(response);
 
             return await CreateResponseAsync<Bundle>(response);
         }
 
-        public async Task<Uri> ExportAsync(string path = "")
+        public async Task<Uri> ExportAsync(string path = "", CancellationToken cancellationToken = default)
         {
             var message = new HttpRequestMessage(HttpMethod.Get, $"{path}$export");
 
             message.Headers.Add("Accept", "application/fhir+json");
             message.Headers.Add("Prefer", "respond-async");
 
-            HttpResponseMessage response = await HttpClient.SendAsync(message);
+            HttpResponseMessage response = await HttpClient.SendAsync(message, cancellationToken);
 
             await EnsureSuccessStatusCodeAsync(response);
 
             return response.Content.Headers.ContentLocation;
         }
 
-        public async Task<HttpResponseMessage> CheckExportAsync(Uri contentLocation)
+        public async Task<HttpResponseMessage> CheckExportAsync(Uri contentLocation, CancellationToken cancellationToken = default)
         {
             var message = new HttpRequestMessage(HttpMethod.Get, contentLocation);
 
-            HttpResponseMessage response = await HttpClient.SendAsync(message);
+            HttpResponseMessage response = await HttpClient.SendAsync(message, cancellationToken);
 
             return response;
         }
 
-        public async Task<FhirResponse<Bundle>> PostBundleAsync(Resource bundle)
+        public async Task<FhirResponse<Bundle>> PostBundleAsync(Resource bundle, CancellationToken cancellationToken = default)
         {
             var message = new HttpRequestMessage(HttpMethod.Post, string.Empty)
             {
@@ -330,7 +331,7 @@ namespace Microsoft.Health.Fhir.Client
 
             message.Headers.Accept.Add(_mediaType);
 
-            HttpResponseMessage response = await HttpClient.SendAsync(message);
+            HttpResponseMessage response = await HttpClient.SendAsync(message, cancellationToken);
 
             await EnsureSuccessStatusCodeAsync(response);
 
@@ -343,12 +344,13 @@ namespace Microsoft.Health.Fhir.Client
         /// <param name="uri">The URL to call</param>
         /// <param name="resource">The resource to be validated. The resource parameter is a string instead of a Resource object because the validate endpoint is frequently sent invalid resources that couldn't be parsed.</param>
         /// <param name="xml">Whether the resource is in JSON or XML formal</param>
-        public async Task<OperationOutcome> ValidateAsync(string uri, string resource, bool xml = false)
+        /// <param name="cancellationToken">The cancellation token</param>
+        public async Task<OperationOutcome> ValidateAsync(string uri, string resource, bool xml = false, CancellationToken cancellationToken = default)
         {
             var message = new HttpRequestMessage(HttpMethod.Post, xml ? uri + "?_format=xml" : uri);
             message.Content = new StringContent(resource, Encoding.UTF8, xml ? ContentType.XML_CONTENT_HEADER : ContentType.JSON_CONTENT_HEADER);
 
-            HttpResponseMessage response = await HttpClient.SendAsync(message);
+            HttpResponseMessage response = await HttpClient.SendAsync(message, cancellationToken);
 
             await EnsureSuccessStatusCodeAsync(response);
 
@@ -396,11 +398,12 @@ namespace Microsoft.Health.Fhir.Client
         /// <remarks>Examines the metadata endpoint to determine if there's a token and authorize url exposed and sets the property <see cref="SecurityEnabled"/> to <value>true</value> or <value>false</value> based on this.
         /// Additionally, the <see cref="TokenUri"/> and <see cref="AuthorizeUri"/> are set if they are found.</remarks>
         /// </summary>
-        public void ConfigureSecurityOptions()
+        /// <param name="cancellationToken">The cancellation token</param>
+        public async Task ConfigureSecurityOptions(CancellationToken cancellationToken = default)
         {
             bool localSecurityEnabled = false;
 
-            using FhirResponse<CapabilityStatement> readResponse = ReadAsync<CapabilityStatement>("metadata").GetAwaiter().GetResult();
+            using FhirResponse<CapabilityStatement> readResponse = await ReadAsync<CapabilityStatement>("metadata", cancellationToken);
             CapabilityStatement metadata = readResponse.Resource;
 
             foreach (var rest in metadata.Rest.Where(r => r.Mode == RestfulCapabilityMode.Server))

--- a/src/Microsoft.Health.Fhir.Shared.Client/IFhirClient.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Client/IFhirClient.cs
@@ -1,0 +1,82 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Rest;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Fhir.Client
+{
+    public interface IFhirClient
+    {
+        Uri AuthorizeUri { get; }
+
+        ResourceFormat Format { get; }
+
+        HttpClient HttpClient { get; }
+
+        bool? SecurityEnabled { get; }
+
+        DateTime TokenExpiration { get; }
+
+        Uri TokenUri { get; }
+
+        Task<HttpResponseMessage> CheckExportAsync(Uri contentLocation, CancellationToken cancellationToken = default);
+
+        Task<FhirResponse<T>> ConditionalUpdateAsync<T>(T resource, string searchCriteria, string ifMatchVersion = null, CancellationToken cancellationToken = default)
+            where T : Resource;
+
+        Task ConfigureSecurityOptions(CancellationToken cancellationToken = default);
+
+        Task<FhirResponse<T>> CreateAsync<T>(string uri, T resource, string conditionalCreateCriteria = null, CancellationToken cancellationToken = default)
+            where T : Resource;
+
+        Task<FhirResponse<T>> CreateAsync<T>(T resource, string conditionalCreateCriteria = null, CancellationToken cancellationToken = default)
+            where T : Resource;
+
+        Task<FhirResponse> DeleteAsync(string uri, CancellationToken cancellationToken = default);
+
+        Task<FhirResponse> DeleteAsync<T>(T resource, CancellationToken cancellationToken = default)
+            where T : Resource;
+
+        Task<Uri> ExportAsync(string path = "", CancellationToken cancellationToken = default);
+
+        Task<FhirResponse> HardDeleteAsync<T>(T resource, CancellationToken cancellationToken = default)
+            where T : Resource;
+
+        Task<FhirResponse> PatchAsync(string uri, string content, CancellationToken cancellationToken = default);
+
+        Task<FhirResponse<Bundle>> PostBundleAsync(Resource bundle, CancellationToken cancellationToken = default);
+
+        Task<FhirResponse<T>> ReadAsync<T>(ResourceType resourceType, string resourceId, CancellationToken cancellationToken = default)
+            where T : Resource;
+
+        Task<FhirResponse<T>> ReadAsync<T>(string uri, CancellationToken cancellationToken = default)
+            where T : Resource;
+
+        Task<FhirResponse<Bundle>> SearchAsync(ResourceType resourceType, string query = null, int? count = null, CancellationToken cancellationToken = default);
+
+        Task<FhirResponse<Bundle>> SearchAsync(string url, CancellationToken cancellationToken = default);
+
+        Task<FhirResponse<Bundle>> SearchPostAsync(string resourceType, CancellationToken cancellationToken = default, params (string key, string value)[] body);
+
+        void SetBearerToken(string token);
+
+        Task<FhirResponse<T>> UpdateAsync<T>(string uri, T resource, string ifMatchVersion = null, CancellationToken cancellationToken = default)
+            where T : Resource;
+
+        Task<FhirResponse<T>> UpdateAsync<T>(T resource, string ifMatchVersion = null, CancellationToken cancellationToken = default)
+            where T : Resource;
+
+        Task<OperationOutcome> ValidateAsync(string uri, string resource, bool xml = false, CancellationToken cancellationToken = default);
+
+        Task<FhirResponse<T>> VReadAsync<T>(ResourceType resourceType, string resourceId, string versionId, CancellationToken cancellationToken = default)
+            where T : Resource;
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Client/Microsoft.Health.Fhir.Shared.Client.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Client/Microsoft.Health.Fhir.Shared.Client.projitems
@@ -15,6 +15,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)FhirException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FhirResponse.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FhirResponse{T}.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)IFhirClient.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Resources.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E.Common/TestFhirClient.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E.Common/TestFhirClient.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using EnsureThat;
@@ -34,7 +33,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Common
             _clientApplication = clientApplication;
             _user = user;
 
-            ConfigureSecurityOptions();
+            ConfigureSecurityOptions().GetAwaiter().GetResult();
             SetupAuthenticationAsync(clientApplication, user).GetAwaiter().GetResult();
         }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/AuditTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/AuditTests.cs
@@ -253,7 +253,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit
         public async Task GivenAServer_WhenSearchedByResourceTypeUsingPost_ThenAuditLogEntriesShouldBeCreated()
         {
             await ExecuteAndValidate(
-                () => _client.SearchPostAsync("Observation", ("_tag", "123")),
+                () => _client.SearchPostAsync("Observation", default, ("_tag", "123")),
                 "search-type",
                 ResourceType.Observation,
                 _ => "Observation/_search",
@@ -277,7 +277,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit
         public async Task GivenAServer_WhenSearchedUsingPost_ThenAuditLogEntriesShouldBeCreated()
         {
             await ExecuteAndValidate(
-                () => _client.SearchPostAsync(null, ("_tag", "123")),
+                () => _client.SearchPostAsync(null, default, ("_tag", "123")),
                 "search-system",
                 null,
                 _ => "_search",

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Net;
+using System.Threading;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Client;
 using Microsoft.Health.Fhir.Core.Extensions;
@@ -92,20 +93,20 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
             await ExecuteAndValidateBundle("?_type=Patient", patients);
 
-            Bundle bundle = await Client.SearchPostAsync(null, ("_type", "Patient"));
+            Bundle bundle = await Client.SearchPostAsync(null, default, ("_type", "Patient"));
             ValidateBundle(bundle, "_search", patients);
 
             bundle = await Client.SearchAsync("?_type=Observation,Patient");
             Assert.True(bundle.Entry.Count > patients.Length);
-            bundle = await Client.SearchPostAsync(null, ("_type", "Patient,Observation"));
+            bundle = await Client.SearchPostAsync(null, default, ("_type", "Patient,Observation"));
             Assert.True(bundle.Entry.Count > patients.Length);
 
             await ExecuteAndValidateBundle($"?_type=Observation,Patient&_id={observation.Id}", observation);
-            bundle = await Client.SearchPostAsync(null, ("_type", "Patient,Observation"), ("_id", observation.Id));
+            bundle = await Client.SearchPostAsync(null, default, ("_type", "Patient,Observation"), ("_id", observation.Id));
             ValidateBundle(bundle, "_search", observation);
 
             await ExecuteAndValidateBundle($"?_type=Observation,Patient&_id={organization.Id}");
-            bundle = await Client.SearchPostAsync(null, ("_type", "Patient,Observation"), ("_id", organization.Id));
+            bundle = await Client.SearchPostAsync(null, default, ("_type", "Patient,Observation"), ("_id", organization.Id));
             ValidateBundle(bundle, "_search");
         }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 ManagingOrganization = new ResourceReference($"Organization/{organizationResponse.Resource.Id}"),
             });
 
-            Bundle bundle = await Client.SearchPostAsync(ResourceType.Location.ToString(), ("_include", "Location:organization:Organization"));
+            Bundle bundle = await Client.SearchPostAsync(ResourceType.Location.ToString(), default, ("_include", "Location:organization:Organization"));
 
             ValidateBundle(
                 bundle,


### PR DESCRIPTION
## Description
Creates the interface `IFhirClient` for `FhirClient` to aid in mocking during unit tests.

## Related issues
Addresses [AB#74009](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/74009).

## Testing
Existing tests that use the `FhirClient` continue to pass. 
