### PR TITLE
Fixes lifetime requirement for Cosmos RequestHandlers

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/FhirCosmosClientInitializerTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/FhirCosmosClientInitializerTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Storage
 
             _initializer = new FhirCosmosClientInitializer(
                 clientTestProvider,
-                Enumerable.Empty<RequestHandler>(),
+                () => new[] { new TestRequestHandler() },
                 NullLogger<FhirCosmosClientInitializer>.Instance);
 
             _collectionInitializers = new List<ICollectionInitializer> { _collectionInitializer1, _collectionInitializer2 };
@@ -85,6 +85,14 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Storage
             var client = _initializer.CreateCosmosClient(_cosmosDataStoreConfiguration);
 
             Assert.Equal(TimeSpan.FromSeconds(99), client.ClientOptions.MaxRetryWaitTimeOnRateLimitedRequests);
+        }
+
+        [Fact]
+        public void CreateClient_CreatesNewHandlers()
+        {
+            // If new handlers are not created the second call will fail
+            _initializer.CreateCosmosClient(_cosmosDataStoreConfiguration);
+            _initializer.CreateCosmosClient(_cosmosDataStoreConfiguration);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/TestRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/TestRequestHandler.cs
@@ -1,0 +1,13 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Azure.Cosmos;
+
+namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Storage
+{
+    public class TestRequestHandler : RequestHandler
+    {
+    }
+}

--- a/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using EnsureThat;
 using Microsoft.Azure.Cosmos;
@@ -188,10 +189,14 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AsSelf()
                 .ReplaceService<ISearchParameterRegistry>();
 
+            // Each CosmosClient needs new instances of a RequestHandler
             services.TypesInSameAssemblyAs<FhirCosmosClientInitializer>()
                 .AssignableTo<RequestHandler>()
-                .Singleton()
+                .Transient()
                 .AsService<RequestHandler>();
+
+            // FhirCosmosClientInitializer is Singleton, so provide a factory that can resolve new RequestHandlers
+            services.AddFactory<IEnumerable<RequestHandler>>();
 
             return fhirServerBuilder;
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
             var responseProcessor = new CosmosResponseProcessor(fhirRequestContextAccessor, Substitute.For<IMediator>(), NullLogger<CosmosResponseProcessor>.Instance);
             var handler = new FhirCosmosResponseHandler(() => new NonDisposingScope(_container), _cosmosDataStoreConfiguration, fhirRequestContextAccessor, responseProcessor);
-            var documentClientInitializer = new FhirCosmosClientInitializer(testProvider, new[] { handler }, NullLogger<FhirCosmosClientInitializer>.Instance);
+            var documentClientInitializer = new FhirCosmosClientInitializer(testProvider, () => new[] { handler }, NullLogger<FhirCosmosClientInitializer>.Instance);
             _cosmosClient = documentClientInitializer.CreateCosmosClient(_cosmosDataStoreConfiguration);
             var fhirCollectionInitializer = new CollectionInitializer(_cosmosCollectionConfiguration.CollectionId, _cosmosDataStoreConfiguration, _cosmosCollectionConfiguration.InitialCollectionThroughput, upgradeManager, NullLogger<CollectionInitializer>.Instance);
 


### PR DESCRIPTION
## Description
Each CosmosClient needs new instances of a RequestHandler. This PR changes IEnumerable<RequestHandler> to a Func and updates the lifetime scopes

## Related issues
Addresses [AB#74757](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/74757)

## Testing
Adds regression test