### PR TITLE
Removes the unwanted schema version entry

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Microsoft.Health.Fhir.SqlServer.csproj
+++ b/src/Microsoft.Health.Fhir.SqlServer/Microsoft.Health.Fhir.SqlServer.csproj
@@ -7,8 +7,6 @@
     <None Remove="Features\Schema\Migrations\3.diff.sql" />
     <None Remove="Features\Schema\Migrations\4.diff.sql" />
     <None Remove="Features\Schema\Migrations\4.sql" />
-    <None Remove="Features\Schema\Migrations\5.diff.sql" />
-    <None Remove="Features\Schema\Migrations\5.sql" />
     <EmbeddedResource Include="Features\Schema\Migrations\2.diff.sql" />
     <EmbeddedResource Include="Features\Schema\Migrations\3.diff.sql" />
     <EmbeddedResource Include="Features\Schema\Migrations\4.diff.sql" />


### PR DESCRIPTION
## Description
Removes the schema version: 5 entry from the .csproj as the maximum supported version is 4.

## Related issues
Addresss Issue [#1318](https://github.com/microsoft/fhir-server/issues/1318#event-3830854363)

## Testing
Existing tests passed
