### PR TITLE
Fix incorrect _lastUpdated to ResourceSurrogateId translation

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/BinaryExpression.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/BinaryExpression.cs
@@ -64,6 +64,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
                         return $"'{Value}'";
                     case DateTime dt:
                         return dt.ToString("O");
+                    case DateTimeOffset dto:
+                        return dto.ToString("O");
                     case IFormattable f:
                         return f.ToString(null, CultureInfo.InvariantCulture);
                     default:

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/LastUpdatedToResourceSurrogateIdRewriterTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/LastUpdatedToResourceSurrogateIdRewriterTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
         [InlineData(BinaryOperator.GreaterThan, "2020-09-24T12:00:00.5001Z", BinaryOperator.GreaterThanOrEqual, "2020-09-24T12:00:00.501Z")]
         [InlineData(BinaryOperator.GreaterThanOrEqual, "2020-09-24T12:00:00.500Z", BinaryOperator.GreaterThanOrEqual, "2020-09-24T12:00:00.500Z")]
         [InlineData(BinaryOperator.GreaterThanOrEqual, "2020-09-24T12:00:00.5001Z", BinaryOperator.GreaterThanOrEqual, "2020-09-24T12:00:00.501Z")]
-        [InlineData(BinaryOperator.LessThan, "2020-09-24T12:00:00.500Z", BinaryOperator.LessThan, "2020-09-24T12:00:00.500Z")] 
+        [InlineData(BinaryOperator.LessThan, "2020-09-24T12:00:00.500Z", BinaryOperator.LessThan, "2020-09-24T12:00:00.500Z")]
         [InlineData(BinaryOperator.LessThan, "2020-09-24T12:00:00.5001Z", BinaryOperator.LessThan, "2020-09-24T12:00:00.501Z")] // will yield 500, 499
         [InlineData(BinaryOperator.LessThanOrEqual, "2020-09-24T12:00:00.500Z", BinaryOperator.LessThan, "2020-09-24T12:00:00.501Z")]
         [InlineData(BinaryOperator.LessThanOrEqual, "2020-09-24T12:00:00.5001Z", BinaryOperator.LessThan, "2020-09-24T12:00:00.501Z")] // will yield 500, 499

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/LastUpdatedToResourceSurrogateIdRewriterTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/LastUpdatedToResourceSurrogateIdRewriterTests.cs
@@ -1,0 +1,38 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
+using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions;
+using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors;
+using Microsoft.Health.Fhir.SqlServer.Features.Storage;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
+{
+    public class LastUpdatedToResourceSurrogateIdRewriterTests
+    {
+        [InlineData(BinaryOperator.GreaterThan, "2020-09-24T12:00:00.500Z", BinaryOperator.GreaterThanOrEqual, "2020-09-24T12:00:00.501Z")]
+        [InlineData(BinaryOperator.GreaterThan, "2020-09-24T12:00:00.5001Z", BinaryOperator.GreaterThanOrEqual, "2020-09-24T12:00:00.501Z")]
+        [InlineData(BinaryOperator.GreaterThanOrEqual, "2020-09-24T12:00:00.500Z", BinaryOperator.GreaterThanOrEqual, "2020-09-24T12:00:00.500Z")]
+        [InlineData(BinaryOperator.GreaterThanOrEqual, "2020-09-24T12:00:00.5001Z", BinaryOperator.GreaterThanOrEqual, "2020-09-24T12:00:00.501Z")]
+        [InlineData(BinaryOperator.LessThan, "2020-09-24T12:00:00.500Z", BinaryOperator.LessThan, "2020-09-24T12:00:00.500Z")] 
+        [InlineData(BinaryOperator.LessThan, "2020-09-24T12:00:00.5001Z", BinaryOperator.LessThan, "2020-09-24T12:00:00.501Z")] // will yield 500, 499
+        [InlineData(BinaryOperator.LessThanOrEqual, "2020-09-24T12:00:00.500Z", BinaryOperator.LessThan, "2020-09-24T12:00:00.501Z")]
+        [InlineData(BinaryOperator.LessThanOrEqual, "2020-09-24T12:00:00.5001Z", BinaryOperator.LessThan, "2020-09-24T12:00:00.501Z")] // will yield 500, 499
+        [Theory]
+        public void GivenAnExpressionOverLastUpdated_WhenTranslatedToResourceSurrogateId_HasCorrectRanges(BinaryOperator inputOperator, string inputDateTimeOffset, BinaryOperator expectedOperator, string expectedDateTimeOffset)
+        {
+            var input = new BinaryExpression(inputOperator, FieldName.DateTimeStart, null, DateTimeOffset.Parse(inputDateTimeOffset));
+
+            var output = input.AcceptVisitor(LastUpdatedToResourceSurrogateIdRewriter.Instance, null);
+
+            BinaryExpression binaryOutput = Assert.IsType<BinaryExpression>(output);
+            Assert.Equal(SqlFieldName.ResourceSurrogateId, binaryOutput.FieldName);
+            Assert.Equal(expectedOperator, binaryOutput.BinaryOperator);
+            Assert.Equal(DateTimeOffset.Parse(expectedDateTimeOffset), ResourceSurrogateIdHelper.ResourceSurrogateIdToLastUpdated((long)binaryOutput.Value));
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/LastUpdatedToResourceSurrogateIdRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/LastUpdatedToResourceSurrogateIdRewriter.cs
@@ -45,6 +45,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
                 throw new ArgumentOutOfRangeException(expression.FieldName.ToString());
             }
 
+            // ResourceSurrogateId has millisecond datetime precision, with lower bits added in to make the value unique.
+
             DateTime original = ((DateTimeOffset)expression.Value).UtcDateTime;
             DateTime truncated = original.TruncateToMillisecond();
 
@@ -56,28 +58,30 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
                         null,
                         ResourceSurrogateIdHelper.LastUpdatedToResourceSurrogateId(truncated.AddTicks(TimeSpan.TicksPerMillisecond)));
                 case BinaryOperator.GreaterThanOrEqual:
-                    return Expression.GreaterThanOrEqual(
-                        SqlFieldName.ResourceSurrogateId,
-                        null,
-                        ResourceSurrogateIdHelper.LastUpdatedToResourceSurrogateId(truncated));
+                    if (original == truncated)
+                    {
+                        return Expression.GreaterThanOrEqual(
+                            SqlFieldName.ResourceSurrogateId,
+                            null,
+                            ResourceSurrogateIdHelper.LastUpdatedToResourceSurrogateId(truncated));
+                    }
+
+                    goto case BinaryOperator.GreaterThan;
                 case BinaryOperator.LessThan:
                     if (original == truncated)
                     {
-                        return Expression.LessThanOrEqual(
+                        return Expression.LessThan(
                             SqlFieldName.ResourceSurrogateId,
                             null,
-                            ResourceSurrogateIdHelper.LastUpdatedToResourceSurrogateId(truncated.AddTicks(-TimeSpan.TicksPerMillisecond)));
+                            ResourceSurrogateIdHelper.LastUpdatedToResourceSurrogateId(truncated));
                     }
 
-                    return Expression.LessThanOrEqual(
-                        SqlFieldName.ResourceSurrogateId,
-                        null,
-                        ResourceSurrogateIdHelper.LastUpdatedToResourceSurrogateId(truncated));
+                    goto case BinaryOperator.LessThanOrEqual;
                 case BinaryOperator.LessThanOrEqual:
-                    return Expression.LessThanOrEqual(
+                    return Expression.LessThan(
                         SqlFieldName.ResourceSurrogateId,
                         null,
-                        ResourceSurrogateIdHelper.LastUpdatedToResourceSurrogateId(truncated));
+                        ResourceSurrogateIdHelper.LastUpdatedToResourceSurrogateId(truncated.AddTicks(TimeSpan.TicksPerMillisecond)));
                 case BinaryOperator.NotEqual:
                 case BinaryOperator.Equal: // expecting eq to have been rewritten as a range
                 default:


### PR DESCRIPTION
## Description
When we get a search expression over `_lastUpdated`, we turn it into an expression over the `ResourceSurrogateId` field. This field encodes the datetime truncated to millisecond precision, with lower bits used to make the value unique.

We were not always doing the translation correctly around millisecond boundaries. 

## Related issues
Addresses #1286

## Testing
Added unit tests.
