### PR TITLE
Correct casing in FHIR Server for Azure brand name

### DIFF
--- a/samples/kubernetes/README.md
+++ b/samples/kubernetes/README.md
@@ -1,6 +1,6 @@
-# Running Microsoft FHIR server for Azure in Kubernetes
+# Running Microsoft FHIR Server for Azure in Kubernetes
 
-The Microsoft FHIR server for Azure can be deployed in a Kubernetes cluster. This document describes how to deploy and configure [Azure Kubernetes Service (AKS)](https://azure.microsoft.com/services/kubernetes-service/) to be able to run the FHIR server in it. Specifically, it describes how to install [Azure Service Operator](https://github.com/Azure/azure-service-operator) in the cluster to allow easy deployment of managed databases (Azure SQL or Cosmos DB). The repo contains a [helm](https://helm.sh) chart that leverages the Azure Service Operator to deploy and configure both FHIR service and backend database. 
+The Microsoft FHIR Server for Azure can be deployed in a Kubernetes cluster. This document describes how to deploy and configure [Azure Kubernetes Service (AKS)](https://azure.microsoft.com/services/kubernetes-service/) to be able to run the FHIR server in it. Specifically, it describes how to install [Azure Service Operator](https://github.com/Azure/azure-service-operator) in the cluster to allow easy deployment of managed databases (Azure SQL or Cosmos DB). The repo contains a [helm](https://helm.sh) chart that leverages the Azure Service Operator to deploy and configure both FHIR service and backend database. 
 
 ## Deploy and configure AKS cluster
 

--- a/samples/kubernetes/helm/fhir-server/Chart.yaml
+++ b/samples/kubernetes/helm/fhir-server/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: fhir-server
-description: A Helm chart for deploying the Microsoft FHIR server for Azure
+description: A Helm chart for deploying the Microsoft FHIR Server for Azure
 
 # A chart can be either an 'application' or a 'library' chart.
 #


### PR DESCRIPTION
## Description
Correct casing for brand name by replacing "FHIR server for Azure" with 'FHIR Server for Azure'

## Related issues
N/A

## Testing
No testing done
