### PR TITLE
Updates the deserializer for ResourceWrapper to include a JsonString of the searchindices

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/CreateReindexRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/CreateReindexRequestHandler.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using EnsureThat;
 using MediatR;
 using Microsoft.Extensions.Options;
-using Microsoft.Health.Core.Features.Security;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Features.Definition;
@@ -21,26 +20,22 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
 {
     public class CreateReindexRequestHandler : IRequestHandler<CreateReindexRequest, CreateReindexResponse>
     {
-        private readonly IClaimsExtractor _claimsExtractor;
         private readonly IFhirOperationDataStore _fhirOperationDataStore;
         private readonly IFhirAuthorizationService _authorizationService;
         private readonly ReindexJobConfiguration _reindexJobConfiguration;
         private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager;
 
         public CreateReindexRequestHandler(
-            IClaimsExtractor claimsExtractor,
             IFhirOperationDataStore fhirOperationDataStore,
             IFhirAuthorizationService authorizationService,
             IOptions<ReindexJobConfiguration> reindexJobConfiguration,
             ISearchParameterDefinitionManager searchParameterDefinitionManager)
         {
-            EnsureArg.IsNotNull(claimsExtractor, nameof(claimsExtractor));
             EnsureArg.IsNotNull(fhirOperationDataStore, nameof(fhirOperationDataStore));
             EnsureArg.IsNotNull(authorizationService, nameof(authorizationService));
             EnsureArg.IsNotNull(reindexJobConfiguration, nameof(reindexJobConfiguration));
             EnsureArg.IsNotNull(searchParameterDefinitionManager, nameof(searchParameterDefinitionManager));
 
-            _claimsExtractor = claimsExtractor;
             _fhirOperationDataStore = fhirOperationDataStore;
             _authorizationService = authorizationService;
             _reindexJobConfiguration = reindexJobConfiguration.Value;

--- a/src/Microsoft.Health.Fhir.Core/Features/Persistence/ResourceWrapper.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Persistence/ResourceWrapper.cs
@@ -119,5 +119,16 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
         {
             SearchIndices = searchIndices;
         }
+
+        public virtual bool SearchIndicesEqual(IReadOnlyCollection<SearchIndexEntry> otherIndices)
+        {
+            var otherHashSet = otherIndices != null ?
+                    new HashSet<SearchIndexEntry>(otherIndices) : new HashSet<SearchIndexEntry>();
+
+            var thisHashSet = SearchIndices != null ?
+                    new HashSet<SearchIndexEntry>(SearchIndices) : new HashSet<SearchIndexEntry>();
+
+            return thisHashSet.SetEquals(otherHashSet);
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchIndexEntry.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchIndexEntry.cs
@@ -4,10 +4,10 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using EnsureThat;
 using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
 using Microsoft.Health.Fhir.Core.Models;
+using Newtonsoft.Json;
 
 namespace Microsoft.Health.Fhir.Core.Features.Search
 {
@@ -30,10 +30,21 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             Value = value;
         }
 
+        [JsonConstructor]
+        public SearchIndexEntry()
+        {
+        }
+
         /// <summary>
         /// Gets the search parameter
         /// </summary>
         public SearchParameterInfo SearchParameter { get; }
+
+        /// <summary>
+        /// Used to capture the Json representation of the search index
+        /// usually when returned from Cosmos DB
+        /// </summary>
+        public string JsonString { get; set; }
 
         /// <summary>
         /// Gets the searchable value.

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/FhirCosmosResourceWrapper.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/FhirCosmosResourceWrapper.cs
@@ -5,6 +5,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
 using EnsureThat;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Search;
@@ -98,6 +101,27 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
             }
 
             return base.Version;
+        }
+
+        public override bool SearchIndicesEqual(IReadOnlyCollection<SearchIndexEntry> otherIndices)
+        {
+            var otherHashSet = new HashSet<string>();
+
+            // convert search param indices to JSON text
+            SearchIndexEntryConverter converter = new SearchIndexEntryConverter();
+
+            foreach (var index in otherIndices)
+            {
+                var sb = new StringBuilder();
+                var stringWriter = new StringWriter(sb);
+                var jsonWriter = new JsonTextWriter(stringWriter);
+                converter.WriteJson(jsonWriter, index, null);
+                otherHashSet.Add(sb.ToString());
+            }
+
+            var searchIndexHashSet = new HashSet<string>(SearchIndices.Select(s => s.JsonString));
+
+            return searchIndexHashSet.SetEquals(otherHashSet);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Search/SearchIndexEntryConverter.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Search/SearchIndexEntryConverter.cs
@@ -23,8 +23,11 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Search
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            // We don't currently support reading the search index from the Cosmos DB.
-            return null;
+            var jObject = JObject.Load(reader);
+            var searchIndexEntry = new SearchIndexEntry();
+            searchIndexEntry.JsonString = jObject.ToString();
+
+            return searchIndexEntry;
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexUtilitiesTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexUtilitiesTests.cs
@@ -45,8 +45,13 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         [Fact]
         public async Task GivenResourcesWithUnchangedOrChangedIndices_WhenResultsProcessed_ThenCorrectResourcesHaveIndicesUpdated()
         {
-            var searchIndices1 = new List<SearchIndexEntry>() { new SearchIndexEntry(new Core.Models.SearchParameterInfo("param1"), new StringSearchValue("value1")) };
-            var searchIndices2 = new List<SearchIndexEntry>() { new SearchIndexEntry(new Core.Models.SearchParameterInfo("param2"), new StringSearchValue("value2")) };
+            var searchIndexEntry1 = new SearchIndexEntry(new Core.Models.SearchParameterInfo("param1"), new StringSearchValue("value1"));
+            searchIndexEntry1.JsonString = "{ \"p\": \"param1\", \"c\": \"value1\" }";
+            var searchIndexEntry2 = new SearchIndexEntry(new Core.Models.SearchParameterInfo("param2"), new StringSearchValue("value2"));
+            searchIndexEntry1.JsonString = "{ \"p\": \"param2\", \"c\": \"value2\" }";
+
+            var searchIndices1 = new List<SearchIndexEntry>() { searchIndexEntry1 };
+            var searchIndices2 = new List<SearchIndexEntry>() { searchIndexEntry2 };
 
             _searchIndexer.Extract(Arg.Any<Core.Models.ResourceElement>()).Returns(searchIndices1);
 

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Reindex/ReindexUtilities.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Reindex/ReindexUtilities.cs
@@ -71,11 +71,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                 entry.Resource.SearchParameterHash = searchParamHash;
                 var resourceElement = _deserializer.Deserialize(entry.Resource);
                 var newIndices = _searchIndexer.Extract(resourceElement);
-                var newIndicesHash = new HashSet<SearchIndexEntry>(newIndices);
-                var prevIndicesHash = entry.Resource.SearchIndices != null ?
-                    new HashSet<SearchIndexEntry>(entry.Resource.SearchIndices) : new HashSet<SearchIndexEntry>();
 
-                if (newIndicesHash.SetEquals(prevIndicesHash))
+                if (entry.Resource.SearchIndicesEqual(newIndices))
                 {
                     updateHashValueOnly.Add(entry.Resource);
                 }


### PR DESCRIPTION
## Description
Adds a new property to ResourceWrapper to include a new property which contains the serialzed version of the search indices
Updates ReindexUtilities to utilize these.

## Related issues
Addresses [issue [AB#75331](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/75331)].

## Testing
Unit tests updated, and manual testing.
