### PR TITLE
Support POST $reindex for a single resource

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Persistence/IFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Persistence/IFhirDataStore.cs
@@ -26,6 +26,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
 
         Task UpdateSearchParameterIndicesBatchAsync(IReadOnlyCollection<ResourceWrapper> resources, CancellationToken cancellationToken);
 
-        Task<ResourceWrapper> UpdateSearchIndexForResourceAsync(ResourceWrapper resourceWrapper, string eTag, CancellationToken cancellationToken);
+        Task<ResourceWrapper> UpdateSearchIndexForResourceAsync(ResourceWrapper resourceWrapper, WeakETag weakETag, CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Messages/Reindex/ReindexSingleResourceRequest.cs
+++ b/src/Microsoft.Health.Fhir.Core/Messages/Reindex/ReindexSingleResourceRequest.cs
@@ -10,14 +10,18 @@ namespace Microsoft.Health.Fhir.Core.Messages.Reindex
 {
     public class ReindexSingleResourceRequest : IRequest<ReindexSingleResourceResponse>
     {
-        public ReindexSingleResourceRequest(string resourceType, string resourceId)
+        public ReindexSingleResourceRequest(string httpMethod, string resourceType, string resourceId)
         {
+            EnsureArg.IsNotNullOrWhiteSpace(httpMethod, nameof(httpMethod));
             EnsureArg.IsNotNullOrWhiteSpace(resourceType, nameof(resourceType));
             EnsureArg.IsNotNullOrWhiteSpace(resourceId, nameof(resourceId));
 
+            HttpMethod = httpMethod;
             ResourceType = resourceType;
             ResourceId = resourceId;
         }
+
+        public string HttpMethod { get; }
 
         public string ResourceType { get; }
 

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -23,6 +23,7 @@ using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.CosmosDb.Configs;
 using Microsoft.Health.Fhir.CosmosDb.Features.Search;
 using Microsoft.Health.Fhir.CosmosDb.Features.Storage.StoredProcedures.HardDelete;
+using Microsoft.Health.Fhir.CosmosDb.Features.Storage.StoredProcedures.Replace;
 using Microsoft.Health.Fhir.CosmosDb.Features.Storage.StoredProcedures.Upsert;
 using Microsoft.Health.Fhir.ValueSets;
 using Task = System.Threading.Tasks.Task;
@@ -39,6 +40,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
 
         private static readonly UpsertWithHistory _upsertWithHistoryProc = new UpsertWithHistory();
         private static readonly HardDelete _hardDelete = new HardDelete();
+        private static readonly ReplaceSingleResource _replaceSingleResource = new ReplaceSingleResource();
         private readonly CoreFeatureConfiguration _coreFeatures;
 
         /// <summary>
@@ -224,41 +226,41 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
             }
         }
 
-        public async Task<ResourceWrapper> UpdateSearchIndexForResourceAsync(ResourceWrapper resourceWrapper, string eTag, CancellationToken cancellationToken)
+        public async Task<ResourceWrapper> UpdateSearchIndexForResourceAsync(ResourceWrapper resourceWrapper, WeakETag weakETag, CancellationToken cancellationToken)
         {
             EnsureArg.IsNotNull(resourceWrapper, nameof(resourceWrapper));
-            EnsureArg.IsNotNullOrWhiteSpace(eTag, nameof(eTag));
+            EnsureArg.IsNotNull(weakETag, nameof(weakETag));
 
             var cosmosWrapper = new FhirCosmosResourceWrapper(resourceWrapper);
-            ItemRequestOptions requestOptions = new ItemRequestOptions()
-            {
-                IfMatchEtag = eTag,
-            };
 
             try
             {
-                ItemResponse<FhirCosmosResourceWrapper> response = await _containerScope.Value.ReplaceItemAsync(
-                    cosmosWrapper,
-                    cosmosWrapper.ResourceId,
-                    new PartitionKey(cosmosWrapper.PartitionKey),
-                    requestOptions,
+                _logger.LogDebug($"Replacing {resourceWrapper.ResourceTypeName}/{resourceWrapper.ResourceId}, ETag: \"{weakETag.VersionId}\"");
+
+                FhirCosmosResourceWrapper response = await _retryExceptionPolicyFactory.CreateRetryPolicy().ExecuteAsync(
+                    async ct => await _replaceSingleResource.Execute(
+                        _containerScope.Value.Scripts,
+                        cosmosWrapper,
+                        weakETag.VersionId,
+                        ct),
                     cancellationToken);
 
-                return response.Resource;
+                return response;
             }
             catch (CosmosException exception)
             {
-                switch (exception.StatusCode)
+                // Check GetSubStatusCode documentation for why we need to get that instead of the status code.
+                switch (exception.GetSubStatusCode())
                 {
                     case HttpStatusCode.PreconditionFailed:
-                        throw new PreconditionFailedException(string.Format(Core.Resources.ResourceVersionConflict, eTag));
+                        throw new PreconditionFailedException(string.Format(Core.Resources.ResourceVersionConflict, weakETag));
 
                     case HttpStatusCode.NotFound:
                         throw new ResourceNotFoundException(string.Format(
                             Core.Resources.ResourceNotFoundByIdAndVersion,
                             resourceWrapper.ResourceTypeName,
                             resourceWrapper.ResourceId,
-                            eTag));
+                            weakETag));
 
                     case HttpStatusCode.ServiceUnavailable:
                         throw new ServiceUnavailableException();

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/StoredProcedures/Replace/ReplaceSingleResource.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/StoredProcedures/Replace/ReplaceSingleResource.cs
@@ -1,0 +1,31 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Threading;
+using System.Threading.Tasks;
+using EnsureThat;
+using Microsoft.Azure.Cosmos.Scripts;
+
+namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.StoredProcedures.Replace
+{
+    internal class ReplaceSingleResource : StoredProcedureBase
+    {
+        public async Task<FhirCosmosResourceWrapper> Execute(Scripts client, FhirCosmosResourceWrapper resource, string matchVersionId, CancellationToken cancellationToken)
+        {
+            EnsureArg.IsNotNull(client, nameof(client));
+            EnsureArg.IsNotNull(resource, nameof(resource));
+
+            StoredProcedureExecuteResponse<FhirCosmosResourceWrapper> result =
+                await ExecuteStoredProc<FhirCosmosResourceWrapper>(
+                    client,
+                    resource.PartitionKey,
+                    cancellationToken,
+                    resource,
+                    matchVersionId);
+
+            return result.Resource;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/StoredProcedures/Replace/replaceSingleResource.js
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/StoredProcedures/Replace/replaceSingleResource.js
@@ -1,0 +1,94 @@
+﻿/**
+* This stored procedure can be used to replace an existing document
+* 
+* @constructor
+* @param {any} doc - The CosmosResourceWrapper to save
+* @param {string} matchVersionId - required etag to match against when replacing an existing document
+*/
+function replaceSingleResource(doc, matchVersionId) {
+    const collection = getContext().getCollection();
+    const collectionLink = collection.getSelfLink();
+    const response = getContext().getResponse();
+
+
+    // Validate input
+    if (!doc) {
+        throwArgumentValidationError("The document is undefined or null.");
+    }
+
+    if (doc instanceof Array) {
+        throwArgumentValidationError("Input should not be an array.");
+    }
+
+    if (stringIsNullOrEmpty(matchVersionId)) {
+        throwArgumentValidationError("Invalid VersionId provided.");
+    }
+
+    let query = {
+        query: "select * from root r where r.id = @id",
+        parameters: [{ name: "@id", value: doc.id }]
+    };
+
+    let isQueryAccepted = collection.queryDocuments(
+        collection.getSelfLink(),
+        query,
+        function (err, documents) {
+            if (err) {
+                throw err;
+            }
+
+            let document = documents.length === 0 ? null : documents[0];
+
+            if (document === null ||
+                doc.isDeleted && document.isDeleted) { // don't create another version if already deleted
+                throw new Error(ErrorCodes.NotFound, "Document not found.");
+            }
+
+            // Check that the version passed in matches with current document version
+            if (document.version !== matchVersionId) {
+                throwPreconditionFailedError();
+            }
+
+            // Replace the primary record
+            doc.version = matchVersionId;
+            let selfLink = document._self;
+            let isAccepted = collection.replaceDocument(selfLink, doc, { disableAutomaticIdGeneration: true, etag: document._etag }, replacePrimaryCallback);
+
+            if (!isAccepted) {
+                throwRequestNotQueuedError();
+            }
+        });
+
+    if (!isQueryAccepted) {
+        throwRequestNotQueuedError();
+    }
+
+    function stringIsNullOrEmpty(str) {
+        return str === undefined || str === null || str === "";
+    }
+
+    function replacePrimaryCallback(err, createdDoc) {
+        if (err) {
+            if (err.number === ErrorCodes.Conflict ||
+                err.number === ErrorCodes.PreconditionFailed) {
+                throw createPreconditionFailedError();
+            } else {
+                throw err;
+            }
+        }
+
+        response.setBody(createdDoc);
+    }
+
+    function throwRequestNotQueuedError() {
+        throw new Error(503, "Request could not be queued.");
+    }
+
+    function throwPreconditionFailedError() {
+        throw new Error(ErrorCodes.PreconditionFailed, "One of the specified pre-conditions is not met.");
+    }
+
+    function throwArgumentValidationError(message) {
+        throw new Error(ErrorCodes.BadRequest, message);
+    }
+}

--- a/src/Microsoft.Health.Fhir.CosmosDb/Microsoft.Health.Fhir.CosmosDb.csproj
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Microsoft.Health.Fhir.CosmosDb.csproj
@@ -8,6 +8,7 @@
     <EmbeddedResource Include="Features\Storage\StoredProcedures\AcquireExportJobs\acquireExportJobs.js" />
     <EmbeddedResource Include="Features\Storage\StoredProcedures\AcquireReindexJobs\acquireReindexJobs.js" />
     <EmbeddedResource Include="Features\Storage\StoredProcedures\HardDelete\hardDelete.js" />
+    <EmbeddedResource Include="Features\Storage\StoredProcedures\Replace\replaceSingleResource.js" />
     <EmbeddedResource Include="Features\Storage\StoredProcedures\Upsert\upsertWithHistory.js" />
   </ItemGroup>
   

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ReindexController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ReindexController.cs
@@ -85,6 +85,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             return result;
         }
 
+        [HttpPost]
         [HttpGet]
         [Route(KnownRoutes.ReindexSingleResource)]
         [AuditEventType(AuditEventSubType.Reindex)]
@@ -92,7 +93,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         {
             CheckIfReindexIsEnabledAndRespond();
 
-            ReindexSingleResourceResponse response = await _mediator.SendReindexSingleResourceRequestAsync(typeParameter, idParameter, HttpContext.RequestAborted);
+            ReindexSingleResourceResponse response = await _mediator.SendReindexSingleResourceRequestAsync(Request.Method, typeParameter, idParameter, HttpContext.RequestAborted);
 
             var result = FhirResult.Create(response.ParameterResource, HttpStatusCode.OK);
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexSingleResourceRequestHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexSingleResourceRequestHandlerTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Threading;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
+using Microsoft.Health.Core;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Operations.Reindex;
@@ -32,8 +33,10 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Reinde
         private readonly ISearchIndexer _searchIndexer;
         private readonly IResourceDeserializer _resourceDeserializer;
         private readonly ReindexSingleResourceRequestHandler _reindexHandler;
-
         private readonly CancellationToken _cancellationToken;
+
+        private const string HttpGetName = "GET";
+        private const string HttpPostName = "POST";
 
         public ReindexSingleResourceRequestHandlerTests()
         {
@@ -56,7 +59,7 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Reinde
         public async Task GivenUserDoesNotHavePermissionForReindex_WhenHandle_ThenUnauthorizedExceptionIsThrown()
         {
             _authorizationService.CheckAccess(Arg.Is(DataActions.Reindex)).Returns(DataActions.None);
-            var request = GetReindexRequest();
+            var request = GetReindexRequest(HttpGetName);
 
             await Assert.ThrowsAsync<UnauthorizedFhirActionException>(() => _reindexHandler.Handle(request, _cancellationToken));
         }
@@ -66,12 +69,14 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Reinde
         {
             _fhirDataStore.GetAsync(Arg.Any<ResourceKey>(), _cancellationToken).Returns(Task.FromResult<ResourceWrapper>(null));
 
-            var request = GetReindexRequest();
+            var request = GetReindexRequest(HttpGetName);
             await Assert.ThrowsAsync<ResourceNotFoundException>(() => _reindexHandler.Handle(request, _cancellationToken));
         }
 
-        [Fact]
-        public async Task GivenNewSearchIndices_WhenHandle_ThenTheirValuesArePresentInResponse()
+        [Theory]
+        [InlineData(HttpGetName)]
+        [InlineData(HttpPostName)]
+        public async Task GivenNewSearchIndicesGetRequest_WhenHandle_ThenTheirValuesArePresentInResponse(string httpMethodName)
         {
             SetupDataStoreToReturnDummyResourceWrapper();
 
@@ -82,7 +87,7 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Reinde
 
             _searchIndexer.Extract(Arg.Any<ResourceElement>()).Returns(searchIndices);
 
-            var request = GetReindexRequest();
+            var request = GetReindexRequest(httpMethodName);
 
             ReindexSingleResourceResponse response = await _reindexHandler.Handle(request, _cancellationToken);
             Assert.NotNull(response.ParameterResource);
@@ -107,10 +112,14 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Reinde
 
             Assert.True(newSearchParamPresent);
             Assert.True(newSearchParam2Present);
+
+            await ValidateUpdateCallBasedOnHttpMethodType(httpMethodName);
         }
 
-        [Fact]
-        public async Task GivenDuplicateNewSearchIndices_WhenHandle_ThenBothValuesArePresentInResponse()
+        [Theory]
+        [InlineData(HttpGetName)]
+        [InlineData(HttpPostName)]
+        public async Task GivenDuplicateNewSearchIndices_WhenHandle_ThenBothValuesArePresentInResponse(string httpMethodName)
         {
             SetupDataStoreToReturnDummyResourceWrapper();
 
@@ -121,7 +130,7 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Reinde
 
             _searchIndexer.Extract(Arg.Any<ResourceElement>()).Returns(searchIndices);
 
-            var request = GetReindexRequest();
+            var request = GetReindexRequest(httpMethodName);
 
             ReindexSingleResourceResponse response = await _reindexHandler.Handle(request, _cancellationToken);
             Assert.NotNull(response.ParameterResource);
@@ -151,6 +160,8 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Reinde
             Assert.True(newSearchParamPresent);
             Assert.True(name1Present);
             Assert.True(name2Present);
+
+            await ValidateUpdateCallBasedOnHttpMethodType(httpMethodName);
         }
 
         private void SetupDataStoreToReturnDummyResourceWrapper()
@@ -160,9 +171,12 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Reinde
             RawResource rawResource = new RawResource(new FhirJsonSerializer().SerializeToString(patientResource), FhirResourceFormat.Json, isMetaSet: false);
 
             ResourceWrapper dummyResourceWrapper = new ResourceWrapper(
-                patientResourceElement,
+                patientResourceElement.Id,
+                versionId: "1",
+                patientResourceElement.InstanceType,
                 rawResource,
                 request: null,
+                patientResourceElement.LastUpdated ?? Clock.UtcNow,
                 deleted: false,
                 searchIndices: null,
                 compartmentIndices: null,
@@ -171,12 +185,24 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Reinde
             _fhirDataStore.GetAsync(Arg.Any<ResourceKey>(), _cancellationToken).Returns(Task.FromResult(dummyResourceWrapper));
         }
 
-        private ReindexSingleResourceRequest GetReindexRequest(string resourceId = null, string resourceType = null)
+        private ReindexSingleResourceRequest GetReindexRequest(string httpMethod, string resourceId = null, string resourceType = null)
         {
             resourceId = resourceId ?? Guid.NewGuid().ToString();
             resourceType = resourceType ?? "Patient";
 
-            return new ReindexSingleResourceRequest(resourceType, resourceId);
+            return new ReindexSingleResourceRequest(httpMethod, resourceType, resourceId);
+        }
+
+        private async Task ValidateUpdateCallBasedOnHttpMethodType(string httpMethodName)
+        {
+            if (httpMethodName == HttpPostName)
+            {
+                await _fhirDataStore.Received().UpdateSearchIndexForResourceAsync(Arg.Any<ResourceWrapper>(), Arg.Any<WeakETag>(), _cancellationToken);
+            }
+            else if (httpMethodName == HttpGetName)
+            {
+                await _fhirDataStore.DidNotReceive().UpdateSearchIndexForResourceAsync(Arg.Any<ResourceWrapper>(), Arg.Any<WeakETag>(), _cancellationToken);
+            }
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexSingleResourceRequestHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexSingleResourceRequestHandlerTests.cs
@@ -24,7 +24,7 @@ using NSubstitute;
 using Xunit;
 using Task = System.Threading.Tasks.Task;
 
-namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Reindex
+namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
 {
     public class ReindexSingleResourceRequestHandlerTests
     {

--- a/src/Microsoft.Health.Fhir.Shared.Core/Extensions/ReindexMediatorExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Extensions/ReindexMediatorExtensions.cs
@@ -31,13 +31,14 @@ namespace Microsoft.Health.Fhir.Core.Extensions
 
         public static async Task<ReindexSingleResourceResponse> SendReindexSingleResourceRequestAsync(
             this IMediator mediator,
+            string httpMethod,
             string resourceType,
             string resourceId,
             CancellationToken cancellationToken)
         {
             EnsureArg.IsNotNull(mediator, nameof(mediator));
 
-            var request = new ReindexSingleResourceRequest(resourceType, resourceId);
+            var request = new ReindexSingleResourceRequest(httpMethod, resourceType, resourceId);
 
             ReindexSingleResourceResponse response = await mediator.Send(request, cancellationToken);
             return response;

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Reindex/ReindexSingleResourceRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Reindex/ReindexSingleResourceRequestHandler.cs
@@ -28,6 +28,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
         private readonly ISearchIndexer _searchIndexer;
         private readonly IResourceDeserializer _resourceDeserializer;
 
+        private const string HttpPostName = "POST";
+
         public ReindexSingleResourceRequestHandler(
             IFhirAuthorizationService authorizationService,
             IFhirDataStore fhirDataStore,
@@ -67,6 +69,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             ResourceElement resourceElement = _resourceDeserializer.Deserialize(storedResource);
             IReadOnlyCollection<SearchIndexEntry> newIndices = _searchIndexer.Extract(resourceElement);
 
+            // If it's a post request we need to go update the resource in the database.
+            if (request.HttpMethod == HttpPostName)
+            {
+                await ProcessPostReindexSingleResourceRequest(storedResource, newIndices);
+            }
+
             // Create a new parameter resource and include the new search indices and the corresponding values.
             var parametersResource = new Parameters
             {
@@ -83,6 +91,23 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             }
 
             return new ReindexSingleResourceResponse(parametersResource.ToResourceElement());
+        }
+
+        private async System.Threading.Tasks.Task ProcessPostReindexSingleResourceRequest(ResourceWrapper originalResource, IReadOnlyCollection<SearchIndexEntry> searchIndices)
+        {
+            ResourceWrapper updatedResource = new ResourceWrapper(
+                originalResource.ResourceId,
+                originalResource.Version,
+                originalResource.ResourceTypeName,
+                originalResource.RawResource,
+                originalResource.Request,
+                originalResource.LastModified,
+                deleted: false,
+                searchIndices,
+                originalResource.CompartmentIndices,
+                originalResource.LastModifiedClaims);
+
+            await _fhirDataStore.UpdateSearchIndexForResourceAsync(updatedResource, WeakETag.FromVersionId(originalResource.Version), CancellationToken.None);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Reindex/ReindexSingleResourceRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Reindex/ReindexSingleResourceRequestHandler.cs
@@ -82,8 +82,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                 VersionId = "1",
                 Parameter = new List<Parameters.ParameterComponent>(),
             };
-            parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = "originalResourceId", Value = new FhirString(request.ResourceId) });
-            parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = "originalResourceType", Value = new FhirString(request.ResourceType) });
 
             foreach (SearchIndexEntry searchIndex in newIndices)
             {

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -282,7 +282,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             }
         }
 
-        public Task<ResourceWrapper> UpdateSearchIndexForResourceAsync(ResourceWrapper resourceWrapper, string eTag, CancellationToken cancellationToken)
+        public Task<ResourceWrapper> UpdateSearchIndexForResourceAsync(ResourceWrapper resourceWrapper, WeakETag weakETag, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
## Description
Added support for POST $reindex endpoint for a single resource where the resource will get updated in the database with the new search parameters. The endpoint will follow the following pattern POST /<fhir-server>/<resourceType>/<resourceId>/$reindex. The response will be a Parameter resource with the search parameters that will be supported for that resource. 

## Related issues
Addresses [issue [AB#75742](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/75742)].

## Testing
UTs. Manual testing on local deployment.
