### PR TITLE
Auto-update for packages related to 'healthcare-components-1.0.0-master-20200909-1'

### DIFF
--- a/src/Microsoft.Health.Fhir.Api.UnitTests/Microsoft.Health.Fhir.R4.Api.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.Api.UnitTests/Microsoft.Health.Fhir.R4.Api.UnitTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200812-1" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200909-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Microsoft.Health.Fhir.Api/Microsoft.Health.Fhir.Api.csproj
+++ b/src/Microsoft.Health.Fhir.Api/Microsoft.Health.Fhir.Api.csproj
@@ -26,9 +26,9 @@
     <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="3.1.6" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.6" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.6" />
-    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20200812-1" />
-    <PackageReference Include="Microsoft.Health.Api" Version="1.0.0-master-20200812-1" />
-    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20200812-1" />
+    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20200909-1" />
+    <PackageReference Include="Microsoft.Health.Api" Version="1.0.0-master-20200909-1" />
+    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20200909-1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Microsoft.Health.Fhir.Core.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Microsoft.Health.Fhir.Core.UnitTests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200812-1" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200909-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Microsoft.Health.Fhir.Core/Microsoft.Health.Fhir.Core.csproj
+++ b/src/Microsoft.Health.Fhir.Core/Microsoft.Health.Fhir.Core.csproj
@@ -36,9 +36,9 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.6" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.6" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.6" />
-    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20200812-1" />
-    <PackageReference Include="Microsoft.Health.Core" Version="1.0.0-master-20200812-1" />
-    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20200812-1" />
+    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20200909-1" />
+    <PackageReference Include="Microsoft.Health.Core" Version="1.0.0-master-20200909-1" />
+    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20200909-1" />
     <PackageReference Include="Hl7.Fhir.Serialization" Version="1.9.0" />
     <PackageReference Include="Hl7.FhirPath" Version="1.9.0" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.13" />

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Microsoft.Health.Fhir.CosmosDb.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Microsoft.Health.Fhir.CosmosDb.UnitTests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200812-1" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200909-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Microsoft.Health.Fhir.CosmosDb/Microsoft.Health.Fhir.CosmosDb.csproj
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Microsoft.Health.Fhir.CosmosDb.csproj
@@ -17,9 +17,9 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.6" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.6" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.6" />
-    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20200812-1" />
-    <PackageReference Include="Microsoft.Health.Extensions.BuildTimeCodeGenerator" Version="1.0.0-master-20200812-1" />
-    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20200812-1" />
+    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20200909-1" />
+    <PackageReference Include="Microsoft.Health.Extensions.BuildTimeCodeGenerator" Version="1.0.0-master-20200909-1" />
+    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20200909-1" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.3.5" />
   </ItemGroup>
 

--- a/src/Microsoft.Health.Fhir.R4.Client/Microsoft.Health.Fhir.R4.Client.csproj
+++ b/src/Microsoft.Health.Fhir.R4.Client/Microsoft.Health.Fhir.R4.Client.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Ensure.That" Version="9.2.0" />
     <PackageReference Include="Hl7.Fhir.R4" Version="1.9.0" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.5.0" />
-    <PackageReference Include="Microsoft.Health.Client" Version="1.0.0-master-20200812-1" />
+    <PackageReference Include="Microsoft.Health.Client" Version="1.0.0-master-20200909-1" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.5.1" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.5.1" />
   </ItemGroup>

--- a/src/Microsoft.Health.Fhir.R4.Core.UnitTests/Microsoft.Health.Fhir.R4.Core.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.R4.Core.UnitTests/Microsoft.Health.Fhir.R4.Core.UnitTests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200812-1" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200909-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Microsoft.Health.Fhir.R5.Api.UnitTests/Microsoft.Health.Fhir.R5.Api.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.R5.Api.UnitTests/Microsoft.Health.Fhir.R5.Api.UnitTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200812-1" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200909-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Microsoft.Health.Fhir.R5.Client/Microsoft.Health.Fhir.R5.Client.csproj
+++ b/src/Microsoft.Health.Fhir.R5.Client/Microsoft.Health.Fhir.R5.Client.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Ensure.That" Version="9.2.0" />
     <PackageReference Include="Hl7.Fhir.R5" Version="1.7.0-beta-may2020" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.5.0" />
-    <PackageReference Include="Microsoft.Health.Client" Version="1.0.0-master-20200812-1" />
+    <PackageReference Include="Microsoft.Health.Client" Version="1.0.0-master-20200909-1" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.5.1" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.5.1" />
   </ItemGroup>

--- a/src/Microsoft.Health.Fhir.R5.Core.UnitTests/Microsoft.Health.Fhir.R5.Core.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.R5.Core.UnitTests/Microsoft.Health.Fhir.R5.Core.UnitTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200812-1" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200909-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Microsoft.Health.Fhir.SqlServer/Microsoft.Health.Fhir.SqlServer.csproj
+++ b/src/Microsoft.Health.Fhir.SqlServer/Microsoft.Health.Fhir.SqlServer.csproj
@@ -25,10 +25,10 @@
 
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="9.2.0" />
-    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20200812-1" />
-    <PackageReference Include="Microsoft.Health.SqlServer" Version="1.0.0-master-20200812-1" />
-    <PackageReference Include="Microsoft.Health.SqlServer.Api" Version="1.0.0-master-20200812-1" />
-    <PackageReference Include="Microsoft.Health.Extensions.BuildTimeCodeGenerator" Version="1.0.0-master-20200812-1" />
+    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20200909-1" />
+    <PackageReference Include="Microsoft.Health.SqlServer" Version="1.0.0-master-20200909-1" />
+    <PackageReference Include="Microsoft.Health.SqlServer.Api" Version="1.0.0-master-20200909-1" />
+    <PackageReference Include="Microsoft.Health.Extensions.BuildTimeCodeGenerator" Version="1.0.0-master-20200909-1" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.3.5" />
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="150.18208.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="3.1.6" />

--- a/src/Microsoft.Health.Fhir.Stu3.Api.UnitTests/Microsoft.Health.Fhir.Stu3.Api.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.Stu3.Api.UnitTests/Microsoft.Health.Fhir.Stu3.Api.UnitTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200812-1" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200909-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Microsoft.Health.Fhir.Stu3.Client/Microsoft.Health.Fhir.Stu3.Client.csproj
+++ b/src/Microsoft.Health.Fhir.Stu3.Client/Microsoft.Health.Fhir.Stu3.Client.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Ensure.That" Version="9.2.0" />
     <PackageReference Include="Hl7.Fhir.STU3" Version="1.9.0" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.5.0" />
-    <PackageReference Include="Microsoft.Health.Client" Version="1.0.0-master-20200812-1" />
+    <PackageReference Include="Microsoft.Health.Client" Version="1.0.0-master-20200909-1" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.5.1" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.5.1" />
   </ItemGroup>

--- a/src/Microsoft.Health.Fhir.Stu3.Core.UnitTests/Microsoft.Health.Fhir.Stu3.Core.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.Stu3.Core.UnitTests/Microsoft.Health.Fhir.Stu3.Core.UnitTests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200812-1" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200909-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
+++ b/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
@@ -324,7 +324,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20200812-1" />
+    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20200909-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/Microsoft.Health.Fhir.R4.Tests.E2E/Microsoft.Health.Fhir.R4.Tests.E2E.csproj
+++ b/test/Microsoft.Health.Fhir.R4.Tests.E2E/Microsoft.Health.Fhir.R4.Tests.E2E.csproj
@@ -23,8 +23,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.6" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.9.2" />
-    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20200812-1" />
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200812-1" />
+    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20200909-1" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200909-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="selenium.chrome.webdriver" Version="79.0.0" />
     <PackageReference Include="selenium.webdriver" Version="3.141.0" />

--- a/test/Microsoft.Health.Fhir.R4.Tests.Integration/Microsoft.Health.Fhir.R4.Tests.Integration.csproj
+++ b/test/Microsoft.Health.Fhir.R4.Tests.Integration/Microsoft.Health.Fhir.R4.Tests.Integration.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.6" />
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200812-1" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200909-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="Microsoft.SqlServer.DACFx" Version="150.4573.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/Microsoft.Health.Fhir.R5.Tests.E2E/Microsoft.Health.Fhir.R5.Tests.E2E.csproj
+++ b/test/Microsoft.Health.Fhir.R5.Tests.E2E/Microsoft.Health.Fhir.R5.Tests.E2E.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.6" />
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200812-1" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200909-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="selenium.chrome.webdriver" Version="79.0.0" />
     <PackageReference Include="selenium.webdriver" Version="3.141.0" />

--- a/test/Microsoft.Health.Fhir.R5.Tests.Integration/Microsoft.Health.Fhir.R5.Tests.Integration.csproj
+++ b/test/Microsoft.Health.Fhir.R5.Tests.Integration/Microsoft.Health.Fhir.R5.Tests.Integration.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.6" />
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200812-1" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200909-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="Microsoft.SqlServer.DACFx" Version="150.4573.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/Microsoft.Health.Fhir.Stu3.Tests.E2E.csproj
+++ b/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/Microsoft.Health.Fhir.Stu3.Tests.E2E.csproj
@@ -21,8 +21,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.6" />
-    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20200812-1" />
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200812-1" />
+    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20200909-1" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200909-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="selenium.chrome.webdriver" Version="79.0.0" />
     <PackageReference Include="selenium.webdriver" Version="3.141.0" />

--- a/test/Microsoft.Health.Fhir.Stu3.Tests.Integration/Microsoft.Health.Fhir.Stu3.Tests.Integration.csproj
+++ b/test/Microsoft.Health.Fhir.Stu3.Tests.Integration/Microsoft.Health.Fhir.Stu3.Tests.Integration.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.6" />
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200812-1" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200909-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="Microsoft.SqlServer.DACFx" Version="150.4573.2" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
Updates package 'Microsoft.Health.Abstractions' to version '1.0.0-master-20200909-1'
Updates package 'Microsoft.Health.Api' to version '1.0.0-master-20200909-1'
Updates package 'Microsoft.Health.Extensions.DependencyInjection' to version '1.0.0-master-20200909-1'
Updates package 'Microsoft.Health.Core' to version '1.0.0-master-20200909-1'
Updates package 'Microsoft.Health.Client' to version '1.0.0-master-20200909-1'
Updates package 'Microsoft.Health.Test.Utilities' to version '1.0.0-master-20200909-1'
Updates package 'Microsoft.Health.SqlServer' to version '1.0.0-master-20200909-1'
Updates package 'Microsoft.Health.SqlServer.Api' to version '1.0.0-master-20200909-1'
Updates package 'Microsoft.Health.Extensions.BuildTimeCodeGenerator' to version '1.0.0-master-20200909-1'