### PR TITLE
Select container for export

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Filters/ValidateExportRequestFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Filters/ValidateExportRequestFilterAttribute.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
             {
                 KnownQueryParameterNames.Since,
                 KnownQueryParameterNames.Type,
+                KnownQueryParameterNames.Container,
             };
         }
 

--- a/src/Microsoft.Health.Fhir.Api/Features/Headers/ResourceActionResultExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Headers/ResourceActionResultExtensions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Headers
         public static ResourceActionResult<TResult> SetContentTypeHeader<TResult>(this ResourceActionResult<TResult> result, string contentTypeValue)
         {
             EnsureArg.IsNotNull(result, nameof(result));
-            EnsureArg.IsNotNullOrWhiteSpace(contentTypeValue);
+            EnsureArg.IsNotNullOrWhiteSpace(contentTypeValue, nameof(contentTypeValue));
 
             result.Headers.Add(HeaderNames.ContentType, contentTypeValue);
             return result;
@@ -38,7 +38,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Headers
         public static ResourceActionResult<TResult> SetDateHeader<TResult>(this ResourceActionResult<TResult> result, string dateTime)
         {
             EnsureArg.IsNotNull(result, nameof(result));
-            EnsureArg.IsNotNullOrWhiteSpace(dateTime);
+            EnsureArg.IsNotNullOrWhiteSpace(dateTime, nameof(dateTime));
 
             result.Headers.Add(HeaderNames.Date, dateTime);
             return result;

--- a/src/Microsoft.Health.Fhir.Api/Features/Headers/ResourceActionResultExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Headers/ResourceActionResultExtensions.cs
@@ -34,5 +34,14 @@ namespace Microsoft.Health.Fhir.Api.Features.Headers
             result.Headers.Add(HeaderNames.ContentType, contentTypeValue);
             return result;
         }
+
+        public static ResourceActionResult<TResult> SetDateHeader<TResult>(this ResourceActionResult<TResult> result, string dateTime)
+        {
+            EnsureArg.IsNotNull(result, nameof(result));
+            EnsureArg.IsNotNullOrWhiteSpace(dateTime);
+
+            result.Headers.Add(HeaderNames.Date, dateTime);
+            return result;
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Features/Headers/ResourceActionResultExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Headers/ResourceActionResultExtensions.cs
@@ -34,14 +34,5 @@ namespace Microsoft.Health.Fhir.Api.Features.Headers
             result.Headers.Add(HeaderNames.ContentType, contentTypeValue);
             return result;
         }
-
-        public static ResourceActionResult<TResult> SetDateHeader<TResult>(this ResourceActionResult<TResult> result, string dateTime)
-        {
-            EnsureArg.IsNotNull(result, nameof(result));
-            EnsureArg.IsNotNullOrWhiteSpace(dateTime, nameof(dateTime));
-
-            result.Headers.Add(HeaderNames.Date, dateTime);
-            return result;
-        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportJobTaskTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportJobTaskTests.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
     {
         private const string PatientFileName = "Patient.ndjson";
         private const string ObservationFileName = "Observation.ndjson";
+        private const string EncounterFileName = "Encounter.ndjson";
         private static readonly WeakETag _weakETag = WeakETag.FromVersionId("0");
 
         private ExportJobRecord _exportJobRecord;
@@ -427,7 +428,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
             await _exportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
 
-            string actualIds = _inMemoryDestinationClient.GetExportedData(new Uri(PatientFileName, UriKind.Relative));
+            string actualIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(PatientFileName), UriKind.Relative));
 
             Assert.Equal(expectedIds, actualIds);
         }
@@ -466,7 +467,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
             await _exportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
 
-            string actualIds = _inMemoryDestinationClient.GetExportedData(new Uri(PatientFileName, UriKind.Relative));
+            string actualIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(PatientFileName), UriKind.Relative));
 
             // All of the ids should be present since it should have committed one last time after all the results were exported.
             Assert.Equal("01234", actualIds);
@@ -637,7 +638,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
             await _exportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
 
-            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(PatientFileName, UriKind.Relative));
+            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(PatientFileName), UriKind.Relative));
 
             Assert.Equal("01", exportedIds);
             Assert.NotNull(_exportJobRecord.Progress);
@@ -659,7 +660,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
             numberOfSuccessfulPages = 5;
             await secondExportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
 
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(PatientFileName, UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(PatientFileName), UriKind.Relative));
             Assert.Equal("23", exportedIds);
         }
 
@@ -705,9 +706,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
             Assert.Equal(4, numberOfCalls);
             Assert.Equal(8, numberOfCompartmentCalls);
 
-            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(PatientFileName, UriKind.Relative));
+            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(PatientFileName), UriKind.Relative));
             Assert.Equal("1234", exportedIds);
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(ObservationFileName, UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(ObservationFileName), UriKind.Relative));
             Assert.Equal("12345678", exportedIds);
 
             Assert.Equal(OperationStatus.Completed, _exportJobRecord.Status);
@@ -750,7 +751,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
             Assert.Equal(4, numberOfCalls);
             Assert.Equal(4, numberOfCompartmentCalls);
 
-            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(PatientFileName, UriKind.Relative));
+            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(PatientFileName), UriKind.Relative));
             Assert.Equal("1234", exportedIds);
             Assert.Equal(1, _inMemoryDestinationClient.ExportedDataFileCount);
 
@@ -811,10 +812,10 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
             await _exportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
 
-            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(PatientFileName, UriKind.Relative));
+            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(PatientFileName), UriKind.Relative));
             Assert.Null(exportedIds);
 
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(ObservationFileName, UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(ObservationFileName), UriKind.Relative));
             Assert.Equal("123", exportedIds);
 
             Assert.NotNull(_exportJobRecord.Progress);
@@ -836,10 +837,10 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
             await secondExportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
 
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(PatientFileName, UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(PatientFileName), UriKind.Relative));
             Assert.Equal("12", exportedIds);
 
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(ObservationFileName, UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(ObservationFileName), UriKind.Relative));
 
             // 4 was in the commit buffer when the crash happened, and 5 is the one that triggered the crash.
             // Since the 'id' is based on the number of times the mock method has been called these values never get exported.
@@ -902,10 +903,10 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
             await _exportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
 
-            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(PatientFileName, UriKind.Relative));
+            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(PatientFileName), UriKind.Relative));
             Assert.Equal("1", exportedIds);
 
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(ObservationFileName, UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(ObservationFileName), UriKind.Relative));
             Assert.Equal("123", exportedIds);
 
             Assert.NotNull(_exportJobRecord.Progress);
@@ -929,11 +930,11 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
             numberOfCalls = 1;
             await secondExportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
 
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(PatientFileName, UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(PatientFileName), UriKind.Relative));
 
             Assert.Equal("2", exportedIds);
 
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(ObservationFileName, UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(ObservationFileName), UriKind.Relative));
 
             // 4 was in the commit buffer when the crash happened, and 5 is the one that triggered the crash.
             // Since the 'id' is based on the number of times the mock method has been called these values never get exported.
@@ -970,9 +971,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
             await _exportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
 
-            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(ObservationFileName, UriKind.Relative));
+            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(ObservationFileName), UriKind.Relative));
             Assert.Equal("0", exportedIds);
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri("Encounter.ndjson", UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(EncounterFileName), UriKind.Relative));
             Assert.Equal("1", exportedIds);
             Assert.Equal(2, _inMemoryDestinationClient.ExportedDataFileCount);
 
@@ -1023,9 +1024,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
             await _exportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
 
-            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(PatientFileName, UriKind.Relative));
+            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(PatientFileName), UriKind.Relative));
             Assert.Equal("1", exportedIds);
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(ObservationFileName, UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(ObservationFileName), UriKind.Relative));
             Assert.Equal("0", exportedIds);
             Assert.Equal(2, _inMemoryDestinationClient.ExportedDataFileCount);
 
@@ -1087,9 +1088,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
             await _exportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
 
-            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(ObservationFileName, UriKind.Relative));
+            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(ObservationFileName), UriKind.Relative));
             Assert.Equal("1", exportedIds);
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri("Encounter.ndjson", UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(EncounterFileName), UriKind.Relative));
             Assert.Equal("1", exportedIds);
             Assert.Equal(2, _inMemoryDestinationClient.ExportedDataFileCount);
 
@@ -1110,9 +1111,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
             // Reseting the number of calls so that the ressource id of the Patient is the same ('2') as it was when the crash happened.
             await secondExportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
 
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(ObservationFileName, UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(ObservationFileName), UriKind.Relative));
             Assert.Equal("34", exportedIds);
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri("Encounter.ndjson", UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(EncounterFileName), UriKind.Relative));
             Assert.Equal("34", exportedIds);
             Assert.Equal(2, _inMemoryDestinationClient.ExportedDataFileCount);
 
@@ -1173,9 +1174,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
             await _exportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
 
-            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(PatientFileName, UriKind.Relative));
+            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(PatientFileName), UriKind.Relative));
             Assert.Equal("12", exportedIds);
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(ObservationFileName, UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(ObservationFileName), UriKind.Relative));
             Assert.Equal("12", exportedIds);
             Assert.Equal(2, _inMemoryDestinationClient.ExportedDataFileCount);
 
@@ -1240,9 +1241,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
             await _exportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
 
-            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(PatientFileName, UriKind.Relative));
+            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(PatientFileName), UriKind.Relative));
             Assert.Equal("123", exportedIds);
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(ObservationFileName, UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(ObservationFileName), UriKind.Relative));
             Assert.Equal("123", exportedIds);
             Assert.Equal(2, _inMemoryDestinationClient.ExportedDataFileCount);
 
@@ -1325,9 +1326,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
             await _exportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
 
-            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(PatientFileName, UriKind.Relative));
+            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(PatientFileName), UriKind.Relative));
             Assert.Equal("1", exportedIds);
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(ObservationFileName, UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(ObservationFileName), UriKind.Relative));
             Assert.Equal("1", exportedIds);
             Assert.Equal(2, _inMemoryDestinationClient.ExportedDataFileCount);
 
@@ -1348,9 +1349,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
             // Reseting the number of calls so that the ressource id of the Patient is the same ('2') as it was when the crash happened.
             await secondExportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
 
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(PatientFileName, UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(PatientFileName), UriKind.Relative));
             Assert.Equal("23", exportedIds);
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(ObservationFileName, UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(ObservationFileName), UriKind.Relative));
             Assert.Equal("23", exportedIds);
             Assert.Equal(2, _inMemoryDestinationClient.ExportedDataFileCount);
 
@@ -1418,11 +1419,11 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
             await _exportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
 
-            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(PatientFileName, UriKind.Relative));
+            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(PatientFileName), UriKind.Relative));
             Assert.Equal("123", exportedIds);
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(ObservationFileName, UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(ObservationFileName), UriKind.Relative));
             Assert.Equal("123", exportedIds);
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri("Encounter.ndjson", UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(EncounterFileName), UriKind.Relative));
             Assert.Equal("123", exportedIds);
             Assert.Equal(3, _inMemoryDestinationClient.ExportedDataFileCount);
 
@@ -1454,6 +1455,37 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
             Assert.Equal("test", _exportJobRecord.FailureDetails.FailureReason);
         }
 
+        [Fact]
+        public async Task GivenAnExportJobWithACustomContainer_WhenExecuted_ThenAllResourcesAreExportedToThatContainer()
+        {
+            string containerName = "test_container";
+            var exportJobRecordWithCommitPages = CreateExportJobRecord(
+                 containerName: containerName);
+            SetupExportJobRecordAndOperationDataStore(exportJobRecordWithCommitPages);
+
+            SearchResult searchResultWithContinuationToken = CreateSearchResult(continuationToken: "ct");
+
+            _searchService.SearchAsync(
+                Arg.Any<string>(),
+                Arg.Any<IReadOnlyList<Tuple<string, string>>>(),
+                _cancellationToken)
+                .Returns(x =>
+                {
+                    return CreateSearchResult(
+                        new[]
+                        {
+                            CreateSearchResultEntry("1", "Patient"),
+                        });
+                });
+
+            await _exportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
+
+            string actualIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(PatientFileName), UriKind.Relative));
+
+            Assert.Equal("1", actualIds);
+            Assert.Equal(containerName, _inMemoryDestinationClient.ConnectedContainer);
+        }
+
         private ExportJobRecord CreateExportJobRecord(
             string requestEndpoint = "https://localhost/ExportJob/",
             ExportJobType exportJobType = ExportJobType.All,
@@ -1464,7 +1496,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
             string storageAccountConnectionHash = "",
             string storageAccountUri = null,
             uint maximumNumberOfResourcesPerQuery = 0,
-            uint numberOfPagesPerCommit = 0)
+            uint numberOfPagesPerCommit = 0,
+            string containerName = null)
         {
             return new ExportJobRecord(
                 new Uri(requestEndpoint),
@@ -1476,7 +1509,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
                 storageAccountConnectionHash: storageAccountConnectionHash,
                 storageAccountUri: storageAccountUri == null ? _exportJobConfiguration.StorageAccountUri : storageAccountUri,
                 maximumNumberOfResourcesPerQuery: maximumNumberOfResourcesPerQuery == 0 ? _exportJobConfiguration.MaximumNumberOfResourcesPerQuery : maximumNumberOfResourcesPerQuery,
-                numberOfPagesPerCommit: numberOfPagesPerCommit == 0 ? _exportJobConfiguration.NumberOfPagesPerCommit : numberOfPagesPerCommit);
+                numberOfPagesPerCommit: numberOfPagesPerCommit == 0 ? _exportJobConfiguration.NumberOfPagesPerCommit : numberOfPagesPerCommit,
+                storageAccountContainerName: containerName);
         }
 
         private SearchResult CreateSearchResult(IEnumerable<SearchResultEntry> resourceWrappers = null, string continuationToken = null)
@@ -1523,6 +1557,14 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
                 return _lastExportJobOutcome;
             });
+        }
+
+        private string FilePath(string fileName)
+        {
+            string dateTime = _exportJobRecord.QueuedTime.UtcDateTime.ToString("s")
+                            .Replace("-", string.Empty, StringComparison.OrdinalIgnoreCase)
+                            .Replace(":", string.Empty, StringComparison.OrdinalIgnoreCase);
+            return dateTime + "-" + _exportJobRecord.Id + "/" + fileName;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportJobTaskTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportJobTaskTests.cs
@@ -428,7 +428,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
             await _exportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
 
-            string actualIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(PatientFileName), UriKind.Relative));
+            string actualIds = _inMemoryDestinationClient.GetExportedData(new Uri(PatientFileName, UriKind.Relative));
 
             Assert.Equal(expectedIds, actualIds);
         }
@@ -467,7 +467,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
             await _exportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
 
-            string actualIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(PatientFileName), UriKind.Relative));
+            string actualIds = _inMemoryDestinationClient.GetExportedData(new Uri(PatientFileName, UriKind.Relative));
 
             // All of the ids should be present since it should have committed one last time after all the results were exported.
             Assert.Equal("01234", actualIds);
@@ -638,7 +638,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
             await _exportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
 
-            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(PatientFileName), UriKind.Relative));
+            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(PatientFileName, UriKind.Relative));
 
             Assert.Equal("01", exportedIds);
             Assert.NotNull(_exportJobRecord.Progress);
@@ -660,7 +660,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
             numberOfSuccessfulPages = 5;
             await secondExportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
 
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(PatientFileName), UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(PatientFileName, UriKind.Relative));
             Assert.Equal("23", exportedIds);
         }
 
@@ -706,9 +706,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
             Assert.Equal(4, numberOfCalls);
             Assert.Equal(8, numberOfCompartmentCalls);
 
-            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(PatientFileName), UriKind.Relative));
+            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(PatientFileName, UriKind.Relative));
             Assert.Equal("1234", exportedIds);
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(ObservationFileName), UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(ObservationFileName, UriKind.Relative));
             Assert.Equal("12345678", exportedIds);
 
             Assert.Equal(OperationStatus.Completed, _exportJobRecord.Status);
@@ -751,7 +751,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
             Assert.Equal(4, numberOfCalls);
             Assert.Equal(4, numberOfCompartmentCalls);
 
-            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(PatientFileName), UriKind.Relative));
+            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(PatientFileName, UriKind.Relative));
             Assert.Equal("1234", exportedIds);
             Assert.Equal(1, _inMemoryDestinationClient.ExportedDataFileCount);
 
@@ -812,10 +812,10 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
             await _exportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
 
-            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(PatientFileName), UriKind.Relative));
+            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(PatientFileName, UriKind.Relative));
             Assert.Null(exportedIds);
 
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(ObservationFileName), UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(ObservationFileName, UriKind.Relative));
             Assert.Equal("123", exportedIds);
 
             Assert.NotNull(_exportJobRecord.Progress);
@@ -837,10 +837,10 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
             await secondExportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
 
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(PatientFileName), UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(PatientFileName, UriKind.Relative));
             Assert.Equal("12", exportedIds);
 
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(ObservationFileName), UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(ObservationFileName, UriKind.Relative));
 
             // 4 was in the commit buffer when the crash happened, and 5 is the one that triggered the crash.
             // Since the 'id' is based on the number of times the mock method has been called these values never get exported.
@@ -903,10 +903,10 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
             await _exportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
 
-            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(PatientFileName), UriKind.Relative));
+            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(PatientFileName, UriKind.Relative));
             Assert.Equal("1", exportedIds);
 
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(ObservationFileName), UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(ObservationFileName, UriKind.Relative));
             Assert.Equal("123", exportedIds);
 
             Assert.NotNull(_exportJobRecord.Progress);
@@ -930,11 +930,11 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
             numberOfCalls = 1;
             await secondExportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
 
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(PatientFileName), UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(PatientFileName, UriKind.Relative));
 
             Assert.Equal("2", exportedIds);
 
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(ObservationFileName), UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(ObservationFileName, UriKind.Relative));
 
             // 4 was in the commit buffer when the crash happened, and 5 is the one that triggered the crash.
             // Since the 'id' is based on the number of times the mock method has been called these values never get exported.
@@ -971,9 +971,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
             await _exportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
 
-            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(ObservationFileName), UriKind.Relative));
+            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(ObservationFileName, UriKind.Relative));
             Assert.Equal("0", exportedIds);
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(EncounterFileName), UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(EncounterFileName, UriKind.Relative));
             Assert.Equal("1", exportedIds);
             Assert.Equal(2, _inMemoryDestinationClient.ExportedDataFileCount);
 
@@ -1024,9 +1024,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
             await _exportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
 
-            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(PatientFileName), UriKind.Relative));
+            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(PatientFileName, UriKind.Relative));
             Assert.Equal("1", exportedIds);
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(ObservationFileName), UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(ObservationFileName, UriKind.Relative));
             Assert.Equal("0", exportedIds);
             Assert.Equal(2, _inMemoryDestinationClient.ExportedDataFileCount);
 
@@ -1088,9 +1088,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
             await _exportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
 
-            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(ObservationFileName), UriKind.Relative));
+            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(ObservationFileName, UriKind.Relative));
             Assert.Equal("1", exportedIds);
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(EncounterFileName), UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(EncounterFileName, UriKind.Relative));
             Assert.Equal("1", exportedIds);
             Assert.Equal(2, _inMemoryDestinationClient.ExportedDataFileCount);
 
@@ -1111,9 +1111,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
             // Reseting the number of calls so that the ressource id of the Patient is the same ('2') as it was when the crash happened.
             await secondExportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
 
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(ObservationFileName), UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(ObservationFileName, UriKind.Relative));
             Assert.Equal("34", exportedIds);
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(EncounterFileName), UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(EncounterFileName, UriKind.Relative));
             Assert.Equal("34", exportedIds);
             Assert.Equal(2, _inMemoryDestinationClient.ExportedDataFileCount);
 
@@ -1174,9 +1174,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
             await _exportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
 
-            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(PatientFileName), UriKind.Relative));
+            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(PatientFileName, UriKind.Relative));
             Assert.Equal("12", exportedIds);
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(ObservationFileName), UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(ObservationFileName, UriKind.Relative));
             Assert.Equal("12", exportedIds);
             Assert.Equal(2, _inMemoryDestinationClient.ExportedDataFileCount);
 
@@ -1241,9 +1241,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
             await _exportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
 
-            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(PatientFileName), UriKind.Relative));
+            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(PatientFileName, UriKind.Relative));
             Assert.Equal("123", exportedIds);
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(ObservationFileName), UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(ObservationFileName, UriKind.Relative));
             Assert.Equal("123", exportedIds);
             Assert.Equal(2, _inMemoryDestinationClient.ExportedDataFileCount);
 
@@ -1326,9 +1326,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
             await _exportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
 
-            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(PatientFileName), UriKind.Relative));
+            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(PatientFileName, UriKind.Relative));
             Assert.Equal("1", exportedIds);
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(ObservationFileName), UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(ObservationFileName, UriKind.Relative));
             Assert.Equal("1", exportedIds);
             Assert.Equal(2, _inMemoryDestinationClient.ExportedDataFileCount);
 
@@ -1349,9 +1349,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
             // Reseting the number of calls so that the ressource id of the Patient is the same ('2') as it was when the crash happened.
             await secondExportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
 
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(PatientFileName), UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(PatientFileName, UriKind.Relative));
             Assert.Equal("23", exportedIds);
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(ObservationFileName), UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(ObservationFileName, UriKind.Relative));
             Assert.Equal("23", exportedIds);
             Assert.Equal(2, _inMemoryDestinationClient.ExportedDataFileCount);
 
@@ -1419,11 +1419,11 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
             await _exportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
 
-            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(PatientFileName), UriKind.Relative));
+            string exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(PatientFileName, UriKind.Relative));
             Assert.Equal("123", exportedIds);
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(ObservationFileName), UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(ObservationFileName, UriKind.Relative));
             Assert.Equal("123", exportedIds);
-            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(EncounterFileName), UriKind.Relative));
+            exportedIds = _inMemoryDestinationClient.GetExportedData(new Uri(EncounterFileName, UriKind.Relative));
             Assert.Equal("123", exportedIds);
             Assert.Equal(3, _inMemoryDestinationClient.ExportedDataFileCount);
 
@@ -1480,7 +1480,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
             await _exportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
 
-            string actualIds = _inMemoryDestinationClient.GetExportedData(new Uri(FilePath(PatientFileName), UriKind.Relative));
+            string actualIds = _inMemoryDestinationClient.GetExportedData(new Uri(ContainerFilePath(PatientFileName), UriKind.Relative));
 
             Assert.Equal("1", actualIds);
             Assert.Equal(containerName, _inMemoryDestinationClient.ConnectedContainer);
@@ -1559,7 +1559,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
             });
         }
 
-        private string FilePath(string fileName)
+        private string ContainerFilePath(string fileName)
         {
             string dateTime = _exportJobRecord.QueuedTime.UtcDateTime.ToString("s")
                             .Replace("-", string.Empty, StringComparison.OrdinalIgnoreCase)

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/InMemoryExportDestinationClient.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/InMemoryExportDestinationClient.cs
@@ -23,13 +23,17 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
         public int ExportedDataFileCount => _exportedData.Keys.Count;
 
+        public string ConnectedContainer { get; private set; }
+
         public async Task ConnectAsync(CancellationToken cancellationToken, string containerId = null)
         {
+            ConnectedContainer = containerId;
             await Task.CompletedTask;
         }
 
         public async Task ConnectAsync(ExportJobConfiguration exportJobConfiguration, CancellationToken cancellationToken, string containerId = null)
         {
+            ConnectedContainer = containerId;
             await Task.CompletedTask;
         }
 

--- a/src/Microsoft.Health.Fhir.Core/Extensions/ExportMediatorExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Extensions/ExportMediatorExtensions.cs
@@ -23,12 +23,13 @@ namespace Microsoft.Health.Fhir.Core.Extensions
             string resourceType,
             PartialDateTime since,
             string groupId,
+            string containerName,
             CancellationToken cancellationToken)
         {
             EnsureArg.IsNotNull(mediator, nameof(mediator));
             EnsureArg.IsNotNull(requestUri, nameof(requestUri));
 
-            var request = new CreateExportRequest(requestUri, requestType, resourceType, since, groupId);
+            var request = new CreateExportRequest(requestUri, requestType, resourceType, since, groupId, containerName);
 
             CreateExportResponse response = await mediator.Send(request, cancellationToken);
             return response;

--- a/src/Microsoft.Health.Fhir.Core/Features/KnownQueryParameterNames.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/KnownQueryParameterNames.cs
@@ -55,5 +55,7 @@ namespace Microsoft.Health.Fhir.Core.Features
         public const string Id = "_id";
 
         public const string Type = "_type";
+
+        public const string Container = "_container";
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
@@ -88,7 +88,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                     storageAccountConnectionHash,
                     _exportJobConfiguration.StorageAccountUri,
                     _exportJobConfiguration.MaximumNumberOfResourcesPerQuery,
-                    _exportJobConfiguration.NumberOfPagesPerCommit);
+                    _exportJobConfiguration.NumberOfPagesPerCommit,
+                    request.ContainerName);
 
                 outcome = await _fhirOperationDataStore.CreateExportJobAsync(jobRecord, cancellationToken);
             }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                 outcome = await _fhirOperationDataStore.CreateExportJobAsync(jobRecord, cancellationToken);
             }
 
-            return new CreateExportResponse(outcome.JobRecord.Id);
+            return new CreateExportResponse(outcome.JobRecord.Id, outcome.JobRecord.QueuedTime);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                 outcome = await _fhirOperationDataStore.CreateExportJobAsync(jobRecord, cancellationToken);
             }
 
-            return new CreateExportResponse(outcome.JobRecord.Id, outcome.JobRecord.QueuedTime);
+            return new CreateExportResponse(outcome.JobRecord.Id);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                 }
 
                 // Connect to export destination using appropriate client.
-                await _exportDestinationClient.ConnectAsync(exportJobConfiguration, cancellationToken, _exportJobRecord.Id);
+                await _exportDestinationClient.ConnectAsync(exportJobConfiguration, cancellationToken, _exportJobRecord.StorageAccountContainerName);
 
                 // If we are resuming a job, we can detect that by checking the progress info from the job record.
                 // If it is null, then we know we are processing a new job.

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -365,10 +365,19 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                     else
                     {
                         // File does not exist. Create it.
-                        string dateTime = _exportJobRecord.QueuedTime.UtcDateTime.ToString("s")
-                            .Replace("-", string.Empty, StringComparison.OrdinalIgnoreCase)
-                            .Replace(":", string.Empty, StringComparison.OrdinalIgnoreCase);
-                        string fileName = $"{dateTime}-{_exportJobRecord.Id}/{resourceType}.ndjson";
+                        string fileName;
+                        if (_exportJobRecord.StorageAccountContainerName.Equals(_exportJobRecord.Id, StringComparison.OrdinalIgnoreCase))
+                        {
+                            fileName = $"{resourceType}.ndjson";
+                        }
+                        else
+                        {
+                            string dateTime = _exportJobRecord.QueuedTime.UtcDateTime.ToString("s")
+                                .Replace("-", string.Empty, StringComparison.OrdinalIgnoreCase)
+                                .Replace(":", string.Empty, StringComparison.OrdinalIgnoreCase);
+                            fileName = $"{dateTime}-{_exportJobRecord.Id}/{resourceType}.ndjson";
+                        }
+
                         Uri fileUri = await _exportDestinationClient.CreateFileAsync(fileName, cancellationToken);
 
                         exportFileInfo = new ExportFileInfo(resourceType, fileUri, sequence: 0);

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -365,7 +365,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                     else
                     {
                         // File does not exist. Create it.
-                        string fileName = resourceType + ".ndjson";
+                        string dateTime = _exportJobRecord.QueuedTime.UtcDateTime.ToString("s")
+                            .Replace("-", string.Empty, StringComparison.OrdinalIgnoreCase)
+                            .Replace(":", string.Empty, StringComparison.OrdinalIgnoreCase);
+                        string fileName = $"{dateTime}-{_exportJobRecord.Id}/{resourceType}.ndjson";
                         Uri fileUri = await _exportDestinationClient.CreateFileAsync(fileName, cancellationToken);
 
                         exportFileInfo = new ExportFileInfo(resourceType, fileUri, sequence: 0);

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobRecord.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobRecord.cs
@@ -28,7 +28,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
             string storageAccountConnectionHash = null,
             string storageAccountUri = null,
             uint maximumNumberOfResourcesPerQuery = 100,
-            uint numberOfPagesPerCommit = 10)
+            uint numberOfPagesPerCommit = 10,
+            string storageAccountContainerName = null)
         {
             EnsureArg.IsNotNull(requestUri, nameof(requestUri));
             EnsureArg.IsNotNullOrWhiteSpace(hash, nameof(hash));
@@ -51,6 +52,15 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
             Status = OperationStatus.Queued;
 
             QueuedTime = Clock.UtcNow;
+
+            if (storageAccountContainerName == null)
+            {
+                StorageAccountContainerName = Id;
+            }
+            else
+            {
+                StorageAccountContainerName = storageAccountContainerName;
+            }
         }
 
         [JsonConstructor]
@@ -103,5 +113,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
 
         [JsonProperty(JobRecordProperties.NumberOfPagesPerCommit)]
         public uint NumberOfPagesPerCommit { get; private set; }
+
+        [JsonProperty(JobRecordProperties.StorageAccountContainerName)]
+        public string StorageAccountContainerName { get; private set; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobRecord.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobRecord.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
 
             QueuedTime = Clock.UtcNow;
 
-            if (storageAccountContainerName == null)
+            if (string.IsNullOrWhiteSpace(storageAccountContainerName))
             {
                 StorageAccountContainerName = Id;
             }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
@@ -94,5 +94,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations
         public const string ContinuationToken = "continuationToken";
 
         public const string GroupId = "groupId";
+
+        public const string StorageAccountContainerName = "storageAccountContainerName";
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Messages/Export/CreateExportRequest.cs
+++ b/src/Microsoft.Health.Fhir.Core/Messages/Export/CreateExportRequest.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Health.Fhir.Core.Messages.Export
 {
     public class CreateExportRequest : IRequest<CreateExportResponse>
     {
-        public CreateExportRequest(Uri requestUri, ExportJobType requestType, string resourceType = null, PartialDateTime since = null, string groupId = null)
+        public CreateExportRequest(Uri requestUri, ExportJobType requestType, string resourceType = null, PartialDateTime since = null, string groupId = null, string containerName = null)
         {
             EnsureArg.IsNotNull(requestUri, nameof(requestUri));
 
@@ -22,6 +22,7 @@ namespace Microsoft.Health.Fhir.Core.Messages.Export
             ResourceType = resourceType;
             Since = since;
             GroupId = groupId;
+            ContainerName = containerName;
         }
 
         public Uri RequestUri { get; }
@@ -33,5 +34,7 @@ namespace Microsoft.Health.Fhir.Core.Messages.Export
         public PartialDateTime Since { get; }
 
         public string GroupId { get; }
+
+        public string ContainerName { get; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Messages/Export/CreateExportResponse.cs
+++ b/src/Microsoft.Health.Fhir.Core/Messages/Export/CreateExportResponse.cs
@@ -3,23 +3,19 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
 using EnsureThat;
 
 namespace Microsoft.Health.Fhir.Core.Messages.Export
 {
     public class CreateExportResponse
     {
-        public CreateExportResponse(string jobId, DateTimeOffset jobTime)
+        public CreateExportResponse(string jobId)
         {
             EnsureArg.IsNotNullOrWhiteSpace(jobId, nameof(jobId));
 
             JobId = jobId;
-            JobTime = jobTime;
         }
 
         public string JobId { get; }
-
-        public DateTimeOffset JobTime { get; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Messages/Export/CreateExportResponse.cs
+++ b/src/Microsoft.Health.Fhir.Core/Messages/Export/CreateExportResponse.cs
@@ -3,19 +3,23 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using EnsureThat;
 
 namespace Microsoft.Health.Fhir.Core.Messages.Export
 {
     public class CreateExportResponse
     {
-        public CreateExportResponse(string jobId)
+        public CreateExportResponse(string jobId, DateTimeOffset jobTime)
         {
             EnsureArg.IsNotNullOrWhiteSpace(jobId, nameof(jobId));
 
             JobId = jobId;
+            JobTime = jobTime;
         }
 
         public string JobId { get; }
+
+        public DateTimeOffset JobTime { get; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ExportControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ExportControllerTests.cs
@@ -35,19 +35,19 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
         {
             var exportController = GetController(new ExportJobConfiguration() { Enabled = false });
 
-            await Assert.ThrowsAsync<RequestNotValidException>(() => exportController.Export(since: null, resourceType: null));
+            await Assert.ThrowsAsync<RequestNotValidException>(() => exportController.Export(since: null, resourceType: null, containerName: null));
         }
 
         [Fact]
         public async Task GivenAnExportByResourceTypeRequest_WhenResourceTypeIsNotPatient_ThenRequestNotValidExceptionShouldBeThrown()
         {
-            await Assert.ThrowsAsync<RequestNotValidException>(() => _exportEnabledController.ExportResourceType(null, null, ResourceType.Observation.ToString()));
+            await Assert.ThrowsAsync<RequestNotValidException>(() => _exportEnabledController.ExportResourceType(null, null, null, ResourceType.Observation.ToString()));
         }
 
         [Fact]
         public async Task GivenAnExportResourceTypeIdRequest_WhenResourceTypeIsNotGroup_ThenRequestNotValidExceptionShouldBeThrown()
         {
-            await Assert.ThrowsAsync<RequestNotValidException>(() => _exportEnabledController.ExportResourceTypeById(null, null, ResourceType.Patient.ToString(), "id"));
+            await Assert.ThrowsAsync<RequestNotValidException>(() => _exportEnabledController.ExportResourceTypeById(null, null, null, ResourceType.Patient.ToString(), "id"));
         }
 
         private ExportController GetController(ExportJobConfiguration exportConfig)

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ExportController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ExportController.cs
@@ -76,17 +76,24 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         [Route(KnownRoutes.Export)]
         [ServiceFilter(typeof(ValidateExportRequestFilterAttribute))]
         [AuditEventType(AuditEventSubType.Export)]
-        public async Task<IActionResult> Export([FromQuery(Name = KnownQueryParameterNames.Since)] PartialDateTime since, [FromQuery(Name = KnownQueryParameterNames.Type)] string resourceType)
+        public async Task<IActionResult> Export(
+            [FromQuery(Name = KnownQueryParameterNames.Since)] PartialDateTime since,
+            [FromQuery(Name = KnownQueryParameterNames.Type)] string resourceType,
+            [FromQuery(Name = KnownQueryParameterNames.Container)] string containerName)
         {
             CheckIfExportIsEnabled();
-            return await SendExportRequest(ExportJobType.All, since, resourceType);
+            return await SendExportRequest(ExportJobType.All, since, resourceType, containerName: containerName);
         }
 
         [HttpGet]
         [Route(KnownRoutes.ExportResourceType)]
         [ServiceFilter(typeof(ValidateExportRequestFilterAttribute))]
         [AuditEventType(AuditEventSubType.Export)]
-        public async Task<IActionResult> ExportResourceType([FromQuery(Name = KnownQueryParameterNames.Since)] PartialDateTime since, [FromQuery(Name = KnownQueryParameterNames.Type)] string resourceType, string typeParameter)
+        public async Task<IActionResult> ExportResourceType(
+            [FromQuery(Name = KnownQueryParameterNames.Since)] PartialDateTime since,
+            [FromQuery(Name = KnownQueryParameterNames.Type)] string resourceType,
+            [FromQuery(Name = KnownQueryParameterNames.Container)] string containerName,
+            string typeParameter)
         {
             CheckIfExportIsEnabled();
 
@@ -96,14 +103,19 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                 throw new RequestNotValidException(string.Format(Resources.UnsupportedResourceType, typeParameter));
             }
 
-            return await SendExportRequest(ExportJobType.Patient, since, resourceType);
+            return await SendExportRequest(ExportJobType.Patient, since, resourceType, containerName: containerName);
         }
 
         [HttpGet]
         [Route(KnownRoutes.ExportResourceTypeById)]
         [ServiceFilter(typeof(ValidateExportRequestFilterAttribute))]
         [AuditEventType(AuditEventSubType.Export)]
-        public async Task<IActionResult> ExportResourceTypeById([FromQuery(Name = KnownQueryParameterNames.Since)] PartialDateTime since, [FromQuery(Name = KnownQueryParameterNames.Type)] string resourceType, string typeParameter, string idParameter)
+        public async Task<IActionResult> ExportResourceTypeById(
+            [FromQuery(Name = KnownQueryParameterNames.Since)] PartialDateTime since,
+            [FromQuery(Name = KnownQueryParameterNames.Type)] string resourceType,
+            [FromQuery(Name = KnownQueryParameterNames.Container)] string containerName,
+            string typeParameter,
+            string idParameter)
         {
             // Export by ResourceTypeId is supported only for Group resource type.
             if (!string.Equals(typeParameter, ResourceType.Group.ToString(), StringComparison.Ordinal) || string.IsNullOrEmpty(idParameter))
@@ -111,7 +123,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                 throw new RequestNotValidException(string.Format(Resources.UnsupportedResourceType, typeParameter));
             }
 
-            return await SendExportRequest(ExportJobType.Group, since, resourceType, idParameter);
+            return await SendExportRequest(ExportJobType.Group, since, resourceType, idParameter, containerName);
         }
 
         [HttpGet]
@@ -150,9 +162,9 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             return new ExportResult(response.StatusCode);
         }
 
-        private async Task<IActionResult> SendExportRequest(ExportJobType exportType, PartialDateTime since, string resourceType = null, string groupId = null)
+        private async Task<IActionResult> SendExportRequest(ExportJobType exportType, PartialDateTime since, string resourceType = null, string groupId = null, string containerName = null)
         {
-            CreateExportResponse response = await _mediator.ExportAsync(_fhirRequestContextAccessor.FhirRequestContext.Uri, exportType, resourceType, since, groupId, HttpContext.RequestAborted);
+            CreateExportResponse response = await _mediator.ExportAsync(_fhirRequestContextAccessor.FhirRequestContext.Uri, exportType, resourceType, since, groupId, containerName, HttpContext.RequestAborted);
 
             var exportResult = ExportResult.Accepted();
             exportResult.SetContentLocationHeader(_urlResolver, OperationsConstants.Export, response.JobId);

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ExportController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ExportController.cs
@@ -168,7 +168,6 @@ namespace Microsoft.Health.Fhir.Api.Controllers
 
             var exportResult = ExportResult.Accepted();
             exportResult.SetContentLocationHeader(_urlResolver, OperationsConstants.Export, response.JobId);
-            exportResult.SetDateHeader(response.JobTime.UtcDateTime.ToString("s"));
             return exportResult;
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ExportController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ExportController.cs
@@ -168,7 +168,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
 
             var exportResult = ExportResult.Accepted();
             exportResult.SetContentLocationHeader(_urlResolver, OperationsConstants.Export, response.JobId);
-
+            exportResult.SetDateHeader(response.JobTime.UtcDateTime.ToString("s"));
             return exportResult;
         }
 

--- a/test/Microsoft.Health.Fhir.R4.Tests.E2E/KnownCrucibleTests.cs
+++ b/test/Microsoft.Health.Fhir.R4.Tests.E2E/KnownCrucibleTests.cs
@@ -664,7 +664,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Crucible
                     {
                         "history001/HI01",
                         "history001/HI02",
-                        "history001/HI06",
                         "history001/HI08",
                     }
                 },
@@ -691,6 +690,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Crucible
             "connectathon-15-patient-fhirserver-99-all-server-id-xml/02-UpdatePatient",
             "connectathon-15-patient-fhirserver-99-all-server-id-json/07-PatientDelete",
             "connectathon-15-patient-fhirserver-99-all-server-id-xml/07-PatientDelete",
+            "history001/HI06", // Appears related to incomplete support for Validation
             "history001/HI09",  // Related to Cosmos DB failure, issue: https://github.com/microsoft/fhir-server/issues/475"
             "resourcetest_questionnaire/X030_Questionnaire", // POCO RequestGroup is not a valid enumeration value for  CarePlanActivityKind
             "resourcetest_clinicalimpression/X010_ClinicalImpression",

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ExportDataValidationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ExportDataValidationTests.cs
@@ -190,7 +190,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         {
             // NOTE: Azure Storage Emulator is required to run these tests locally.
 
-            string testContainer = "test-contianer";
+            string testContainer = "test-container";
 
             // Trigger export request and check for export status
             Uri contentLocation = await _testFhirClient.ExportAsync(parameters: $"_container={testContainer}");

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ExportDataValidationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ExportDataValidationTests.cs
@@ -185,6 +185,28 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.True(ValidateDataFromBothSources(dataInFhirServer, dataFromExport));
         }
 
+        [Fact]
+        public async Task GivenFhirServer_WhenAllDataIsExportedToASpecificContainer_ThenExportedDataIsInTheSpecifiedContianer()
+        {
+            // NOTE: Azure Storage Emulator is required to run these tests locally.
+
+            string testContainer = "test-contianer";
+
+            // Trigger export request and check for export status
+            Uri contentLocation = await _testFhirClient.ExportAsync(parameters: $"_container={testContainer}");
+            IList<Uri> blobUris = await CheckExportStatus(contentLocation);
+
+            // Download exported data from storage account
+            Dictionary<(string resourceType, string resourceId), Resource> dataFromExport = await DownloadBlobAndParse(blobUris);
+
+            // Download all resources from fhir server
+            Dictionary<(string resourceType, string resourceId), Resource> dataFromFhirServer = await GetResourcesFromFhirServer(_testFhirClient.HttpClient.BaseAddress);
+
+            // Assert both data are equal
+            Assert.True(ValidateDataFromBothSources(dataFromFhirServer, dataFromExport));
+            Assert.True(blobUris.All((url) => url.OriginalString.Contains(testContainer)));
+        }
+
         private bool ValidateDataFromBothSources(Dictionary<(string resourceType, string resourceId), Resource> dataFromServer, Dictionary<(string resourceType, string resourceId), Resource> dataFromStorageAccount)
         {
             bool result = true;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ExportTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ExportTests.cs
@@ -83,11 +83,13 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [InlineData("$export")]
         [InlineData("Patient/$export")]
         [InlineData("Group/123456/$export")]
-        public async Task GivenExportIsEnabled_WhenRequestingExportWithSinceQueryParam_ThenServerShouldReturnAcceptedAndNonEmptyContentLocationHeader(string path)
+        public async Task GivenExportIsEnabled_WhenRequestingExportWithSupportedQueryParam_ThenServerShouldReturnAcceptedAndNonEmptyContentLocationHeader(string path)
         {
             var queryParam = new Dictionary<string, string>()
             {
                 { KnownQueryParameterNames.Since, DateTimeOffset.UtcNow.ToString() },
+                { KnownQueryParameterNames.Type, "Patient" },
+                { KnownQueryParameterNames.Container, "test-container" },
             };
             using HttpRequestMessage request = GenerateExportRequest(path, queryParams: queryParam);
 


### PR DESCRIPTION
## Description
Allows the user to select the container that data will be sent to as part of an export request.
The container is specified with the parameter _container when making the export job.

Additionally all data will now be exported to a folder in the container with the name <timestamp>-<id> to avoid overwrite issues.

## Related issues
Addresses [74055](https://microsofthealth.visualstudio.com/Health/_workitems/edit/74055)

## Testing
New unit and E2E tests have been added to cover the new scenario.
