### PR TITLE
_include:iterate support - Phase#1

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
@@ -107,5 +107,19 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
 
             return componentSearchParameter.Type;
         }
+
+        public bool TryGetAllReferences(string resourceType, out IEnumerable<SearchParameterInfo> references)
+        {
+            IDictionary<string, SearchParameterInfo> searchParameters = null;
+
+            if (_typeLookup.TryGetValue(resourceType, out searchParameters))
+            {
+                references = searchParameters.Values.Where(v => v.Type == ValueSets.SearchParamType.Reference);
+                return true;
+            }
+
+            references = null;
+            return false;
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Expression.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Expression.cs
@@ -75,12 +75,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// <param name="resourceType">The source resource type.</param>
         /// <param name="referenceSearchParameter">The search parameter that establishes the reference between resources</param>
         /// <param name="targetResourceType">The target resource type.</param>
+        /// <param name="referencedTypes">The type of resources referenced by resourceType</param>
         /// <param name="wildCard">If this is a wildcard include.</param>
         /// <param name="reversed">If this is a reversed include (revinclude) expression.</param>
+        /// <param name="iterate">If this is include has :iterate (:recurse) modifier.</param>
         /// <returns>A <see cref="IncludeExpression"/> that represents an include on <param name="targetResourceType"> through <paramref name="referenceSearchParameter"/>.</param></returns>
-        public static IncludeExpression Include(string resourceType, SearchParameterInfo referenceSearchParameter, string targetResourceType, bool wildCard, bool reversed)
+        public static IncludeExpression Include(string resourceType, SearchParameterInfo referenceSearchParameter, string targetResourceType, IEnumerable<string> referencedTypes, bool wildCard, bool reversed, bool iterate)
         {
-            return new IncludeExpression(resourceType, referenceSearchParameter, targetResourceType, wildCard, reversed);
+            return new IncludeExpression(resourceType, referenceSearchParameter, targetResourceType, referencedTypes, wildCard, reversed, iterate);
         }
 
         /// <summary>

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/IncludeExpression.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/IncludeExpression.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
+using System.Linq;
 using EnsureThat;
 using Microsoft.Health.Fhir.Core.Models;
 
@@ -19,9 +21,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// <param name="resourceType">The resource that supports the reference.</param>
         /// <param name="referenceSearchParameter">THe search parameter that establishes the reference relationship.</param>
         /// <param name="targetResourceType">The target type of the reference.</param>
+        /// <param name="referencedTypes">All the resource types referenced by resourceType</param>
         /// <param name="wildCard">If this is a wildcard reference include (include all referenced resources).</param>
         /// <param name="reversed">If this is a reversed include (revinclude) expression.</param>
-        public IncludeExpression(string resourceType, SearchParameterInfo referenceSearchParameter, string targetResourceType, bool wildCard, bool reversed)
+        /// <param name="iterate"> If :iterate (:recurse) modifer was applied.</param>
+        public IncludeExpression(string resourceType, SearchParameterInfo referenceSearchParameter, string targetResourceType, IEnumerable<string> referencedTypes, bool wildCard, bool reversed, bool iterate)
         {
             EnsureArg.IsNotNullOrWhiteSpace(resourceType, nameof(resourceType));
 
@@ -33,8 +37,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
             ResourceType = resourceType;
             ReferenceSearchParameter = referenceSearchParameter;
             TargetResourceType = targetResourceType;
+            ReferencedTypes = referencedTypes?.ToList().AsReadOnly();
             WildCard = wildCard;
             Reversed = reversed;
+            Iterate = iterate;
+            SetRecursive();
         }
 
         /// <summary>
@@ -53,6 +60,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         public string TargetResourceType { get; }
 
         /// <summary>
+        ///  Gets the type of resources referenced by resourceType. Used when iterating over wildcard results.
+        /// </summary>
+        public IReadOnlyCollection<string> ReferencedTypes { get; }
+
+        /// <summary>
         /// Gets if the include is a wildcard include.
         /// </summary>
         public bool WildCard { get; }
@@ -61,6 +73,16 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// Get if the expression is reversed.
         /// </summary>
         public bool Reversed { get; }
+
+        /// <summary>
+        /// Gets if the include has :iterate (:recurse) modifier.
+        /// </summary>
+        public bool Iterate { get; }
+
+        /// <summary>
+        /// Gets if the include is recursive (i.e., circular reference: target reference is of the same resource type, e.g., Organization:partof)
+        /// </summary>
+        public bool Recursive { get; private set; }
 
         public override TOutput AcceptVisitor<TContext, TOutput>(IExpressionVisitor<TContext, TOutput> visitor, TContext context)
         {
@@ -71,13 +93,35 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
 
         public override string ToString()
         {
-            if (WildCard)
-            {
-                return "(Include wildcard)";
-            }
-
             var targetType = TargetResourceType != null ? $":{TargetResourceType}" : string.Empty;
-            return $"({(Reversed ? "Reverse " : string.Empty)}Include {ReferenceSearchParameter.Name}{targetType})";
+            var iterate = Iterate ? "Iterate" : string.Empty;
+            var reversed = Reversed ? "Reversed" : string.Empty;
+            var wildcard = WildCard ? "Wildcard" : string.Empty;
+            var paramName = ReferenceSearchParameter != null ? ReferenceSearchParameter.Name : string.Empty;
+            return $"({reversed} Include {iterate} {wildcard} {paramName}{targetType})";
+        }
+
+        /// <summary>
+        /// Returns if the include expression is Recursive (target reference is of the same as base resource type, e.g., Organization:partof)
+        private void SetRecursive()
+        {
+            Recursive = false;
+
+            if (Iterate)
+            {
+                if (TargetResourceType != null)
+                {
+                    Recursive = ResourceType == TargetResourceType;
+                }
+                else if (ReferenceSearchParameter?.TargetResourceTypes != null)
+                {
+                    if (new List<string>(ReferenceSearchParameter.TargetResourceTypes).Contains(ResourceType))
+                    {
+                        Recursive = true;
+                        return;
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/IExpressionParser.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/IExpressionParser.cs
@@ -9,6 +9,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
     {
         Expression Parse(string resourceType, string key, string value);
 
-        IncludeExpression ParseInclude(string resourceType, string value, bool isReversed);
+        IncludeExpression ParseInclude(string resourceType, string value, bool isReversed, bool iterate);
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/IncludeRewriterTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/IncludeRewriterTests.cs
@@ -1,0 +1,95 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using Microsoft.Health.Fhir.Core;
+using Microsoft.Health.Fhir.Core.Features.Definition;
+using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
+using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions;
+using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors;
+using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.QueryGenerators;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
+{
+    public class IncludeRewriterTests
+    {
+        private readonly SearchParameterDefinitionManager _searchParameterDefinitionManager;
+        private IReadOnlyList<string> _includeTargetTypes = new List<string>() { "MedicationRequest" };
+
+        public IncludeRewriterTests()
+        {
+            ModelInfoProvider.SetProvider(new VersionSpecificModelInfoProvider());
+            _searchParameterDefinitionManager = new SearchParameterDefinitionManager(ModelInfoProvider.Instance);
+            _searchParameterDefinitionManager.Start();
+        }
+
+        [Fact]
+        public void GivenASqlRootExpressionWithIncludes_WhenVisitedByIncludeRewriter_OrderIncludesAfterOtherSearchParametersSoIncludeIterateAppearAfterRelatedIncludes()
+        {
+            // Order the following query:
+            // [base]/MedicationDispense?_include:iterate=Patient:general-practitioner&_include:iterate=MedicationRequest:patient&_include=MedicationDispense:prescription&_count=10&_id=smart-MedicationDispense-567
+
+            var refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("Patient", "general-practitioner");
+            var includeIteratePatientGeneralPractitioner = new IncludeExpression("Patient", refSearchParameter, null, false, false, true);
+
+            refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationRequest", "patient");
+            var includeIterateMedicationRequestPatient = new IncludeExpression("MedicationRequest", refSearchParameter, null, false, false, true);
+
+            refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationDispense", "prescription");
+            var includeMedicationDispensePrescription = new IncludeExpression("MedicationDispense", refSearchParameter, null, false, false, false);
+
+            Expression denormalizedExpression = Expression.And(new List<Expression>
+                {
+                    new SearchParameterExpression(new SearchParameterInfo("_type"), new StringExpression(StringOperator.Equals, FieldName.String, null, "MedicationDispense", false)),
+                    new SearchParameterExpression(new SearchParameterInfo("_id"), new StringExpression(StringOperator.Equals, FieldName.String, null, "smart-MedicationDispense-567", false)),
+                });
+
+            var sqlExpression = new SqlRootExpression(
+                new List<TableExpression>
+                {
+                    new TableExpression(null, null, denormalizedExpression, TableExpressionKind.All),
+                    new TableExpression(IncludeQueryGenerator.Instance,  includeIteratePatientGeneralPractitioner, null, TableExpressionKind.Include),
+                    new TableExpression(IncludeQueryGenerator.Instance,  includeIterateMedicationRequestPatient, null, TableExpressionKind.Include),
+                    new TableExpression(IncludeQueryGenerator.Instance,  includeMedicationDispensePrescription, null, TableExpressionKind.Include),
+                    new TableExpression(null, null, null, TableExpressionKind.Top),
+                },
+                new List<Expression>());
+
+            var reorderedExpressions = ((SqlRootExpression)sqlExpression.AcceptVisitor(IncludeRewriter.Instance)).TableExpressions;
+
+            // Assert the number of expressions and their order is correct, including IncludeUnionAll expression, which was added in the IncludeRewriter visit.
+            Assert.NotNull(reorderedExpressions);
+            Assert.Equal(9, reorderedExpressions.Count);
+
+            Assert.Equal(TableExpressionKind.All, reorderedExpressions[0].Kind);
+            Assert.Equal(TableExpressionKind.Top, reorderedExpressions[1].Kind);
+
+            Assert.Equal(TableExpressionKind.Include, reorderedExpressions[2].Kind);
+            var includeExpression = (IncludeExpression)reorderedExpressions[2].NormalizedPredicate;
+            Assert.Equal("MedicationDispense", includeExpression.ResourceType);
+            Assert.Equal("prescription", includeExpression.ReferenceSearchParameter.Name);
+
+            Assert.Equal(TableExpressionKind.IncludeLimit, reorderedExpressions[3].Kind);
+
+            Assert.Equal(TableExpressionKind.Include, reorderedExpressions[4].Kind);
+            includeExpression = (IncludeExpression)reorderedExpressions[4].NormalizedPredicate;
+            Assert.Equal("MedicationRequest", includeExpression.ResourceType);
+            Assert.Equal("patient", includeExpression.ReferenceSearchParameter.Name);
+
+            Assert.Equal(TableExpressionKind.IncludeLimit, reorderedExpressions[5].Kind);
+
+            Assert.Equal(TableExpressionKind.Include, reorderedExpressions[6].Kind);
+            includeExpression = (IncludeExpression)reorderedExpressions[6].NormalizedPredicate;
+            Assert.Equal("Patient", includeExpression.ResourceType);
+            Assert.Equal("general-practitioner", includeExpression.ReferenceSearchParameter.Name);
+
+            Assert.Equal(TableExpressionKind.IncludeLimit, reorderedExpressions[7].Kind);
+
+            Assert.Equal(TableExpressionKind.IncludeUnionAll, reorderedExpressions[8].Kind);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/RemoveIncludesRewriterTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/RemoveIncludesRewriterTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
         [Fact]
         public void GivenAnExpressionWithIncludes_WhenVisitedByRemoveIncludesRewriter_IncludesAreRemoved()
         {
-            IncludeExpression includeExpression = Expression.Include("a", new SearchParameterInfo("p", "Token"), "Patient", false, false);
+            IncludeExpression includeExpression = Expression.Include("a", new SearchParameterInfo("p", "Token"), "Patient", false, false, false);
             BinaryExpression fieldExpression = Expression.Equals(FieldName.Number, null, 1);
 
             Assert.Null(includeExpression.AcceptVisitor(RemoveIncludesRewriter.Instance));

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Microsoft.Health.Fhir.SqlServer.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Microsoft.Health.Fhir.SqlServer.UnitTests.csproj
@@ -9,5 +9,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Health.Fhir.SqlServer\Microsoft.Health.Fhir.SqlServer.csproj" />
+    <ProjectReference Include="..\Microsoft.Health.Fhir.Core\Microsoft.Health.Fhir.Core.csproj" />
+    <ProjectReference Include="..\Microsoft.Health.Fhir.Stu3.Core\Microsoft.Health.Fhir.Stu3.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/IncludeRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/IncludeRewriter.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
 using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.QueryGenerators;
 
@@ -27,40 +28,79 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
                 return expression;
             }
 
-            bool containsInclude = false;
+            List<TableExpression> reorderedExpressions = expression.TableExpressions.OrderByDescending(t => t, new TableExpressionComparer()).ToList();
 
-            List<TableExpression> reorderedExpressions = expression.TableExpressions.OrderByDescending(t =>
-            {
-                switch (t.SearchParameterQueryGenerator)
-                {
-                    case IncludeQueryGenerator _:
-                        containsInclude = true;
-                        return 0;
-                    default:
-                        return 10;
-                }
-            }).ToList();
-
-            // We are adding an extra CTE after each include cte, so we traverse the ordered
-            // list from the end and add a limit expression after each include expression
-            for (var i = reorderedExpressions.Count - 1; i >= 0; i--)
-            {
-                switch (reorderedExpressions[i].SearchParameterQueryGenerator)
-                {
-                    case IncludeQueryGenerator _:
-                        reorderedExpressions.Insert(i + 1, IncludeLimitExpression);
-                        break;
-                    default:
-                        break;
-                }
-            }
+            bool containsInclude = expression.TableExpressions.AsEnumerable().Where(e => e.SearchParameterQueryGenerator is IncludeQueryGenerator).Any();
 
             if (containsInclude)
             {
+                // We are adding an extra CTE after each include cte (except recursive :iterate), so we traverse the ordered
+                // list from the end and add a limit expression after each include expression
+                for (var i = reorderedExpressions.Count - 1; i >= 0; i--)
+                {
+                    switch (reorderedExpressions[i].SearchParameterQueryGenerator)
+                    {
+                        case IncludeQueryGenerator _:
+                            var includeExpression = (IncludeExpression)reorderedExpressions[i].NormalizedPredicate;
+                            if (!includeExpression.Recursive)
+                            {
+                                reorderedExpressions.Insert(i + 1, IncludeLimitExpression);
+                            }
+
+                            break;
+                        default:
+                            break;
+                    }
+                }
+
                 reorderedExpressions.Add(IncludeUnionAllExpression);
             }
 
             return new SqlRootExpression(reorderedExpressions, expression.DenormalizedExpressions);
+        }
+
+        private class TableExpressionComparer : IComparer<TableExpression>
+        {
+            public int Compare(TableExpression x, TableExpression y)
+            {
+                if (x.SearchParameterQueryGenerator is IncludeQueryGenerator)
+                {
+                    if (!(y.SearchParameterQueryGenerator is IncludeQueryGenerator))
+                    {
+                        return -1;
+                    }
+
+                    // Both expressions are Include expressions
+                    var xInclude = (IncludeExpression)x.NormalizedPredicate;
+                    var yInclude = (IncludeExpression)y.NormalizedPredicate;
+
+                    if (!xInclude.Iterate && yInclude.Iterate)
+                    {
+                        return 1;
+                    }
+
+                    if (xInclude.Iterate && !yInclude.Iterate)
+                    {
+                        return -1;
+                    }
+
+                    // Both expressions are Include:iterate expressions, order so that _include:iterate source type will appear after relevant include target
+                    var xTargetTypes = !string.IsNullOrEmpty(xInclude.TargetResourceType) ? new List<string>() { xInclude.TargetResourceType } : xInclude.ReferenceSearchParameter.TargetResourceTypes;
+
+                    if (xTargetTypes.Contains(yInclude.ResourceType))
+                    {
+                        return 1;
+                    }
+
+                    return 0;
+                }
+                else if (!(y.SearchParameterQueryGenerator is IncludeQueryGenerator))
+                {
+                    return 0;
+                }
+
+                return 1;
+            }
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTestFixture.cs
@@ -31,33 +31,57 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Search
                     },
             };
 
+            PercocetMedication = TestFhirClient.CreateAsync(new Medication { Meta = meta, Code = new CodeableConcept("http://snomed.info/sct", "16590-619-30", "Percocet tablet") }).Result.Resource;
+            TramadolMedication = TestFhirClient.CreateAsync(new Medication { Meta = meta, Code = new CodeableConcept("http://snomed.info/sct", "108505002", "Tramadol hydrochloride (substance)") }).Result.Resource;
             Organization = TestFhirClient.CreateAsync(new Organization { Meta = meta, Address = new List<Address> { new Address { City = "Seattle" } } }).Result.Resource;
             Practitioner = TestFhirClient.CreateAsync(new Practitioner { Meta = meta }).Result.Resource;
 
-            AdamsPatient = TestFhirClient.CreateAsync(new Patient { Meta = meta, Name = new List<HumanName> { new HumanName { Family = "Adams" } } }).Result.Resource;
-            SmithPatient = TestFhirClient.CreateAsync(new Patient { Meta = meta, Name = new List<HumanName> { new HumanName { Family = "Smith" } }, ManagingOrganization = new ResourceReference($"Organization/{Organization.Id}") }).Result.Resource;
-            TrumanPatient = TestFhirClient.CreateAsync(new Patient { Meta = meta, Name = new List<HumanName> { new HumanName { Family = "Truman" } } }).Result.Resource;
+            // Organization Hierarchy
+            LabFOrganization = TestFhirClient.CreateAsync(new Organization { Meta = meta }).Result.Resource;
+            LabEOrganization = TestFhirClient.CreateAsync(new Organization { Meta = meta, PartOf = new ResourceReference($"Organization/{LabFOrganization.Id}") }).Result.Resource;
+            LabDOrganization = TestFhirClient.CreateAsync(new Organization { Meta = meta, PartOf = new ResourceReference($"Organization/{LabEOrganization.Id}") }).Result.Resource;
+            LabCOrganization = TestFhirClient.CreateAsync(new Organization { Meta = meta, PartOf = new ResourceReference($"Organization/{LabDOrganization.Id}") }).Result.Resource;
+            LabBOrganization = TestFhirClient.CreateAsync(new Organization { Meta = meta, PartOf = new ResourceReference($"Organization/{LabCOrganization.Id}") }).Result.Resource;
+            LabAOrganization = TestFhirClient.CreateAsync(new Organization { Meta = meta, PartOf = new ResourceReference($"Organization/{LabBOrganization.Id}") }).Result.Resource;
 
-            AdamsLoincObservation = CreateObservation(AdamsPatient, loincCode);
-            SmithLoincObservation = CreateObservation(SmithPatient, loincCode);
-            SmithSnomedObservation = CreateObservation(SmithPatient, snomedCode);
-            TrumanLoincObservation = CreateObservation(TrumanPatient, loincCode);
-            TrumanSnomedObservation = CreateObservation(TrumanPatient, snomedCode);
+            AndersonPractitioner = TestFhirClient.CreateAsync(new Practitioner { Meta = meta, Name = new List<HumanName> { new HumanName { Family = "Anderson" } } }).Result.Resource;
+            SanchezPractitioner = TestFhirClient.CreateAsync(new Practitioner { Meta = meta, Name = new List<HumanName> { new HumanName { Family = "Sanchez" } } }).Result.Resource;
+            TaylorPractitioner = TestFhirClient.CreateAsync(new Practitioner { Meta = meta, Name = new List<HumanName> { new HumanName { Family = "Taylor" } } }).Result.Resource;
+
+            AdamsPatient = CreatePatient("Adams", AndersonPractitioner, Organization);
+            SmithPatient = CreatePatient("Smith",  SanchezPractitioner, Organization);
+            TrumanPatient = CreatePatient("Truman",  TaylorPractitioner, Organization);
+
+            AdamsLoincObservation = CreateObservation(AdamsPatient, Practitioner, Organization, loincCode);
+            SmithLoincObservation = CreateObservation(SmithPatient, Practitioner, Organization, loincCode);
+            SmithSnomedObservation = CreateObservation(SmithPatient, Practitioner, Organization, snomedCode);
+            TrumanLoincObservation = CreateObservation(TrumanPatient, Practitioner, Organization, loincCode);
+            TrumanSnomedObservation = CreateObservation(TrumanPatient, Practitioner, Organization, snomedCode);
 
             SmithSnomedDiagnosticReport = CreateDiagnosticReport(SmithPatient, SmithSnomedObservation, snomedCode);
             TrumanSnomedDiagnosticReport = CreateDiagnosticReport(TrumanPatient, TrumanSnomedObservation, snomedCode);
             SmithLoincDiagnosticReport = CreateDiagnosticReport(SmithPatient, SmithLoincObservation, loincCode);
             TrumanLoincDiagnosticReport = CreateDiagnosticReport(TrumanPatient, TrumanLoincObservation, loincCode);
 
+            AdamsMedicationRequest = CreateMedicationRequest(AdamsPatient, PercocetMedication);
+            SmithMedicationRequest = CreateMedicationRequest(SmithPatient, PercocetMedication);
+            TrumanMedicationRequest = CreateMedicationRequest(TrumanPatient, PercocetMedication);
+
+            AdamsMedicationDispense = CreateMedicationDispense(AdamsMedicationRequest, AdamsPatient, TramadolMedication);
+            SmithMedicationDispense = CreateMedicationDispense(SmithMedicationRequest, SmithPatient, TramadolMedication);
+            TrumanMedicationDispense = CreateMedicationDispense(TrumanMedicationRequest, TrumanPatient, TramadolMedication);
+
+            CareTeam = CreateCareTeam();
+
             Location = TestFhirClient.CreateAsync(new Location
             {
                 ManagingOrganization = new ResourceReference($"Organization/{Organization.Id}"),
-                Meta = new Meta { Tag = new List<Coding> { new Coding("testTag", Tag) } },
+                Meta = meta,
             }).Result.Resource;
 
             var group = new Group
             {
-                Meta = new Meta { Tag = new List<Coding> { new Coding("testTag", Tag) } },
+                Meta = meta,
                 Type = Group.GroupType.Person, Actual = true,
                 Member = new List<Group.MemberComponent>
                     {
@@ -82,7 +106,7 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Search
                     }).Result.Resource;
             }
 
-            Observation CreateObservation(Patient patient, CodeableConcept code)
+            Observation CreateObservation(Patient patient, Practitioner practitioner, Organization organization, CodeableConcept code)
             {
                 return TestFhirClient.CreateAsync(
                     new Observation()
@@ -91,18 +115,141 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Search
                         Status = ObservationStatus.Final,
                         Code = code,
                         Subject = new ResourceReference($"Patient/{patient.Id}"),
-                        Performer = new List<ResourceReference>
+                        Performer = new List<ResourceReference>()
                         {
-                            new ResourceReference($"Organization/{Organization.Id}"),
-                            new ResourceReference($"Practitioner/{Practitioner.Id}"),
+                            new ResourceReference($"Organization/{organization.Id}"),
+                            new ResourceReference($"Practitioner/{practitioner.Id}"),
+                        },
+                    }).Result.Resource;
+            }
+
+            Patient CreatePatient(string familyName, Practitioner practitioner, Organization organization)
+            {
+                return TestFhirClient.CreateAsync(
+                    new Patient
+                    {
+                        Meta = meta,
+                        Name = new List<HumanName> { new HumanName { Family = familyName } },
+                        GeneralPractitioner = new List<ResourceReference>()
+                        {
+                            new ResourceReference($"Practitioner/{practitioner.Id}"),
+                        },
+                        ManagingOrganization = new ResourceReference($"Organization/{organization.Id}"),
+                    }).Result.Resource;
+            }
+
+            MedicationDispense CreateMedicationDispense(MedicationRequest medicationRequest, Patient patient, Medication medication)
+            {
+               return TestFhirClient.CreateAsync(
+                    new MedicationDispense
+                    {
+                        Meta = meta,
+                        AuthorizingPrescription = new List<ResourceReference>
+                        {
+                            new ResourceReference($"MedicationRequest/{medicationRequest.Id}"),
+                        },
+                        Subject = new ResourceReference($"Patient/{patient.Id}"),
+                        Performer = new List<MedicationDispense.PerformerComponent>()
+                        {
+                            new MedicationDispense.PerformerComponent()
+                            {
+                                Actor = new ResourceReference($"Practitioner/{Practitioner.Id}"),
+                            },
+                        },
+#if R5
+                        Medication = new CodeableReference
+                        {
+                            Concept = medication.Code,
+                            Reference = new ResourceReference($"Medication/{medication.Id}"),
+                        },
+#else
+                        Medication = medication.Code,
+#endif
+#if Stu3
+                        Status = MedicationDispense.MedicationDispenseStatus.InProgress,
+#else
+                        Status = MedicationDispense.MedicationDispenseStatusCodes.InProgress,
+#endif
+                    }).Result.Resource;
+            }
+
+            MedicationRequest CreateMedicationRequest(Patient patient, Medication medication)
+            {
+                return TestFhirClient.CreateAsync(
+                    new MedicationRequest
+                    {
+                        Meta = meta,
+                        Subject = new ResourceReference($"Patient/{patient.Id}"),
+#if Stu3
+                        Intent = MedicationRequest.MedicationRequestIntent.Order,
+                        Status = MedicationRequest.MedicationRequestStatus.Completed,
+                        Requester = new MedicationRequest.RequesterComponent
+                        {
+                            Agent = new ResourceReference($"Practitioner/{Practitioner.Id}"),
+                        },
+#else
+                        IntentElement = new Code<MedicationRequest.medicationRequestIntent> { Value = MedicationRequest.medicationRequestIntent.Order },
+                        StatusElement = new Code<MedicationRequest.medicationrequestStatus> { Value = MedicationRequest.medicationrequestStatus.Completed },
+                        Requester = new ResourceReference($"Practitioner/{Practitioner.Id}"),
+
+#endif
+#if R5
+                        Medication = new CodeableReference
+                        {
+                            Concept = medication.Code,
+                            Reference = new ResourceReference($"Medication/{medication.Id}"),
+                        },
+#else
+                        Medication = medication.Code,
+#endif
+                    }).Result.Resource;
+            }
+
+            CareTeam CreateCareTeam()
+            {
+                return TestFhirClient.CreateAsync(
+                    new CareTeam
+                    {
+                        Meta = meta,
+                        Participant = new List<CareTeam.ParticipantComponent>()
+                        {
+                            new CareTeam.ParticipantComponent { Member = new ResourceReference($"Patient/{AdamsPatient.Id}") },
+                            new CareTeam.ParticipantComponent { Member = new ResourceReference($"Patient/{SmithPatient.Id}") },
+                            new CareTeam.ParticipantComponent { Member = new ResourceReference($"Patient/{TrumanPatient.Id}") },
+                            new CareTeam.ParticipantComponent { Member = new ResourceReference($"Organization/{Organization.Id}") },
+                            new CareTeam.ParticipantComponent { Member = new ResourceReference($"Practitioner/{Practitioner.Id}") },
                         },
                     }).Result.Resource;
             }
         }
 
+        public CareTeam CareTeam { get; }
+
+        public Medication PercocetMedication { get; }
+
+        public Medication TramadolMedication { get; }
+
         public Organization Organization { get; }
 
+        public Organization LabAOrganization { get; }
+
+        public Organization LabBOrganization { get; }
+
+        public Organization LabCOrganization { get; }
+
+        public Organization LabDOrganization { get; }
+
+        public Organization LabEOrganization { get; }
+
+        public Organization LabFOrganization { get; }
+
         public Practitioner Practitioner { get; }
+
+        public Practitioner AndersonPractitioner { get; }
+
+        public Practitioner SanchezPractitioner { get; }
+
+        public Practitioner TaylorPractitioner { get; }
 
         public Group PatientGroup { get; }
 
@@ -111,6 +258,10 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Search
         public Patient AdamsPatient { get; }
 
         public Observation AdamsLoincObservation { get; }
+
+        public MedicationDispense AdamsMedicationDispense { get; }
+
+        public MedicationRequest AdamsMedicationRequest { get; }
 
         public Patient TrumanPatient { get; }
 
@@ -122,6 +273,10 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Search
 
         public DiagnosticReport TrumanLoincDiagnosticReport { get; }
 
+        public MedicationDispense TrumanMedicationDispense { get; }
+
+        public MedicationRequest TrumanMedicationRequest { get; }
+
         public Patient SmithPatient { get; }
 
         public Observation SmithSnomedObservation { get; }
@@ -131,6 +286,10 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Search
         public DiagnosticReport SmithSnomedDiagnosticReport { get; }
 
         public DiagnosticReport SmithLoincDiagnosticReport { get; }
+
+        public MedicationDispense SmithMedicationDispense { get; }
+
+        public MedicationRequest SmithMedicationRequest { get; }
 
         public Location Location { get; }
     }


### PR DESCRIPTION
## Description
Adding :iterate support for _include and _revinclude - Phase #1:
* Adding _include:iterate support for non recursive queries & wildcard
* Adding E2E test to cover these cases

The solution is based on using a dictionary in SqlQueryGenerator.cs that maps target resource types to ctes.
This was _include:iterate expressions selects from the relevant CTE (and not from _cteMainSelect).
A sort was added to IncludeRewrite to organize parameters so that the include:iterate expressions appear after the relevant include

It includes implementation of recursive queries, but the tests were commented out. That is sincde the _Revinclude PR introduced a new cte for IncludeLimit cte, which requires some adjustment to be discussed.

Next phases will include:
* Adding IncludeLimits to all Includes (not only to RevInclude)
* _revinclude:iterate support
* Supporting recursive iterations  

## Related issues
Addresses [issue #306 ].

## Testing
Multiple use cases were added to cover multiple cases such as:
* Simple iteration (e.g.,  /MedicationDispense?_include=MedicationDispense:prescription&_include:iterate=MedicationRequest:patient
* Multiple iterations (e.g., /MedicationDispense?_include=MedicationDispense:prescription&_include:iterate=MedicationRequest:patient&_include:iterate=Patient:general-practitioner&_include:iterate=Patient:organization)
* Wild card variations (on _include and include:iterate)
* Variations on the include source type (array to a reference of a single type, array to a reference of multiple types)