### PR TITLE
Feature/iterate cyclic unsupported

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/IncludeExpression.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/IncludeExpression.cs
@@ -51,7 +51,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
             WildCard = wildCard;
             Reversed = reversed;
             Iterate = iterate;
-            CircularReference = SourceResourceType == TargetResourceType || (ReferenceSearchParameter?.TargetResourceTypes != null && ReferenceSearchParameter.TargetResourceTypes.Contains(sourceResourceType));
+            CircularReference = TargetResourceType != null ? SourceResourceType == TargetResourceType
+                                                           : ReferenceSearchParameter?.TargetResourceTypes != null && ReferenceSearchParameter.TargetResourceTypes.Contains(sourceResourceType);
         }
 
         /// <summary>

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/IncludeExpression.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/IncludeExpression.cs
@@ -51,6 +51,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
             WildCard = wildCard;
             Reversed = reversed;
             Iterate = iterate;
+            CircularReference = SourceResourceType == TargetResourceType || (ReferenceSearchParameter?.TargetResourceTypes != null && ReferenceSearchParameter.TargetResourceTypes.Contains(sourceResourceType));
         }
 
         /// <summary>
@@ -89,7 +90,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         public IReadOnlyCollection<string> Produces => _produces ??= GetProducedResources();
 
         /// <summary>
-        /// Gets if the include is a wildcard include.
+        /// Gets if the expression is a wildcard include.
         /// </summary>
         public bool WildCard { get; }
 
@@ -99,9 +100,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         public bool Reversed { get; }
 
         /// <summary>
-        /// Gets if the include has :iterate (:recurse) modifier.
+        /// Gets if the expression has :iterate (:recurse) modifier.
         /// </summary>
         public bool Iterate { get; }
+
+        /// <summary>
+        /// Gets if the expression has a circular reference (source type = target type).
+        /// </summary>
+        public bool CircularReference { get; }
 
         public override TOutput AcceptVisitor<TContext, TOutput>(IExpressionVisitor<TContext, TOutput> visitor, TContext context)
         {

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -366,7 +366,16 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("IncludeCannotBeAgainstBase", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The include iterate circular reference executed once..
+        /// </summary>
+        internal static string IncludeIterateCircularReferenceExecutedOnce {
+            get {
+                return ResourceManager.GetString("IncludeIterateCircularReferenceExecutedOnce", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to The _include search is missing the type to search..
         /// </summary>
@@ -376,7 +385,7 @@ namespace Microsoft.Health.Fhir.Core {
             }
         }
 
-        /// <summary>
+        // <summary>
         ///   Looks up a localized string similar to The _revinclude search is missing the type to search..
         /// </summary>
         internal static string RevIncludeMissingType {
@@ -989,3 +998,4 @@ namespace Microsoft.Health.Fhir.Core {
         }
     }
 }
+

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -385,7 +385,7 @@ namespace Microsoft.Health.Fhir.Core {
             }
         }
 
-        // <summary>
+        /// <summary>
         ///   Looks up a localized string similar to The _revinclude search is missing the type to search..
         /// </summary>
         internal static string RevIncludeMissingType {

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -227,6 +227,10 @@
     <value>The _include search cannot be used against the base route.</value>
     <comment>_include is a query parameter.</comment>
   </data>
+  <data name="IncludeIterateCircularReferenceExecutedOnce" xml:space="preserve">
+    <value>The parameter {0}={1} with circular reference is executed once (a single iteration).</value>
+    <comment>_include:iterate or _revinclude:iterate is a query parameter.</comment>
+  </data>
   <data name="IncludeMissingType" xml:space="preserve">
     <value>The _include search is missing the type to search.</value>
     <comment>_include is a query parameter.</comment>

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -321,6 +321,17 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                         throw new BadRequestException(string.Format(Core.Resources.RevIncludeIterateTargetTypeNotSpecified, p.Item2));
                     }
 
+                    // For circular include iterate expressions, add an informational issue indicating that a single iteration is supported.
+                    // See https://www.hl7.org/fhir/search.html#revinclude.
+                    if (expression.Iterate && expression.CircularReference)
+                    {
+                        _contextAccessor.FhirRequestContext.BundleIssues.Add(
+                        new OperationOutcomeIssue(
+                            OperationOutcomeConstants.IssueSeverity.Information,
+                            OperationOutcomeConstants.IssueType.Informational,
+                            string.Format(Core.Resources.IncludeIterateCircularReferenceExecutedOnce, p.Item1, p.Item2)));
+                    }
+
                     return expression;
                 });
             }

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/IncludeRewriterTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/IncludeRewriterTests.cs
@@ -1615,7 +1615,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
                 },
                 new List<Expression>());
 
-            Assert.Throws<InvalidSearchOperationException>(() => ((SqlRootExpression)sqlExpression.AcceptVisitor(IncludeRewriter.Instance)).TableExpressions);
+            Assert.Throws<SearchOperationNotSupportedException>(() => ((SqlRootExpression)sqlExpression.AcceptVisitor(IncludeRewriter.Instance)).TableExpressions);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/VLatest.Generated.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/VLatest.Generated.cs
@@ -733,7 +733,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly TinyIntColumn CompartmentTypeId = new TinyIntColumn("CompartmentTypeId");
             internal readonly VarCharColumn ReferenceResourceId = new VarCharColumn("ReferenceResourceId", 64, "Latin1_General_100_CS_AS");
             protected override global::System.Collections.Generic.IEnumerable<Column> Columns => new Column[]{CompartmentTypeId, ReferenceResourceId};
-            protected override void FillSqlDataRecord(global::Microsoft.SqlServer.Server.SqlDataRecord record, CompartmentAssignmentTableTypeRow rowData)
+            protected override void FillSqlDataRecord(global::Microsoft.Data.SqlClient.Server.SqlDataRecord record, CompartmentAssignmentTableTypeRow rowData)
             {
                 CompartmentTypeId.Set(record, 0, rowData.CompartmentTypeId);
                 ReferenceResourceId.Set(record, 1, rowData.ReferenceResourceId);
@@ -770,7 +770,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly DateTimeOffsetColumn EndDateTime = new DateTimeOffsetColumn("EndDateTime", 7);
             internal readonly BitColumn IsLongerThanADay = new BitColumn("IsLongerThanADay");
             protected override global::System.Collections.Generic.IEnumerable<Column> Columns => new Column[]{SearchParamId, StartDateTime, EndDateTime, IsLongerThanADay};
-            protected override void FillSqlDataRecord(global::Microsoft.SqlServer.Server.SqlDataRecord record, DateTimeSearchParamTableTypeRow rowData)
+            protected override void FillSqlDataRecord(global::Microsoft.Data.SqlClient.Server.SqlDataRecord record, DateTimeSearchParamTableTypeRow rowData)
             {
                 SearchParamId.Set(record, 0, rowData.SearchParamId);
                 StartDateTime.Set(record, 1, rowData.StartDateTime);
@@ -821,7 +821,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly NullableDecimalColumn LowValue = new NullableDecimalColumn("LowValue", 18, 6);
             internal readonly NullableDecimalColumn HighValue = new NullableDecimalColumn("HighValue", 18, 6);
             protected override global::System.Collections.Generic.IEnumerable<Column> Columns => new Column[]{SearchParamId, SingleValue, LowValue, HighValue};
-            protected override void FillSqlDataRecord(global::Microsoft.SqlServer.Server.SqlDataRecord record, NumberSearchParamTableTypeRow rowData)
+            protected override void FillSqlDataRecord(global::Microsoft.Data.SqlClient.Server.SqlDataRecord record, NumberSearchParamTableTypeRow rowData)
             {
                 SearchParamId.Set(record, 0, rowData.SearchParamId);
                 SingleValue.Set(record, 1, rowData.SingleValue);
@@ -874,7 +874,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly NullableDecimalColumn LowValue = new NullableDecimalColumn("LowValue", 18, 6);
             internal readonly NullableDecimalColumn HighValue = new NullableDecimalColumn("HighValue", 18, 6);
             protected override global::System.Collections.Generic.IEnumerable<Column> Columns => new Column[]{SearchParamId, SystemId, QuantityCodeId, SingleValue, LowValue, HighValue};
-            protected override void FillSqlDataRecord(global::Microsoft.SqlServer.Server.SqlDataRecord record, QuantitySearchParamTableTypeRow rowData)
+            protected override void FillSqlDataRecord(global::Microsoft.Data.SqlClient.Server.SqlDataRecord record, QuantitySearchParamTableTypeRow rowData)
             {
                 SearchParamId.Set(record, 0, rowData.SearchParamId);
                 SystemId.Set(record, 1, rowData.SystemId);
@@ -940,7 +940,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly VarCharColumn ReferenceResourceId = new VarCharColumn("ReferenceResourceId", 64, "Latin1_General_100_CS_AS");
             internal readonly NullableIntColumn ReferenceResourceVersion = new NullableIntColumn("ReferenceResourceVersion");
             protected override global::System.Collections.Generic.IEnumerable<Column> Columns => new Column[]{SearchParamId, BaseUri, ReferenceResourceTypeId, ReferenceResourceId, ReferenceResourceVersion};
-            protected override void FillSqlDataRecord(global::Microsoft.SqlServer.Server.SqlDataRecord record, ReferenceSearchParamTableTypeRow rowData)
+            protected override void FillSqlDataRecord(global::Microsoft.Data.SqlClient.Server.SqlDataRecord record, ReferenceSearchParamTableTypeRow rowData)
             {
                 SearchParamId.Set(record, 0, rowData.SearchParamId);
                 BaseUri.Set(record, 1, rowData.BaseUri);
@@ -1001,7 +1001,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly NullableIntColumn SystemId2 = new NullableIntColumn("SystemId2");
             internal readonly VarCharColumn Code2 = new VarCharColumn("Code2", 128, "Latin1_General_100_CS_AS");
             protected override global::System.Collections.Generic.IEnumerable<Column> Columns => new Column[]{SearchParamId, BaseUri1, ReferenceResourceTypeId1, ReferenceResourceId1, ReferenceResourceVersion1, SystemId2, Code2};
-            protected override void FillSqlDataRecord(global::Microsoft.SqlServer.Server.SqlDataRecord record, ReferenceTokenCompositeSearchParamTableTypeRow rowData)
+            protected override void FillSqlDataRecord(global::Microsoft.Data.SqlClient.Server.SqlDataRecord record, ReferenceTokenCompositeSearchParamTableTypeRow rowData)
             {
                 SearchParamId.Set(record, 0, rowData.SearchParamId);
                 BaseUri1.Set(record, 1, rowData.BaseUri1);
@@ -1071,7 +1071,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly TinyIntColumn ClaimTypeId = new TinyIntColumn("ClaimTypeId");
             internal readonly NVarCharColumn ClaimValue = new NVarCharColumn("ClaimValue", 128);
             protected override global::System.Collections.Generic.IEnumerable<Column> Columns => new Column[]{ClaimTypeId, ClaimValue};
-            protected override void FillSqlDataRecord(global::Microsoft.SqlServer.Server.SqlDataRecord record, ResourceWriteClaimTableTypeRow rowData)
+            protected override void FillSqlDataRecord(global::Microsoft.Data.SqlClient.Server.SqlDataRecord record, ResourceWriteClaimTableTypeRow rowData)
             {
                 ClaimTypeId.Set(record, 0, rowData.ClaimTypeId);
                 ClaimValue.Set(record, 1, rowData.ClaimValue);
@@ -1107,7 +1107,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly NVarCharColumn Text = new NVarCharColumn("Text", 256, "Latin1_General_100_CI_AI_SC");
             internal readonly NullableNVarCharColumn TextOverflow = new NullableNVarCharColumn("TextOverflow", -1, "Latin1_General_100_CI_AI_SC");
             protected override global::System.Collections.Generic.IEnumerable<Column> Columns => new Column[]{SearchParamId, Text, TextOverflow};
-            protected override void FillSqlDataRecord(global::Microsoft.SqlServer.Server.SqlDataRecord record, StringSearchParamTableTypeRow rowData)
+            protected override void FillSqlDataRecord(global::Microsoft.Data.SqlClient.Server.SqlDataRecord record, StringSearchParamTableTypeRow rowData)
             {
                 SearchParamId.Set(record, 0, rowData.SearchParamId);
                 Text.Set(record, 1, rowData.Text);
@@ -1153,7 +1153,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly DateTimeOffsetColumn EndDateTime2 = new DateTimeOffsetColumn("EndDateTime2", 7);
             internal readonly BitColumn IsLongerThanADay2 = new BitColumn("IsLongerThanADay2");
             protected override global::System.Collections.Generic.IEnumerable<Column> Columns => new Column[]{SearchParamId, SystemId1, Code1, StartDateTime2, EndDateTime2, IsLongerThanADay2};
-            protected override void FillSqlDataRecord(global::Microsoft.SqlServer.Server.SqlDataRecord record, TokenDateTimeCompositeSearchParamTableTypeRow rowData)
+            protected override void FillSqlDataRecord(global::Microsoft.Data.SqlClient.Server.SqlDataRecord record, TokenDateTimeCompositeSearchParamTableTypeRow rowData)
             {
                 SearchParamId.Set(record, 0, rowData.SearchParamId);
                 SystemId1.Set(record, 1, rowData.SystemId1);
@@ -1224,7 +1224,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly NullableDecimalColumn HighValue3 = new NullableDecimalColumn("HighValue3", 18, 6);
             internal readonly BitColumn HasRange = new BitColumn("HasRange");
             protected override global::System.Collections.Generic.IEnumerable<Column> Columns => new Column[]{SearchParamId, SystemId1, Code1, SingleValue2, LowValue2, HighValue2, SingleValue3, LowValue3, HighValue3, HasRange};
-            protected override void FillSqlDataRecord(global::Microsoft.SqlServer.Server.SqlDataRecord record, TokenNumberNumberCompositeSearchParamTableTypeRow rowData)
+            protected override void FillSqlDataRecord(global::Microsoft.Data.SqlClient.Server.SqlDataRecord record, TokenNumberNumberCompositeSearchParamTableTypeRow rowData)
             {
                 SearchParamId.Set(record, 0, rowData.SearchParamId);
                 SystemId1.Set(record, 1, rowData.SystemId1);
@@ -1321,7 +1321,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly NullableDecimalColumn LowValue2 = new NullableDecimalColumn("LowValue2", 18, 6);
             internal readonly NullableDecimalColumn HighValue2 = new NullableDecimalColumn("HighValue2", 18, 6);
             protected override global::System.Collections.Generic.IEnumerable<Column> Columns => new Column[]{SearchParamId, SystemId1, Code1, SystemId2, QuantityCodeId2, SingleValue2, LowValue2, HighValue2};
-            protected override void FillSqlDataRecord(global::Microsoft.SqlServer.Server.SqlDataRecord record, TokenQuantityCompositeSearchParamTableTypeRow rowData)
+            protected override void FillSqlDataRecord(global::Microsoft.Data.SqlClient.Server.SqlDataRecord record, TokenQuantityCompositeSearchParamTableTypeRow rowData)
             {
                 SearchParamId.Set(record, 0, rowData.SearchParamId);
                 SystemId1.Set(record, 1, rowData.SystemId1);
@@ -1399,7 +1399,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly NullableIntColumn SystemId = new NullableIntColumn("SystemId");
             internal readonly VarCharColumn Code = new VarCharColumn("Code", 128, "Latin1_General_100_CS_AS");
             protected override global::System.Collections.Generic.IEnumerable<Column> Columns => new Column[]{SearchParamId, SystemId, Code};
-            protected override void FillSqlDataRecord(global::Microsoft.SqlServer.Server.SqlDataRecord record, TokenSearchParamTableTypeRow rowData)
+            protected override void FillSqlDataRecord(global::Microsoft.Data.SqlClient.Server.SqlDataRecord record, TokenSearchParamTableTypeRow rowData)
             {
                 SearchParamId.Set(record, 0, rowData.SearchParamId);
                 SystemId.Set(record, 1, rowData.SystemId);
@@ -1444,7 +1444,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly NVarCharColumn Text2 = new NVarCharColumn("Text2", 256, "Latin1_General_100_CI_AI_SC");
             internal readonly NullableNVarCharColumn TextOverflow2 = new NullableNVarCharColumn("TextOverflow2", -1, "Latin1_General_100_CI_AI_SC");
             protected override global::System.Collections.Generic.IEnumerable<Column> Columns => new Column[]{SearchParamId, SystemId1, Code1, Text2, TextOverflow2};
-            protected override void FillSqlDataRecord(global::Microsoft.SqlServer.Server.SqlDataRecord record, TokenStringCompositeSearchParamTableTypeRow rowData)
+            protected override void FillSqlDataRecord(global::Microsoft.Data.SqlClient.Server.SqlDataRecord record, TokenStringCompositeSearchParamTableTypeRow rowData)
             {
                 SearchParamId.Set(record, 0, rowData.SearchParamId);
                 SystemId1.Set(record, 1, rowData.SystemId1);
@@ -1500,7 +1500,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly SmallIntColumn SearchParamId = new SmallIntColumn("SearchParamId");
             internal readonly NVarCharColumn Text = new NVarCharColumn("Text", 400, "Latin1_General_CI_AI");
             protected override global::System.Collections.Generic.IEnumerable<Column> Columns => new Column[]{SearchParamId, Text};
-            protected override void FillSqlDataRecord(global::Microsoft.SqlServer.Server.SqlDataRecord record, TokenTextTableTypeRow rowData)
+            protected override void FillSqlDataRecord(global::Microsoft.Data.SqlClient.Server.SqlDataRecord record, TokenTextTableTypeRow rowData)
             {
                 SearchParamId.Set(record, 0, rowData.SearchParamId);
                 Text.Set(record, 1, rowData.Text);
@@ -1538,7 +1538,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly NullableIntColumn SystemId2 = new NullableIntColumn("SystemId2");
             internal readonly VarCharColumn Code2 = new VarCharColumn("Code2", 128, "Latin1_General_100_CS_AS");
             protected override global::System.Collections.Generic.IEnumerable<Column> Columns => new Column[]{SearchParamId, SystemId1, Code1, SystemId2, Code2};
-            protected override void FillSqlDataRecord(global::Microsoft.SqlServer.Server.SqlDataRecord record, TokenTokenCompositeSearchParamTableTypeRow rowData)
+            protected override void FillSqlDataRecord(global::Microsoft.Data.SqlClient.Server.SqlDataRecord record, TokenTokenCompositeSearchParamTableTypeRow rowData)
             {
                 SearchParamId.Set(record, 0, rowData.SearchParamId);
                 SystemId1.Set(record, 1, rowData.SystemId1);
@@ -1594,7 +1594,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly SmallIntColumn SearchParamId = new SmallIntColumn("SearchParamId");
             internal readonly VarCharColumn Uri = new VarCharColumn("Uri", 256, "Latin1_General_100_CS_AS");
             protected override global::System.Collections.Generic.IEnumerable<Column> Columns => new Column[]{SearchParamId, Uri};
-            protected override void FillSqlDataRecord(global::Microsoft.SqlServer.Server.SqlDataRecord record, UriSearchParamTableTypeRow rowData)
+            protected override void FillSqlDataRecord(global::Microsoft.Data.SqlClient.Server.SqlDataRecord record, UriSearchParamTableTypeRow rowData)
             {
                 SearchParamId.Set(record, 0, rowData.SearchParamId);
                 Uri.Set(record, 1, rowData.Uri);

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/VLatest.Generated.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Model/VLatest.Generated.cs
@@ -733,7 +733,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly TinyIntColumn CompartmentTypeId = new TinyIntColumn("CompartmentTypeId");
             internal readonly VarCharColumn ReferenceResourceId = new VarCharColumn("ReferenceResourceId", 64, "Latin1_General_100_CS_AS");
             protected override global::System.Collections.Generic.IEnumerable<Column> Columns => new Column[]{CompartmentTypeId, ReferenceResourceId};
-            protected override void FillSqlDataRecord(global::Microsoft.Data.SqlClient.Server.SqlDataRecord record, CompartmentAssignmentTableTypeRow rowData)
+            protected override void FillSqlDataRecord(global::Microsoft.SqlServer.Server.SqlDataRecord record, CompartmentAssignmentTableTypeRow rowData)
             {
                 CompartmentTypeId.Set(record, 0, rowData.CompartmentTypeId);
                 ReferenceResourceId.Set(record, 1, rowData.ReferenceResourceId);
@@ -770,7 +770,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly DateTimeOffsetColumn EndDateTime = new DateTimeOffsetColumn("EndDateTime", 7);
             internal readonly BitColumn IsLongerThanADay = new BitColumn("IsLongerThanADay");
             protected override global::System.Collections.Generic.IEnumerable<Column> Columns => new Column[]{SearchParamId, StartDateTime, EndDateTime, IsLongerThanADay};
-            protected override void FillSqlDataRecord(global::Microsoft.Data.SqlClient.Server.SqlDataRecord record, DateTimeSearchParamTableTypeRow rowData)
+            protected override void FillSqlDataRecord(global::Microsoft.SqlServer.Server.SqlDataRecord record, DateTimeSearchParamTableTypeRow rowData)
             {
                 SearchParamId.Set(record, 0, rowData.SearchParamId);
                 StartDateTime.Set(record, 1, rowData.StartDateTime);
@@ -821,7 +821,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly NullableDecimalColumn LowValue = new NullableDecimalColumn("LowValue", 18, 6);
             internal readonly NullableDecimalColumn HighValue = new NullableDecimalColumn("HighValue", 18, 6);
             protected override global::System.Collections.Generic.IEnumerable<Column> Columns => new Column[]{SearchParamId, SingleValue, LowValue, HighValue};
-            protected override void FillSqlDataRecord(global::Microsoft.Data.SqlClient.Server.SqlDataRecord record, NumberSearchParamTableTypeRow rowData)
+            protected override void FillSqlDataRecord(global::Microsoft.SqlServer.Server.SqlDataRecord record, NumberSearchParamTableTypeRow rowData)
             {
                 SearchParamId.Set(record, 0, rowData.SearchParamId);
                 SingleValue.Set(record, 1, rowData.SingleValue);
@@ -874,7 +874,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly NullableDecimalColumn LowValue = new NullableDecimalColumn("LowValue", 18, 6);
             internal readonly NullableDecimalColumn HighValue = new NullableDecimalColumn("HighValue", 18, 6);
             protected override global::System.Collections.Generic.IEnumerable<Column> Columns => new Column[]{SearchParamId, SystemId, QuantityCodeId, SingleValue, LowValue, HighValue};
-            protected override void FillSqlDataRecord(global::Microsoft.Data.SqlClient.Server.SqlDataRecord record, QuantitySearchParamTableTypeRow rowData)
+            protected override void FillSqlDataRecord(global::Microsoft.SqlServer.Server.SqlDataRecord record, QuantitySearchParamTableTypeRow rowData)
             {
                 SearchParamId.Set(record, 0, rowData.SearchParamId);
                 SystemId.Set(record, 1, rowData.SystemId);
@@ -940,7 +940,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly VarCharColumn ReferenceResourceId = new VarCharColumn("ReferenceResourceId", 64, "Latin1_General_100_CS_AS");
             internal readonly NullableIntColumn ReferenceResourceVersion = new NullableIntColumn("ReferenceResourceVersion");
             protected override global::System.Collections.Generic.IEnumerable<Column> Columns => new Column[]{SearchParamId, BaseUri, ReferenceResourceTypeId, ReferenceResourceId, ReferenceResourceVersion};
-            protected override void FillSqlDataRecord(global::Microsoft.Data.SqlClient.Server.SqlDataRecord record, ReferenceSearchParamTableTypeRow rowData)
+            protected override void FillSqlDataRecord(global::Microsoft.SqlServer.Server.SqlDataRecord record, ReferenceSearchParamTableTypeRow rowData)
             {
                 SearchParamId.Set(record, 0, rowData.SearchParamId);
                 BaseUri.Set(record, 1, rowData.BaseUri);
@@ -1001,7 +1001,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly NullableIntColumn SystemId2 = new NullableIntColumn("SystemId2");
             internal readonly VarCharColumn Code2 = new VarCharColumn("Code2", 128, "Latin1_General_100_CS_AS");
             protected override global::System.Collections.Generic.IEnumerable<Column> Columns => new Column[]{SearchParamId, BaseUri1, ReferenceResourceTypeId1, ReferenceResourceId1, ReferenceResourceVersion1, SystemId2, Code2};
-            protected override void FillSqlDataRecord(global::Microsoft.Data.SqlClient.Server.SqlDataRecord record, ReferenceTokenCompositeSearchParamTableTypeRow rowData)
+            protected override void FillSqlDataRecord(global::Microsoft.SqlServer.Server.SqlDataRecord record, ReferenceTokenCompositeSearchParamTableTypeRow rowData)
             {
                 SearchParamId.Set(record, 0, rowData.SearchParamId);
                 BaseUri1.Set(record, 1, rowData.BaseUri1);
@@ -1071,7 +1071,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly TinyIntColumn ClaimTypeId = new TinyIntColumn("ClaimTypeId");
             internal readonly NVarCharColumn ClaimValue = new NVarCharColumn("ClaimValue", 128);
             protected override global::System.Collections.Generic.IEnumerable<Column> Columns => new Column[]{ClaimTypeId, ClaimValue};
-            protected override void FillSqlDataRecord(global::Microsoft.Data.SqlClient.Server.SqlDataRecord record, ResourceWriteClaimTableTypeRow rowData)
+            protected override void FillSqlDataRecord(global::Microsoft.SqlServer.Server.SqlDataRecord record, ResourceWriteClaimTableTypeRow rowData)
             {
                 ClaimTypeId.Set(record, 0, rowData.ClaimTypeId);
                 ClaimValue.Set(record, 1, rowData.ClaimValue);
@@ -1107,7 +1107,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly NVarCharColumn Text = new NVarCharColumn("Text", 256, "Latin1_General_100_CI_AI_SC");
             internal readonly NullableNVarCharColumn TextOverflow = new NullableNVarCharColumn("TextOverflow", -1, "Latin1_General_100_CI_AI_SC");
             protected override global::System.Collections.Generic.IEnumerable<Column> Columns => new Column[]{SearchParamId, Text, TextOverflow};
-            protected override void FillSqlDataRecord(global::Microsoft.Data.SqlClient.Server.SqlDataRecord record, StringSearchParamTableTypeRow rowData)
+            protected override void FillSqlDataRecord(global::Microsoft.SqlServer.Server.SqlDataRecord record, StringSearchParamTableTypeRow rowData)
             {
                 SearchParamId.Set(record, 0, rowData.SearchParamId);
                 Text.Set(record, 1, rowData.Text);
@@ -1153,7 +1153,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly DateTimeOffsetColumn EndDateTime2 = new DateTimeOffsetColumn("EndDateTime2", 7);
             internal readonly BitColumn IsLongerThanADay2 = new BitColumn("IsLongerThanADay2");
             protected override global::System.Collections.Generic.IEnumerable<Column> Columns => new Column[]{SearchParamId, SystemId1, Code1, StartDateTime2, EndDateTime2, IsLongerThanADay2};
-            protected override void FillSqlDataRecord(global::Microsoft.Data.SqlClient.Server.SqlDataRecord record, TokenDateTimeCompositeSearchParamTableTypeRow rowData)
+            protected override void FillSqlDataRecord(global::Microsoft.SqlServer.Server.SqlDataRecord record, TokenDateTimeCompositeSearchParamTableTypeRow rowData)
             {
                 SearchParamId.Set(record, 0, rowData.SearchParamId);
                 SystemId1.Set(record, 1, rowData.SystemId1);
@@ -1224,7 +1224,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly NullableDecimalColumn HighValue3 = new NullableDecimalColumn("HighValue3", 18, 6);
             internal readonly BitColumn HasRange = new BitColumn("HasRange");
             protected override global::System.Collections.Generic.IEnumerable<Column> Columns => new Column[]{SearchParamId, SystemId1, Code1, SingleValue2, LowValue2, HighValue2, SingleValue3, LowValue3, HighValue3, HasRange};
-            protected override void FillSqlDataRecord(global::Microsoft.Data.SqlClient.Server.SqlDataRecord record, TokenNumberNumberCompositeSearchParamTableTypeRow rowData)
+            protected override void FillSqlDataRecord(global::Microsoft.SqlServer.Server.SqlDataRecord record, TokenNumberNumberCompositeSearchParamTableTypeRow rowData)
             {
                 SearchParamId.Set(record, 0, rowData.SearchParamId);
                 SystemId1.Set(record, 1, rowData.SystemId1);
@@ -1321,7 +1321,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly NullableDecimalColumn LowValue2 = new NullableDecimalColumn("LowValue2", 18, 6);
             internal readonly NullableDecimalColumn HighValue2 = new NullableDecimalColumn("HighValue2", 18, 6);
             protected override global::System.Collections.Generic.IEnumerable<Column> Columns => new Column[]{SearchParamId, SystemId1, Code1, SystemId2, QuantityCodeId2, SingleValue2, LowValue2, HighValue2};
-            protected override void FillSqlDataRecord(global::Microsoft.Data.SqlClient.Server.SqlDataRecord record, TokenQuantityCompositeSearchParamTableTypeRow rowData)
+            protected override void FillSqlDataRecord(global::Microsoft.SqlServer.Server.SqlDataRecord record, TokenQuantityCompositeSearchParamTableTypeRow rowData)
             {
                 SearchParamId.Set(record, 0, rowData.SearchParamId);
                 SystemId1.Set(record, 1, rowData.SystemId1);
@@ -1399,7 +1399,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly NullableIntColumn SystemId = new NullableIntColumn("SystemId");
             internal readonly VarCharColumn Code = new VarCharColumn("Code", 128, "Latin1_General_100_CS_AS");
             protected override global::System.Collections.Generic.IEnumerable<Column> Columns => new Column[]{SearchParamId, SystemId, Code};
-            protected override void FillSqlDataRecord(global::Microsoft.Data.SqlClient.Server.SqlDataRecord record, TokenSearchParamTableTypeRow rowData)
+            protected override void FillSqlDataRecord(global::Microsoft.SqlServer.Server.SqlDataRecord record, TokenSearchParamTableTypeRow rowData)
             {
                 SearchParamId.Set(record, 0, rowData.SearchParamId);
                 SystemId.Set(record, 1, rowData.SystemId);
@@ -1444,7 +1444,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly NVarCharColumn Text2 = new NVarCharColumn("Text2", 256, "Latin1_General_100_CI_AI_SC");
             internal readonly NullableNVarCharColumn TextOverflow2 = new NullableNVarCharColumn("TextOverflow2", -1, "Latin1_General_100_CI_AI_SC");
             protected override global::System.Collections.Generic.IEnumerable<Column> Columns => new Column[]{SearchParamId, SystemId1, Code1, Text2, TextOverflow2};
-            protected override void FillSqlDataRecord(global::Microsoft.Data.SqlClient.Server.SqlDataRecord record, TokenStringCompositeSearchParamTableTypeRow rowData)
+            protected override void FillSqlDataRecord(global::Microsoft.SqlServer.Server.SqlDataRecord record, TokenStringCompositeSearchParamTableTypeRow rowData)
             {
                 SearchParamId.Set(record, 0, rowData.SearchParamId);
                 SystemId1.Set(record, 1, rowData.SystemId1);
@@ -1500,7 +1500,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly SmallIntColumn SearchParamId = new SmallIntColumn("SearchParamId");
             internal readonly NVarCharColumn Text = new NVarCharColumn("Text", 400, "Latin1_General_CI_AI");
             protected override global::System.Collections.Generic.IEnumerable<Column> Columns => new Column[]{SearchParamId, Text};
-            protected override void FillSqlDataRecord(global::Microsoft.Data.SqlClient.Server.SqlDataRecord record, TokenTextTableTypeRow rowData)
+            protected override void FillSqlDataRecord(global::Microsoft.SqlServer.Server.SqlDataRecord record, TokenTextTableTypeRow rowData)
             {
                 SearchParamId.Set(record, 0, rowData.SearchParamId);
                 Text.Set(record, 1, rowData.Text);
@@ -1538,7 +1538,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly NullableIntColumn SystemId2 = new NullableIntColumn("SystemId2");
             internal readonly VarCharColumn Code2 = new VarCharColumn("Code2", 128, "Latin1_General_100_CS_AS");
             protected override global::System.Collections.Generic.IEnumerable<Column> Columns => new Column[]{SearchParamId, SystemId1, Code1, SystemId2, Code2};
-            protected override void FillSqlDataRecord(global::Microsoft.Data.SqlClient.Server.SqlDataRecord record, TokenTokenCompositeSearchParamTableTypeRow rowData)
+            protected override void FillSqlDataRecord(global::Microsoft.SqlServer.Server.SqlDataRecord record, TokenTokenCompositeSearchParamTableTypeRow rowData)
             {
                 SearchParamId.Set(record, 0, rowData.SearchParamId);
                 SystemId1.Set(record, 1, rowData.SystemId1);
@@ -1594,7 +1594,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema.Model
             internal readonly SmallIntColumn SearchParamId = new SmallIntColumn("SearchParamId");
             internal readonly VarCharColumn Uri = new VarCharColumn("Uri", 256, "Latin1_General_100_CS_AS");
             protected override global::System.Collections.Generic.IEnumerable<Column> Columns => new Column[]{SearchParamId, Uri};
-            protected override void FillSqlDataRecord(global::Microsoft.Data.SqlClient.Server.SqlDataRecord record, UriSearchParamTableTypeRow rowData)
+            protected override void FillSqlDataRecord(global::Microsoft.SqlServer.Server.SqlDataRecord record, UriSearchParamTableTypeRow rowData)
             {
                 SearchParamId.Set(record, 0, rowData.SearchParamId);
                 Uri.Set(record, 1, rowData.Uri);

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/IncludeRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/IncludeRewriter.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
             // If there are edges, then the graph contains a cycle
             if (graph.OutgoingEdges.Any())
             {
-                throw new InvalidSearchOperationException("Cyclic include iterate queries are not allowed");
+                throw new SearchOperationNotSupportedException(Resources.CyclicIncludeIterateNotSupported);
             }
 
             return sortedExpressions;

--- a/src/Microsoft.Health.Fhir.SqlServer/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Resources.Designer.cs
@@ -77,5 +77,14 @@ namespace Microsoft.Health.Fhir.SqlServer {
                 return ResourceManager.GetString("TransactionProcessingException", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cyclic Include Iterate Not Supported..
+        /// </summary>
+        internal static string CyclicIncludeIterateNotSupported {
+            get {
+                return ResourceManager.GetString("CyclicIncludeIterateNotSupported", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Resources.resx
+++ b/src/Microsoft.Health.Fhir.SqlServer/Resources.resx
@@ -123,4 +123,7 @@
   <data name="TransactionProcessingException" xml:space="preserve">
     <value>There was an internal server error while processing the transaction.</value>
   </data>
+  <data name="CyclicIncludeIterateNotSupported" xml:space="preserve">
+    <value>Cyclic include iterate queries are not supported.</value>
+  </data>
 </root>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
@@ -984,6 +984,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         public async Task GivenARevIncludeIterateSearchExpressionWithMultitypeArrayReference_WhenSearched_TheIterativeResultsShouldBeAddedToTheBundle()
         {
             // Non-recursive iteration - Reference array of multiple target types: CareTeam:participant of type Patient, Practitioner, Organization, etc.
+            // CareTeam:participant is a circular reference, however CareTeam:participant:Patient isn't, so we're not expecting an informational Issue
             string query = $"_revinclude:iterate=CareTeam:participant:Patient&_revinclude=Patient:general-practitioner&_tag={Fixture.Tag}";
 
             Bundle bundle = await Client.SearchAsync(ResourceType.Practitioner, query);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
@@ -1129,17 +1129,33 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             ValidateSearchEntryMode(bundle, ResourceType.Patient);
         }
 
+        // Circular Reference - Iteration executed once
+
         [Fact]
-        public async Task GivenAnIncludeIterateSearchExpressionWithCircularReference_WhenSearched_IncludedOneIterationResults()
+        public async Task GivenAnIncludeIterateSearchExpressionWithCircularReference_WhenSearched_SingleIterationIsExecutedAndInformationalIssueIsAdded()
         {
             // Recursive queries (circular references) are not supported (see https://github.com/microsoft/fhir-server/issues/1310)
-            // Here we expect one iteration of included results
+            // Here we expect a single iteration of included results
             string query = $"_include:iterate=Organization:partof&_id={Fixture.LabAOrganization.Id}&_tag={Fixture.Tag}";
 
             Bundle bundle = await Client.SearchAsync(ResourceType.Organization, query);
 
+            // Create OperationOutcome with Informational Issue
+            var issue = new IssueComponent
+            {
+                Code = IssueType.Informational,
+                Diagnostics = string.Format(Core.Resources.IncludeIterateCircularReferenceExecutedOnce, "_include:iterate", "Organization:partof"),
+                Severity = IssueSeverity.Information,
+            };
+
+            var operationOutcome = new OperationOutcome
+                {
+                    Issue = new List<OperationOutcome.IssueComponent> { issue },
+                };
+
             ValidateBundle(
                 bundle,
+                operationOutcome,
                 Fixture.LabAOrganization,
                 Fixture.LabBOrganization);
 
@@ -1151,16 +1167,30 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         }
 
         [Fact]
-        public async Task GivenARevIncludeIterateSearchExpressionWithCircularReference_WhenSearched_IncludedOneIterationResults()
+        public async Task GivenARevIncludeIterateSearchExpressionWithCircularReference_WhenSearched_SingleIterationIsExecutedAndInformationalIssueIsAdded()
         {
-            // Recursive queries (circular references) are not supported (see https://github.com/microsoft/fhir-server/issues/1310)
-            // Here we expect one iteration of included results
+            // Recursive include iterate queries (circular references) are not supported (see https://github.com/microsoft/fhir-server/issues/1310)
+            // Here we expect a single iteration of included results
             string query = $"_revinclude:iterate=Organization:partof&_id={Fixture.LabBOrganization.Id}&_tag={Fixture.Tag}";
 
             Bundle bundle = await Client.SearchAsync(ResourceType.Organization, query);
 
+            // Create OperationOutcome with Informational Issue
+            var issue = new IssueComponent
+            {
+                Code = IssueType.Informational,
+                Diagnostics = string.Format(Core.Resources.IncludeIterateCircularReferenceExecutedOnce, "_revinclude:iterate", "Organization:partof"),
+                Severity = IssueSeverity.Information,
+            };
+
+            var operationOutcome = new OperationOutcome
+            {
+                Issue = new List<OperationOutcome.IssueComponent> { issue },
+            };
+
             ValidateBundle(
                 bundle,
+                operationOutcome,
                 Fixture.LabAOrganization,
                 Fixture.LabBOrganization);
 


### PR DESCRIPTION
## Description
This PR is a continuation of https://github.com/microsoft/fhir-server/pull/1314.
It addresses two cases:

1. Cyclic include iterate queries - which are not supported.
   That is, include iterate queries that include a (transitive) cycle. For example, in this query the parameter _include:iterate=DiagnosticReport:patient produces what Patient:general-practitioner consumes: 
`/MedicationDispense?_include=MedicationDispense:prescription&_include:iterate=MedicationRequest:patient&_include:iterate=Patient:general-practitioner&_revinclude:iterate=DiagnosticReport:performer:Practitioner&_include:iterate=DiagnosticReport:patient&_id=12345`
2. Include Iterate parameters with Circular Reference - which according to the spec results in multiple iterations and up to the implementer to decide how many. We implement it with one iteration and the  For example, in this query, 'partof' reference is os type Organization:
`Organization?_include:iterate=Organization:partof`
  
## Related issues
Addresses #1313

## Testing
1. Unit tests in IncludeRewriterTests to assert that exception is thrown for cyclic queries
2. E2E tests in IncludeSearchTests to assert that for a include iterate parameters with circular reference, the iteration is executed once and an informational issue is added to indicate that  
