### PR TITLE
UTF-8 encoding for raw resources

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Storage/CompressedRawResourceConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Storage/CompressedRawResourceConverterTests.cs
@@ -1,0 +1,46 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.IO;
+using System.IO.Compression;
+using System.Threading.Tasks;
+using Microsoft.Health.Fhir.SqlServer.Features.Storage;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Storage
+{
+    public class CompressedRawResourceConverterTests
+    {
+        [Fact]
+        public async Task ResourceWithCurrentEncoding_WhenDecoded_ProducesCorrectResult()
+        {
+            string data = "Hello 😊";
+
+            using var stream = new MemoryStream();
+            CompressedRawResourceConverter.WriteCompressedRawResource(stream, data);
+
+            stream.Seek(0, 0);
+            string actual = await CompressedRawResourceConverter.ReadCompressedRawResource(stream);
+            Assert.Equal(data, actual);
+        }
+
+        [Fact]
+        public async Task ResourceWithLegacyEncoding_WhenDecoded_ProducesCorrectResult()
+        {
+            string data = "Hello 😊";
+
+            using var stream = new MemoryStream();
+            using var gzipStream = new GZipStream(stream, CompressionMode.Compress);
+            using var writer = new StreamWriter(gzipStream, CompressedRawResourceConverter.LegacyResourceEncoding);
+
+            writer.Write(data);
+            writer.Flush();
+
+            stream.Seek(0, 0);
+            string actual = await CompressedRawResourceConverter.ReadCompressedRawResource(stream);
+            Assert.Equal(data, actual);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -255,12 +255,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                         }
 
                         string rawResource;
-
                         using (rawResourceStream)
-                        using (var gzipStream = new GZipStream(rawResourceStream, CompressionMode.Decompress))
-                        using (var streamReader = new StreamReader(gzipStream, SqlServerFhirDataStore.ResourceEncoding))
                         {
-                            rawResource = await streamReader.ReadToEndAsync();
+                            rawResource = await CompressedRawResourceConverter.ReadCompressedRawResource(rawResourceStream);
                         }
 
                         // as long as at least one entry was marked as partial, this resultset

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/CompressedRawResourceConverter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/CompressedRawResourceConverter.cs
@@ -1,0 +1,39 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
+{
+    /// <summary>
+    /// Handles converting raw resource strings to compressed streams for storage in the database and vice-versa.
+    /// </summary>
+    internal class CompressedRawResourceConverter
+    {
+        internal static readonly Encoding LegacyResourceEncoding = new UnicodeEncoding(bigEndian: false, byteOrderMark: false);
+        internal static readonly Encoding ResourceEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+
+        public static async Task<string> ReadCompressedRawResource(Stream compressedResourceStream)
+        {
+            await using var gzipStream = new GZipStream(compressedResourceStream, CompressionMode.Decompress, leaveOpen: true);
+
+            // The current resource encoding uses byte-order marks. The legacy encoding does not, so we provide is as the fallback encoding
+            // when there is no BOM
+            using var reader = new StreamReader(gzipStream, LegacyResourceEncoding, detectEncodingFromByteOrderMarks: true);
+
+            return await reader.ReadToEndAsync();
+        }
+
+        public static void WriteCompressedRawResource(Stream outputStream, string rawResource)
+        {
+            using var gzipStream = new GZipStream(outputStream, CompressionMode.Compress, leaveOpen: true);
+            using var writer = new StreamWriter(gzipStream, ResourceEncoding);
+            writer.Write(rawResource);
+        }
+    }
+}


### PR DESCRIPTION
Changing the encoding of raw resources in the database before they are compressed from UTF-16 to UTF-8.

This results in a size reduction of nearly 20%. On a FHIR server loaded with 51MB of NDJSON data,

```SQL
select Sum(DATALENGTH(RawResource)) from Resource
```
now returns ~24MB instead of ~30MB previously.

One nice thing is that this change will be backwards-compatible, as the byte-order mark will tell us which encoding to use (and the existing code will just work as well). We previously did not use a BOM because T-SQL is not expecting it. We also did not use UTF-8 originally so that we could parse the JSON using T-SQL if we wanted to, and UTF-8 support was not available during development last year.

It is, however, [clumsy](https://stackoverflow.com/questions/64354878/convert-utf-8-varbinarymax-to-varcharmax/64357235#64357235) to work with UTF-8 encoded text in T-SQL, but the storage savings we get make this worthwhile IMO since we are not actually parsing the data on the server at the moment.
