### PR TITLE
Adds accent search test for SQL

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/StringSearchTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/StringSearchTestFixture.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Client;
@@ -17,31 +18,35 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         public StringSearchTestFixture(DataStore dataStore, Format format, TestFhirServerFactory testFhirServerFactory)
             : base(dataStore, format, testFhirServerFactory)
         {
-            // Prepare the resources used for string search tests.
-            TestFhirClient.DeleteAllResources(ResourceType.Patient).Wait();
-
             Patients = TestFhirClient.CreateResourcesAsync<Patient>(
                     p => SetPatientInfo(p, "Seattle", "Smith", given: "Bea"),
                     p => SetPatientInfo(p, "Portland", "Williams"),
                     p => SetPatientInfo(p, "Vancouver", "Anderson"),
                     p => SetPatientInfo(p, LongString, "Murphy"),
-                    p => SetPatientInfo(p, "Montreal", "Richard", given: "Bea"))
+                    p => SetPatientInfo(p, "Montreal", "Richard", given: "Bea"),
+                    p => SetPatientInfo(p, "New York", "Muller"),
+                    p => SetPatientInfo(p, "Portland", "Müller"))
                 .Result;
 
             void SetPatientInfo(Patient patient, string city, string family, string given = null)
             {
                 patient.Address = new List<Address>()
                 {
-                    new Address() { City = city },
+                    new Address { City = city },
                 };
 
                 patient.Name = new List<HumanName>()
                 {
-                    new HumanName() { Family = family, Given = new[] { given } },
+                    new HumanName { Family = family, Given = new[] { given } },
                 };
+
+                patient.Meta = new Meta();
+                patient.Meta.Tag.Add(new Coding("http://e2e-test", FixtureTag));
             }
         }
 
         public IReadOnlyList<Patient> Patients { get; }
+
+        public string FixtureTag { get; } = Guid.NewGuid().ToString();
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/StringSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/StringSearchTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [InlineData(":contains", "123", false)]
         public async Task GivenAStringSearchParam_WhenSearched_ThenCorrectBundleShouldBeReturned(string modifier, string valueToSearch, bool shouldMatch)
         {
-            string query = string.Format("address-city{0}={1}", modifier, valueToSearch);
+            string query = string.Format("address-city{0}={1}&_tag={2}", modifier, valueToSearch, Fixture.FixtureTag);
 
             Bundle bundle = await Client.SearchAsync(ResourceType.Patient, query);
 
@@ -71,7 +71,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [InlineData(":contains", "NotInString", false)]
         public async Task GivenAStringSearchParamAndAResourceWithALongSearchParamValue_WhenSearched_ThenCorrectBundleShouldBeReturned(string modifier, string valueToSearch, bool shouldMatch)
         {
-            string query = string.Format("address-city{0}={1}", modifier, valueToSearch);
+            string query = string.Format("address-city{0}={1}&_tag={2}", modifier, valueToSearch, Fixture.FixtureTag);
 
             Bundle bundle = await Client.SearchAsync(ResourceType.Patient, query);
 
@@ -95,7 +95,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [Fact]
         public async Task GivenAStringSearchParamWithMultipleValues_WhenSearched_ThenCorrectBundleShouldBeReturned()
         {
-            Bundle bundle = await Client.SearchAsync(ResourceType.Patient, "family=Smith,Ander");
+            Bundle bundle = await Client.SearchAsync(ResourceType.Patient, $"family=Smith,Ander&_tag={Fixture.FixtureTag}");
 
             ValidateBundle(bundle, Fixture.Patients[0], Fixture.Patients[2]);
         }
@@ -103,9 +103,25 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [Fact]
         public async Task GivenAStringSearchParamThatCoversSeveralFields_WhenSpecifiedTwiceInASearch_IntersectsTheTwoResultsProperly()
         {
-            Bundle bundle = await Client.SearchAsync(ResourceType.Patient, "name=Bea&name=Smith");
+            Bundle bundle = await Client.SearchAsync(ResourceType.Patient, $"name=Bea&name=Smith&_tag={Fixture.FixtureTag}");
 
             ValidateBundle(bundle, Fixture.Patients[0]);
+        }
+
+        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
+        [Theory]
+        [Trait(Traits.Priority, Priority.One)]
+        [InlineData("muller")]
+        [InlineData("müller")]
+        public async Task GivenAStringSearchParamWithAccentAndAResourceWithAccent_WhenSearched_ThenCorrectBundleShouldBeReturned(string searchText)
+        {
+            string query = $"name={searchText}&_total=accurate&_tag={Fixture.FixtureTag}";
+
+            Bundle bundle = await Client.SearchAsync(ResourceType.Patient, query);
+
+            Assert.NotNull(bundle);
+            Assert.Equal(2, bundle.Total);
+            Assert.NotEmpty(bundle.Entry);
         }
     }
 }


### PR DESCRIPTION
## Description
Adds a test validating accent search in SQL. This fails in CosmosDB

## Related issues
Refs #1364

