### PR TITLE
Fix incorrect SQL when a query contains _include, _id, and another parameter like _tag

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/DenormalizedPredicateRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/DenormalizedPredicateRewriter.cs
@@ -57,6 +57,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
 
             if (containsDenormalizedExpressionNotOnSearchParameterTables)
             {
+                // There is a predicate over _id, which is on the Resource table but not on the search parameter tables.
+                // So the first table expression should be an "All" expression, where we restrict the resultset to resources with that ID.
                 newTableExpressions.Add(new TableExpression(null, null, TableExpression.And(expression.DenormalizedExpressions), TableExpressionKind.All));
             }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/DenormalizedPredicateRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/DenormalizedPredicateRewriter.cs
@@ -22,13 +22,14 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
 
         public Expression VisitSqlRoot(SqlRootExpression expression, object context)
         {
-            if (expression.TableExpressions.Count == 0 || expression.DenormalizedExpressions.Count == 0 || expression.TableExpressions.All(t => t.Kind == TableExpressionKind.Include))
+            if (expression.TableExpressions.Count == 0 || expression.DenormalizedExpressions.Count == 0)
             {
                 return expression;
             }
 
             Expression extractedDenormalizedExpression = null;
             List<Expression> newDenormalizedPredicates = null;
+            bool containsDenormalizedExpressionNotOnSearchParameterTables = false;
 
             for (int i = 0; i < expression.DenormalizedExpressions.Count; i++)
             {
@@ -45,18 +46,20 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
 
                             break;
                         default:
+                            containsDenormalizedExpressionNotOnSearchParameterTables = true;
                             newDenormalizedPredicates?.Add(currentExpression);
                             break;
                     }
                 }
             }
 
-            if (extractedDenormalizedExpression == null)
+            var newTableExpressions = new List<TableExpression>(expression.TableExpressions.Count);
+
+            if (containsDenormalizedExpressionNotOnSearchParameterTables)
             {
-                return expression;
+                newTableExpressions.Add(new TableExpression(null, null, TableExpression.And(expression.DenormalizedExpressions), TableExpressionKind.All));
             }
 
-            var newTableExpressions = new List<TableExpression>(expression.TableExpressions.Count);
             foreach (var tableExpression in expression.TableExpressions)
             {
                 if (tableExpression.Kind == TableExpressionKind.Include)
@@ -77,7 +80,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
                 }
             }
 
-            return new SqlRootExpression(newTableExpressions, newDenormalizedPredicates);
+            return new SqlRootExpression(newTableExpressions, Array.Empty<Expression>());
         }
 
         public Expression VisitTable(TableExpression tableExpression, object context)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/MissingSearchParamVisitor.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/MissingSearchParamVisitor.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
                 TableExpression tableExpression = expression.TableExpressions[i];
 
                 // process only normalized predicates. Ignore Sort as it has its own visitor.
-                if (tableExpression.Kind != TableExpressionKind.Sort && tableExpression.NormalizedPredicate.AcceptVisitor(Scout.Instance, null))
+                if (tableExpression.Kind != TableExpressionKind.Sort && tableExpression.NormalizedPredicate?.AcceptVisitor(Scout.Instance, null) == true)
                 {
                     EnsureAllocatedAndPopulated(ref newTableExpressions, expression.TableExpressions, i);
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
@@ -46,6 +46,32 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             Assert.Equal(1, bundle.Total);
         }
 
+        /// <summary>
+        /// Ensures that the _id predicate is not applied to the included resources.
+        /// </summary>
+        [Fact]
+        public async Task GivenAnIncludeSearchExpressionWithAPredicateOnId_WhenSearched_ThenCorrectBundleShouldBeReturned()
+        {
+            string query = $"_include=Location:organization:Organization&_tag={Fixture.Tag}&_id={Fixture.Location.Id}";
+
+            Bundle bundle = await Client.SearchAsync(ResourceType.Location, query);
+
+            ValidateBundle(
+                bundle,
+                Fixture.Organization,
+                Fixture.Location);
+
+            ValidateSearchEntryMode(bundle, ResourceType.Location);
+
+            // ensure that the included resources are not counted
+            bundle = await Client.SearchAsync(ResourceType.Location, $"{query}&_summary=count");
+            Assert.Equal(1, bundle.Total);
+
+            // ensure that the included resources are not counted when _total is specified and the results fit in a single bundle.
+            bundle = await Client.SearchAsync(ResourceType.Location, $"{query}&_total=accurate");
+            Assert.Equal(1, bundle.Total);
+        }
+
         [Fact]
         public async Task GivenAnIncludeSearchExpression_WhenSearchedWithPost_ThenCorrectBundleShouldBeReturned()
         {


### PR DESCRIPTION
## Description
We generated incorrect SQL for searches like `Patient?_revinclude=Observation:subject&_id=186xxxa1c&_tag=774xxxce98`.

The `_id` predicate was being applied to the final `SELECT` and was therefore being applied to all returned resources, including the "included" resources. Instead the predicate should only apply to the matches

## Related issues
Addresses #1235 

## Testing
Manual, E2E, unit
