### PR TITLE
Remove scope as Reindex job property

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Reindex/ReindexHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Reindex/ReindexHandlerTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         {
             var request = new GetReindexRequest("id");
 
-            var jobRecord = new ReindexJobRecord(_resourceTypeSearchParameterHashMap, 1, null);
+            var jobRecord = new ReindexJobRecord(_resourceTypeSearchParameterHashMap, 1);
             var jobWrapper = new ReindexJobWrapper(jobRecord, WeakETag.FromVersionId("id"));
             _fhirOperationDataStore.GetReindexJobByIdAsync("id", Arg.Any<CancellationToken>()).Returns(jobWrapper);
 
@@ -54,7 +54,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         {
             var request = new GetReindexRequest("id");
 
-            var jobRecord = new ReindexJobRecord(_resourceTypeSearchParameterHashMap, 1, null);
+            var jobRecord = new ReindexJobRecord(_resourceTypeSearchParameterHashMap, 1);
             var jobWrapper = new ReindexJobWrapper(jobRecord, WeakETag.FromVersionId("id"));
             _fhirOperationDataStore.GetReindexJobByIdAsync("id", Arg.Any<CancellationToken>()).Returns(jobWrapper);
 
@@ -71,7 +71,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         {
             var request = new GetReindexRequest("id");
 
-            var jobRecord = new ReindexJobRecord(_resourceTypeSearchParameterHashMap, 1, null);
+            var jobRecord = new ReindexJobRecord(_resourceTypeSearchParameterHashMap, 1);
             var jobWrapper = new ReindexJobWrapper(jobRecord, WeakETag.FromVersionId("id"));
             _fhirOperationDataStore.GetReindexJobByIdAsync("id", Arg.Any<CancellationToken>()).Throws(new JobNotFoundException("not found"));
 
@@ -85,7 +85,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         {
             var request = new GetReindexRequest("id");
 
-            var jobRecord = new ReindexJobRecord(_resourceTypeSearchParameterHashMap, 1, null);
+            var jobRecord = new ReindexJobRecord(_resourceTypeSearchParameterHashMap, 1);
             var jobWrapper = new ReindexJobWrapper(jobRecord, WeakETag.FromVersionId("id"));
             _fhirOperationDataStore.GetReindexJobByIdAsync("id", CancellationToken.None).Throws(new RequestRateExceededException(TimeSpan.FromMilliseconds(100)));
 
@@ -99,7 +99,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         {
             var request = new CancelReindexRequest("id");
 
-            var jobRecord = new ReindexJobRecord(_resourceTypeSearchParameterHashMap, 1, null);
+            var jobRecord = new ReindexJobRecord(_resourceTypeSearchParameterHashMap, 1);
             var jobWrapper = new ReindexJobWrapper(jobRecord, WeakETag.FromVersionId("id"));
             _fhirOperationDataStore.GetReindexJobByIdAsync("id", Arg.Any<CancellationToken>()).Returns(jobWrapper);
 
@@ -116,7 +116,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         {
             var request = new CancelReindexRequest("id");
 
-            var jobRecord = new ReindexJobRecord(_resourceTypeSearchParameterHashMap, 1, null)
+            var jobRecord = new ReindexJobRecord(_resourceTypeSearchParameterHashMap, 1)
             {
                 Status = OperationStatus.Completed,
             };
@@ -134,7 +134,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         {
             var request = new CancelReindexRequest("id");
 
-            var jobRecord = new ReindexJobRecord(_resourceTypeSearchParameterHashMap, 1, null)
+            var jobRecord = new ReindexJobRecord(_resourceTypeSearchParameterHashMap, 1)
             {
                 Status = OperationStatus.Running,
             };

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Reindex/ReindexJobWorkerTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Reindex/ReindexJobWorkerTests.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         {
             Dictionary<string, string> searchParameterHashMap = new Dictionary<string, string>();
             searchParameterHashMap.Add("patient", "hash1");
-            return new ReindexJobWrapper(new ReindexJobRecord(searchParameterHashMap, 5, "patient"), WeakETag.FromVersionId("0"));
+            return new ReindexJobWrapper(new ReindexJobRecord(searchParameterHashMap, 5), WeakETag.FromVersionId("0"));
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
@@ -69,8 +69,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations
 
         public const string FailureCount = "failureCount";
 
-        public const string Scope = "scope";
-
         public const string StorageAccountConnectionHash = "storageAccountConnectionHash";
 
         public const string StorageAccountUri = "storageAccountUri";

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/CreateReindexRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/CreateReindexRequestHandler.cs
@@ -59,7 +59,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             var jobRecord = new ReindexJobRecord(
                 _searchParameterDefinitionManager.SearchParameterHashMap,
                 request.MaximumConcurrency ?? _reindexJobConfiguration.DefaultMaximumThreadsPerReindexJob,
-                request.Scope,
                 _reindexJobConfiguration.MaximumNumberOfResourcesPerQuery);
             var outcome = await _fhirOperationDataStore.CreateReindexJobAsync(jobRecord, cancellationToken);
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobRecord.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobRecord.cs
@@ -21,7 +21,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
         public ReindexJobRecord(
             IReadOnlyDictionary<string, string> searchParametersHash,
             ushort maxiumumConcurrency = 1,
-            string scope = null,
             uint maxResourcesPerQuery = 100)
         {
             EnsureArg.IsNotNull(searchParametersHash, nameof(searchParametersHash));
@@ -36,7 +35,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
 
             ResourceTypeSearchParameterHashMap = searchParametersHash;
             MaximumConcurrency = maxiumumConcurrency;
-            Scope = scope;
             MaximumNumberOfResourcesPerQuery = maxResourcesPerQuery;
         }
 
@@ -44,9 +42,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
         protected ReindexJobRecord()
         {
         }
-
-        [JsonProperty(JobRecordProperties.Scope)]
-        public string Scope { get; private set; }
 
         [JsonProperty(JobRecordProperties.MaximumConcurrency)]
         public ushort MaximumConcurrency { get; private set; }

--- a/src/Microsoft.Health.Fhir.Core/Messages/Reindex/CreateReindexRequest.cs
+++ b/src/Microsoft.Health.Fhir.Core/Messages/Reindex/CreateReindexRequest.cs
@@ -9,14 +9,11 @@ namespace Microsoft.Health.Fhir.Core.Messages.Reindex
 {
     public class CreateReindexRequest : IRequest<CreateReindexResponse>
     {
-        public CreateReindexRequest(ushort? maximumConcurrency = null, string scope = null)
+        public CreateReindexRequest(ushort? maximumConcurrency = null)
         {
             MaximumConcurrency = maximumConcurrency;
-            Scope = scope;
         }
 
         public ushort? MaximumConcurrency { get; }
-
-        public string Scope { get; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ReindexControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ReindexControllerTests.cs
@@ -108,8 +108,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
             var result = await _reindexEnabledController.CreateReindexJob(body);
             await _mediator.Received().Send(
                 Arg.Is<CreateReindexRequest>(
-                    r => r.MaximumConcurrency.ToString().Equals(body.Parameter.Find(p => p.Name.Equals(JobRecordProperties.MaximumConcurrency)).Value.ToString())
-                && r.Scope == body.Parameter.Find(p => p.Name.Equals(JobRecordProperties.Scope)).Value.ToString()),
+                    r => r.MaximumConcurrency.ToString().Equals(body.Parameter.Find(p => p.Name.Equals(JobRecordProperties.MaximumConcurrency)).Value.ToString())),
                 Arg.Any<CancellationToken>());
             _mediator.ClearReceivedCalls();
 
@@ -137,7 +136,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
 
         private static CreateReindexResponse GetCreateReindexResponse()
         {
-            var jobRecord = new ReindexJobRecord(_searchParameterHashMap, 5, "patient");
+            var jobRecord = new ReindexJobRecord(_searchParameterHashMap, 5);
             var jobWrapper = new ReindexJobWrapper(
                 jobRecord,
                 WeakETag.FromVersionId("33a64df551425fcc55e4d42a148795d9f25f89d4"));
@@ -146,7 +145,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
 
         private static GetReindexResponse GetReindexJobResponse()
         {
-            var jobRecord = new ReindexJobRecord(_searchParameterHashMap, 5, "patient");
+            var jobRecord = new ReindexJobRecord(_searchParameterHashMap, 5);
             var jobWrapper = new ReindexJobWrapper(
                 jobRecord,
                 WeakETag.FromVersionId("33a64df551425fcc55e4d42a148795d9f25f89d4"));
@@ -160,7 +159,6 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
 
             parametersResource.Parameter.Add(new Parameters.ParameterComponent()
                 { Name = JobRecordProperties.MaximumConcurrency, Value = new FhirDecimal(maxConcurrency ?? _reindexJobConfig.DefaultMaximumThreadsPerReindexJob) });
-            parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = JobRecordProperties.Scope, Value = new FhirString(scope) });
 
             return parametersResource;
         }
@@ -171,7 +169,6 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
             parametersResource.Parameter = new List<Parameters.ParameterComponent>();
 
             parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = "foo", Value = new FhirDecimal(5) });
-            parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = JobRecordProperties.Scope, Value = new FhirString("scope") });
 
             return parametersResource;
         }
@@ -182,7 +179,6 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
             parametersResource.Parameter = new List<Parameters.ParameterComponent>();
 
             parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = JobRecordProperties.MaximumConcurrency, Value = new FhirDecimal(5) });
-            parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = JobRecordProperties.Scope, Value = new FhirString("scope") });
             parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = "foo", Value = new FhirDecimal(5) });
 
             return parametersResource;

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ReindexController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ReindexController.cs
@@ -73,9 +73,8 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             ValidateParams(inputParams);
 
             ushort? maximumConcurrency = ReadNumericParameter(inputParams, JobRecordProperties.MaximumConcurrency);
-            string scope = ReadStringParameter(inputParams, JobRecordProperties.Scope);
 
-            ResourceElement response = await _mediator.CreateReindexJobAsync(maximumConcurrency, scope, HttpContext.RequestAborted);
+            ResourceElement response = await _mediator.CreateReindexJobAsync(maximumConcurrency, HttpContext.RequestAborted);
 
             var result = FhirResult.Create(response, HttpStatusCode.Created)
                 .SetETagHeader()
@@ -213,7 +212,6 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             var postParams = new HashSet<string>()
             {
                 JobRecordProperties.MaximumConcurrency,
-                JobRecordProperties.Scope,
             };
 
             var patchParams = new HashSet<string>()

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexJobTaskTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexJobTaskTests.cs
@@ -333,7 +333,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                 paramHashMap = new Dictionary<string, string>() { { "Patient", "patientHash" } };
             }
 
-            return new ReindexJobRecord(paramHashMap, maxiumumConcurrency: 1, scope: null, maxResourcePerQuery);
+            return new ReindexJobRecord(paramHashMap, maxiumumConcurrency: 1, maxResourcePerQuery);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Extensions/ReindexJobRecordExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Extensions/ReindexJobRecordExtensions.cs
@@ -40,7 +40,6 @@ namespace Microsoft.Health.Fhir.Core.Extensions
             parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = JobRecordProperties.Progress, Value = new FhirDecimal(job.PercentComplete) });
             parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = JobRecordProperties.Status, Value = new FhirString(job.Status.ToString()) });
             parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = JobRecordProperties.MaximumConcurrency, Value = new FhirDecimal(job.MaximumConcurrency) });
-            parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = JobRecordProperties.Scope, Value = new FhirString(job.Scope) });
             parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = JobRecordProperties.Resources, Value = new FhirString(job.ResourceList) });
             parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = JobRecordProperties.SearchParams, Value = new FhirString(job.SearchParamList) });
 

--- a/src/Microsoft.Health.Fhir.Shared.Core/Extensions/ReindexMediatorExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Extensions/ReindexMediatorExtensions.cs
@@ -18,12 +18,11 @@ namespace Microsoft.Health.Fhir.Core.Extensions
         public static async Task<ResourceElement> CreateReindexJobAsync(
             this IMediator mediator,
             ushort? maximumConcurrency,
-            string scope,
             CancellationToken cancellationToken)
         {
             EnsureArg.IsNotNull(mediator, nameof(mediator));
 
-            var request = new CreateReindexRequest(maximumConcurrency, scope);
+            var request = new CreateReindexRequest(maximumConcurrency);
 
             CreateReindexResponse response = await mediator.Send(request, cancellationToken);
             return response.Job.ToParametersResourceElement();

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/FhirOperationDataStoreReindexTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/FhirOperationDataStoreReindexTests.cs
@@ -182,7 +182,7 @@ namespace Microsoft.Health.Fhir.Shared.Tests.Integration.Features.Operations
         {
             Dictionary<string, string> searchParamHashMap = new Dictionary<string, string>();
             searchParamHashMap.Add("Patient", "searchParamHash");
-            var jobRecord = new ReindexJobRecord(searchParamHashMap, maxiumumConcurrency: 1, scope: "all");
+            var jobRecord = new ReindexJobRecord(searchParamHashMap, maxiumumConcurrency: 1);
 
             jobRecordCustomizer?.Invoke(jobRecord);
 


### PR DESCRIPTION
## Description
Initial design allowed an end user to specify a scope of resources to reindex.  This design was updated to use the url, i.e. //server/<resourcetype>/id to define a specific scope.  Which is also more inline with the FHIR spec.

## Related issues
Addresses [issue [AB#76593](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/76593)].

## Testing
Unit tests updated and run.
