### PR TITLE
Updated search and history tests to tag resources

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HistoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HistoryTests.cs
@@ -75,11 +75,11 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Thread.Sleep(500);  // put a small gap between since and the first edits
             _createdResource.Resource.Text = new Narrative { Div = "<div>Changed by E2E test</div>" };
 
-            var tag = new Coding(string.Empty, Guid.NewGuid().ToString());
+            var tag = Guid.NewGuid().ToString();
 
-            var updatedResource = await _client.UpdateAsync(AddTagToResource(_createdResource.Resource, tag));
+            var updatedResource = await CreateResourceWithTag(_createdResource.Resource, tag);
 
-            using FhirResponse<Bundle> readResponse = await _client.SearchAsync($"_history?_tag={tag.Code}&_since={sinceUriString}");
+            using FhirResponse<Bundle> readResponse = await _client.SearchAsync($"_history?_tag={tag}&_since={sinceUriString}");
 
             Assert.Single(readResponse.Resource.Entry);
 
@@ -106,17 +106,17 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Thread.Sleep(500);  // put a small gap between since and the first edits
 
             _createdResource.Resource.Text = new Narrative { Div = "<div>Changed by E2E test</div>" };
-            var tag = new Coding(string.Empty, Guid.NewGuid().ToString());
-            await _client.UpdateAsync(AddTagToResource(_createdResource.Resource, tag));
-            using FhirResponse<Resource> newPatient = await _client.CreateAsync(AddTagToResource(Samples.GetDefaultPatient().ToPoco(), tag));
+            var tag = Guid.NewGuid().ToString();
+            await CreateResourceWithTag(_createdResource.Resource, tag);
+            var newPatient = await CreateResourceWithTag(Samples.GetDefaultPatient().ToPoco(), tag);
 
-            var before = newPatient.Resource.Meta.LastUpdated.Value.AddMilliseconds(100);
+            var before = newPatient.Meta.LastUpdated.Value.AddMilliseconds(100);
             Thread.Sleep(500);  // make sure that the before time is not in the future
 
             var sinceUriString = HttpUtility.UrlEncode(since.ToString("o"));
             var beforeUriString = HttpUtility.UrlEncode(before.ToString("o"));
 
-            using FhirResponse<Bundle> readResponse = await _client.SearchAsync($"_history?_tag={tag.Code}&_since={sinceUriString}&_before={beforeUriString}");
+            using FhirResponse<Bundle> readResponse = await _client.SearchAsync($"_history?_tag={tag}&_since={sinceUriString}&_before={beforeUriString}");
 
             Assert.Equal(2, readResponse.Resource.Entry.Count);
 
@@ -136,11 +136,11 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.NotNull(obsHistory);
             Assert.NotNull(patientHistory);
             Assert.Contains("Changed by E2E test", obsHistory.Text.Div);
-            Assert.Equal(newPatient.Resource.Id, patientHistory.Id);
+            Assert.Equal(newPatient.Id, patientHistory.Id);
 
-            if (newPatient?.Resource != null)
+            if (newPatient != null)
             {
-                await _client.DeleteAsync(newPatient.Resource);
+                await _client.DeleteAsync(newPatient);
             }
         }
 
@@ -153,21 +153,21 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             // First make a few edits
             _createdResource.Resource.Text = new Narrative { Div = "<div>Changed by E2E test</div>" };
-            var tag = new Coding(string.Empty, Guid.NewGuid().ToString());
-            await _client.UpdateAsync<Observation>(AddTagToResource(_createdResource.Resource, tag));
+            var tag = Guid.NewGuid().ToString();
+            await CreateResourceWithTag(_createdResource.Resource, tag);
 
-            newResources.Add(await _client.CreateAsync(AddTagToResource(Samples.GetDefaultPatient().ToPoco(), tag)));
-            newResources.Add(await _client.CreateAsync(AddTagToResource(Samples.GetDefaultOrganization().ToPoco(), tag)));
+            newResources.Add(await CreateResourceWithTag(Samples.GetDefaultPatient().ToPoco(), tag));
+            newResources.Add(await CreateResourceWithTag(Samples.GetDefaultOrganization().ToPoco(), tag));
             Thread.Sleep(1000);
-            newResources.Add(await _client.CreateAsync(AddTagToResource(Samples.GetJsonSample("BloodGlucose").ToPoco(), tag)));
-            newResources.Add(await _client.CreateAsync(AddTagToResource(Samples.GetJsonSample("BloodPressure").ToPoco(), tag)));
-            newResources.Add(await _client.CreateAsync(AddTagToResource(Samples.GetJsonSample("Patient-f001").ToPoco(), tag)));
-            newResources.Add(await _client.CreateAsync(AddTagToResource(Samples.GetJsonSample("Condition-For-Patient-f001").ToPoco(), tag)));
+            newResources.Add(await CreateResourceWithTag(Samples.GetJsonSample("BloodGlucose").ToPoco(), tag));
+            newResources.Add(await CreateResourceWithTag(Samples.GetJsonSample("BloodPressure").ToPoco(), tag));
+            newResources.Add(await CreateResourceWithTag(Samples.GetJsonSample("Patient-f001").ToPoco(), tag));
+            newResources.Add(await CreateResourceWithTag(Samples.GetJsonSample("Condition-For-Patient-f001").ToPoco(), tag));
 
             var sinceUriString = HttpUtility.UrlEncode(since.ToString("o"));
 
             // Query all the recent changes
-            using FhirResponse<Bundle> allChanges = await _client.SearchAsync($"_history?_tag={tag.Code}&_since=" + sinceUriString);
+            using FhirResponse<Bundle> allChanges = await _client.SearchAsync($"_history?_tag={tag}&_since=" + sinceUriString);
 
             Assert.Equal(7, allChanges.Resource.Entry.Count);
 
@@ -177,7 +177,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             var before = lastUpdatedTimes.ToList()[4];
             var beforeUriString = HttpUtility.UrlEncode(before.Value.ToString("o"));
             Thread.Sleep(500);
-            var firstSet = await _client.SearchAsync($"_history?_tag={tag.Code}&_since={sinceUriString}&_before={beforeUriString}");
+            var firstSet = await _client.SearchAsync($"_history?_tag={tag}&_since={sinceUriString}&_before={beforeUriString}");
 
             Assert.Equal(4, firstSet.Resource.Entry.Count);
 
@@ -185,7 +185,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             before = DateTime.UtcNow;
             beforeUriString = HttpUtility.UrlEncode(before.Value.ToString("o"));
             Thread.Sleep(500); // wait 500 milliseconds to make sure that the value passed to the server for _before is not a time in the future
-            var secondSet = await _client.SearchAsync($"_history?_tag={tag.Code}&_since={sinceUriString}&_before={beforeUriString}");
+            var secondSet = await _client.SearchAsync($"_history?_tag={tag}&_since={sinceUriString}&_before={beforeUriString}");
 
             Assert.Equal(3, secondSet.Resource.Entry.Count);
 
@@ -204,18 +204,18 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             // First make 11 edits
             _createdResource.Resource.Text = new Narrative { Div = "<div>Changed by E2E test</div>" };
-            var tag = new Coding(string.Empty, Guid.NewGuid().ToString());
-            await _client.UpdateAsync<Observation>(AddTagToResource(_createdResource.Resource, tag));
-            newResources.Add(await _client.CreateAsync(AddTagToResource(Samples.GetDefaultPatient().ToPoco(), tag)));
-            newResources.Add(await _client.CreateAsync(AddTagToResource(Samples.GetDefaultOrganization().ToPoco(), tag)));
-            newResources.Add(await _client.CreateAsync(AddTagToResource(Samples.GetJsonSample("BloodGlucose").ToPoco(), tag)));
-            newResources.Add(await _client.CreateAsync(AddTagToResource(Samples.GetJsonSample("BloodPressure").ToPoco(), tag)));
-            newResources.Add(await _client.CreateAsync(AddTagToResource(Samples.GetJsonSample("Patient-f001").ToPoco(), tag)));
-            newResources.Add(await _client.CreateAsync(AddTagToResource(Samples.GetJsonSample("Condition-For-Patient-f001").ToPoco(), tag)));
-            newResources.Add(await _client.CreateAsync(AddTagToResource(Samples.GetJsonSample("Encounter-For-Patient-f001").ToPoco(), tag)));
-            newResources.Add(await _client.CreateAsync(AddTagToResource(Samples.GetJsonSample("Observation-For-Patient-f001").ToPoco(), tag)));
-            newResources.Add(await _client.CreateAsync(AddTagToResource(Samples.GetJsonSample("ObservationWith1MinuteApgarScore").ToPoco(), tag)));
-            newResources.Add(await _client.CreateAsync(AddTagToResource(Samples.GetJsonSample("ObservationWith20MinuteApgarScore").ToPoco(), tag)));
+            var tag = Guid.NewGuid().ToString();
+            await CreateResourceWithTag(_createdResource.Resource, tag);
+            newResources.Add(await CreateResourceWithTag(Samples.GetDefaultPatient().ToPoco(), tag));
+            newResources.Add(await CreateResourceWithTag(Samples.GetDefaultOrganization().ToPoco(), tag));
+            newResources.Add(await CreateResourceWithTag(Samples.GetJsonSample("BloodGlucose").ToPoco(), tag));
+            newResources.Add(await CreateResourceWithTag(Samples.GetJsonSample("BloodPressure").ToPoco(), tag));
+            newResources.Add(await CreateResourceWithTag(Samples.GetJsonSample("Patient-f001").ToPoco(), tag));
+            newResources.Add(await CreateResourceWithTag(Samples.GetJsonSample("Condition-For-Patient-f001").ToPoco(), tag));
+            newResources.Add(await CreateResourceWithTag(Samples.GetJsonSample("Encounter-For-Patient-f001").ToPoco(), tag));
+            newResources.Add(await CreateResourceWithTag(Samples.GetJsonSample("Observation-For-Patient-f001").ToPoco(), tag));
+            newResources.Add(await CreateResourceWithTag(Samples.GetJsonSample("ObservationWith1MinuteApgarScore").ToPoco(), tag));
+            newResources.Add(await CreateResourceWithTag(Samples.GetJsonSample("ObservationWith20MinuteApgarScore").ToPoco(), tag));
 
             var lastUpdatedTimes = newResources.Select(e => e.Meta.LastUpdated).OrderBy(d => d.Value);
             var before = lastUpdatedTimes.Last().Value.AddMilliseconds(100);
@@ -223,7 +223,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             var sinceUriString = HttpUtility.UrlEncode(since.ToString("o"));
             var beforeUriString = HttpUtility.UrlEncode(before.ToString("o"));
 
-            using FhirResponse<Bundle> readResponse = await _client.SearchAsync($"_history?_tag={tag.Code}&_since={sinceUriString}");
+            using FhirResponse<Bundle> readResponse = await _client.SearchAsync($"_history?_tag={tag}&_since={sinceUriString}");
 
             Assert.Equal(10, readResponse.Resource.Entry.Count);
 
@@ -234,7 +234,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             Thread.Sleep(500);
 
-            using FhirResponse<Bundle> firstBatch = await _client.SearchAsync($"_history?_tag={tag.Code}&_since={sinceUriString}&_before={beforeUriString}");
+            using FhirResponse<Bundle> firstBatch = await _client.SearchAsync($"_history?_tag={tag}&_since={sinceUriString}&_before={beforeUriString}");
 
             Assert.Equal(10, firstBatch.Resource.Entry.Count);
 
@@ -252,15 +252,15 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         public async Task GivenAValueForSinceAfterAllModificatons_WhenGettingSystemHistory_TheServerShouldReturnAnEmptyResult()
         {
             _createdResource.Resource.Text = new Narrative { Div = "<div>Changed by E2E test</div>" };
-            var tag = new Coding(string.Empty, Guid.NewGuid().ToString());
-            var updatedResource = await _client.UpdateAsync<Observation>(AddTagToResource(_createdResource.Resource, tag));
+            var tag = Guid.NewGuid().ToString();
+            var updatedResource = await CreateResourceWithTag(_createdResource.Resource, tag);
 
             // ensure that the server has fully processed the PUT
             var since = await GetStartTimeForHistoryTest();
 
             var sinceUriString = HttpUtility.UrlEncode(since.ToString("o"));
 
-            using FhirResponse<Bundle> readResponse = await _client.SearchAsync($"_history?_tag={tag.Code}&_since={sinceUriString}");
+            using FhirResponse<Bundle> readResponse = await _client.SearchAsync($"_history?_tag={tag}&_since={sinceUriString}");
 
             Assert.Empty(readResponse.Resource.Entry);
         }
@@ -269,12 +269,12 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         public async Task GivenAValueForSinceAndBeforeWithNoModifications_WhenGettingSystemHistory_TheServerShouldReturnAnEmptyResult()
         {
             _createdResource.Resource.Text = new Narrative { Div = "<div>Changed by E2E test</div>" };
-            var tag = new Coding(string.Empty, Guid.NewGuid().ToString());
-            var updatedResource = await _client.UpdateAsync<Observation>(AddTagToResource(_createdResource.Resource, tag));
+            var tag = Guid.NewGuid().ToString();
+            var updatedResource = await CreateResourceWithTag(_createdResource.Resource, tag);
 
             // ensure that the server has fully processed the PUT
             var since = await GetStartTimeForHistoryTest();
-            var before = updatedResource.Resource.Meta.LastUpdated.Value.AddMilliseconds(100);
+            var before = updatedResource.Meta.LastUpdated.Value.AddMilliseconds(100);
 
             Thread.Sleep(500);
 
@@ -285,7 +285,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             var sinceUriString = HttpUtility.UrlEncode(since.ToString("o"));
             var beforeUriString = HttpUtility.UrlEncode(before.ToString("o"));
 
-            using FhirResponse<Bundle> readResponse = await _client.SearchAsync($"_history?_tag={tag.Code}&_since={sinceUriString}&_before={beforeUriString}");
+            using FhirResponse<Bundle> readResponse = await _client.SearchAsync($"_history?_tag={tag}&_since={sinceUriString}&_before={beforeUriString}");
 
             Assert.Empty(readResponse.Resource.Entry);
 
@@ -331,12 +331,12 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             return response.Resource.Meta.LastUpdated.Value.AddMilliseconds(1);
         }
 
-        private T AddTagToResource<T>(T resource, Coding tag)
+        private async Task<T> CreateResourceWithTag<T>(T resource, string tag)
             where T : Resource
         {
             resource.Meta = new Meta();
-            resource.Meta.Tag.Add(tag);
-            return resource;
+            resource.Meta.Tag.Add(new Coding(string.Empty, tag));
+            return await _client.CreateAsync(resource);
         }
 
         public void Dispose()

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HistoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HistoryTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.NotEmpty(readResponse.Resource.Entry);
         }
 
-        [Fact(Skip = "Failing CI build")]
+        [Fact]
         public async Task GivenAValueForSince_WhenGettingSystemHistory_TheServerShouldReturnOnlyRecordsModifiedAfterSinceValue()
         {
             var since = await GetStartTimeForHistoryTest();
@@ -75,9 +75,11 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Thread.Sleep(500);  // put a small gap between since and the first edits
             _createdResource.Resource.Text = new Narrative { Div = "<div>Changed by E2E test</div>" };
 
-            var updatedResource = await _client.UpdateAsync<Observation>(_createdResource);
+            var tag = new Coding(string.Empty, Guid.NewGuid().ToString());
 
-            using FhirResponse<Bundle> readResponse = await _client.SearchAsync("_history?_since=" + sinceUriString);
+            var updatedResource = await _client.UpdateAsync(AddTagToResource(_createdResource.Resource, tag));
+
+            using FhirResponse<Bundle> readResponse = await _client.SearchAsync($"_history?_tag={tag.Code}&_since={sinceUriString}");
 
             Assert.Single(readResponse.Resource.Entry);
 
@@ -96,7 +98,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.Contains("Changed by E2E test", obsHistory.Text.Div);
         }
 
-        [Fact(Skip = "Failing CI build")]
+        [Fact]
         public async Task GivenAValueForSinceAndBeforeWithModifications_WhenGettingSystemHistory_TheServerShouldOnlyCorrectResources()
         {
             var since = await GetStartTimeForHistoryTest();
@@ -104,8 +106,9 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Thread.Sleep(500);  // put a small gap between since and the first edits
 
             _createdResource.Resource.Text = new Narrative { Div = "<div>Changed by E2E test</div>" };
-            await _client.UpdateAsync<Observation>(_createdResource);
-            using FhirResponse<Resource> newPatient = await _client.CreateAsync(Samples.GetDefaultPatient().ToPoco());
+            var tag = new Coding(string.Empty, Guid.NewGuid().ToString());
+            await _client.UpdateAsync(AddTagToResource(_createdResource.Resource, tag));
+            using FhirResponse<Resource> newPatient = await _client.CreateAsync(AddTagToResource(Samples.GetDefaultPatient().ToPoco(), tag));
 
             var before = newPatient.Resource.Meta.LastUpdated.Value.AddMilliseconds(100);
             Thread.Sleep(500);  // make sure that the before time is not in the future
@@ -113,7 +116,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             var sinceUriString = HttpUtility.UrlEncode(since.ToString("o"));
             var beforeUriString = HttpUtility.UrlEncode(before.ToString("o"));
 
-            using FhirResponse<Bundle> readResponse = await _client.SearchAsync("_history?_since=" + sinceUriString + "&_before=" + beforeUriString);
+            using FhirResponse<Bundle> readResponse = await _client.SearchAsync($"_history?_tag={tag.Code}&_since={sinceUriString}&_before={beforeUriString}");
 
             Assert.Equal(2, readResponse.Resource.Entry.Count);
 
@@ -141,7 +144,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             }
         }
 
-        [Fact(Skip = "Failing CI build")]
+        [Fact]
         public async Task GivenAValueForSinceAndBeforeCloseToLastModifiedTime_WhenGettingSystemHistory_TheServerShouldNotMissRecords()
         {
             var since = await GetStartTimeForHistoryTest();
@@ -150,19 +153,21 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             // First make a few edits
             _createdResource.Resource.Text = new Narrative { Div = "<div>Changed by E2E test</div>" };
-            await _client.UpdateAsync<Observation>(_createdResource);
-            newResources.Add(await _client.CreateAsync(Samples.GetDefaultPatient().ToPoco()));
-            newResources.Add(await _client.CreateAsync(Samples.GetDefaultOrganization().ToPoco()));
+            var tag = new Coding(string.Empty, Guid.NewGuid().ToString());
+            await _client.UpdateAsync<Observation>(AddTagToResource(_createdResource.Resource, tag));
+
+            newResources.Add(await _client.CreateAsync(AddTagToResource(Samples.GetDefaultPatient().ToPoco(), tag)));
+            newResources.Add(await _client.CreateAsync(AddTagToResource(Samples.GetDefaultOrganization().ToPoco(), tag)));
             Thread.Sleep(1000);
-            newResources.Add(await _client.CreateAsync(Samples.GetJsonSample("BloodGlucose").ToPoco()));
-            newResources.Add(await _client.CreateAsync(Samples.GetJsonSample("BloodPressure").ToPoco()));
-            newResources.Add(await _client.CreateAsync(Samples.GetJsonSample("Patient-f001").ToPoco()));
-            newResources.Add(await _client.CreateAsync(Samples.GetJsonSample("Condition-For-Patient-f001").ToPoco()));
+            newResources.Add(await _client.CreateAsync(AddTagToResource(Samples.GetJsonSample("BloodGlucose").ToPoco(), tag)));
+            newResources.Add(await _client.CreateAsync(AddTagToResource(Samples.GetJsonSample("BloodPressure").ToPoco(), tag)));
+            newResources.Add(await _client.CreateAsync(AddTagToResource(Samples.GetJsonSample("Patient-f001").ToPoco(), tag)));
+            newResources.Add(await _client.CreateAsync(AddTagToResource(Samples.GetJsonSample("Condition-For-Patient-f001").ToPoco(), tag)));
 
             var sinceUriString = HttpUtility.UrlEncode(since.ToString("o"));
 
             // Query all the recent changes
-            using FhirResponse<Bundle> allChanges = await _client.SearchAsync("_history?_since=" + sinceUriString);
+            using FhirResponse<Bundle> allChanges = await _client.SearchAsync($"_history?_tag={tag.Code}&_since=" + sinceUriString);
 
             Assert.Equal(7, allChanges.Resource.Entry.Count);
 
@@ -172,7 +177,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             var before = lastUpdatedTimes.ToList()[4];
             var beforeUriString = HttpUtility.UrlEncode(before.Value.ToString("o"));
             Thread.Sleep(500);
-            var firstSet = await _client.SearchAsync("_history?_since=" + sinceUriString + "&_before=" + beforeUriString);
+            var firstSet = await _client.SearchAsync($"_history?_tag={tag.Code}&_since={sinceUriString}&_before={beforeUriString}");
 
             Assert.Equal(4, firstSet.Resource.Entry.Count);
 
@@ -180,7 +185,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             before = DateTime.UtcNow;
             beforeUriString = HttpUtility.UrlEncode(before.Value.ToString("o"));
             Thread.Sleep(500); // wait 500 milliseconds to make sure that the value passed to the server for _before is not a time in the future
-            var secondSet = await _client.SearchAsync("_history?_since=" + sinceUriString + "&_before=" + beforeUriString);
+            var secondSet = await _client.SearchAsync($"_history?_tag={tag.Code}&_since={sinceUriString}&_before={beforeUriString}");
 
             Assert.Equal(3, secondSet.Resource.Entry.Count);
 
@@ -190,7 +195,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             }
         }
 
-        [Fact(Skip = "Failing CI build")]
+        [Fact]
         public async Task GivenAQueryThatReturnsMoreThan10Results_WhenGettingSystemHistory_TheServerShouldBatchTheResponse()
         {
             var since = await GetStartTimeForHistoryTest();
@@ -199,17 +204,18 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             // First make 11 edits
             _createdResource.Resource.Text = new Narrative { Div = "<div>Changed by E2E test</div>" };
-            await _client.UpdateAsync<Observation>(_createdResource);
-            newResources.Add(await _client.CreateAsync(Samples.GetDefaultPatient().ToPoco()));
-            newResources.Add(await _client.CreateAsync(Samples.GetDefaultOrganization().ToPoco()));
-            newResources.Add(await _client.CreateAsync(Samples.GetJsonSample("BloodGlucose").ToPoco()));
-            newResources.Add(await _client.CreateAsync(Samples.GetJsonSample("BloodPressure").ToPoco()));
-            newResources.Add(await _client.CreateAsync(Samples.GetJsonSample("Patient-f001").ToPoco()));
-            newResources.Add(await _client.CreateAsync(Samples.GetJsonSample("Condition-For-Patient-f001").ToPoco()));
-            newResources.Add(await _client.CreateAsync(Samples.GetJsonSample("Encounter-For-Patient-f001").ToPoco()));
-            newResources.Add(await _client.CreateAsync(Samples.GetJsonSample("Observation-For-Patient-f001").ToPoco()));
-            newResources.Add(await _client.CreateAsync(Samples.GetJsonSample("ObservationWith1MinuteApgarScore").ToPoco()));
-            newResources.Add(await _client.CreateAsync(Samples.GetJsonSample("ObservationWith20MinuteApgarScore").ToPoco()));
+            var tag = new Coding(string.Empty, Guid.NewGuid().ToString());
+            await _client.UpdateAsync<Observation>(AddTagToResource(_createdResource.Resource, tag));
+            newResources.Add(await _client.CreateAsync(AddTagToResource(Samples.GetDefaultPatient().ToPoco(), tag)));
+            newResources.Add(await _client.CreateAsync(AddTagToResource(Samples.GetDefaultOrganization().ToPoco(), tag)));
+            newResources.Add(await _client.CreateAsync(AddTagToResource(Samples.GetJsonSample("BloodGlucose").ToPoco(), tag)));
+            newResources.Add(await _client.CreateAsync(AddTagToResource(Samples.GetJsonSample("BloodPressure").ToPoco(), tag)));
+            newResources.Add(await _client.CreateAsync(AddTagToResource(Samples.GetJsonSample("Patient-f001").ToPoco(), tag)));
+            newResources.Add(await _client.CreateAsync(AddTagToResource(Samples.GetJsonSample("Condition-For-Patient-f001").ToPoco(), tag)));
+            newResources.Add(await _client.CreateAsync(AddTagToResource(Samples.GetJsonSample("Encounter-For-Patient-f001").ToPoco(), tag)));
+            newResources.Add(await _client.CreateAsync(AddTagToResource(Samples.GetJsonSample("Observation-For-Patient-f001").ToPoco(), tag)));
+            newResources.Add(await _client.CreateAsync(AddTagToResource(Samples.GetJsonSample("ObservationWith1MinuteApgarScore").ToPoco(), tag)));
+            newResources.Add(await _client.CreateAsync(AddTagToResource(Samples.GetJsonSample("ObservationWith20MinuteApgarScore").ToPoco(), tag)));
 
             var lastUpdatedTimes = newResources.Select(e => e.Meta.LastUpdated).OrderBy(d => d.Value);
             var before = lastUpdatedTimes.Last().Value.AddMilliseconds(100);
@@ -217,7 +223,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             var sinceUriString = HttpUtility.UrlEncode(since.ToString("o"));
             var beforeUriString = HttpUtility.UrlEncode(before.ToString("o"));
 
-            using FhirResponse<Bundle> readResponse = await _client.SearchAsync("_history?_since=" + sinceUriString);
+            using FhirResponse<Bundle> readResponse = await _client.SearchAsync($"_history?_tag={tag.Code}&_since={sinceUriString}");
 
             Assert.Equal(10, readResponse.Resource.Entry.Count);
 
@@ -228,7 +234,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             Thread.Sleep(500);
 
-            using FhirResponse<Bundle> firstBatch = await _client.SearchAsync("_history?_since=" + sinceUriString + "&_before=" + beforeUriString);
+            using FhirResponse<Bundle> firstBatch = await _client.SearchAsync($"_history?_tag={tag.Code}&_since={sinceUriString}&_before={beforeUriString}");
 
             Assert.Equal(10, firstBatch.Resource.Entry.Count);
 
@@ -242,27 +248,29 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             }
         }
 
-        [Fact(Skip = "Failing CI build")]
+        [Fact]
         public async Task GivenAValueForSinceAfterAllModificatons_WhenGettingSystemHistory_TheServerShouldReturnAnEmptyResult()
         {
             _createdResource.Resource.Text = new Narrative { Div = "<div>Changed by E2E test</div>" };
-            var updatedResource = await _client.UpdateAsync<Observation>(_createdResource);
+            var tag = new Coding(string.Empty, Guid.NewGuid().ToString());
+            var updatedResource = await _client.UpdateAsync<Observation>(AddTagToResource(_createdResource.Resource, tag));
 
             // ensure that the server has fully processed the PUT
             var since = await GetStartTimeForHistoryTest();
 
             var sinceUriString = HttpUtility.UrlEncode(since.ToString("o"));
 
-            using FhirResponse<Bundle> readResponse = await _client.SearchAsync("_history?_since=" + sinceUriString);
+            using FhirResponse<Bundle> readResponse = await _client.SearchAsync($"_history?_tag={tag.Code}&_since={sinceUriString}");
 
             Assert.Empty(readResponse.Resource.Entry);
         }
 
-        [Fact(Skip = "Failing CI build")]
+        [Fact]
         public async Task GivenAValueForSinceAndBeforeWithNoModifications_WhenGettingSystemHistory_TheServerShouldReturnAnEmptyResult()
         {
             _createdResource.Resource.Text = new Narrative { Div = "<div>Changed by E2E test</div>" };
-            var updatedResource = await _client.UpdateAsync<Observation>(_createdResource);
+            var tag = new Coding(string.Empty, Guid.NewGuid().ToString());
+            var updatedResource = await _client.UpdateAsync<Observation>(AddTagToResource(_createdResource.Resource, tag));
 
             // ensure that the server has fully processed the PUT
             var since = await GetStartTimeForHistoryTest();
@@ -277,7 +285,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             var sinceUriString = HttpUtility.UrlEncode(since.ToString("o"));
             var beforeUriString = HttpUtility.UrlEncode(before.ToString("o"));
 
-            using FhirResponse<Bundle> readResponse = await _client.SearchAsync("_history?_since=" + sinceUriString + "&_before=" + beforeUriString);
+            using FhirResponse<Bundle> readResponse = await _client.SearchAsync($"_history?_tag={tag.Code}&_since={sinceUriString}&_before={beforeUriString}");
 
             Assert.Empty(readResponse.Resource.Entry);
 
@@ -321,6 +329,14 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             using FhirResponse<Resource> response = await _client.CreateAsync(Samples.GetDefaultPatient().ToPoco());
             await Task.Delay(10);
             return response.Resource.Meta.LastUpdated.Value.AddMilliseconds(1);
+        }
+
+        private T AddTagToResource<T>(T resource, Coding tag)
+            where T : Resource
+        {
+            resource.Meta = new Meta();
+            resource.Meta.Tag.Add(tag);
+            return resource;
         }
 
         public void Dispose()


### PR DESCRIPTION
## Description
Updated the resources used in the tests to have a unique tag.  This avoids conflicts with other resources being created on the test server.

## Related issues
Addresses [issue [AB#76319](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/76319)].

## Testing
Reran the automated tests
