### PR TITLE
Fix errors when _summary=count or _total=accurate is specified with an _include parameter

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/RemoveIncludesRewriterTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/RemoveIncludesRewriterTests.cs
@@ -1,0 +1,36 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
+using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
+{
+    public class RemoveIncludesRewriterTests
+    {
+        [Fact]
+        public void GivenAnExpressionWithIncludes_WhenVisitedByRemoveIncludesRewriter_IncludesAreRemoved()
+        {
+            IncludeExpression includeExpression = Expression.Include("a", new SearchParameterInfo("p", "Token"), "Patient", false);
+            BinaryExpression fieldExpression = Expression.Equals(FieldName.Number, null, 1);
+
+            Assert.Null(includeExpression.AcceptVisitor(RemoveIncludesRewriter.Instance));
+            Assert.Null(Expression.And(includeExpression, includeExpression).AcceptVisitor(RemoveIncludesRewriter.Instance));
+
+            Assert.Same(fieldExpression, fieldExpression.AcceptVisitor(RemoveIncludesRewriter.Instance));
+            var andWithoutIncludes = Expression.And(fieldExpression, fieldExpression);
+            Assert.Same(andWithoutIncludes, andWithoutIncludes.AcceptVisitor(RemoveIncludesRewriter.Instance));
+
+            Assert.Same(fieldExpression, Expression.And(includeExpression, fieldExpression).AcceptVisitor(RemoveIncludesRewriter.Instance));
+            Assert.Same(fieldExpression, Expression.And(fieldExpression, includeExpression).AcceptVisitor(RemoveIncludesRewriter.Instance));
+
+            Assert.Equal(andWithoutIncludes.ToString(), Expression.And(includeExpression, fieldExpression, fieldExpression).AcceptVisitor(RemoveIncludesRewriter.Instance).ToString());
+            Assert.Equal(andWithoutIncludes.ToString(), Expression.And(fieldExpression, includeExpression, fieldExpression).AcceptVisitor(RemoveIncludesRewriter.Instance).ToString());
+            Assert.Equal(andWithoutIncludes.ToString(), Expression.And(fieldExpression, fieldExpression, includeExpression).AcceptVisitor(RemoveIncludesRewriter.Instance).ToString());
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/RemoveIncludesRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/RemoveIncludesRewriter.cs
@@ -1,0 +1,54 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
+
+namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
+{
+    /// <summary>
+    /// A rewriter that removes <see cref="IncludeExpression">s from an expression tree.
+    /// </summary>
+    internal class RemoveIncludesRewriter : ExpressionRewriterWithInitialContext<object>
+    {
+        public static readonly RemoveIncludesRewriter Instance = new RemoveIncludesRewriter();
+
+        public override Expression VisitInclude(IncludeExpression expression, object context)
+        {
+            return null;
+        }
+
+        public override Expression VisitMultiary(MultiaryExpression expression, object context)
+        {
+            List<Expression> newChildExpressions = null;
+            for (int i = 0; i < expression.Expressions.Count; i++)
+            {
+                Expression childExpression = expression.Expressions[i];
+                if (childExpression is IncludeExpression)
+                {
+                    if (i == 0 && expression.Expressions.All(e => e is IncludeExpression))
+                    {
+                        return null;
+                    }
+
+                    EnsureAllocatedAndPopulated(ref newChildExpressions, expression.Expressions, i);
+                }
+                else
+                {
+                    newChildExpressions?.Add(childExpression);
+                }
+            }
+
+            return newChildExpressions switch
+            {
+                null => expression,
+                { Count: 0 } => null,
+                { Count: 1 } => newChildExpressions[0],
+                _ => new MultiaryExpression(expression.MultiaryOperation, newChildExpressions)
+            };
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -82,8 +82,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                 // If this is the first page and there aren't any more pages
                 if (searchOptions.ContinuationToken == null && searchResult.ContinuationToken == null)
                 {
-                    // Count the results on the page.
-                    searchResult.TotalCount = searchResult.Results.Count();
+                    // Count the match results on the page.
+                    searchResult.TotalCount = searchResult.Results.Count(r => r.SearchEntryMode == SearchEntryMode.Match);
                 }
                 else
                 {
@@ -138,6 +138,12 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                 {
                     throw new BadRequestException(Resources.InvalidContinuationToken);
                 }
+            }
+
+            if (searchOptions.CountOnly)
+            {
+                // if we're only returning a count, discard any _include parameters since included resources are not counted.
+                searchExpression = searchExpression?.AcceptVisitor(RemoveIncludesRewriter.Instance);
             }
 
             SqlRootExpression expression = (SqlRootExpression)searchExpression

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             bundle = await Client.SearchAsync(ResourceType.Location, $"{query}&_summary=count");
             Assert.Equal(1, bundle.Total);
 
-            // ensure that the included resources are not counted when _total is specified and the results fi in a single bundle.
+            // ensure that the included resources are not counted when _total is specified and the results fit in a single bundle.
             bundle = await Client.SearchAsync(ResourceType.Location, $"{query}&_total=accurate");
             Assert.Equal(1, bundle.Total);
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
@@ -44,6 +44,14 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 locationResponse.Resource);
 
             ValidateSearchEntryMode(bundle, ResourceType.Location);
+
+            // ensure that the included resources are not counted
+            bundle = await Client.SearchAsync(ResourceType.Location, $"{query}&_summary=count");
+            Assert.Equal(1, bundle.Total);
+
+            // ensure that the included resources are not counted when _total is specified and the results fi in a single bundle.
+            bundle = await Client.SearchAsync(ResourceType.Location, $"{query}&_total=accurate");
+            Assert.Equal(1, bundle.Total);
         }
 
         [Fact]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
@@ -130,8 +130,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [Fact]
         public async Task GivenAnIncludeSearchExpressionWithSimpleSearchAndCount_WhenSearched_ThenCorrectBundleShouldBeReturned()
         {
-            // Workaround for issue (https://github.com/microsoft/fhir-server/issues/1011) SQL DataProvider _total=accurate does not work with _include searches
-            string query = $"_tag={Fixture.Tag}&_include=DiagnosticReport:patient:Patient&code=429858000&_count=1&_total=none";
+            string query = $"_tag={Fixture.Tag}&_include=DiagnosticReport:patient:Patient&code=429858000&_count=1";
 
             Bundle bundle = await Client.SearchAsync(ResourceType.DiagnosticReport, query);
 


### PR DESCRIPTION
## Description
We generated invalid SQL when `_summary=count` and `_include` are specified together. For `total=accurate` we would either have the same error or would return an incorrect total id the results all fit in a single bundle.

The fix is to add another visitor pass and to only count match results when computing total from a bundle.

## Related issues
Addresses #1011 

## Testing
Unit and E2E tests
