### PR TITLE
Enable history tests

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HistoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HistoryTests.cs
@@ -92,7 +92,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.Contains("Changed by E2E test", obsHistory.Text.Div);
         }
 
-        [HttpIntegrationFixtureArgumentSets(dataStores: DataStore.SqlServer)] // History tests are unstable at the moment due to Cosmos DB issue with continuation tokens
         [Fact]
         public async Task GivenAValueForSinceAndBeforeWithModifications_WhenGettingSystemHistory_TheServerShouldOnlyCorrectResources()
         {
@@ -138,7 +137,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             }
         }
 
-        [HttpIntegrationFixtureArgumentSets(dataStores: DataStore.SqlServer)] // History tests are unstable at the moment due to Cosmos DB issue with continuation tokens
         [Fact]
         public async Task GivenAValueForSinceAndBeforeCloseToLastModifiedTime_WhenGettingSystemHistory_TheServerShouldNotMissRecords()
         {
@@ -188,7 +186,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             }
         }
 
-        [HttpIntegrationFixtureArgumentSets(dataStores: DataStore.SqlServer)] // History tests are unstable at the moment due to Cosmos DB issue with continuation tokens
         [Fact]
         public async Task GivenAQueryThatReturnsMoreThan10Results_WhenGettingSystemHistory_TheServerShouldBatchTheResponse()
         {


### PR DESCRIPTION
## Description
History tests are enabled for Cosmosdb since the Cosmosdb SDK issue is resolved by upgrading to V3

## Related issues
Addresses #74969

## Testing
Enabled history tests pass
