### PR TITLE
Removes "registry" from search parameter status class naming

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/Registry/SearchParameterStatusManagerTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/Registry/SearchParameterStatusManagerTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Registry
         private static readonly string ResourceQuery = "http://hl7.org/fhir/SearchParameter/Resource-query";
 
         private readonly SearchParameterStatusManager _manager;
-        private readonly IStatusRegistryDataStore _statusRegistryDataStore;
+        private readonly ISearchParameterStatusDataStore _searchParameterStatusDataStore;
         private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager;
         private readonly IMediator _mediator;
         private readonly SearchParameterInfo[] _searchParameterInfos;
@@ -38,18 +38,18 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Registry
 
         public SearchParameterStatusManagerTests()
         {
-            _statusRegistryDataStore = Substitute.For<IStatusRegistryDataStore>();
+            _searchParameterStatusDataStore = Substitute.For<ISearchParameterStatusDataStore>();
             _searchParameterDefinitionManager = Substitute.For<ISearchParameterDefinitionManager>();
             _searchParameterSupportResolver = Substitute.For<ISearchParameterSupportResolver>();
             _mediator = Substitute.For<IMediator>();
 
             _manager = new SearchParameterStatusManager(
-                _statusRegistryDataStore,
+                _searchParameterStatusDataStore,
                 _searchParameterDefinitionManager,
                 _searchParameterSupportResolver,
                 _mediator);
 
-            _statusRegistryDataStore.GetSearchParameterStatuses()
+            _searchParameterStatusDataStore.GetSearchParameterStatuses()
                 .Returns(new[]
                 {
                     new ResourceSearchParameterStatus
@@ -151,7 +151,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Registry
         {
             await _manager.EnsureInitialized();
 
-            await _statusRegistryDataStore
+            await _searchParameterStatusDataStore
                 .DidNotReceive()
                 .UpsertStatuses(Arg.Any<IEnumerable<ResourceSearchParameterStatus>>());
         }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/FilebasedSearchParameterStatusDataStore.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/FilebasedSearchParameterStatusDataStore.cs
@@ -16,13 +16,13 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
 {
-    public class FilebasedStatusRegistryDataStore : IStatusRegistryDataStore
+    public class FilebasedSearchParameterStatusDataStore : ISearchParameterStatusDataStore
     {
         private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager;
         private readonly IModelInfoProvider _modelInfoProvider;
         private ResourceSearchParameterStatus[] _statusResults;
 
-        public FilebasedStatusRegistryDataStore(
+        public FilebasedSearchParameterStatusDataStore(
             ISearchParameterDefinitionManager searchParameterDefinitionManager,
             IModelInfoProvider modelInfoProvider)
         {
@@ -32,7 +32,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
             _modelInfoProvider = modelInfoProvider;
         }
 
-        public delegate IStatusRegistryDataStore Resolver();
+        public delegate ISearchParameterStatusDataStore Resolver();
 
         public Task<IReadOnlyCollection<ResourceSearchParameterStatus>> GetSearchParameterStatuses()
         {

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/ISearchParameterStatusDataStore.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/ISearchParameterStatusDataStore.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
 {
-    public interface IStatusRegistryDataStore
+    public interface ISearchParameterStatusDataStore
     {
         Task<IReadOnlyCollection<ResourceSearchParameterStatus>> GetSearchParameterStatuses();
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
@@ -18,23 +18,23 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
 {
     public class SearchParameterStatusManager : IRequireInitializationOnFirstRequest
     {
-        private readonly IStatusRegistryDataStore _statusRegistryDataStore;
+        private readonly ISearchParameterStatusDataStore _searchParameterStatusDataStore;
         private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager;
         private readonly ISearchParameterSupportResolver _searchParameterSupportResolver;
         private readonly IMediator _mediator;
 
         public SearchParameterStatusManager(
-            IStatusRegistryDataStore statusRegistryDataStore,
+            ISearchParameterStatusDataStore searchParameterStatusDataStore,
             ISearchParameterDefinitionManager searchParameterDefinitionManager,
             ISearchParameterSupportResolver searchParameterSupportResolver,
             IMediator mediator)
         {
-            EnsureArg.IsNotNull(statusRegistryDataStore, nameof(statusRegistryDataStore));
+            EnsureArg.IsNotNull(searchParameterStatusDataStore, nameof(searchParameterStatusDataStore));
             EnsureArg.IsNotNull(searchParameterDefinitionManager, nameof(searchParameterDefinitionManager));
             EnsureArg.IsNotNull(searchParameterSupportResolver, nameof(searchParameterSupportResolver));
             EnsureArg.IsNotNull(mediator, nameof(mediator));
 
-            _statusRegistryDataStore = statusRegistryDataStore;
+            _searchParameterStatusDataStore = searchParameterStatusDataStore;
             _searchParameterDefinitionManager = searchParameterDefinitionManager;
             _searchParameterSupportResolver = searchParameterSupportResolver;
             _mediator = mediator;
@@ -44,7 +44,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
         {
             var updated = new List<SearchParameterInfo>();
 
-            var parameters = (await _statusRegistryDataStore.GetSearchParameterStatuses())
+            var parameters = (await _searchParameterStatusDataStore.GetSearchParameterStatuses())
                 .ToDictionary(x => x.Uri);
 
             // Set states of known parameters

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/Registry/CosmosDbSearchParameterStatusInitializerTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/Registry/CosmosDbSearchParameterStatusInitializerTests.cs
@@ -17,23 +17,23 @@ using Xunit;
 
 namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Storage.Registry
 {
-    public class CosmosDbStatusRegistryInitializerTests
+    public class CosmosDbSearchParameterStatusInitializerTests
     {
-        private readonly CosmosDbStatusRegistryInitializer _initializer;
+        private readonly CosmosDbSearchParameterStatusInitializer _initializer;
         private readonly ICosmosQueryFactory _cosmosDocumentQueryFactory;
         private readonly Uri _testParameterUri;
 
-        public CosmosDbStatusRegistryInitializerTests()
+        public CosmosDbSearchParameterStatusInitializerTests()
         {
-            IStatusRegistryDataStore statusRegistryDataStore = Substitute.For<IStatusRegistryDataStore>();
+            ISearchParameterStatusDataStore searchParameterStatusDataStore = Substitute.For<ISearchParameterStatusDataStore>();
             _cosmosDocumentQueryFactory = Substitute.For<ICosmosQueryFactory>();
 
-            _initializer = new CosmosDbStatusRegistryInitializer(
-                () => statusRegistryDataStore,
+            _initializer = new CosmosDbSearchParameterStatusInitializer(
+                () => searchParameterStatusDataStore,
                 _cosmosDocumentQueryFactory);
 
             _testParameterUri = new Uri("/test", UriKind.Relative);
-            statusRegistryDataStore
+            searchParameterStatusDataStore
                 .GetSearchParameterStatuses()
                 .Returns(new[]
                 {

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Registry/CosmosDbSearchParameterStatusDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Registry/CosmosDbSearchParameterStatusDataStore.cs
@@ -16,12 +16,12 @@ using Microsoft.Health.Fhir.CosmosDb.Configs;
 
 namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Registry
 {
-    public class CosmosDbStatusRegistryDataStore : IStatusRegistryDataStore
+    public class CosmosDbSearchParameterStatusDataStore : ISearchParameterStatusDataStore
     {
         private readonly Func<IScoped<Container>> _containerScopeFactory;
         private readonly ICosmosQueryFactory _queryFactory;
 
-        public CosmosDbStatusRegistryDataStore(
+        public CosmosDbSearchParameterStatusDataStore(
             Func<IScoped<Container>> containerScopeFactory,
             CosmosDataStoreConfiguration cosmosDataStoreConfiguration,
             ICosmosQueryFactory queryFactory)

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Registry/CosmosDbSearchParameterStatusInitializer.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Registry/CosmosDbSearchParameterStatusInitializer.cs
@@ -14,19 +14,19 @@ using Microsoft.Health.Fhir.CosmosDb.Features.Storage.Versioning;
 
 namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Registry
 {
-    public class CosmosDbStatusRegistryInitializer : ICollectionUpdater
+    public class CosmosDbSearchParameterStatusInitializer : ICollectionUpdater
     {
-        private readonly IStatusRegistryDataStore _filebasedRegistryDataStore;
+        private readonly ISearchParameterStatusDataStore _filebasedSearchParameterStatusDataStore;
         private readonly ICosmosQueryFactory _queryFactory;
 
-        public CosmosDbStatusRegistryInitializer(
-            FilebasedStatusRegistryDataStore.Resolver filebasedRegistry,
+        public CosmosDbSearchParameterStatusInitializer(
+            FilebasedSearchParameterStatusDataStore.Resolver filebasedRegistry,
             ICosmosQueryFactory queryFactory)
         {
             EnsureArg.IsNotNull(filebasedRegistry, nameof(filebasedRegistry));
             EnsureArg.IsNotNull(queryFactory, nameof(queryFactory));
 
-            _filebasedRegistryDataStore = filebasedRegistry.Invoke();
+            _filebasedSearchParameterStatusDataStore = filebasedRegistry.Invoke();
             _queryFactory = queryFactory;
         }
 
@@ -46,7 +46,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Registry
 
             if (!results.Any())
             {
-                var statuses = await _filebasedRegistryDataStore.GetSearchParameterStatuses();
+                var statuses = await _filebasedSearchParameterStatusDataStore.GetSearchParameterStatuses();
 
                 foreach (var batch in statuses.TakeBatch(100))
                 {

--- a/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .Transient()
                 .AsService<ICollectionUpdater>();
 
-            services.Add<CosmosDbStatusRegistryInitializer>()
+            services.Add<CosmosDbSearchParameterStatusInitializer>()
                 .Transient()
                 .AsService<ICollectionUpdater>();
 
@@ -184,10 +184,10 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AsSelf()
                 .AsImplementedInterfaces();
 
-            services.Add<CosmosDbStatusRegistryDataStore>()
+            services.Add<CosmosDbSearchParameterStatusDataStore>()
                 .Singleton()
                 .AsSelf()
-                .ReplaceService<IStatusRegistryDataStore>();
+                .ReplaceService<ISearchParameterStatusDataStore>();
 
             // Each CosmosClient needs new instances of a RequestHandler
             services.TypesInSameAssemblyAs<FhirCosmosClientInitializer>()

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/SearchModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/SearchModule.cs
@@ -65,11 +65,11 @@ namespace Microsoft.Health.Fhir.Api.Modules
                 .AsSelf()
                 .AsImplementedInterfaces();
 
-            services.Add<FilebasedStatusRegistryDataStore>()
+            services.Add<FilebasedSearchParameterStatusDataStore>()
                 .Transient()
                 .AsSelf()
-                .AsService<IStatusRegistryDataStore>()
-                .AsDelegate<FilebasedStatusRegistryDataStore.Resolver>();
+                .AsService<ISearchParameterStatusDataStore>()
+                .AsDelegate<FilebasedSearchParameterStatusDataStore.Resolver>();
 
             services.Add<SearchParameterSupportResolver>()
                 .Singleton()

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         private static readonly string ResourceTest = "http://hl7.org/fhir/SearchParameter/Resource-test";
 
         private readonly SearchParameterStatusManager _manager;
-        private readonly IStatusRegistryDataStore _statusRegistryDataStore;
+        private readonly ISearchParameterStatusDataStore _searchParameterStatusDataStore;
         private readonly SearchParameterDefinitionManager _searchParameterDefinitionManager;
         private readonly IMediator _mediator;
         private readonly SearchParameterInfo[] _searchParameterInfos;
@@ -39,16 +39,16 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         {
             _searchParameterSupportResolver = Substitute.For<ISearchParameterSupportResolver>();
             _mediator = Substitute.For<IMediator>();
-            _statusRegistryDataStore = Substitute.For<IStatusRegistryDataStore>();
+            _searchParameterStatusDataStore = Substitute.For<ISearchParameterStatusDataStore>();
             _searchParameterDefinitionManager = new SearchParameterDefinitionManager(ModelInfoProvider.Instance);
 
             _manager = new SearchParameterStatusManager(
-                _statusRegistryDataStore,
+                _searchParameterStatusDataStore,
                 _searchParameterDefinitionManager,
                 _searchParameterSupportResolver,
                 _mediator);
 
-            _statusRegistryDataStore.GetSearchParameterStatuses()
+            _searchParameterStatusDataStore.GetSearchParameterStatuses()
                 .Returns(new[]
                 {
                     new ResourceSearchParameterStatus

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterFixtureData.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterFixtureData.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             var definitionManager = new SearchParameterDefinitionManager(modelInfoProvider);
             definitionManager.Start();
 
-            var statusRegistry = new FilebasedStatusRegistryDataStore(
+            var statusRegistry = new FilebasedSearchParameterStatusDataStore(
                 definitionManager,
                 modelInfoProvider);
             var statusManager = new SearchParameterStatusManager(

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerSearchParameterStatusDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerSearchParameterStatusDataStore.cs
@@ -19,12 +19,12 @@ using Microsoft.Health.SqlServer.Features.Storage;
 
 namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry
 {
-    internal class SqlServerStatusRegistryDataStore : IStatusRegistryDataStore
+    internal class SqlServerSearchParameterStatusDataStore : ISearchParameterStatusDataStore
     {
         private readonly Func<IScoped<SqlConnectionWrapperFactory>> _scopedSqlConnectionWrapperFactory;
         private readonly VLatest.UpsertSearchParamsTvpGenerator<List<ResourceSearchParameterStatus>> _updateSearchParamsTvpGenerator;
 
-        public SqlServerStatusRegistryDataStore(
+        public SqlServerSearchParameterStatusDataStore(
             Func<IScoped<SqlConnectionWrapperFactory>> scopedSqlConnectionWrapperFactory,
             VLatest.UpsertSearchParamsTvpGenerator<List<ResourceSearchParameterStatus>> updateSearchParamsTvpGenerator)
         {

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
         private readonly SqlServerDataStoreConfiguration _configuration;
         private readonly SchemaInitializer _schemaInitializer;
         private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager;
-        private readonly IStatusRegistryDataStore _filebasedRegistryDataStore;
+        private readonly ISearchParameterStatusDataStore _filebasedSearchParameterStatusDataStore;
         private readonly SecurityConfiguration _securityConfiguration;
         private readonly ILogger<SqlServerFhirModel> _logger;
         private Dictionary<string, short> _resourceTypeToId;
@@ -55,7 +55,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             SqlServerDataStoreConfiguration configuration,
             SchemaInitializer schemaInitializer,
             ISearchParameterDefinitionManager searchParameterDefinitionManager,
-            FilebasedStatusRegistryDataStore.Resolver filebasedRegistry,
+            FilebasedSearchParameterStatusDataStore.Resolver filebasedRegistry,
             IOptions<SecurityConfiguration> securityConfiguration,
             ILogger<SqlServerFhirModel> logger)
         {
@@ -69,7 +69,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             _configuration = configuration;
             _schemaInitializer = schemaInitializer;
             _searchParameterDefinitionManager = searchParameterDefinitionManager;
-            _filebasedRegistryDataStore = filebasedRegistry.Invoke();
+            _filebasedSearchParameterStatusDataStore = filebasedRegistry.Invoke();
             _securityConfiguration = securityConfiguration.Value;
             _logger = logger;
         }
@@ -205,7 +205,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                     string commaSeparatedResourceTypes = string.Join(",", ModelInfoProvider.GetResourceTypeNames());
                     string commaSeparatedClaimTypes = string.Join(',', _securityConfiguration.PrincipalClaims);
                     string commaSeparatedCompartmentTypes = string.Join(',', ModelInfoProvider.GetCompartmentTypeNames());
-                    IEnumerable<ResourceSearchParameterStatus> statuses = _filebasedRegistryDataStore.GetSearchParameterStatuses().Result;
+                    IEnumerable<ResourceSearchParameterStatus> statuses = _filebasedSearchParameterStatusDataStore.GetSearchParameterStatuses().Result;
 
                     sqlCommand.Parameters.AddWithValue("@resourceTypes", commaSeparatedResourceTypes);
                     sqlCommand.Parameters.AddWithValue("@claimTypes", commaSeparatedClaimTypes);

--- a/src/Microsoft.Health.Fhir.SqlServer/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
@@ -38,10 +38,10 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AsSelf()
                 .AsImplementedInterfaces();
 
-            services.Add<SqlServerStatusRegistryDataStore>()
+            services.Add<SqlServerSearchParameterStatusDataStore>()
                 .Singleton()
                 .AsSelf()
-                .ReplaceService<IStatusRegistryDataStore>();
+                .ReplaceService<ISearchParameterStatusDataStore>();
 
             services.Add<SqlServerFhirModel>()
                 .Singleton()

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Microsoft.Health.Fhir.Shared.Tests.Integration.projitems
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Microsoft.Health.Fhir.Shared.Tests.Integration.projitems
@@ -26,6 +26,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlServerFhirStorageTestHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlServerFhirStorageTestsFixture.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlServerTransactionScopeTests.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Persistence\StatusRegistryDataStoreTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Persistence\SearchParameterStatusDataStoreTests.cs" />
   </ItemGroup>
 </Project>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
@@ -44,8 +44,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         private IFhirDataStore _fhirDataStore;
         private IFhirOperationDataStore _fhirOperationDataStore;
         private IFhirStorageTestHelper _fhirStorageTestHelper;
-        private FilebasedStatusRegistryDataStore _filebasedStatusRegistryDataStore;
-        private IStatusRegistryDataStore _statusRegistryDataStore;
+        private FilebasedSearchParameterStatusDataStore _filebasedSearchParameterStatusDataStore;
+        private ISearchParameterStatusDataStore _searchParameterStatusDataStore;
         private CosmosClient _cosmosClient;
 
         public CosmosDbFhirStorageTestsFixture()
@@ -80,14 +80,14 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             var searchParameterDefinitionManager = new SearchParameterDefinitionManager(ModelInfoProvider.Instance);
             searchParameterDefinitionManager.Start();
 
-            _filebasedStatusRegistryDataStore = new FilebasedStatusRegistryDataStore(searchParameterDefinitionManager, ModelInfoProvider.Instance);
+            _filebasedSearchParameterStatusDataStore = new FilebasedSearchParameterStatusDataStore(searchParameterDefinitionManager, ModelInfoProvider.Instance);
 
             var updaters = new ICollectionUpdater[]
             {
                 new FhirCollectionSettingsUpdater(_cosmosDataStoreConfiguration, optionsMonitor, NullLogger<FhirCollectionSettingsUpdater>.Instance),
                 new StoredProcedureInstaller(fhirStoredProcs),
-                new CosmosDbStatusRegistryInitializer(
-                    () => _filebasedStatusRegistryDataStore,
+                new CosmosDbSearchParameterStatusInitializer(
+                    () => _filebasedSearchParameterStatusDataStore,
                     new CosmosQueryFactory(
                         new CosmosResponseProcessor(Substitute.For<IFhirRequestContextAccessor>(), Substitute.For<IMediator>(), NullLogger<CosmosResponseProcessor>.Instance),
                         NullFhirCosmosQueryLogger.Instance)),
@@ -125,7 +125,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
             var documentClient = new NonDisposingScope(_container);
 
-            _statusRegistryDataStore = new CosmosDbStatusRegistryDataStore(
+            _searchParameterStatusDataStore = new CosmosDbSearchParameterStatusDataStore(
                 () => documentClient,
                 _cosmosDataStoreConfiguration,
                 cosmosDocumentQueryFactory);
@@ -183,14 +183,14 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 return this;
             }
 
-            if (serviceType == typeof(IStatusRegistryDataStore))
+            if (serviceType == typeof(ISearchParameterStatusDataStore))
             {
-                return _statusRegistryDataStore;
+                return _searchParameterStatusDataStore;
             }
 
-            if (serviceType == typeof(FilebasedStatusRegistryDataStore))
+            if (serviceType == typeof(FilebasedSearchParameterStatusDataStore))
             {
-                return _filebasedStatusRegistryDataStore;
+                return _filebasedSearchParameterStatusDataStore;
             }
 
             return null;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTestsFixture.cs
@@ -42,9 +42,9 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
         public ITransactionHandler TransactionHandler => _fixture.GetRequiredService<ITransactionHandler>();
 
-        public IStatusRegistryDataStore StatusRegistryDataStore => _fixture.GetRequiredService<IStatusRegistryDataStore>();
+        public ISearchParameterStatusDataStore SearchParameterStatusDataStore => _fixture.GetRequiredService<ISearchParameterStatusDataStore>();
 
-        public FilebasedStatusRegistryDataStore FilebasedStatusRegistryDataStore => _fixture.GetRequiredService<FilebasedStatusRegistryDataStore>();
+        public FilebasedSearchParameterStatusDataStore FilebasedSearchParameterStatusDataStore => _fixture.GetRequiredService<FilebasedSearchParameterStatusDataStore>();
 
         void IDisposable.Dispose()
         {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SearchParameterStatusDataStoreTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SearchParameterStatusDataStoreTests.cs
@@ -14,12 +14,12 @@ using Xunit;
 namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 {
     [FhirStorageTestsFixtureArgumentSets(DataStore.All)]
-    public class StatusRegistryDataStoreTests : IClassFixture<FhirStorageTestsFixture>
+    public class SearchParameterStatusDataStoreTests : IClassFixture<FhirStorageTestsFixture>
     {
         private readonly FhirStorageTestsFixture _fixture;
         private readonly IFhirStorageTestHelper _testHelper;
 
-        public StatusRegistryDataStoreTests(FhirStorageTestsFixture fixture)
+        public SearchParameterStatusDataStoreTests(FhirStorageTestsFixture fixture)
         {
             _fixture = fixture;
             _testHelper = fixture.TestHelper;
@@ -28,8 +28,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         [Fact]
         public async Task GivenAStatusRegistry_WhenGettingStatuses_ThenTheStatusesAreRetrieved()
         {
-            IReadOnlyCollection<ResourceSearchParameterStatus> expectedStatuses = await _fixture.FilebasedStatusRegistryDataStore.GetSearchParameterStatuses();
-            IReadOnlyCollection<ResourceSearchParameterStatus> actualStatuses = await _fixture.StatusRegistryDataStore.GetSearchParameterStatuses();
+            IReadOnlyCollection<ResourceSearchParameterStatus> expectedStatuses = await _fixture.FilebasedSearchParameterStatusDataStore.GetSearchParameterStatuses();
+            IReadOnlyCollection<ResourceSearchParameterStatus> actualStatuses = await _fixture.SearchParameterStatusDataStore.GetSearchParameterStatuses();
 
             ValidateSearchParameterStatuses(expectedStatuses, actualStatuses);
         }
@@ -50,7 +50,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 Uri = new Uri(statusName2), Status = SearchParameterStatus.Disabled, IsPartiallySupported = false,
             };
 
-            IReadOnlyCollection<ResourceSearchParameterStatus> readonlyStatusesBeforeUpsert = await _fixture.StatusRegistryDataStore.GetSearchParameterStatuses();
+            IReadOnlyCollection<ResourceSearchParameterStatus> readonlyStatusesBeforeUpsert = await _fixture.SearchParameterStatusDataStore.GetSearchParameterStatuses();
             var expectedStatuses = readonlyStatusesBeforeUpsert.ToList();
             expectedStatuses.Add(status1);
             expectedStatuses.Add(status2);
@@ -59,9 +59,9 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
             try
             {
-                await _fixture.StatusRegistryDataStore.UpsertStatuses(statusesToUpsert);
+                await _fixture.SearchParameterStatusDataStore.UpsertStatuses(statusesToUpsert);
 
-                IReadOnlyCollection<ResourceSearchParameterStatus> actualStatuses = await _fixture.StatusRegistryDataStore.GetSearchParameterStatuses();
+                IReadOnlyCollection<ResourceSearchParameterStatus> actualStatuses = await _fixture.SearchParameterStatusDataStore.GetSearchParameterStatuses();
 
                 ValidateSearchParameterStatuses(expectedStatuses, actualStatuses);
             }
@@ -75,7 +75,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         [Fact]
         public async Task GivenAStatusRegistry_WhenUpsertingExistingStatuses_ThenTheExistingStatusesAreUpdated()
         {
-            IReadOnlyCollection<ResourceSearchParameterStatus> statusesBeforeUpdate = await _fixture.StatusRegistryDataStore.GetSearchParameterStatuses();
+            IReadOnlyCollection<ResourceSearchParameterStatus> statusesBeforeUpdate = await _fixture.SearchParameterStatusDataStore.GetSearchParameterStatuses();
 
             // Get two existing statuses.
             ResourceSearchParameterStatus expectedStatus1 = statusesBeforeUpdate.First();
@@ -90,10 +90,10 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             try
             {
                 // Upsert the two existing, modified statuses.
-                await _fixture.StatusRegistryDataStore.UpsertStatuses(statusesToUpsert);
+                await _fixture.SearchParameterStatusDataStore.UpsertStatuses(statusesToUpsert);
 
                 IReadOnlyCollection<ResourceSearchParameterStatus> statusesAfterUpdate =
-                    await _fixture.StatusRegistryDataStore.GetSearchParameterStatuses();
+                    await _fixture.SearchParameterStatusDataStore.GetSearchParameterStatuses();
 
                 Assert.Equal(statusesBeforeUpdate.Count, statusesAfterUpdate.Count);
 
@@ -117,7 +117,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
                 statusesToUpsert = new List<ResourceSearchParameterStatus> { expectedStatus1, expectedStatus2 };
 
-                await _fixture.StatusRegistryDataStore.UpsertStatuses(statusesToUpsert);
+                await _fixture.SearchParameterStatusDataStore.UpsertStatuses(statusesToUpsert);
             }
         }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         private readonly IFhirOperationDataStore _fhirOperationDataStore;
         private readonly SqlServerFhirStorageTestHelper _testHelper;
         private readonly SchemaInitializer _schemaInitializer;
-        private readonly FilebasedStatusRegistryDataStore _filebasedStatusRegistryDataStore;
+        private readonly FilebasedSearchParameterStatusDataStore _filebasedSearchParameterStatusDataStore;
 
         public SqlServerFhirStorageTestsFixture()
         {
@@ -61,11 +61,11 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             _schemaInitializer = new SchemaInitializer(config, schemaUpgradeRunner, schemaInformation, NullLogger<SchemaInitializer>.Instance);
 
             var searchParameterDefinitionManager = new SearchParameterDefinitionManager(ModelInfoProvider.Instance);
-            _filebasedStatusRegistryDataStore = new FilebasedStatusRegistryDataStore(searchParameterDefinitionManager, ModelInfoProvider.Instance);
+            _filebasedSearchParameterStatusDataStore = new FilebasedSearchParameterStatusDataStore(searchParameterDefinitionManager, ModelInfoProvider.Instance);
 
             var securityConfiguration = new SecurityConfiguration { PrincipalClaims = { "oid" } };
 
-            var sqlServerFhirModel = new SqlServerFhirModel(config, _schemaInitializer, searchParameterDefinitionManager, () => _filebasedStatusRegistryDataStore, Options.Create(securityConfiguration), NullLogger<SqlServerFhirModel>.Instance);
+            var sqlServerFhirModel = new SqlServerFhirModel(config, _schemaInitializer, searchParameterDefinitionManager, () => _filebasedSearchParameterStatusDataStore, Options.Create(securityConfiguration), NullLogger<SqlServerFhirModel>.Instance);
 
             var serviceCollection = new ServiceCollection();
             serviceCollection.AddSqlServerTableRowParameterGenerators();
@@ -81,7 +81,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             SqlTransactionHandler = new SqlTransactionHandler();
             SqlConnectionWrapperFactory = new SqlConnectionWrapperFactory(config, SqlTransactionHandler, new SqlCommandWrapperFactory());
 
-            SqlServerStatusRegistryDataStore = new SqlServerStatusRegistryDataStore(
+            SqlServerSearchParameterStatusDataStore = new SqlServerSearchParameterStatusDataStore(
                 () => SqlConnectionWrapperFactory.CreateMockScope(),
                 upsertSearchParamsTvpGenerator);
 
@@ -98,7 +98,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
         internal SqlConnectionWrapperFactory SqlConnectionWrapperFactory { get; }
 
-        internal SqlServerStatusRegistryDataStore SqlServerStatusRegistryDataStore { get; }
+        internal SqlServerSearchParameterStatusDataStore SqlServerSearchParameterStatusDataStore { get; }
 
         public async Task InitializeAsync()
         {
@@ -137,14 +137,14 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 return SqlTransactionHandler;
             }
 
-            if (serviceType == typeof(IStatusRegistryDataStore))
+            if (serviceType == typeof(ISearchParameterStatusDataStore))
             {
-                return SqlServerStatusRegistryDataStore;
+                return SqlServerSearchParameterStatusDataStore;
             }
 
-            if (serviceType == typeof(FilebasedStatusRegistryDataStore))
+            if (serviceType == typeof(FilebasedSearchParameterStatusDataStore))
             {
-                return _filebasedStatusRegistryDataStore;
+                return _filebasedSearchParameterStatusDataStore;
             }
 
             return null;


### PR DESCRIPTION
## Description
Since classes for managing search parameter statuses on the SQL side aren't interacting with an independent "registry", it makes sense to remove this and use more accurate naming that is consistent across files.

This PR renames:

`StatusRegistryDataStoreTests --> SearchParameterStatusDataStoreTests`
`CosmosDbStatusRegistryInitializer --> CosmosDbSearchParameterStatusInitializer`
`CosmosDbStatusRegistryInitializerTests --> CosmosDbSearchParameterStatusInitializerTests`
`SqlServerStatusRegistryDataStore --> SqlServerSearchParameterStatusDataStore`
`CosmosDbStatusRegistryDataStore --> CosmosDbSearchParameterStatusDataStore`
`FilebasedStatusRegistryDataStore --> FilebasedSearchParameterStatusDataStore`
`IStatusRegistryDataStore --> ISearchParameterStatusDataStore`

## Related issues
Addresses [#AB74985](https://microsofthealth.visualstudio.com/Health/_workitems/edit/74985).

## Testing
Tests pass as before.
