### PR TITLE
Fix continuation token issues with chained searches

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/TableExpression.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/TableExpression.cs
@@ -20,7 +20,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions
             Expression normalizedPredicate,
             Expression denormalizedPredicate,
             TableExpressionKind kind,
-            int chainLevel = 0)
+            int chainLevel = 0,
+            Expression denormalizedPredicateOnChainRoot = null)
         {
             switch (normalizedPredicate)
             {
@@ -39,11 +40,14 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions
             DenormalizedPredicate = denormalizedPredicate;
             Kind = kind;
             ChainLevel = chainLevel;
+            DenormalizedPredicateOnChainRoot = denormalizedPredicateOnChainRoot;
         }
 
         public TableExpressionKind Kind { get; }
 
         public int ChainLevel { get; }
+
+        public Expression DenormalizedPredicateOnChainRoot { get; }
 
         public NormalizedSearchParameterQueryGenerator SearchParameterQueryGenerator { get; }
 
@@ -63,7 +67,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions
 
         public override string ToString()
         {
-            return $"(Table {Kind} {(ChainLevel == 0 ? null : $"ChainLevel:{ChainLevel} ")}{SearchParameterQueryGenerator?.Table} Normalized:{NormalizedPredicate} Denormalized:{DenormalizedPredicate})";
+            return $"(Table {Kind} {(ChainLevel == 0 ? null : $"ChainLevel:{ChainLevel} ")}{SearchParameterQueryGenerator?.Table} Normalized:{NormalizedPredicate} Denormalized:{DenormalizedPredicate} DenormalizedOnChainRoot:{DenormalizedPredicateOnChainRoot})";
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/TableExpression.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/TableExpression.cs
@@ -15,6 +15,16 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions
     /// </summary>
     internal class TableExpression : Expression
     {
+        /// <summary>
+        /// Creates a new instance of the <see cref="TableExpression"/> class.
+        /// </summary>
+        /// <param name="searchParameterQueryGenerator">The search parameter query generator</param>
+        /// <param name="normalizedPredicate">The search expression over a columns belonging exclusively to a search parameter table.
+        /// Applies to the chain target if a chained expression.</param>
+        /// <param name="denormalizedPredicate">The search expression over columns that exist the Resource table. Applies to the chain target if a chained expression.</param>
+        /// <param name="kind">The table expression kind.</param>
+        /// <param name="chainLevel">The nesting chain nesting level of the current expression. 0 if not a chain expression.</param>
+        /// <param name="denormalizedPredicateOnChainRoot">The search expression over columns that exist the Resource table. Applies to the chain root if a chained expression.</param>
         public TableExpression(
             NormalizedSearchParameterQueryGenerator searchParameterQueryGenerator,
             Expression normalizedPredicate,
@@ -45,15 +55,28 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions
 
         public TableExpressionKind Kind { get; }
 
+        /// <summary>
+        /// The nesting chain nesting level of the current expression. 0 if not a chain expression.
+        /// </summary>
         public int ChainLevel { get; }
-
-        public Expression DenormalizedPredicateOnChainRoot { get; }
 
         public NormalizedSearchParameterQueryGenerator SearchParameterQueryGenerator { get; }
 
+        /// <summary>
+        /// The search expression over a columns belonging exclusively to a search parameter table.
+        /// Applies to the chain target if a chained expression.
+        /// </summary>
         public Expression NormalizedPredicate { get; }
 
+        /// <summary>
+        /// The search expression over columns that exist the Resource table. Applies to the chain target if a chained expression.
+        /// </summary>
         public Expression DenormalizedPredicate { get; }
+
+        /// <summary>
+        /// The search expression over columns that exist the Resource table. Applies to the chain root if a chained expression.
+        /// </summary>
+        public Expression DenormalizedPredicateOnChainRoot { get; }
 
         public override TOutput AcceptVisitor<TContext, TOutput>(IExpressionVisitor<TContext, TOutput> visitor, TContext context)
         {

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/ChainFlatteningRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/ChainFlatteningRewriter.cs
@@ -66,7 +66,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
                     expression,
                     denormalizedPredicate: normalizedParameterQueryGenerator == null ? expression.Expression : null,
                     TableExpressionKind.Chain,
-                    context.chainLevel);
+                    context.chainLevel,
+                    thisTableExpression?.DenormalizedPredicateOnChainRoot);
             }
 
             if (normalizedParameterQueryGenerator == null)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/DenormalizedPredicateRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/DenormalizedPredicateRewriter.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
 
         public Expression VisitSqlRoot(SqlRootExpression expression, object context)
         {
-            if (expression.TableExpressions.Count == 0 || expression.DenormalizedExpressions.Count == 0 || expression.TableExpressions.All(t => t.Kind == TableExpressionKind.Chain) || expression.TableExpressions.All(t => t.Kind == TableExpressionKind.Include))
+            if (expression.TableExpressions.Count == 0 || expression.DenormalizedExpressions.Count == 0 || expression.TableExpressions.All(t => t.Kind == TableExpressionKind.Include))
             {
                 return expression;
             }
@@ -59,9 +59,13 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
             var newTableExpressions = new List<TableExpression>(expression.TableExpressions.Count);
             foreach (var tableExpression in expression.TableExpressions)
             {
-                if (tableExpression.Kind == TableExpressionKind.Chain || tableExpression.Kind == TableExpressionKind.Include)
+                if (tableExpression.Kind == TableExpressionKind.Include)
                 {
                     newTableExpressions.Add(tableExpression);
+                }
+                else if (tableExpression.Kind == TableExpressionKind.Chain)
+                {
+                    newTableExpressions.Add(new TableExpression(tableExpression.SearchParameterQueryGenerator, tableExpression.NormalizedPredicate, tableExpression.DenormalizedPredicate, tableExpression.Kind, chainLevel: tableExpression.ChainLevel, denormalizedPredicateOnChainRoot: extractedDenormalizedExpression));
                 }
                 else
                 {

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -134,8 +134,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
         public object VisitTable(TableExpression tableExpression, SearchOptions context)
         {
-            string referenceTableAlias = "ref";
-            string resourceTableAlias = "r";
+            const string referenceSourceTableAlias = "refSource";
+            const string referenceTargetResourceTableAlias = "refTarget";
 
             switch (tableExpression.Kind)
             {
@@ -245,43 +245,48 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
                 case TableExpressionKind.Chain:
                     var chainedExpression = (ChainedExpression)tableExpression.NormalizedPredicate;
-                    string resourceTableAlias2 = "r2";
 
                     StringBuilder.Append("SELECT ");
                     if (tableExpression.ChainLevel == 1)
                     {
-                        StringBuilder.Append(VLatest.ReferenceSearchParam.ResourceSurrogateId, referenceTableAlias).Append(" AS ").Append(chainedExpression.Reversed ? "Sid2" : "Sid1").Append(", ");
+                        StringBuilder.Append(VLatest.ReferenceSearchParam.ResourceSurrogateId, referenceSourceTableAlias).Append(" AS ").Append(chainedExpression.Reversed ? "Sid2" : "Sid1").Append(", ");
                     }
                     else
                     {
                         StringBuilder.Append("Sid1, ");
                     }
 
-                    StringBuilder.Append(VLatest.Resource.ResourceSurrogateId, chainedExpression.Reversed && tableExpression.ChainLevel > 1 ? referenceTableAlias : resourceTableAlias).Append(" AS ").AppendLine(chainedExpression.Reversed && tableExpression.ChainLevel == 1 ? "Sid1 " : "Sid2 ")
-                        .Append("FROM ").Append(VLatest.ReferenceSearchParam).Append(' ').AppendLine(referenceTableAlias)
-                        .Append("INNER JOIN ").Append(VLatest.Resource).Append(' ').AppendLine(resourceTableAlias);
+                    StringBuilder.Append(VLatest.Resource.ResourceSurrogateId, chainedExpression.Reversed && tableExpression.ChainLevel > 1 ? referenceSourceTableAlias : referenceTargetResourceTableAlias).Append(" AS ").AppendLine(chainedExpression.Reversed && tableExpression.ChainLevel == 1 ? "Sid1 " : "Sid2 ")
+                        .Append("FROM ").Append(VLatest.ReferenceSearchParam).Append(' ').AppendLine(referenceSourceTableAlias)
+                        .Append("INNER JOIN ").Append(VLatest.Resource).Append(' ').AppendLine(referenceTargetResourceTableAlias);
 
                     using (var delimited = StringBuilder.BeginDelimitedOnClause())
                     {
-                        delimited.BeginDelimitedElement().Append(VLatest.ReferenceSearchParam.ReferenceResourceTypeId, referenceTableAlias)
-                            .Append(" = ").Append(VLatest.Resource.ResourceTypeId, resourceTableAlias);
+                        delimited.BeginDelimitedElement().Append(VLatest.ReferenceSearchParam.ReferenceResourceTypeId, referenceSourceTableAlias)
+                            .Append(" = ").Append(VLatest.Resource.ResourceTypeId, referenceTargetResourceTableAlias);
 
-                        delimited.BeginDelimitedElement().Append(VLatest.ReferenceSearchParam.ReferenceResourceId, referenceTableAlias)
-                            .Append(" = ").Append(VLatest.Resource.ResourceId, resourceTableAlias);
+                        delimited.BeginDelimitedElement().Append(VLatest.ReferenceSearchParam.ReferenceResourceId, referenceSourceTableAlias)
+                            .Append(" = ").Append(VLatest.Resource.ResourceId, referenceTargetResourceTableAlias);
                     }
 
-                    // Denormalized predicates on reverse chains need to be applied via a join to the resource table
-                    if (tableExpression.DenormalizedPredicate != null && chainedExpression.Reversed)
+                    // For reverse chaning, if there is a parameter on the _id search parameter, we need another join to get the resource ID of the reference source (all we have is the surrogate ID at this point)
+
+                    bool denormalizedHandledBySecondJoin = tableExpression.DenormalizedPredicate != null && chainedExpression.Reversed && tableExpression.DenormalizedPredicate.AcceptVisitor(DenormalizedExpressionContainsIdParameterVisitor.Instance, null);
+
+                    if (denormalizedHandledBySecondJoin)
                     {
-                        StringBuilder.Append("INNER JOIN ").Append(VLatest.Resource).Append(' ').AppendLine(resourceTableAlias2);
+                        const string referenceSourceResourceTableAlias = "refSourceResource";
+
+                        denormalizedHandledBySecondJoin = true;
+                        StringBuilder.Append("INNER JOIN ").Append(VLatest.Resource).Append(' ').AppendLine(referenceSourceResourceTableAlias);
 
                         using (var delimited = StringBuilder.BeginDelimitedOnClause())
                         {
-                            delimited.BeginDelimitedElement().Append(VLatest.ReferenceSearchParam.ResourceSurrogateId, referenceTableAlias)
-                                .Append(" = ").Append(VLatest.Resource.ResourceSurrogateId, resourceTableAlias2);
+                            delimited.BeginDelimitedElement().Append(VLatest.ReferenceSearchParam.ResourceSurrogateId, referenceSourceTableAlias)
+                                .Append(" = ").Append(VLatest.Resource.ResourceSurrogateId, referenceSourceResourceTableAlias);
 
                             delimited.BeginDelimitedElement();
-                            tableExpression.DenormalizedPredicate?.AcceptVisitor(DispatchingDenormalizedSearchParameterQueryGenerator.Instance, GetContext(resourceTableAlias2));
+                            tableExpression.DenormalizedPredicate?.AcceptVisitor(DispatchingDenormalizedSearchParameterQueryGenerator.Instance, GetContext(referenceSourceResourceTableAlias));
                         }
                     }
 
@@ -291,34 +296,40 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
                         using (var delimited = StringBuilder.BeginDelimitedOnClause())
                         {
-                            delimited.BeginDelimitedElement().Append(VLatest.Resource.ResourceSurrogateId, chainedExpression.Reversed ? resourceTableAlias : referenceTableAlias).Append(" = ").Append("Sid2");
+                            delimited.BeginDelimitedElement().Append(VLatest.Resource.ResourceSurrogateId, chainedExpression.Reversed ? referenceTargetResourceTableAlias : referenceSourceTableAlias).Append(" = ").Append("Sid2");
                         }
                     }
 
                     using (var delimited = StringBuilder.BeginDelimitedWhereClause())
                     {
-                        delimited.BeginDelimitedElement().Append(VLatest.ReferenceSearchParam.SearchParamId, referenceTableAlias)
+                        delimited.BeginDelimitedElement().Append(VLatest.ReferenceSearchParam.SearchParamId, referenceSourceTableAlias)
                             .Append(" = ").Append(Parameters.AddParameter(VLatest.ReferenceSearchParam.SearchParamId, Model.GetSearchParamId(chainedExpression.ReferenceSearchParameter.Url)));
 
-                        AppendHistoryClause(delimited, resourceTableAlias);
-                        AppendHistoryClause(delimited, referenceTableAlias);
+                        AppendHistoryClause(delimited, referenceTargetResourceTableAlias);
+                        AppendHistoryClause(delimited, referenceSourceTableAlias);
 
-                        delimited.BeginDelimitedElement().Append(VLatest.ReferenceSearchParam.ResourceTypeId, referenceTableAlias)
+                        delimited.BeginDelimitedElement().Append(VLatest.ReferenceSearchParam.ResourceTypeId, referenceSourceTableAlias)
                             .Append(" = ").Append(Parameters.AddParameter(VLatest.ReferenceSearchParam.ResourceTypeId, Model.GetResourceTypeId(chainedExpression.ResourceType)));
 
-                        delimited.BeginDelimitedElement().Append(VLatest.ReferenceSearchParam.ReferenceResourceTypeId, referenceTableAlias)
+                        delimited.BeginDelimitedElement().Append(VLatest.ReferenceSearchParam.ReferenceResourceTypeId, referenceSourceTableAlias)
                             .Append(" = ").Append(Parameters.AddParameter(VLatest.ReferenceSearchParam.ReferenceResourceTypeId, Model.GetResourceTypeId(chainedExpression.TargetResourceType)));
 
                         if (tableExpression.ChainLevel == 1)
                         {
                             // if > 1, the intersection is handled by the JOIN
-                            AppendIntersectionWithPredecessor(delimited, tableExpression, chainedExpression.Reversed ? resourceTableAlias : referenceTableAlias);
+                            AppendIntersectionWithPredecessor(delimited, tableExpression, chainedExpression.Reversed ? referenceTargetResourceTableAlias : referenceSourceTableAlias);
                         }
 
-                        if (tableExpression.DenormalizedPredicate != null && !chainedExpression.Reversed)
+                        if (tableExpression.DenormalizedPredicate != null && !denormalizedHandledBySecondJoin)
                         {
                             delimited.BeginDelimitedElement();
-                            tableExpression.DenormalizedPredicate?.AcceptVisitor(DispatchingDenormalizedSearchParameterQueryGenerator.Instance, GetContext(resourceTableAlias));
+                            tableExpression.DenormalizedPredicate?.AcceptVisitor(DispatchingDenormalizedSearchParameterQueryGenerator.Instance, GetContext(chainedExpression.Reversed ? referenceSourceTableAlias : referenceTargetResourceTableAlias));
+                        }
+
+                        if (tableExpression.DenormalizedPredicateOnChainRoot != null)
+                        {
+                            delimited.BeginDelimitedElement();
+                            tableExpression.DenormalizedPredicateOnChainRoot.AcceptVisitor(DispatchingDenormalizedSearchParameterQueryGenerator.Instance, GetContext(chainedExpression.Reversed ? referenceTargetResourceTableAlias : referenceSourceTableAlias));
                         }
                     }
 
@@ -327,42 +338,42 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     var includeExpression = (IncludeExpression)tableExpression.NormalizedPredicate;
 
                     StringBuilder.Append("SELECT DISTINCT ");
-                    StringBuilder.Append(VLatest.Resource.ResourceSurrogateId, resourceTableAlias).AppendLine(" AS Sid1, 0 AS IsMatch")
-                        .Append("FROM ").Append(VLatest.ReferenceSearchParam).Append(' ').AppendLine(referenceTableAlias)
-                        .Append("INNER JOIN ").Append(VLatest.Resource).Append(' ').AppendLine(resourceTableAlias);
+                    StringBuilder.Append(VLatest.Resource.ResourceSurrogateId, referenceTargetResourceTableAlias).AppendLine(" AS Sid1, 0 AS IsMatch")
+                        .Append("FROM ").Append(VLatest.ReferenceSearchParam).Append(' ').AppendLine(referenceSourceTableAlias)
+                        .Append("INNER JOIN ").Append(VLatest.Resource).Append(' ').AppendLine(referenceTargetResourceTableAlias);
 
                     using (var delimited = StringBuilder.BeginDelimitedOnClause())
                     {
-                        delimited.BeginDelimitedElement().Append(VLatest.ReferenceSearchParam.ReferenceResourceTypeId, referenceTableAlias)
-                            .Append(" = ").Append(VLatest.Resource.ResourceTypeId, resourceTableAlias);
+                        delimited.BeginDelimitedElement().Append(VLatest.ReferenceSearchParam.ReferenceResourceTypeId, referenceSourceTableAlias)
+                            .Append(" = ").Append(VLatest.Resource.ResourceTypeId, referenceTargetResourceTableAlias);
 
-                        delimited.BeginDelimitedElement().Append(VLatest.ReferenceSearchParam.ReferenceResourceId, referenceTableAlias)
-                            .Append(" = ").Append(VLatest.Resource.ResourceId, resourceTableAlias);
+                        delimited.BeginDelimitedElement().Append(VLatest.ReferenceSearchParam.ReferenceResourceId, referenceSourceTableAlias)
+                            .Append(" = ").Append(VLatest.Resource.ResourceId, referenceTargetResourceTableAlias);
                     }
 
                     using (var delimited = StringBuilder.BeginDelimitedWhereClause())
                     {
                         if (!includeExpression.WildCard)
                         {
-                            delimited.BeginDelimitedElement().Append(VLatest.ReferenceSearchParam.SearchParamId, referenceTableAlias)
+                            delimited.BeginDelimitedElement().Append(VLatest.ReferenceSearchParam.SearchParamId, referenceSourceTableAlias)
                                 .Append(" = ").Append(Parameters.AddParameter(VLatest.ReferenceSearchParam.SearchParamId, Model.GetSearchParamId(includeExpression.ReferenceSearchParameter.Url)));
 
                             if (includeExpression.TargetResourceType != null)
                             {
-                                delimited.BeginDelimitedElement().Append(VLatest.ReferenceSearchParam.ReferenceResourceTypeId, referenceTableAlias)
+                                delimited.BeginDelimitedElement().Append(VLatest.ReferenceSearchParam.ReferenceResourceTypeId, referenceSourceTableAlias)
                                     .Append(" = ").Append(Parameters.AddParameter(VLatest.ReferenceSearchParam.ReferenceResourceTypeId, Model.GetResourceTypeId(includeExpression.TargetResourceType)));
                             }
                         }
 
-                        AppendHistoryClause(delimited, resourceTableAlias);
-                        AppendHistoryClause(delimited, referenceTableAlias);
+                        AppendHistoryClause(delimited, referenceTargetResourceTableAlias);
+                        AppendHistoryClause(delimited, referenceSourceTableAlias);
 
-                        delimited.BeginDelimitedElement().Append(VLatest.ReferenceSearchParam.ResourceTypeId, referenceTableAlias)
+                        delimited.BeginDelimitedElement().Append(VLatest.ReferenceSearchParam.ResourceTypeId, referenceSourceTableAlias)
                             .Append(" = ").Append(Parameters.AddParameter(VLatest.ReferenceSearchParam.ResourceTypeId, Model.GetResourceTypeId(includeExpression.ResourceType)));
 
                         // Limit the join to the main select CTE.
                         // The main select will have max+1 items in the result set to account for paging, so we only want to join using the max amount.
-                        delimited.BeginDelimitedElement().Append(VLatest.Resource.ResourceSurrogateId, referenceTableAlias)
+                        delimited.BeginDelimitedElement().Append(VLatest.Resource.ResourceSurrogateId, referenceSourceTableAlias)
                             .Append(" IN (SELECT TOP(")
                             .Append(Parameters.AddParameter(context.MaxItemCount))
                             .Append(") Sid1 FROM ").Append(_cteMainSelect).Append(")");
@@ -452,6 +463,21 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
                 StringBuilder.Append(VLatest.Resource.IsHistory, tableAlias).Append(" = 0");
             }
+        }
+
+        /// <summary>
+        /// A visitor to determine if there are any references to the _id search parameter in an expression
+        /// </summary>
+        private class DenormalizedExpressionContainsIdParameterVisitor : DefaultExpressionVisitor<object, bool>
+        {
+            public static readonly DenormalizedExpressionContainsIdParameterVisitor Instance = new DenormalizedExpressionContainsIdParameterVisitor();
+
+            private DenormalizedExpressionContainsIdParameterVisitor()
+            : base((acc, curr) => acc || curr)
+            {
+            }
+
+            public override bool VisitSearchParameter(SearchParameterExpression expression, object context) => expression.Parameter.Name == SearchParameterNames.Id;
         }
     }
 }


### PR DESCRIPTION
## Description
We were not "promoting" denormalized predicates to chained table expressions. This would have the result of the continuation clause (a predicate on `ResourceSurrgodateId`) being applied after the `TOP` clause had been applied.

The fix is to promote the denomalized predicate to the chained table expression, but to not mix it in with the `DenormalizedPredicate` field -  which is used to store the denormalized predicate on chain target - but to introduce a new `DenormalizedPredicateOnChainRoot` property.

## Related issues
Addresses #1095 
Addresses #1102  

## Testing
Added E2E and unit tests.
