### PR TITLE
Fixed missing modifier search on references

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/MissingSearchParamVisitorTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/MissingSearchParamVisitorTests.cs
@@ -1,0 +1,78 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
+using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions;
+using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
+{
+    public class MissingSearchParamVisitorTests
+    {
+        [Fact]
+        public void GivenExpressionWithMissingParameterExpression_WhenVisited_AllExpressionPrependedToExpressionList()
+        {
+            var tableExpressions = new List<TableExpression>
+            {
+                new TableExpression(null, new MissingSearchParameterExpression(new SearchParameterInfo("TestParam"), true), null, TableExpressionKind.Normal),
+            };
+
+            var inputExpression = SqlRootExpression.WithTableExpressions(tableExpressions);
+            var visitedExpression = (SqlRootExpression)inputExpression.AcceptVisitor(MissingSearchParamVisitor.Instance);
+            Assert.Collection(
+                visitedExpression.TableExpressions,
+                e => { Assert.Equal(TableExpressionKind.All, e.Kind); },
+                e => { Assert.NotNull(e.NormalizedPredicate as MissingSearchParameterExpression); });
+            Assert.Equal(tableExpressions.Count + 1, visitedExpression.TableExpressions.Count);
+        }
+
+        [Fact]
+        public void GivenExpressionWithNoMissingParameterExpression_WhenVisited_OriginalExpressionReturned()
+        {
+            var tableExpressions = new List<TableExpression>
+            {
+                new TableExpression(null, null, null, TableExpressionKind.Normal),
+            };
+
+            var inputExpression = SqlRootExpression.WithTableExpressions(tableExpressions);
+            var visitedExpression = (SqlRootExpression)inputExpression.AcceptVisitor(MissingSearchParamVisitor.Instance);
+            Assert.Equal(inputExpression, visitedExpression);
+        }
+
+        [Fact]
+        public void GivenExpressionWithMissingParameterExpressionFalseLast_WhenVisited_OriginalExpressionReturned()
+        {
+            var tableExpressions = new List<TableExpression>
+            {
+                new TableExpression(null, null, null, TableExpressionKind.Normal),
+                new TableExpression(null, new MissingSearchParameterExpression(new SearchParameterInfo("TestParam"), false), null, TableExpressionKind.Normal),
+            };
+
+            var inputExpression = SqlRootExpression.WithTableExpressions(tableExpressions);
+            var visitedExpression = (SqlRootExpression)inputExpression.AcceptVisitor(MissingSearchParamVisitor.Instance);
+            Assert.Equal(inputExpression, visitedExpression);
+        }
+
+        [Fact]
+        public void GivenExpressionWithMissingParameterExpressionLast_WhenVisited_MissingParameterExpressionNegated()
+        {
+            var tableExpressions = new List<TableExpression>
+            {
+                new TableExpression(null, null, null, TableExpressionKind.Normal),
+                new TableExpression(null, new MissingSearchParameterExpression(new SearchParameterInfo("TestParam"), true), null, TableExpressionKind.Normal),
+            };
+
+            var inputExpression = SqlRootExpression.WithTableExpressions(tableExpressions);
+            var visitedExpression = (SqlRootExpression)inputExpression.AcceptVisitor(MissingSearchParamVisitor.Instance);
+            Assert.Collection(
+                visitedExpression.TableExpressions,
+                e => { Assert.Equal(tableExpressions[0], e); },
+                e => { Assert.Equal(TableExpressionKind.NotExists, e.Kind); });
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/NormalizedPredicateReordererTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/NormalizedPredicateReordererTests.cs
@@ -1,0 +1,72 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Hl7.FhirPath.Sprache;
+using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
+using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions;
+using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors;
+using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.QueryGenerators;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
+{
+    public class NormalizedPredicateReordererTests
+    {
+        [Fact]
+        public void GivenExpressionWithSingleTableExpression_WhenReordered_ReturnsOriginalExpression()
+        {
+            var inputExpression = SqlRootExpression.WithTableExpressions(
+                new TableExpression(null, null, null, TableExpressionKind.Normal));
+            var visitedExpression = (SqlRootExpression)inputExpression.AcceptVisitor(NormalizedPredicateReorderer.Instance);
+            Assert.Equal(inputExpression, visitedExpression);
+        }
+
+        [Fact]
+        public void GivenExpressionWithMulthMultipleTableExpressions_WhenReordered_ReferenceExpressionReturnedFirst()
+        {
+            var tableExpressions = new List<TableExpression>
+            {
+                new TableExpression(null, null, null, TableExpressionKind.Normal),
+                new TableExpression(new ReferenceSearchParameterQueryGenerator(), null, null, TableExpressionKind.Normal),
+            };
+
+            var inputExpression = SqlRootExpression.WithTableExpressions(tableExpressions);
+            var visitedExpression = (SqlRootExpression)inputExpression.AcceptVisitor(NormalizedPredicateReorderer.Instance);
+            Assert.Collection(visitedExpression.TableExpressions, new[] { 1, 0 }.Select<int, Action<TableExpression>>(x => e => Assert.Equal(tableExpressions[x], e)).ToArray());
+        }
+
+        [Fact]
+        public void GivenExpressionWithMulthMultipleTableExpressions_WhenReordered_CompartmentExpressionReturnedFirst()
+        {
+            var tableExpressions = new List<TableExpression>
+            {
+                new TableExpression(null, null, null, TableExpressionKind.Normal),
+                new TableExpression(new CompartmentSearchParameterQueryGenerator(), null, null, TableExpressionKind.Normal),
+            };
+
+            var inputExpression = SqlRootExpression.WithTableExpressions(tableExpressions);
+            var visitedExpression = (SqlRootExpression)inputExpression.AcceptVisitor(NormalizedPredicateReorderer.Instance);
+            Assert.Collection(visitedExpression.TableExpressions, new[] { 1, 0 }.Select<int, Action<TableExpression>>(x => e => Assert.Equal(tableExpressions[x], e)).ToArray());
+        }
+
+        [Fact]
+        public void GivenExpressionWithMulthMultipleTableExpressions_WhenReordered_MissingParameterExpressionReturnedLast()
+        {
+            var tableExpressions = new List<TableExpression>
+            {
+                new TableExpression(null, new MissingSearchParameterExpression(new SearchParameterInfo("TestParam"), true), null, TableExpressionKind.Normal),
+                new TableExpression(null, null, null, TableExpressionKind.Normal),
+            };
+
+            var inputExpression = SqlRootExpression.WithTableExpressions(tableExpressions);
+            var visitedExpression = (SqlRootExpression)inputExpression.AcceptVisitor(NormalizedPredicateReorderer.Instance);
+            Assert.Collection(visitedExpression.TableExpressions, new[] { 1, 0 }.Select<int, Action<TableExpression>>(x => e => Assert.Equal(tableExpressions[x], e)).ToArray());
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/NormalizedPredicateReordererTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/NormalizedPredicateReordererTests.cs
@@ -56,11 +56,25 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
         }
 
         [Fact]
-        public void GivenExpressionWithMulthMultipleTableExpressions_WhenReordered_MissingParameterExpressionReturnedLast()
+        public void GivenExpressionWithMulthMultipleTableExpressions_WhenReordered_MissingParameterExpressionReturnedBeforeInclude()
         {
             var tableExpressions = new List<TableExpression>
             {
+                new TableExpression(new IncludeQueryGenerator(), null, null, TableExpressionKind.Include),
                 new TableExpression(null, new MissingSearchParameterExpression(new SearchParameterInfo("TestParam"), true), null, TableExpressionKind.Normal),
+            };
+
+            var inputExpression = SqlRootExpression.WithTableExpressions(tableExpressions);
+            var visitedExpression = (SqlRootExpression)inputExpression.AcceptVisitor(NormalizedPredicateReorderer.Instance);
+            Assert.Collection(visitedExpression.TableExpressions, new[] { 1, 0 }.Select<int, Action<TableExpression>>(x => e => Assert.Equal(tableExpressions[x], e)).ToArray());
+        }
+
+        [Fact]
+        public void GivenExpressionWithMulthMultipleTableExpressions_WhenReordered_IncludeExpressionReturnedLast()
+        {
+            var tableExpressions = new List<TableExpression>
+            {
+                new TableExpression(new IncludeQueryGenerator(), null, null, TableExpressionKind.Include),
                 new TableExpression(null, null, null, TableExpressionKind.Normal),
             };
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/MissingSearchParamVisitor.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/MissingSearchParamVisitor.cs
@@ -33,7 +33,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
                 {
                     EnsureAllocatedAndPopulated(ref newTableExpressions, expression.TableExpressions, i);
 
-                    if (expression.TableExpressions.Count == 1)
+                    // If this is the first expression, we need to add another expression before it
+                    if (i == 0)
                     {
                         // seed with all resources so that we have something to restrict
                         newTableExpressions.Add(

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/NormalizedPredicateReorderer.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/NormalizedPredicateReorderer.cs
@@ -26,6 +26,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
 
             List<TableExpression> reorderedExpressions = expression.TableExpressions.OrderByDescending(t =>
             {
+                if (t.NormalizedPredicate is MissingSearchParameterExpression)
+                {
+                    return -10;
+                }
+
                 switch (t.SearchParameterQueryGenerator)
                 {
                     case ReferenceSearchParameterQueryGenerator _:

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/NormalizedPredicateReorderer.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/NormalizedPredicateReorderer.cs
@@ -37,6 +37,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
                         return 10;
                     case CompartmentSearchParameterQueryGenerator _:
                         return 10;
+                    case IncludeQueryGenerator _:
+                        return -20;
                     default:
                         return 0;
                 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -85,6 +85,22 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenResourcesWithMissingReference_WhenSearchedWithTheMissingModiferAndOtherParameter_ThenOnlyMatchingResourcesWithMissingOrPresentReferenceAreReturned()
+        {
+            Patient patientWithReference = (await Client.CreateResourcesAsync<Patient>(p =>
+            {
+                p.Gender = AdministrativeGender.Female;
+                p.ManagingOrganization = new ResourceReference("Organization/123");
+            })).Single();
+            Patient femalePatient = (await Client.CreateResourcesAsync<Patient>(p => p.Gender = AdministrativeGender.Female)).Single();
+            Patient unspecifiedPatient = (await Client.CreateResourcesAsync<Patient>(p => { })).Single();
+
+            await ExecuteAndValidateBundle("Patient?gender=female&organization:missing=true", femalePatient);
+            await ExecuteAndValidateBundle("Patient?gender=female&organization:missing=false", patientWithReference);
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
         public async Task GivenVariousTypesOfResources_WhenSearchingAcrossAllResourceTypes_ThenOnlyResourcesMatchingTypeParameterShouldBeReturned()
         {
             // Create various resources.

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
@@ -138,6 +138,23 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         }
 
         [Fact]
+        public async Task GivenAnIncludeSearchExpressionWithMissingModifier_WhenSearched_ThenCorrectBundleShouldBeReturned()
+        {
+            string query = $"_tag={Fixture.Tag}&_include=DiagnosticReport:patient:Patient&code=429858000&organization:missing=true";
+
+            Bundle bundle = await Client.SearchAsync(ResourceType.DiagnosticReport, query);
+
+            ValidateBundle(
+                bundle,
+                Fixture.SmithSnomedDiagnosticReport,
+                Fixture.SmithPatient,
+                Fixture.TrumanSnomedDiagnosticReport,
+                Fixture.TrumanPatient);
+
+            ValidateSearchEntryMode(bundle, ResourceType.DiagnosticReport);
+        }
+
+        [Fact]
         public async Task GivenAnIncludeSearchExpressionWithSimpleSearchAndCount_WhenSearched_ThenCorrectBundleShouldBeReturned()
         {
             string query = $"_tag={Fixture.Tag}&_include=DiagnosticReport:patient:Patient&code=429858000&_count=1";


### PR DESCRIPTION
## Description
Changed NormalizedPredicate SortOrder to order MissingSearchParameterExpression after all other expressions.
Changed MissingSearchParamVisitor to create an `All` table expression if the MissingSearchParameterExpression is the first in the expression list (rather than the onle one)

## Related issues
Addresses #1295.

## Testing
Added unit and E2E tests
