### PR TITLE
Reorder background workers

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
@@ -29,7 +29,6 @@ namespace Microsoft.Health.Fhir.Web
             services.AddDevelopmentIdentityProvider(Configuration);
 
             Core.Registration.IFhirServerBuilder fhirServerBuilder = services.AddFhirServer(Configuration)
-                .AddBackgroundWorkers()
                 .AddAzureExportDestinationClient()
                 .AddAzureExportClientInitializer(Configuration);
 
@@ -42,6 +41,12 @@ namespace Microsoft.Health.Fhir.Web
             {
                 fhirServerBuilder.AddSqlServer(Configuration);
             }
+
+            /*
+            IHostedServices are executed depends on the order they are added to the DI Container.
+            So need to ensure that the schema is initialized before the background workers are started
+            */
+            fhirServerBuilder.AddBackgroundWorkers();
 
             if (string.Equals(Configuration["ASPNETCORE_FORWARDEDHEADERS_ENABLED"], "true", StringComparison.OrdinalIgnoreCase))
             {

--- a/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
@@ -43,8 +43,8 @@ namespace Microsoft.Health.Fhir.Web
             }
 
             /*
-            IHostedServices are executed depends on the order they are added to the DI Container.
-            So need to ensure that the schema is initialized before the background workers are started
+            The execution of IHostedServices depends on the order they are added to the dependency injection container, so we
+            need to ensure that the schema is initialized before the background workers are started.
             */
             fhirServerBuilder.AddBackgroundWorkers();
 


### PR DESCRIPTION
## Description
Fixes the issue on server startup when the database does not exists.
Prior to the fix, ExportJobWorker is starting up before the SchemaInitializer is run and throws the exception
 Microsoft.Health.Fhir.Core.Features.Operations.Export.ExportJobWorker[0]
      ExportJobWorker: Cancellation requested.
Unhandled exception. Microsoft.Data.SqlClient.SqlException (0x80131904): Cannot open database "FHIR_R4_50" requested by the login. The login failed.

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.
Tested manually with standing up a new database and server is able to start.
