### PR TITLE
Defaults TypedElementIndexer to on

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Configs/CoreFeatureConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/CoreFeatureConfiguration.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Health.Fhir.Core.Configs
         /// <summary>
         /// Gets or sets a value indicating whether to use the ITypedElement based search indexer.
         /// </summary>
-        public bool UseTypedElementIndexer { get; set; }
+        public bool UseTypedElementIndexer { get; set; } = true;
 
         /// <summary>
         /// Gets or sets the default value for IncludeTotal in search bundles.

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -26,7 +26,6 @@
         "CoreFeatures": {
             "SupportsBatch": true,
             "SupportsTransaction": true,
-            "UseTypedElementIndexer": true,
             "IncludeTotalInBundle": "None"
         },
         "CosmosDb": {


### PR DESCRIPTION
## Description
This has been turned on via config in OSS for a while now, changing to default this on in code. In future we'll remove the old (poco-based) indexer

