### PR TITLE
Add YAML file indent to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -162,3 +162,7 @@ indent_size = 2
 end_of_line = lf
 [*.{cmd, bat}]
 end_of_line = crlf
+
+# YAML files
+[*.{yml, yaml}]
+indent_size = 2


### PR DESCRIPTION
## Description
Updates the `.editorconfig` to have a section for setting the YAML file indent sizing to 2 spaces.