### PR TITLE
Adds locking behavior to ConditionalCreate pipeline

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Persistence/ResourceConflictException.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Persistence/ResourceConflictException.cs
@@ -20,5 +20,15 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
                     OperationOutcomeConstants.IssueType.Conflict,
                     string.Format(Core.Resources.ResourceVersionConflict, etag?.VersionId)));
         }
+
+        public ResourceConflictException(string message)
+        {
+            Debug.Assert(message != null, "Message should not be null");
+
+            Issues.Add(new OperationOutcomeIssue(
+                OperationOutcomeConstants.IssueSeverity.Error,
+                OperationOutcomeConstants.IssueType.Conflict,
+                message));
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -10,8 +10,8 @@
 
 namespace Microsoft.Health.Fhir.Core {
     using System;
-
-
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -19,19 +19,19 @@ namespace Microsoft.Health.Fhir.Core {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
-
+        
         private static global::System.Resources.ResourceManager resourceMan;
-
+        
         private static global::System.Globalization.CultureInfo resourceCulture;
-
+        
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         internal Resources() {
         }
-
+        
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
@@ -45,7 +45,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return resourceMan;
             }
         }
-
+        
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
@@ -59,7 +59,7 @@ namespace Microsoft.Health.Fhir.Core {
                 resourceCulture = value;
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {0} and {1} cannot both be specified..
         /// </summary>
@@ -68,7 +68,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("AtCannotBeSpecifiedWithBeforeOrSince", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Only a bundle can be submitted for batch or transaction processing..
         /// </summary>
@@ -77,7 +77,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("BundleRequiredForBatchOrTransaction", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The chained parameter must be a reference search parameter type..
         /// </summary>
@@ -86,7 +86,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ChainedParameterMustBeReferenceSearchParamType", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The chained parameter is not supported..
         /// </summary>
@@ -95,7 +95,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ChainedParameterNotSupported", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The reference search parameter &apos;{0}&apos; refers to multiple possible resource types. Please specify a type in the search expression: {1}.
         /// </summary>
@@ -104,7 +104,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ChainedParameterSpecifyType", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Comparator &apos;{0}&apos; is not supported for search parameter &apos;{1}&apos;..
         /// </summary>
@@ -113,7 +113,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ComparatorNotSupported", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The compartment definition contains one or more invalid entries..
         /// </summary>
@@ -122,7 +122,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CompartmentDefinitionContainsInvalidEntry", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to bundle.entry[{0}].resource has duplicate resources..
         /// </summary>
@@ -131,7 +131,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CompartmentDefinitionDupeResource", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to bundle.entry[{0}] is null..
         /// </summary>
@@ -140,7 +140,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CompartmentDefinitionInvalidBundle", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to bundle.entry[{0}].resource.code is null. Not a valid compartment type..
         /// </summary>
@@ -149,7 +149,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CompartmentDefinitionInvalidCompartmentType", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to bundle.entry[{0}].resource is null or is not a CompartmentDefinition resource..
         /// </summary>
@@ -158,7 +158,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CompartmentDefinitionInvalidResource", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to bundle.entry[{0}].resource.url is invalid..
         /// </summary>
@@ -167,7 +167,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CompartmentDefinitionInvalidUrl", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to bundle.entry[{0}].resource has duplicate compartment definitions..
         /// </summary>
@@ -176,7 +176,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CompartmentDefinitionIsDupe", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Compartment id is null or empty..
         /// </summary>
@@ -185,7 +185,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CompartmentIdIsInvalid", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Compartment type {0} is invalid..
         /// </summary>
@@ -194,7 +194,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CompartmentTypeIsInvalid", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The composite separator cannot be found..
         /// </summary>
@@ -203,7 +203,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CompositeSeparatorNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Operation was not attempted because search criteria was not selective enough..
         /// </summary>
@@ -212,7 +212,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ConditionalOperationNotSelectiveEnough", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Found result with Id &apos;{0}&apos;, which did not match the provided Id &apos;{1}&apos;..
         /// </summary>
@@ -221,7 +221,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ConditionalUpdateMismatchedIds", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The prefix used to identify custom audit headers cannot be empty..
         /// </summary>
@@ -230,7 +230,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CustomHeaderPrefixCannotBeEmpty", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The date time string &apos;{0}&apos; is not in a correct format..
         /// </summary>
@@ -239,7 +239,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("DateTimeStringIsIncorrectlyFormatted", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to At least one portion of the date time string &apos;{0}&apos; is out of range..
         /// </summary>
@@ -248,7 +248,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("DateTimeStringIsOutOfRange", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Deleting a specific record version is not supported..
         /// </summary>
@@ -257,7 +257,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("DeleteVersionNotAllowed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to There are {0} roles with the name &apos;{1}&apos;.
         /// </summary>
@@ -266,7 +266,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("DuplicateRoleNames", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Error validating roles:
         ///{0}.
@@ -276,7 +276,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ErrorValidatingRoles", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Authorization failed..
         /// </summary>
@@ -285,7 +285,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("Forbidden", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Parameter {0} cannot a be a value in the future..
         /// </summary>
@@ -294,7 +294,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("HistoryParameterBeforeCannotBeFuture", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Id must be any combination of upper or lower case ASCII letters (&apos;A&apos;..&apos;Z&apos;, and &apos;a&apos;..&apos;z&apos;), numerals (&apos;0&apos;..&apos;9&apos;), &apos;-&apos; and &apos;.&apos;, with a length limit of 64 characters. (This might be an integer, an un-prefixed OID, UUID, or any other identifier pattern that meets these constraints.).
         /// </summary>
@@ -303,7 +303,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("IdRequirements", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to A valid if-match header is required for resource type &apos;{0}&apos;..
         /// </summary>
@@ -312,7 +312,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("IfMatchHeaderRequiredForResource", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Illegal attribute name &apos;{0}&apos; on element &apos;{1}&apos;..
         /// </summary>
@@ -321,7 +321,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("IllegalHtmlAttribute", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Illegal element name &apos;{0}&apos;..
         /// </summary>
@@ -330,7 +330,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("IllegalHtmlElement", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The div element must not be empty or only whitespace..
         /// </summary>
@@ -339,7 +339,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("IllegalHtmlEmpty", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to XHTML content should be contained within a single &lt;div&gt; element..
         /// </summary>
@@ -348,7 +348,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("IllegalHtmlOuterDiv", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Error while parsing XHTML: {0} Line: {1} Col: {2}..
         /// </summary>
@@ -357,7 +357,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("IllegalHtmlParsingError", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The _include search cannot be used against the base route..
         /// </summary>
@@ -366,7 +366,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("IncludeCannotBeAgainstBase", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The _include search is missing the type to search..
         /// </summary>
@@ -375,16 +375,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("IncludeMissingType", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to The _revinclude search is missing the type to search..
-        /// </summary>
-        internal static string RevIncludeMissingType {
-            get {
-                return ResourceManager.GetString("RevIncludeMissingType", resourceCulture);
-            }
-        }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to reversed include iterate target type not specified is not supported..
         /// </summary>
@@ -402,7 +393,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("InvalidBooleanConfigSetting", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Given conditional reference &apos;{0}&apos; does not resolve to a resource..
         /// </summary>
@@ -411,7 +402,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("InvalidConditionalReference", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Resource type and query parameter must be present in a given request &apos;{0}&apos;..
         /// </summary>
@@ -420,7 +411,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("InvalidConditionalReferenceParameters", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Value &apos;{0}&apos; is not supported. Please select from the following list of supported capabilities: [{1}]..
         /// </summary>
@@ -429,7 +420,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("InvalidConfigSetting", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The continuation token is invalid..
         /// </summary>
@@ -438,7 +429,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("InvalidContinuationToken", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The count must be greater than zero..
         /// </summary>
@@ -447,7 +438,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("InvalidSearchCountSpecified", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The &apos;_total&apos; parameter value &apos;{0}&apos; is invalid. The supported values are: {1}..
         /// </summary>
@@ -456,7 +447,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("InvalidTotalParameter", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Invalid value for :missing modifier. Valid values are: true, false..
         /// </summary>
@@ -465,7 +456,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("InvalidValueTypeForMissingModifier", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The requested job &quot;{0}&quot; was not found..
         /// </summary>
@@ -474,7 +465,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("JobNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Malformed search value &apos;{0}&apos;..
         /// </summary>
@@ -483,7 +474,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("MalformedSearchValue", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Modifier &apos;{0}&apos; is not supported for search parameter &apos;{1}&apos;..
         /// </summary>
@@ -492,7 +483,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ModifierNotSupported", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Only one token separator can be specified..
         /// </summary>
@@ -501,7 +492,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("MoreThanOneTokenSeparatorSpecified", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to No more than two token separators can be specified..
         /// </summary>
@@ -510,7 +501,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("MoreThanTwoTokenSeparatorSpecified", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Query parameter &apos;{0}&apos; cannot be specified more than once..
         /// </summary>
@@ -519,7 +510,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("MultipleQueryParametersNotAllowed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Multiple sort parameters are currently not supported. Only a single sort parameter is supported..
         /// </summary>
@@ -528,7 +519,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("MultiSortParameterNotSupported", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to No search parameters found needing to be indexed.  Job cancelled..
         /// </summary>
@@ -537,7 +528,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("NoSearchParametersNeededToBeIndexed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The number of composite components specified for search parameter &apos;{0}&apos; exceeded the number of components defined..
         /// </summary>
@@ -546,7 +537,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("NumberOfCompositeComponentsExceeded", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Only equal comparator is supported for this search type..
         /// </summary>
@@ -555,7 +546,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("OnlyEqualComparatorIsSupported", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Only one modifier separator can be specified..
         /// </summary>
@@ -564,7 +555,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("OnlyOneModifierSeparatorSupported", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Only one active or paused reindex job allowed.  Cancel any previous jobs before submitting a new job..
         /// </summary>
@@ -573,7 +564,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("OnlyOneResourceJobAllowed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Failed to retrieve the OpenId configuration from the authentication provider..
         /// </summary>
@@ -582,7 +573,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("OpenIdConfiguration", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {0} operation failed for reason: {1}.
         /// </summary>
@@ -591,7 +582,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("OperationFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to  or .
         /// </summary>
@@ -600,7 +591,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("OrDelimiter", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to ReadHistory is disabled for resources of type &apos;{0}&apos;..
         /// </summary>
@@ -609,7 +600,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ReadHistoryDisabled", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Resource type &apos;{0}&apos; in the reference &apos;{1}&apos; is not supported..
         /// </summary>
@@ -618,7 +609,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ReferenceResourceTypeNotSupported", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Reindex job id {0} is in state {1} and cannot be cancelled..
         /// </summary>
@@ -627,7 +618,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ReindexJobInCompletedState", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The requested action is not allowed..
         /// </summary>
@@ -636,7 +627,16 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("RequestedActionNotAllowed", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A conditional create or update is currently being attempted with the same parameters..
+        /// </summary>
+        internal static string ResourceConflict {
+            get {
+                return ResourceManager.GetString("ResourceConflict", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to Resource creation is not allowed..
         /// </summary>
@@ -645,7 +645,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ResourceCreationNotAllowed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Resource type &apos;{0}&apos; with id &apos;{1}&apos; couldn&apos;t be found..
         /// </summary>
@@ -654,7 +654,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ResourceNotFoundById", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Resource type &apos;{0}&apos; with id &apos;{1}&apos; and version &apos;{2}&apos; couldn&apos;t be found..
         /// </summary>
@@ -663,7 +663,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ResourceNotFoundByIdAndVersion", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Resource type &apos;{0}&apos; is not supported..
         /// </summary>
@@ -672,7 +672,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ResourceNotSupported", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The requested resource exceeded the backing database&apos;s size limit..
         /// </summary>
@@ -681,7 +681,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ResourceTooLarge", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The supplied version &apos;{0}&apos; did not match..
         /// </summary>
@@ -690,7 +690,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ResourceVersionConflict", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The reverse chain search is missing the reference to search..
         /// </summary>
@@ -699,7 +699,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ReverseChainMissingReference", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The reverse chain search is missing the type to search..
         /// </summary>
@@ -708,7 +708,16 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ReverseChainMissingType", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The _revinclude search is missing the type to search..
+        /// </summary>
+        internal static string RevIncludeMissingType {
+            get {
+                return ResourceManager.GetString("RevIncludeMissingType", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to Comparator is not supported when multiple values are specified using OR search parameter..
         /// </summary>
@@ -717,7 +726,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchComparatorNotSupported", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The &apos;_count&apos; parameter exceeds limit configured for server. Current limit is {0} while `_count` parameter set to {1}..
         /// </summary>
@@ -726,7 +735,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParamaterCountExceedLimit", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The search parameter with definition URL &apos;{0}&apos; is not supported..
         /// </summary>
@@ -735,7 +744,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterByDefinitionUriNotSupported", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to bundle.entry[{0}].resource.base is not defined..
         /// </summary>
@@ -744,7 +753,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionBaseNotDefined", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to bundle.entry[{0}].component[{1}] cannot refer to a composite SearchParameter..
         /// </summary>
@@ -753,7 +762,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionComponentReferenceCannotBeComposite", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The search parameter definition contains one or more invalid entries..
         /// </summary>
@@ -762,7 +771,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionContainsInvalidEntry", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to A search parameter with the same definition URL &apos;{0}&apos; already exists..
         /// </summary>
@@ -771,7 +780,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionDuplicatedEntry", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to bundle.entry[{0}].component is null or empty..
         /// </summary>
@@ -780,7 +789,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionInvalidComponent", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to bundle.entry[{0}].component[{1}].expression is null or empty..
         /// </summary>
@@ -789,7 +798,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionInvalidComponentExpression", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to bundle.entry[{0}].component[{1}].definition.reference is null or empty or does not refer to a valid SearchParameter resource..
         /// </summary>
@@ -798,7 +807,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionInvalidComponentReference", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to bundle.entry[{0}].url is invalid..
         /// </summary>
@@ -807,7 +816,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionInvalidDefinitionUri", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to bundle.entry[{0}].resource.expression is null or empty..
         /// </summary>
@@ -816,7 +825,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionInvalidExpression", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to bundle.entry[{0}].resource is not a SearchParameter resource..
         /// </summary>
@@ -825,7 +834,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionInvalidResource", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Search parameter {0} is no longer supported and cannot be marked enabled..
         /// </summary>
@@ -834,7 +843,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterNoLongerSupported", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The search parameter &apos;{0}&apos; is not supported for resource type &apos;{1}&apos;..
         /// </summary>
@@ -843,7 +852,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterNotSupported", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The search sort parameter &apos;{0}&apos; is not supported..
         /// </summary>
@@ -852,7 +861,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchSortParameterNotSupported", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Microsoft FHIR Server.
         /// </summary>
@@ -861,7 +870,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ServerName", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The _sort parameter is not supported..
         /// </summary>
@@ -870,7 +879,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SortNotSupported", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Include result was truncated.
         /// </summary>
@@ -879,7 +888,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("TruncatedIncludeMessage", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Bundle type is not present. Possible values are: transaction or batch.
         /// </summary>
@@ -888,7 +897,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("TypeNotPresent", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Unable to delete secret from SecretStore.
         /// </summary>
@@ -897,7 +906,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("UnableToDeleteSecret", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Unable to get secret from SecretStore.
         /// </summary>
@@ -906,7 +915,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("UnableToGetSecret", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Unable to set secret in SecretStore.
         /// </summary>
@@ -915,7 +924,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("UnableToSetSecret", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Unknown Error..
         /// </summary>
@@ -924,7 +933,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("UnknownError", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Unsupported configuration found..
         /// </summary>
@@ -933,7 +942,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("UnsupportedConfigurationMessage", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The &apos;_total&apos; parameter value &apos;{0}&apos; is not supported. The supported values are: {1}..
         /// </summary>
@@ -942,7 +951,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("UnsupportedTotalParameter", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Resource id is required for updates..
         /// </summary>
@@ -951,7 +960,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("UpdateRequestsRequireId", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to User requested cancellation of operation..
         /// </summary>
@@ -960,7 +969,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("UserRequestedCancellation", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to All OK.
         /// </summary>
@@ -969,7 +978,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ValidationPassed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to VersionId should not be in the weak ETag format..
         /// </summary>
@@ -978,7 +987,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("VersionIdFormatNotETag", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to WeakETag must be in the weak ETag format..
         /// </summary>

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -450,4 +450,7 @@
     <value>Reindex job id {0} is in state {1} and cannot be cancelled.</value>
     <comment>{0} is the id of the reindex which is a a GUID.  {1} is the state, an enumerated set of state values.</comment>
   </data>
+  <data name="ResourceConflict" xml:space="preserve">
+    <value>A conditional create or update is currently being attempted with the same parameters.</value>
+  </data>
 </root>

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/ConditionalCreateLockingBehavior.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/ConditionalCreateLockingBehavior.cs
@@ -1,0 +1,84 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using EnsureThat;
+using MediatR;
+using Microsoft.Health.Core.Extensions;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Microsoft.Health.Fhir.Core.Messages.Create;
+using Microsoft.Health.Fhir.Core.Messages.Upsert;
+
+namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
+{
+    /// <summary>
+    /// Intercepts ConditionalCreateResourceRequests and wraps them in a CosmosDbDistributedLock
+    /// </summary>
+    public class ConditionalCreateLockingBehavior
+        : IPipelineBehavior<ConditionalCreateResourceRequest, UpsertResourceResponse>,
+            IPipelineBehavior<ConditionalUpsertResourceRequest, UpsertResourceResponse>
+    {
+        private readonly ICosmosDbDistributedLockFactory _lockFactory;
+
+        public ConditionalCreateLockingBehavior(ICosmosDbDistributedLockFactory lockFactory)
+        {
+            EnsureArg.IsNotNull(lockFactory, nameof(lockFactory));
+
+            _lockFactory = lockFactory;
+        }
+
+        public async Task<UpsertResourceResponse> Handle(ConditionalCreateResourceRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<UpsertResourceResponse> next)
+        {
+            EnsureArg.IsNotNull(request, nameof(request));
+            EnsureArg.IsNotNull(next, nameof(next));
+
+            return await Execute(request.Resource.InstanceType, request.ConditionalParameters, next);
+        }
+
+        public async Task<UpsertResourceResponse> Handle(ConditionalUpsertResourceRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<UpsertResourceResponse> next)
+        {
+            EnsureArg.IsNotNull(request, nameof(request));
+            EnsureArg.IsNotNull(next, nameof(next));
+
+            return await Execute(request.Resource.InstanceType, request.ConditionalParameters, next);
+        }
+
+        private async Task<UpsertResourceResponse> Execute(string resourceType, IReadOnlyList<Tuple<string, string>> conditions, RequestHandlerDelegate<UpsertResourceResponse> next)
+        {
+            EnsureArg.IsNotNullOrEmpty(resourceType, nameof(resourceType));
+            EnsureArg.IsNotNull(conditions, nameof(conditions));
+            EnsureArg.IsNotNull(next, nameof(next));
+
+            var hashBuilder = new StringBuilder();
+            conditions.Aggregate(hashBuilder, (builder, tuple) => builder.AppendFormat("{0}={1}&", tuple.Item1, tuple.Item2));
+
+            var conditionalHash = hashBuilder.ToString().ComputeHash();
+            ICosmosDbDistributedLock lockDocument = _lockFactory.Create($"ConditionalCreate:{resourceType}:{conditionalHash}");
+
+            UpsertResourceResponse response;
+            try
+            {
+                if (await lockDocument.TryAcquireLock() == false)
+                {
+                    // This is a fast-fail lock acquisition, if a lock cannot be obtained, return a conflict
+                    throw new ResourceConflictException(Core.Resources.ResourceConflict);
+                }
+
+                response = await next();
+            }
+            finally
+            {
+                await lockDocument.DisposeAsync();
+            }
+
+            return response;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
@@ -199,6 +199,10 @@ namespace Microsoft.Extensions.DependencyInjection
             // FhirCosmosClientInitializer is Singleton, so provide a factory that can resolve new RequestHandlers
             services.AddFactory<IEnumerable<RequestHandler>>();
 
+            services.Add<ConditionalCreateLockingBehavior>()
+                .Transient()
+                .AsImplementedInterfaces();
+
             return fhirServerBuilder;
         }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/ConditionalCreateTransactionBehavior.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/ConditionalCreateTransactionBehavior.cs
@@ -1,0 +1,103 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Threading;
+using System.Threading.Tasks;
+using EnsureThat;
+using MediatR;
+using Microsoft.Data.SqlClient;
+using Microsoft.Health.Abstractions.Features.Transactions;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Microsoft.Health.Fhir.Core.Messages.Create;
+using Microsoft.Health.Fhir.Core.Messages.Upsert;
+using Microsoft.Health.SqlServer.Features.Client;
+using Microsoft.Health.SqlServer.Features.Storage;
+using IsolationLevel = System.Data.IsolationLevel;
+
+namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
+{
+    /// <summary>
+    /// Intercepts ConditionalCreateResourceRequests and wraps them in a SQL Transaction
+    /// </summary>
+    public class ConditionalCreateTransactionBehavior
+        : IPipelineBehavior<ConditionalCreateResourceRequest, UpsertResourceResponse>,
+            IPipelineBehavior<ConditionalUpsertResourceRequest, UpsertResourceResponse>
+    {
+        private readonly ITransactionHandler _transactionHandler;
+        private readonly SqlConnectionWrapperFactory _wrapperFactory;
+
+        public ConditionalCreateTransactionBehavior(
+            ITransactionHandler transactionHandler,
+            SqlConnectionWrapperFactory wrapperFactory)
+        {
+            EnsureArg.IsNotNull(transactionHandler, nameof(transactionHandler));
+            EnsureArg.IsNotNull(wrapperFactory, nameof(wrapperFactory));
+
+            _transactionHandler = transactionHandler;
+            _wrapperFactory = wrapperFactory;
+        }
+
+        public async Task<UpsertResourceResponse> Handle(ConditionalCreateResourceRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<UpsertResourceResponse> next)
+        {
+            EnsureArg.IsNotNull(request, nameof(request));
+            EnsureArg.IsNotNull(next, nameof(next));
+
+            return await Execute(next, cancellationToken);
+        }
+
+        public async Task<UpsertResourceResponse> Handle(ConditionalUpsertResourceRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<UpsertResourceResponse> next)
+        {
+            EnsureArg.IsNotNull(request, nameof(request));
+            EnsureArg.IsNotNull(next, nameof(next));
+
+            return await Execute(next, cancellationToken);
+        }
+
+        private async Task<UpsertResourceResponse> Execute(RequestHandlerDelegate<UpsertResourceResponse> next, CancellationToken cancellationToken)
+        {
+            EnsureArg.IsNotNull(next, nameof(next));
+
+            UpsertResourceResponse result;
+            try
+            {
+                SqlTransactionScope transactionScope = null;
+
+                try
+                {
+                    if (_transactionHandler is SqlTransactionHandler sqlTransactionHandler && sqlTransactionHandler.SqlTransactionScope == null)
+                    {
+                        transactionScope = (SqlTransactionScope)sqlTransactionHandler.BeginTransaction();
+
+                        // Create a transaction only if one doesn't already exist. This could be executed from within Bundle processing
+                        if (transactionScope.SqlTransaction == null)
+                        {
+                            // These variables will be disposed by transactionScope
+                            SqlConnectionWrapper wrapper = await _wrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken);
+                            SqlTransaction trans = wrapper.SqlConnection.BeginTransaction(IsolationLevel.Serializable);
+
+                            transactionScope.SqlConnection = wrapper.SqlConnection;
+                            transactionScope.SqlTransaction = trans;
+                        }
+                    }
+
+                    result = await next();
+                    transactionScope?.Complete();
+                }
+                finally
+                {
+                    transactionScope?.Dispose();
+                }
+
+                return result;
+            }
+            catch (SqlException ex) when (ex.Number == 1205)
+            {
+                // Handles threads that were rejected by a SQL deadlock on the current resources
+                // 1205: https://docs.microsoft.com/en-us/sql/relational-databases/errors-events/mssqlserver-1205-database-engine-error?view=sql-server-ver15
+                throw new ResourceConflictException(Core.Resources.ResourceConflict);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
@@ -82,6 +82,10 @@ namespace Microsoft.Extensions.DependencyInjection
                 .Singleton()
                 .AsSelf();
 
+            services.Add<ConditionalCreateTransactionBehavior>()
+                .Transient()
+                .AsImplementedInterfaces();
+
             return fhirServerBuilder;
         }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Metric/MetricTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Metric/MetricTests.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Metric
             await ExecuteAndValidate(
                 () => _client.PostBundleAsync(Samples.GetDefaultBatch().ToPoco()),
                 (type: typeof(ApiResponseNotification), count: 1, resourceType: Samples.GetDefaultBatch().ToPoco().ResourceType.ToString()),
-                (type: typeof(CosmosStorageRequestMetricsNotification), count: 10, resourceType: Samples.GetDefaultBatch().ToPoco().ResourceType.ToString()));
+                (type: typeof(CosmosStorageRequestMetricsNotification), count: 14, resourceType: Samples.GetDefaultBatch().ToPoco().ResourceType.ToString()));
         }
 
         [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]


### PR DESCRIPTION
## Description
Exploring solutions for adding concurrency safety around Conditional Creates/Updates.

- CosmosDB uses a lock document with `ResourceType:ConditionalParameters` as the key
- SQL wraps the operations in a `Serializable` transaction

One thread will succeed, other competing requests will result in a 409 conflict when competing with the same Condition.

### Known issues

- CosmosDB - Does not solve for the case were a resource could use a normal Create call which results in a resource that should be picked up by Conditional Create
- CosmosDB - Does not solve for the case where another concurrent Conditional Create uses a different search parameter that would result in the creation of the same resource

### When does this work?

- Conditional Create is highly utilized with the `identifier` parameter when importing or replicating data from another system. Under these circumstances, this solution would reject concurrent conditional creates with a 409.

Refs #1382