### PR TITLE
Disable container build stage

### DIFF
--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -92,23 +92,6 @@ stages:
       imageTag: $(ImageTag)
       dnsSuffix: $(aksDnsSuffix)
 
-- stage: deployAksR4SqlContainer
-  displayName: 'Deploy R4 SqlContainer in AKS'
-  dependsOn:
-  - DockerBuild
-  jobs:
-  - template: ./jobs/deploy-aks.yml
-    parameters: 
-      version: R4
-      dataStore: SqlContainer
-      subscription: $(ConnectedServiceName)
-      clusterName: $(clusterName)
-      clusterResourceGroup: $(clusterResourceGroup)
-      clusterLocation: $(clusterLocation)
-      testEnvironmentUrl: $(TestEnvironmentUrl)
-      imageTag: $(ImageTag)
-      dnsSuffix: $(aksDnsSuffix)
-
 - stage: deployStu3
   displayName: 'Deploy STU3 Site'
   dependsOn:
@@ -240,20 +223,6 @@ stages:
       dataStore: SqlServer
       dnsSuffix: $(aksDnsSuffix)
 
-- stage: testAksR4SqlContainer
-  displayName: 'R4 SqlContainer AKS Tests'
-  dependsOn:
-  - BuildUnitTests
-  - aadTestEnvironment
-  - deployAksR4SqlContainer
-  jobs:
-  - template: ./jobs/run-tests-aks.yml
-    parameters:
-      version: R4
-      dataStore: SqlContainer
-      dnsSuffix: $(aksDnsSuffix)
-
-
 - stage: testStu3
   displayName: 'Run Stu3 Tests'
   dependsOn:
@@ -298,7 +267,6 @@ stages:
   dependsOn:
   - testAksR4Cosmos
   - testAksR4Sql
-  - testAksR4SqlContainer
   jobs:
   - template: ./jobs/cleanup-aks.yml
     parameters:
@@ -314,6 +282,5 @@ stages:
   - testR5
   - testAksR4Cosmos
   - testAksR4Sql
-  - testAksR4SqlContainer
   jobs:
   - template: ./jobs/cleanup.yml


### PR DESCRIPTION
## Description
Disables the AKS SQL Container stage in the PR build because it is constantly failing due to cluster errors.

## Related issues

## Testing
