### PR TITLE
Make query parameter '_container' mandatory for anonymized export

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
@@ -97,6 +97,15 @@ namespace Microsoft.Health.Fhir.Api {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Missing &apos;_container&apos; for anonymized export.
+        /// </summary>
+        public static string ContainerIsRequiredForAnonymizedExport {
+            get {
+                return ResourceManager.GetString("ContainerIsRequiredForAnonymizedExport", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The &quot;content-type&quot; header is required..
         /// </summary>
         public static string ContentTypeHeaderRequired {

--- a/src/Microsoft.Health.Fhir.Api/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Api/Resources.resx
@@ -316,4 +316,7 @@
   <data name="TooManyConcurrentRequests" xml:space="preserve">
     <value>The maximum number of concurrent API calls on this instance was reached.</value>
   </data>
+  <data name="ContainerIsRequiredForAnonymizedExport" xml:space="preserve">
+    <value>Missing '_container' for anonymized export</value>
+  </data>
 </root>

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ExportController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ExportController.cs
@@ -203,9 +203,9 @@ namespace Microsoft.Health.Fhir.Api.Controllers
 
         private static void CheckContainerNameForAnonymizedExport(string containerName)
         {
-            if (string.IsNullOrEmpty(containerName))
+            if (string.IsNullOrWhiteSpace(containerName))
             {
-                throw new RequestNotValidException(string.Format(Resources.ContainerIsRequiredForAnonymizedExport, OperationsConstants.AnonymizedExport));
+                throw new RequestNotValidException(Resources.ContainerIsRequiredForAnonymizedExport);
             }
         }
     }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ExportController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ExportController.cs
@@ -93,6 +93,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             if (!string.IsNullOrWhiteSpace(anonymizationConfigLocation) || !string.IsNullOrWhiteSpace(anonymizationConfigFileETag))
             {
                 CheckIfAnonymizedExportIsEnabled();
+                CheckContainerNameForAnonymizedExport(containerName);
             }
 
             return await SendExportRequest(ExportJobType.All, since, resourceType, containerName: containerName, anonymizationConfigLocation: anonymizationConfigLocation, anonymizationConfigFileETag: anonymizationConfigFileETag);
@@ -197,6 +198,14 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             if (!_features.SupportsAnonymizedExport)
             {
                 throw new RequestNotValidException(string.Format(Resources.OperationNotEnabled, OperationsConstants.AnonymizedExport));
+            }
+        }
+
+        private static void CheckContainerNameForAnonymizedExport(string containerName)
+        {
+            if (string.IsNullOrEmpty(containerName))
+            {
+                throw new RequestNotValidException(string.Format(Resources.ContainerIsRequiredForAnonymizedExport, OperationsConstants.AnonymizedExport));
             }
         }
     }

--- a/src/Microsoft.Health.Fhir.Shared.Client/FhirClient.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Client/FhirClient.cs
@@ -284,11 +284,12 @@ namespace Microsoft.Health.Fhir.Client
             return response.Content.Headers.ContentLocation;
         }
 
-        public async Task<Uri> AnonymizedExportAsync(string anonymizationConfig, string etag = null, CancellationToken cancellationToken = default)
+        public async Task<Uri> AnonymizedExportAsync(string anonymizationConfig, string container, string etag = null, CancellationToken cancellationToken = default)
         {
             anonymizationConfig = HttpUtility.UrlEncode(anonymizationConfig);
             etag = HttpUtility.UrlEncode(etag);
-            string requestUrl = $"$export?_anonymizationConfig={anonymizationConfig}&_anonymizationConfigEtag={etag}";
+            container = HttpUtility.UrlEncode(container);
+            string requestUrl = $"$export?_container={container}&_anonymizationConfig={anonymizationConfig}&_anonymizationConfigEtag={etag}";
 
             using var message = new HttpRequestMessage(HttpMethod.Get, requestUrl);
             message.Headers.Add("Accept", "application/fhir+json");

--- a/test/Microsoft.Health.Fhir.R4.Tests.E2E/Microsoft.Health.Fhir.R4.Tests.E2E.csproj
+++ b/test/Microsoft.Health.Fhir.R4.Tests.E2E/Microsoft.Health.Fhir.R4.Tests.E2E.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\Microsoft.Health.Fhir.Shared.Tests.E2E\Rest\AnonymizedExportDataValidationTests.cs" Link="Rest\AnonymizedExportDataValidationTests.cs" />
+    <Compile Include="..\Microsoft.Health.Fhir.Shared.Tests.E2E\Rest\AnonymizedExportTests.cs" Link="Rest\AnonymizedExportTests.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Microsoft.Health.Fhir.Shared.Tests.E2E.shproj
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Microsoft.Health.Fhir.Shared.Tests.E2E.shproj
@@ -8,11 +8,9 @@
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
   <PropertyGroup />
-  
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)Rest\AnonymizedExportDataValidationTests.cs" />
+    <None Include="Rest\AnonymizedExportTests.cs" />
   </ItemGroup>
-  
   <Import Project="Microsoft.Health.Fhir.Shared.Tests.E2E.projitems" Label="Shared" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
 </Project>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/AnonymizedExportTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/AnonymizedExportTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
 {
     [Trait(Traits.Category, Categories.Export)]
     [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.Json)]
-    public class AnonymizedExportDataValidationTests : IClassFixture<HttpIntegrationTestFixture<StartupForAnonymizedExportTestProvider>>
+    public class AnonymizedExportTests : IClassFixture<HttpIntegrationTestFixture<StartupForAnonymizedExportTestProvider>>
     {
         private bool _isUsingInProcTestServer = false;
         private readonly TestFhirClient _testFhirClient;
@@ -44,7 +44,7 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
     ]
 }";
 
-        public AnonymizedExportDataValidationTests(HttpIntegrationTestFixture<StartupForAnonymizedExportTestProvider> fixture)
+        public AnonymizedExportTests(HttpIntegrationTestFixture<StartupForAnonymizedExportTestProvider> fixture)
         {
             _isUsingInProcTestServer = fixture.IsUsingInProcTestServer;
             _testFhirClient = fixture.TestFhirClient;

--- a/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/Microsoft.Health.Fhir.Stu3.Tests.E2E.csproj
+++ b/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/Microsoft.Health.Fhir.Stu3.Tests.E2E.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\Microsoft.Health.Fhir.Shared.Tests.E2E\Rest\AnonymizedExportDataValidationTests.cs" Link="Rest\AnonymizedExportDataValidationTests.cs" />
+    <Compile Include="..\Microsoft.Health.Fhir.Shared.Tests.E2E\Rest\AnonymizedExportTests.cs" Link="Rest\AnonymizedExportTests.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description
Make query parameter '_container' mandatory for anonymized export

## Related issues
Addresses task: https://microsofthealth.visualstudio.com/Health/_workitems/edit/75405/.

## Testing
Add E2E tests on anonymized export and update current tests.
