### PR TITLE
Remove environment pipeline

### DIFF
--- a/build/remove-environment.yml
+++ b/build/remove-environment.yml
@@ -1,0 +1,24 @@
+# DESCRIPTION: 	
+# Cleans up a PR environment if it has gotten into a bad state.
+
+trigger: none
+
+variables:
+- name: DeploymentEnvironmentName
+  value: 'msh-fhir-pr-$(pr_number)'
+- template: build-variables.yml
+
+stages:
+- stage: cleanupAks
+  displayName: 'Cleanup AKS Deployments'
+  jobs:
+  - template: ./jobs/cleanup-aks.yml
+    parameters:
+      subscription: $(ConnectedServiceName)
+      clusterName: $(clusterName)
+      clusterResourceGroup: $(clusterResourceGroup)
+
+- stage: cleanup
+  displayName: 'Cleanup Azure Environment'
+  jobs:
+  - template: ./jobs/cleanup.yml

--- a/build/remove-environment.yml
+++ b/build/remove-environment.yml
@@ -20,5 +20,6 @@ stages:
 
 - stage: cleanup
   displayName: 'Cleanup Azure Environment'
+  dependsOn: []
   jobs:
   - template: ./jobs/cleanup.yml


### PR DESCRIPTION
## Description
Adds a pipeline that cleans up an environment in a bad state. This removes the need to manually delete the resource group or container if they get into a bad state.

## Related issues

## Testing
Run against another PR environment and it deleted both environments.
