### PR TITLE
Add Cloud RoleName for AppInsights

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Web/CloudRoleNameTelemetryInitializer.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web/CloudRoleNameTelemetryInitializer.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Health.Fhir.Web
     {
         public void Initialize(ITelemetry telemetry)
         {
-            telemetry.Context.Cloud.RoleName = "Microsoft Fhir Server";
+            telemetry.Context.Cloud.RoleName = "Microsoft FHIR Server";
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Web/CloudRoleNameTelemetryInitializer.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web/CloudRoleNameTelemetryInitializer.cs
@@ -1,0 +1,18 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace Microsoft.Health.Fhir.Web
+{
+    public class CloudRoleNameTelemetryInitializer : ITelemetryInitializer
+    {
+        public void Initialize(ITelemetry telemetry)
+        {
+            telemetry.Context.Cloud.RoleName = "Microsoft Fhir Server";
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Web/Microsoft.Health.Fhir.Shared.Web.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Web/Microsoft.Health.Fhir.Shared.Web.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>Microsoft.Health.Fhir.Shared.Web</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)CloudRoleNameTelemetryInitializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DevelopmentIdentityProviderApplicationConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DevelopmentIdentityProviderConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DevelopmentIdentityProviderRegistrationExtensions.cs" />
@@ -18,7 +19,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)PrometheusMetricsConfig.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PrometheusMetricsApplicationBuilderExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PrometheusMetricsServicesCollectionExtensions.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)PrometheusMetricsServer.cs" />    
+    <Compile Include="$(MSBuildThisFileDirectory)PrometheusMetricsServer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Startup.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.Configuration;
@@ -88,6 +89,7 @@ namespace Microsoft.Health.Fhir.Web
             if (!string.IsNullOrWhiteSpace(instrumentationKey))
             {
                 services.AddApplicationInsightsTelemetry(instrumentationKey);
+                services.AddSingleton<ITelemetryInitializer, CloudRoleNameTelemetryInitializer>();
                 services.AddLogging(loggingBuilder => loggingBuilder.AddApplicationInsights(instrumentationKey));
             }
         }


### PR DESCRIPTION
## Description
When using AppInsights it is useful to know which app created different entries especially when multiple applications are taking part in the same solution (like fhir server and proxy).
This PR adds that information to the Cloud RoleName property for each tracked item sent from the server.
(please let me know if you'd like a different name)

## Related issues
Addresses #1198.

## Testing
Run locally and seen the information received in AppInsights.
