### PR TITLE
Added a deploy master images step to CI build

### DIFF
--- a/build/ci-pipeline.yml
+++ b/build/ci-pipeline.yml
@@ -143,16 +143,17 @@ stages:
       version: R5
       keyVaultName: $(DeploymentEnvironmentNameR5)
 
-- stage: buildMasterImages
-  displayName: 'Build master images'
+- stage: DockerAddTag
+  displayName: 'Docker add master tag'
   dependsOn:
   - testStu3
   - testR4
   - testR5
   jobs:
-  - template: ./jobs/docker-build-all.yml
-    parameters: 
-      tag: master
+  - template: ./jobs/docker-add-tag.yml
+    parameters:
+      sourceTag: $(ImageTag)
+      targetTag: 'master'
 
 - stage: cleanStorageAccounts
   displayName: 'Clean Storage Accounts'

--- a/build/ci-pipeline.yml
+++ b/build/ci-pipeline.yml
@@ -143,6 +143,17 @@ stages:
       version: R5
       keyVaultName: $(DeploymentEnvironmentNameR5)
 
+- stage: buildMasterImages
+  displayName: 'Build master images'
+  dependsOn:
+  - testStu3
+  - testR4
+  - testR5
+  jobs:
+  - template: ./jobs/docker-build-all.yml
+    parameters: 
+      tag: master
+
 - stage: cleanStorageAccounts
   displayName: 'Clean Storage Accounts'
   dependsOn: []

--- a/build/jobs/docker-add-tag.yml
+++ b/build/jobs/docker-add-tag.yml
@@ -6,7 +6,7 @@ parameters:
   type: string
 
 jobs:
-- job: Docker Add Tag
+- job: DockerAddTag
   pool:
     vmImage: 'ubuntu-latest'
   steps:

--- a/build/jobs/docker-add-tag.yml
+++ b/build/jobs/docker-add-tag.yml
@@ -19,8 +19,8 @@ jobs:
       inlineScript: |
         az acr login -n $(azureContainerRegistry)
         for v in stu3 r4 r5; do
-          sourceImage="$(azureContainerRegistry)/${v}_fhir-server:${{parameters.sourceTag}}
-          targetImage="$(azureContainerRegistry)/${v}_fhir-server:${{parameters.targetTag}}
+          sourceImage="$(azureContainerRegistry)/${v}_fhir-server:${{parameters.sourceTag}}"
+          targetImage="$(azureContainerRegistry)/${v}_fhir-server:${{parameters.targetTag}}"
           docker pull $sourceImage
           docker tag $sourceImage $targetImage
           docker push $targetImage

--- a/build/jobs/docker-add-tag.yml
+++ b/build/jobs/docker-add-tag.yml
@@ -1,0 +1,27 @@
+
+parameters:
+- name: sourceTag
+  type: string
+- name: targetTag
+  type: string
+
+jobs:
+- job: Docker Add Tag
+  pool:
+    vmImage: 'ubuntu-latest'
+  steps:
+  - task: AzureCLI@2
+    displayName: 'Azure CLI: InlineScript'
+    inputs:
+      azureSubscription: $(ConnectedServiceName)
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        az acr login -n $(azureContainerRegistry)
+        for v in stu3 r4 r5; do
+          sourceImage="$(azureContainerRegistry)/${v}_fhir-server:${{parameters.sourceTag}}
+          targetImage="$(azureContainerRegistry)/${v}_fhir-server:${{parameters.targetTag}}
+          docker pull $sourceImage
+          docker tag $sourceImage $targetImage
+          docker push $targetImage
+        done

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -35,6 +35,16 @@ stages:
     parameters: 
       tag: $(ImageTag)
 
+- stage: DockerAddTag
+  displayName: 'Docker add tag'
+  dependsOn:
+  - DockerBuild
+  jobs:
+  - template: ./jobs/docker-add-tag.yml
+    parameters:
+      sourceTag: $(ImageTag)
+      targetTag: 'myTestTag'
+
 - stage: provisionEnvironment
   displayName: Provision Environment
   dependsOn: []

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -35,16 +35,6 @@ stages:
     parameters: 
       tag: $(ImageTag)
 
-- stage: DockerAddTag
-  displayName: 'Docker add tag'
-  dependsOn:
-  - DockerBuild
-  jobs:
-  - template: ./jobs/docker-add-tag.yml
-    parameters:
-      sourceTag: $(ImageTag)
-      targetTag: 'mytesttag'
-
 - stage: provisionEnvironment
   displayName: Provision Environment
   dependsOn: []

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -43,7 +43,7 @@ stages:
   - template: ./jobs/docker-add-tag.yml
     parameters:
       sourceTag: $(ImageTag)
-      targetTag: 'myTestTag'
+      targetTag: 'mytesttag'
 
 - stage: provisionEnvironment
   displayName: Provision Environment


### PR DESCRIPTION
## Description
Images with tag `master` were no longer being updated on successful CI build and deploy. This adds tag `master` back as a last known good version of the master branch.

## Testing
The stage was first added to the PR pipeline to ensure it adds tag correctly and then moved to the CI pipeline.