### PR TITLE
Auto-update for packages related to 'healthcare-components-1.0.0-master-20201012-1'

### DIFF
--- a/src/Microsoft.Health.Fhir.Api.UnitTests/Microsoft.Health.Fhir.R4.Api.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.Api.UnitTests/Microsoft.Health.Fhir.R4.Api.UnitTests.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>Microsoft.Health.Fhir.Api.UnitTests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200910-2" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201012-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Microsoft.Health.Fhir.Api/Microsoft.Health.Fhir.Api.csproj
+++ b/src/Microsoft.Health.Fhir.Api/Microsoft.Health.Fhir.Api.csproj
@@ -23,9 +23,9 @@
     <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="3.1.7" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.7" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20200910-2" />
-    <PackageReference Include="Microsoft.Health.Api" Version="1.0.0-master-20200910-2" />
-    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20200910-2" />
+    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20201012-1" />
+    <PackageReference Include="Microsoft.Health.Api" Version="1.0.0-master-20201012-1" />
+    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20201012-1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Health.Fhir.Core\Microsoft.Health.Fhir.Core.csproj" />

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Microsoft.Health.Fhir.Core.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Microsoft.Health.Fhir.Core.UnitTests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200910-2" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201012-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Microsoft.Health.Fhir.Core/Microsoft.Health.Fhir.Core.csproj
+++ b/src/Microsoft.Health.Fhir.Core/Microsoft.Health.Fhir.Core.csproj
@@ -32,9 +32,9 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.7" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.7" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20200910-2" />
-    <PackageReference Include="Microsoft.Health.Core" Version="1.0.0-master-20200910-2" />
-    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20200910-2" />
+    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20201012-1" />
+    <PackageReference Include="Microsoft.Health.Core" Version="1.0.0-master-20201012-1" />
+    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20201012-1" />
     <PackageReference Include="Hl7.Fhir.Serialization" Version="1.9.0" />
     <PackageReference Include="Hl7.FhirPath" Version="1.9.0" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.3.5" />

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Microsoft.Health.Fhir.CosmosDb.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Microsoft.Health.Fhir.CosmosDb.UnitTests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200910-2" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201012-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Microsoft.Health.Fhir.CosmosDb/Microsoft.Health.Fhir.CosmosDb.csproj
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Microsoft.Health.Fhir.CosmosDb.csproj
@@ -15,9 +15,9 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.7" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.7" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20200910-2" />
-    <PackageReference Include="Microsoft.Health.Extensions.BuildTimeCodeGenerator" Version="1.0.0-master-20200910-2" />
-    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20200910-2" />
+    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20201012-1" />
+    <PackageReference Include="Microsoft.Health.Extensions.BuildTimeCodeGenerator" Version="1.0.0-master-20201012-1" />
+    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20201012-1" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.3.5" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.Health.Fhir.R4.Client/Microsoft.Health.Fhir.R4.Client.csproj
+++ b/src/Microsoft.Health.Fhir.R4.Client/Microsoft.Health.Fhir.R4.Client.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Ensure.That" Version="9.2.0" />
     <PackageReference Include="Hl7.Fhir.R4" Version="1.9.0" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.5.0" />
-    <PackageReference Include="Microsoft.Health.Client" Version="1.0.0-master-20200910-2" />
+    <PackageReference Include="Microsoft.Health.Client" Version="1.0.0-master-20201012-1" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.5.1" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.5.1" />
   </ItemGroup>

--- a/src/Microsoft.Health.Fhir.R4.Core.UnitTests/Microsoft.Health.Fhir.R4.Core.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.R4.Core.UnitTests/Microsoft.Health.Fhir.R4.Core.UnitTests.csproj
@@ -9,7 +9,7 @@
     <Compile Include="..\Microsoft.Health.Fhir.Shared.Core.UnitTests\Features\Operations\Export\ExportAnonymizerFactoryTests.cs" Link="Operations\Export\ExportAnonymizerFactoryTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200910-2" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201012-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Microsoft.Health.Fhir.R5.Api.UnitTests/Microsoft.Health.Fhir.R5.Api.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.R5.Api.UnitTests/Microsoft.Health.Fhir.R5.Api.UnitTests.csproj
@@ -5,7 +5,7 @@
     <NoWarn>$(NoWarn);NU1603</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200910-2" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201012-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Microsoft.Health.Fhir.R5.Client/Microsoft.Health.Fhir.R5.Client.csproj
+++ b/src/Microsoft.Health.Fhir.R5.Client/Microsoft.Health.Fhir.R5.Client.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Ensure.That" Version="9.2.0" />
     <PackageReference Include="Hl7.Fhir.R5" Version="1.10.0-alpha-20200811-1" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.5.0" />
-    <PackageReference Include="Microsoft.Health.Client" Version="1.0.0-master-20200910-2" />
+    <PackageReference Include="Microsoft.Health.Client" Version="1.0.0-master-20201012-1" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.5.1" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.5.1" />
   </ItemGroup>

--- a/src/Microsoft.Health.Fhir.R5.Core.UnitTests/Microsoft.Health.Fhir.R5.Core.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.R5.Core.UnitTests/Microsoft.Health.Fhir.R5.Core.UnitTests.csproj
@@ -7,7 +7,7 @@
     <DefineConstants>R5</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200910-2" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201012-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Microsoft.Health.Fhir.SqlServer/Microsoft.Health.Fhir.SqlServer.csproj
+++ b/src/Microsoft.Health.Fhir.SqlServer/Microsoft.Health.Fhir.SqlServer.csproj
@@ -20,10 +20,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="9.2.0" />
-    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20200910-2" />
-    <PackageReference Include="Microsoft.Health.SqlServer" Version="1.0.0-master-20200910-2" />
-    <PackageReference Include="Microsoft.Health.SqlServer.Api" Version="1.0.0-master-20200910-2" />
-    <PackageReference Include="Microsoft.Health.Extensions.BuildTimeCodeGenerator" Version="1.0.0-master-20200910-2" />
+    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20201012-1" />
+    <PackageReference Include="Microsoft.Health.SqlServer" Version="1.0.0-master-20201012-1" />
+    <PackageReference Include="Microsoft.Health.SqlServer.Api" Version="1.0.0-master-20201012-1" />
+    <PackageReference Include="Microsoft.Health.Extensions.BuildTimeCodeGenerator" Version="1.0.0-master-20201012-1" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.3.5" />
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="150.18208.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="3.1.7" />

--- a/src/Microsoft.Health.Fhir.Stu3.Api.UnitTests/Microsoft.Health.Fhir.Stu3.Api.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.Stu3.Api.UnitTests/Microsoft.Health.Fhir.Stu3.Api.UnitTests.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>Microsoft.Health.Fhir.Api.UnitTests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200910-2" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201012-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Microsoft.Health.Fhir.Stu3.Client/Microsoft.Health.Fhir.Stu3.Client.csproj
+++ b/src/Microsoft.Health.Fhir.Stu3.Client/Microsoft.Health.Fhir.Stu3.Client.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Ensure.That" Version="9.2.0" />
     <PackageReference Include="Hl7.Fhir.STU3" Version="1.9.0" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.5.0" />
-    <PackageReference Include="Microsoft.Health.Client" Version="1.0.0-master-20200910-2" />
+    <PackageReference Include="Microsoft.Health.Client" Version="1.0.0-master-20201012-1" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.5.1" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.5.1" />
   </ItemGroup>

--- a/src/Microsoft.Health.Fhir.Stu3.Core.UnitTests/Microsoft.Health.Fhir.Stu3.Core.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.Stu3.Core.UnitTests/Microsoft.Health.Fhir.Stu3.Core.UnitTests.csproj
@@ -9,7 +9,7 @@
     <Compile Include="..\Microsoft.Health.Fhir.Shared.Core.UnitTests\Features\Operations\Export\ExportAnonymizerFactoryTests.cs" Link="Features\Export\ExportAnonymizerFactoryTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200910-2" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201012-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
+++ b/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
@@ -320,7 +320,7 @@
     <EmbeddedResource Include="TestFiles\Stu3\WeightInPounds.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20200910-2" />
+    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20201012-1" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />

--- a/test/Microsoft.Health.Fhir.R4.Tests.E2E/Microsoft.Health.Fhir.R4.Tests.E2E.csproj
+++ b/test/Microsoft.Health.Fhir.R4.Tests.E2E/Microsoft.Health.Fhir.R4.Tests.E2E.csproj
@@ -21,8 +21,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20200910-2" />
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200910-2" />
+    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20201012-1" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201012-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="selenium.chrome.webdriver" Version="83.0.0" />
     <PackageReference Include="selenium.webdriver" Version="3.141.0" />

--- a/test/Microsoft.Health.Fhir.R4.Tests.Integration/Microsoft.Health.Fhir.R4.Tests.Integration.csproj
+++ b/test/Microsoft.Health.Fhir.R4.Tests.Integration/Microsoft.Health.Fhir.R4.Tests.Integration.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200910-2" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201012-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="Microsoft.SqlServer.DACFx" Version="150.4573.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/Microsoft.Health.Fhir.R5.Tests.E2E/Microsoft.Health.Fhir.R5.Tests.E2E.csproj
+++ b/test/Microsoft.Health.Fhir.R5.Tests.E2E/Microsoft.Health.Fhir.R5.Tests.E2E.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200910-2" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201012-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="selenium.chrome.webdriver" Version="83.0.0" />
     <PackageReference Include="selenium.webdriver" Version="3.141.0" />

--- a/test/Microsoft.Health.Fhir.R5.Tests.Integration/Microsoft.Health.Fhir.R5.Tests.Integration.csproj
+++ b/test/Microsoft.Health.Fhir.R5.Tests.Integration/Microsoft.Health.Fhir.R5.Tests.Integration.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200910-2" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201012-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="Microsoft.SqlServer.DACFx" Version="150.4573.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/Microsoft.Health.Fhir.Stu3.Tests.E2E.csproj
+++ b/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/Microsoft.Health.Fhir.Stu3.Tests.E2E.csproj
@@ -18,8 +18,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20200910-2" />
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200910-2" />
+    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20201012-1" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201012-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="selenium.chrome.webdriver" Version="83.0.0" />
     <PackageReference Include="selenium.webdriver" Version="3.141.0" />

--- a/test/Microsoft.Health.Fhir.Stu3.Tests.Integration/Microsoft.Health.Fhir.Stu3.Tests.Integration.csproj
+++ b/test/Microsoft.Health.Fhir.Stu3.Tests.Integration/Microsoft.Health.Fhir.Stu3.Tests.Integration.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20200910-2" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201012-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="Microsoft.SqlServer.DACFx" Version="150.4573.2" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
Updates package 'Microsoft.Health.Abstractions' to version '1.0.0-master-20201012-1'
Updates package 'Microsoft.Health.Api' to version '1.0.0-master-20201012-1'
Updates package 'Microsoft.Health.Extensions.DependencyInjection' to version '1.0.0-master-20201012-1'
Updates package 'Microsoft.Health.Core' to version '1.0.0-master-20201012-1'
Updates package 'Microsoft.Health.SqlServer' to version '1.0.0-master-20201012-1'
Updates package 'Microsoft.Health.SqlServer.Api' to version '1.0.0-master-20201012-1'
Updates package 'Microsoft.Health.Extensions.BuildTimeCodeGenerator' to version '1.0.0-master-20201012-1'
Updates package 'Microsoft.Health.Test.Utilities' to version '1.0.0-master-20201012-1'
Updates package 'Microsoft.Health.Client' to version '1.0.0-master-20201012-1'