### PR TITLE
Update export test to cancel export request after test is complete

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Client/FhirClient.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Client/FhirClient.cs
@@ -322,6 +322,17 @@ namespace Microsoft.Health.Fhir.Client
             return response;
         }
 
+        public async Task CancelExport(Uri contentLocation, CancellationToken cancellationToken = default)
+        {
+            var message = new HttpRequestMessage
+            {
+                Method = HttpMethod.Delete,
+                RequestUri = contentLocation,
+            };
+
+            await HttpClient.SendAsync(message, cancellationToken);
+        }
+
         public async Task<FhirResponse<Bundle>> PostBundleAsync(Resource bundle, CancellationToken cancellationToken = default)
         {
             var message = new HttpRequestMessage(HttpMethod.Post, string.Empty)

--- a/src/Microsoft.Health.Fhir.Shared.Client/FhirClient.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Client/FhirClient.cs
@@ -301,8 +301,7 @@ namespace Microsoft.Health.Fhir.Client
 
         public async Task<Uri> ExportAsync(string path = "", CancellationToken cancellationToken = default)
         {
-            var message = new HttpRequestMessage(HttpMethod.Get, $"{path}$export");
-
+            using var message = new HttpRequestMessage(HttpMethod.Get, $"{path}$export");
             message.Headers.Add("Accept", "application/fhir+json");
             message.Headers.Add("Prefer", "respond-async");
 
@@ -315,8 +314,7 @@ namespace Microsoft.Health.Fhir.Client
 
         public async Task<HttpResponseMessage> CheckExportAsync(Uri contentLocation, CancellationToken cancellationToken = default)
         {
-            var message = new HttpRequestMessage(HttpMethod.Get, contentLocation);
-
+            using var message = new HttpRequestMessage(HttpMethod.Get, contentLocation);
             HttpResponseMessage response = await HttpClient.SendAsync(message, cancellationToken);
 
             return response;
@@ -324,12 +322,7 @@ namespace Microsoft.Health.Fhir.Client
 
         public async Task CancelExport(Uri contentLocation, CancellationToken cancellationToken = default)
         {
-            var message = new HttpRequestMessage
-            {
-                Method = HttpMethod.Delete,
-                RequestUri = contentLocation,
-            };
-
+            using var message = new HttpRequestMessage(HttpMethod.Delete, contentLocation);
             await HttpClient.SendAsync(message, cancellationToken);
         }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BasicAuthTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BasicAuthTests.cs
@@ -206,7 +206,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         {
             TestFhirClient tempClient = _client.CreateClientForUser(TestUsers.ExportUser, TestApplications.NativeClient);
 
-            await tempClient.ExportAsync();
+            Uri contentLocation = await tempClient.ExportAsync();
+            await tempClient.CancelExport(contentLocation);
         }
     }
 }


### PR DESCRIPTION
## Description
Updating the auth export test to cancel export request after the test is complete. The test only aims to validate that the export API works as expected. Cancelling the export request will prevent the export job from being picked up by the ExportJobWorker and trying to actually export data.

## Related issues
Addresses [issue [AB#74585](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/74585)].

## Testing
Describe how this change was tested.
