### PR TITLE
Add cleanup action

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,8 +1,6 @@
 name: Clean up PR environment on close
 
-on: 
-  pull_request:
-    types: [closed]
+on: pull_request
 
 jobs:
   clean-up-environment:

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,6 +1,8 @@
 name: Clean up PR environment on close
 
-on: pull_request
+on: 
+  pull_request:
+    types: [closed]
 
 jobs:
   clean-up-environment:

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,16 @@
+name: Clean up PR environment on close
+
+on: 
+  pull_request:
+    types: [closed]
+
+jobs:
+  clean-up-environment:
+    runs-on: ubuntu-latest
+    steps:
+    - name: 'Trigger an Azure Pipeline to cleanup a PR environment'
+      uses: Azure/pipelines@releases/v1
+      with:
+        azure-devops-project-url: 'https://microsofthealthoss.visualstudio.com/FhirServer'
+        azure-pipeline-name: 'Remove PR Environment' 
+        azure-devops-token: '${{ secrets.AZURE_DEVOPS_TOKEN }}'


### PR DESCRIPTION
## Description
Add a GitHub action for cleaning up PR environment when a PR is closed. This will prevent old environments from not being deleted when a PR is closed instead of merged.

## Related issues

## Testing
Triggered build run: https://microsofthealthoss.visualstudio.com/FhirServer/_build/results?buildId=6407&view=results