### PR TITLE
Always apply continuation token limit

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/FhirCosmosResponseHandler.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/FhirCosmosResponseHandler.cs
@@ -59,10 +59,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
 
         private void UpdateOptions(RequestMessage options)
         {
-            if (_cosmosDataStoreConfiguration.InitialDatabaseThroughput != null)
-            {
-                options.Headers[_continuationTokenLimitHeaderName] = _cosmosDataStoreConfiguration.ContinuationTokenSizeLimitInKb?.ToString();
-            }
+            options.Headers[_continuationTokenLimitHeaderName] = _cosmosDataStoreConfiguration.ContinuationTokenSizeLimitInKb?.ToString();
 
             (ConsistencyLevel? consistencyLevel, string sessionToken) = GetConsistencyHeaders();
 

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/FhirCosmosResponseHandler.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/FhirCosmosResponseHandler.cs
@@ -59,7 +59,10 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
 
         private void UpdateOptions(RequestMessage options)
         {
-            options.Headers[_continuationTokenLimitHeaderName] = _cosmosDataStoreConfiguration.ContinuationTokenSizeLimitInKb?.ToString();
+            if (_cosmosDataStoreConfiguration.ContinuationTokenSizeLimitInKb != null)
+            {
+                options.Headers[_continuationTokenLimitHeaderName] = _cosmosDataStoreConfiguration.ContinuationTokenSizeLimitInKb.ToString();
+            }
 
             (ConsistencyLevel? consistencyLevel, string sessionToken) = GetConsistencyHeaders();
 


### PR DESCRIPTION
## Description
Applies the continuation token limit setting always, instead of only when the initial throughput is specified.

## Related issues
Addresses [issue [AB#75512](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/75512)].

## Testing
Manual testing with query that reproduces the error, then applied the fix and tried the query again.
