### PR TITLE
Improves test run reliability for Search Parameter tests

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchIndexerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchIndexerTests.cs
@@ -20,9 +20,8 @@ using Xunit;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 {
-    public class SearchIndexerTests : IClassFixture<SearchParameterFixtureData>
+    public class SearchIndexerTests
     {
-        private readonly SearchParameterFixtureData _fixtureData;
         private ISearchIndexer _indexer;
 
         private JsonSerializerSettings _settings = new JsonSerializerSettings
@@ -34,12 +33,10 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             ContractResolver = new CamelCasePropertyNamesContractResolver(),
         };
 
-        public SearchIndexerTests(SearchParameterFixtureData fixtureData)
+        public SearchIndexerTests()
         {
-            _fixtureData = fixtureData;
-
             _indexer = new SearchIndexer(
-                () => _fixtureData.SearchDefinitionManager,
+                () => SearchParameterFixtureData.SearchDefinitionManager,
                 SearchParameterFixtureData.Manager,
                 new LightweightReferenceToElementResolver(new ReferenceSearchValueParser(new FhirRequestContextAccessor()), ModelInfoProvider.Instance),
                 NullLogger<SearchIndexer>.Instance);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchConverterForAllSearchTypes.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchConverterForAllSearchTypes.cs
@@ -19,15 +19,13 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 {
-    public class SearchConverterForAllSearchTypes : IClassFixture<SearchParameterFixtureData>
+    public class SearchConverterForAllSearchTypes
     {
         private readonly ITestOutputHelper _outputHelper;
-        private readonly SearchParameterFixtureData _fixtureData;
 
-        public SearchConverterForAllSearchTypes(ITestOutputHelper outputHelper, SearchParameterFixtureData fixtureData)
+        public SearchConverterForAllSearchTypes(ITestOutputHelper outputHelper)
         {
             _outputHelper = outputHelper;
-            _fixtureData = fixtureData;
         }
 
         [Theory]
@@ -36,8 +34,6 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             string resourceType,
             IEnumerable<SearchParameterInfo> parameters)
         {
-            SearchParameterToTypeResolver.Log = s => _outputHelper.WriteLine(s);
-
             foreach (var parameterInfo in parameters)
             {
                 var fhirPath = parameterInfo.Expression;
@@ -74,7 +70,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         {
             var unsupported = new UnsupportedSearchParameters();
 
-            SearchParameterDefinitionManager manager = SearchParameterFixtureData.CreateSearchParameterDefinitionManager();
+            SearchParameterDefinitionManager manager = SearchParameterFixtureData.CreateSearchParameterDefinitionManager(ModelInfoProvider.Instance);
 
             var resourceAndSearchParameters = ModelInfoProvider.Instance
                 .GetResourceTypeNames()
@@ -133,7 +129,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             var parsed = SearchParameterFixtureData.Compiler.Parse(parameterInfo.Expression);
 
             (SearchParamType Type, Expression, Uri DefinitionUrl)[] componentExpressions = parameterInfo.Component
-                .Select(x => (_fixtureData.SearchDefinitionManager.UrlLookup[x.DefinitionUrl].Type,
+                .Select(x => (SearchParameterFixtureData.SearchDefinitionManager.UrlLookup[x.DefinitionUrl].Type,
                     SearchParameterFixtureData.Compiler.Parse(x.Expression),
                     x.DefinitionUrl))
                 .ToArray();
@@ -158,7 +154,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
         public static IEnumerable<object[]> GetAllSearchParameters()
         {
-            var manager = SearchParameterFixtureData.CreateSearchParameterDefinitionManager();
+            var manager = SearchParameterFixtureData.CreateSearchParameterDefinitionManager(ModelInfoProvider.Instance);
 
             var values = ModelInfoProvider.Instance
                 .GetResourceTypeNames()

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterFixtureData.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterFixtureData.cs
@@ -3,10 +3,12 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Linq;
 using Hl7.Fhir.FhirPath;
 using Hl7.FhirPath;
 using MediatR;
+using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Search.Converters;
@@ -21,17 +23,20 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 {
     public class SearchParameterFixtureData
     {
-        public SearchParameterFixtureData()
+        static SearchParameterFixtureData()
         {
-            SearchDefinitionManager = CreateSearchParameterDefinitionManager();
             FhirPathCompiler.DefaultSymbolTable.AddFhirExtensions();
+
+            Compiler = new FhirPathCompiler();
+            Manager = CreateFhirElementToSearchValueTypeConverterManager();
+            SearchDefinitionManager = CreateSearchParameterDefinitionManager(new VersionSpecificModelInfoProvider());
         }
 
-        public SearchParameterDefinitionManager SearchDefinitionManager { get; }
+        public static SearchParameterDefinitionManager SearchDefinitionManager { get; }
 
-        public static FhirElementToSearchValueTypeConverterManager Manager { get; } = CreateFhirElementToSearchValueTypeConverterManager();
+        public static FhirElementToSearchValueTypeConverterManager Manager { get; }
 
-        public static FhirPathCompiler Compiler { get; } = new FhirPathCompiler();
+        public static FhirPathCompiler Compiler { get; }
 
         public static FhirElementToSearchValueTypeConverterManager CreateFhirElementToSearchValueTypeConverterManager()
         {
@@ -46,22 +51,27 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             return new FhirElementToSearchValueTypeConverterManager(fhirElementToSearchValueTypeConverters);
         }
 
-        public static SearchParameterDefinitionManager CreateSearchParameterDefinitionManager()
+        public static SearchParameterDefinitionManager CreateSearchParameterDefinitionManager(IModelInfoProvider modelInfoProvider)
         {
-            var manager = new SearchParameterDefinitionManager(ModelInfoProvider.Instance);
-            manager.Start();
+            if (Manager == null)
+            {
+                throw new InvalidOperationException($"{nameof(Manager)} was not instantiated.");
+            }
+
+            var definitionManager = new SearchParameterDefinitionManager(modelInfoProvider);
+            definitionManager.Start();
 
             var statusRegistry = new FilebasedSearchParameterRegistry(
-                manager,
-                ModelInfoProvider.Instance);
+                definitionManager,
+                modelInfoProvider);
             var statusManager = new SearchParameterStatusManager(
                 statusRegistry,
-                manager,
-                new SearchParameterSupportResolver(manager, Manager),
+                definitionManager,
+                new SearchParameterSupportResolver(definitionManager, Manager),
                 Substitute.For<IMediator>());
             statusManager.EnsureInitialized().GetAwaiter().GetResult();
 
-            return manager;
+            return definitionManager;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterSupportResolverTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterSupportResolverTests.cs
@@ -11,13 +11,13 @@ using Xunit;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 {
-    public class SearchParameterSupportResolverTests : IClassFixture<SearchParameterFixtureData>
+    public class SearchParameterSupportResolverTests
     {
         private readonly SearchParameterSupportResolver _resolver;
 
-        public SearchParameterSupportResolverTests(SearchParameterFixtureData fixtureData)
+        public SearchParameterSupportResolverTests()
         {
-            _resolver = new SearchParameterSupportResolver(fixtureData.SearchDefinitionManager, SearchParameterFixtureData.Manager);
+            _resolver = new SearchParameterSupportResolver(SearchParameterFixtureData.SearchDefinitionManager, SearchParameterFixtureData.Manager);
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Parameters/SearchParameterToTypeResolver.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Parameters/SearchParameterToTypeResolver.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
@@ -29,8 +28,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
     internal static class SearchParameterToTypeResolver
     {
         private static readonly ModelInspector ModelInspector = GetModelInspector();
-
-        internal static Action<string> Log { get; set; } = s => Debug.WriteLine(s);
 
         public static EnumerableReturnType Resolve(
             string resourceType,
@@ -233,7 +230,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
                             }
 
                             pathBuilder.AppendFormat("({0})", string.Join(",", prop.FhirType.Select(x => x.Name)));
-                            Log($"Resolved path '{pathBuilder}'");
 
                             yield break;
                         }
@@ -245,8 +241,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
                         break;
                     }
                 }
-
-                Log($"Resolved path '{pathBuilder}'");
 
                 yield return new SearchParameterTypeResult(mapping, ctx.SearchParamType, pathBuilder.ToString(), ctx.Definition);
             }


### PR DESCRIPTION
## Description
This PR looks at the random test failures during builds for Search Parameter tests.

It looks like a root cause for these failures is mixing Test Fixture, Static and Instance variables. For example, setting the TestOutputHelper as a logger in the `SearchParameterToTypeResolver` causes random failures if the resolver is used out of the context of a running test, and has the potential to override the TestOutputHelper if tests are running in parallel.
