### PR TITLE
Fixes case where resource content is not included in bundle output

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Formatters/FhirJsonOutputFormatter.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Formatters/FhirJsonOutputFormatter.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Formatters
                 var bundle = context.Object as Hl7.Fhir.Model.Bundle;
                 resource = bundle;
 
-                if (elementsSearchParameter != null && elementsSearchParameter.Any())
+                if (elementsSearchParameter?.Any() == true || !bundle.Entry.All(x => x is RawBundleEntryComponent))
                 {
                     // _elements is not supported for a raw resource, revert to using FhirJsonSerializer
                     foreach (var rawBundleEntryComponent in bundle.Entry)
@@ -96,7 +96,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Formatters
                         }
                     }
                 }
-                else if (bundle.Entry.All(x => x is RawBundleEntryComponent))
+                else
                 {
                     await _bundleSerializer.Serialize(context.Object as Hl7.Fhir.Model.Bundle, context.HttpContext.Response.Body);
                     return;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -544,5 +544,22 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             Assert.Equal(KnownResourceTypes.OperationOutcome, bundle.Entry.First().Resource.TypeName);
             Assert.Contains("exceeds limit", (string)bundle.Scalar("entry.resource.issue.diagnostics"));
         }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenASearchRequest_WhenExceedingMaxCount_ThenResourcesAreSerializedInBundle()
+        {
+            var tag = new Coding(string.Empty, Guid.NewGuid().ToString());
+
+            Patient patient = Samples.GetDefaultPatient().ToPoco<Patient>();
+            patient.Meta = new Meta();
+            patient.Meta.Tag.Add(tag);
+            await Client.CreateAsync(patient);
+
+            Bundle bundle = await Client.SearchAsync($"Patient?_tag={tag.Code}&_count=" + int.MaxValue);
+
+            Assert.Equal(KnownResourceTypes.OperationOutcome, bundle.Entry.First().Resource.TypeName);
+            Assert.NotNull(bundle.Entry.Skip(1).First().Resource);
+        }
     }
 }


### PR DESCRIPTION
## Description
Fixes case where resource content is not included in bundle output, this can happen when an issue is included then the "RawResource" bundle entries do not get serialized

## Related issues
Refs  #1263, [AB#76267](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/76267)

## Testing
Adds regression E2E test
