### PR TITLE
Refactor SqlServerFhirModel initialization

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/ISearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/ISearchParameterDefinitionManager.cs
@@ -64,11 +64,5 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         /// <param name="componentIndex">The optional component index if the search parameter is a composite</param>
         /// <returns>The search parameter type.</returns>
         SearchParamType GetSearchParameterType(SearchParameterInfo searchParameter, int? componentIndex);
-
-        /// <summary>
-        /// Initializes the definition manager, reading in search parameter information from a JSON file.
-        /// </summary>
-        /// <remarks>This method is idempotent.</remarks>
-        void Start();
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/ISearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/ISearchParameterDefinitionManager.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
     /// <summary>
     /// Provides mechanism to access search parameter definition.
     /// </summary>
-    public interface ISearchParameterDefinitionManager : IStartable
+    public interface ISearchParameterDefinitionManager
     {
         public delegate ISearchParameterDefinitionManager SearchableSearchParameterDefinitionManagerResolver();
 
@@ -64,5 +64,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         /// <param name="componentIndex">The optional component index if the search parameter is a composite</param>
         /// <returns>The search parameter type.</returns>
         SearchParamType GetSearchParameterType(SearchParameterInfo searchParameter, int? componentIndex);
+
+        /// <summary>
+        /// Initializes the definition manager, reading in search parameter information from a JSON file.
+        /// </summary>
+        /// <remarks>This method is idempotent.</remarks>
+        void Start();
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using EnsureThat;
-using Hl7.Fhir.Serialization;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Models;

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         private readonly IModelInfoProvider _modelInfoProvider;
 
         private IDictionary<string, IDictionary<string, SearchParameterInfo>> _typeLookup;
+        private bool _started;
 
         public SearchParameterDefinitionManager(IModelInfoProvider modelInfoProvider)
         {
@@ -36,16 +37,21 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
 
         public void Start()
         {
-            var builder = new SearchParameterDefinitionBuilder(
-                _modelInfoProvider,
-                "search-parameters.json");
+            if (!_started)
+            {
+                var builder = new SearchParameterDefinitionBuilder(
+                    _modelInfoProvider,
+                    "search-parameters.json");
 
-            builder.Build();
+                builder.Build();
 
-            _typeLookup = builder.ResourceTypeDictionary;
-            UrlLookup = builder.UriDictionary;
+                _typeLookup = builder.ResourceTypeDictionary;
+                UrlLookup = builder.UriDictionary;
 
-            List<string> list = UrlLookup.Values.Where(p => p.Type == ValueSets.SearchParamType.Composite).Select(p => string.Join("|", p.Component.Select(c => UrlLookup[c.DefinitionUrl].Type))).Distinct().ToList();
+                List<string> list = UrlLookup.Values.Where(p => p.Type == ValueSets.SearchParamType.Composite).Select(p => string.Join("|", p.Component.Select(c => UrlLookup[c.DefinitionUrl].Type))).Distinct().ToList();
+
+                _started = true;
+            }
         }
 
         public IEnumerable<SearchParameterInfo> GetSearchParameters(string resourceType)

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
 
         public void Start()
         {
+            // This method is idempotent because dependent Start methods are not guaranteed to be executed in order.
             if (!_started)
             {
                 var builder = new SearchParameterDefinitionBuilder(

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchableSearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchableSearchParameterDefinitionManager.cs
@@ -77,9 +77,5 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         {
             return _inner.GetSearchParameterType(searchParameter, componentIndex);
         }
-
-        public void Start()
-        {
-        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SupportedSearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SupportedSearchParameterDefinitionManager.cs
@@ -74,9 +74,5 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         {
             return _inner.GetSearchParameterType(searchParameter, componentIndex);
         }
-
-        public void Start()
-        {
-        }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -118,8 +118,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
 
         private async Task<SearchResult> SearchImpl(SearchOptions searchOptions, bool historySearch, CancellationToken cancellationToken)
         {
-            await _model.StartAsync();
-
             Expression searchExpression = searchOptions.Expression;
 
             // AND in the continuation token

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -151,8 +151,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
         public async Task<ResourceWrapper> GetAsync(ResourceKey key, CancellationToken cancellationToken)
         {
-            await _model.StartAsync();
-
             using (SqlConnectionWrapper sqlConnectionWrapper = _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapper(true))
             {
                 int? requestedVersion = null;
@@ -220,8 +218,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
         public async Task HardDeleteAsync(ResourceKey key, CancellationToken cancellationToken)
         {
-            await _model.StartAsync();
-
             using (SqlConnectionWrapper sqlConnectionWrapper = _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapper(true))
             using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateSqlCommand())
             {

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -77,8 +77,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
         public async Task<UpsertOutcome> UpsertAsync(ResourceWrapper resource, WeakETag weakETag, bool allowCreate, bool keepHistory, CancellationToken cancellationToken)
         {
-            await _model.StartAsync();
-
             int etag = 0;
             if (weakETag != null && !int.TryParse(weakETag.VersionId, out etag))
             {

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
         public void Start()
         {
-            StartAsync().GetAwaiter().GetResult();
+            StartAsync().Wait();
         }
 
         // TODO: Add this to IStartable interface.

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
@@ -150,6 +150,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             {
                 connection.Open();
 
+                // Synchronous calls are used because this code is executed on startup and doesn't need to be async.
+                // Additionally, XUnit task scheduler constraints prevent async calls from being easily tested.
                 using (SqlCommand sqlCommand = connection.CreateCommand())
                 {
                     sqlCommand.CommandText = @"

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
@@ -135,12 +135,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
         public void Start()
         {
-            StartAsync().Wait();
-        }
-
-        // TODO: Add this to IStartable interface.
-        internal async Task StartAsync()
-        {
             _schemaInitializer.Start();
 
             if (_searchParameterDefinitionManager is IStartable startable)
@@ -154,7 +148,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
             using (var connection = new SqlConnection(_configuration.ConnectionString))
             {
-                await connection.OpenAsync();
+                connection.Open();
 
                 using (SqlCommand sqlCommand = connection.CreateCommand())
                 {
@@ -209,7 +203,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                     sqlCommand.Parameters.AddWithValue("@claimTypes", commaSeparatedClaimTypes);
                     sqlCommand.Parameters.AddWithValue("@compartmentTypes", commaSeparatedCompartmentTypes);
 
-                    using (SqlDataReader reader = await sqlCommand.ExecuteReaderAsync(CommandBehavior.SequentialAccess))
+                    using (SqlDataReader reader = sqlCommand.ExecuteReader(CommandBehavior.SequentialAccess))
                     {
                         var resourceTypeToId = new Dictionary<string, short>(StringComparer.Ordinal);
                         var resourceTypeIdToTypeName = new Dictionary<short, string>();

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
         }
 
         // TODO: Add this to IStartable interface.
-        public async Task StartAsync()
+        internal async Task StartAsync()
         {
             _schemaInitializer.Start();
             _searchParameterDefinitionManager.Start();

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
             using (var connection = new SqlConnection(_configuration.ConnectionString))
             {
-                await connection.OpenAsync().ConfigureAwait(false);
+                await connection.OpenAsync();
 
                 using (SqlCommand sqlCommand = connection.CreateCommand())
                 {
@@ -195,7 +195,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                     sqlCommand.Parameters.AddWithValue("@claimTypes", commaSeparatedClaimTypes);
                     sqlCommand.Parameters.AddWithValue("@compartmentTypes", commaSeparatedCompartmentTypes);
 
-                    using (SqlDataReader reader = await sqlCommand.ExecuteReaderAsync(CommandBehavior.SequentialAccess).ConfigureAwait(false))
+                    using (SqlDataReader reader = await sqlCommand.ExecuteReaderAsync(CommandBehavior.SequentialAccess))
                     {
                         var resourceTypeToId = new Dictionary<string, short>(StringComparer.Ordinal);
                         var resourceTypeIdToTypeName = new Dictionary<short, string>();

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
@@ -128,7 +128,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
         internal async Task StartAsync()
         {
             _schemaInitializer.Start();
-            _searchParameterDefinitionManager.Start();
+
+            if (_searchParameterDefinitionManager is IStartable startable)
+            {
+                startable.Start();
+            }
 
             var connectionStringBuilder = new SqlConnectionStringBuilder(_configuration.ConnectionString);
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
@@ -73,8 +73,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                     }
                 });
 
-            schemaInitializer.Initialize(forceIncrementalSchemaUpgrade);
-
+            // TODO: re-add forceIncrementalSchemaUpgrade test functionality
             _sqlServerFhirModel.Start();
         }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Health.Fhir.SqlServer.Features.Schema;
+using Microsoft.Health.Fhir.SqlServer.Features.Storage;
 using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Features.Schema;
 using Microsoft.SqlServer.Dac.Compare;
@@ -25,12 +26,14 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         private readonly string _connectionString;
         private readonly string _initialConnectionString;
         private readonly string _masterConnectionString;
+        private readonly SqlServerFhirModel _sqlServerFhirModel;
 
-        public SqlServerFhirStorageTestHelper(string connectionString, string initialConnectionString, string masterConnectionString)
+        public SqlServerFhirStorageTestHelper(string connectionString, string initialConnectionString, string masterConnectionString, SqlServerFhirModel sqlServerFhirModel)
         {
             _connectionString = connectionString;
             _initialConnectionString = initialConnectionString;
             _masterConnectionString = masterConnectionString;
+            _sqlServerFhirModel = sqlServerFhirModel;
         }
 
         public async Task CreateAndInitializeDatabase(string databaseName, bool forceIncrementalSchemaUpgrade, SchemaInitializer schemaInitializer = null, CancellationToken cancellationToken = default)
@@ -71,6 +74,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 });
 
             schemaInitializer.Initialize(forceIncrementalSchemaUpgrade);
+
+            _sqlServerFhirModel.Start();
         }
 
         public async Task DeleteDatabase(string databaseName, CancellationToken cancellationToken = default)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
             _fhirOperationDataStore = new SqlServerFhirOperationDataStore(SqlConnectionWrapperFactory, NullLogger<SqlServerFhirOperationDataStore>.Instance);
 
-            _testHelper = new SqlServerFhirStorageTestHelper(TestConnectionString, initialConnectionString, masterConnectionString);
+            _testHelper = new SqlServerFhirStorageTestHelper(TestConnectionString, initialConnectionString, masterConnectionString, sqlServerFhirModel);
         }
 
         public string TestConnectionString { get; }


### PR DESCRIPTION
## Description

- Updates `SqlServerFhirModel` to:
  - inherit from `IStartable` instead of `SqlServerModelInitialization`
  - start up the Schema Initializer and the Search Parameter Definition Manager
- Puts `SqlServerModelInitialization.GetStringId()` in `SqlServerFhirModel` (`SqlServerModelInitialization` will be removed in [#AB74343](https://microsofthealth.visualstudio.com/Health/_workitems/edit/74343))
- Makes`SearchParameterDefinitionManager.Start()` idempotent

## Related issues
Addresses [#AB74281](https://microsofthealth.visualstudio.com/Health/_workitems/edit/74281).

## Testing
- All tests pass as before