### PR TITLE
Improve error handling for bad continuation tokens and search values.

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/ContinuationToken.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/ContinuationToken.cs
@@ -67,8 +67,15 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                 return new ContinuationToken(new object[] { sid });
             }
 
-            var result = JsonSerializer.Deserialize<object[]>(json, Options);
-            return new ContinuationToken(result);
+            try
+            {
+                object[] result = JsonSerializer.Deserialize<object[]>(json, Options);
+                return new ContinuationToken(result);
+            }
+            catch (JsonException)
+            {
+                return null;
+            }
         }
 
         private class ContinuationTokenConverter : System.Text.Json.Serialization.JsonConverter<object>

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/SearchParameterExpressionParser.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/SearchParameterExpressionParser.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using EnsureThat;
 using Hl7.Fhir.Utility;
 using Microsoft.Health.Fhir.Core.Features.Definition;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.ValueSets;
@@ -39,16 +40,17 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
 
             _searchParameterDefinitionManager = searchParameterDefinitionManagerResolver();
 
-            _parserDictionary = new Dictionary<SearchParamType, Func<string, ISearchValue>>()
-            {
-                { SearchParamType.Date, DateTimeSearchValue.Parse },
-                { SearchParamType.Number, NumberSearchValue.Parse },
-                { SearchParamType.Quantity, QuantitySearchValue.Parse },
-                { SearchParamType.Reference, referenceSearchValueParser.Parse },
-                { SearchParamType.String, StringSearchValue.Parse },
-                { SearchParamType.Token, TokenSearchValue.Parse },
-                { SearchParamType.Uri, UriSearchValue.Parse },
-            };
+            _parserDictionary = new (SearchParamType type, Func<string, ISearchValue> parser)[]
+                {
+                    (SearchParamType.Date, DateTimeSearchValue.Parse),
+                    (SearchParamType.Number, NumberSearchValue.Parse),
+                    (SearchParamType.Quantity, QuantitySearchValue.Parse),
+                    (SearchParamType.Reference, referenceSearchValueParser.Parse),
+                    (SearchParamType.String, StringSearchValue.Parse),
+                    (SearchParamType.Token, TokenSearchValue.Parse),
+                    (SearchParamType.Uri, UriSearchValue.Parse),
+                }
+                .ToDictionary(entry => entry.type, entry => CreateParserWithErrorHandling(entry.parser));
         }
 
         public Expression Parse(
@@ -217,5 +219,26 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
                 return Expression.Or(expressions);
             }
         }
+
+        private static Func<string, ISearchValue> CreateParserWithErrorHandling(Func<string, ISearchValue> parser) =>
+            input =>
+            {
+                try
+                {
+                    return parser(input);
+                }
+                catch (FormatException e)
+                {
+                    throw new BadRequestException(e.Message);
+                }
+                catch (OverflowException e)
+                {
+                    throw new BadRequestException(e.Message);
+                }
+                catch (ArgumentException e)
+                {
+                    throw new BadRequestException(e.Message);
+                }
+            };
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
@@ -184,22 +184,6 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
                 context.Result = healthExceptionResult;
                 context.ExceptionHandled = true;
             }
-            else
-            {
-                switch (context.Exception)
-                {
-                    case FormatException ex:
-                        context.Result = CreateOperationOutcomeResult(ex.Message, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Structure, HttpStatusCode.BadRequest);
-                        context.ExceptionHandled = true;
-
-                        break;
-                    case ArgumentException ex:
-                        context.Result = CreateOperationOutcomeResult(ex.Message, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid, HttpStatusCode.BadRequest);
-                        context.ExceptionHandled = true;
-
-                        break;
-                }
-            }
         }
 
         private OperationOutcomeResult CreateOperationOutcomeResult(string message, OperationOutcome.IssueSeverity issueSeverity, OperationOutcome.IssueType issueType, HttpStatusCode httpStatusCode)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -573,5 +573,20 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             Assert.Equal(KnownResourceTypes.OperationOutcome, bundle.Entry.First().Resource.TypeName);
             Assert.NotNull(bundle.Entry.Skip(1).First().Resource);
         }
+
+        [Theory]
+        [InlineData("RiskAssessment?probability=gt55555555555555555555555555555555555555555555555")]
+        [InlineData("RiskAssessment?probability=gt")]
+        [InlineData("RiskAssessment?probability=foo")]
+        [InlineData("Observation?date=05")]
+        [InlineData("Observation?code=a|b|c|d")]
+        [InlineData("Observation?value-quantity=5.40e-3|http://unitsofmeasure.org|g|extra")]
+        [InlineData("Observation?ct=YWJj")]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenASearchRequestWithInvalidValues_WhenHandled_ReturnsABadRequestError(string uri)
+        {
+            System.Net.Http.HttpResponseMessage httpResponseMessage = await Client.HttpClient.GetAsync(uri);
+            Assert.Equal(HttpStatusCode.BadRequest, httpResponseMessage.StatusCode);
+        }
     }
 }


### PR DESCRIPTION
## Description
Improves handling for malformed SQL and Cosmos DB continuation tokens, and improves error handling when parsing search values. Also avoids being over broad with our error handling. For instance, `ArgumentException`s, like those raised in `EnsureArg` calls, would be translated to 400 response codes instead of 500.

## Related issues
Addresses #1259, #674.
Addresses part of #1342.

## Testing
Added E2E test cases.
