### PR TITLE
Add max resources and pages to job record

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportJobTaskTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportJobTaskTests.cs
@@ -70,7 +70,16 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
         {
             bool capturedSearch = false;
 
-            _exportJobConfiguration.MaximumNumberOfResourcesPerQuery = 1;
+            var exportJobRecordWithOneResource = new ExportJobRecord(
+                new Uri("https://localhost/ExportJob/"),
+                "Patient",
+                "hash",
+                storageAccountConnectionHash: string.Empty,
+                storageAccountUri: _exportJobConfiguration.StorageAccountUri,
+                maximumNumberOfResourcesPerQuery: 1,
+                numberOfPagesPerCommit: _exportJobConfiguration.NumberOfPagesPerCommit);
+
+            SetupExportJobRecordAndOperationDataStore(exportJobRecordWithOneResource);
 
             // First search should not have continuation token in the list of query parameters.
             _searchService.SearchAsync(
@@ -94,14 +103,15 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
         {
             bool capturedSearch = false;
 
-            _exportJobConfiguration.MaximumNumberOfResourcesPerQuery = 1;
             var exportJobRecordWithSince = new ExportJobRecord(
                 new Uri("https://localhost/ExportJob/"),
                 "Patient",
                 "hash",
                 since: Core.Models.PartialDateTime.MinValue,
                 storageAccountConnectionHash: string.Empty,
-                storageAccountUri: _exportJobConfiguration.StorageAccountUri);
+                storageAccountUri: _exportJobConfiguration.StorageAccountUri,
+                maximumNumberOfResourcesPerQuery: 1,
+                numberOfPagesPerCommit: _exportJobConfiguration.NumberOfPagesPerCommit);
 
             SetupExportJobRecordAndOperationDataStore(exportJobRecordWithSince);
 
@@ -127,7 +137,16 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
         {
             const string continuationToken = "ct";
 
-            _exportJobConfiguration.MaximumNumberOfResourcesPerQuery = 1;
+            var exportJobRecordWithOneResource = new ExportJobRecord(
+                new Uri("https://localhost/ExportJob/"),
+                "Patient",
+                "hash",
+                storageAccountConnectionHash: string.Empty,
+                storageAccountUri: _exportJobConfiguration.StorageAccountUri,
+                maximumNumberOfResourcesPerQuery: 1,
+                numberOfPagesPerCommit: _exportJobConfiguration.NumberOfPagesPerCommit);
+
+            SetupExportJobRecordAndOperationDataStore(exportJobRecordWithOneResource);
 
             // First search returns a search result with continuation token.
             _searchService.SearchAsync(
@@ -160,14 +179,15 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
         {
             const string continuationToken = "ct";
 
-            _exportJobConfiguration.MaximumNumberOfResourcesPerQuery = 1;
             var exportJobRecordWithSince = new ExportJobRecord(
                 new Uri("https://localhost/ExportJob/"),
                 "Patient",
                 "hash",
                 since: PartialDateTime.MinValue,
                 storageAccountConnectionHash: string.Empty,
-                storageAccountUri: _exportJobConfiguration.StorageAccountUri);
+                storageAccountUri: _exportJobConfiguration.StorageAccountUri,
+                maximumNumberOfResourcesPerQuery: 1,
+                numberOfPagesPerCommit: _exportJobConfiguration.NumberOfPagesPerCommit);
             SetupExportJobRecordAndOperationDataStore(exportJobRecordWithSince);
 
             // First search returns a search result with continuation token.
@@ -201,7 +221,16 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
         {
             const string continuationToken = "ct";
 
-            _exportJobConfiguration.MaximumNumberOfResourcesPerQuery = 1;
+            var exportJobRecordWithOneResource = new ExportJobRecord(
+                new Uri("https://localhost/ExportJob/"),
+                "Patient",
+                "hash",
+                storageAccountConnectionHash: string.Empty,
+                storageAccountUri: _exportJobConfiguration.StorageAccountUri,
+                maximumNumberOfResourcesPerQuery: 1,
+                numberOfPagesPerCommit: _exportJobConfiguration.NumberOfPagesPerCommit);
+
+            SetupExportJobRecordAndOperationDataStore(exportJobRecordWithOneResource);
 
             // First search returns a search result with continuation token.
             _searchService.SearchAsync(
@@ -250,14 +279,15 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
         {
             const string continuationToken = "ct";
 
-            _exportJobConfiguration.MaximumNumberOfResourcesPerQuery = 1;
             var exportJobRecordWithSince = new ExportJobRecord(
                 new Uri("https://localhost/ExportJob/"),
                 "Patient",
                 "hash",
                 since: PartialDateTime.MinValue,
                 storageAccountConnectionHash: string.Empty,
-                storageAccountUri: _exportJobConfiguration.StorageAccountUri);
+                storageAccountUri: _exportJobConfiguration.StorageAccountUri,
+                maximumNumberOfResourcesPerQuery: 1,
+                numberOfPagesPerCommit: _exportJobConfiguration.NumberOfPagesPerCommit);
             SetupExportJobRecordAndOperationDataStore(exportJobRecordWithSince);
 
             // First search returns a search result with continuation token.
@@ -390,7 +420,16 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
         [InlineData(6, "012345")] // Because it fails to perform the 7th search, the file is created and the first 6 pages are committed.
         public async Task GivenVariousNumberOfSuccessfulSearch_WhenExecuted_ThenItShouldCommitAtScheduledPage(int numberOfSuccessfulPages, string expectedIds)
         {
-            _exportJobConfiguration.NumberOfPagesPerCommit = 3;
+            var exportJobRecordWithCommitPages = new ExportJobRecord(
+                new Uri("https://localhost/ExportJob/"),
+                "Patient",
+                "hash",
+                since: PartialDateTime.MinValue,
+                storageAccountConnectionHash: string.Empty,
+                storageAccountUri: _exportJobConfiguration.StorageAccountUri,
+                maximumNumberOfResourcesPerQuery: _exportJobConfiguration.MaximumNumberOfResourcesPerQuery,
+                numberOfPagesPerCommit: 3);
+            SetupExportJobRecordAndOperationDataStore(exportJobRecordWithCommitPages);
 
             int numberOfCalls = 0;
 
@@ -436,7 +475,16 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
         [Fact]
         public async Task GivenNumberOfSearch_WhenExecuted_ThenItShouldCommitOneLastTime()
         {
-            _exportJobConfiguration.NumberOfPagesPerCommit = 3;
+            var exportJobRecordWithCommitPages = new ExportJobRecord(
+                 new Uri("https://localhost/ExportJob/"),
+                 "Patient",
+                 "hash",
+                 since: PartialDateTime.MinValue,
+                 storageAccountConnectionHash: string.Empty,
+                 storageAccountUri: _exportJobConfiguration.StorageAccountUri,
+                 maximumNumberOfResourcesPerQuery: _exportJobConfiguration.MaximumNumberOfResourcesPerQuery,
+                 numberOfPagesPerCommit: 2);
+            SetupExportJobRecordAndOperationDataStore(exportJobRecordWithCommitPages);
 
             SearchResult searchResultWithContinuationToken = CreateSearchResult(continuationToken: "ct");
 
@@ -623,7 +671,16 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
         {
             // We are using the SearchService to throw an exception in order to simulate the export job task
             // "crashing" while in the middle of the process.
-            _exportJobConfiguration.NumberOfPagesPerCommit = 2;
+            var exportJobRecordWithCommitPages = new ExportJobRecord(
+                new Uri("https://localhost/ExportJob/"),
+                "Patient",
+                "hash",
+                since: PartialDateTime.MinValue,
+                storageAccountConnectionHash: string.Empty,
+                storageAccountUri: _exportJobConfiguration.StorageAccountUri,
+                maximumNumberOfResourcesPerQuery: _exportJobConfiguration.MaximumNumberOfResourcesPerQuery,
+                numberOfPagesPerCommit: 2);
+            SetupExportJobRecordAndOperationDataStore(exportJobRecordWithCommitPages);
 
             int numberOfCalls = 0;
             int numberOfSuccessfulPages = 2;
@@ -705,7 +762,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
                 "Patient",
                 "hash",
                 storageAccountConnectionHash: string.Empty,
-                storageAccountUri: _exportJobConfiguration.StorageAccountUri);
+                storageAccountUri: _exportJobConfiguration.StorageAccountUri,
+                maximumNumberOfResourcesPerQuery: _exportJobConfiguration.MaximumNumberOfResourcesPerQuery,
+                numberOfPagesPerCommit: _exportJobConfiguration.NumberOfPagesPerCommit);
 
             _fhirOperationDataStore.UpdateExportJobAsync(_exportJobRecord, _weakETag, _cancellationToken).Returns(x =>
             {

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
@@ -77,7 +77,16 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
             if (outcome == null)
             {
-                var jobRecord = new ExportJobRecord(request.RequestUri, request.ResourceType, hash, requestorClaims, request.Since, storageAccountConnectionHash, _exportJobConfiguration.StorageAccountUri);
+                var jobRecord = new ExportJobRecord(
+                    request.RequestUri,
+                    request.ResourceType,
+                    hash,
+                    requestorClaims,
+                    request.Since,
+                    storageAccountConnectionHash,
+                    _exportJobConfiguration.StorageAccountUri,
+                    _exportJobConfiguration.MaximumNumberOfResourcesPerQuery,
+                    _exportJobConfiguration.NumberOfPagesPerCommit);
 
                 outcome = await _fhirOperationDataStore.CreateExportJobAsync(jobRecord, cancellationToken);
             }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                 // from the search result.
                 var queryParametersList = new List<Tuple<string, string>>()
                 {
-                    Tuple.Create(KnownQueryParameterNames.Count, _exportJobConfiguration.MaximumNumberOfResourcesPerQuery.ToString(CultureInfo.InvariantCulture)),
+                    Tuple.Create(KnownQueryParameterNames.Count, _exportJobRecord.MaximumNumberOfResourcesPerQuery.ToString(CultureInfo.InvariantCulture)),
                     Tuple.Create(KnownQueryParameterNames.LastUpdated, $"le{_exportJobRecord.QueuedTime.ToString("o", CultureInfo.InvariantCulture)}"),
                 };
 
@@ -156,7 +156,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                         queryParametersList.Add(Tuple.Create(KnownQueryParameterNames.ContinuationToken, progress.ContinuationToken));
                     }
 
-                    if (progress.Page % _exportJobConfiguration.NumberOfPagesPerCommit == 0)
+                    if (progress.Page % _exportJobRecord.NumberOfPagesPerCommit == 0)
                     {
                         // Commit the changes.
                         await _exportDestinationClient.CommitAsync(exportJobConfiguration, cancellationToken);

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobRecord.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobRecord.cs
@@ -17,7 +17,16 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
     /// </summary>
     public class ExportJobRecord : JobRecord
     {
-        public ExportJobRecord(Uri requestUri, string resourceType, string hash, IReadOnlyCollection<KeyValuePair<string, string>> requestorClaims = null, PartialDateTime since = null, string storageAccountConnectionHash = null, string storageAccountUri = null)
+        public ExportJobRecord(
+            Uri requestUri,
+            string resourceType,
+            string hash,
+            IReadOnlyCollection<KeyValuePair<string, string>> requestorClaims = null,
+            PartialDateTime since = null,
+            string storageAccountConnectionHash = null,
+            string storageAccountUri = null,
+            uint maximumNumberOfResourcesPerQuery = 100,
+            uint numberOfPagesPerCommit = 10)
         {
             EnsureArg.IsNotNull(requestUri, nameof(requestUri));
             EnsureArg.IsNotNullOrWhiteSpace(hash, nameof(hash));
@@ -29,6 +38,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
             Since = since;
             StorageAccountConnectionHash = storageAccountConnectionHash;
             StorageAccountUri = storageAccountUri;
+            MaximumNumberOfResourcesPerQuery = maximumNumberOfResourcesPerQuery;
+            NumberOfPagesPerCommit = numberOfPagesPerCommit;
 
             // Default values
             SchemaVersion = 1;
@@ -76,5 +87,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
             Justification = "Set from an ExportJobConfiguration where the value is a string and is never used as a URI.")]
         [JsonProperty(JobRecordProperties.StorageAccountUri)]
         public string StorageAccountUri { get; private set; }
+
+        [JsonProperty(JobRecordProperties.MaximumNumberOfResourcesPerQuery)]
+        public uint MaximumNumberOfResourcesPerQuery { get; private set; }
+
+        [JsonProperty(JobRecordProperties.NumberOfPagesPerCommit)]
+        public uint NumberOfPagesPerCommit { get; private set; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
@@ -76,5 +76,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations
         public const string StorageAccountUri = "storageAccountUri";
 
         public const string MaximumConcurrency = "maximumConcurrency";
+
+        public const string MaximumNumberOfResourcesPerQuery = "maximumNumberOfResourcesPerQuery";
+
+        public const string NumberOfPagesPerCommit = "numberOfPagesPerCommit";
     }
 }


### PR DESCRIPTION
## Description
Adds snapshots of the MaximumNumberOfResourcesPerQuery and NumberOfPagesPerCommit settings to export job records. If the number of resources per query is changed in the middle of an export job it will invalidate the continuation token and mess up the search results.

## Related issues

## Testing

