### PR TITLE
Updated test case to use JToken comparison

### DIFF
--- a/src/Microsoft.Health.Fhir.R5.Api/Microsoft.Health.Fhir.R5.Api.csproj
+++ b/src/Microsoft.Health.Fhir.R5.Api/Microsoft.Health.Fhir.R5.Api.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="9.2.0" />
     <PackageReference Include="FluentValidation" Version="8.6.1" />
-    <PackageReference Include="Hl7.Fhir.R5" Version="1.10.0-alpha-20200811-1" />
+    <PackageReference Include="Hl7.Fhir.R5" Version="1.9.0-beta-june2020" />
     <PackageReference Include="MediatR" Version="8.1.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.8" />

--- a/src/Microsoft.Health.Fhir.R5.Client/Microsoft.Health.Fhir.R5.Client.csproj
+++ b/src/Microsoft.Health.Fhir.R5.Client/Microsoft.Health.Fhir.R5.Client.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="9.2.0" />
-    <PackageReference Include="Hl7.Fhir.R5" Version="1.10.0-alpha-20200811-1" />
+    <PackageReference Include="Hl7.Fhir.R5" Version="1.9.0-beta-june2020" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.5.0" />
     <PackageReference Include="Microsoft.Health.Client" Version="1.0.0-master-20201008-2" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.7.1" />

--- a/src/Microsoft.Health.Fhir.R5.Core/Microsoft.Health.Fhir.R5.Core.csproj
+++ b/src/Microsoft.Health.Fhir.R5.Core/Microsoft.Health.Fhir.R5.Core.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
-    <PackageReference Include="Hl7.Fhir.R5" Version="1.10.0-alpha-20200811-1" />
+    <PackageReference Include="Hl7.Fhir.R5" Version="1.9.0-beta-june2020" />
     <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchIndexerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchIndexerTests.cs
@@ -15,6 +15,7 @@ using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Tests.Common;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using Xunit;
 
@@ -52,14 +53,23 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             var document = Samples.GetJsonSample<DocumentReference>(resourceFile).ToResourceElement();
             var indexDocument = Samples.GetJson($"{resourceFile}.indexes");
 
-            var indexes = _indexer.Extract(document)
+            var indices = _indexer.Extract(document)
                 .Select(x => new { x.SearchParameter.Name, x.SearchParameter.Type, x.Value })
                 .OrderBy(x => x.Name)
                 .ToArray();
 
-            var asJson = JsonConvert.SerializeObject(indexes, Formatting.Indented, _settings);
+            var extractedIndices = new List<JToken>();
+            foreach (var index in indices)
+            {
+                extractedIndices.Add(JToken.Parse(JsonConvert.SerializeObject(index, Formatting.Indented, _settings)));
+            }
 
-            Assert.Equal(indexDocument, asJson);
+            var expectedJObjects = JArray.Parse(indexDocument);
+
+            for (var i = 0; i < expectedJObjects.Count; i++)
+            {
+                Assert.True(JToken.DeepEquals(expectedJObjects[i], extractedIndices[i]));
+            }
         }
     }
 }


### PR DESCRIPTION
## Description
Rather than one comparison of the entire list of extracted search indices, the test case is updated to use individual comparisons using JToken

## Related issues
Addresses [issue [AB#76216](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/76216)].

## Testing
Reran the test case
