### PR TITLE
Add support for Sub Searches to export

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobProgress.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobProgress.cs
@@ -10,10 +10,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
 {
     public class ExportJobProgress
     {
-        public ExportJobProgress(string continuationToken, uint page)
+        public ExportJobProgress(string continuationToken, uint page, string resourceId = null, ExportJobProgress subSearch = null)
         {
             ContinuationToken = continuationToken;
             Page = page;
+            SubSearchResourceId = resourceId;
+            SubSearch = subSearch;
         }
 
         [JsonConstructor]
@@ -27,12 +29,30 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
         [JsonProperty(JobRecordProperties.Page)]
         public uint Page { get; private set; }
 
+        [JsonProperty(JobRecordProperties.SubSearchResourceId)]
+        public string SubSearchResourceId { get; private set; }
+
+        [JsonProperty(JobRecordProperties.SubSearch)]
+        public ExportJobProgress SubSearch { get; private set; }
+
         public void UpdateContinuationToken(string continuationToken)
         {
             EnsureArg.IsNotNullOrWhiteSpace(continuationToken, nameof(continuationToken));
 
             ContinuationToken = continuationToken;
             Page++;
+        }
+
+        public void NewSubSearch(string resourceId, ExportJobProgress subSearch)
+        {
+            SubSearchResourceId = resourceId;
+            SubSearch = subSearch;
+        }
+
+        public void ClearSubSearch()
+        {
+            SubSearchResourceId = null;
+            SubSearch = null;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
@@ -72,5 +72,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations
         public const string Scope = "scope";
 
         public const string MaximumConcurrency = "maximumConcurrency";
+
+        public const string SubSearch = "subSearch";
+
+        public const string SubSearchResourceId = "subSearchResourceId";
     }
 }


### PR DESCRIPTION
## Description
As part of Patient and Group exports additional resources need to be retrieved based on the primary resources being exported. This requires additional searches based on the results returned from the primary search. As each of these sub searches could have multiple pages of data, and in the case of Group export could have sub searches of their own, the continuation tokens and page counts for these searches need to be stored. This will allow the export job to resume if it is interrupted in the middle of a sub search without duplicating exported data. 
Within the ExportJobRecord the continuation token and current page of the search is stored in the ExportJobProgress object. This object just stores the continuation token and page. By adding a recursive reference to the ExportJobProgress and an Id for the resource that is currently being used for sub searches all the necessary data to resume an interrupted job would be present.

## Related issues


## Testing
No new functionality to test yet.
