### PR TITLE
Changes behavior so exceeding _count limit no longer throws a bad request

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Context/FhirRequestContext.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Context/FhirRequestContext.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Security.Claims;
 using EnsureThat;
 using Microsoft.Extensions.Primitives;
+using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Core.Features.Context
 {
@@ -59,6 +60,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Context
         public IDictionary<string, StringValues> RequestHeaders { get; }
 
         public IDictionary<string, StringValues> ResponseHeaders { get; }
+
+        public IList<OperationOutcomeIssue> BundleIssues { get; } = new List<OperationOutcomeIssue>();
 
         public string ResourceType { get; set; }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Context/IFhirRequestContext.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Context/IFhirRequestContext.cs
@@ -3,13 +3,20 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
 using Microsoft.Health.Core.Features.Context;
+using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Core.Features.Context
 {
     public interface IFhirRequestContext : IRequestContext
     {
         string ResourceType { get; set; }
+
+        /// <summary>
+        /// A list of issues that will be returned inside a resulting search bundle
+        /// </summary>
+        IList<OperationOutcomeIssue> BundleIssues { get; }
 
         bool IncludePartiallyIndexedSearchParams { get; set; }
     }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchOptionsFactoryTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchOptionsFactoryTests.cs
@@ -12,12 +12,14 @@ using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features;
+using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
 using Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers;
 using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.Core.UnitTests.Features.Context;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -38,6 +40,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         private readonly SearchParameterInfo _resourceTypeSearchParameterInfo;
         private readonly SearchParameterInfo _lastUpdatedSearchParameterInfo;
         private readonly CoreFeatureConfiguration _coreFeatures;
+        private DefaultFhirRequestContext _defaultFhirRequestContext;
 
         public SearchOptionsFactoryTests()
         {
@@ -48,11 +51,13 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             searchParameterDefinitionManager.GetSearchParameter(Arg.Any<string>(), SearchParameterNames.ResourceType).Returns(_resourceTypeSearchParameterInfo);
             searchParameterDefinitionManager.GetSearchParameter(Arg.Any<string>(), SearchParameterNames.LastUpdated).Returns(_lastUpdatedSearchParameterInfo);
             _coreFeatures = new CoreFeatureConfiguration();
+            _defaultFhirRequestContext = new DefaultFhirRequestContext();
 
             _factory = new SearchOptionsFactory(
                 _expressionParser,
                 () => searchParameterDefinitionManager,
                 new OptionsWrapper<CoreFeatureConfiguration>(_coreFeatures),
+                _defaultFhirRequestContext.SetupAccessor(),
                 NullLogger<SearchOptionsFactory>.Instance);
         }
 
@@ -432,12 +437,14 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         }
 
         [Fact]
-        public void GivenCountParameterAboveThanMaximumAllowed_WhenCreated_ThenSearchOptionsThrowException()
+        public void GivenCountParameterAboveThanMaximumAllowed_WhenCreated_ThenSearchOptionsAddIssueToContext()
         {
             _coreFeatures.MaxItemCountPerSearch = 10;
             _coreFeatures.DefaultItemCountPerSearch = 1;
 
-            Assert.Throws<BadRequestException>(() => CreateSearchOptions(queryParameters: new[] { Tuple.Create<string, string>("_count", "11"), }));
+            CreateSearchOptions(queryParameters: new[] { Tuple.Create<string, string>("_count", "11"), });
+
+            Assert.Collection(_defaultFhirRequestContext.BundleIssues, issue => issue.Diagnostics.Contains("exceeds limit"));
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/BundleFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/BundleFactory.cs
@@ -79,39 +79,57 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             // Create the bundle from the result.
             var bundle = new Bundle();
 
-            if (result != null)
+            if (_fhirRequestContextAccessor.FhirRequestContext.BundleIssues.Any())
             {
-                IEnumerable<Bundle.EntryComponent> entries = result.Results.Select(selectionFunction);
-
-                bundle.Entry.AddRange(entries);
-
-                if (result.ContinuationToken != null)
+                var operationOutcome = new OperationOutcome
                 {
-                    bundle.NextLink = _urlResolver.ResolveRouteUrl(
-                        result.UnsupportedSearchParameters,
-                        result.UnsupportedSortingParameters,
-                        Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(result.ContinuationToken)),
-                        true);
-                }
+                    Issue = new List<OperationOutcome.IssueComponent>(_fhirRequestContextAccessor.FhirRequestContext.BundleIssues.Select(x => x.ToPoco())),
+                };
 
-                if (result.Partial)
+                bundle.Entry.Add(new Bundle.EntryComponent
                 {
-                    // if the query resulted in a partial indication, add appropriate outcome
-                    // as an entry
-                    var resource = new OperationOutcome();
-                    resource.Issue = new List<OperationOutcome.IssueComponent>();
-                    resource.Issue.Add(new OperationOutcome.IssueComponent
+                    Resource = operationOutcome,
+                    Search = new Bundle.SearchComponent
                     {
-                        Severity = OperationOutcome.IssueSeverity.Warning,
-                        Code = OperationOutcome.IssueType.Incomplete,
-                        Diagnostics = Core.Resources.TruncatedIncludeMessage,
-                    });
+                        Mode = Bundle.SearchEntryMode.Outcome,
+                    },
+                });
+            }
 
-                    bundle.Entry.Add(new Bundle.EntryComponent()
+            IEnumerable<Bundle.EntryComponent> entries = result.Results.Select(selectionFunction);
+
+            bundle.Entry.AddRange(entries);
+
+            if (result.ContinuationToken != null)
+            {
+                bundle.NextLink = _urlResolver.ResolveRouteUrl(
+                    result.UnsupportedSearchParameters,
+                    result.UnsupportedSortingParameters,
+                    Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(result.ContinuationToken)),
+                    true);
+            }
+
+            if (result.Partial)
+            {
+                // if the query resulted in a partial indication, add appropriate outcome
+                // as an entry
+                var resource = new OperationOutcome();
+                resource.Issue = new List<OperationOutcome.IssueComponent>();
+                resource.Issue.Add(new OperationOutcome.IssueComponent
+                {
+                    Severity = OperationOutcome.IssueSeverity.Warning,
+                    Code = OperationOutcome.IssueType.Incomplete,
+                    Diagnostics = Core.Resources.TruncatedIncludeMessage,
+                });
+
+                bundle.Entry.Add(new Bundle.EntryComponent()
+                {
+                    Resource = resource,
+                    Search = new Bundle.SearchComponent
                     {
-                        Resource = resource,
-                    });
-                }
+                        Mode = Bundle.SearchEntryMode.Outcome,
+                    },
+                });
             }
 
             // Add the self link to indicate which search parameters were used.

--- a/src/Microsoft.Health.Fhir.Shared.Tests/Context/DefaultFhirRequestContext.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Tests/Context/DefaultFhirRequestContext.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Security.Claims;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Health.Fhir.Core.Features.Context;
+using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Context
 {
@@ -30,6 +31,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Context
         public IDictionary<string, StringValues> RequestHeaders { get; set; }
 
         public IDictionary<string, StringValues> ResponseHeaders { get; set; }
+
+        public IList<OperationOutcomeIssue> BundleIssues { get; set; } = new List<OperationOutcomeIssue>();
 
         public string ResourceType { get; set; }
 

--- a/src/Microsoft.Health.Fhir.Shared.Tests/Context/FhirRequestContextExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Tests/Context/FhirRequestContextExtensions.cs
@@ -1,0 +1,20 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Fhir.Core.Features.Context;
+using NSubstitute;
+
+namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Context
+{
+    public static class FhirRequestContextExtensions
+    {
+        public static IFhirRequestContextAccessor SetupAccessor(this IFhirRequestContext context)
+        {
+            IFhirRequestContextAccessor accessor = Substitute.For<IFhirRequestContextAccessor>();
+            accessor.FhirRequestContext.Returns(context);
+            return accessor;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Tests/Microsoft.Health.Fhir.Shared.Tests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Tests/Microsoft.Health.Fhir.Shared.Tests.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Context\DefaultFhirRequestContext.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Context\FhirRequestContextExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Definitions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Deserializers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Mocks\CapabilityStatementMock.cs" />

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -9,10 +9,12 @@ using System.Globalization;
 using System.Linq;
 using System.Net;
 using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.FhirPath;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Client;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Search;
+using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Test.Utilities;
@@ -531,6 +533,16 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 });
 
             await ExecuteAndValidateBundle($"NamingSystem?type={code}", library);
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenASearchRequest_WhenExceedingMaxCount_ThenAnOperationOutcomeWarningIsReturnedInTheBundle()
+        {
+            Bundle bundle = await Client.SearchAsync("?_count=" + int.MaxValue);
+
+            Assert.Equal(KnownResourceTypes.OperationOutcome, bundle.Entry.First().Resource.TypeName);
+            Assert.Contains("exceeds limit", (string)bundle.Scalar("entry.resource.issue.diagnostics"));
         }
     }
 }


### PR DESCRIPTION
## Description
Changes behavior so exceeding _count limit no longer throws a bad request
Instead the max configured items are returned and a warning is added to the result

## Related issues
Addresses #1263, [AB#76267](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/76267)

## Testing
Adds unit and e2e tests
