### PR TITLE
Remove start/end time from return Parameters after initial job creation

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Headers/ResourceActionResultExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Headers/ResourceActionResultExtensions.cs
@@ -10,10 +10,10 @@ using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.Health.Fhir.Api.Features.Headers
 {
-    public static class ExportResultExtensions
+    public static class ResourceActionResultExtensions
     {
         // Generates the url to be included in the response based on the operation and sets the content location header.
-        public static ExportResult SetContentLocationHeader(this ExportResult exportResult, IUrlResolver urlResolver, string operationName, string id)
+        public static ResourceActionResult<TResult> SetContentLocationHeader<TResult>(this ResourceActionResult<TResult> result, IUrlResolver urlResolver, string operationName, string id)
         {
             EnsureArg.IsNotNull(urlResolver, nameof(urlResolver));
             EnsureArg.IsNotNullOrWhiteSpace(operationName, nameof(operationName));
@@ -21,16 +21,16 @@ namespace Microsoft.Health.Fhir.Api.Features.Headers
 
             var url = urlResolver.ResolveOperationResultUrl(operationName, id);
 
-            exportResult.Headers.Add(HeaderNames.ContentLocation, url.ToString());
-            return exportResult;
+            result.Headers.Add(HeaderNames.ContentLocation, url.ToString());
+            return result;
         }
 
-        public static ExportResult SetContentTypeHeader(this ExportResult exportResult, string contentTypeValue)
+        public static ResourceActionResult<TResult> SetContentTypeHeader<TResult>(this ResourceActionResult<TResult> result, string contentTypeValue)
         {
             EnsureArg.IsNotNullOrWhiteSpace(contentTypeValue);
 
-            exportResult.Headers.Add(HeaderNames.ContentType, contentTypeValue);
-            return exportResult;
+            result.Headers.Add(HeaderNames.ContentType, contentTypeValue);
+            return result;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Features/Headers/ResourceActionResultExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Headers/ResourceActionResultExtensions.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Headers
         // Generates the url to be included in the response based on the operation and sets the content location header.
         public static ResourceActionResult<TResult> SetContentLocationHeader<TResult>(this ResourceActionResult<TResult> result, IUrlResolver urlResolver, string operationName, string id)
         {
+            EnsureArg.IsNotNull(result, nameof(result));
             EnsureArg.IsNotNull(urlResolver, nameof(urlResolver));
             EnsureArg.IsNotNullOrWhiteSpace(operationName, nameof(operationName));
             EnsureArg.IsNotNullOrWhiteSpace(id, nameof(id));
@@ -27,6 +28,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Headers
 
         public static ResourceActionResult<TResult> SetContentTypeHeader<TResult>(this ResourceActionResult<TResult> result, string contentTypeValue)
         {
+            EnsureArg.IsNotNull(result, nameof(result));
             EnsureArg.IsNotNullOrWhiteSpace(contentTypeValue);
 
             result.Headers.Add(HeaderNames.ContentType, contentTypeValue);

--- a/src/Microsoft.Health.Fhir.Api/Features/Routing/KnownRoutes.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Routing/KnownRoutes.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
         public const string ValidateResourceTypeById = ResourceTypeById + "/" + Validate;
 
         public const string Reindex = "$reindex";
-        public const string ReindexJobLocation = "$reindex" + "/" + IdRouteSegment;
+        public const string ReindexJobLocation = OperationsConstants.Operations + "/" + OperationsConstants.Reindex + "/" + IdRouteSegment;
 
         public const string CompartmentTypeByResourceType = CompartmentTypeRouteSegment + "/" + IdRouteSegment + "/" + CompartmentResourceTypeRouteSegment;
 

--- a/src/Microsoft.Health.Fhir.Api/Features/Routing/RouteNames.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Routing/RouteNames.cs
@@ -39,6 +39,8 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
 
         internal const string CancelExport = "CancelExport";
 
+        internal const string GetReindexStatusById = "GetReindexStatusById";
+
         internal const string PostBundle = "PostBundle";
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Features/Routing/UrlResolver.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Routing/UrlResolver.cs
@@ -240,9 +240,18 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
             EnsureArg.IsNotNullOrWhiteSpace(operationName, nameof(operationName));
             EnsureArg.IsNotNullOrWhiteSpace(id, nameof(id));
 
-            if (!string.Equals(operationName, OperationsConstants.Export, StringComparison.OrdinalIgnoreCase))
+            string routName = null;
+
+            switch (operationName)
             {
-                throw new OperationNotImplementedException(string.Format(Resources.OperationNotImplemented, operationName));
+                case OperationsConstants.Export:
+                    routName = RouteNames.GetExportStatusById;
+                    break;
+                case OperationsConstants.Reindex:
+                    routName = RouteNames.GetReindexStatusById;
+                    break;
+                default:
+                    throw new OperationNotImplementedException(string.Format(Resources.OperationNotImplemented, operationName));
             }
 
             var routeValues = new RouteValueDictionary()
@@ -251,7 +260,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
             };
 
             string uriString = UrlHelper.RouteUrl(
-                RouteNames.GetExportStatusById,
+                routName,
                 routeValues,
                 Request.Scheme,
                 Request.Host.Value);

--- a/src/Microsoft.Health.Fhir.Api/Features/Routing/UrlResolver.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Routing/UrlResolver.cs
@@ -240,15 +240,15 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
             EnsureArg.IsNotNullOrWhiteSpace(operationName, nameof(operationName));
             EnsureArg.IsNotNullOrWhiteSpace(id, nameof(id));
 
-            string routName = null;
+            string routeName = null;
 
             switch (operationName)
             {
                 case OperationsConstants.Export:
-                    routName = RouteNames.GetExportStatusById;
+                    routeName = RouteNames.GetExportStatusById;
                     break;
                 case OperationsConstants.Reindex:
-                    routName = RouteNames.GetReindexStatusById;
+                    routeName = RouteNames.GetReindexStatusById;
                     break;
                 default:
                     throw new OperationNotImplementedException(string.Format(Resources.OperationNotImplemented, operationName));
@@ -260,7 +260,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
             };
 
             string uriString = UrlHelper.RouteUrl(
-                routName,
+                routeName,
                 routeValues,
                 Request.Scheme,
                 Request.Host.Value);

--- a/src/Microsoft.Health.Fhir.Api/Microsoft.Health.Fhir.Api.csproj
+++ b/src/Microsoft.Health.Fhir.Api/Microsoft.Health.Fhir.Api.csproj
@@ -51,4 +51,8 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Features\Headers\" />
+  </ItemGroup>
+
 </Project>

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -65,7 +65,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                 }
 
                 // This is just a shell for now, will be completed in future
-
                 await CompleteJobAsync(OperationStatus.Completed, cancellationToken);
 
                 _logger.LogTrace("Successfully completed the job.");
@@ -92,6 +91,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
         private async Task CompleteJobAsync(OperationStatus completionStatus, CancellationToken cancellationToken)
         {
             _reindexJobRecord.Status = completionStatus;
+            _reindexJobRecord.StartTime = Clock.UtcNow;
             _reindexJobRecord.EndTime = Clock.UtcNow;
             _reindexJobRecord.LastModified = Clock.UtcNow;
 

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Operations/CosmosFhirOperationDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Operations/CosmosFhirOperationDataStore.cs
@@ -291,7 +291,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Operations
                     throw new RequestRateExceededException(dce.RetryAfter);
                 }
 
-                _logger.LogError(dce, "Failed to create an reindex job.");
+                _logger.LogError(dce, "Failed to create a reindex job.");
                 throw;
             }
         }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Operations/CosmosFhirOperationDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Operations/CosmosFhirOperationDataStore.cs
@@ -347,9 +347,35 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Operations
             }
         }
 
-        public Task<ReindexJobWrapper> GetReindexJobByIdAsync(string jobId, CancellationToken cancellationToken)
+        public async Task<ReindexJobWrapper> GetReindexJobByIdAsync(string jobId, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            EnsureArg.IsNotNullOrWhiteSpace(jobId, nameof(jobId));
+
+            try
+            {
+                DocumentResponse<CosmosReindexJobRecordWrapper> cosmosReindexJobRecord = await _documentClientScope.Value.ReadDocumentAsync<CosmosReindexJobRecordWrapper>(
+                    UriFactory.CreateDocumentUri(DatabaseId, CollectionId, jobId),
+                    new RequestOptions { PartitionKey = new PartitionKey(CosmosDbReindexConstants.ReindexJobPartitionKey) },
+                    cancellationToken);
+
+                var outcome = new ReindexJobWrapper(cosmosReindexJobRecord.Document.JobRecord, WeakETag.FromVersionId(cosmosReindexJobRecord.Document.ETag));
+
+                return outcome;
+            }
+            catch (DocumentClientException dce)
+            {
+                if (dce.StatusCode == HttpStatusCode.TooManyRequests)
+                {
+                    throw new RequestRateExceededException(dce.RetryAfter);
+                }
+                else if (dce.StatusCode == HttpStatusCode.NotFound)
+                {
+                    throw new JobNotFoundException(string.Format(Core.Resources.JobNotFound, jobId));
+                }
+
+                _logger.LogError(dce, $"Failed to get reindex job by id: {jobId}.");
+                throw;
+            }
         }
 
         public async Task<ReindexJobWrapper> UpdateReindexJobAsync(ReindexJobRecord jobRecord, WeakETag eTag, CancellationToken cancellationToken)

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ReindexControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ReindexControllerTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
                 Arg.Is<GetReindexRequest>(r => r.JobId == "id"), Arg.Any<CancellationToken>());
 
             var parametersResource = ((FhirResult)result).Result.ResourceInstance as Parameters;
-            Assert.Equal("Queued", parametersResource.Parameter[2].Value.ToString());
+            Assert.Equal("Queued", parametersResource.Parameter[3].Value.ToString());
         }
 
         [Theory]
@@ -112,7 +112,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
             _mediator.ClearReceivedCalls();
 
             var parametersResource = ((FhirResult)result).Result.ResourceInstance as Parameters;
-            Assert.Equal("Queued", parametersResource.Parameter[2].Value.ToString());
+            Assert.Equal("Queued", parametersResource.Parameter[3].Value.ToString());
         }
 
         private ReindexController GetController(ReindexJobConfiguration reindexConfig)

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ReindexControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ReindexControllerTests.cs
@@ -18,6 +18,7 @@ using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Microsoft.Health.Fhir.Core.Features.Routing;
 using Microsoft.Health.Fhir.Core.Messages.Reindex;
 using NSubstitute;
 using Xunit;
@@ -32,12 +33,14 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
         private IFhirRequestContextAccessor _fhirRequestContextAccessor = Substitute.For<IFhirRequestContextAccessor>();
         private HttpContext _httpContext = new DefaultHttpContext();
         private static ReindexJobConfiguration _reindexJobConfig = new ReindexJobConfiguration() { Enabled = true };
+        private IUrlResolver _urlResolver = Substitute.For<IUrlResolver>();
 
         public ReindexControllerTests()
         {
             _reindexEnabledController = GetController(_reindexJobConfig);
             var controllerContext = new ControllerContext() { HttpContext = _httpContext };
             _reindexEnabledController.ControllerContext = controllerContext;
+            _urlResolver.ResolveOperationResultUrl(Arg.Any<string>(), Arg.Any<string>()).Returns(new System.Uri("https://test.com"));
         }
 
         public static TheoryData<Parameters> InvalidBody =>
@@ -100,6 +103,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
                 _mediator,
                 _fhirRequestContextAccessor,
                 optionsOperationConfiguration,
+                _urlResolver,
                 NullLogger<ReindexController>.Instance);
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Routing/UrlResolverTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Routing/UrlResolverTests.cs
@@ -301,7 +301,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Routing
         }
 
         [Fact]
-        public void GivenANonExportOperation_WhenOperationResultUrlIsResolved_ThenOperationNotImplementedExceptionShouldBeThrown()
+        public void GivenAnUnknownOperation_WhenOperationResultUrlIsResolved_ThenOperationNotImplementedExceptionShouldBeThrown()
         {
             const string id = "12345";
             const string opName = "import";

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Routing/UrlResolverTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Routing/UrlResolverTests.cs
@@ -285,6 +285,22 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Routing
         }
 
         [Fact]
+        public void GivenAReindexOperation_WhenOperationResultUrlIsResolved_ThenCorrectUrlShouldBeReturned()
+        {
+            const string id = "12345";
+            const string opName = OperationsConstants.Reindex;
+
+            _urlResolver.ResolveOperationResultUrl(opName, id);
+
+            ValidateUrlRouteContext(
+                RouteNames.GetReindexStatusById,
+                routeValues =>
+                {
+                    Assert.Equal(id, routeValues[KnownActionParameterNames.Id]);
+                });
+        }
+
+        [Fact]
         public void GivenANonExportOperation_WhenOperationResultUrlIsResolved_ThenOperationNotImplementedExceptionShouldBeThrown()
         {
             const string id = "12345";

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ReindexController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ReindexController.cs
@@ -24,6 +24,7 @@ using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Operations;
+using Microsoft.Health.Fhir.Core.Features.Routing;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.ValueSets;
 
@@ -38,21 +39,25 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         private readonly ReindexJobConfiguration _config;
         private readonly ILogger<ReindexController> _logger;
         private static Dictionary<string, HashSet<string>> _supportedParams = InitSupportedParams();
+        private readonly IUrlResolver _urlResolver;
 
         public ReindexController(
             IMediator mediator,
             IFhirRequestContextAccessor fhirRequestContextAccessor,
             IOptions<OperationsConfiguration> operationsConfig,
+            IUrlResolver urlResolver,
             ILogger<ReindexController> logger)
         {
             EnsureArg.IsNotNull(mediator, nameof(mediator));
             EnsureArg.IsNotNull(fhirRequestContextAccessor, nameof(fhirRequestContextAccessor));
             EnsureArg.IsNotNull(operationsConfig?.Value?.Reindex, nameof(operationsConfig));
+            EnsureArg.IsNotNull(urlResolver, nameof(urlResolver));
             EnsureArg.IsNotNull(logger, nameof(logger));
 
             _mediator = mediator;
             _fhirRequestContextAccessor = fhirRequestContextAccessor;
             _config = operationsConfig.Value.Reindex;
+            _urlResolver = urlResolver;
             _logger = logger;
         }
 
@@ -71,9 +76,12 @@ namespace Microsoft.Health.Fhir.Api.Controllers
 
             ResourceElement response = await _mediator.CreateReindexJobAsync(maximumConcurrency, scope, HttpContext.RequestAborted);
 
-            return FhirResult.Create(response, HttpStatusCode.Created)
+            var result = FhirResult.Create(response, HttpStatusCode.Created)
                 .SetETagHeader()
                 .SetLastModifiedHeader();
+
+            result.SetContentLocationHeader(_urlResolver, OperationsConstants.Reindex, response.Id);
+            return result;
         }
 
         [HttpGet]
@@ -84,6 +92,20 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             CheckIfReindexIsEnabledAndRespond();
 
             ResourceElement response = await _mediator.GetReindexJobAsync(null, HttpContext.RequestAborted);
+
+            return FhirResult.Create(response, HttpStatusCode.OK)
+                .SetETagHeader()
+                .SetLastModifiedHeader();
+        }
+
+        [HttpGet]
+        [Route(KnownRoutes.ReindexJobLocation, Name = RouteNames.GetReindexStatusById)]
+        [AuditEventType(AuditEventSubType.Reindex)]
+        public async Task<IActionResult> GetReindexJob(string idParameter)
+        {
+            CheckIfReindexIsEnabledAndRespond();
+
+            ResourceElement response = await _mediator.GetReindexJobAsync(idParameter, HttpContext.RequestAborted);
 
             return FhirResult.Create(response, HttpStatusCode.OK)
                 .SetETagHeader()

--- a/src/Microsoft.Health.Fhir.Shared.Core/Extensions/ReindexJobRecordExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Extensions/ReindexJobRecordExtensions.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
 using EnsureThat;
 using Hl7.Fhir.Model;
@@ -23,12 +22,20 @@ namespace Microsoft.Health.Fhir.Core.Extensions
             parametersResource.VersionId = record.ETag.VersionId;
             var job = record.JobRecord;
 
-            var startTime = job.StartTime ?? DateTimeOffset.MinValue;
-            var endTime = job.StartTime ?? DateTimeOffset.MaxValue;
+            parametersResource.Id = job.Id;
             parametersResource.Parameter = new List<Parameters.ParameterComponent>();
             parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = JobRecordProperties.Id, Value = new FhirString(job.Id) });
-            parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = JobRecordProperties.StartTime, Value = new FhirDateTime(startTime) });
-            parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = JobRecordProperties.EndTime, Value = new FhirDateTime(endTime) });
+
+            if (job.StartTime.HasValue)
+            {
+                parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = JobRecordProperties.StartTime, Value = new FhirDateTime(job.StartTime.Value) });
+            }
+
+            if (job.EndTime.HasValue)
+            {
+                parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = JobRecordProperties.EndTime, Value = new FhirDateTime(job.EndTime.Value) });
+            }
+
             parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = JobRecordProperties.Progress, Value = new FhirDecimal(job.PercentComplete) });
             parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = JobRecordProperties.Status, Value = new FhirString(job.Status.ToString()) });
             parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = JobRecordProperties.MaximumConcurrency, Value = new FhirDecimal(job.MaximumConcurrency) });

--- a/src/Microsoft.Health.Fhir.Shared.Core/Extensions/ReindexJobRecordExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Extensions/ReindexJobRecordExtensions.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Health.Fhir.Core.Extensions
                 parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = JobRecordProperties.EndTime, Value = new FhirDateTime(job.EndTime.Value) });
             }
 
+            parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = JobRecordProperties.QueuedTime, Value = new FhirDateTime(job.QueuedTime) });
             parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = JobRecordProperties.Progress, Value = new FhirDecimal(job.PercentComplete) });
             parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = JobRecordProperties.Status, Value = new FhirString(job.Status.ToString()) });
             parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = JobRecordProperties.MaximumConcurrency, Value = new FhirDecimal(job.MaximumConcurrency) });


### PR DESCRIPTION
When a reindex job is first created, it is neither started, nor finished, only queued, so removing start/end time from the returned Parameters resource as the default values where incorrect.  This PR also updates the GET for the reindex job, so you can query the Parameters resource for a job.

## Related issues
Addresses [issue [AB#74594](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/74594)].

## Testing
Additional unit tests added, and manually tested
