### PR TITLE
Enable pod identity and export for AKS deployments

### DIFF
--- a/build/jobs/cleanup-aks.yml
+++ b/build/jobs/cleanup-aks.yml
@@ -25,6 +25,6 @@ jobs:
           echo "Deleting helm release $r"
           helm delete $r
           STORAGE_ACCOUNT_NAME=$(echo $r | tr -d '-' | cut -c1-24)
-          az storage account delete -n $STORAGE_ACCOUNT_NAME -g ${{parameters.clusterResourceGroup}}
+          az storage account delete --yes -n $STORAGE_ACCOUNT_NAME -g ${{parameters.clusterResourceGroup}}
           az identity delete -g ${{parameters.clusterResourceGroup}} -n $r
         done

--- a/build/jobs/cleanup-aks.yml
+++ b/build/jobs/cleanup-aks.yml
@@ -24,4 +24,6 @@ jobs:
         for r in $(helm list -o json | jq -r '.[] | select(.name | contains("$(deploymentEnvironmentName)")) | .name'); do
           echo "Deleting helm release $r"
           helm delete $r
+          STORAGE_ACCOUNT_NAME=$(echo $r | tr -d '-' | cut -c1-24)
+          az storage account delete -n $STORAGE_ACCOUNT_NAME -g ${{parameters.clusterResourceGroup}}
         done

--- a/build/jobs/cleanup-aks.yml
+++ b/build/jobs/cleanup-aks.yml
@@ -26,4 +26,5 @@ jobs:
           helm delete $r
           STORAGE_ACCOUNT_NAME=$(echo $r | tr -d '-' | cut -c1-24)
           az storage account delete -n $STORAGE_ACCOUNT_NAME -g ${{parameters.clusterResourceGroup}}
+          az identity delete -g ${{parameters.clusterResourceGroup}} -n $r
         done

--- a/build/jobs/deploy-aks.yml
+++ b/build/jobs/deploy-aks.yml
@@ -57,7 +57,7 @@ jobs:
         IDENTITY_CLIENT_ID="$(az identity show -g ${{parameters.clusterResourceGroup}} -n $IDENTITY_NAME --subscription $SUBSCRIPTION_ID --query clientId -otsv)"
         IDENTITY_RESOURCE_ID="$(az identity show -g ${{parameters.clusterResourceGroup}} -n $IDENTITY_NAME --subscription $SUBSCRIPTION_ID --query id -otsv)"
         
-        STORAGE_ACCOUNT_NAME=$(echo $releaseName | tr -d '-')
+        STORAGE_ACCOUNT_NAME=$(echo $releaseName | tr -d '-' | cut -c1-24)
         az storage account create -g ${{parameters.clusterResourceGroup}} -n $STORAGE_ACCOUNT_NAME
         STORAGE_ACCOUNT_ID=$(az storage account show -g ${{parameters.clusterResourceGroup}} -n $STORAGE_ACCOUNT_NAME | jq -r .id)
         BLOB_URI=$(az storage account show -g ${{parameters.clusterResourceGroup}} -n $STORAGE_ACCOUNT_NAME | jq -r .primaryEndpoints.blob)

--- a/build/jobs/deploy-aks.yml
+++ b/build/jobs/deploy-aks.yml
@@ -56,12 +56,16 @@ jobs:
         az identity create -g ${{parameters.clusterResourceGroup}} -n $IDENTITY_NAME --subscription $SUBSCRIPTION_ID
         IDENTITY_CLIENT_ID="$(az identity show -g ${{parameters.clusterResourceGroup}} -n $IDENTITY_NAME --subscription $SUBSCRIPTION_ID --query clientId -otsv)"
         IDENTITY_RESOURCE_ID="$(az identity show -g ${{parameters.clusterResourceGroup}} -n $IDENTITY_NAME --subscription $SUBSCRIPTION_ID --query id -otsv)"
-        
+        PRINCIPAL_ID="$(az identity show -g ${{parameters.clusterResourceGroup}} -n $IDENTITY_NAME --subscription $SUBSCRIPTION_ID --query principalId -otsv)"
+
         STORAGE_ACCOUNT_NAME=$(echo $releaseName | tr -d '-' | cut -c1-24)
         az storage account create -g ${{parameters.clusterResourceGroup}} -n $STORAGE_ACCOUNT_NAME
         STORAGE_ACCOUNT_ID=$(az storage account show -g ${{parameters.clusterResourceGroup}} -n $STORAGE_ACCOUNT_NAME | jq -r .id)
         BLOB_URI=$(az storage account show -g ${{parameters.clusterResourceGroup}} -n $STORAGE_ACCOUNT_NAME | jq -r .primaryEndpoints.blob)
-        az role assignment create --role "Storage Blob Data Contributor" --assignee $IDENTITY_CLIENT_ID --scope $STORAGE_ACCOUNT_ID
+
+        # Note, we are using --assignee-object-id here to avoid problems with DevOps service principal credentials not having read access to the Graph
+        # https://medium.com/microsoftazure/how-to-perform-role-assignments-on-azure-resources-from-an-azure-devops-pipeline-c9f4dc10d0a4
+        az role assignment create --role "Storage Blob Data Contributor" --assignee-object-id $PRINCIPAL_ID --assignee-principal-type ServicePrincipal --scope $STORAGE_ACCOUNT_ID
 
         cat <<EOF > release-values.yaml
         image:

--- a/build/jobs/deploy-aks.yml
+++ b/build/jobs/deploy-aks.yml
@@ -49,7 +49,20 @@ jobs:
         releaseName=`echo "$(DeploymentEnvironmentName)-${{parameters.version}}-${{parameters.dataStore}}" | tr '[:upper:]' '[:lower:]'`
         hostName=`echo "${releaseName}.${{parameters.dnsSuffix}}" | tr '[:upper:]' '[:lower:]'`
         tenantId="$(tenant-id)"
+
+        # Create pod identity and storage account
+        SUBSCRIPTION_ID=$(az account show | jq -r .id)
+        IDENTITY_NAME=$releaseName
+        az identity create -g ${{parameters.clusterResourceGroup}} -n $IDENTITY_NAME --subscription $SUBSCRIPTION_ID
+        IDENTITY_CLIENT_ID="$(az identity show -g ${{parameters.clusterResourceGroup}} -n $IDENTITY_NAME --subscription $SUBSCRIPTION_ID --query clientId -otsv)"
+        IDENTITY_RESOURCE_ID="$(az identity show -g ${{parameters.clusterResourceGroup}} -n $IDENTITY_NAME --subscription $SUBSCRIPTION_ID --query id -otsv)"
         
+        STORAGE_ACCOUNT_NAME=$(echo $releaseName | tr -d '-')
+        az storage account create -g ${{parameters.clusterResourceGroup}} -n $STORAGE_ACCOUNT_NAME
+        STORAGE_ACCOUNT_ID=$(az storage account show -g ${{parameters.clusterResourceGroup}} -n $STORAGE_ACCOUNT_NAME | jq -r .id)
+        BLOB_URI=$(az storage account show -g ${{parameters.clusterResourceGroup}} -n $STORAGE_ACCOUNT_NAME | jq -r .primaryEndpoints.blob)
+        az role assignment create --role "Storage Blob Data Contributor" --assignee $IDENTITY_CLIENT_ID --scope $STORAGE_ACCOUNT_ID
+
         cat <<EOF > release-values.yaml
         image:
           repository: $repositoryName
@@ -87,6 +100,13 @@ jobs:
               requests:
                 cpu: 500m
                 memory: 2000Mi
+        podIdentity:
+          enabled: true
+          identityClientId: $IDENTITY_CLIENT_ID
+          identityResourceId: $IDENTITY_RESOURCE_ID
+        export:
+          enabled: true
+          blobStorageUri: $BLOB_URI
         security:
           enabled: true
           enableAadSmartOnFhirProxy: false

--- a/build/jobs/run-tests-aks.yml
+++ b/build/jobs/run-tests-aks.yml
@@ -75,7 +75,10 @@ jobs:
         $storageAccountName=$storageAccountName.Substring(0,[System.Math]::Min($storageAccountName.Length,24))
         $accKey = Get-AzStorageAccountKey -ResourceGroupName ${{parameters.clusterResourceGroup}} -Name $storageAccountName | Where-Object {$_.KeyName -eq "key1"}
         $storageSecretName = "${$storageAccountName}_secret"
+        Write-Host "storageAccountName: ${storageAccountName}"
+        Write-Host "storageKey: ${accKey.Value}"
         Write-Host "##vso[task.setvariable variable=$($storageSecretName)]$($accKey.Value)"
+        Write-Host "##vso[task.setvariable variable=$($storageSecretName)]${accKey.Value}"
         # ----------------------------------------
 
   - task: VSTest@2

--- a/build/jobs/run-tests-aks.yml
+++ b/build/jobs/run-tests-aks.yml
@@ -5,6 +5,10 @@ parameters:
   type: string
 - name: dnsSuffix
   type: string
+- name: clusterName
+  type: string
+- name: clusterResourceGroup
+  type: string
 
 jobs:
 - job: 'e2eTests'
@@ -53,7 +57,7 @@ jobs:
             exit 1    
         }
 
-        Write-Host "##vso[task.setvariable variable=TestFilter]Category!=Export&Category!=ExportDataValidation&Category!=SmartOnFhir&${testFilter}"
+        Write-Host "##vso[task.setvariable variable=TestFilter]Category!=SmartOnFhir&${testFilter}"
         Write-Host "##vso[task.setvariable variable=Resource]$(TestEnvironmentUrl)"
         
         $secrets = Get-AzKeyVaultSecret -VaultName resolute-oss-tenant-info
@@ -65,6 +69,11 @@ jobs:
             $secretValue = Get-AzKeyVaultSecret -VaultName resolute-oss-tenant-info -Name $secret.Name
             Write-Host "##vso[task.setvariable variable=$($environmentVariableName)]$($secretValue.SecretValueText)"
         }
+
+        $storageAccountName="$(DeploymentEnvironmentName)${{parameters.version}}${{parameters.dataStore}}".ToLower()
+        $accKey = Get-AzStorageAccountKey -ResourceGroupName ${{parameters.clusterResourceGroup}} -Name $storageAccountName | Where-Object {$_.KeyName -eq "key1"}
+        $storageSecretName = "${$storageAccountName}_secret"
+        Write-Host "##vso[task.setvariable variable=$($storageSecretName)]$($accKey.Value)"
         # ----------------------------------------
 
   - task: VSTest@2

--- a/build/jobs/run-tests-aks.yml
+++ b/build/jobs/run-tests-aks.yml
@@ -74,11 +74,8 @@ jobs:
         $storageAccountName=$storageAccountName.Replace('-','')
         $storageAccountName=$storageAccountName.Substring(0,[System.Math]::Min($storageAccountName.Length,24))
         $accKey = Get-AzStorageAccountKey -ResourceGroupName ${{parameters.clusterResourceGroup}} -Name $storageAccountName | Where-Object {$_.KeyName -eq "key1"}
-        $storageSecretName = "${$storageAccountName}_secret"
-        Write-Host "storageAccountName: ${storageAccountName}"
-        Write-Host "storageKey: ${accKey.Value}"
+        $storageSecretName = "${storageAccountName}_secret"
         Write-Host "##vso[task.setvariable variable=$($storageSecretName)]$($accKey.Value)"
-        Write-Host "##vso[task.setvariable variable=$($storageSecretName)]${accKey.Value}"
         # ----------------------------------------
 
   - task: VSTest@2

--- a/build/jobs/run-tests-aks.yml
+++ b/build/jobs/run-tests-aks.yml
@@ -72,7 +72,7 @@ jobs:
 
         $storageAccountName="$(DeploymentEnvironmentName)${{parameters.version}}${{parameters.dataStore}}".ToLower()
         Write-Host "The storageAccountName is ${storageAccountName}"
-        $storageAccountName=$storageAccountName.Substring(0,[System.Math]::Min($test.Length,24))
+        $storageAccountName=$storageAccountName.Substring(0,[System.Math]::Min($storageAccountName.Length,24))
         Write-Host "The storageAccountName is ${storageAccountName}"
         $accKey = Get-AzStorageAccountKey -ResourceGroupName ${{parameters.clusterResourceGroup}} -Name $storageAccountName | Where-Object {$_.KeyName -eq "key1"}
         $storageSecretName = "${$storageAccountName}_secret"

--- a/build/jobs/run-tests-aks.yml
+++ b/build/jobs/run-tests-aks.yml
@@ -71,7 +71,9 @@ jobs:
         }
 
         $storageAccountName="$(DeploymentEnvironmentName)${{parameters.version}}${{parameters.dataStore}}".ToLower()
+        Write-Host "The storageAccountName is ${storageAccountName}"
         $storageAccountName=$storageAccountName.Substring(0,[System.Math]::Min($test.Length,24))
+        Write-Host "The storageAccountName is ${storageAccountName}"
         $accKey = Get-AzStorageAccountKey -ResourceGroupName ${{parameters.clusterResourceGroup}} -Name $storageAccountName | Where-Object {$_.KeyName -eq "key1"}
         $storageSecretName = "${$storageAccountName}_secret"
         Write-Host "##vso[task.setvariable variable=$($storageSecretName)]$($accKey.Value)"

--- a/build/jobs/run-tests-aks.yml
+++ b/build/jobs/run-tests-aks.yml
@@ -71,6 +71,7 @@ jobs:
         }
 
         $storageAccountName="$(DeploymentEnvironmentName)${{parameters.version}}${{parameters.dataStore}}".ToLower()
+        $storageAccountName=$storageAccountName.Substring(0,[System.Math]::Min($test.Length,24))
         $accKey = Get-AzStorageAccountKey -ResourceGroupName ${{parameters.clusterResourceGroup}} -Name $storageAccountName | Where-Object {$_.KeyName -eq "key1"}
         $storageSecretName = "${$storageAccountName}_secret"
         Write-Host "##vso[task.setvariable variable=$($storageSecretName)]$($accKey.Value)"

--- a/build/jobs/run-tests-aks.yml
+++ b/build/jobs/run-tests-aks.yml
@@ -71,9 +71,8 @@ jobs:
         }
 
         $storageAccountName="$(DeploymentEnvironmentName)${{parameters.version}}${{parameters.dataStore}}".ToLower()
-        Write-Host "The storageAccountName is ${storageAccountName}"
+        $storageAccountName=$storageAccountName.Replace('-','')
         $storageAccountName=$storageAccountName.Substring(0,[System.Math]::Min($storageAccountName.Length,24))
-        Write-Host "The storageAccountName is ${storageAccountName}"
         $accKey = Get-AzStorageAccountKey -ResourceGroupName ${{parameters.clusterResourceGroup}} -Name $storageAccountName | Where-Object {$_.KeyName -eq "key1"}
         $storageSecretName = "${$storageAccountName}_secret"
         Write-Host "##vso[task.setvariable variable=$($storageSecretName)]$($accKey.Value)"

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -230,6 +230,8 @@ stages:
       version: R4
       dataStore: CosmosDb
       dnsSuffix: $(aksDnsSuffix)
+      clusterName: $(clusterName)
+      clusterResourceGroup: $(clusterResourceGroup)
 
 - stage: testAksR4Sql
   displayName: 'R4 SqlServer AKS Tests'
@@ -244,6 +246,8 @@ stages:
       version: R4
       dataStore: SqlServer
       dnsSuffix: $(aksDnsSuffix)
+      clusterName: $(clusterName)
+      clusterResourceGroup: $(clusterResourceGroup)
 
 - stage: testAksR4SqlContainer
   displayName: 'R4 SqlContainer AKS Tests'
@@ -258,6 +262,8 @@ stages:
       version: R4
       dataStore: SqlContainer
       dnsSuffix: $(aksDnsSuffix)
+      clusterName: $(clusterName)
+      clusterResourceGroup: $(clusterResourceGroup)
 
 - stage: testStu3
   displayName: 'Run Stu3 Tests'

--- a/samples/kubernetes/README.md
+++ b/samples/kubernetes/README.md
@@ -248,7 +248,7 @@ to work with the settings above.
 
 ## Enabling `$export`
 
-To use the `$export` operator, the FHIR server must be configured with a [pod identity](https://github.com/Azure/aad-pod-identity) and the identity of the FHIR server must have access to an existing storage account.
+To use the `$export` operation, the FHIR server must be configured with a [pod identity](https://github.com/Azure/aad-pod-identity) and the identity of the FHIR server must have access to an existing storage account.
 
 1. Ensure that AAD Pod Identity is deployed in your cluster. The [deploy-aks.sh](deploy-aks.sh) script does that. You can verify it with:
 
@@ -273,38 +273,38 @@ To use the `$export` operator, the FHIR server must be configured with a [pod id
     IDENTITY_RESOURCE_ID="$(az identity show -g $RESOURCE_GROUP -n $IDENTITY_NAME --subscription $SUBSCRIPTION_ID --query id -otsv)"
     ```
 
-  3. Create a storage account and assign role to identity:
+3. Create a storage account and assign role to identity:
 
-      ```bash
-      STORAGE_ACCOUNT_NAME="myfhirstorage"
-      az storage account create -g $RESOURCE_GROUP -n $STORAGE_ACCOUNT_NAME
-      STORAGE_ACCOUNT_ID=$(az storage account show -g $RESOURCE_GROUP -n $STORAGE_ACCOUNT_NAME | jq -r .id)
-      BLOB_URI=$(az storage account show -g $RESOURCE_GROUP -n $STORAGE_ACCOUNT_NAME | jq -r .primaryEndpoints.blob)
-      az role assignment create --role "Storage Blob Data Contributor" --assignee $IDENTITY_CLIENT_ID --scope $STORAGE_ACCOUNT_ID
-      ```      
+    ```bash
+    STORAGE_ACCOUNT_NAME="myfhirstorage"
+    az storage account create -g $RESOURCE_GROUP -n $STORAGE_ACCOUNT_NAME
+    STORAGE_ACCOUNT_ID=$(az storage account show -g $RESOURCE_GROUP -n $STORAGE_ACCOUNT_NAME | jq -r .id)
+    BLOB_URI=$(az storage account show -g $RESOURCE_GROUP -n $STORAGE_ACCOUNT_NAME | jq -r .primaryEndpoints.blob)
+    az role assignment create --role "Storage Blob Data Contributor" --assignee $IDENTITY_CLIENT_ID --scope $STORAGE_ACCOUNT_ID
+    ```      
 
-  4. Provision FHIR server:
+4. Provision FHIR server:
 
-      First create a `fhir-server-export-values.yaml` file:
+    First create a `fhir-server-export-values.yaml` file:
 
-      ```bash
-      cat > fhir-server-export-values.yaml <<EOF
-      database:
-        dataStore: SqlServer
-        resourceGroup: $RESOURCE_GROUP
-        location: $LOCATION
-      podIdentity:
-        enabled: true
-        identityClientId: $IDENTITY_CLIENT_ID
-        identityResourceId: $IDENTITY_RESOURCE_ID
-      export:
-        enabled: true
-        blobStorageUri: $BLOB_URI
-      EOF
-      ```
+    ```bash
+    cat > fhir-server-export-values.yaml <<EOF
+    database:
+      dataStore: SqlServer
+      resourceGroup: $RESOURCE_GROUP
+      location: $LOCATION
+    podIdentity:
+      enabled: true
+      identityClientId: $IDENTITY_CLIENT_ID
+      identityResourceId: $IDENTITY_RESOURCE_ID
+    export:
+      enabled: true
+      blobStorageUri: $BLOB_URI
+    EOF
+    ```
 
-      Add additional settings you might need (see ingress, CORS, etc. above) and then deploy with:
+    Add additional settings you might need (see ingress, CORS, etc. above) and then deploy with:
 
-      ```bash
-      helm upgrade --install mihansenfhir2 helm/fhir-server -f fhir-server-export-values.yaml
-      ```
+    ```bash
+    helm upgrade --install mihansenfhir2 helm/fhir-server -f fhir-server-export-values.yaml
+    ```

--- a/samples/kubernetes/deploy-aks.sh
+++ b/samples/kubernetes/deploy-aks.sh
@@ -217,3 +217,9 @@ helm upgrade --install aso ./install-aso/azure-service-operator -n azureoperator
     --set createNamespace=true \
     --set image.repository="mcr.microsoft.com/k8s/azureserviceoperator:latest"
 
+
+# Install Pod Identities (needed for export)
+# see https://github.com/Azure/aad-pod-identity for details
+helm repo add aad-pod-identity https://raw.githubusercontent.com/Azure/aad-pod-identity/master/charts
+helm install aad-pod-identity aad-pod-identity/aad-pod-identity
+

--- a/samples/kubernetes/helm/fhir-server/Chart.yaml
+++ b/samples/kubernetes/helm/fhir-server/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.0
+version: 0.2.0

--- a/samples/kubernetes/helm/fhir-server/templates/azureidentity.yaml
+++ b/samples/kubernetes/helm/fhir-server/templates/azureidentity.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.podIdentity.enabled -}}
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentity
+metadata:
+  name: {{ include "fhir-server.fullname" . }}
+  labels:
+    {{- include "fhir-server.labels" . | nindent 4 }}
+
+spec:
+  type: 0
+  resourceID: {{ .Values.podIdentity.identityResourceGroup }}
+  clientID: {{ .Values.podIdentity.identityClientId }}
+{{- end }}

--- a/samples/kubernetes/helm/fhir-server/templates/azureidentity.yaml
+++ b/samples/kubernetes/helm/fhir-server/templates/azureidentity.yaml
@@ -8,6 +8,6 @@ metadata:
 
 spec:
   type: 0
-  resourceID: {{ .Values.podIdentity.identityResourceGroup }}
+  resourceID: {{ .Values.podIdentity.identityResourceId }}
   clientID: {{ .Values.podIdentity.identityClientId }}
 {{- end }}

--- a/samples/kubernetes/helm/fhir-server/templates/azureidentity.yaml
+++ b/samples/kubernetes/helm/fhir-server/templates/azureidentity.yaml
@@ -5,7 +5,6 @@ metadata:
   name: {{ include "fhir-server.fullname" . }}
   labels:
     {{- include "fhir-server.labels" . | nindent 4 }}
-
 spec:
   type: 0
   resourceID: {{ .Values.podIdentity.identityResourceId }}

--- a/samples/kubernetes/helm/fhir-server/templates/azureidentitybinding.yaml
+++ b/samples/kubernetes/helm/fhir-server/templates/azureidentitybinding.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.podIdentity.enable }}
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentityBinding
+metadata:
+  name: {{ include "fhir-server.fullname" . }}-binding
+spec:
+  azureIdentity: {{ include "fhir-server.fullname" . }}
+  selector: {{ include "fhir-server.fullname" . }}
+{{- end }}

--- a/samples/kubernetes/helm/fhir-server/templates/azureidentitybinding.yaml
+++ b/samples/kubernetes/helm/fhir-server/templates/azureidentitybinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.podIdentity.enable }}
+{{- if .Values.podIdentity.enabled -}}
 apiVersion: "aadpodidentity.k8s.io/v1"
 kind: AzureIdentityBinding
 metadata:

--- a/samples/kubernetes/helm/fhir-server/templates/deployment.yaml
+++ b/samples/kubernetes/helm/fhir-server/templates/deployment.yaml
@@ -6,6 +6,9 @@ metadata:
   name: {{ include "fhir-server.fullname" . }}
   labels:
     {{- include "fhir-server.labels" . | nindent 4 }}
+    {{- if .Values.podIdentity.enable }}
+    aadpodidbinding: {{ include "fhir-server.fullname" . }}
+    {{- end}}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/samples/kubernetes/helm/fhir-server/templates/deployment.yaml
+++ b/samples/kubernetes/helm/fhir-server/templates/deployment.yaml
@@ -6,9 +6,6 @@ metadata:
   name: {{ include "fhir-server.fullname" . }}
   labels:
     {{- include "fhir-server.labels" . | nindent 4 }}
-    {{- if .Values.podIdentity.enable }}
-    aadpodidbinding: {{ include "fhir-server.fullname" . }}
-    {{- end}}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -18,6 +15,9 @@ spec:
     metadata:
       labels:
         {{- include "fhir-server.selectorLabels" . | nindent 8 }}
+        {{- if .Values.podIdentity.enabled }}
+        aadpodidbinding: {{ include "fhir-server.fullname" . }}
+        {{- end}}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -35,6 +35,12 @@ spec:
           env:
             - name: ASPNETCORE_FORWARDEDHEADERS_ENABLED
               value: "true"
+            {{- if .Values.export.enabled }}
+            - name: FhirServer__Operations__Export__Enabled
+              value: "true"
+            - name: FhirServer__Operations__Export__StorageAccountUri
+              value: {{ .Values.export.blobStorageUri | quote }}
+            {{- end }}
             {{- if .Values.serviceMonitor.enabled }}
             - name: PrometheusMetrics__enabled
               value: "true"

--- a/samples/kubernetes/helm/fhir-server/values.yaml
+++ b/samples/kubernetes/helm/fhir-server/values.yaml
@@ -22,6 +22,11 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
+podIdentity:
+  enabled: false
+  # identityId: my-id
+  # identityResourceGroup: my-rg
+
 podSecurityContext: {}
   # fsGroup: 2000
 

--- a/samples/kubernetes/helm/fhir-server/values.yaml
+++ b/samples/kubernetes/helm/fhir-server/values.yaml
@@ -24,8 +24,8 @@ serviceAccount:
 
 podIdentity:
   enabled: false
-  # identityId: my-id
-  # identityResourceGroup: my-rg
+  # identityClientId: my-id
+  # identityResourceId: my-identity-resource-id
 
 podSecurityContext: {}
   # fsGroup: 2000

--- a/samples/kubernetes/helm/fhir-server/values.yaml
+++ b/samples/kubernetes/helm/fhir-server/values.yaml
@@ -27,6 +27,10 @@ podIdentity:
   # identityClientId: my-id
   # identityResourceId: my-identity-resource-id
 
+export:
+  enabled: false
+  blobStorageUri: https://mystorageaccount.blob.core.windows.net
+
 podSecurityContext: {}
   # fsGroup: 2000
 


### PR DESCRIPTION
## Description
This PR enables pod identities for AKS deployments and uses the pod identity for export to a storage account.

## Related issues
Addresses issue #1079.

## Testing
E2E export tests enabled. 
