### PR TITLE
Always apply continuation token limit (#1228)

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/FhirCosmosResponseHandler.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/FhirCosmosResponseHandler.cs
@@ -59,9 +59,9 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
 
         private void UpdateOptions(RequestMessage options)
         {
-            if (_cosmosDataStoreConfiguration.InitialDatabaseThroughput != null)
+            if (_cosmosDataStoreConfiguration.ContinuationTokenSizeLimitInKb != null)
             {
-                options.Headers[_continuationTokenLimitHeaderName] = _cosmosDataStoreConfiguration.ContinuationTokenSizeLimitInKb?.ToString();
+                options.Headers[_continuationTokenLimitHeaderName] = _cosmosDataStoreConfiguration.ContinuationTokenSizeLimitInKb.ToString();
             }
 
             (ConsistencyLevel? consistencyLevel, string sessionToken) = GetConsistencyHeaders();


### PR DESCRIPTION
Applies the continuation token limit correctly if value is set in settings

## Description
Merges a hotfix into master

## Related issues

## Testing
