### PR TITLE
Updates history _at parameter as unsupported

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchService.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchService.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
 
             if (at != null)
             {
-                queryParameters.Add(Tuple.Create(SearchParameterNames.LastUpdated, at.ToString()));
+                queryParameters.Add(Tuple.Create(KnownQueryParameterNames.At, at.ToString()));
             }
             else
             {


### PR DESCRIPTION
## Description
Since the history _at parameter behavior is not as expected so we will no longer support it until the fix is made.
This PR drops the _at param from url and returns the history results.

## Related issues
Addresses [#AB75665](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Resolute/Stories/?workitem=75665)

## Testing
Added a e2e test
