### PR TITLE
Update auth extensions to use IFhirClient, add cancellation token support.

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Client/FhirClientAuthExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Client/FhirClientAuthExtensions.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Azure.Services.AppAuthentication;
@@ -15,37 +16,41 @@ namespace Microsoft.Health.Fhir.Client
     public static class FhirClientAuthExtensions
     {
         /// <summary>
-        /// Sets the authenticated token on the FhirClient to the supplied resource via Managed Identity.
+        /// Sets the authenticated token on the <see cref="IFhirClient"/> to the supplied resource via Managed Identity.
         /// </summary>
-        /// <param name="fhirClient">The FhirClient to authenticate.</param>
+        /// <param name="fhirClient">The <see cref="IFhirClient"/> to authenticate.</param>
         /// <param name="resource">The resource to obtain a token to.</param>
-        /// <returns>A task representing the successful setting of the token.</returns>
-        public static async Task AuthenticateWithManagedIdentity(this FhirClient fhirClient, string resource)
+        /// <param name="tenantId">The optional tenantId to use when requesting a token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>A <see cref="Task"/> representing the successful setting of the token.</returns>
+        public static async Task AuthenticateWithManagedIdentity(this IFhirClient fhirClient, string resource, string tenantId = null, CancellationToken cancellationToken = default)
         {
             EnsureArg.IsNotNull(fhirClient, nameof(fhirClient));
             EnsureArg.IsNotNullOrWhiteSpace(resource, nameof(resource));
 
             var azureServiceTokenProvider = new AzureServiceTokenProvider();
-            string accessToken = await azureServiceTokenProvider.GetAccessTokenAsync(resource);
+            string accessToken = await azureServiceTokenProvider.GetAccessTokenAsync(resource, tenantId, cancellationToken);
 
             fhirClient.SetBearerToken(accessToken);
         }
 
         /// <summary>
-        /// Sets the authenticated token on the FhirClient via OpenId client credentials.
+        /// Sets the authenticated token on the <see cref="IFhirClient"/> via OpenId client credentials.
         /// </summary>
-        /// <param name="fhirClient">The FhirClient to authenticate.</param>
+        /// <param name="fhirClient">The <see cref="IFhirClient"/> to authenticate.</param>
         /// <param name="clientId">The clientId of the application.</param>
         /// <param name="clientSecret">The clientSecret of the application.</param>
         /// <param name="resource">The resource to authenticate with.</param>
         /// <param name="scope">The scope to authenticate with.</param>
-        /// <returns>A task representing the successful setting of the token.</returns>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>A <see cref="Task"/> representing the successful setting of the token.</returns>
         public static async Task AuthenticateOpenIdClientCredentials(
-            this FhirClient fhirClient,
+            this IFhirClient fhirClient,
             string clientId,
             string clientSecret,
             string resource,
-            string scope)
+            string scope,
+            CancellationToken cancellationToken)
         {
             EnsureArg.IsNotNull(fhirClient, nameof(fhirClient));
             EnsureArg.IsNotNullOrWhiteSpace(clientId, nameof(clientId));
@@ -62,28 +67,30 @@ namespace Microsoft.Health.Fhir.Client
                 new KeyValuePair<string, string>(OpenIdConnectParameterNames.Resource, resource),
             };
 
-            await ObtainTokenAndSetOnClient(fhirClient, formData);
+            await ObtainTokenAndSetOnClient(fhirClient, formData, cancellationToken);
         }
 
         /// <summary>
-        /// Sets the authenticated token on the FhirClient via OpenId user password.
+        /// Sets the authenticated token on the <see cref="IFhirClient"/> via OpenId user password.
         /// </summary>
-        /// <param name="fhirClient">The FhirClient to authenticate.</param>
+        /// <param name="fhirClient">The <see cref="IFhirClient"/> to authenticate.</param>
         /// <param name="clientId">The clientId of the application.</param>
         /// <param name="clientSecret">The clientSecret of the application.</param>
         /// <param name="resource">The resource to authenticate with.</param>
         /// <param name="scope">The scope to authenticate with.</param>
         /// <param name="username">The username to authenticate.</param>
         /// <param name="password">The password to authenticate.</param>
-        /// <returns>A task representing the successful setting of the token.</returns>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>A <see cref="Task"/> representing the successful setting of the token.</returns>
         public static async Task AuthenticateOpenIdUserPassword(
-            this FhirClient fhirClient,
+            this IFhirClient fhirClient,
             string clientId,
             string clientSecret,
             string resource,
             string scope,
             string username,
-            string password)
+            string password,
+            CancellationToken cancellationToken)
         {
             var formData = new List<KeyValuePair<string, string>>
             {
@@ -96,13 +103,13 @@ namespace Microsoft.Health.Fhir.Client
                 new KeyValuePair<string, string>(OpenIdConnectParameterNames.Password, password),
             };
 
-            await ObtainTokenAndSetOnClient(fhirClient, formData);
+            await ObtainTokenAndSetOnClient(fhirClient, formData, cancellationToken);
         }
 
-        private static async Task ObtainTokenAndSetOnClient(FhirClient fhirClient, List<KeyValuePair<string, string>> formData)
+        private static async Task ObtainTokenAndSetOnClient(IFhirClient fhirClient, List<KeyValuePair<string, string>> formData, CancellationToken cancellationToken)
         {
             using var formContent = new FormUrlEncodedContent(formData);
-            using HttpResponseMessage tokenResponse = await fhirClient.HttpClient.PostAsync(fhirClient.TokenUri, formContent);
+            using HttpResponseMessage tokenResponse = await fhirClient.HttpClient.PostAsync(fhirClient.TokenUri, formContent, cancellationToken);
 
             var openIdConnectMessage = new OpenIdConnectMessage(await tokenResponse.Content.ReadAsStringAsync());
             fhirClient.SetBearerToken(openIdConnectMessage.AccessToken);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E.Common/TestFhirClient.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E.Common/TestFhirClient.cs
@@ -89,7 +89,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Common
                     clientApplication.ClientId,
                     clientApplication.ClientSecret,
                     resource,
-                    scope);
+                    scope,
+                    cancellationToken: default);
             }
             else
             {
@@ -99,7 +100,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Common
                     AuthenticationSettings.Resource,
                     AuthenticationSettings.Scope,
                     user.UserId,
-                    user.Password);
+                    user.Password,
+                    cancellationToken: default);
             }
         }
     }


### PR DESCRIPTION
## Description
This PR updates the `FhirClientAuthExtensions` to work on the `IFhirClient` and also adds `CancellationToken` support.

## Related issues
Addresses [AB#74009](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/74009).

## Testing
Existing tests continue to pass.
