### PR TITLE
Helper method to calculate hash of search parameters

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/SearchHelperUtilitiesTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/SearchHelperUtilitiesTests.cs
@@ -14,19 +14,19 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
     public class SearchHelperUtilitiesTests
     {
         [Fact]
-        public void GivenNullSearchParamInfo_WhenCalculateSearchParamHash_ThenThrowsException()
+        public void GivenNullSearchParamInfo_WhenCalculateSearchParameterNameHash_ThenThrowsException()
         {
             Assert.ThrowsAny<Exception>(() => SearchHelperUtilities.CalculateSearchParameterNameHash(null));
         }
 
         [Fact]
-        public void GivenEmptySearchParamInfo_WhenCalculateSearchParamHash_ThenThrowsException()
+        public void GivenEmptySearchParamInfo_WhenCalculateSearchParameterNameHash_ThenThrowsException()
         {
             Assert.ThrowsAny<Exception>(() => SearchHelperUtilities.CalculateSearchParameterNameHash(new List<SearchParameterInfo>()));
         }
 
         [Fact]
-        public void GivenTwoSameListsOfSearchParamInfo_WhenCalculateSearchParamHash_ThenHashIsSame()
+        public void GivenTwoSameListsOfSearchParamInfo_WhenCalculateSearchParameterNameHash_ThenHashIsSame()
         {
             IEnumerable<SearchParameterInfo> paramInfo1 = GenerateSearchParamInfo("_type", "supplement", "study");
             IEnumerable<SearchParameterInfo> paramInfo2 = GenerateSearchParamInfo("_type", "supplement", "study");
@@ -38,7 +38,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         }
 
         [Fact]
-        public void GivenTwoDifferentListsOfSearchParamInfo_WhenCalculateSearchParamHash_ThenHashIsNotSame()
+        public void GivenTwoDifferentListsOfSearchParamInfo_WhenCalculateSearchParameterNameHash_ThenHashIsNotSame()
         {
             IEnumerable<SearchParameterInfo> paramInfo1 = GenerateSearchParamInfo("_type", "supplement", "study");
             IEnumerable<SearchParameterInfo> paramInfo2 = GenerateSearchParamInfo("_type", "study");
@@ -50,7 +50,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         }
 
         [Fact]
-        public void GivenTwoSameListsDifferentOrderOfSearchParamInfo_WhenCalculateSearchParamHash_ThenHashIsNotSame()
+        public void GivenTwoSameListsDifferentOrderOfSearchParamInfo_WhenCalculateSearchParameterNameHash_ThenHashIsSame()
         {
             IEnumerable<SearchParameterInfo> paramInfo1 = GenerateSearchParamInfo("_type", "supplement", "study");
             IEnumerable<SearchParameterInfo> paramInfo2 = GenerateSearchParamInfo("_type", "study", "supplement");

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/SearchHelperUtilitiesTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/SearchHelperUtilitiesTests.cs
@@ -18,78 +18,73 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         private readonly Uri _paramUri3 = new Uri("https://localhost/searchParam3");
 
         [Fact]
-        public void GivenNullSearchParamInfo_WhenCalculateSearchParameterNameHash_ThenThrowsException()
+        public void GivenNullResourceSearchParameterStatus_WhenCalculateSearchParameterHash_ThenThrowsException()
         {
-            Assert.ThrowsAny<Exception>(() => SearchHelperUtilities.CalculateSearchParameterNameHash(null));
+            Assert.ThrowsAny<Exception>(() => SearchHelperUtilities.CalculateSearchParameterHash(null));
         }
 
         [Fact]
-        public void GivenEmptySearchParamInfo_WhenCalculateSearchParameterNameHash_ThenThrowsException()
+        public void GivenEmptyResourceSearchParameterStatus_WhenCalculateSearchParameterHash_ThenThrowsException()
         {
-            Assert.ThrowsAny<Exception>(() => SearchHelperUtilities.CalculateSearchParameterNameHash(new List<ResourceSearchParameterStatus>()));
+            Assert.ThrowsAny<Exception>(() => SearchHelperUtilities.CalculateSearchParameterHash(new List<ResourceSearchParameterStatus>()));
         }
 
         [Fact]
-        public void GivenTwoSameListsOfResourceSearchParameterStatus_WhenCalculateSearchParameterNameHash_ThenHashIsSame()
+        public void GivenTwoSameListsOfResourceSearchParameterStatus_WhenCalculateSearchParameterHash_ThenHashIsSame()
         {
             DateTimeOffset lastUpdated = DateTimeOffset.UtcNow;
             var param1 = GenerateResourceSearchParameterStatus(_paramUri1, lastUpdated);
             var param2 = GenerateResourceSearchParameterStatus(_paramUri2, lastUpdated);
 
-            string hash1 = SearchHelperUtilities.CalculateSearchParameterNameHash(new List<ResourceSearchParameterStatus>() { param1, param2 });
-            string hash2 = SearchHelperUtilities.CalculateSearchParameterNameHash(new List<ResourceSearchParameterStatus>() { param1, param2 });
+            string hash1 = SearchHelperUtilities.CalculateSearchParameterHash(new List<ResourceSearchParameterStatus>() { param1, param2 });
+            string hash2 = SearchHelperUtilities.CalculateSearchParameterHash(new List<ResourceSearchParameterStatus>() { param1, param2 });
 
             Assert.Equal(hash1, hash2);
         }
 
         [Fact]
-        public void GivenTwoDifferentListsOfResourceSearchParameterStatus_WhenCalculateSearchParameterNameHash_ThenHashIsDifferent()
+        public void GivenTwoDifferentListsOfResourceSearchParameterStatus_WhenCalculateSearchParameterHash_ThenHashIsDifferent()
         {
             DateTimeOffset lastUpdated = DateTimeOffset.UtcNow;
             var param1 = GenerateResourceSearchParameterStatus(_paramUri1, lastUpdated);
             var param2 = GenerateResourceSearchParameterStatus(_paramUri2, lastUpdated);
 
-            string hash1 = SearchHelperUtilities.CalculateSearchParameterNameHash(new List<ResourceSearchParameterStatus>() { param1, param2 });
-            string hash2 = SearchHelperUtilities.CalculateSearchParameterNameHash(new List<ResourceSearchParameterStatus>() { param1 });
+            string hash1 = SearchHelperUtilities.CalculateSearchParameterHash(new List<ResourceSearchParameterStatus>() { param1, param2 });
+            string hash2 = SearchHelperUtilities.CalculateSearchParameterHash(new List<ResourceSearchParameterStatus>() { param1 });
 
             Assert.NotEqual(hash1, hash2);
         }
 
         [Fact]
-        public void GivenTwoSameListsDifferentOrderOfResourceSearchParameterStatus_WhenCalculateSearchParameterNameHash_ThenHashIsSame()
+        public void GivenTwoSameListsDifferentOrderOfResourceSearchParameterStatus_WhenCalculateSearchParameterHash_ThenHashIsSame()
         {
             DateTimeOffset lastUpdated = DateTimeOffset.UtcNow;
             var param1 = GenerateResourceSearchParameterStatus(_paramUri1, lastUpdated);
             var param2 = GenerateResourceSearchParameterStatus(_paramUri2, lastUpdated);
             var param3 = GenerateResourceSearchParameterStatus(_paramUri3, lastUpdated);
 
-            string hash1 = SearchHelperUtilities.CalculateSearchParameterNameHash(new List<ResourceSearchParameterStatus>() { param1, param2, param3 });
-            string hash2 = SearchHelperUtilities.CalculateSearchParameterNameHash(new List<ResourceSearchParameterStatus>() { param2, param3, param1 });
+            string hash1 = SearchHelperUtilities.CalculateSearchParameterHash(new List<ResourceSearchParameterStatus>() { param1, param2, param3 });
+            string hash2 = SearchHelperUtilities.CalculateSearchParameterHash(new List<ResourceSearchParameterStatus>() { param2, param3, param1 });
 
             Assert.Equal(hash1, hash2);
         }
 
         [Fact]
-        public void GivenTwoSameListsDifferentLastUpdatedResourceSearchParameterStatus_WhenCalculateSearchParameterNameHash_ThenHashIsDifferent()
+        public void GivenTwoSameListsDifferentLastUpdatedResourceSearchParameterStatus_WhenCalculateSearchParameterHash_ThenHashIsDifferent()
         {
             DateTimeOffset lastUpdated = DateTimeOffset.UtcNow.AddSeconds(-600);
             var param1 = GenerateResourceSearchParameterStatus(_paramUri1, lastUpdated);
             var param2 = GenerateResourceSearchParameterStatus(_paramUri2, lastUpdated);
             var latestParam1 = GenerateResourceSearchParameterStatus(_paramUri1, DateTimeOffset.UtcNow);
 
-            string hash1 = SearchHelperUtilities.CalculateSearchParameterNameHash(new List<ResourceSearchParameterStatus>() { param1, param2 });
-            string hash2 = SearchHelperUtilities.CalculateSearchParameterNameHash(new List<ResourceSearchParameterStatus>() { latestParam1, param2 });
+            string hash1 = SearchHelperUtilities.CalculateSearchParameterHash(new List<ResourceSearchParameterStatus>() { param1, param2 });
+            string hash2 = SearchHelperUtilities.CalculateSearchParameterHash(new List<ResourceSearchParameterStatus>() { latestParam1, param2 });
 
             Assert.NotEqual(hash1, hash2);
         }
 
         private ResourceSearchParameterStatus GenerateResourceSearchParameterStatus(Uri uri, DateTimeOffset lastUpdated)
         {
-            if (lastUpdated == default)
-            {
-                lastUpdated = DateTimeOffset.UtcNow;
-            }
-
             return new ResourceSearchParameterStatus()
             {
                 Uri = uri,

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/SearchHelperUtilitiesTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/SearchHelperUtilitiesTests.cs
@@ -1,0 +1,75 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Health.Fhir.Core.Features.Search;
+using Microsoft.Health.Fhir.Core.Models;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
+{
+    public class SearchHelperUtilitiesTests
+    {
+        [Fact]
+        public void GivenNullSearchParamInfo_WhenCalculateSearchParamHash_ThenThrowsException()
+        {
+            Assert.ThrowsAny<Exception>(() => SearchHelperUtilities.CalculateSearchParameterNameHash(null));
+        }
+
+        [Fact]
+        public void GivenEmptySearchParamInfo_WhenCalculateSearchParamHash_ThenThrowsException()
+        {
+            Assert.ThrowsAny<Exception>(() => SearchHelperUtilities.CalculateSearchParameterNameHash(new List<SearchParameterInfo>()));
+        }
+
+        [Fact]
+        public void GivenTwoSameListsOfSearchParamInfo_WhenCalculateSearchParamHash_ThenHashIsSame()
+        {
+            IEnumerable<SearchParameterInfo> paramInfo1 = GenerateSearchParamInfo("_type", "supplement", "study");
+            IEnumerable<SearchParameterInfo> paramInfo2 = GenerateSearchParamInfo("_type", "supplement", "study");
+
+            string hash1 = SearchHelperUtilities.CalculateSearchParameterNameHash(paramInfo1);
+            string hash2 = SearchHelperUtilities.CalculateSearchParameterNameHash(paramInfo2);
+
+            Assert.Equal(hash1, hash2);
+        }
+
+        [Fact]
+        public void GivenTwoDifferentListsOfSearchParamInfo_WhenCalculateSearchParamHash_ThenHashIsNotSame()
+        {
+            IEnumerable<SearchParameterInfo> paramInfo1 = GenerateSearchParamInfo("_type", "supplement", "study");
+            IEnumerable<SearchParameterInfo> paramInfo2 = GenerateSearchParamInfo("_type", "study");
+
+            string hash1 = SearchHelperUtilities.CalculateSearchParameterNameHash(paramInfo1);
+            string hash2 = SearchHelperUtilities.CalculateSearchParameterNameHash(paramInfo2);
+
+            Assert.NotEqual(hash1, hash2);
+        }
+
+        [Fact]
+        public void GivenTwoSameListsDifferentOrderOfSearchParamInfo_WhenCalculateSearchParamHash_ThenHashIsNotSame()
+        {
+            IEnumerable<SearchParameterInfo> paramInfo1 = GenerateSearchParamInfo("_type", "supplement", "study");
+            IEnumerable<SearchParameterInfo> paramInfo2 = GenerateSearchParamInfo("_type", "study", "supplement");
+
+            string hash1 = SearchHelperUtilities.CalculateSearchParameterNameHash(paramInfo1);
+            string hash2 = SearchHelperUtilities.CalculateSearchParameterNameHash(paramInfo2);
+
+            Assert.Equal(hash1, hash2);
+        }
+
+        private List<SearchParameterInfo> GenerateSearchParamInfo(params string[] searchParamNames)
+        {
+            List<SearchParameterInfo> paramInfo = new List<SearchParameterInfo>();
+            foreach (string paramName in searchParamNames)
+            {
+                paramInfo.Add(new SearchParameterInfo(paramName));
+            }
+
+            return paramInfo;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchHelperUtilities.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchHelperUtilities.cs
@@ -8,29 +8,30 @@ using System.Linq;
 using System.Text;
 using EnsureThat;
 using Microsoft.Health.Core.Extensions;
-using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.Core.Features.Search.Registry;
 
 namespace Microsoft.Health.Fhir.Core.Features.Search
 {
     public static class SearchHelperUtilities
     {
         /// <summary>
-        /// Given a list of <see cref="SearchParameterInfo"/> calculates a hash using the
-        /// <see cref="SearchParameterInfo.Name"/> values of each component.
-        /// The same collection of search parameters (irrespective of their order in the input)
+        /// Given a list of <see cref="ResourceSearchParameterStatus"/> calculates a hash using the
+        /// <see cref="ResourceSearchParameterStatus.Uri"/> and <see cref="ResourceSearchParameterStatus.LastUpdated"/>
+        /// values of each component. The same collection of search parameter status (irrespective of their order in the input)
         /// will return the same hash.
         /// </summary>
-        /// <param name="searchParamInfo">A list of <see cref="SearchSearchParameterInfo" /></param>
-        /// <returns>A hash based on the search parameter names present in the input.</returns>
-        public static string CalculateSearchParameterNameHash(IEnumerable<SearchParameterInfo> searchParamInfo)
+        /// <param name="resourceSearchParameterStatus">A list of <see cref="ResourceSearchParameterStatus" /></param>
+        /// <returns>A hash based on the search parameter uri and last updated value.</returns>
+        public static string CalculateSearchParameterNameHash(IEnumerable<ResourceSearchParameterStatus> resourceSearchParameterStatus)
         {
-            EnsureArg.IsNotNull(searchParamInfo, nameof(searchParamInfo));
-            EnsureArg.IsGt(searchParamInfo.Count(), 0, nameof(searchParamInfo));
+            EnsureArg.IsNotNull(resourceSearchParameterStatus, nameof(resourceSearchParameterStatus));
+            EnsureArg.IsGt(resourceSearchParameterStatus.Count(), 0, nameof(resourceSearchParameterStatus));
 
             StringBuilder sb = new StringBuilder();
-            foreach (string paramName in searchParamInfo.Select(x => x.Name).OrderBy(x => x))
+            foreach (ResourceSearchParameterStatus searchParameterStatus in resourceSearchParameterStatus.OrderBy(x => x.Uri.ToString()))
             {
-                sb.Append(paramName);
+                sb.Append(searchParameterStatus.Uri.ToString());
+                sb.Append(searchParameterStatus.LastUpdated.ToString());
             }
 
             string hash = sb.ToString().ComputeHash();

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchHelperUtilities.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchHelperUtilities.cs
@@ -1,0 +1,40 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using EnsureThat;
+using Microsoft.Health.Core.Extensions;
+using Microsoft.Health.Fhir.Core.Models;
+
+namespace Microsoft.Health.Fhir.Core.Features.Search
+{
+    public static class SearchHelperUtilities
+    {
+        /// <summary>
+        /// Given a list of <see cref="SearchParameterInfo"/> calculates a hash using the
+        /// <see cref="SearchParameterInfo.Name"/> values of each component. The collection of
+        /// search parameters (irrespective of the order they are present) will return the
+        /// same hash.
+        /// </summary>
+        /// <param name="searchParamInfo">A list of <see cref="SearchSearchParameterInfo" /></param>
+        /// <returns>A hash based on the search parameter names present in the input.</returns>
+        public static string CalculateSearchParameterNameHash(IEnumerable<SearchParameterInfo> searchParamInfo)
+        {
+            EnsureArg.IsNotNull(searchParamInfo, nameof(searchParamInfo));
+            EnsureArg.IsGt(searchParamInfo.Count(), 0, nameof(searchParamInfo));
+
+            StringBuilder sb = new StringBuilder();
+            foreach (string paramName in searchParamInfo.Select(x => x.Name).OrderBy(x => x))
+            {
+                sb.Append(paramName);
+            }
+
+            string hash = sb.ToString().ComputeHash();
+            return hash;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchHelperUtilities.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchHelperUtilities.cs
@@ -16,9 +16,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
     {
         /// <summary>
         /// Given a list of <see cref="SearchParameterInfo"/> calculates a hash using the
-        /// <see cref="SearchParameterInfo.Name"/> values of each component. The collection of
-        /// search parameters (irrespective of the order they are present) will return the
-        /// same hash.
+        /// <see cref="SearchParameterInfo.Name"/> values of each component.
+        /// The same collection of search parameters (irrespective of their order in the input)
+        /// will return the same hash.
         /// </summary>
         /// <param name="searchParamInfo">A list of <see cref="SearchSearchParameterInfo" /></param>
         /// <returns>A hash based on the search parameter names present in the input.</returns>

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchHelperUtilities.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchHelperUtilities.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
         /// </summary>
         /// <param name="resourceSearchParameterStatus">A list of <see cref="ResourceSearchParameterStatus" /></param>
         /// <returns>A hash based on the search parameter uri and last updated value.</returns>
-        public static string CalculateSearchParameterNameHash(IEnumerable<ResourceSearchParameterStatus> resourceSearchParameterStatus)
+        public static string CalculateSearchParameterHash(IEnumerable<ResourceSearchParameterStatus> resourceSearchParameterStatus)
         {
             EnsureArg.IsNotNull(resourceSearchParameterStatus, nameof(resourceSearchParameterStatus));
             EnsureArg.IsGt(resourceSearchParameterStatus.Count(), 0, nameof(resourceSearchParameterStatus));


### PR DESCRIPTION
## Description
Added a method that generates a hash given a list of `SearchParameterInfo`. It uses the `Name` property from each object to generate a unique hash for the entire list of `SearchParameterInfo`.

## Related issues
Addresses [issue [AB#73617](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/73617)].

## Testing
Added UTs.
