### PR TITLE
Add multi-threading and error recovery to reindex job task

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/CreateReindexRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/CreateReindexRequestHandler.cs
@@ -66,7 +66,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             var jobRecord = new ReindexJobRecord(
                 hash,
                 request.MaximumConcurrency ?? _reindexJobConfiguration.DefaultMaximumThreadsPerReindexJob,
-                request.Scope);
+                request.Scope,
+                _reindexJobConfiguration.MaximumNumberOfResourcesPerQuery);
             var outcome = await _fhirOperationDataStore.CreateReindexJobAsync(jobRecord, cancellationToken);
 
             return new CreateReindexResponse(outcome);

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobRecord.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobRecord.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using EnsureThat;
 using Microsoft.Health.Core;
 using Microsoft.Health.Fhir.Core.Models;
 using Newtonsoft.Json;
@@ -17,8 +18,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
     /// </summary>
     public class ReindexJobRecord : JobRecord
     {
-        public ReindexJobRecord(string searchParametersHash, ushort maxiumumConcurrency, string scope)
+        public ReindexJobRecord(
+            string searchParametersHash,
+            ushort maxiumumConcurrency = 1,
+            string scope = null,
+            uint maxResourcesPerQuery = 100)
         {
+            EnsureArg.IsNotNull(searchParametersHash, nameof(searchParametersHash));
+
             // Default values
             SchemaVersion = 1;
             Id = Guid.NewGuid().ToString();
@@ -30,6 +37,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
             Hash = searchParametersHash;
             MaximumConcurrency = maxiumumConcurrency;
             Scope = scope;
+            MaximumNumberOfResourcesPerQuery = maxResourcesPerQuery;
         }
 
         [JsonConstructor]
@@ -69,6 +77,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
 
         [JsonProperty(JobRecordProperties.SearchParams)]
         public List<string> SearchParams { get; private set; } = new List<string>();
+
+        [JsonProperty(JobRecordProperties.MaximumNumberOfResourcesPerQuery)]
+        public uint MaximumNumberOfResourcesPerQuery { get; private set; }
 
         [JsonIgnore]
         public int PercentComplete

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobRecord.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobRecord.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Microsoft.Health.Core;
 using Microsoft.Health.Fhir.Core.Models;
@@ -46,7 +47,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
         public IList<OperationOutcomeIssue> Error { get; private set; } = new List<OperationOutcomeIssue>();
 
         [JsonProperty(JobRecordProperties.QueryList)]
-        public IList<ReindexJobQueryStatus> QueryList { get; private set; } = new List<ReindexJobQueryStatus>();
+        public ConcurrentBag<ReindexJobQueryStatus> QueryList { get; private set; } = new ConcurrentBag<ReindexJobQueryStatus>();
 
         [JsonProperty(JobRecordProperties.Count)]
         public int Count { get; set; }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -243,6 +243,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     jobSemaphore.Release();
                 }
             }
+            finally
+            {
+                jobSemaphore.Dispose();
+            }
         }
 
         private async Task<ReindexJobQueryStatus> ProcessQueryAsync(ReindexJobQueryStatus query, SemaphoreSlim jobSemaphore, CancellationToken cancellationToken)

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Queries/QueryHelper.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Queries/QueryHelper.cs
@@ -5,6 +5,7 @@
 
 using System.Text;
 using EnsureThat;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
 
 namespace Microsoft.Health.Fhir.CosmosDb.Features.Queries
 {
@@ -64,6 +65,23 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Queries
                 .Append(_rootAliasName).Append(".isSystem")
                 .Append(" = ")
                 .AppendLine(_queryParameterManager.AddOrGetParameterMapping(systemDataValue));
+        }
+
+        public void AppendSearchParameterHashFliter(string hashValue)
+        {
+            _queryBuilder
+                .Append("AND")
+                .Append(" (")
+                .Append(_rootAliasName).Append(".")
+                .Append(KnownResourceWrapperProperties.SearchParameterHash)
+                .Append(" != ")
+                .Append(_queryParameterManager.AddOrGetParameterMapping(hashValue))
+                .Append(" OR IS_DEFINED(")
+                .Append(_rootAliasName).Append(".")
+                .Append(KnownResourceWrapperProperties.SearchParameterHash)
+                .Append(") = ")
+                .Append(_queryParameterManager.AddOrGetParameterMapping(false))
+                .Append(")");
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/QueryBuilder.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/QueryBuilder.cs
@@ -166,10 +166,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries
                    true,
                    (KnownResourceWrapperProperties.IsDeleted, false));
 
-                AppendFilterCondition(
-                   "AND",
-                   false,
-                   (KnownResourceWrapperProperties.SearchParameterHash, searchParameterHash));
+                _queryHelper.AppendSearchParameterHashFliter(searchParameterHash);
 
                 var query = new QueryDefinition(_queryBuilder.ToString());
                 _queryParameterManager.AddToQuery(query);

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -207,19 +207,21 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
 
         public async Task UpdateSearchParameterHashBatchAsync(IReadOnlyCollection<ResourceWrapper> resources, CancellationToken cancellationToken)
         {
-            // TODO: use bach command to update
+            // TODO: use batch command to update both hash values and search index values for list updateSearchIndices
+            // this is a place holder update until we batch update resources
             foreach (var resource in resources)
             {
-                await UpdateSearchIndexForResourceAsync(resource, WeakETag.FromVersionId(resource.Version).ToString(), cancellationToken);
+                await UpdateSearchIndexForResourceAsync(resource, WeakETag.FromVersionId(resource.Version), cancellationToken);
             }
         }
 
         public async Task UpdateSearchParameterIndicesBatchAsync(IReadOnlyCollection<ResourceWrapper> resources, CancellationToken cancellationToken)
         {
-            // TODO: use bach command to update
+            // TODO: use batch command to update both hash values and search index values for list updateSearchIndices
+            // this is a place holder update until we batch update resources
             foreach (var resource in resources)
             {
-                await UpdateSearchIndexForResourceAsync(resource, WeakETag.FromVersionId(resource.Version).ToString(), cancellationToken);
+                await UpdateSearchIndexForResourceAsync(resource, WeakETag.FromVersionId(resource.Version), cancellationToken);
             }
         }
 

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -207,22 +207,19 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
 
         public async Task UpdateSearchParameterHashBatchAsync(IReadOnlyCollection<ResourceWrapper> resources, CancellationToken cancellationToken)
         {
-            // TODO: use bach command to update only hash values for list updateHashValueOnly
-            // this is a place holder update until we batch update resources
+            // TODO: use bach command to update
             foreach (var resource in resources)
             {
-                await UpsertAsync(resource, WeakETag.FromVersionId(resource.Version), false, true, cancellationToken);
+                await UpdateSearchIndexForResourceAsync(resource, WeakETag.FromVersionId(resource.Version).ToString(), cancellationToken);
             }
         }
 
         public async Task UpdateSearchParameterIndicesBatchAsync(IReadOnlyCollection<ResourceWrapper> resources, CancellationToken cancellationToken)
         {
-            // TODO: use batch command to update both hash values and search index values for list updateSearchIndices
-
-            // this is a place holder update until we batch update resources
+            // TODO: use bach command to update
             foreach (var resource in resources)
             {
-                await UpsertAsync(resource, WeakETag.FromVersionId(resource.Version), false, true, cancellationToken);
+                await UpdateSearchIndexForResourceAsync(resource, WeakETag.FromVersionId(resource.Version).ToString(), cancellationToken);
             }
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexJobTaskTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexJobTaskTests.cs
@@ -19,7 +19,6 @@ using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.UnitTests.Extensions;
 using Microsoft.Health.Fhir.Core.UnitTests.Features.Search;
-using Microsoft.Health.Fhir.Tests.Common;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -41,8 +40,6 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
 
         private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
         private readonly CancellationToken _cancellationToken;
-
-        private InMemoryLogger<ReindexJobTask> _inMemoryLogger = new InMemoryLogger<ReindexJobTask>();
 
         public ReindexJobTaskTests()
         {
@@ -229,14 +226,6 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
 
             job.QueryList.Add(new ReindexJobQueryStatus("token") { Status = OperationStatus.Running });
 
-            _reindexJobTask = new ReindexJobTask(
-                () => _fhirOperationDataStore.CreateMockScope(),
-                Options.Create(_reindexJobConfiguration),
-                () => _searchService.CreateMockScope(),
-                SearchParameterFixtureData.SupportedSearchDefinitionManager,
-                _reindexUtilities,
-                _inMemoryLogger);
-
             // setup search results
             _searchService.SearchForReindexAsync(
                 Arg.Any<IReadOnlyList<Tuple<string, string>>>(),
@@ -268,14 +257,6 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
             var job = new ReindexJobRecord("hash", maxiumumConcurrency: 1, scope: null, 3);
 
             job.QueryList.Add(new ReindexJobQueryStatus("token") { Status = OperationStatus.Running });
-
-            _reindexJobTask = new ReindexJobTask(
-                () => _fhirOperationDataStore.CreateMockScope(),
-                Options.Create(_reindexJobConfiguration),
-                () => _searchService.CreateMockScope(),
-                SearchParameterFixtureData.SupportedSearchDefinitionManager,
-                _reindexUtilities,
-                _inMemoryLogger);
 
             // setup search results
             _searchService.SearchForReindexAsync(

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Reindex/ReindexUtilities.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Reindex/ReindexUtilities.cs
@@ -69,6 +69,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     entry.Resource.UpdateSearchIndices(newIndices);
                     updateSearchIndices.Add(entry.Resource);
                 }
+
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
             }
 
             using (IScoped<IFhirDataStore> store = _fhirDataStoreFactory())

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Reindex/ReindexUtilities.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Reindex/ReindexUtilities.cs
@@ -45,6 +45,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
         /// <returns>A Task</returns>
         public async Task ProcessSearchResultsAsync(SearchResult results, string searchParamHash, CancellationToken cancellationToken)
         {
+            EnsureArg.IsNotNull(results, nameof(results));
+            EnsureArg.IsNotNull(searchParamHash, nameof(searchParamHash));
+
             var updateHashValueOnly = new List<ResourceWrapper>();
             var updateSearchIndices = new List<ResourceWrapper>();
 
@@ -54,7 +57,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                 var resourceElement = _deserializer.Deserialize(entry.Resource);
                 var newIndices = _searchIndexer.Extract(resourceElement);
                 var newIndicesHash = new HashSet<SearchIndexEntry>(newIndices);
-                var prevIndicesHash = new HashSet<SearchIndexEntry>(entry.Resource.SearchIndices);
+                var prevIndicesHash = entry.Resource.SearchIndices != null ?
+                    new HashSet<SearchIndexEntry>(entry.Resource.SearchIndices) : new HashSet<SearchIndexEntry>();
 
                 if (newIndicesHash.SetEquals(prevIndicesHash))
                 {


### PR DESCRIPTION
## Description
Updates the reindex job task to created multiple threads up to a limit of max allowed concurrency.  Also adds updates to recover from a failure condition

## Related issues
Addresses [issue [AB#73390](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/73390)].

## Testing
Manual testing, and updated unit tests.
