### PR TITLE
Removes remaining reference to SqlServerModelInitializer

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 using System.Data;
 using System.Data.SqlClient;
 using System.Linq;
-using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -330,7 +329,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
         {
             if (!_started)
             {
-                _logger.LogError($"The {nameof(SqlServerModelInitializer)} instance has not been initialized.");
+                _logger.LogError($"The {nameof(SqlServerFhirModel)} instance has not been initialized.");
                 throw new ServiceUnavailableException();
             }
         }


### PR DESCRIPTION
## Description
`SqlServerModelInitializer.cs` has been removed from the healthcare shared components repo in [PR #50](https://github.com/microsoft/healthcare-shared-components/pull/50). This PR removes a remaining reference to the `SqlServerModelInitializer` class.

## Related issues
Addresses [#AB74855](https://microsofthealth.visualstudio.com/Health/_workitems/edit/74855).

## Testing
All tests pass as before.
