### PR TITLE
Implement IHostedService instead of IStartable and avoid blocking on async calls

### DIFF
--- a/src/Microsoft.Health.Fhir.Api.UnitTests/Microsoft.Health.Fhir.R4.Api.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.Api.UnitTests/Microsoft.Health.Fhir.R4.Api.UnitTests.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>Microsoft.Health.Fhir.Api.UnitTests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201008-2" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201022-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditHelper.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditHelper.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
         }
 
         /// <inheritdoc />
-        public void LogExecuted(HttpContext httpContext, IClaimsExtractor claimsExtractor)
+        public void LogExecuted(HttpContext httpContext, IClaimsExtractor claimsExtractor, bool shouldCheckForAuthXFailure = false)
         {
             EnsureArg.IsNotNull(claimsExtractor, nameof(claimsExtractor));
             EnsureArg.IsNotNull(httpContext, nameof(httpContext));

--- a/src/Microsoft.Health.Fhir.Api/Microsoft.Health.Fhir.Api.csproj
+++ b/src/Microsoft.Health.Fhir.Api/Microsoft.Health.Fhir.Api.csproj
@@ -23,9 +23,9 @@
     <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20201008-2" />
-    <PackageReference Include="Microsoft.Health.Api" Version="1.0.0-master-20201008-2" />
-    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20201008-2" />
+    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20201022-1" />
+    <PackageReference Include="Microsoft.Health.Api" Version="1.0.0-master-20201022-1" />
+    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20201022-1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Health.Fhir.Core\Microsoft.Health.Fhir.Core.csproj" />

--- a/src/Microsoft.Health.Fhir.Api/Modules/AuditModule.cs
+++ b/src/Microsoft.Health.Fhir.Api/Modules/AuditModule.cs
@@ -5,6 +5,7 @@
 
 using EnsureThat;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Health.Api.Features.Audit;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Api.Controllers;
@@ -41,7 +42,7 @@ namespace Microsoft.Health.Fhir.Api.Modules
             services.Add<AuditEventTypeMapping>()
                 .Singleton()
                 .AsService<IAuditEventTypeMapping>()
-                .AsService<IStartable>();
+                .AsService<IHostedService>();
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Security/RoleLoaderTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Security/RoleLoaderTests.cs
@@ -8,6 +8,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Health.Fhir.Core.Configs;
@@ -156,7 +158,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Security
         }
 
         [Fact]
-        public void GivenValidRoles_WhenLoaded_AreProperlyTransformed()
+        public async Task GivenValidRoles_WhenLoaded_AreProperlyTransformed()
         {
             var roles = new
             {
@@ -172,7 +174,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Security
                 },
             };
 
-            AuthorizationConfiguration authConfig = Load(roles);
+            AuthorizationConfiguration authConfig = await Load(roles);
 
             Role actualRole = Assert.Single(authConfig.Roles);
             Assert.Equal(roles.roles.First().name, actualRole.Name);
@@ -180,7 +182,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Security
         }
 
         [Fact]
-        public void GivenValidDataActions_WhenSpecifiedAsRoleActions_AreRecognized()
+        public async Task GivenValidDataActions_WhenSpecifiedAsRoleActions_AreRecognized()
         {
             var actionNames = Enum.GetValues(typeof(DataActions)).Cast<DataActions>()
                 .Where(a => a != DataActions.All && a != DataActions.None);
@@ -197,7 +199,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Security
                     }).ToArray(),
             };
 
-            AuthorizationConfiguration authConfig = Load(roles);
+            AuthorizationConfiguration authConfig = await Load(roles);
 
             Assert.All(
                 actionNames.Zip(authConfig.Roles.Select(r => r.AllowedDataActions)),
@@ -206,13 +208,13 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Security
 
         [Theory]
         [MemberData(nameof(GetInvalidRoles))]
-        public void GivenInvalidRoles_WhenLoaded_RaiseValidationErrors(string description, object roles)
+        public async Task GivenInvalidRoles_WhenLoaded_RaiseValidationErrors(string description, object roles)
         {
             Assert.NotEmpty(description);
-            Assert.Throws<InvalidDefinitionException>(() => Load(roles));
+            await Assert.ThrowsAsync<InvalidDefinitionException>(() => Load(roles));
         }
 
-        private static AuthorizationConfiguration Load(object roles)
+        private static async Task<AuthorizationConfiguration> Load(object roles)
         {
             IFileProvider fileProvider = Substitute.For<IFileProvider>();
             var hostEnvironment = Substitute.For<IHostEnvironment>();
@@ -223,7 +225,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Security
 
             var authConfig = new AuthorizationConfiguration();
             var roleLoader = new RoleLoader(authConfig, hostEnvironment);
-            roleLoader.Start();
+            await roleLoader.StartAsync(CancellationToken.None);
             return authConfig;
         }
     }

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Security/RoleLoaderTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Security/RoleLoaderTests.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Security
                 },
             };
 
-            AuthorizationConfiguration authConfig = await Load(roles);
+            AuthorizationConfiguration authConfig = await LoadAsync(roles);
 
             Role actualRole = Assert.Single(authConfig.Roles);
             Assert.Equal(roles.roles.First().name, actualRole.Name);
@@ -199,7 +199,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Security
                     }).ToArray(),
             };
 
-            AuthorizationConfiguration authConfig = await Load(roles);
+            AuthorizationConfiguration authConfig = await LoadAsync(roles);
 
             Assert.All(
                 actionNames.Zip(authConfig.Roles.Select(r => r.AllowedDataActions)),
@@ -211,10 +211,10 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Security
         public async Task GivenInvalidRoles_WhenLoaded_RaiseValidationErrors(string description, object roles)
         {
             Assert.NotEmpty(description);
-            await Assert.ThrowsAsync<InvalidDefinitionException>(() => Load(roles));
+            await Assert.ThrowsAsync<InvalidDefinitionException>(() => LoadAsync(roles));
         }
 
-        private static async Task<AuthorizationConfiguration> Load(object roles)
+        private static async Task<AuthorizationConfiguration> LoadAsync(object roles)
         {
             IFileProvider fileProvider = Substitute.For<IFileProvider>();
             var hostEnvironment = Substitute.For<IHostEnvironment>();

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Microsoft.Health.Fhir.Core.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Microsoft.Health.Fhir.Core.UnitTests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201008-2" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201022-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
@@ -7,8 +7,10 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using EnsureThat;
-using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Models;
 
@@ -17,7 +19,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
     /// <summary>
     /// Provides mechanism to access search parameter definition.
     /// </summary>
-    public class SearchParameterDefinitionManager : ISearchParameterDefinitionManager, IStartable
+    public class SearchParameterDefinitionManager : ISearchParameterDefinitionManager, IHostedService
     {
         private readonly IModelInfoProvider _modelInfoProvider;
 
@@ -44,7 +46,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             get { return new ReadOnlyDictionary<string, string>(_resourceTypeSearchParameterHashMap); }
         }
 
-        public void Start()
+        public Task StartAsync(CancellationToken cancellationToken)
         {
             // This method is idempotent because dependent Start methods are not guaranteed to be executed in order.
             if (!_started)
@@ -62,7 +64,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
 
                 _started = true;
             }
+
+            return Task.CompletedTask;
         }
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
         public IEnumerable<SearchParameterInfo> GetSearchParameters(string resourceType)
         {

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -199,7 +199,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                         foreach (var finishedTask in finishedTasks)
                         {
                             queryTasks.Remove(finishedTask);
-                            queryCancellationTokens.Remove(finishedTask.Result);
+                            queryCancellationTokens.Remove(await finishedTask);
                         }
                     }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/CodeSystemResolver.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/CodeSystemResolver.cs
@@ -7,15 +7,17 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
 using EnsureThat;
-using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Health.Fhir.Core.Data;
 using Microsoft.Health.Fhir.Core.Models;
 using Newtonsoft.Json;
 
 namespace Microsoft.Health.Fhir.Core.Features.Search
 {
-    public class CodeSystemResolver : ICodeSystemResolver, IStartable
+    public class CodeSystemResolver : ICodeSystemResolver, IHostedService
     {
         private readonly IModelInfoProvider _modelInfoProvider;
         private Dictionary<string, string> _dictionary;
@@ -44,11 +46,18 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             return null;
         }
 
-        public void Start()
+        public Task StartAsync(CancellationToken cancellationToken)
         {
             using Stream file = _modelInfoProvider.OpenVersionedFileStream("resourcepath-codesystem-mappings.json");
             using var reader = new StreamReader(file);
             _dictionary = JsonConvert.DeserializeObject<Dictionary<string, string>>(reader.ReadToEnd());
+
+            return Task.CompletedTask;
+        }
+
+        Task IHostedService.StopAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
         }
 
         private string NormalizePath(string path)

--- a/src/Microsoft.Health.Fhir.Core/Features/Security/RoleLoader.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Security/RoleLoader.cs
@@ -6,9 +6,10 @@
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Newtonsoft.Json;
@@ -26,7 +27,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Security
     /// behavior when multiple config providers set array elements can
     /// lead to unexpected results)
     /// </summary>
-    public class RoleLoader : IStartable
+    public class RoleLoader : IHostedService
     {
         private readonly AuthorizationConfiguration _authorizationConfiguration;
         private readonly IHostEnvironment _hostEnvironment;
@@ -43,7 +44,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Security
             _fileProvider = hostEnvironment.ContentRootFileProvider;
         }
 
-        public void Start()
+        public Task StartAsync(CancellationToken cancellationToken)
         {
             using Stream schemaContents = GetType().Assembly.GetManifestResourceStream(GetType(), "roles.schema.json");
 
@@ -73,7 +74,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Security
                         string.Format(CultureInfo.CurrentCulture, Resources.DuplicateRoleNames, grouping.Count(), grouping.Key));
                 }
             }
+
+            return Task.CompletedTask;
         }
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
         private Role RoleContractToRole(RoleContract roleContract)
         {

--- a/src/Microsoft.Health.Fhir.Core/Microsoft.Health.Fhir.Core.csproj
+++ b/src/Microsoft.Health.Fhir.Core/Microsoft.Health.Fhir.Core.csproj
@@ -32,9 +32,9 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20201008-2" />
-    <PackageReference Include="Microsoft.Health.Core" Version="1.0.0-master-20201008-2" />
-    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20201008-2" />
+    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20201022-1" />
+    <PackageReference Include="Microsoft.Health.Core" Version="1.0.0-master-20201022-1" />
+    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20201022-1" />
     <PackageReference Include="Hl7.Fhir.Serialization" Version="1.9.0" />
     <PackageReference Include="Hl7.FhirPath" Version="1.9.0" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.3.5" />

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Microsoft.Health.Fhir.CosmosDb.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Microsoft.Health.Fhir.CosmosDb.UnitTests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201008-2" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201022-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosContainerProvider.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosContainerProvider.cs
@@ -5,10 +5,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Abstractions.Exceptions;
@@ -22,7 +23,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
     /// Provides an <see cref="Container"/> instance that is opened and whose collection has been properly initialized for use.
     /// Initialization starts asynchronously during application startup and is guaranteed to complete before any web request is handled by a controller.
     /// </summary>
-    public class CosmosContainerProvider : IStartable, IRequireInitializationOnFirstRequest, IDisposable
+    public class CosmosContainerProvider : IHostedService, IRequireInitializationOnFirstRequest, IDisposable
     {
         private readonly ILogger<CosmosContainerProvider> _logger;
         private Lazy<Container> _container;
@@ -73,13 +74,18 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
         /// <summary>
         /// Starts the initialization of the document client and cosmos data store.
         /// </summary>
-        public void Start()
+        /// <param name="cancellationToken">The cancellation token</param>
+        public Task StartAsync(CancellationToken cancellationToken)
         {
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             // The result is ignored and will be awaited in EnsureInitialized(). Exceptions are logged within CosmosClientInitializer.
             _initializationOperation.EnsureInitialized();
 #pragma warning restore CS4014
+
+            return Task.CompletedTask;
         }
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
         /// <summary>
         /// Returns a task representing the initialization operation. Once completed,

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosContainerProvider.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosContainerProvider.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
         /// <summary>
         /// Starts the initialization of the document client and cosmos data store.
         /// </summary>
-        /// <param name="cancellationToken">The cancellation token</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         public Task StartAsync(CancellationToken cancellationToken)
         {
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed

--- a/src/Microsoft.Health.Fhir.CosmosDb/Microsoft.Health.Fhir.CosmosDb.csproj
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Microsoft.Health.Fhir.CosmosDb.csproj
@@ -15,9 +15,9 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20201008-2" />
-    <PackageReference Include="Microsoft.Health.Extensions.BuildTimeCodeGenerator" Version="1.0.0-master-20201008-2" />
-    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20201008-2" />
+    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20201022-1" />
+    <PackageReference Include="Microsoft.Health.Extensions.BuildTimeCodeGenerator" Version="1.0.0-master-20201022-1" />
+    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20201022-1" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.3.5" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using EnsureThat;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Extensions.DependencyInjection;
@@ -70,7 +71,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Add<CosmosContainerProvider>()
                 .Singleton()
                 .AsSelf()
-                .AsService<IStartable>() // so that it starts initializing ASAP
+                .AsService<IHostedService>() // so that it starts initializing ASAP
                 .AsService<IRequireInitializationOnFirstRequest>(); // so that web requests block on its initialization.
 
             services.Add<CosmosClientReadWriteTestProvider>()

--- a/src/Microsoft.Health.Fhir.R4.Client/Microsoft.Health.Fhir.R4.Client.csproj
+++ b/src/Microsoft.Health.Fhir.R4.Client/Microsoft.Health.Fhir.R4.Client.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Ensure.That" Version="9.2.0" />
     <PackageReference Include="Hl7.Fhir.R4" Version="1.9.0" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.5.0" />
-    <PackageReference Include="Microsoft.Health.Client" Version="1.0.0-master-20201008-2" />
+    <PackageReference Include="Microsoft.Health.Client" Version="1.0.0-master-20201022-1" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.7.1" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.7.1" />
   </ItemGroup>

--- a/src/Microsoft.Health.Fhir.R4.Core.UnitTests/Microsoft.Health.Fhir.R4.Core.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.R4.Core.UnitTests/Microsoft.Health.Fhir.R4.Core.UnitTests.csproj
@@ -9,7 +9,7 @@
     <Compile Include="..\Microsoft.Health.Fhir.Shared.Core.UnitTests\Features\Operations\Export\ExportAnonymizerFactoryTests.cs" Link="Operations\Export\ExportAnonymizerFactoryTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201008-2" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201022-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Microsoft.Health.Fhir.R5.Api.UnitTests/Microsoft.Health.Fhir.R5.Api.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.R5.Api.UnitTests/Microsoft.Health.Fhir.R5.Api.UnitTests.csproj
@@ -5,7 +5,7 @@
     <NoWarn>$(NoWarn);NU1603</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201008-2" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201022-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Microsoft.Health.Fhir.R5.Client/Microsoft.Health.Fhir.R5.Client.csproj
+++ b/src/Microsoft.Health.Fhir.R5.Client/Microsoft.Health.Fhir.R5.Client.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Ensure.That" Version="9.2.0" />
     <PackageReference Include="Hl7.Fhir.R5" Version="1.10.0-alpha-20200811-1" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.5.0" />
-    <PackageReference Include="Microsoft.Health.Client" Version="1.0.0-master-20201008-2" />
+    <PackageReference Include="Microsoft.Health.Client" Version="1.0.0-master-20201022-1" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.7.1" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.5.1" />
   </ItemGroup>

--- a/src/Microsoft.Health.Fhir.R5.Core.UnitTests/Microsoft.Health.Fhir.R5.Core.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.R5.Core.UnitTests/Microsoft.Health.Fhir.R5.Core.UnitTests.csproj
@@ -7,7 +7,7 @@
     <DefineConstants>R5</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201008-2" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201022-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/AadSmartOnFhirProxyControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/AadSmartOnFhirProxyControllerTests.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
         [InlineData("authorization_code", "clientId", "clientSecret", null, null)]
         [InlineData("authorization_code", "clientId", "clientSecret", "InvalidCode", null)]
         [InlineData("authorization_code", "clientId", "clientSecret", "eyAiY29kZSIgOiAiZm9vIiB9", null)] // eyAiY29kZSIgOiAiZm9vIiB9 is { "code" : "foo" } base 64 encoded
-        public void GivenInvalidQueryParams_WhenTokenRequestAction_ThenBadRequestExceptionThrown(
+        public async Task GivenInvalidQueryParams_WhenTokenRequestAction_ThenBadRequestExceptionThrown(
             string grantType, string clientId, string clientSecret, string compoundCode, string redirectUriString)
         {
             Uri redirectUri = null;
@@ -188,7 +188,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
                 Content = new StringContent("{ \"client_id\" : \"client id\", \"scope\" : \"scope\"}"),
             };
 
-            Assert.ThrowsAsync<AadSmartOnFhirProxyBadRequestException>(() => _controller.Token(grantType, compoundCode, redirectUri, clientId, clientSecret)).Wait();
+            await Assert.ThrowsAsync<AadSmartOnFhirProxyBadRequestException>(() => _controller.Token(grantType, compoundCode, redirectUri, clientId, clientSecret));
         }
 
         [Theory]

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/SearchModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/SearchModule.cs
@@ -5,6 +5,7 @@
 
 using EnsureThat;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Api.Configs;
 using Microsoft.Health.Fhir.Api.Features.Routing;
@@ -48,7 +49,7 @@ namespace Microsoft.Health.Fhir.Api.Modules
                 .Singleton()
                 .AsSelf()
                 .AsService<ISearchParameterDefinitionManager>()
-                .AsService<IStartable>();
+                .AsService<IHostedService>();
 
             services.Add<SearchableSearchParameterDefinitionManager>()
                 .Singleton()
@@ -121,7 +122,7 @@ namespace Microsoft.Health.Fhir.Api.Modules
             services.Add<CompartmentDefinitionManager>()
                 .Singleton()
                 .AsSelf()
-                .AsService<IStartable>()
+                .AsService<IHostedService>()
                 .AsService<ICompartmentDefinitionManager>();
 
             services.Add<CompartmentIndexer>()

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexJobTaskTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexJobTaskTests.cs
@@ -25,8 +25,9 @@ using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
 {
-    public class ReindexJobTaskTests : IAsyncLifetime
+    public class ReindexJobTaskTests : IClassFixture<SearchParameterFixtureData>, IAsyncLifetime
     {
+        private readonly SearchParameterFixtureData _fixture;
         private const string PatientFileName = "Patient.ndjson";
         private const string ObservationFileName = "Observation.ndjson";
         private static readonly WeakETag _weakETag = WeakETag.FromVersionId("0");
@@ -40,6 +41,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
 
         private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
         private CancellationToken _cancellationToken;
+
+        public ReindexJobTaskTests(SearchParameterFixtureData fixture) => _fixture = fixture;
 
         public async Task InitializeAsync()
         {
@@ -60,7 +63,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                 () => _fhirOperationDataStore.CreateMockScope(),
                 Options.Create(_reindexJobConfiguration),
                 () => _searchService.CreateMockScope(),
-                await SearchParameterFixtureData.GetSupportedSearchDefinitionManager(),
+                await _fixture.GetSupportedSearchDefinitionManager(),
                 _reindexUtilities,
                 NullLogger<ReindexJobTask>.Instance);
 
@@ -73,7 +76,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         public async Task GivenSupportedParams_WhenExecuted_ThenCorrectSearchIsPerformed()
         {
             // Add one parameter that needs to be indexed
-            var param = (await SearchParameterFixtureData.GetSearchDefinitionManager()).AllSearchParameters.FirstOrDefault(p => p.Name == "status");
+            var param = (await _fixture.GetSearchDefinitionManager()).AllSearchParameters.FirstOrDefault(p => p.Name == "status");
             param.IsSearchable = false;
 
             ReindexJobRecord job = CreateReindexJobRecord();
@@ -113,7 +116,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         public async Task GivenContinuationToken_WhenExecuted_ThenAdditionalQueryAdded()
         {
             // Add one parameter that needs to be indexed
-            var param = (await SearchParameterFixtureData.GetSearchDefinitionManager()).AllSearchParameters.FirstOrDefault(p => p.Name == "identifier");
+            var param = (await _fixture.GetSearchDefinitionManager()).AllSearchParameters.FirstOrDefault(p => p.Name == "identifier");
             param.IsSearchable = false;
 
             ReindexJobRecord job = CreateReindexJobRecord();
@@ -135,7 +138,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
 
             // verify search for results
             await _searchService.Received().SearchForReindexAsync(
-                Arg.Is<IReadOnlyList<Tuple<string, string>>>(l => l.Where(t => t.Item1 == "_type" && t.Item2 == "Account").Any()),
+                Arg.Is<IReadOnlyList<Tuple<string, string>>>(l => l.Any(t => t.Item1 == "_type" && t.Item2 == "Account")),
                 Arg.Any<string>(),
                 false,
                 Arg.Any<CancellationToken>());
@@ -156,7 +159,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         public async Task GivenRunningJob_WhenExecuted_ThenQueuedQueryCompleted()
         {
             // Add one parameter that needs to be indexed
-            var param = (await SearchParameterFixtureData.GetSearchDefinitionManager()).AllSearchParameters.FirstOrDefault(p => p.Name == "appointment");
+            var param = (await _fixture.GetSearchDefinitionManager()).AllSearchParameters.FirstOrDefault(p => p.Name == "appointment");
             param.IsSearchable = false;
 
             var resourceTypeSearchParamHashMap = new Dictionary<string, string>();
@@ -184,13 +187,13 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
 
             // verify search for results
             await _searchService.Received().SearchForReindexAsync(
-                Arg.Is<IReadOnlyList<Tuple<string, string>>>(l => l.Where(t => t.Item1 == "_type" && t.Item2 == "Appointment").Any()),
+                Arg.Is<IReadOnlyList<Tuple<string, string>>>(l => l.Any(t => t.Item1 == "_type" && t.Item2 == "Appointment")),
                 Arg.Is<string>("appointmentHash"),
                 false,
                 Arg.Any<CancellationToken>());
 
             await _searchService.Received().SearchForReindexAsync(
-                Arg.Is<IReadOnlyList<Tuple<string, string>>>(l => l.Where(t => t.Item1 == "_type" && t.Item2 == "AppointmentResponse").Any()),
+                Arg.Is<IReadOnlyList<Tuple<string, string>>>(l => l.Any(t => t.Item1 == "_type" && t.Item2 == "AppointmentResponse")),
                 Arg.Is<string>("appointmentResponseHash"),
                 false,
                 Arg.Any<CancellationToken>());
@@ -198,16 +201,16 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
             // verify search for results with token
             await _searchService.Received().SearchForReindexAsync(
                 Arg.Is<IReadOnlyList<Tuple<string, string>>>(
-                    l => l.Where(t => t.Item1 == "_type" && t.Item2 == "Appointment").Any() &&
-                    l.Where(t => t.Item1 == KnownQueryParameterNames.ContinuationToken && t.Item2 == "token").Any()),
+                    l => l.Any(t => t.Item1 == "_type" && t.Item2 == "Appointment") &&
+                         l.Any(t => t.Item1 == KnownQueryParameterNames.ContinuationToken && t.Item2 == "token")),
                 Arg.Is<string>("appointmentHash"),
                 false,
                 Arg.Any<CancellationToken>());
 
             await _searchService.Received().SearchForReindexAsync(
                 Arg.Is<IReadOnlyList<Tuple<string, string>>>(
-                    l => l.Where(t => t.Item1 == "_type" && t.Item2 == "AppointmentResponse").Any() &&
-                    l.Where(t => t.Item1 == KnownQueryParameterNames.ContinuationToken && t.Item2 == "token").Any()),
+                    l => l.Any(t => t.Item1 == "_type" && t.Item2 == "AppointmentResponse") &&
+                         l.Any(t => t.Item1 == KnownQueryParameterNames.ContinuationToken && t.Item2 == "token")),
                 Arg.Is<string>("appointmentResponseHash"),
                 false,
                 Arg.Any<CancellationToken>());
@@ -227,8 +230,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                 item4 => Assert.True(item4.ContinuationToken == null && item4.Status == OperationStatus.Completed && item4.ResourceType == "Appointment"));
 
             await _reindexUtilities.Received().UpdateSearchParameters(
-                Arg.Is<IReadOnlyCollection<string>>(r => r.Where(s => s.Contains("Appointment")).Any() &&
-                                            r.Where(s => s.Contains("AppointmentResponse")).Any()),
+                Arg.Is<IReadOnlyCollection<string>>(r => r.Any(s => s.Contains("Appointment")) &&
+                                                         r.Any(s => s.Contains("AppointmentResponse"))),
                 Arg.Any<CancellationToken>());
 
             param.IsSearchable = true;
@@ -249,7 +252,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         public async Task GivenQueryInRunningState_WhenExecuted_ThenQueryResetToQueuedOnceStale()
         {
             // Add one parameter that needs to be indexed
-            var param = (await SearchParameterFixtureData.GetSearchDefinitionManager()).AllSearchParameters.FirstOrDefault(p => p.Name == "appointment");
+            var param = (await _fixture.GetSearchDefinitionManager()).AllSearchParameters.FirstOrDefault(p => p.Name == "appointment");
             param.IsSearchable = false;
 
             _reindexJobConfiguration.JobHeartbeatTimeoutThreshold = new TimeSpan(0, 0, 0, 1, 0);
@@ -283,7 +286,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         public async Task GivenQueryWhichContinuallyFails_WhenExecuted_ThenJobWillBeMarkedFailed()
         {
             // Add one parameter that needs to be indexed
-            var param = (await SearchParameterFixtureData.GetSearchDefinitionManager()).AllSearchParameters.FirstOrDefault(p => p.Name == "appointment");
+            var param = (await _fixture.GetSearchDefinitionManager()).AllSearchParameters.FirstOrDefault(p => p.Name == "appointment");
             param.IsSearchable = false;
 
             var job = CreateReindexJobRecord(maxResourcePerQuery: 3);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexJobTaskTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexJobTaskTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                 () => _fhirOperationDataStore.CreateMockScope(),
                 Options.Create(_reindexJobConfiguration),
                 () => _searchService.CreateMockScope(),
-                await _fixture.GetSupportedSearchDefinitionManager(),
+                await _fixture.GetSupportedSearchDefinitionManagerAsync(),
                 _reindexUtilities,
                 NullLogger<ReindexJobTask>.Instance);
 
@@ -76,7 +76,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         public async Task GivenSupportedParams_WhenExecuted_ThenCorrectSearchIsPerformed()
         {
             // Add one parameter that needs to be indexed
-            var param = (await _fixture.GetSearchDefinitionManager()).AllSearchParameters.FirstOrDefault(p => p.Name == "status");
+            var param = (await _fixture.GetSearchDefinitionManagerAsync()).AllSearchParameters.FirstOrDefault(p => p.Name == "status");
             param.IsSearchable = false;
 
             ReindexJobRecord job = CreateReindexJobRecord();
@@ -116,7 +116,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         public async Task GivenContinuationToken_WhenExecuted_ThenAdditionalQueryAdded()
         {
             // Add one parameter that needs to be indexed
-            var param = (await _fixture.GetSearchDefinitionManager()).AllSearchParameters.FirstOrDefault(p => p.Name == "identifier");
+            var param = (await _fixture.GetSearchDefinitionManagerAsync()).AllSearchParameters.FirstOrDefault(p => p.Name == "identifier");
             param.IsSearchable = false;
 
             ReindexJobRecord job = CreateReindexJobRecord();
@@ -159,7 +159,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         public async Task GivenRunningJob_WhenExecuted_ThenQueuedQueryCompleted()
         {
             // Add one parameter that needs to be indexed
-            var param = (await _fixture.GetSearchDefinitionManager()).AllSearchParameters.FirstOrDefault(p => p.Name == "appointment");
+            var param = (await _fixture.GetSearchDefinitionManagerAsync()).AllSearchParameters.FirstOrDefault(p => p.Name == "appointment");
             param.IsSearchable = false;
 
             var resourceTypeSearchParamHashMap = new Dictionary<string, string>();
@@ -252,7 +252,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         public async Task GivenQueryInRunningState_WhenExecuted_ThenQueryResetToQueuedOnceStale()
         {
             // Add one parameter that needs to be indexed
-            var param = (await _fixture.GetSearchDefinitionManager()).AllSearchParameters.FirstOrDefault(p => p.Name == "appointment");
+            var param = (await _fixture.GetSearchDefinitionManagerAsync()).AllSearchParameters.FirstOrDefault(p => p.Name == "appointment");
             param.IsSearchable = false;
 
             _reindexJobConfiguration.JobHeartbeatTimeoutThreshold = new TimeSpan(0, 0, 0, 1, 0);
@@ -286,7 +286,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         public async Task GivenQueryWhichContinuallyFails_WhenExecuted_ThenJobWillBeMarkedFailed()
         {
             // Add one parameter that needs to be indexed
-            var param = (await _fixture.GetSearchDefinitionManager()).AllSearchParameters.FirstOrDefault(p => p.Name == "appointment");
+            var param = (await _fixture.GetSearchDefinitionManagerAsync()).AllSearchParameters.FirstOrDefault(p => p.Name == "appointment");
             param.IsSearchable = false;
 
             var job = CreateReindexJobRecord(maxResourcePerQuery: 3);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/AddressNodeToStringSearchValueTypeConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/AddressNodeToStringSearchValueTypeConverterTests.cs
@@ -7,89 +7,90 @@ using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Features.Search.Converters;
 using Xunit;
 using static Microsoft.Health.Fhir.Tests.Common.Search.SearchValueValidationHelper;
+using Task=System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
 {
     public class AddressNodeToStringSearchValueTypeConverterTests : FhirNodeToSearchValueTypeConverterTests<AddressNodeToStringSearchValueConverter, Address>
     {
         [Fact]
-        public void GivenAnAddressWithCity_WhenConverted_ThenAStringSearchValueShouldBeCreated()
+        public async Task GivenAnAddressWithCity_WhenConverted_ThenAStringSearchValueShouldBeCreated()
         {
             const string city = "Seattle";
 
-            Test(
+            await Test(
                 address => address.City = city,
                 ValidateString,
                 city);
         }
 
         [Fact]
-        public void GivenAnAddressWithCountry_WhenConverted_ThenAStringSearchValueShouldBeCreated()
+        public async Task GivenAnAddressWithCountry_WhenConverted_ThenAStringSearchValueShouldBeCreated()
         {
             const string country = "USA";
 
-            Test(
+            await Test(
                 address => address.Country = country,
                 ValidateString,
                 country);
         }
 
         [Fact]
-        public void GivenAnAddressWithDistrict_WhenConverted_ThenAStringSearchValueShouldBeCreated()
+        public async Task GivenAnAddressWithDistrict_WhenConverted_ThenAStringSearchValueShouldBeCreated()
         {
             const string district = "DC";
 
-            Test(
+            await Test(
                 address => address.District = district,
                 ValidateString,
                 district);
         }
 
         [Fact]
-        public void GivenAnAddressWithNoLine_WhenConverted_ThenOneOrMultipleStringSearchValueShouldBeCreated()
+        public async Task GivenAnAddressWithNoLine_WhenConverted_ThenOneOrMultipleStringSearchValueShouldBeCreated()
         {
-            Test(address => address.Line = null);
+            await Test(address => address.Line = null);
         }
 
         [Theory]
         [InlineData("Line1")]
         [InlineData("Line1", "Line2")]
-        public void GivenAnAddressWithLine_WhenConverted_ThenOneOrMultipleStringSearchValueShouldBeCreated(params string[] lines)
+        public async Task GivenAnAddressWithLine_WhenConverted_ThenOneOrMultipleStringSearchValueShouldBeCreated(params string[] lines)
         {
-            Test(
+            await Test(
                 address => address.Line = lines,
                 ValidateString,
                 lines);
         }
 
         [Fact]
-        public void GivenAnAddressWithPostalCode_WhenConverted_ThenAStringSearchValueShouldBeCreated()
+        public async Task GivenAnAddressWithPostalCode_WhenConverted_ThenAStringSearchValueShouldBeCreated()
         {
             const string postalCode = "98052";
 
-            Test(
+            await Test(
                 address => address.PostalCode = postalCode,
                 ValidateString,
                 postalCode);
         }
 
         [Fact]
-        public void GivenAnAddressWithState_WhenConverted_ThenAStringSearchValueShouldBeCreated()
+        public async Task GivenAnAddressWithState_WhenConverted_ThenAStringSearchValueShouldBeCreated()
         {
             const string state = "Washington";
 
-            Test(
+            await Test(
                 address => address.State = state,
                 ValidateString,
                 state);
         }
 
         [Fact]
-        public void GivenAnAddressWithText_WhenConverted_ThenAStringSearchValueShouldBeCreated()
+        public async Task GivenAnAddressWithText_WhenConverted_ThenAStringSearchValueShouldBeCreated()
         {
             const string text = "Text";
 
-            Test(
+            await Test(
                 address => address.Text = text,
                 ValidateString,
                 text);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/BooleanNodeToBooleanSearchValueTypeConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/BooleanNodeToBooleanSearchValueTypeConverterTests.cs
@@ -7,23 +7,24 @@ using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Features.Search.Converters;
 using Xunit;
 using static Microsoft.Health.Fhir.Tests.Common.Search.SearchValueValidationHelper;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
 {
     public class BooleanNodeToBooleanSearchValueTypeConverterTests : FhirNodeToSearchValueTypeConverterTests<BooleanNodeToTokenSearchValueTypeConverter, FhirBoolean>
     {
         [Fact]
-        public void GivenAFhirBooleanWithNoValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
+        public async Task GivenAFhirBooleanWithNoValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
         {
-            Test(b => b.Value = null);
+            await Test(b => b.Value = null);
         }
 
         [Theory]
         [InlineData(true, "true")]
         [InlineData(false, "false")]
-        public void GivenAFhirBooleanWithValue_WhenConverted_ThenATokenSearchValueShouldBeCreated(bool value, string expected)
+        public async Task GivenAFhirBooleanWithValue_WhenConverted_ThenATokenSearchValueShouldBeCreated(bool value, string expected)
         {
-            Test(
+            await Test(
                 b => b.Value = value,
                 ValidateToken,
                 new Token("http://hl7.org/fhir/special-values", expected));

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/CodeNodeToTokenSearchValueTypeConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/CodeNodeToTokenSearchValueTypeConverterTests.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Threading;
+using System.Threading.Tasks;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Features.Search.Converters;
@@ -10,29 +12,30 @@ using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters.NodeConverterTests;
 using Xunit;
 using static Microsoft.Health.Fhir.Tests.Common.Search.SearchValueValidationHelper;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
 {
     public class CodeNodeToTokenSearchValueTypeConverterTests : FhirNodeInstanceToSearchValueTypeConverterTests<Code>
     {
         public CodeNodeToTokenSearchValueTypeConverterTests()
-            : base(new CodeNodeToTokenSearchValueTypeConverter(CodeSystemResolver()))
+            : base()
         {
         }
 
-        private static CodeSystemResolver CodeSystemResolver()
+        protected override async Task<IFhirNodeToSearchValueTypeConverter> GetTypeConverter()
         {
             var resolver = new CodeSystemResolver(ModelInfoProvider.Instance);
-            resolver.Start();
-            return resolver;
+            await resolver.StartAsync(CancellationToken.None);
+            return new CodeNodeToTokenSearchValueTypeConverter(resolver);
         }
 
         [Fact]
-        public void GivenACode_WhenConverted_ThenATokenSearchValueShouldBeCreated()
+        public async Task GivenACode_WhenConverted_ThenATokenSearchValueShouldBeCreated()
         {
             const string code = "code";
 
-            Test(
+            await Test(
                 c => c.Value = code,
                 ValidateToken,
                 new Token(code: code));

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/CodeNodeToTokenSearchValueTypeConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/CodeNodeToTokenSearchValueTypeConverterTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
         {
         }
 
-        protected override async Task<IFhirNodeToSearchValueTypeConverter> GetTypeConverter()
+        protected override async Task<IFhirNodeToSearchValueTypeConverter> GetTypeConverterAsync()
         {
             var resolver = new CodeSystemResolver(ModelInfoProvider.Instance);
             await resolver.StartAsync(CancellationToken.None);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/CodeOfTNodeToTokenSearchValueTypeConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/CodeOfTNodeToTokenSearchValueTypeConverterTests.cs
@@ -4,6 +4,8 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.FhirPath;
 using Hl7.Fhir.Model;
@@ -14,16 +16,12 @@ using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters.NodeConverterTests;
 using Xunit;
 using static Microsoft.Health.Fhir.Tests.Common.Search.SearchValueValidationHelper;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
 {
     public class CodeOfTNodeToTokenSearchValueTypeConverterTests : FhirNodeInstanceToSearchValueTypeConverterTests<Code<ObservationStatus>>
     {
-        public CodeOfTNodeToTokenSearchValueTypeConverterTests()
-            : base(new CodeNodeToTokenSearchValueTypeConverter(CodeSystemResolver()))
-        {
-        }
-
         protected override ITypedElement TypedElement
         {
             get
@@ -37,26 +35,26 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
             }
         }
 
-        private static CodeSystemResolver CodeSystemResolver()
+        protected override async Task<IFhirNodeToSearchValueTypeConverter> GetTypeConverter()
         {
             var resolver = new CodeSystemResolver(ModelInfoProvider.Instance);
-            resolver.Start();
-            return resolver;
+            await resolver.StartAsync(CancellationToken.None);
+            return new CodeNodeToTokenSearchValueTypeConverter(resolver);
         }
 
         [Fact]
-        public void GivenACodeAndSystem_WhenConverted_ThenATokenSearchValueShouldBeCreated()
+        public async Task GivenACodeAndSystem_WhenConverted_ThenATokenSearchValueShouldBeCreated()
         {
-            Test(
+            await Test(
                 code => code.Value = ObservationStatus.Final,
                 ValidateToken,
                 new Token("http://hl7.org/fhir/observation-status", "final"));
         }
 
         [Fact]
-        public void GivenANullCode_WhenConverted_ThenNullValueReturned()
+        public async Task GivenANullCode_WhenConverted_ThenNullValueReturned()
         {
-            Test(
+            await Test(
                 code => code.Value = null,
                 ValidateNull,
                 new Code<ResourceType>(null));

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/CodeOfTNodeToTokenSearchValueTypeConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/CodeOfTNodeToTokenSearchValueTypeConverterTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
             }
         }
 
-        protected override async Task<IFhirNodeToSearchValueTypeConverter> GetTypeConverter()
+        protected override async Task<IFhirNodeToSearchValueTypeConverter> GetTypeConverterAsync()
         {
             var resolver = new CodeSystemResolver(ModelInfoProvider.Instance);
             await resolver.StartAsync(CancellationToken.None);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/CodeableConceptNodeToTokenSearchValueTypeConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/CodeableConceptNodeToTokenSearchValueTypeConverterTests.cs
@@ -9,6 +9,7 @@ using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Features.Search.Converters;
 using Xunit;
 using static Microsoft.Health.Fhir.Tests.Common.Search.SearchValueValidationHelper;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
 {
@@ -22,23 +23,23 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
         }
 
         [Fact]
-        public void GivenACodeableConceptWithText_WhenConverted_ThenATokenSearchValueShouldBeCreated()
+        public async Task GivenACodeableConceptWithText_WhenConverted_ThenATokenSearchValueShouldBeCreated()
         {
             const string text = "text";
 
-            Test(
+            await Test(
                 cc => cc.Text = text,
                 ValidateToken,
                 new Token(text: text));
         }
 
         [Fact]
-        public void GivenACodeableConceptWithTextThatIsTheSameAsTheDisplayOfACoding_WhenConverted_ThenATokenSearchValueShouldNotBeCreatedForTheConceptText()
+        public async Task GivenACodeableConceptWithTextThatIsTheSameAsTheDisplayOfACoding_WhenConverted_ThenATokenSearchValueShouldNotBeCreatedForTheConceptText()
         {
             const string system = "system";
             const string text = "text";
 
-            Test(
+            await Test(
                 cc =>
                 {
                     cc.Text = text;
@@ -49,13 +50,13 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
         }
 
         [Fact]
-        public void GivenACodeableConceptWithTextThatIsDifferentThanTheDisplayOfACoding_WhenConverted_ThenATokenSearchValueShouldBeCreatedForTheConceptText()
+        public async Task GivenACodeableConceptWithTextThatIsDifferentThanTheDisplayOfACoding_WhenConverted_ThenATokenSearchValueShouldBeCreatedForTheConceptText()
         {
             const string system = "system";
             const string conceptText = "conceptText";
             const string codingDisplayText = "codingDisplay";
 
-            Test(
+            await Test(
                 cc =>
                 {
                     cc.Text = conceptText;
@@ -67,28 +68,28 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
         }
 
         [Fact]
-        public void GivenACodeableConceptWithNullCoding_WhenConverted_ThenNoSearchValueShouldBeCreated()
+        public async Task GivenACodeableConceptWithNullCoding_WhenConverted_ThenNoSearchValueShouldBeCreated()
         {
-            Test(cc => cc.Coding = null);
+            await Test(cc => cc.Coding = null);
         }
 
         [Theory]
         [MemberData(nameof(GetMultipleCodingDataSource))]
-        public void GivenACodeableConceptWithCodings_WhenConverted_ThenOneOrMultipleTokenSearchValuesShouldBeCreated(params Token[] tokens)
+        public async Task GivenACodeableConceptWithCodings_WhenConverted_ThenOneOrMultipleTokenSearchValuesShouldBeCreated(params Token[] tokens)
         {
-            Test(
+            await Test(
                 cc => cc.Coding.AddRange(tokens.Select(token => new Coding(token.System, token.Code, token.Text))),
                 ValidateToken,
                 tokens);
         }
 
         [Fact]
-        public void GivenACodeableConceptWithEmptyCoding_WhenConverted_ThenEmptyCodingShouldBeExcluded()
+        public async Task GivenACodeableConceptWithEmptyCoding_WhenConverted_ThenEmptyCodingShouldBeExcluded()
         {
             const string system = "system";
             const string text = "text";
 
-            Test(
+            await Test(
                 cc =>
                 {
                     cc.Coding.Add(new Coding(null, null, null));
@@ -103,9 +104,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
         [InlineData("system", null, null)]
         [InlineData(null, "code", null)]
         [InlineData(null, null, "text")]
-        public void GivenACodeableConceptWithPartialCoding_WhenConverted_ThenATokenSearchValueShouldBeCreated(string system, string code, string text)
+        public async Task GivenACodeableConceptWithPartialCoding_WhenConverted_ThenATokenSearchValueShouldBeCreated(string system, string code, string text)
         {
-            Test(
+            await Test(
                 cc =>
                 {
                     cc.Coding.Add(new Coding(system, code, text));

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/CodingNodeToTokenSearchValueTypeConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/CodingNodeToTokenSearchValueTypeConverterTests.cs
@@ -7,15 +7,16 @@ using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Features.Search.Converters;
 using Xunit;
 using static Microsoft.Health.Fhir.Tests.Common.Search.SearchValueValidationHelper;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
 {
     public class CodingNodeToTokenSearchValueTypeConverterTests : FhirNodeToSearchValueTypeConverterTests<CodingNodeToTokenSearchValueTypeConverter, Coding>
     {
         [Fact]
-        public void GivenAnEmptyCoding_WhenConverted_ThenNoSearchValueShouldBeCreated()
+        public async Task GivenAnEmptyCoding_WhenConverted_ThenNoSearchValueShouldBeCreated()
         {
-            Test(
+            await Test(
                 cc =>
                 {
                     cc.System = null;
@@ -28,9 +29,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
         [InlineData("system", null, null)]
         [InlineData(null, "code", null)]
         [InlineData(null, null, "display")]
-        public void GivenAPartialCoding_WhenConverted_ThenATokenSearchValueShouldBeCreated(string system, string code, string display)
+        public async Task GivenAPartialCoding_WhenConverted_ThenATokenSearchValueShouldBeCreated(string system, string code, string display)
         {
-            Test(
+            await Test(
                 cc =>
                 {
                     cc.System = system;

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/ContactPointNodeToTokenSearchValueTypeConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/ContactPointNodeToTokenSearchValueTypeConverterTests.cs
@@ -7,23 +7,24 @@ using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Features.Search.Converters;
 using Xunit;
 using static Microsoft.Health.Fhir.Tests.Common.Search.SearchValueValidationHelper;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
 {
     public class ContactPointNodeToTokenSearchValueTypeConverterTests : FhirNodeToSearchValueTypeConverterTests<ContactPointNodeToTokenSearchValueTypeConverter, ContactPoint>
     {
         [Fact]
-        public void GivenAContactPointWithNoValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
+        public async Task GivenAContactPointWithNoValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
         {
-            Test(cp => cp.Value = null);
+            await Test(cp => cp.Value = null);
         }
 
         [Fact]
-        public void GivenAContactPointWithValue_WhenConverted_ThenATokenSearchValueShouldBeCreated()
+        public async Task GivenAContactPointWithValue_WhenConverted_ThenATokenSearchValueShouldBeCreated()
         {
             const string number = "123";
 
-            Test(
+            await Test(
                 cp =>
                 {
                     cp.Use = ContactPoint.ContactPointUse.Home;

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/DateNodeToDateTimeSearchValueTypeConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/DateNodeToDateTimeSearchValueTypeConverterTests.cs
@@ -7,23 +7,24 @@ using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Features.Search.Converters;
 using Xunit;
 using static Microsoft.Health.Fhir.Tests.Common.Search.SearchValueValidationHelper;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
 {
     public class DateNodeToDateTimeSearchValueTypeConverterTests : FhirNodeToSearchValueTypeConverterTests<DateNodeToDateTimeSearchValueTypeConverter, Date>
     {
         [Fact]
-        public void GivenADateWithNoValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
+        public async Task GivenADateWithNoValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
         {
-            Test(date => date.Value = null);
+            await Test(date => date.Value = null);
         }
 
         [Fact]
-        public void GivenADateWithValue_WhenConverted_ThenADateTimeSearchValueShouldBeCreated()
+        public async Task GivenADateWithValue_WhenConverted_ThenADateTimeSearchValueShouldBeCreated()
         {
             const string partialDate = "2018-01-05";
 
-            Test(
+            await Test(
                 date => date.Value = partialDate,
                 ValidateDateTime,
                 partialDate);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/DateTimeNodeToDateTimeSearchValueTypeConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/DateTimeNodeToDateTimeSearchValueTypeConverterTests.cs
@@ -7,23 +7,24 @@ using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Features.Search.Converters;
 using Xunit;
 using static Microsoft.Health.Fhir.Tests.Common.Search.SearchValueValidationHelper;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
 {
     public class DateTimeNodeToDateTimeSearchValueTypeConverterTests : FhirNodeToSearchValueTypeConverterTests<DateNodeToDateTimeSearchValueTypeConverter, FhirDateTime>
     {
         [Fact]
-        public void GivenAFhirDateTimeWithNoValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
+        public async Task GivenAFhirDateTimeWithNoValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
         {
-            Test(date => date.Value = null);
+            await Test(date => date.Value = null);
         }
 
         [Fact]
-        public void GivenAFhirDateTimeWithValue_WhenConverted_ThenADateTimeSearchValueShouldBeCreated()
+        public async Task GivenAFhirDateTimeWithValue_WhenConverted_ThenADateTimeSearchValueShouldBeCreated()
         {
             const string partialDate = "2018-03-30T05:12";
 
-            Test(
+            await Test(
                 date => date.Value = partialDate,
                 ValidateDateTime,
                 partialDate);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/DecimalNodeToDecimalSearchValueTypeConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/DecimalNodeToDecimalSearchValueTypeConverterTests.cs
@@ -7,23 +7,24 @@ using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Features.Search.Converters;
 using Xunit;
 using static Microsoft.Health.Fhir.Tests.Common.Search.SearchValueValidationHelper;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
 {
     public class DecimalNodeToDecimalSearchValueTypeConverterTests : FhirNodeToSearchValueTypeConverterTests<DecimalNodeToNumberSearchValueTypeConverter, FhirDecimal>
     {
         [Fact]
-        public void GivenAFhirDecimalWithNoValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
+        public async Task GivenAFhirDecimalWithNoValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
         {
-            Test(d => d.Value = null);
+            await Test(d => d.Value = null);
         }
 
         [Fact]
-        public void GivenAFhirDecimalWithValue_WhenConverted_ThenASearchValueShouldBeCreated()
+        public async Task GivenAFhirDecimalWithValue_WhenConverted_ThenASearchValueShouldBeCreated()
         {
             const decimal value = 190.5m;
 
-            Test(
+            await Test(
                 d => d.Value = value,
                 ValidateNumber,
                 value);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/FhirNodeInstanceToSearchValueTypeConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/FhirNodeInstanceToSearchValueTypeConverterTests.cs
@@ -6,42 +6,39 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Features.Search.Converters;
 using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
 using Xunit;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters.NodeConverterTests
 {
     public abstract class FhirNodeInstanceToSearchValueTypeConverterTests<TElement>
         where TElement : Element, new()
     {
-        protected FhirNodeInstanceToSearchValueTypeConverterTests(IFhirNodeToSearchValueTypeConverter converter)
-        {
-            TypeConverter = converter;
-        }
-
-        protected IFhirNodeToSearchValueTypeConverter TypeConverter { get; }
-
         protected TElement Element { get; } = new TElement();
 
         protected virtual ITypedElement TypedElement => Element.ToTypedElement();
 
+        protected abstract Task<IFhirNodeToSearchValueTypeConverter> GetTypeConverter();
+
         [Fact]
-        public void GivenANullValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
+        public async Task GivenANullValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
         {
-            IEnumerable<ISearchValue> values = TypeConverter.ConvertTo(null);
+            IEnumerable<ISearchValue> values = (await GetTypeConverter()).ConvertTo(null);
 
             Assert.NotNull(values);
             Assert.Empty(values);
         }
 
-        protected void Test<TValue>(Action<TElement> setup, Action<TValue, ISearchValue> validator, params TValue[] expected)
+        protected async Task Test<TValue>(Action<TElement> setup, Action<TValue, ISearchValue> validator, params TValue[] expected)
         {
             setup(Element);
 
-            IEnumerable<ISearchValue> values = TypeConverter.ConvertTo(TypedElement);
+            IEnumerable<ISearchValue> values = (await GetTypeConverter()).ConvertTo(TypedElement);
 
             Assert.NotNull(values);
             Assert.Collection(
@@ -49,11 +46,11 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters.NodeCo
                 expected.Select(e => new Action<ISearchValue>(sv => validator(e, sv))).ToArray());
         }
 
-        protected void Test(Action<TElement> setup)
+        protected async Task Test(Action<TElement> setup)
         {
             setup(Element);
 
-            IEnumerable<ISearchValue> values = TypeConverter.ConvertTo(TypedElement);
+            IEnumerable<ISearchValue> values = (await GetTypeConverter()).ConvertTo(TypedElement);
 
             Assert.NotNull(values);
             Assert.Empty(values);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/FhirNodeInstanceToSearchValueTypeConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/FhirNodeInstanceToSearchValueTypeConverterTests.cs
@@ -23,12 +23,12 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters.NodeCo
 
         protected virtual ITypedElement TypedElement => Element.ToTypedElement();
 
-        protected abstract Task<IFhirNodeToSearchValueTypeConverter> GetTypeConverter();
+        protected abstract Task<IFhirNodeToSearchValueTypeConverter> GetTypeConverterAsync();
 
         [Fact]
         public async Task GivenANullValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
         {
-            IEnumerable<ISearchValue> values = (await GetTypeConverter()).ConvertTo(null);
+            IEnumerable<ISearchValue> values = (await GetTypeConverterAsync()).ConvertTo(null);
 
             Assert.NotNull(values);
             Assert.Empty(values);
@@ -38,7 +38,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters.NodeCo
         {
             setup(Element);
 
-            IEnumerable<ISearchValue> values = (await GetTypeConverter()).ConvertTo(TypedElement);
+            IEnumerable<ISearchValue> values = (await GetTypeConverterAsync()).ConvertTo(TypedElement);
 
             Assert.NotNull(values);
             Assert.Collection(
@@ -50,7 +50,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters.NodeCo
         {
             setup(Element);
 
-            IEnumerable<ISearchValue> values = (await GetTypeConverter()).ConvertTo(TypedElement);
+            IEnumerable<ISearchValue> values = (await GetTypeConverterAsync()).ConvertTo(TypedElement);
 
             Assert.NotNull(values);
             Assert.Empty(values);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/FhirNodeToSearchValueTypeConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/FhirNodeToSearchValueTypeConverterTests.cs
@@ -3,9 +3,11 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Threading.Tasks;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Features.Search.Converters;
 using Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters.NodeConverterTests;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
 {
@@ -13,9 +15,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
         where TTypeConverter : IFhirNodeToSearchValueTypeConverter, new()
         where TElement : Element, new()
     {
-        protected FhirNodeToSearchValueTypeConverterTests()
-            : base(new TTypeConverter())
+        protected override Task<IFhirNodeToSearchValueTypeConverter> GetTypeConverter()
         {
+            return Task.FromResult((IFhirNodeToSearchValueTypeConverter)new TTypeConverter());
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/FhirNodeToSearchValueTypeConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/FhirNodeToSearchValueTypeConverterTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
         where TTypeConverter : IFhirNodeToSearchValueTypeConverter, new()
         where TElement : Element, new()
     {
-        protected override Task<IFhirNodeToSearchValueTypeConverter> GetTypeConverter()
+        protected override Task<IFhirNodeToSearchValueTypeConverter> GetTypeConverterAsync()
         {
             return Task.FromResult((IFhirNodeToSearchValueTypeConverter)new TTypeConverter());
         }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/HumanNameNodeToStringSearchValueTypeConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/HumanNameNodeToStringSearchValueTypeConverterTests.cs
@@ -7,79 +7,80 @@ using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Features.Search.Converters;
 using Xunit;
 using static Microsoft.Health.Fhir.Tests.Common.Search.SearchValueValidationHelper;
+using Task=System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
 {
     public class HumanNameNodeToStringSearchValueTypeConverterTests : FhirNodeToSearchValueTypeConverterTests<HumanNameNodeToStringSearchValueTypeConverter, HumanName>
     {
         [Fact]
-        public void GivenAHumaneNameWithNoGiven_WhenConverted_ThenOneOrMoreStringSearchValuesShouldBeCreated()
+        public async Task GivenAHumaneNameWithNoGiven_WhenConverted_ThenOneOrMoreStringSearchValuesShouldBeCreated()
         {
-            Test(hn => hn.Given = null);
+            await Test(hn => hn.Given = null);
         }
 
         [Theory]
         [InlineData("given")]
         [InlineData("given1", "given2")]
-        public void GivenAHumaneNameWithGiven_WhenConverted_ThenOneOrMoreStringSearchValuesShouldBeCreated(params string[] given)
+        public async Task GivenAHumaneNameWithGiven_WhenConverted_ThenOneOrMoreStringSearchValuesShouldBeCreated(params string[] given)
         {
-            Test(
+            await Test(
                 hn => hn.Given = given,
                 ValidateString,
                 given);
         }
 
         [Fact]
-        public void GivenAnHumanNameWithFamily_WhenConverted_ThenAStringSearchValueShouldBeCreated()
+        public async Task GivenAnHumanNameWithFamily_WhenConverted_ThenAStringSearchValueShouldBeCreated()
         {
             const string family = "Doe";
 
-            Test(
+            await Test(
                 hn => hn.Family = family,
                 ValidateString,
                 family);
         }
 
         [Fact]
-        public void GivenAnHumanNameWithNoPrefix_WhenConverted_ThenOneOrMoreStringSearchValueShouldBeCreated()
+        public async Task GivenAnHumanNameWithNoPrefix_WhenConverted_ThenOneOrMoreStringSearchValueShouldBeCreated()
         {
-            Test(hn => hn.Prefix = null);
+            await Test(hn => hn.Prefix = null);
         }
 
         [Theory]
         [InlineData("prefix")]
         [InlineData("prefix1", "prefix2")]
-        public void GivenAnHumanNameWithPrefix_WhenConverted_ThenOneOrMoreStringSearchValueShouldBeCreated(params string[] prefix)
+        public async Task GivenAnHumanNameWithPrefix_WhenConverted_ThenOneOrMoreStringSearchValueShouldBeCreated(params string[] prefix)
         {
-            Test(
+            await Test(
                 hn => hn.Prefix = prefix,
                 ValidateString,
                 prefix);
         }
 
         [Fact]
-        public void GivenAnHumanNameWithNoSuffix_WhenConverted_ThenAStringSearchValueShouldBeCreated()
+        public async Task GivenAnHumanNameWithNoSuffix_WhenConverted_ThenAStringSearchValueShouldBeCreated()
         {
-            Test(hn => hn.Suffix = null);
+            await Test(hn => hn.Suffix = null);
         }
 
         [Theory]
         [InlineData("suffix")]
         [InlineData("suffix1", "suffix2")]
-        public void GivenAnHumanNameWithSuffix_WhenConverted_ThenAStringSearchValueShouldBeCreated(params string[] suffix)
+        public async Task GivenAnHumanNameWithSuffix_WhenConverted_ThenAStringSearchValueShouldBeCreated(params string[] suffix)
         {
-            Test(
+            await Test(
                 hn => hn.Suffix = suffix,
                 ValidateString,
                 suffix);
         }
 
         [Fact]
-        public void GivenAnHumanNameWithText_WhenConverted_ThenAStringSearchValueShouldBeCreated()
+        public async Task GivenAnHumanNameWithText_WhenConverted_ThenAStringSearchValueShouldBeCreated()
         {
             const string text = "text";
 
-            Test(
+            await Test(
                 hn => hn.Text = text,
                 ValidateString,
                 text);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/IdNodeToTokenSearchValueTypeConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/IdNodeToTokenSearchValueTypeConverterTests.cs
@@ -7,23 +7,24 @@ using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Features.Search.Converters;
 using Xunit;
 using static Microsoft.Health.Fhir.Tests.Common.Search.SearchValueValidationHelper;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
 {
     public class IdNodeToTokenSearchValueTypeConverterTests : FhirNodeToSearchValueTypeConverterTests<IdNodeToTokenSearchValueTypeConverter, Id>
     {
         [Fact]
-        public void GivenAnIdWithNoValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
+        public async Task GivenAnIdWithNoValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
         {
-            Test(id => id.Value = null);
+            await Test(id => id.Value = null);
         }
 
         [Fact]
-        public void GivenAnIdWithValue_WhenConverted_ThenATokenSearchValueShouldBeCreated()
+        public async Task GivenAnIdWithValue_WhenConverted_ThenATokenSearchValueShouldBeCreated()
         {
             const string identifier = "id";
 
-            Test(
+            await Test(
                 id => id.Value = identifier,
                 ValidateToken,
                 new Token(null, identifier, null));

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/IdentifierNodeToTokenSearchValueTypeConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/IdentifierNodeToTokenSearchValueTypeConverterTests.cs
@@ -7,24 +7,25 @@ using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Features.Search.Converters;
 using Xunit;
 using static Microsoft.Health.Fhir.Tests.Common.Search.SearchValueValidationHelper;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
 {
     public class IdentifierNodeToTokenSearchValueTypeConverterTests : FhirNodeToSearchValueTypeConverterTests<IdentifierNodeToTokenSearchValueTypeConverter, Identifier>
     {
         [Fact]
-        public void GivenAnIdentifierWithNoValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
+        public async Task GivenAnIdentifierWithNoValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
         {
-            Test(id => id.Value = null);
+            await Test(id => id.Value = null);
         }
 
         [Theory]
         [InlineData("system", "identifier", "text")]
         [InlineData(null, "identifier", "text")]
         [InlineData("system", "identifier", null)]
-        public void GivenAnIdentifierWithValue_WhenConverted_ThenATokenSearchValueShouldBeCreated(string system, string identifier, string text)
+        public async Task GivenAnIdentifierWithValue_WhenConverted_ThenATokenSearchValueShouldBeCreated(string system, string identifier, string text)
         {
-            Test(
+            await Test(
                 id =>
                 {
                     id.System = system;

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/InstantNodeToDateTimeSearchValueTypeConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/InstantNodeToDateTimeSearchValueTypeConverterTests.cs
@@ -8,24 +8,25 @@ using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Features.Search.Converters;
 using Xunit;
 using static Microsoft.Health.Fhir.Tests.Common.Search.SearchValueValidationHelper;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
 {
     public class InstantNodeToDateTimeSearchValueTypeConverterTests : FhirNodeToSearchValueTypeConverterTests<InstantNodeToDateTimeSearchValueTypeConverter, Instant>
     {
         [Fact]
-        public void GivenAInstantWithNoValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
+        public async Task GivenAInstantWithNoValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
         {
-            Test(i => i.Value = null);
+            await Test(i => i.Value = null);
         }
 
         [Fact]
-        public void GivenAInstantWithValue_WhenConverted_ThenADateTimeSearchValueShouldBeCreated()
+        public async Task GivenAInstantWithValue_WhenConverted_ThenADateTimeSearchValueShouldBeCreated()
         {
             var dateTimeOffset = new DateTimeOffset(2018, 01, 20, 14, 34, 24, TimeSpan.FromMinutes(60));
 
             // The date time will be stored as UTC.
-            Test(
+            await Test(
                 i => i.Value = dateTimeOffset,
                 ValidateDateTime,
                 "2018-01-20T13:34:24.0000000-00:00");

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/IntegerNodeToIntegerSearchValueTypeConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/IntegerNodeToIntegerSearchValueTypeConverterTests.cs
@@ -7,23 +7,24 @@ using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Features.Search.Converters;
 using Xunit;
 using static Microsoft.Health.Fhir.Tests.Common.Search.SearchValueValidationHelper;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
 {
     public class IntegerNodeToIntegerSearchValueTypeConverterTests : FhirNodeToSearchValueTypeConverterTests<IntegerNodeToNumberSearchValueTypeConverter, Integer>
     {
         [Fact]
-        public void GivenAIntegerWithNoValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
+        public async Task GivenAIntegerWithNoValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
         {
-            Test(i => i.Value = null);
+            await Test(i => i.Value = null);
         }
 
         [Fact]
-        public void GivenAIntegerWithValue_WhenConverted_ThenANumberValueShouldBeCreated()
+        public async Task GivenAIntegerWithValue_WhenConverted_ThenANumberValueShouldBeCreated()
         {
             const int value = 500;
 
-            Test(
+            await Test(
                 i => i.Value = value,
                 ValidateNumber,
                 (decimal)value);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/MarkdownNodeToStringSearchValueTypeConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/MarkdownNodeToStringSearchValueTypeConverterTests.cs
@@ -7,23 +7,24 @@ using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Features.Search.Converters;
 using Xunit;
 using static Microsoft.Health.Fhir.Tests.Common.Search.SearchValueValidationHelper;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
 {
     public class MarkdownNodeToStringSearchValueTypeConverterTests : FhirNodeToSearchValueTypeConverterTests<MarkdownNodeToStringSearchValueTypeConverter, Markdown>
     {
         [Fact]
-        public void GivenAMarkdownWithNoValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
+        public async Task GivenAMarkdownWithNoValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
         {
-            Test(md => md.Value = null);
+            await Test(md => md.Value = null);
         }
 
         [Fact]
-        public void GivenAMarkdownWithValue_WhenConverted_ThenAStringSearchValueShouldBeCreated()
+        public async Task GivenAMarkdownWithValue_WhenConverted_ThenAStringSearchValueShouldBeCreated()
         {
             const string markdown = "```code```";
 
-            Test(
+            await Test(
                 md => md.Value = markdown,
                 ValidateString,
                 markdown);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/OidNodeToUriSearchValueTypeConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/OidNodeToUriSearchValueTypeConverterTests.cs
@@ -7,23 +7,24 @@ using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Features.Search.Converters;
 using Xunit;
 using static Microsoft.Health.Fhir.Tests.Common.Search.SearchValueValidationHelper;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
 {
     public class OidNodeToUriSearchValueTypeConverterTests : FhirNodeToSearchValueTypeConverterTests<OidNodeToUriSearchValueTypeConverter, Oid>
     {
         [Fact]
-        public void GivenAOidWithNoValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
+        public async Task GivenAOidWithNoValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
         {
-            Test(oid => oid.Value = null);
+            await Test(oid => oid.Value = null);
         }
 
         [Fact]
-        public void GivenAOidWithValue_WhenConverted_ThenAUriSearchValueShouldBeCreated()
+        public async Task GivenAOidWithValue_WhenConverted_ThenAUriSearchValueShouldBeCreated()
         {
             const string id = "1.3.6.1.4.1.343";
 
-            Test(
+            await Test(
                 oid => oid.Value = id,
                 ValidateUri,
                 id);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/PeriodNodeToDateTimeSearchValueTypeConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/PeriodNodeToDateTimeSearchValueTypeConverterTests.cs
@@ -7,6 +7,7 @@ using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Features.Search.Converters;
 using Xunit;
 using static Microsoft.Health.Fhir.Tests.Common.Search.SearchValueValidationHelper;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
 {
@@ -16,12 +17,12 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
         [InlineData("2018-01", "2018-12-25T15:30")]
         [InlineData(null, "2017")]
         [InlineData("2018-10-15T12:33:55", null)]
-        public void GivenAPeriodWithValue_WhenConverted_ThenADateTimeSearchValueShouldBeCreated(string start, string end)
+        public async Task GivenAPeriodWithValue_WhenConverted_ThenADateTimeSearchValueShouldBeCreated(string start, string end)
         {
             string expectedStart = start ?? "0001-01-01T00:00:00";
             string expectedEnd = end ?? "9999-12-31T23:59:59";
 
-            Test(
+            await Test(
                 period =>
                 {
                     period.Start = start;

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/PositiveIntNodeToNumberSearchValueTypeConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/PositiveIntNodeToNumberSearchValueTypeConverterTests.cs
@@ -7,23 +7,24 @@ using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Features.Search.Converters;
 using Xunit;
 using static Microsoft.Health.Fhir.Tests.Common.Search.SearchValueValidationHelper;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
 {
     public class PositiveIntNodeToNumberSearchValueTypeConverterTests : FhirNodeToSearchValueTypeConverterTests<IntegerNodeToNumberSearchValueTypeConverter, PositiveInt>
     {
         [Fact]
-        public void GivenAPositiveIntWithNoValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
+        public async Task GivenAPositiveIntWithNoValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
         {
-            Test(pi => pi.Value = null);
+            await Test(pi => pi.Value = null);
         }
 
         [Fact]
-        public void GivenAPositiveIntWithValue_WhenConverted_ThenANumberValueShouldBeCreated()
+        public async Task GivenAPositiveIntWithValue_WhenConverted_ThenANumberValueShouldBeCreated()
         {
             const int value = 10;
 
-            Test(
+            await Test(
                 pi => pi.Value = value,
                 ValidateNumber,
                 (decimal)value);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/QuantityNodeToQuantitySearchValueTypeConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/QuantityNodeToQuantitySearchValueTypeConverterTests.cs
@@ -7,25 +7,26 @@ using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Features.Search.Converters;
 using Xunit;
 using static Microsoft.Health.Fhir.Tests.Common.Search.SearchValueValidationHelper;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
 {
     public class QuantityNodeToQuantitySearchValueTypeConverterTests : FhirNodeToSearchValueTypeConverterTests<QuantityNodeToQuantitySearchValueTypeConverter, Quantity>
     {
         [Fact]
-        public void GivenAQuantityWithNoValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
+        public async Task GivenAQuantityWithNoValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
         {
-            Test(q => q.Value = null);
+            await Test(q => q.Value = null);
         }
 
         [Fact]
-        public void GivenAQuantityWithValue_WhenConverted_ThenAQuantityValueShouldBeCreated()
+        public async Task GivenAQuantityWithValue_WhenConverted_ThenAQuantityValueShouldBeCreated()
         {
             const string system = "qs";
             const string code = "qc";
             const decimal value = 100.123456m;
 
-            Test(
+            await Test(
                 q =>
                 {
                     q.System = system;
@@ -37,13 +38,13 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
         }
 
         [Fact]
-        public void GivenASimpleQuantityWithValue_WhenConverted_ThenASimpleQuantityValueShouldBeCreated()
+        public async Task GivenASimpleQuantityWithValue_WhenConverted_ThenASimpleQuantityValueShouldBeCreated()
         {
             const string system = "s";
             const string code = "g";
             const decimal value = 0.123m;
 
-            Test(
+            await Test(
                 sq =>
                 {
                     sq.System = system;

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/StringNodeToStringSearchValueTypeConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/StringNodeToStringSearchValueTypeConverterTests.cs
@@ -7,23 +7,24 @@ using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Features.Search.Converters;
 using Xunit;
 using static Microsoft.Health.Fhir.Tests.Common.Search.SearchValueValidationHelper;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
 {
     public class StringNodeToStringSearchValueTypeConverterTests : FhirNodeToSearchValueTypeConverterTests<StringNodeToStringSearchValueConverter, FhirString>
     {
         [Fact]
-        public void GivenAFhirStringWithNoValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
+        public async Task GivenAFhirStringWithNoValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
         {
-            Test(s => s.Value = null);
+            await Test(s => s.Value = null);
         }
 
         [Fact]
-        public void GivenAFhirStringWithValue_WhenConverted_ThenAStringSearchValueShouldBeCreated()
+        public async Task GivenAFhirStringWithValue_WhenConverted_ThenAStringSearchValueShouldBeCreated()
         {
             const string value = "test";
 
-            Test(
+            await Test(
                 s => s.Value = value,
                 ValidateString,
                 value);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/UnsignedIntNodeToNumberSearchValueTypeConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/UnsignedIntNodeToNumberSearchValueTypeConverterTests.cs
@@ -7,23 +7,24 @@ using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Features.Search.Converters;
 using Xunit;
 using static Microsoft.Health.Fhir.Tests.Common.Search.SearchValueValidationHelper;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
 {
     public class UnsignedIntNodeToNumberSearchValueTypeConverterTests : FhirNodeToSearchValueTypeConverterTests<IntegerNodeToNumberSearchValueTypeConverter, UnsignedInt>
     {
         [Fact]
-        public void GivenAUnsignedIntWithNoValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
+        public async Task GivenAUnsignedIntWithNoValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
         {
-            Test(ui => ui.Value = null);
+            await Test(ui => ui.Value = null);
         }
 
         [Fact]
-        public void GivenAUnsignedIntWithValue_WhenConverted_ThenANumberValueShouldBeCreated()
+        public async Task GivenAUnsignedIntWithValue_WhenConverted_ThenANumberValueShouldBeCreated()
         {
             const int value = 10;
 
-            Test(
+            await Test(
                 ui => ui.Value = value,
                 ValidateNumber,
                 (decimal)value);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/UriNodeToUriSearchValueTypeConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/NodeConverterTests/UriNodeToUriSearchValueTypeConverterTests.cs
@@ -7,23 +7,24 @@ using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Features.Search.Converters;
 using Xunit;
 using static Microsoft.Health.Fhir.Tests.Common.Search.SearchValueValidationHelper;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
 {
     public class UriNodeToUriSearchValueTypeConverterTests : FhirNodeToSearchValueTypeConverterTests<UriNodeToUriSearchValueTypeConverter, FhirUri>
     {
         [Fact]
-        public void GivenAFhirUriWithNoValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
+        public async Task GivenAFhirUriWithNoValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
         {
-            Test(uri => uri.Value = null);
+            await Test(uri => uri.Value = null);
         }
 
         [Fact]
-        public void GivenAFhirUriWithValue_WhenConverted_ThenAUriSearchValueShouldBeCreated()
+        public async Task GivenAFhirUriWithValue_WhenConverted_ThenAUriSearchValueShouldBeCreated()
         {
             const string value = "http://uri";
 
-            Test(
+            await Test(
                 uri => uri.Value = value,
                 ValidateUri,
                 value);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchIndexerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchIndexerTests.cs
@@ -22,11 +22,12 @@ using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 {
-    public class SearchIndexerTests : IAsyncLifetime
+    public class SearchIndexerTests : IClassFixture<SearchParameterFixtureData>, IAsyncLifetime
     {
+        private readonly SearchParameterFixtureData _fixture;
         private ISearchIndexer _indexer;
 
-        private JsonSerializerSettings _settings = new JsonSerializerSettings
+        private readonly JsonSerializerSettings _settings = new JsonSerializerSettings
         {
             Converters = new List<JsonConverter>
             {
@@ -35,10 +36,12 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             ContractResolver = new CamelCasePropertyNamesContractResolver(),
         };
 
+        public SearchIndexerTests(SearchParameterFixtureData fixture) => _fixture = fixture;
+
         public async Task InitializeAsync()
         {
             _indexer = new TypedElementSearchIndexer(
-                await SearchParameterFixtureData.GetSupportedSearchDefinitionManager(),
+                await _fixture.GetSupportedSearchDefinitionManager(),
                 await SearchParameterFixtureData.GetManager(),
                 new LightweightReferenceToElementResolver(new ReferenceSearchValueParser(new FhirRequestContextAccessor()), ModelInfoProvider.Instance),
                 ModelInfoProvider.Instance,

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchIndexerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchIndexerTests.cs
@@ -17,10 +17,11 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
 using Xunit;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 {
-    public class SearchIndexerTests
+    public class SearchIndexerTests : IAsyncLifetime
     {
         private ISearchIndexer _indexer;
 
@@ -33,15 +34,17 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             ContractResolver = new CamelCasePropertyNamesContractResolver(),
         };
 
-        public SearchIndexerTests()
+        public async Task InitializeAsync()
         {
             _indexer = new TypedElementSearchIndexer(
-                SearchParameterFixtureData.SupportedSearchDefinitionManager,
-                SearchParameterFixtureData.Manager,
+                await SearchParameterFixtureData.GetSupportedSearchDefinitionManager(),
+                await SearchParameterFixtureData.GetManager(),
                 new LightweightReferenceToElementResolver(new ReferenceSearchValueParser(new FhirRequestContextAccessor()), ModelInfoProvider.Instance),
                 ModelInfoProvider.Instance,
                 NullLogger<SearchIndexer>.Instance);
         }
+
+        public Task DisposeAsync() => Task.CompletedTask;
 
         [Theory]
         [InlineData("DocumentReference-example-relatesTo-code-appends")]

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchIndexerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchIndexerTests.cs
@@ -41,8 +41,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         public async Task InitializeAsync()
         {
             _indexer = new TypedElementSearchIndexer(
-                await _fixture.GetSupportedSearchDefinitionManager(),
-                await SearchParameterFixtureData.GetManager(),
+                await _fixture.GetSupportedSearchDefinitionManagerAsync(),
+                await SearchParameterFixtureData.GetFhirNodeToSearchValueTypeConverterManagerAsync(),
                 new LightweightReferenceToElementResolver(new ReferenceSearchValueParser(new FhirRequestContextAccessor()), ModelInfoProvider.Instance),
                 ModelInfoProvider.Instance,
                 NullLogger<SearchIndexer>.Instance);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchConverterForAllSearchTypes.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchConverterForAllSearchTypes.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
                 foreach (var result in converters.Where(x => x.hasConverter || !parameterInfo.IsPartiallySupported))
                 {
-                    var found = (await SearchParameterFixtureData.GetManager()).TryGetConverter(result.result.FhirNodeType, SearchIndexer.GetSearchValueTypeForSearchParamType(result.result.SearchParamType), out var converter);
+                    var found = (await SearchParameterFixtureData.GetFhirNodeToSearchValueTypeConverterManagerAsync()).TryGetConverter(result.result.FhirNodeType, SearchIndexer.GetSearchValueTypeForSearchParamType(result.result.SearchParamType), out var converter);
 
                     var converterText = found ? converter.GetType().Name : "None";
                     string searchTermMapping = $"Search term '{parameterName}' ({result.result.SearchParamType}) mapped to '{result.result.FhirNodeType}', converter: {converterText}";
@@ -73,7 +73,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         {
             var unsupported = new UnsupportedSearchParameters();
 
-            SearchParameterDefinitionManager manager = await SearchParameterFixtureData.CreateSearchParameterDefinitionManager(ModelInfoProvider.Instance);
+            SearchParameterDefinitionManager manager = await SearchParameterFixtureData.CreateSearchParameterDefinitionManagerAsync(ModelInfoProvider.Instance);
 
             var resourceAndSearchParameters = ModelInfoProvider.Instance
                 .GetResourceTypeNames()
@@ -131,7 +131,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         {
             var parsed = SearchParameterFixtureData.Compiler.Parse(parameterInfo.Expression);
 
-            SearchParameterDefinitionManager searchParameterDefinitionManager = await _fixture.GetSearchDefinitionManager();
+            SearchParameterDefinitionManager searchParameterDefinitionManager = await _fixture.GetSearchDefinitionManagerAsync();
 
             (SearchParamType Type, Expression, Uri DefinitionUrl)[] componentExpressions = parameterInfo.Component
                 .Select(x => (searchParameterDefinitionManager.UrlLookup[x.DefinitionUrl].Type,
@@ -144,7 +144,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
                 (parameterInfo.Type, parsed, parameterInfo.Url),
                 componentExpressions).ToArray();
 
-            var fhirNodeToSearchValueTypeConverterManager = await SearchParameterFixtureData.GetManager();
+            var fhirNodeToSearchValueTypeConverterManager = await SearchParameterFixtureData.GetFhirNodeToSearchValueTypeConverterManagerAsync();
 
             var converters = results
                 .Select(result => (
@@ -161,7 +161,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
         public static IEnumerable<object[]> GetAllSearchParameters()
         {
-            Task<SearchParameterDefinitionManager> searchParameterDefinitionManagerTask = SearchParameterFixtureData.CreateSearchParameterDefinitionManager(ModelInfoProvider.Instance);
+            Task<SearchParameterDefinitionManager> searchParameterDefinitionManagerTask = SearchParameterFixtureData.CreateSearchParameterDefinitionManagerAsync(ModelInfoProvider.Instance);
 
             // XUnit does not currently support async signatures for MemberDataAttributes. Until it does we need to block on
             // this task, which could cause a deadlock, but we know that the task should have completed synchronously,

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchConverterForAllSearchTypes.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchConverterForAllSearchTypes.cs
@@ -20,12 +20,14 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 {
-    public class SearchConverterForAllSearchTypes
+    public class SearchConverterForAllSearchTypes : IClassFixture<SearchParameterFixtureData>
     {
+        private readonly SearchParameterFixtureData _fixture;
         private readonly ITestOutputHelper _outputHelper;
 
-        public SearchConverterForAllSearchTypes(ITestOutputHelper outputHelper)
+        public SearchConverterForAllSearchTypes(SearchParameterFixtureData fixture, ITestOutputHelper outputHelper)
         {
+            _fixture = fixture;
             _outputHelper = outputHelper;
         }
 
@@ -129,7 +131,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         {
             var parsed = SearchParameterFixtureData.Compiler.Parse(parameterInfo.Expression);
 
-            SearchParameterDefinitionManager searchParameterDefinitionManager = await SearchParameterFixtureData.GetSearchDefinitionManager();
+            SearchParameterDefinitionManager searchParameterDefinitionManager = await _fixture.GetSearchDefinitionManager();
 
             (SearchParamType Type, Expression, Uri DefinitionUrl)[] componentExpressions = parameterInfo.Component
                 .Select(x => (searchParameterDefinitionManager.UrlLookup[x.DefinitionUrl].Type,
@@ -161,7 +163,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         {
             Task<SearchParameterDefinitionManager> searchParameterDefinitionManagerTask = SearchParameterFixtureData.CreateSearchParameterDefinitionManager(ModelInfoProvider.Instance);
 
-            // XUnit does not currently support async signatures for MemberDataAttributes. Until it dooes we need to block on
+            // XUnit does not currently support async signatures for MemberDataAttributes. Until it does we need to block on
             // this task, which could cause a deadlock, but we know that the task should have completed synchronously,
             // so there should not be a problem.
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
 using Microsoft.Health.Fhir.Core.Features.Context;
@@ -20,7 +21,7 @@ using Xunit;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 {
-    public class SearchParameterDefinitionManagerTests
+    public class SearchParameterDefinitionManagerTests : IAsyncLifetime
     {
         private static readonly string ResourceId = "http://hl7.org/fhir/SearchParameter/Resource-id";
         private static readonly string ResourceLastUpdated = "http://hl7.org/fhir/SearchParameter/Resource-lastUpdated";
@@ -100,9 +101,14 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             _searchParameterSupportResolver
                 .IsSearchParameterSupported(Arg.Is(_searchParameterInfos[4]))
                 .Returns((true, false));
-
-            _searchParameterDefinitionManager.Start();
         }
+
+        public async Task InitializeAsync()
+        {
+            await _searchParameterDefinitionManager.StartAsync(CancellationToken.None);
+        }
+
+        public Task DisposeAsync() => Task.CompletedTask;
 
         [Fact]
         public async Task GivenSupportedParams_WhenGettingSupported_ThenSupportedParamsReturned()

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterFixtureData.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterFixtureData.cs
@@ -37,22 +37,22 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
         public static FhirPathCompiler Compiler { get; } = new FhirPathCompiler();
 
-        public async Task<SearchParameterDefinitionManager> GetSearchDefinitionManager()
+        public async Task<SearchParameterDefinitionManager> GetSearchDefinitionManagerAsync()
         {
-            return _searchDefinitionManager ??= await CreateSearchParameterDefinitionManager(new VersionSpecificModelInfoProvider());
+            return _searchDefinitionManager ??= await CreateSearchParameterDefinitionManagerAsync(new VersionSpecificModelInfoProvider());
         }
 
-        public async Task<SupportedSearchParameterDefinitionManager> GetSupportedSearchDefinitionManager()
+        public async Task<SupportedSearchParameterDefinitionManager> GetSupportedSearchDefinitionManagerAsync()
         {
-            return _supportedSearchDefinitionManager ??= new SupportedSearchParameterDefinitionManager(await GetSearchDefinitionManager());
+            return _supportedSearchDefinitionManager ??= new SupportedSearchParameterDefinitionManager(await GetSearchDefinitionManagerAsync());
         }
 
-        public static async Task<FhirNodeToSearchValueTypeConverterManager> GetManager()
+        public static async Task<FhirNodeToSearchValueTypeConverterManager> GetFhirNodeToSearchValueTypeConverterManagerAsync()
         {
-            return _fhirNodeToSearchValueTypeConverterManager ??= await CreateFhirElementToSearchValueTypeConverterManager();
+            return _fhirNodeToSearchValueTypeConverterManager ??= await CreateFhirElementToSearchValueTypeConverterManagerAsync();
         }
 
-        private static async Task<FhirNodeToSearchValueTypeConverterManager> CreateFhirElementToSearchValueTypeConverterManager()
+        private static async Task<FhirNodeToSearchValueTypeConverterManager> CreateFhirElementToSearchValueTypeConverterManagerAsync()
         {
             var types = typeof(IFhirNodeToSearchValueTypeConverter)
                 .Assembly
@@ -69,7 +69,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             return new FhirNodeToSearchValueTypeConverterManager(fhirNodeToSearchValueTypeConverters);
         }
 
-        public static async Task<SearchParameterDefinitionManager> CreateSearchParameterDefinitionManager(IModelInfoProvider modelInfoProvider)
+        public static async Task<SearchParameterDefinitionManager> CreateSearchParameterDefinitionManagerAsync(IModelInfoProvider modelInfoProvider)
         {
             var definitionManager = new SearchParameterDefinitionManager(modelInfoProvider);
             await definitionManager.StartAsync(CancellationToken.None);
@@ -80,7 +80,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             var statusManager = new SearchParameterStatusManager(
                 statusRegistry,
                 definitionManager,
-                new SearchParameterSupportResolver(definitionManager, await GetManager()),
+                new SearchParameterSupportResolver(definitionManager, await GetFhirNodeToSearchValueTypeConverterManagerAsync()),
                 Substitute.For<IMediator>());
             await statusManager.EnsureInitialized();
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterFixtureData.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterFixtureData.cs
@@ -24,9 +24,11 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 {
     public class SearchParameterFixtureData
     {
-        private static SearchParameterDefinitionManager _searchDefinitionManager;
-        private static SupportedSearchParameterDefinitionManager _supportedSearchDefinitionManager;
+        // this type is immutable and is safe to reuse
         private static FhirNodeToSearchValueTypeConverterManager _fhirNodeToSearchValueTypeConverterManager;
+
+        private SearchParameterDefinitionManager _searchDefinitionManager;
+        private SupportedSearchParameterDefinitionManager _supportedSearchDefinitionManager;
 
         static SearchParameterFixtureData()
         {
@@ -35,12 +37,12 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
         public static FhirPathCompiler Compiler { get; } = new FhirPathCompiler();
 
-        public static async Task<SearchParameterDefinitionManager> GetSearchDefinitionManager()
+        public async Task<SearchParameterDefinitionManager> GetSearchDefinitionManager()
         {
             return _searchDefinitionManager ??= await CreateSearchParameterDefinitionManager(new VersionSpecificModelInfoProvider());
         }
 
-        public static async Task<SupportedSearchParameterDefinitionManager> GetSupportedSearchDefinitionManager()
+        public async Task<SupportedSearchParameterDefinitionManager> GetSupportedSearchDefinitionManager()
         {
             return _supportedSearchDefinitionManager ??= new SupportedSearchParameterDefinitionManager(await GetSearchDefinitionManager());
         }
@@ -50,7 +52,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             return _fhirNodeToSearchValueTypeConverterManager ??= await CreateFhirElementToSearchValueTypeConverterManager();
         }
 
-        public static async Task<FhirNodeToSearchValueTypeConverterManager> CreateFhirElementToSearchValueTypeConverterManager()
+        private static async Task<FhirNodeToSearchValueTypeConverterManager> CreateFhirElementToSearchValueTypeConverterManager()
         {
             var types = typeof(IFhirNodeToSearchValueTypeConverter)
                 .Assembly

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterSupportResolverTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterSupportResolverTests.cs
@@ -22,8 +22,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         public async Task InitializeAsync()
         {
             _resolver = new SearchParameterSupportResolver(
-                await _fixture.GetSearchDefinitionManager(),
-                await SearchParameterFixtureData.GetManager());
+                await _fixture.GetSearchDefinitionManagerAsync(),
+                await SearchParameterFixtureData.GetFhirNodeToSearchValueTypeConverterManagerAsync());
         }
 
         public Task DisposeAsync() => Task.CompletedTask;

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterSupportResolverTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterSupportResolverTests.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.Health.Fhir.Core.Features.Search.Parameters;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.ValueSets;
@@ -11,14 +12,18 @@ using Xunit;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 {
-    public class SearchParameterSupportResolverTests
+    public class SearchParameterSupportResolverTests : IAsyncLifetime
     {
-        private readonly SearchParameterSupportResolver _resolver;
+        private SearchParameterSupportResolver _resolver;
 
-        public SearchParameterSupportResolverTests()
+        public async Task InitializeAsync()
         {
-            _resolver = new SearchParameterSupportResolver(SearchParameterFixtureData.SearchDefinitionManager, SearchParameterFixtureData.Manager);
+            _resolver = new SearchParameterSupportResolver(
+                await SearchParameterFixtureData.GetSearchDefinitionManager(),
+                await SearchParameterFixtureData.GetManager());
         }
+
+        public Task DisposeAsync() => Task.CompletedTask;
 
         [Fact]
         public void GivenASupportedSearchParameter_WhenResolvingSupport_ThenTrueIsReturned()

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterSupportResolverTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterSupportResolverTests.cs
@@ -12,14 +12,17 @@ using Xunit;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 {
-    public class SearchParameterSupportResolverTests : IAsyncLifetime
+    public class SearchParameterSupportResolverTests : IClassFixture<SearchParameterFixtureData>, IAsyncLifetime
     {
+        private readonly SearchParameterFixtureData _fixture;
         private SearchParameterSupportResolver _resolver;
+
+        public SearchParameterSupportResolverTests(SearchParameterFixtureData fixture) => _fixture = fixture;
 
         public async Task InitializeAsync()
         {
             _resolver = new SearchParameterSupportResolver(
-                await SearchParameterFixtureData.GetSearchDefinitionManager(),
+                await _fixture.GetSearchDefinitionManager(),
                 await SearchParameterFixtureData.GetManager());
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Web/PrometheusMetricsServer.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web/PrometheusMetricsServer.cs
@@ -4,19 +4,21 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.Health.Extensions.DependencyInjection;
 using Prometheus;
 using Prometheus.DotNetRuntime;
 
 namespace Microsoft.Health.Fhir.Web
 {
-    public sealed class PrometheusMetricsServer : IStartable, IDisposable
+    public sealed class PrometheusMetricsServer : IHostedService, IDisposable
     {
         private readonly PrometheusMetricsConfig _prometheusMetricsConfig;
         private readonly ILogger<PrometheusMetricsServer> _logger;
-        private KestrelMetricServer _metricsServer = null;
+        private KestrelMetricServer _metricsServer;
 
         public PrometheusMetricsServer(IOptions<PrometheusMetricsConfig> config, ILogger<PrometheusMetricsServer> logger)
         {
@@ -24,7 +26,7 @@ namespace Microsoft.Health.Fhir.Web
             _logger = logger;
         }
 
-        void IStartable.Start()
+        Task IHostedService.StartAsync(CancellationToken cancellationToken)
         {
             if (_prometheusMetricsConfig.Enabled)
             {
@@ -44,6 +46,14 @@ namespace Microsoft.Health.Fhir.Web
 
                 _metricsServer.Start();
             }
+
+            return Task.CompletedTask;
+        }
+
+        Task IHostedService.StopAsync(CancellationToken cancellationToken)
+        {
+            Dispose();
+            return Task.CompletedTask;
         }
 
         public void Dispose()

--- a/src/Microsoft.Health.Fhir.Shared.Web/PrometheusMetricsServicesCollectionExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web/PrometheusMetricsServicesCollectionExtensions.cs
@@ -5,6 +5,7 @@
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Prometheus.SystemMetrics;
@@ -25,7 +26,7 @@ namespace Microsoft.Health.Fhir.Web
             {
                 services.Add<PrometheusMetricsServer>()
                     .Singleton()
-                    .AsService<IStartable>();
+                    .AsService<IHostedService>();
 
                 if (prometheusConfig.SystemMetrics)
                 {

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/DenormalizedPredicateRewriterTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/DenormalizedPredicateRewriterTests.cs
@@ -4,7 +4,6 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Collections.Generic;
-using Hl7.FhirPath.Sprache;
 using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
 using Microsoft.Health.Fhir.Core.Models;

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/TableExpressionKind.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/TableExpressionKind.cs
@@ -59,6 +59,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions
         /// </summary>
         Sort,
 
+        /// <summary>
         /// Represents a table expression that is used to limit the number of included items.
         /// </summary>
         IncludeLimit,

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/DenormalizedPredicateRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/DenormalizedPredicateRewriter.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/SortRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/SortRewriter.cs
@@ -10,8 +10,9 @@ using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
 
 namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
 {
-    /// A visitor for a Sort paramater.
-    /// It creates the correct Generator and populates the normalized predicates.
+    /// <summary>
+    /// It creates the correct generator and populates the normalized predicates for sort parameters.
+    /// </summary>
     internal class SortRewriter : SqlExpressionRewriter<SearchOptions>
     {
         private readonly NormalizedSearchParameterQueryGeneratorFactory _normalizedSearchParameterQueryGeneratorFactory;

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -9,7 +9,6 @@ using System.Data;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
 using System.Text;
 using System.Threading;

--- a/src/Microsoft.Health.Fhir.SqlServer/Microsoft.Health.Fhir.SqlServer.csproj
+++ b/src/Microsoft.Health.Fhir.SqlServer/Microsoft.Health.Fhir.SqlServer.csproj
@@ -22,10 +22,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="9.2.0" />
-    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20201008-2" />
-    <PackageReference Include="Microsoft.Health.SqlServer" Version="1.0.0-master-20201008-2" />
-    <PackageReference Include="Microsoft.Health.SqlServer.Api" Version="1.0.0-master-20201008-2" />
-    <PackageReference Include="Microsoft.Health.Extensions.BuildTimeCodeGenerator" Version="1.0.0-master-20201008-2" />
+    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20201022-1" />
+    <PackageReference Include="Microsoft.Health.SqlServer" Version="1.0.0-master-20201022-1" />
+    <PackageReference Include="Microsoft.Health.SqlServer.Api" Version="1.0.0-master-20201022-1" />
+    <PackageReference Include="Microsoft.Health.Extensions.BuildTimeCodeGenerator" Version="1.0.0-master-20201022-1" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.3.5" />
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="161.41011.9" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="3.1.8" />

--- a/src/Microsoft.Health.Fhir.Stu3.Api.UnitTests/Microsoft.Health.Fhir.Stu3.Api.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.Stu3.Api.UnitTests/Microsoft.Health.Fhir.Stu3.Api.UnitTests.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>Microsoft.Health.Fhir.Api.UnitTests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201008-2" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201022-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Microsoft.Health.Fhir.Stu3.Client/Microsoft.Health.Fhir.Stu3.Client.csproj
+++ b/src/Microsoft.Health.Fhir.Stu3.Client/Microsoft.Health.Fhir.Stu3.Client.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Ensure.That" Version="9.2.0" />
     <PackageReference Include="Hl7.Fhir.STU3" Version="1.9.0" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.5.0" />
-    <PackageReference Include="Microsoft.Health.Client" Version="1.0.0-master-20201008-2" />
+    <PackageReference Include="Microsoft.Health.Client" Version="1.0.0-master-20201022-1" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.7.1" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.7.1" />
   </ItemGroup>

--- a/src/Microsoft.Health.Fhir.Stu3.Core.UnitTests/Microsoft.Health.Fhir.Stu3.Core.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.Stu3.Core.UnitTests/Microsoft.Health.Fhir.Stu3.Core.UnitTests.csproj
@@ -9,7 +9,7 @@
     <Compile Include="..\Microsoft.Health.Fhir.Shared.Core.UnitTests\Features\Operations\Export\ExportAnonymizerFactoryTests.cs" Link="Features\Export\ExportAnonymizerFactoryTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201008-2" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201022-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
+++ b/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
@@ -320,7 +320,7 @@
     <EmbeddedResource Include="TestFiles\Stu3\WeightInPounds.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20201008-2" />
+    <PackageReference Include="Microsoft.Health.Abstractions" Version="1.0.0-master-20201022-1" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />

--- a/test/Microsoft.Health.Fhir.R4.Tests.E2E/Microsoft.Health.Fhir.R4.Tests.E2E.csproj
+++ b/test/Microsoft.Health.Fhir.R4.Tests.E2E/Microsoft.Health.Fhir.R4.Tests.E2E.csproj
@@ -21,8 +21,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20201008-2" />
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201008-2" />
+    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20201022-1" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201022-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="selenium.chrome.webdriver" Version="83.0.0" />
     <PackageReference Include="selenium.webdriver" Version="3.141.0" />

--- a/test/Microsoft.Health.Fhir.R4.Tests.Integration/Microsoft.Health.Fhir.R4.Tests.Integration.csproj
+++ b/test/Microsoft.Health.Fhir.R4.Tests.Integration/Microsoft.Health.Fhir.R4.Tests.Integration.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201008-2" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201022-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="Microsoft.SqlServer.DACFx" Version="150.4897.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/Microsoft.Health.Fhir.R5.Tests.E2E/Microsoft.Health.Fhir.R5.Tests.E2E.csproj
+++ b/test/Microsoft.Health.Fhir.R5.Tests.E2E/Microsoft.Health.Fhir.R5.Tests.E2E.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201008-2" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201022-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="selenium.chrome.webdriver" Version="83.0.0" />
     <PackageReference Include="selenium.webdriver" Version="3.141.0" />

--- a/test/Microsoft.Health.Fhir.R5.Tests.Integration/Microsoft.Health.Fhir.R5.Tests.Integration.csproj
+++ b/test/Microsoft.Health.Fhir.R5.Tests.Integration/Microsoft.Health.Fhir.R5.Tests.Integration.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201008-2" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201022-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="Microsoft.SqlServer.DACFx" Version="150.4897.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Crucible/CrucibleDataSource.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Crucible/CrucibleDataSource.cs
@@ -49,9 +49,9 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Crucible
         {
             await client.RefreshConformanceStatementAsync();
 
-            using (var testFhirServerFactory = new TestFhirServerFactory())
+            await using (var testFhirServerFactory = new TestFhirServerFactory())
             {
-                var testFhirServer = testFhirServerFactory
+                var testFhirServer = await testFhirServerFactory
                     .GetTestFhirServer(_dataStore, null);
 
                 // Obtaining a client is required for configuring the security options.

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Crucible/CrucibleDataSource.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Crucible/CrucibleDataSource.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Crucible
             await using (var testFhirServerFactory = new TestFhirServerFactory())
             {
                 var testFhirServer = await testFhirServerFactory
-                    .GetTestFhirServer(_dataStore, null);
+                    .GetTestFhirServerAsync(_dataStore, null);
 
                 // Obtaining a client is required for configuring the security options.
                 testFhirServer.GetTestFhirClient(ResourceFormat.Json, reusable: false);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Crucible/CrucibleTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Crucible/CrucibleTestFixture.cs
@@ -3,16 +3,12 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.E2E.Rest;
 using Microsoft.Health.Test.Utilities;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Crucible
 {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/AuditTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/AuditTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit
     /// Provides Audit specific tests.
     /// </summary
     [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb, Format.Json)]
-    public class AuditTests : IClassFixture<AuditTestFixture>
+    public class AuditTests : IClassFixture<AuditTestFixture>, IAsyncLifetime
     {
         private const string RequestIdHeaderName = "X-Request-Id";
         private const string CustomAuditHeaderPrefix = "X-MS-AZUREFHIR-AUDIT-";
@@ -43,8 +43,14 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit
             _fixture = fixture;
             _client = fixture.TestFhirClient;
             _auditLogger = _fixture.AuditLogger;
-            _client.DeleteAllResources(ResourceType.Patient).Wait();
         }
+
+        public async Task InitializeAsync()
+        {
+            await _client.DeleteAllResources(ResourceType.Patient);
+        }
+
+        public Task DisposeAsync() => Task.CompletedTask;
 
         [Fact]
         public async Task GivenMetadata_WhenRead_ThenAuditLogEntriesShouldNotBeCreated()

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/CompartmentTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/CompartmentTestFixture.cs
@@ -6,12 +6,11 @@
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
-using Xunit;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
-    public class CompartmentTestFixture : HttpIntegrationTestFixture, IAsyncLifetime
+    public class CompartmentTestFixture : HttpIntegrationTestFixture
     {
         public CompartmentTestFixture(DataStore dataStore, Format format, TestFhirServerFactory testFhirServerFactory)
             : base(dataStore, format, testFhirServerFactory)
@@ -28,7 +27,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
         public Condition Condition { get; private set; }
 
-        public async Task InitializeAsync()
+        protected override async Task OnInitializedAsync()
         {
             // Create various resources.
             Device = await TestFhirClient.CreateAsync(Samples.GetJsonSample<Device>("Device-d1"));
@@ -56,11 +55,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             conditionToCreate.Subject.Reference = patientReference;
 
             Condition = await TestFhirClient.CreateAsync(conditionToCreate);
-        }
-
-        public Task DisposeAsync()
-        {
-            return Task.CompletedTask;
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HttpIntegrationTestFixture{TStartup}.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HttpIntegrationTestFixture{TStartup}.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
         public async Task InitializeAsync()
         {
-            TestFhirServer = await _testFhirServerFactory.GetTestFhirServer(_dataStore, typeof(TStartup));
+            TestFhirServer = await _testFhirServerFactory.GetTestFhirServerAsync(_dataStore, typeof(TStartup));
 
             TestFhirClient = TestFhirServer.GetTestFhirClient(_resourceFormat);
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HttpIntegrationTestFixture{TStartup}.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HttpIntegrationTestFixture{TStartup}.cs
@@ -4,13 +4,13 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading.Tasks;
 using EnsureThat;
 using Hl7.Fhir.Rest;
-using Microsoft.Health.Client;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.E2E.Common;
+using Xunit;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
@@ -18,45 +18,59 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
     /// A test fixture that is intended to provide a <see cref="TestFhirClient"/> to end-to-end FHIR test classes.
     /// </summary>
     /// <typeparam name="TStartup">The type to use as the ASP.NET startup type when hosting the fhir server in-process</typeparam>
-    public class HttpIntegrationTestFixture<TStartup>
+    public class HttpIntegrationTestFixture<TStartup> : IAsyncLifetime
     {
-        private Dictionary<string, AuthenticationHttpMessageHandler> _authenticationHandlers = new Dictionary<string, AuthenticationHttpMessageHandler>();
+        private readonly DataStore _dataStore;
+        private readonly TestFhirServerFactory _testFhirServerFactory;
+        private readonly ResourceFormat _resourceFormat;
 
         public HttpIntegrationTestFixture(DataStore dataStore, Format format, TestFhirServerFactory testFhirServerFactory)
         {
             EnsureArg.IsNotNull(testFhirServerFactory, nameof(testFhirServerFactory));
+            _dataStore = dataStore;
+            _testFhirServerFactory = testFhirServerFactory;
 
-            TestFhirServer = testFhirServerFactory.GetTestFhirServer(dataStore, typeof(TStartup));
-
-            ResourceFormat resourceFormat;
-            switch (format)
+            _resourceFormat = format switch
             {
-                case Format.Json:
-                    resourceFormat = ResourceFormat.Json;
-                    break;
-                case Format.Xml:
-                    resourceFormat = ResourceFormat.Xml;
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(format), format, null);
-            }
+                Format.Json => ResourceFormat.Json,
+                Format.Xml => ResourceFormat.Xml,
+                _ => throw new ArgumentOutOfRangeException(nameof(format), format, null)
+            };
 
-            TestFhirClient = TestFhirServer.GetTestFhirClient(resourceFormat);
-
-            IsUsingInProcTestServer = TestFhirServer is InProcTestFhirServer;
+            TestFhirServer.CreateSession();
         }
 
-        public bool IsUsingInProcTestServer { get; }
+        public bool IsUsingInProcTestServer { get; private set; }
 
         public HttpClient HttpClient => TestFhirClient.HttpClient;
 
-        public TestFhirClient TestFhirClient { get; }
+        public TestFhirClient TestFhirClient { get; private set; }
 
-        protected internal TestFhirServer TestFhirServer { get; }
+        protected internal TestFhirServer TestFhirServer { get; private set; }
+
+        public async Task InitializeAsync()
+        {
+            TestFhirServer = await _testFhirServerFactory.GetTestFhirServer(_dataStore, typeof(TStartup));
+
+            TestFhirClient = TestFhirServer.GetTestFhirClient(_resourceFormat);
+
+            IsUsingInProcTestServer = TestFhirServer is InProcTestFhirServer;
+
+            await OnInitializedAsync();
+        }
+
+        public async Task DisposeAsync()
+        {
+            await OnDisposedAsync();
+        }
 
         public string GenerateFullUrl(string relativeUrl)
         {
             return $"{TestFhirServer.BaseAddress}{relativeUrl}";
         }
+
+        protected virtual Task OnInitializedAsync() => Task.CompletedTask;
+
+        protected virtual Task OnDisposedAsync() => Task.CompletedTask;
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -24,14 +24,20 @@ using Task = System.Threading.Tasks.Task;
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 {
     [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.Json)]
-    public class BasicSearchTests : SearchTestsBase<HttpIntegrationTestFixture>
+    public class BasicSearchTests : SearchTestsBase<HttpIntegrationTestFixture>, IAsyncLifetime
     {
         public BasicSearchTests(HttpIntegrationTestFixture fixture)
             : base(fixture)
         {
-            // Delete all patients before starting the test.
-            Client.DeleteAllResources(ResourceType.Patient).Wait();
         }
+
+        public async Task InitializeAsync()
+        {
+            // Delete all patients before starting the test.
+            await Client.DeleteAllResources(ResourceType.Patient);
+        }
+
+        public Task DisposeAsync() => Task.CompletedTask;
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/DateSearchTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/DateSearchTestFixture.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Client;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 {
@@ -16,6 +17,14 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         public DateSearchTestFixture(DataStore dataStore, Format format, TestFhirServerFactory testFhirServerFactory)
             : base(dataStore, format, testFhirServerFactory)
         {
+        }
+
+        public Coding Coding { get; private set; }
+
+        public IReadOnlyList<Observation> Observations { get; private set; }
+
+        protected override async Task OnInitializedAsync()
+        {
             // Creates a unique code for searches
             Coding = new Coding
             {
@@ -23,14 +32,14 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 System = "http://fhir-server-test/guid",
             };
 
-            Observations = TestFhirClient.CreateResourcesAsync<Observation>(
+            Observations = await TestFhirClient.CreateResourcesAsync<Observation>(
                 p => SetObservation(p, "1979-12-31"),                // 1979-12-31T00:00:00.0000000 <-> 1979-12-31T23:59:59.9999999
                 p => SetObservation(p, "1980"),                      // 1980-01-01T00:00:00.0000000 <-> 1980-12-31T23:59:59.9999999
                 p => SetObservation(p, "1980-05"),                   // 1980-05-01T00:00:00.0000000 <-> 1980-05-31T23:59:59.9999999
                 p => SetObservation(p, "1980-05-11"),                // 1980-05-11T00:00:00.0000000 <-> 1980-05-11T23:59:59.9999999
                 p => SetObservation(p, "1980-05-11T16:32:15"),       // 1980-05-11T16:32:15.0000000 <-> 1980-05-11T16:32:15.9999999
                 p => SetObservation(p, "1980-05-11T16:32:15.500"),   // 1980-05-11T16:32:15.5000000 <-> 1980-05-11T16:32:15.5000000
-                p => SetObservation(p, "1981-01-01")).Result;        // 1981-01-01T00:00:00.0000000 <-> 1981-12-31T23:59:59.9999999
+                p => SetObservation(p, "1981-01-01"));        // 1981-01-01T00:00:00.0000000 <-> 1981-12-31T23:59:59.9999999
 
             void SetObservation(Observation observation, string date)
             {
@@ -45,9 +54,5 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 observation.Effective = new FhirDateTime(date);
             }
         }
-
-        public Coding Coding { get; }
-
-        public IReadOnlyList<Observation> Observations { get; }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTestFixture.cs
@@ -5,10 +5,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Hl7.Fhir.Model;
-using Microsoft.Health.Fhir.Client;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.E2E.Rest;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Search
 {
@@ -16,6 +17,44 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Search
     {
         public IncludeSearchTestFixture(DataStore dataStore, Format format, TestFhirServerFactory testFhirServerFactory)
             : base(dataStore, format, testFhirServerFactory)
+        {
+        }
+
+        public Organization Organization { get; private set; }
+
+        public Practitioner Practitioner { get; private set; }
+
+        public Group PatientGroup { get; private set; }
+
+        public string Tag { get; private set; }
+
+        public Patient AdamsPatient { get; private set; }
+
+        public Observation AdamsLoincObservation { get; private set; }
+
+        public Patient TrumanPatient { get; private set; }
+
+        public Observation TrumanSnomedObservation { get; private set; }
+
+        public Observation TrumanLoincObservation { get; private set; }
+
+        public DiagnosticReport TrumanSnomedDiagnosticReport { get; private set; }
+
+        public DiagnosticReport TrumanLoincDiagnosticReport { get; private set; }
+
+        public Patient SmithPatient { get; private set; }
+
+        public Observation SmithSnomedObservation { get; private set; }
+
+        public Observation SmithLoincObservation { get; private set; }
+
+        public DiagnosticReport SmithSnomedDiagnosticReport { get; private set; }
+
+        public DiagnosticReport SmithLoincDiagnosticReport { get; private set; }
+
+        public Location Location { get; private set; }
+
+        protected override async Task OnInitializedAsync()
         {
             Tag = Guid.NewGuid().ToString();
 
@@ -31,29 +70,29 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Search
                     },
             };
 
-            Organization = TestFhirClient.CreateAsync(new Organization { Meta = meta, Address = new List<Address> { new Address { City = "Seattle" } } }).Result.Resource;
-            Practitioner = TestFhirClient.CreateAsync(new Practitioner { Meta = meta }).Result.Resource;
+            Organization = (await TestFhirClient.CreateAsync(new Organization { Meta = meta, Address = new List<Address> { new Address { City = "Seattle" } } })).Resource;
+            Practitioner = (await TestFhirClient.CreateAsync(new Practitioner { Meta = meta })).Resource;
 
-            AdamsPatient = TestFhirClient.CreateAsync(new Patient { Meta = meta, Name = new List<HumanName> { new HumanName { Family = "Adams" } } }).Result.Resource;
-            SmithPatient = TestFhirClient.CreateAsync(new Patient { Meta = meta, Name = new List<HumanName> { new HumanName { Family = "Smith" } }, ManagingOrganization = new ResourceReference($"Organization/{Organization.Id}") }).Result.Resource;
-            TrumanPatient = TestFhirClient.CreateAsync(new Patient { Meta = meta, Name = new List<HumanName> { new HumanName { Family = "Truman" } } }).Result.Resource;
+            AdamsPatient = (await TestFhirClient.CreateAsync(new Patient { Meta = meta, Name = new List<HumanName> { new HumanName { Family = "Adams" } } })).Resource;
+            SmithPatient = (await TestFhirClient.CreateAsync(new Patient { Meta = meta, Name = new List<HumanName> { new HumanName { Family = "Smith" } }, ManagingOrganization = new ResourceReference($"Organization/{Organization.Id}") })).Resource;
+            TrumanPatient = (await TestFhirClient.CreateAsync(new Patient { Meta = meta, Name = new List<HumanName> { new HumanName { Family = "Truman" } } })).Resource;
 
-            AdamsLoincObservation = CreateObservation(AdamsPatient, loincCode);
-            SmithLoincObservation = CreateObservation(SmithPatient, loincCode);
-            SmithSnomedObservation = CreateObservation(SmithPatient, snomedCode);
-            TrumanLoincObservation = CreateObservation(TrumanPatient, loincCode);
-            TrumanSnomedObservation = CreateObservation(TrumanPatient, snomedCode);
+            AdamsLoincObservation = await CreateObservation(AdamsPatient, loincCode);
+            SmithLoincObservation = await CreateObservation(SmithPatient, loincCode);
+            SmithSnomedObservation = await CreateObservation(SmithPatient, snomedCode);
+            TrumanLoincObservation = await CreateObservation(TrumanPatient, loincCode);
+            TrumanSnomedObservation = await CreateObservation(TrumanPatient, snomedCode);
 
-            SmithSnomedDiagnosticReport = CreateDiagnosticReport(SmithPatient, SmithSnomedObservation, snomedCode);
-            TrumanSnomedDiagnosticReport = CreateDiagnosticReport(TrumanPatient, TrumanSnomedObservation, snomedCode);
-            SmithLoincDiagnosticReport = CreateDiagnosticReport(SmithPatient, SmithLoincObservation, loincCode);
-            TrumanLoincDiagnosticReport = CreateDiagnosticReport(TrumanPatient, TrumanLoincObservation, loincCode);
+            SmithSnomedDiagnosticReport = await CreateDiagnosticReport(SmithPatient, SmithSnomedObservation, snomedCode);
+            TrumanSnomedDiagnosticReport = await CreateDiagnosticReport(TrumanPatient, TrumanSnomedObservation, snomedCode);
+            SmithLoincDiagnosticReport = await CreateDiagnosticReport(SmithPatient, SmithLoincObservation, loincCode);
+            TrumanLoincDiagnosticReport = await CreateDiagnosticReport(TrumanPatient, TrumanLoincObservation, loincCode);
 
-            Location = TestFhirClient.CreateAsync(new Location
+            Location = (await TestFhirClient.CreateAsync(new Location
             {
                 ManagingOrganization = new ResourceReference($"Organization/{Organization.Id}"),
                 Meta = new Meta { Tag = new List<Coding> { new Coding("testTag", Tag) } },
-            }).Result.Resource;
+            })).Resource;
 
             var group = new Group
             {
@@ -67,11 +106,11 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Search
                     },
             };
 
-            PatientGroup = TestFhirClient.CreateAsync(group).Result.Resource;
+            PatientGroup = (await TestFhirClient.CreateAsync(@group)).Resource;
 
-            DiagnosticReport CreateDiagnosticReport(Patient patient, Observation observation, CodeableConcept code)
+            async Task<DiagnosticReport> CreateDiagnosticReport(Patient patient, Observation observation, CodeableConcept code)
             {
-                return TestFhirClient.CreateAsync(
+                return (await TestFhirClient.CreateAsync(
                     new DiagnosticReport
                     {
                         Meta = meta,
@@ -79,12 +118,12 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Search
                         Code = code,
                         Subject = new ResourceReference($"Patient/{patient.Id}"),
                         Result = new List<ResourceReference> { new ResourceReference($"Observation/{observation.Id}") },
-                    }).Result.Resource;
+                    })).Resource;
             }
 
-            Observation CreateObservation(Patient patient, CodeableConcept code)
+            async Task<Observation> CreateObservation(Patient patient, CodeableConcept code)
             {
-                return TestFhirClient.CreateAsync(
+                return (await TestFhirClient.CreateAsync(
                     new Observation()
                     {
                         Meta = meta,
@@ -96,42 +135,8 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Search
                             new ResourceReference($"Organization/{Organization.Id}"),
                             new ResourceReference($"Practitioner/{Practitioner.Id}"),
                         },
-                    }).Result.Resource;
+                    })).Resource;
             }
         }
-
-        public Organization Organization { get; }
-
-        public Practitioner Practitioner { get; }
-
-        public Group PatientGroup { get; }
-
-        public string Tag { get; }
-
-        public Patient AdamsPatient { get; }
-
-        public Observation AdamsLoincObservation { get; }
-
-        public Patient TrumanPatient { get; }
-
-        public Observation TrumanSnomedObservation { get; }
-
-        public Observation TrumanLoincObservation { get; }
-
-        public DiagnosticReport TrumanSnomedDiagnosticReport { get; }
-
-        public DiagnosticReport TrumanLoincDiagnosticReport { get; }
-
-        public Patient SmithPatient { get; }
-
-        public Observation SmithSnomedObservation { get; }
-
-        public Observation SmithLoincObservation { get; }
-
-        public DiagnosticReport SmithSnomedDiagnosticReport { get; }
-
-        public DiagnosticReport SmithLoincDiagnosticReport { get; }
-
-        public Location Location { get; }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTestFixture.cs
@@ -106,27 +106,27 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Search
                     },
             };
 
-            PercocetMedication = TestFhirClient.CreateAsync(new Medication { Meta = meta, Code = new CodeableConcept("http://snomed.info/sct", "16590-619-30", "Percocet tablet") }).Result.Resource;
-            TramadolMedication = TestFhirClient.CreateAsync(new Medication { Meta = meta, Code = new CodeableConcept("http://snomed.info/sct", "108505002", "Tramadol hydrochloride (substance)") }).Result.Resource;
-            Organization = TestFhirClient.CreateAsync(new Organization { Meta = meta, Address = new List<Address> { new Address { City = "Seattle" } } }).Result.Resource;
-            Practitioner = TestFhirClient.CreateAsync(new Practitioner { Meta = meta }).Result.Resource;
-            Patient = CreatePatient("Pati", Practitioner, Organization);
+            PercocetMedication = (await TestFhirClient.CreateAsync(new Medication { Meta = meta, Code = new CodeableConcept("http://snomed.info/sct", "16590-619-30", "Percocet tablet") })).Resource;
+            TramadolMedication = (await TestFhirClient.CreateAsync(new Medication { Meta = meta, Code = new CodeableConcept("http://snomed.info/sct", "108505002", "Tramadol hydrochloride (substance)") })).Resource;
+            Organization = (await TestFhirClient.CreateAsync(new Organization { Meta = meta, Address = new List<Address> { new Address { City = "Seattle" } } })).Resource;
+            Practitioner = (await TestFhirClient.CreateAsync(new Practitioner { Meta = meta })).Resource;
+            Patient = await CreatePatient("Pati", Practitioner, Organization);
 
             // Organization Hierarchy
             LabFOrganization = TestFhirClient.CreateAsync(new Organization { Meta = meta }).Result.Resource;
-            LabEOrganization = TestFhirClient.CreateAsync(new Organization { Meta = meta, PartOf = new ResourceReference($"Organization/{LabFOrganization.Id}") }).Result.Resource;
-            LabDOrganization = TestFhirClient.CreateAsync(new Organization { Meta = meta, PartOf = new ResourceReference($"Organization/{LabEOrganization.Id}") }).Result.Resource;
-            LabCOrganization = TestFhirClient.CreateAsync(new Organization { Meta = meta, PartOf = new ResourceReference($"Organization/{LabDOrganization.Id}") }).Result.Resource;
-            LabBOrganization = TestFhirClient.CreateAsync(new Organization { Meta = meta, PartOf = new ResourceReference($"Organization/{LabCOrganization.Id}") }).Result.Resource;
-            LabAOrganization = TestFhirClient.CreateAsync(new Organization { Meta = meta, PartOf = new ResourceReference($"Organization/{LabBOrganization.Id}") }).Result.Resource;
+            LabEOrganization = (await TestFhirClient.CreateAsync(new Organization { Meta = meta, PartOf = new ResourceReference($"Organization/{LabFOrganization.Id}") })).Resource;
+            LabDOrganization = (await TestFhirClient.CreateAsync(new Organization { Meta = meta, PartOf = new ResourceReference($"Organization/{LabEOrganization.Id}") })).Resource;
+            LabCOrganization = (await TestFhirClient.CreateAsync(new Organization { Meta = meta, PartOf = new ResourceReference($"Organization/{LabDOrganization.Id}") })).Resource;
+            LabBOrganization = (await TestFhirClient.CreateAsync(new Organization { Meta = meta, PartOf = new ResourceReference($"Organization/{LabCOrganization.Id}") })).Resource;
+            LabAOrganization = (await TestFhirClient.CreateAsync(new Organization { Meta = meta, PartOf = new ResourceReference($"Organization/{LabBOrganization.Id}") })).Resource;
 
-            AndersonPractitioner = TestFhirClient.CreateAsync(new Practitioner { Meta = meta, Name = new List<HumanName> { new HumanName { Family = "Anderson" } } }).Result.Resource;
-            SanchezPractitioner = TestFhirClient.CreateAsync(new Practitioner { Meta = meta, Name = new List<HumanName> { new HumanName { Family = "Sanchez" } } }).Result.Resource;
-            TaylorPractitioner = TestFhirClient.CreateAsync(new Practitioner { Meta = meta, Name = new List<HumanName> { new HumanName { Family = "Taylor" } } }).Result.Resource;
+            AndersonPractitioner = (await TestFhirClient.CreateAsync(new Practitioner { Meta = meta, Name = new List<HumanName> { new HumanName { Family = "Anderson" } } })).Resource;
+            SanchezPractitioner = (await TestFhirClient.CreateAsync(new Practitioner { Meta = meta, Name = new List<HumanName> { new HumanName { Family = "Sanchez" } } })).Resource;
+            TaylorPractitioner = (await TestFhirClient.CreateAsync(new Practitioner { Meta = meta, Name = new List<HumanName> { new HumanName { Family = "Taylor" } } })).Resource;
 
-            AdamsPatient = CreatePatient("Adams", AndersonPractitioner, Organization);
-            SmithPatient = CreatePatient("Smith",  SanchezPractitioner, Organization);
-            TrumanPatient = CreatePatient("Truman",  TaylorPractitioner, Organization);
+            AdamsPatient = await CreatePatient("Adams", AndersonPractitioner, Organization);
+            SmithPatient = await CreatePatient("Smith",  SanchezPractitioner, Organization);
+            TrumanPatient = await CreatePatient("Truman",  TaylorPractitioner, Organization);
 
             AdamsLoincObservation = await CreateObservation(AdamsPatient, Practitioner, Organization, loincCode);
             SmithLoincObservation = await CreateObservation(SmithPatient, Practitioner, Organization, loincCode);
@@ -139,20 +139,20 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Search
             SmithLoincDiagnosticReport = await CreateDiagnosticReport(SmithPatient, SmithLoincObservation, loincCode);
             TrumanLoincDiagnosticReport = await CreateDiagnosticReport(TrumanPatient, TrumanLoincObservation, loincCode);
 
-            AdamsMedicationRequest = CreateMedicationRequest(AdamsPatient, AndersonPractitioner, PercocetMedication);
-            SmithMedicationRequest = CreateMedicationRequest(SmithPatient, SanchezPractitioner, PercocetMedication);
+            AdamsMedicationRequest = await CreateMedicationRequest(AdamsPatient, AndersonPractitioner, PercocetMedication);
+            SmithMedicationRequest = await CreateMedicationRequest(SmithPatient, SanchezPractitioner, PercocetMedication);
 
-            AdamsMedicationDispense = CreateMedicationDispense(AdamsMedicationRequest, AdamsPatient, TramadolMedication);
-            SmithMedicationDispense = CreateMedicationDispense(SmithMedicationRequest, SmithPatient, TramadolMedication);
-            TrumanMedicationDispenseWithoutRequest = CreateMedicationDispense(null, TrumanPatient, TramadolMedication);
+            AdamsMedicationDispense = await CreateMedicationDispense(AdamsMedicationRequest, AdamsPatient, TramadolMedication);
+            SmithMedicationDispense = await CreateMedicationDispense(SmithMedicationRequest, SmithPatient, TramadolMedication);
+            TrumanMedicationDispenseWithoutRequest = await CreateMedicationDispense(null, TrumanPatient, TramadolMedication);
 
             CareTeam = await CreateCareTeam();
 
-            Location = TestFhirClient.CreateAsync(new Location
+            Location = (await TestFhirClient.CreateAsync(new Location
             {
                 ManagingOrganization = new ResourceReference($"Organization/{Organization.Id}"),
                 Meta = meta,
-            }).Result.Resource;
+            })).Resource;
 
             var group = new Group
             {
@@ -198,9 +198,9 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Search
                     })).Resource;
             }
 
-            Patient CreatePatient(string familyName, Practitioner practitioner, Organization organization)
+            async Task<Patient> CreatePatient(string familyName, Practitioner practitioner, Organization organization)
             {
-                return TestFhirClient.CreateAsync(
+                return (await TestFhirClient.CreateAsync(
                     new Patient
                     {
                         Meta = meta,
@@ -210,12 +210,12 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Search
                             new ResourceReference($"Practitioner/{practitioner.Id}"),
                         },
                         ManagingOrganization = new ResourceReference($"Organization/{organization.Id}"),
-                    }).Result.Resource;
+                    })).Resource;
             }
 
-            MedicationDispense CreateMedicationDispense(MedicationRequest medicationRequest, Patient patient, Medication medication)
+            async Task<MedicationDispense> CreateMedicationDispense(MedicationRequest medicationRequest, Patient patient, Medication medication)
             {
-               return TestFhirClient.CreateAsync(
+               return (await TestFhirClient.CreateAsync(
                     new MedicationDispense
                     {
                         Meta = meta,
@@ -245,12 +245,12 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Search
 #else
                         Status = MedicationDispense.MedicationDispenseStatusCodes.InProgress,
 #endif
-                    }).Result.Resource;
+                    })).Resource;
             }
 
-            MedicationRequest CreateMedicationRequest(Patient patient, Practitioner practitioner, Medication medication)
+            async Task<MedicationRequest> CreateMedicationRequest(Patient patient, Practitioner practitioner, Medication medication)
             {
-                return TestFhirClient.CreateAsync(
+                return (await TestFhirClient.CreateAsync(
                     new MedicationRequest
                     {
                         Meta = meta,
@@ -277,7 +277,7 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Search
 #else
                         Medication = medication.Code,
 #endif
-                    }).Result.Resource;
+                    })).Resource;
             }
 
             async Task<CareTeam> CreateCareTeam()

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.Web;
 using Hl7.Fhir.Model;
-using Microsoft.Health.Fhir.Client;
 using Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Search;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Xunit;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/NumberSearchTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/NumberSearchTestFixture.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Client;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 {
@@ -15,15 +16,21 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         public NumberSearchTestFixture(DataStore dataStore, Format format, TestFhirServerFactory testFhirServerFactory)
             : base(dataStore, format, testFhirServerFactory)
         {
-            // Prepare the resources used for number search tests.
-            TestFhirClient.DeleteAllResources(ResourceType.RiskAssessment).Wait();
+        }
 
-            RiskAssessments = TestFhirClient.CreateResourcesAsync<RiskAssessment>(
+        public IReadOnlyList<RiskAssessment> RiskAssessments { get; private set; }
+
+        protected override async Task OnInitializedAsync()
+        {
+            // Prepare the resources used for number search tests.
+            await TestFhirClient.DeleteAllResources(ResourceType.RiskAssessment);
+
+            RiskAssessments = await TestFhirClient.CreateResourcesAsync<RiskAssessment>(
                 i => SetRiskAssessment(i, 1),
                 i => SetRiskAssessment(i, 4),
                 i => SetRiskAssessment(i, 5),
                 i => SetRiskAssessment(i, 6),
-                i => SetRiskAssessment(i, 100)).Result;
+                i => SetRiskAssessment(i, 100));
 
             void SetRiskAssessment(RiskAssessment riskAssessment, int probability)
             {
@@ -35,7 +42,5 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 };
             }
         }
-
-        public IReadOnlyList<RiskAssessment> RiskAssessments { get; }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/QuantitySearchTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/QuantitySearchTestFixture.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Client;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 {
@@ -15,10 +16,16 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         public QuantitySearchTestFixture(DataStore dataStore, Format format, TestFhirServerFactory testFhirServerFactory)
             : base(dataStore, format, testFhirServerFactory)
         {
-            // Prepare the resources used for number search tests.
-            TestFhirClient.DeleteAllResources(ResourceType.Observation).Wait();
+        }
 
-            Observations = TestFhirClient.CreateResourcesAsync<Observation>(
+        public IReadOnlyList<Observation> Observations { get; private set; }
+
+        protected override async Task OnInitializedAsync()
+        {
+            // Prepare the resources used for number search tests.
+            await TestFhirClient.DeleteAllResources(ResourceType.Observation);
+
+            Observations = await TestFhirClient.CreateResourcesAsync<Observation>(
                 o => SetObservation(o, 1.0m, "unit1", "system1"),
                 o => SetObservation(o, 3.12m, "unit1", "system2"),
                 o => SetObservation(o, 4.0m, "unit1", "system1"),
@@ -26,7 +33,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 o => SetObservation(o, 5.0m, "unit2", "system2"),
                 o => SetObservation(o, 6.0m, "unit2", "system2"),
                 o => SetObservation(o, 8.95m, "unit2", "system1"),
-                o => SetObservation(o, 10.0m, "unit1", "system1")).Result;
+                o => SetObservation(o, 10.0m, "unit1", "system1"));
 
             void SetObservation(Observation observation, decimal quantity, string unit, string system)
             {
@@ -36,7 +43,5 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 observation.Value = new Quantity(quantity, unit, system);
             }
         }
-
-        public IReadOnlyList<Observation> Observations { get; }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ReferenceSearchTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ReferenceSearchTestFixture.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Client;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 {
@@ -15,15 +16,18 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         public ReferenceSearchTestFixture(DataStore dataStore, Format format, TestFhirServerFactory testFhirServerFactory)
             : base(dataStore, format, testFhirServerFactory)
         {
-            // Prepare the resources used for string search tests.
-            TestFhirClient.DeleteAllResources(ResourceType.Patient).Wait();
-
-            Patients = TestFhirClient.CreateResourcesAsync<Patient>(
-                p => p.ManagingOrganization = new ResourceReference("Organization/123"),
-                p => p.ManagingOrganization = new ResourceReference("Organization/abc"))
-                .Result;
         }
 
-        public IReadOnlyList<Patient> Patients { get; }
+        public IReadOnlyList<Patient> Patients { get; private set; }
+
+        protected override async Task OnInitializedAsync()
+        {
+            // Prepare the resources used for string search tests.
+            await TestFhirClient.DeleteAllResources(ResourceType.Patient);
+
+            Patients = await TestFhirClient.CreateResourcesAsync<Patient>(
+                p => p.ManagingOrganization = new ResourceReference("Organization/123"),
+                p => p.ManagingOrganization = new ResourceReference("Organization/abc"));
+        }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/StringSearchTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/StringSearchTestFixture.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Client;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 {
@@ -18,15 +19,22 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         public StringSearchTestFixture(DataStore dataStore, Format format, TestFhirServerFactory testFhirServerFactory)
             : base(dataStore, format, testFhirServerFactory)
         {
-            Patients = TestFhirClient.CreateResourcesAsync<Patient>(
-                    p => SetPatientInfo(p, "Seattle", "Smith", given: "Bea"),
-                    p => SetPatientInfo(p, "Portland", "Williams"),
-                    p => SetPatientInfo(p, "Vancouver", "Anderson"),
-                    p => SetPatientInfo(p, LongString, "Murphy"),
-                    p => SetPatientInfo(p, "Montreal", "Richard", given: "Bea"),
-                    p => SetPatientInfo(p, "New York", "Muller"),
-                    p => SetPatientInfo(p, "Portland", "Müller"))
-                .Result;
+        }
+
+        public IReadOnlyList<Patient> Patients { get; private set; }
+
+        public string FixtureTag { get; } = Guid.NewGuid().ToString();
+
+        protected override async Task OnInitializedAsync()
+        {
+            Patients = await TestFhirClient.CreateResourcesAsync<Patient>(
+                p => SetPatientInfo(p, "Seattle", "Smith", given: "Bea"),
+                p => SetPatientInfo(p, "Portland", "Williams"),
+                p => SetPatientInfo(p, "Vancouver", "Anderson"),
+                p => SetPatientInfo(p, LongString, "Murphy"),
+                p => SetPatientInfo(p, "Montreal", "Richard", given: "Bea"),
+                p => SetPatientInfo(p, "New York", "Muller"),
+                p => SetPatientInfo(p, "Portland", "Müller"));
 
             void SetPatientInfo(Patient patient, string city, string family, string given = null)
             {
@@ -44,9 +52,5 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 patient.Meta.Tag.Add(new Coding("http://e2e-test", FixtureTag));
             }
         }
-
-        public IReadOnlyList<Patient> Patients { get; }
-
-        public string FixtureTag { get; } = Guid.NewGuid().ToString();
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/TokenSearchTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/TokenSearchTestFixture.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Client;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 {
@@ -16,10 +17,16 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         public TokenSearchTestFixture(DataStore dataStore, Format format, TestFhirServerFactory testFhirServerFactory)
             : base(dataStore, format, testFhirServerFactory)
         {
-            // Prepare the resources used for number search tests.
-            TestFhirClient.DeleteAllResources(ResourceType.Observation).Wait();
+        }
 
-            Observations = TestFhirClient.CreateResourcesAsync<Observation>(
+        public IReadOnlyList<Observation> Observations { get; private set; }
+
+        protected override async Task OnInitializedAsync()
+        {
+            // Prepare the resources used for number search tests.
+            await TestFhirClient.DeleteAllResources(ResourceType.Observation);
+
+            Observations = await TestFhirClient.CreateResourcesAsync<Observation>(
                 o => SetObservation(o, cc => cc.Coding.Add(new Coding("system1", "code1"))),
                 o => SetObservation(o, cc => cc.Coding.Add(new Coding("system2", "code2"))),
                 o => SetObservation(o, cc => cc.Text = "text"),
@@ -36,7 +43,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                     cc.Coding.Add(new Coding("system2", "code1"));
                     cc.Coding.Add(new Coding("system3", "code3", "text2"));
                 }),
-                o => SetObservation(o, cc => cc.Coding.Add(new Coding(null, "code3")))).Result;
+                o => SetObservation(o, cc => cc.Coding.Add(new Coding(null, "code3"))));
 
             void SetObservation(Observation observation, Action<CodeableConcept> codeableConceptCustomizer)
             {
@@ -50,7 +57,5 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 observation.Value = codeableConcept;
             }
         }
-
-        public IReadOnlyList<Observation> Observations { get; }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/UriSearchTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/UriSearchTestFixture.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Client;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 {
@@ -15,12 +16,18 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         public UriSearchTestFixture(DataStore dataStore, Format format, TestFhirServerFactory testFhirServerFactory)
             : base(dataStore, format, testFhirServerFactory)
         {
-            // Prepare the resources used for URI search tests.
-            TestFhirClient.DeleteAllResources(ResourceType.ValueSet).Wait();
+        }
 
-            ValueSets = TestFhirClient.CreateResourcesAsync<ValueSet>(
+        public IReadOnlyList<ValueSet> ValueSets { get; private set; }
+
+        protected override async Task OnInitializedAsync()
+        {
+            // Prepare the resources used for URI search tests.
+            await TestFhirClient.DeleteAllResources(ResourceType.ValueSet);
+
+            ValueSets = await TestFhirClient.CreateResourcesAsync<ValueSet>(
                 vs => AddValueSet(vs, "http://somewhere.com/test/system"),
-                vs => AddValueSet(vs, "urn://localhost/test")).Result;
+                vs => AddValueSet(vs, "urn://localhost/test"));
 
             void AddValueSet(ValueSet vs, string url)
             {
@@ -28,7 +35,5 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 vs.Url = url;
             }
         }
-
-        public IReadOnlyList<ValueSet> ValueSets { get; }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TestFhirServerFactory.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TestFhirServerFactory.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
     {
         private readonly ConcurrentDictionary<(DataStore dataStore, Type startupType), Lazy<Task<TestFhirServer>>> _cache = new ConcurrentDictionary<(DataStore dataStore, Type startupType), Lazy<Task<TestFhirServer>>>();
 
-        public async Task<TestFhirServer> GetTestFhirServer(DataStore dataStore, Type startupType)
+        public async Task<TestFhirServer> GetTestFhirServerAsync(DataStore dataStore, Type startupType)
         {
             return await _cache.GetOrAdd(
                     (dataStore, startupType),

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TestFhirServerFactory.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TestFhirServerFactory.cs
@@ -6,7 +6,9 @@
 using System;
 using System.Collections.Concurrent;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Xunit;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
@@ -14,16 +16,16 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
     /// Creates and caches <see cref="TestFhirServer"/> instances. This class is intended to be used as an assembly fixture,
     /// so that the <see cref="TestFhirServer"/> instances can be reused across test classes in an assembly.
     /// </summary>
-    public class TestFhirServerFactory : IDisposable
+    public class TestFhirServerFactory : IAsyncLifetime, IAsyncDisposable
     {
-        private readonly ConcurrentDictionary<(DataStore dataStore, Type startupType), Lazy<TestFhirServer>> _cache = new ConcurrentDictionary<(DataStore dataStore, Type startupType), Lazy<TestFhirServer>>();
+        private readonly ConcurrentDictionary<(DataStore dataStore, Type startupType), Lazy<Task<TestFhirServer>>> _cache = new ConcurrentDictionary<(DataStore dataStore, Type startupType), Lazy<Task<TestFhirServer>>>();
 
-        public TestFhirServer GetTestFhirServer(DataStore dataStore, Type startupType)
+        public async Task<TestFhirServer> GetTestFhirServer(DataStore dataStore, Type startupType)
         {
-            return _cache.GetOrAdd(
+            return await _cache.GetOrAdd(
                     (dataStore, startupType),
                     tuple =>
-                        new Lazy<TestFhirServer>(() =>
+                        new Lazy<Task<TestFhirServer>>(() =>
                         {
                             TestFhirServer testFhirServer;
                             string environmentUrl = GetEnvironmentUrl(tuple.dataStore);
@@ -42,9 +44,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
                                 testFhirServer = new RemoteTestFhirServer(environmentUrl);
                             }
 
-                            testFhirServer.ConfigureSecurityOptions().GetAwaiter().GetResult();
-
-                            return testFhirServer;
+                            return testFhirServer.ConfigureSecurityOptions().ContinueWith(_ => testFhirServer, TaskContinuationOptions.ExecuteSynchronously);
                         }))
                 .Value;
         }
@@ -62,13 +62,20 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             }
         }
 
-        public void Dispose()
+        Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+
+        async Task IAsyncLifetime.DisposeAsync()
         {
-            foreach (Lazy<TestFhirServer> cacheValue in _cache.Values)
+            await DisposeAsync();
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            foreach (Lazy<Task<TestFhirServer>> cacheValue in _cache.Values)
             {
                 if (cacheValue.IsValueCreated)
                 {
-                    cacheValue.Value.Dispose();
+                    (await cacheValue.Value).Dispose();
                 }
             }
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TransactionTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TransactionTests.cs
@@ -24,15 +24,21 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
     [Trait(Traits.Category, Categories.Transaction)]
     [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.All)]
-    public class TransactionTests : IClassFixture<HttpIntegrationTestFixture>
+    public class TransactionTests : IClassFixture<HttpIntegrationTestFixture>, IAsyncLifetime
     {
         private readonly TestFhirClient _client;
 
         public TransactionTests(HttpIntegrationTestFixture fixture)
         {
             _client = fixture.TestFhirClient;
-            _client.DeleteAllResources(ResourceType.Patient).Wait();
         }
+
+        public async Task InitializeAsync()
+        {
+            await _client.DeleteAllResources(ResourceType.Patient);
+        }
+
+        public Task DisposeAsync() => Task.CompletedTask;
 
         [Fact]
         [HttpIntegrationFixtureArgumentSets(dataStores: DataStore.CosmosDb)]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -39,18 +39,19 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
     [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb)]
     public class ReindexJobTests : IClassFixture<FhirStorageTestsFixture>, IAsyncLifetime
     {
-        private readonly IFhirOperationDataStore _fhirOperationDataStore;
-        private readonly IScoped<IFhirOperationDataStore> _scopedOperationDataStore;
-        private readonly IScoped<IFhirDataStore> _scopedDataStore;
-        private readonly IFhirStorageTestHelper _fhirStorageTestHelper;
-        private readonly SearchParameterDefinitionManager _searchParameterDefinitionManager;
+        private readonly FhirStorageTestsFixture _fixture;
+        private IFhirOperationDataStore _fhirOperationDataStore;
+        private IScoped<IFhirOperationDataStore> _scopedOperationDataStore;
+        private IScoped<IFhirDataStore> _scopedDataStore;
+        private IFhirStorageTestHelper _fhirStorageTestHelper;
+        private SearchParameterDefinitionManager _searchParameterDefinitionManager;
 
-        private readonly ReindexJobConfiguration _jobConfiguration;
-        private readonly CreateReindexRequestHandler _createReindexRequestHandler;
-        private readonly ReindexUtilities _reindexUtilities;
+        private ReindexJobConfiguration _jobConfiguration;
+        private CreateReindexRequestHandler _createReindexRequestHandler;
+        private ReindexUtilities _reindexUtilities;
         private readonly ISearchIndexer _searchIndexer = Substitute.For<ISearchIndexer>();
-        private readonly ISupportedSearchParameterDefinitionManager _supportedSearchParameterDefinitionManager;
-        private readonly SearchableSearchParameterDefinitionManager _searchableSearchParameterDefinitionManager;
+        private ISupportedSearchParameterDefinitionManager _supportedSearchParameterDefinitionManager;
+        private SearchableSearchParameterDefinitionManager _searchableSearchParameterDefinitionManager;
         private readonly ISearchParameterRegistry _searchParameterRegistry = Substitute.For<ISearchParameterRegistry>();
         private readonly IOptions<CoreFeatureConfiguration> coreOptions = Substitute.For<IOptions<CoreFeatureConfiguration>>();
 
@@ -59,18 +60,22 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
 
         public ReindexJobTests(FhirStorageTestsFixture fixture)
         {
-            _fhirOperationDataStore = fixture.OperationDataStore;
-            _fhirStorageTestHelper = fixture.TestHelper;
-            _scopedOperationDataStore = fixture.OperationDataStore.CreateMockScope();
-            _scopedOperationDataStore = fixture.OperationDataStore.CreateMockScope();
-            _scopedDataStore = fixture.DataStore.CreateMockScope();
+            _fixture = fixture;
+        }
+
+        public async Task InitializeAsync()
+        {
+            _fhirOperationDataStore = _fixture.OperationDataStore;
+            _fhirStorageTestHelper = _fixture.TestHelper;
+            _scopedOperationDataStore = _fixture.OperationDataStore.CreateMockScope();
+            _scopedDataStore = _fixture.DataStore.CreateMockScope();
 
             _jobConfiguration = new ReindexJobConfiguration();
             IOptions<ReindexJobConfiguration> optionsReindexConfig = Substitute.For<IOptions<ReindexJobConfiguration>>();
             optionsReindexConfig.Value.Returns(_jobConfiguration);
 
             _searchParameterDefinitionManager = new SearchParameterDefinitionManager(ModelInfoProvider.Instance);
-            _searchParameterDefinitionManager.Start();
+            await _searchParameterDefinitionManager.StartAsync(CancellationToken.None);
             _searchParameterDefinitionManager.UpdateSearchParameterHashMap(new Dictionary<string, string>() { { "Patient", "newHash" } });
             _supportedSearchParameterDefinitionManager = new SupportedSearchParameterDefinitionManager(_searchParameterDefinitionManager);
             var fhirRequestContextAccessor = Substitute.For<IFhirRequestContextAccessor>();
@@ -93,9 +98,11 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
             var searchParameterExpressionParser = new SearchParameterExpressionParser(() => _searchParameterDefinitionManager, new ReferenceSearchValueParser(fhirRequestContextAccessor));
             var expressionParser = new ExpressionParser(() => _searchableSearchParameterDefinitionManager, searchParameterExpressionParser);
             var searchOptionsFactory = new SearchOptionsFactory(expressionParser, () => _searchableSearchParameterDefinitionManager, coreOptions, fhirRequestContextAccessor, NullLogger<SearchOptionsFactory>.Instance);
-            var cosmosSearchService = new FhirCosmosSearchService(searchOptionsFactory, fixture.DataStore as CosmosFhirDataStore, new QueryBuilder()) as ISearchService;
+            var cosmosSearchService = new FhirCosmosSearchService(searchOptionsFactory, _fixture.DataStore as CosmosFhirDataStore, new QueryBuilder()) as ISearchService;
 
             _searchService = cosmosSearchService.CreateMockScope();
+
+            await _fhirStorageTestHelper.DeleteAllReindexJobRecordsAsync(CancellationToken.None);
         }
 
         public Task DisposeAsync()
@@ -289,11 +296,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
             {
                 cancellationTokenSource.Cancel();
             }
-        }
-
-        public Task InitializeAsync()
-        {
-            return _fhirStorageTestHelper.DeleteAllReindexJobRecordsAsync(CancellationToken.None);
         }
 
         private ReindexJobTask InitializeReindexJobTask()

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             optionsMonitor.Get(CosmosDb.Constants.CollectionConfigurationName).Returns(_cosmosCollectionConfiguration);
 
             var searchParameterDefinitionManager = new SearchParameterDefinitionManager(ModelInfoProvider.Instance);
-            searchParameterDefinitionManager.Start();
+            await searchParameterDefinitionManager.StartAsync(CancellationToken.None);
 
             _filebasedSearchParameterRegistry = new FilebasedSearchParameterRegistry(searchParameterDefinitionManager, ModelInfoProvider.Instance);
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 });
 
             await schemaInitializer.InitializeAsync(forceIncrementalSchemaUpgrade, cancellationToken);
-            _sqlServerFhirModel.Start();
+            await _sqlServerFhirModel.StartAsync(cancellationToken);
         }
 
         public async Task DeleteDatabase(string databaseName, CancellationToken cancellationToken = default)

--- a/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/Microsoft.Health.Fhir.Stu3.Tests.E2E.csproj
+++ b/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/Microsoft.Health.Fhir.Stu3.Tests.E2E.csproj
@@ -18,8 +18,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20201008-2" />
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201008-2" />
+    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.0-master-20201022-1" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201022-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="selenium.chrome.webdriver" Version="83.0.0" />
     <PackageReference Include="selenium.webdriver" Version="3.141.0" />

--- a/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/SmartProxy/SmartProxyTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/SmartProxy/SmartProxyTestFixture.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.SmartProxy
                 WebServer = builder.Build();
                 WebServer.Start();
 
-                TestFhirServer testFhirServer = await _testFhirServerFactory.GetTestFhirServer(DataStore.CosmosDb, null);
+                TestFhirServer testFhirServer = await _testFhirServerFactory.GetTestFhirServerAsync(DataStore.CosmosDb, null);
                 TestFhirClient = testFhirServer.GetTestFhirClient(ResourceFormat.Json);
             }
         }

--- a/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/SmartProxy/SmartProxyTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/SmartProxy/SmartProxyTestFixture.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using EnsureThat;
 using Hl7.Fhir.Rest;
 using Microsoft.AspNetCore;
@@ -13,15 +14,30 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.E2E.Common;
 using Microsoft.Health.Fhir.Tests.E2E.Rest;
+using Xunit;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.SmartProxy
 {
-    public class SmartProxyTestFixture : IDisposable
+    public class SmartProxyTestFixture : IDisposable, IAsyncLifetime
     {
+        private readonly TestFhirServerFactory _testFhirServerFactory;
+
         public SmartProxyTestFixture(TestFhirServerFactory testFhirServerFactory)
         {
             EnsureArg.IsNotNull(testFhirServerFactory, nameof(testFhirServerFactory));
+            _testFhirServerFactory = testFhirServerFactory;
+        }
 
+        public IWebHost WebServer { get; private set; }
+
+        public int Port { get; private set; } = 6001;
+
+        public string SmartLauncherUrl { get; private set; }
+
+        public TestFhirClient TestFhirClient { get; private set; }
+
+        public async Task InitializeAsync()
+        {
             string environmentUrl = Environment.GetEnvironmentVariable($"TestEnvironmentUrl{Constants.TestEnvironmentVariableVersionSuffix}");
 
             // Only set up test fixture if running against remote server
@@ -46,17 +62,16 @@ namespace Microsoft.Health.Fhir.Tests.E2E.SmartProxy
                 WebServer = builder.Build();
                 WebServer.Start();
 
-                TestFhirClient = testFhirServerFactory.GetTestFhirServer(DataStore.CosmosDb, null).GetTestFhirClient(ResourceFormat.Json);
+                TestFhirServer testFhirServer = await _testFhirServerFactory.GetTestFhirServer(DataStore.CosmosDb, null);
+                TestFhirClient = testFhirServer.GetTestFhirClient(ResourceFormat.Json);
             }
         }
 
-        public IWebHost WebServer { get; }
-
-        public int Port { get; } = 6001;
-
-        public string SmartLauncherUrl { get; }
-
-        public TestFhirClient TestFhirClient { get; }
+        public Task DisposeAsync()
+        {
+            Dispose();
+            return Task.CompletedTask;
+        }
 
         public void Dispose()
         {

--- a/test/Microsoft.Health.Fhir.Stu3.Tests.Integration/Microsoft.Health.Fhir.Stu3.Tests.Integration.csproj
+++ b/test/Microsoft.Health.Fhir.Stu3.Tests.Integration/Microsoft.Health.Fhir.Stu3.Tests.Integration.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201008-2" />
+    <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.0-master-20201022-1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
     <PackageReference Include="Microsoft.SqlServer.DACFx" Version="150.4897.1" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
## Description
- Incorporates shared components build 1.0.0-master-20201022-1
- Implements `IHostedService` instead of `IStartable`
- Eliminates calls to `Task.Result`, `Task.Wait()`, and `Task.GetAwaiter().GetResult()` in test code which can result in deadlocks with xUnit's custom `SynchronizationContext`. (Some are still required, ironically, in our xUnit extension, because of the xunit design)
- Fixed test instabilities resulting from modification of `SearchParameterDefinitionManager`s that were shared across test classes.
