### PR TITLE
Auto-update for packages related to 'healthcare-components-1.0.0-master-20200608-1'

### DIFF
--- a/src/Microsoft.Health.CosmosDb/Microsoft.Health.CosmosDb.csproj
+++ b/src/Microsoft.Health.CosmosDb/Microsoft.Health.CosmosDb.csproj
@@ -11,9 +11,9 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.3" />
-    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20200528-2" />
-    <PackageReference Include="Microsoft.Health.Core" Version="1.0.0-master-20200528-2" />
-    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20200528-2" />
+    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20200608-1" />
+    <PackageReference Include="Microsoft.Health.Core" Version="1.0.0-master-20200608-1" />
+    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20200608-1" />
     <PackageReference Include="Polly" Version="7.2.0" />
   </ItemGroup>
 

--- a/src/Microsoft.Health.Fhir.Api/Microsoft.Health.Fhir.Api.csproj
+++ b/src/Microsoft.Health.Fhir.Api/Microsoft.Health.Fhir.Api.csproj
@@ -26,9 +26,9 @@
     <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.3" />
-    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20200528-2" />
-    <PackageReference Include="Microsoft.Health.Api" Version="1.0.0-master-20200528-2" />
-    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20200528-2" />
+    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20200608-1" />
+    <PackageReference Include="Microsoft.Health.Api" Version="1.0.0-master-20200608-1" />
+    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20200608-1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Health.Fhir.Core/Microsoft.Health.Fhir.Core.csproj
+++ b/src/Microsoft.Health.Fhir.Core/Microsoft.Health.Fhir.Core.csproj
@@ -33,9 +33,9 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.3" />
-    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20200528-2" />
-    <PackageReference Include="Microsoft.Health.Core" Version="1.0.0-master-20200528-2" />
-    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20200528-2" />
+    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20200608-1" />
+    <PackageReference Include="Microsoft.Health.Core" Version="1.0.0-master-20200608-1" />
+    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20200608-1" />
     <PackageReference Include="Hl7.Fhir.Serialization" Version="1.7.0" />
     <PackageReference Include="Hl7.FhirPath" Version="1.7.0" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.11" />

--- a/src/Microsoft.Health.Fhir.CosmosDb/Microsoft.Health.Fhir.CosmosDb.csproj
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Microsoft.Health.Fhir.CosmosDb.csproj
@@ -15,9 +15,9 @@
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.9.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.3" />
-    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20200528-2" />
-    <PackageReference Include="Microsoft.Health.Extensions.BuildTimeCodeGenerator" Version="1.0.0-master-20200528-2" />
-    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20200528-2" />
+    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20200608-1" />
+    <PackageReference Include="Microsoft.Health.Extensions.BuildTimeCodeGenerator" Version="1.0.0-master-20200608-1" />
+    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20200608-1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Health.Fhir.SqlServer/Microsoft.Health.Fhir.SqlServer.csproj
+++ b/src/Microsoft.Health.Fhir.SqlServer/Microsoft.Health.Fhir.SqlServer.csproj
@@ -25,10 +25,10 @@
 
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="8.1.2" />
-    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20200528-2" />
-    <PackageReference Include="Microsoft.Health.SqlServer" Version="1.0.0-master-20200528-2" />
-    <PackageReference Include="Microsoft.Health.SqlServer.Api" Version="1.0.0-master-20200528-2" />
-    <PackageReference Include="Microsoft.Health.Extensions.BuildTimeCodeGenerator" Version="1.0.0-master-20200528-2" />
+    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20200608-1" />
+    <PackageReference Include="Microsoft.Health.SqlServer" Version="1.0.0-master-20200608-1" />
+    <PackageReference Include="Microsoft.Health.SqlServer.Api" Version="1.0.0-master-20200608-1" />
+    <PackageReference Include="Microsoft.Health.Extensions.BuildTimeCodeGenerator" Version="1.0.0-master-20200608-1" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.3.2" />
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="150.18208.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="3.1.3" />

--- a/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
+++ b/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
@@ -286,7 +286,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20200528-2" />
+    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20200608-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/Microsoft.Health.Fhir.R4.Tests.E2E/Microsoft.Health.Fhir.R4.Tests.E2E.csproj
+++ b/test/Microsoft.Health.Fhir.R4.Tests.E2E/Microsoft.Health.Fhir.R4.Tests.E2E.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.3" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.9.2" />
-    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20200528-2" />
+    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20200608-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="selenium.chrome.webdriver" Version="79.0.0" />
     <PackageReference Include="selenium.webdriver" Version="3.141.0" />

--- a/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/Microsoft.Health.Fhir.Stu3.Tests.E2E.csproj
+++ b/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/Microsoft.Health.Fhir.Stu3.Tests.E2E.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.3" />
-    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20200528-2" />
+    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20200608-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="selenium.chrome.webdriver" Version="79.0.0" />
     <PackageReference Include="selenium.webdriver" Version="3.141.0" />


### PR DESCRIPTION
Updates package 'Microsoft.Health.Abstractions' to version '1.0.0-master-20200608-1'
Updates package 'Microsoft.Health.Core' to version '1.0.0-master-20200608-1'
Updates package 'Microsoft.Health.Extensions.DependencyInjection' to version '1.0.0-master-20200608-1'
Updates package 'Microsoft.Health.Api' to version '1.0.0-master-20200608-1'
Updates package 'Microsoft.Health.Extensions.BuildTimeCodeGenerator' to version '1.0.0-master-20200608-1'
Updates package 'Microsoft.Health.SqlServer' to version '1.0.0-master-20200608-1'
Updates package 'Microsoft.Health.SqlServer.Api' to version '1.0.0-master-20200608-1'