### PR TITLE
Improve inner-loop docker build performance

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# directories
+**/bin/
+**/obj/
+.github/
+.vscode/
+build/
+docs/
+release/
+samples/
+test/
+tools/
+.git/
+
+# keep minimal git info for SourceLink
+!.git/HEAD
+!.git/config
+!.git/refs/
+!.git/objects
+
+# files
+Dockerfile*
+**/*.md

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -49,9 +49,6 @@ COPY ./src/Microsoft.Health.Fhir.Shared.Web/Microsoft.Health.Fhir.Shared.Web.pro
 COPY ./src/Microsoft.Health.Fhir.Shared.Core/Microsoft.Health.Fhir.Shared.Core.projitems \
      ./src/Microsoft.Health.Fhir.Shared.Core/Microsoft.Health.Fhir.Shared.Core.projitems
 
-COPY ./src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems \
-     ./src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
-
 COPY ./src/Microsoft.Health.Fhir.Shared.Client/Microsoft.Health.Fhir.Shared.Client.projitems \
      ./src/Microsoft.Health.Fhir.Shared.Client/Microsoft.Health.Fhir.Shared.Client.projitems
 

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -2,12 +2,69 @@ FROM mcr.microsoft.com/dotnet/core/sdk:3.1.401-bionic AS build
 
 ARG FHIR_VERSION
 
-WORKDIR /src
+WORKDIR /repo
 
-COPY ./ ./
+COPY .editorconfig \
+     CustomAnalysisRules.ruleset \
+     CustomAnalysisRules.Test.ruleset \
+     Directory.Build.props \
+     global.json \
+     nuget.config \
+     stylecop.json \
+     ./
 
-RUN dotnet build --configuration Release
-RUN dotnet publish "./src/Microsoft.Health.Fhir.${FHIR_VERSION}.Web/Microsoft.Health.Fhir.${FHIR_VERSION}.Web.csproj" -c Release -o "/build" --no-build
+# Copy csproj and projitem files first, then do a dotnet restore. These layers are only invalidated
+# when these project files change.
+
+COPY ./src/Microsoft.Health.Fhir.ValueSets/Microsoft.Health.Fhir.ValueSets.csproj \
+     ./src/Microsoft.Health.Fhir.ValueSets/Microsoft.Health.Fhir.ValueSets.csproj
+
+COPY ./src/Microsoft.Health.Fhir.Core/Microsoft.Health.Fhir.Core.csproj \
+     ./src/Microsoft.Health.Fhir.Core/Microsoft.Health.Fhir.Core.csproj
+
+COPY ./src/Microsoft.Health.Fhir.Azure/Microsoft.Health.Fhir.Azure.csproj \
+     ./src/Microsoft.Health.Fhir.Azure/Microsoft.Health.Fhir.Azure.csproj
+
+COPY ./src/Microsoft.Health.Fhir.SqlServer/Microsoft.Health.Fhir.SqlServer.csproj \
+     ./src/Microsoft.Health.Fhir.SqlServer/Microsoft.Health.Fhir.SqlServer.csproj
+
+COPY ./src/Microsoft.Health.Fhir.Api/Microsoft.Health.Fhir.Api.csproj \
+     ./src/Microsoft.Health.Fhir.Api/Microsoft.Health.Fhir.Api.csproj
+
+COPY ./src/Microsoft.Health.Fhir.CosmosDb/Microsoft.Health.Fhir.CosmosDb.csproj \
+     ./src/Microsoft.Health.Fhir.CosmosDb/Microsoft.Health.Fhir.CosmosDb.csproj
+
+COPY ./src/Microsoft.Health.Fhir.${FHIR_VERSION}.Core/Microsoft.Health.Fhir.${FHIR_VERSION}.Core.csproj \
+     ./src/Microsoft.Health.Fhir.${FHIR_VERSION}.Core/Microsoft.Health.Fhir.${FHIR_VERSION}.Core.csproj
+
+COPY ./src/Microsoft.Health.Fhir.${FHIR_VERSION}.Api/Microsoft.Health.Fhir.${FHIR_VERSION}.Api.csproj \
+     ./src/Microsoft.Health.Fhir.${FHIR_VERSION}.Api/Microsoft.Health.Fhir.${FHIR_VERSION}.Api.csproj
+
+COPY ./src/Microsoft.Health.Fhir.${FHIR_VERSION}.Web/Microsoft.Health.Fhir.${FHIR_VERSION}.Web.csproj \
+     ./src/Microsoft.Health.Fhir.${FHIR_VERSION}.Web/Microsoft.Health.Fhir.${FHIR_VERSION}.Web.csproj
+
+COPY ./src/Microsoft.Health.Fhir.Shared.Web/Microsoft.Health.Fhir.Shared.Web.projitems \
+     ./src/Microsoft.Health.Fhir.Shared.Web/Microsoft.Health.Fhir.Shared.Web.projitems
+
+COPY ./src/Microsoft.Health.Fhir.Shared.Core/Microsoft.Health.Fhir.Shared.Core.projitems \
+     ./src/Microsoft.Health.Fhir.Shared.Core/Microsoft.Health.Fhir.Shared.Core.projitems
+
+COPY ./src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems \
+     ./src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
+
+COPY ./src/Microsoft.Health.Fhir.Shared.Client/Microsoft.Health.Fhir.Shared.Client.projitems \
+     ./src/Microsoft.Health.Fhir.Shared.Client/Microsoft.Health.Fhir.Shared.Client.projitems
+
+COPY ./src/Microsoft.Health.Fhir.Shared.Api/Microsoft.Health.Fhir.Shared.Api.projitems \
+     ./src/Microsoft.Health.Fhir.Shared.Api/Microsoft.Health.Fhir.Shared.Api.projitems
+
+RUN dotnet restore ./src/Microsoft.Health.Fhir.${FHIR_VERSION}.Web/Microsoft.Health.Fhir.${FHIR_VERSION}.Web.csproj
+
+# now copy over everything else and publish
+
+COPY . .
+
+RUN dotnet publish /repo/src/Microsoft.Health.Fhir.${FHIR_VERSION}.Web/Microsoft.Health.Fhir.${FHIR_VERSION}.Web.csproj -c Release -o "/build" --no-restore
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-alpine AS runtime
 


### PR DESCRIPTION
Improves the Dockerfile to enable faster inner-loop builds. We previously did not have a `.dockerignore` file, which can result in a large amount of data (build output) being copied around. We also did not do restores and publish in separate layers. So previously, on my box, a docker build would always take around **3 minutes, 30 seconds**. Now, the times are:

**Initial build (or with `--no-cache`):** 1 minute, 23 seconds
**Change a `.csproj` file:** 1 minute, 14 seconds
**Change a `.cs` file:** 32 seconds
**No changes:** 1 second

Note also that the Dockerfile does not include any test projects.