### PR TITLE
Fixed search by _id + reference

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/NormalizedPredicateReorderer.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/NormalizedPredicateReorderer.cs
@@ -26,6 +26,12 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
 
             List<TableExpression> reorderedExpressions = expression.TableExpressions.OrderByDescending(t =>
             {
+                // Sort _id (denormalized) expression to the front
+                if (t.NormalizedPredicate == null && t.DenormalizedPredicate != null && t.Kind == TableExpressionKind.All)
+                {
+                    return 20;
+                }
+
                 if (t.NormalizedPredicate is MissingSearchParameterExpression)
                 {
                     return -10;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -127,6 +127,25 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenResourcesWithReference_WhenSearchedWithReferenceAndIdParameter_ThenOnlyResourcesMatchingAllSearchParamsShouldBeReturned()
+        {
+            Patient patientWithMatchingReference = (await Client.CreateResourcesAsync<Patient>(p =>
+            {
+                p.Gender = AdministrativeGender.Female;
+                p.ManagingOrganization = new ResourceReference("Organization/123");
+            })).Single();
+            Patient patientWithNonMatchingReference = (await Client.CreateResourcesAsync<Patient>(p =>
+            {
+                p.Gender = AdministrativeGender.Female;
+                p.ManagingOrganization = new ResourceReference("Organization/234");
+            })).Single();
+
+            await ExecuteAndValidateBundle($"Patient?_id={patientWithMatchingReference.Id}&organization=Organization/123", patientWithMatchingReference);
+            await ExecuteAndValidateBundle($"Patient?_id={patientWithMatchingReference.Id}&organization=Organization/234");
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
         public async Task GivenResourcesWithMissingReference_WhenSearchedWithTheMissingModiferAndOtherParameter_ThenOnlyMatchingResourcesWithMissingOrPresentReferenceAreReturned()
         {
             Patient patientWithReference = (await Client.CreateResourcesAsync<Patient>(p =>


### PR DESCRIPTION
## Description
Fixed Normalized Predicate Reorderer to sort `_id` expression first.

## Related issues
Fixes #1423.

## Testing
Added unit and E2E tests.
