### PR TITLE
Fix: ExportDataValidationTest fails when run on empty servers

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ExportDataValidationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ExportDataValidationTests.cs
@@ -43,6 +43,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [InlineData("Patient/")]
         public async Task GivenFhirServer_WhenDataIsExported_ThenExportedDataIsSameAsDataInFhirServer(string path)
         {
+            // NOTE: Azure Storage Emulator is required to run these tests locally.
+
             // Trigger export request and check for export status
             Uri contentLocation = await _testFhirClient.ExportAsync(path);
             IList<Uri> blobUris = await CheckExportStatus(contentLocation);
@@ -191,6 +193,13 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
                 JObject result = JObject.Parse(responseString);
 
                 JArray entries = (JArray)result["entry"];
+
+                // Fhir server has not returned any data. Return existing mapping.
+                if (entries == null)
+                {
+                    return resourceIdToResourceMapping;
+                }
+
                 foreach (JToken entry in entries)
                 {
                     string id = entry["resource"]["id"].ToString();


### PR DESCRIPTION
## Description
When running these tests on an empty fhir-server, we run into a null ref exception. Adding code to handle this case.

## Related issues
Addresses [issue #].

## Testing
Ran the tests locally using an empty fhir-server
