### PR TITLE
Removes SqlServerFhirModel initialization redundancies

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         private readonly IModelInfoProvider _modelInfoProvider;
 
         private IDictionary<string, IDictionary<string, SearchParameterInfo>> _typeLookup;
-        private bool _started;
         private Dictionary<string, string> _resourceTypeSearchParameterHashMap;
 
         public SearchParameterDefinitionManager(IModelInfoProvider modelInfoProvider)
@@ -46,22 +45,16 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
 
         public void Start()
         {
-            // This method is idempotent because dependent Start methods are not guaranteed to be executed in order.
-            if (!_started)
-            {
-                var builder = new SearchParameterDefinitionBuilder(
-                    _modelInfoProvider,
-                    "search-parameters.json");
+            var builder = new SearchParameterDefinitionBuilder(
+                _modelInfoProvider,
+                "search-parameters.json");
 
-                builder.Build();
+            builder.Build();
 
-                _typeLookup = builder.ResourceTypeDictionary;
-                UrlLookup = builder.UriDictionary;
+            _typeLookup = builder.ResourceTypeDictionary;
+            UrlLookup = builder.UriDictionary;
 
-                List<string> list = UrlLookup.Values.Where(p => p.Type == ValueSets.SearchParamType.Composite).Select(p => string.Join("|", p.Component.Select(c => UrlLookup[c.DefinitionUrl].Type))).Distinct().ToList();
-
-                _started = true;
-            }
+            List<string> list = UrlLookup.Values.Where(p => p.Type == ValueSets.SearchParamType.Composite).Select(p => string.Join("|", p.Component.Select(c => UrlLookup[c.DefinitionUrl].Type))).Distinct().ToList();
         }
 
         public IEnumerable<SearchParameterInfo> GetSearchParameters(string resourceType)

--- a/src/Microsoft.Health.Fhir.R5.Api/Microsoft.Health.Fhir.R5.Api.csproj
+++ b/src/Microsoft.Health.Fhir.R5.Api/Microsoft.Health.Fhir.R5.Api.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="9.2.0" />
     <PackageReference Include="FluentValidation" Version="8.6.1" />
-    <PackageReference Include="Hl7.Fhir.R5" Version="1.10.0-alpha-20200811-1" />
+    <PackageReference Include="Hl7.Fhir.R5" Version="1.9.0-beta-june2020" />
     <PackageReference Include="MediatR" Version="8.1.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.8" />

--- a/src/Microsoft.Health.Fhir.R5.Client/Microsoft.Health.Fhir.R5.Client.csproj
+++ b/src/Microsoft.Health.Fhir.R5.Client/Microsoft.Health.Fhir.R5.Client.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="9.2.0" />
-    <PackageReference Include="Hl7.Fhir.R5" Version="1.10.0-alpha-20200811-1" />
+    <PackageReference Include="Hl7.Fhir.R5" Version="1.9.0-beta-june2020" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.5.0" />
     <PackageReference Include="Microsoft.Health.Client" Version="1.0.0-master-20201008-2" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.7.1" />

--- a/src/Microsoft.Health.Fhir.R5.Core/Microsoft.Health.Fhir.R5.Core.csproj
+++ b/src/Microsoft.Health.Fhir.R5.Core/Microsoft.Health.Fhir.R5.Core.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
-    <PackageReference Include="Hl7.Fhir.R5" Version="1.10.0-alpha-20200811-1" />
+    <PackageReference Include="Hl7.Fhir.R5" Version="1.9.0-beta-june2020" />
     <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaVersionConstants.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaVersionConstants.cs
@@ -9,5 +9,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema
     {
         public const int Min = (int)SchemaVersion.V4;
         public const int Max = (int)SchemaVersion.V6;
+        public const int SearchParameterStatusSchemaVersion = (int)SchemaVersion.V6;
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerSearchParameterStatusDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerSearchParameterStatusDataStore.cs
@@ -14,6 +14,7 @@ using EnsureThat;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Search.Registry;
+using Microsoft.Health.Fhir.SqlServer.Features.Schema;
 using Microsoft.Health.Fhir.SqlServer.Features.Schema.Model;
 using Microsoft.Health.SqlServer.Features.Client;
 using Microsoft.Health.SqlServer.Features.Schema;
@@ -49,7 +50,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry
         public async Task<IReadOnlyCollection<ResourceSearchParameterStatus>> GetSearchParameterStatuses()
         {
             // If the search parameter table in SQL does not yet contain status columns
-            if (_schemaInformation.Current < 6)
+            if (_schemaInformation.Current < SchemaVersionConstants.SearchParameterStatusSchemaVersion)
             {
                 // Get status information from file.
                 return await _filebasedSearchParameterStatusDataStore.GetSearchParameterStatuses();
@@ -96,7 +97,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry
         {
             EnsureArg.IsNotNull(statuses, nameof(statuses));
 
-            if (_schemaInformation.Current < 6)
+            if (_schemaInformation.Current < SchemaVersionConstants.SearchParameterStatusSchemaVersion)
             {
                 throw new BadRequestException(Resources.SchemaVersionNeedsUpgrading);
             }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerSearchParameterStatusDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerSearchParameterStatusDataStore.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry
         public async Task<IReadOnlyCollection<ResourceSearchParameterStatus>> GetSearchParameterStatuses()
         {
             // If the search parameter table in SQL does not yet contain status columns
-            if (_schemaInformation.Current < 4)
+            if (_schemaInformation.Current < 6)
             {
                 // Get status information from file.
                 return await _filebasedSearchParameterStatusDataStore.GetSearchParameterStatuses();
@@ -96,7 +96,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry
         {
             EnsureArg.IsNotNull(statuses, nameof(statuses));
 
-            if (_schemaInformation.Current < 4)
+            if (_schemaInformation.Current < 6)
             {
                 throw new BadRequestException(Resources.SchemaVersionNeedsUpgrading);
             }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SchemaUpgradedHandler.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SchemaUpgradedHandler.cs
@@ -26,9 +26,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
         {
             EnsureArg.IsNotNull(notification, nameof(notification));
 
-            // TODO: Use version information to call modularized start methods (work item 75557).
-            int? version = notification.Version;
-            _sqlServerFhirModel.Start();
+            int version = notification.Version;
+            bool isFullSchemaSnapshot = notification.IsFullSchemaSnapshot;
+
+            // If it is a snapshot upgrade, then we need to run initialization for all schema versions up to the current version.
+            _sqlServerFhirModel.Initialize(version, isFullSchemaSnapshot);
 
             return Task.CompletedTask;
         }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SchemaUpgradedHandler.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SchemaUpgradedHandler.cs
@@ -26,11 +26,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
         {
             EnsureArg.IsNotNull(notification, nameof(notification));
 
-            int version = notification.Version;
-            bool isFullSchemaSnapshot = notification.IsFullSchemaSnapshot;
-
             // If it is a snapshot upgrade, then we need to run initialization for all schema versions up to the current version.
-            _sqlServerFhirModel.Initialize(version, isFullSchemaSnapshot);
+            _sqlServerFhirModel.Initialize(notification.Version, notification.IsFullSchemaSnapshot);
 
             return Task.CompletedTask;
         }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
@@ -142,10 +142,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
         public Task EnsureInitialized()
         {
-            if (_schemaInformation.Current == null)
-            {
-                throw new InvalidOperationException(Resources.SchemaVersionShouldNotBeNull);
-            }
+            ThrowIfCurrentSchemaVersionIsNull();
 
             // If the fhir-server is just starting up, synchronize the fhir-server dictionaries with the SQL database
             Initialize((int)_schemaInformation.Current, true);
@@ -406,10 +403,20 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
         private void ThrowIfNotInitialized()
         {
+            ThrowIfCurrentSchemaVersionIsNull();
+
             if (_highestInitializedVersion < _schemaInformation.Current)
             {
                 _logger.LogError($"The {nameof(SqlServerFhirModel)} instance has not run the initialization required for the current schema version");
                 throw new ServiceUnavailableException();
+            }
+        }
+
+        private void ThrowIfCurrentSchemaVersionIsNull()
+        {
+            if (_schemaInformation.Current == null)
+            {
+                throw new InvalidOperationException(Resources.SchemaVersionShouldNotBeNull);
             }
         }
     }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
@@ -19,6 +19,7 @@ using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Search.Registry;
 using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.SqlServer.Features.Schema;
 using Microsoft.Health.Fhir.SqlServer.Features.Schema.Model;
 using Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry;
 using Microsoft.Health.SqlServer.Configs;
@@ -164,32 +165,30 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
             if (runAllInitialization)
             {
-                InitializeV1();
+                InitializeBase();
 
-                if (version >= 6)
+                if (version >= SchemaVersionConstants.SearchParameterStatusSchemaVersion)
                 {
-                    InitializeV6();
+                    InitializeSearchParameterStatuses();
                 }
-
-                _highestInitializedVersion = version;
             }
             else
             {
                 switch (version)
                 {
                     case 1:
-                        InitializeV1();
+                        InitializeBase();
                         break;
-                    case 6:
-                        InitializeV6();
+                    case SchemaVersionConstants.SearchParameterStatusSchemaVersion:
+                        InitializeSearchParameterStatuses();
                         break;
                 }
-
-                _highestInitializedVersion = version;
             }
+
+            _highestInitializedVersion = version;
         }
 
-        private void InitializeV1()
+        private void InitializeBase()
         {
             using (var connection = new SqlConnection(_configuration.ConnectionString))
             {
@@ -326,7 +325,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             }
         }
 
-        private void InitializeV6()
+        private void InitializeSearchParameterStatuses()
         {
             using (var connection = new SqlConnection(_configuration.ConnectionString))
             {

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
@@ -13,7 +13,6 @@ using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Abstractions.Exceptions;
-using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Search.Registry;
@@ -34,10 +33,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
     /// many many times in the database. For more compact storage, we use IDs instead of the strings when referencing these.
     /// Also, because the number of distinct values is small, we can maintain all values in memory and avoid joins when querying.
     /// </summary>
-    public sealed class SqlServerFhirModel : IStartable
+    public sealed class SqlServerFhirModel
     {
         private readonly SqlServerDataStoreConfiguration _configuration;
-        private readonly SchemaInitializer _schemaInitializer;
         private readonly SchemaInformation _schemaInformation;
         private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager;
         private readonly ISearchParameterStatusDataStore _filebasedSearchParameterStatusDataStore;
@@ -50,11 +48,10 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
         private ConcurrentDictionary<string, int> _quantityCodeToId;
         private Dictionary<string, byte> _claimNameToId;
         private Dictionary<string, byte> _compartmentTypeToId;
-        private bool _started;
+        private int _highestInitializedVersion;
 
         public SqlServerFhirModel(
             SqlServerDataStoreConfiguration configuration,
-            SchemaInitializer schemaInitializer,
             SchemaInformation schemaInformation,
             ISearchParameterDefinitionManager searchParameterDefinitionManager,
             FilebasedSearchParameterStatusDataStore.Resolver filebasedRegistry,
@@ -62,7 +59,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             ILogger<SqlServerFhirModel> logger)
         {
             EnsureArg.IsNotNull(configuration, nameof(configuration));
-            EnsureArg.IsNotNull(schemaInitializer, nameof(schemaInitializer));
             EnsureArg.IsNotNull(schemaInformation, nameof(schemaInformation));
             EnsureArg.IsNotNull(searchParameterDefinitionManager, nameof(searchParameterDefinitionManager));
             EnsureArg.IsNotNull(filebasedRegistry, nameof(filebasedRegistry));
@@ -70,7 +66,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             EnsureArg.IsNotNull(logger, nameof(logger));
 
             _configuration = configuration;
-            _schemaInitializer = schemaInitializer;
             _schemaInformation = schemaInformation;
             _searchParameterDefinitionManager = searchParameterDefinitionManager;
             _filebasedSearchParameterStatusDataStore = filebasedRegistry.Invoke();
@@ -80,49 +75,49 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
         public short GetResourceTypeId(string resourceTypeName)
         {
-            ThrowIfNotStarted();
+            ThrowIfNotInitialized();
             return _resourceTypeToId[resourceTypeName];
         }
 
         public bool TryGetResourceTypeId(string resourceTypeName, out short id)
         {
-            ThrowIfNotStarted();
+            ThrowIfNotInitialized();
             return _resourceTypeToId.TryGetValue(resourceTypeName, out id);
         }
 
         public string GetResourceTypeName(short resourceTypeId)
         {
-            ThrowIfNotStarted();
+            ThrowIfNotInitialized();
             return _resourceTypeIdToTypeName[resourceTypeId];
         }
 
         public byte GetClaimTypeId(string claimTypeName)
         {
-            ThrowIfNotStarted();
+            ThrowIfNotInitialized();
             return _claimNameToId[claimTypeName];
         }
 
         public short GetSearchParamId(Uri searchParamUri)
         {
-            ThrowIfNotStarted();
+            ThrowIfNotInitialized();
             return _searchParamUriToId[searchParamUri];
         }
 
         public byte GetCompartmentTypeId(string compartmentType)
         {
-            ThrowIfNotStarted();
+            ThrowIfNotInitialized();
             return _compartmentTypeToId[compartmentType];
         }
 
         public bool TryGetSystemId(string system, out int systemId)
         {
-            ThrowIfNotStarted();
+            ThrowIfNotInitialized();
             return _systemToId.TryGetValue(system, out systemId);
         }
 
         public int GetSystemId(string system)
         {
-            ThrowIfNotStarted();
+            ThrowIfNotInitialized();
 
             VLatest.SystemTable systemTable = VLatest.System;
             return GetStringId(_systemToId, system, systemTable, systemTable.SystemId, systemTable.Value);
@@ -130,7 +125,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
         public int GetQuantityCodeId(string code)
         {
-            ThrowIfNotStarted();
+            ThrowIfNotInitialized();
 
             VLatest.QuantityCodeTable quantityCodeTable = VLatest.QuantityCode;
             return GetStringId(_quantityCodeToId, code, quantityCodeTable, quantityCodeTable.QuantityCodeId, quantityCodeTable.Value);
@@ -138,30 +133,41 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
         public bool TryGetQuantityCodeId(string code, out int quantityCodeId)
         {
-            ThrowIfNotStarted();
+            ThrowIfNotInitialized();
             return _quantityCodeToId.TryGetValue(code, out quantityCodeId);
         }
 
-        // TODO: Once this no longer implements IStartable, rename to "EnsureInitialized" (work item 75558).
-        public void Start()
+        public void Initialize(int version, bool runAllInitialization)
         {
-            _schemaInitializer.Start();
-
-            if (_searchParameterDefinitionManager is IStartable startable)
-            {
-                startable.Start();
-            }
-
-            // As long as SqlServerFhirModel implements IStartable, avoid initialization if we are only running the base schema.
-            if (_schemaInformation.Current == null)
-            {
-                return;
-            }
-
             var connectionStringBuilder = new SqlConnectionStringBuilder(_configuration.ConnectionString);
+            _logger.LogInformation("Initializing {Server} {Database} to version {Version}", connectionStringBuilder.DataSource, connectionStringBuilder.InitialCatalog, version);
 
-            _logger.LogInformation("Initializing {Server} {Database}", connectionStringBuilder.DataSource, connectionStringBuilder.InitialCatalog);
+            if (runAllInitialization)
+            {
+                InitializeV1();
+                InitializeV6();
+                _highestInitializedVersion = 6;
+            }
+            else
+            {
+                switch (version)
+                {
+                    case 1:
+                        InitializeV1();
+                        _highestInitializedVersion = 1;
+                        break;
+                    case 5:
+                        InitializeV6();
+                        _highestInitializedVersion = 6;
+                        break;
+                }
 
+                _highestInitializedVersion = version;
+            }
+        }
+
+        private void InitializeV1()
+        {
             using (var connection = new SqlConnection(_configuration.ConnectionString))
             {
                 connection.Open();
@@ -173,33 +179,25 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                     sqlCommand.CommandText = @"
                         SET XACT_ABORT ON
                         BEGIN TRANSACTION
-
                         INSERT INTO dbo.ResourceType (Name) 
                         SELECT value FROM string_split(@resourceTypes, ',')
                         EXCEPT SELECT Name FROM dbo.ResourceType WITH (TABLOCKX); 
-
                         -- result set 1
                         SELECT ResourceTypeId, Name FROM dbo.ResourceType;
-
                         INSERT INTO dbo.SearchParam (Uri)
                         SELECT * FROM  OPENJSON (@searchParams) 
                         WITH (Uri varchar(128) '$.Uri')
-                        EXCEPT SELECT Uri FROM dbo.SearchParam;
-
+                        EXCEPT SELECT Uri FROM dbo.SearchParam
                         -- result set 2
                         SELECT Uri, SearchParamId FROM dbo.SearchParam;
-
                         INSERT INTO dbo.ClaimType (Name) 
                         SELECT value FROM string_split(@claimTypes, ',')
                         EXCEPT SELECT Name FROM dbo.ClaimType; 
-
                         -- result set 3
                         SELECT ClaimTypeId, Name FROM dbo.ClaimType;
-
                         INSERT INTO dbo.CompartmentType (Name) 
                         SELECT value FROM string_split(@compartmentTypes, ',')
                         EXCEPT SELECT Name FROM dbo.CompartmentType; 
-
                         -- result set 4
                         SELECT CompartmentTypeId, Name FROM dbo.CompartmentType;
                         
@@ -207,17 +205,16 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
     
                         -- result set 5
                         SELECT Value, SystemId from dbo.System;
-
                         -- result set 6
                         SELECT Value, QuantityCodeId FROM dbo.QuantityCode";
 
-                    string commaSeparatedResourceTypes = string.Join(",", ModelInfoProvider.GetResourceTypeNames());
                     string searchParametersJson = JsonConvert.SerializeObject(_searchParameterDefinitionManager.AllSearchParameters.Select(p => new { Name = p.Name, Uri = p.Url }));
+                    string commaSeparatedResourceTypes = string.Join(",", ModelInfoProvider.GetResourceTypeNames());
                     string commaSeparatedClaimTypes = string.Join(',', _securityConfiguration.PrincipalClaims);
                     string commaSeparatedCompartmentTypes = string.Join(',', ModelInfoProvider.GetCompartmentTypeNames());
 
-                    sqlCommand.Parameters.AddWithValue("@resourceTypes", commaSeparatedResourceTypes);
                     sqlCommand.Parameters.AddWithValue("@searchParams", searchParametersJson);
+                    sqlCommand.Parameters.AddWithValue("@resourceTypes", commaSeparatedResourceTypes);
                     sqlCommand.Parameters.AddWithValue("@claimTypes", commaSeparatedClaimTypes);
                     sqlCommand.Parameters.AddWithValue("@compartmentTypes", commaSeparatedCompartmentTypes);
 
@@ -294,18 +291,10 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                         _compartmentTypeToId = compartmentTypeToId;
                     }
                 }
-
-                // Search parameter statuses are only supported in version four and higher.
-                if (_schemaInformation.Current >= 5)
-                {
-                    InitializeSearchParameterStatusInformation();
-                }
-
-                _started = true;
             }
         }
 
-        private void InitializeSearchParameterStatusInformation()
+        private void InitializeV6()
         {
             using (var connection = new SqlConnection(_configuration.ConnectionString))
             {
@@ -363,9 +352,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                     sqlCommand.CommandText = $@"
                         SET TRANSACTION ISOLATION LEVEL SERIALIZABLE
                         BEGIN TRANSACTION
-
                         DECLARE @id int = (SELECT {idColumn} FROM {table} WITH (UPDLOCK) WHERE {stringColumn} = @stringValue)
-
                         IF (@id IS NULL) BEGIN
                             INSERT INTO {table} 
                                 ({stringColumn})
@@ -373,9 +360,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                                 (@stringValue)
                             SET @id = SCOPE_IDENTITY()
                         END
-
                         COMMIT TRANSACTION
-
                         SELECT @id";
 
                     sqlCommand.Parameters.AddWithValue("@stringValue", stringValue);
@@ -388,11 +373,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             }
         }
 
-        private void ThrowIfNotStarted()
+        private void ThrowIfNotInitialized()
         {
-            if (!_started)
+            if (_highestInitializedVersion < _schemaInformation.Current)
             {
-                _logger.LogError($"The {nameof(SqlServerFhirModel)} instance has not been initialized.");
+                _logger.LogError($"The {nameof(SqlServerFhirModel)} instance has not run the initialization required for the current schema version");
                 throw new ServiceUnavailableException();
             }
         }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
@@ -145,8 +145,13 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             if (runAllInitialization)
             {
                 InitializeV1();
-                InitializeV6();
-                _highestInitializedVersion = 6;
+
+                if (version >= 6)
+                {
+                    InitializeV6();
+                }
+
+                _highestInitializedVersion = version;
             }
             else
             {
@@ -156,7 +161,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                         InitializeV1();
                         _highestInitializedVersion = 1;
                         break;
-                    case 5:
+                    case 6:
                         InitializeV6();
                         _highestInitializedVersion = 6;
                         break;

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
@@ -162,6 +162,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
             if (runAllInitialization)
             {
+                // Run schema initialization required for [SchemaVersion.Min, SchemaVersion.Current]
                 InitializeBase();
 
                 if (version >= SchemaVersionConstants.SearchParameterStatusSchemaVersion)
@@ -171,14 +172,10 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             }
             else
             {
-                switch (version)
+                // Only run the schema initialization required for the current version
+                if (version == SchemaVersionConstants.SearchParameterStatusSchemaVersion)
                 {
-                    case 1:
-                        InitializeBase();
-                        break;
-                    case SchemaVersionConstants.SearchParameterStatusSchemaVersion:
-                        InitializeSearchParameterStatuses();
-                        break;
+                    InitializeSearchParameterStatuses();
                 }
             }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Resources.Designer.cs
@@ -79,6 +79,15 @@ namespace Microsoft.Health.Fhir.SqlServer {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The current schema version should not be null..
+        /// </summary>
+        internal static string SchemaVersionShouldNotBeNull {
+            get {
+                return ResourceManager.GetString("SchemaVersionShouldNotBeNull", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to There was an internal server error while processing the transaction..
         /// </summary>
         internal static string TransactionProcessingException {

--- a/src/Microsoft.Health.Fhir.SqlServer/Resources.resx
+++ b/src/Microsoft.Health.Fhir.SqlServer/Resources.resx
@@ -126,4 +126,7 @@
   <data name="SchemaVersionNeedsUpgrading" xml:space="preserve">
     <value>Search parameter status information should not be null.</value>
   </data>
+  <data name="SchemaVersionShouldNotBeNull" xml:space="preserve">
+    <value>The current schema version should not be null.</value>
+  </data>
 </root>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 });
 
             await schemaInitializer.InitializeAsync(forceIncrementalSchemaUpgrade, cancellationToken);
-            _sqlServerFhirModel.Start();
+            _sqlServerFhirModel.Initialize(SchemaVersionConstants.Max, true);
         }
 
         public async Task DeleteDatabase(string databaseName, CancellationToken cancellationToken = default)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -67,6 +67,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             _schemaInitializer = new SchemaInitializer(config, schemaUpgradeRunner, schemaInformation, sqlConnectionFactory, NullLogger<SchemaInitializer>.Instance);
 
             var searchParameterDefinitionManager = new SearchParameterDefinitionManager(ModelInfoProvider.Instance);
+            searchParameterDefinitionManager.Start();
+
             _filebasedSearchParameterStatusDataStore = new FilebasedSearchParameterStatusDataStore(searchParameterDefinitionManager, ModelInfoProvider.Instance);
 
             var securityConfiguration = new SecurityConfiguration { PrincipalClaims = { "oid" } };

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -73,7 +73,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
             var sqlServerFhirModel = new SqlServerFhirModel(
                 config,
-                _schemaInitializer,
                 schemaInformation,
                 searchParameterDefinitionManager,
                 () => _filebasedSearchParameterStatusDataStore,


### PR DESCRIPTION
## Description

Note: this PR replaces #1262. I created new dev and feature branches that are up-to-date with master.

Description from #1262:

Currently (in my feature branch), the `Start()` method in `SqlServerFhirModel.cs` is being called on startup and every time the schema is upgraded.

This PR:
- Updates `SqlServerFhirModel` to no longer implement `IStartable` because it's initialization is now invoked on every schema upgrade
- Modularizes `SqlServerFhirModel`'s initialization code by schema version, allowing us to invoke schema version-specific initialization on schema upgrade.

## Related issues
Addresses [AB#75557](https://microsofthealth.visualstudio.com/Health/_workitems/edit/75557) and [#AB75558](https://microsofthealth.visualstudio.com/Health/_workitems/edit/75558).

## Testing
Local testing to check that the correct information is being passed when the schema is upgraded.

Followed the manual test scenarios that are outlined [here](https://microsoft-my.sharepoint.com/:x:/g/personal/rotodd_microsoft_com1/EZf3FpQrmZxHldZDZBjWS0UBK4SgbEFu9eZet1UwvyU67g?e=P3UGTN).
