### PR TITLE
Move PR region

### DIFF
--- a/build/pr-variables.yml
+++ b/build/pr-variables.yml
@@ -1,5 +1,5 @@
 variables:
-    ResourceGroupRegion: 'southcentralus'
+    ResourceGroupRegion: 'westus2'
     resourceGroupRoot: 'msh-fhir-pr'
     appServicePlanName: '$(resourceGroupRoot)-$(prNumber)-asp'
     prNumber: $(system.pullRequest.pullRequestNumber)


### PR DESCRIPTION
## Description
FHIR and DICOM servers are both deploying PRs to the same Azure region which is causing competition for Azure quota. This moves the PR region to remove quota competition.

## Related issues

## Testing
