### PR TITLE
Added PathBase to allow hosting FHIR Server behind a rewriting reverse proxy on a subpath

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Configs/FhirServerConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Api/Configs/FhirServerConfiguration.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Health.Fhir.Api.Configs
 {
     public class FhirServerConfiguration : IApiConfiguration
     {
+        public string PathBase { get; set; } = string.Empty;
+
         public FeatureConfiguration Features { get; } = new FeatureConfiguration();
 
         public SecurityConfiguration Security { get; } = new SecurityConfiguration();

--- a/src/Microsoft.Health.Fhir.Api/Registration/FhirServerApplicationBuilderExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Api/Registration/FhirServerApplicationBuilderExtensions.cs
@@ -3,9 +3,13 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
+using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 using Microsoft.Health.Api.Registration;
+using Microsoft.Health.Fhir.Api.Configs;
 using Microsoft.Health.Fhir.Api.Features.Routing;
 
 namespace Microsoft.AspNetCore.Builder
@@ -23,10 +27,56 @@ namespace Microsoft.AspNetCore.Builder
 
             app.UseHealthChecksExtension(new PathString(KnownRoutes.HealthCheck));
 
+            var config = app.ApplicationServices.GetService(typeof(IOptions<FhirServerConfiguration>)) as IOptions<FhirServerConfiguration>;
+            EnsureArg.IsNotNull(config, nameof(config));
+
+            var pathBase = new PathString(config.Value.PathBase.TrimEnd('/'));
+            if (pathBase.HasValue)
+            {
+                app.UseMiddleware<PathBaseMiddleware>(pathBase);
+            }
+
             app.UseStaticFiles();
             app.UseMvc();
 
             return app;
+        }
+
+        private class PathBaseMiddleware
+        {
+            private readonly RequestDelegate _next;
+            private readonly PathString _pathBase;
+
+            public PathBaseMiddleware(RequestDelegate next, PathString pathBase)
+            {
+                if (!pathBase.HasValue)
+                {
+                    throw new ArgumentException($"{nameof(pathBase)} cannot be null or empty.");
+                }
+
+                _next = next ?? throw new ArgumentNullException(nameof(next));
+                _pathBase = pathBase;
+            }
+
+            public async Task Invoke(HttpContext context)
+            {
+                if (context == null)
+                {
+                    throw new ArgumentNullException(nameof(context));
+                }
+
+                var originalPathBase = context.Request.PathBase;
+                context.Request.PathBase = originalPathBase.Add(_pathBase);
+
+                try
+                {
+                    await _next(context);
+                }
+                finally
+                {
+                    context.Request.PathBase = originalPathBase;
+                }
+            }
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
@@ -71,6 +71,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
         private readonly IAuditEventTypeMapping _auditEventTypeMapping;
         private readonly IFhirAuthorizationService _authorizationService;
         private readonly BundleConfiguration _bundleConfiguration;
+        private readonly string _originalRequestBase;
 
         public BundleHandler(
             IHttpContextAccessor httpContextAccessor,
@@ -121,6 +122,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
             _httpAuthenticationFeature = httpContextAccessor.HttpContext.Features.Get<IHttpAuthenticationFeature>();
             _router = httpContextAccessor.HttpContext.GetRouteData().Routers.First();
             _requestServices = httpContextAccessor.HttpContext.RequestServices;
+            _originalRequestBase = httpContextAccessor.HttpContext.Request.PathBase;
             _emptyRequestsOrder = new List<int>();
             _referenceIdDictionary = new Dictionary<string, (string resourceId, string resourceType)>();
         }
@@ -282,6 +284,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
             var requestUri = new Uri(_fhirRequestContextAccessor.FhirRequestContext.BaseUri, requestUrl);
             httpContext.Request.Scheme = requestUri.Scheme;
             httpContext.Request.Host = new HostString(requestUri.Host, requestUri.Port);
+            httpContext.Request.PathBase = _originalRequestBase;
             httpContext.Request.Path = requestUri.LocalPath;
             httpContext.Request.QueryString = new QueryString(requestUri.Query);
             httpContext.Request.Method = requestMethod.ToString();


### PR DESCRIPTION
## Description
When FHIR server is hosted behind a rewriting reverse proxy (on a subpath), the URLs returned by FHIR server are missing a prefix. This PR fixes this.

#### Example:
- Reverse proxy is configured on `{{host}}` to forward traffic from `/r4` to `{{fhirHost}}` (removing the `/r4` prefix). 
- `GET {{host}}/r4/Patient --> GET {{fhirHost}}/Patient`. 
- The returned URLs in `entry[].fullUrl` will be `{{host}}/Patient/{{id}}`, but should be `{{host}}/r4/Patient/{{id}}` to be valid.

This behaviour is configurable with optional configuration variable `FhirServer:PathBase`.

## Testing
All existing tests pass (Integration and E2E checked with SqlServer only). 

Starting the server with `FhirServer:PathBase`:
- Create resource request returns location header with prefix
- Create resource transaction request returns `entry[].response.location` with prefix
- Search request
  -  Returns `entry[].fullUrl` with prefix
  -  Returns `link[].url` with prefix (both `self` and `next`)
