### PR TITLE
Adds Semver for builds and releases using GitVersion package

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,9 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
+    - name: Fetch all history for all tags and branches
+      run: |
+        git fetch --prune --unshallow
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
+    <!-- allow pre-release dependencies -->
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
     <DebugType>Portable</DebugType>
     <LangVersion>8.0</LangVersion>
     <HighEntropyVA>true</HighEntropyVA>

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,40 @@
+mode: Mainline
+assembly-versioning-scheme: MajorMinorPatch
+tag-prefix: release\/
+ignore:
+  sha: []
+
+branches:
+  master:
+    regex: ^master$|^main$
+    tag: ''
+    increment: Patch
+    prevent-increment-of-merged-branch-version: true
+    track-merge-target: false
+    tracks-release-branches: false
+    is-release-branch: true
+  pull-request:
+    regex: ^(pull|pull\-requests|pr)[/-]
+    tag: pr
+    increment: Inherit
+    prevent-increment-of-merged-branch-version: false
+    tag-number-pattern: '[/-](?<number>\d+)[-/]'
+    track-merge-target: false
+    tracks-release-branches: false
+    is-release-branch: false
+  hotfix:
+    regex: ^hotfix(es)?[/-]
+    tag: beta
+    increment: Patch
+    prevent-increment-of-merged-branch-version: false
+    track-merge-target: false
+    tracks-release-branches: false
+    is-release-branch: false
+  feature:
+    regex: ^(personal|dev|feature|auto\-nuget\-update)[/-]
+    tag: useBranchName
+    increment: Patch
+    prevent-increment-of-merged-branch-version: false
+    track-merge-target: false
+    tracks-release-branches: false
+    is-release-branch: false

--- a/Microsoft.Health.Fhir.sln
+++ b/Microsoft.Health.Fhir.sln
@@ -32,6 +32,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.props = Directory.Build.props
 		global.json = global.json
 		testauthenvironment.json = testauthenvironment.json
+		GitVersion.yml = GitVersion.yml
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{B5F2D2DF-D0C7-4861-8259-F6A041DB9854}"

--- a/build/ci-pipeline.yml
+++ b/build/ci-pipeline.yml
@@ -9,9 +9,25 @@ variables:
 - template: build-variables.yml
 
 stages:
+- stage: UpdateVersion
+  displayName: 'Determine Semver'
+  dependsOn: []
+  jobs:
+  - job: Semver
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+    - template: ./jobs/update-semver.yml
+    - script: echo %Action%%BuildVersion%
+      displayName: 'Set build version'
+      env:
+        Action: '##vso[build.updatebuildnumber]'
+        BuildVersion: $(GitVersion.semVer)
+
 - stage: BuildUnitTests
   displayName: 'Build and run unit tests'
-  dependsOn: []
+  dependsOn:
+  - UpdateVersion
   jobs:
   - job: Windows
     pool:
@@ -29,7 +45,8 @@ stages:
 
 - stage: DockerBuild  
   displayName: 'Build images'
-  dependsOn: []
+  dependsOn:
+  - UpdateVersion
   jobs:
   - template: ./jobs/docker-build-all.yml
     parameters: 

--- a/build/jobs/build.yml
+++ b/build/jobs/build.yml
@@ -3,13 +3,18 @@ parameters:
   packageArtifacts: true
 
 steps:
+- template: update-semver.yml
+
 - task: UseDotNet@2
   displayName: 'Use .NET Core sdk'
   inputs:
     useGlobalJson: true
 
-- script: dotnet build --configuration $(buildConfiguration) --version-suffix $(build.buildNumber) /warnaserror
+- task: DotNetCoreCLI@2
   displayName: 'dotnet build $(buildConfiguration)'
+  inputs:
+    command: build
+    arguments: '--configuration $(buildConfiguration) /p:AssemblyVersion="$(assemblySemVer)" /p:FileVersion="$(assemblySemFileVer)" /p:InformationalVersion="$(informationalVersion)" /p:Version="$(majorMinorPatch)" /warnaserror'
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test UnitTests'

--- a/build/jobs/package-web.yml
+++ b/build/jobs/package-web.yml
@@ -10,5 +10,5 @@ steps:
     inputs:
       command: publish
       projects: '${{parameters.csproj}}'
-      arguments: '--output $(build.artifactStagingDirectory)/web --configuration $(buildConfiguration) --version-suffix $(build.buildnumber)'
+      arguments: '--output $(build.artifactStagingDirectory)/web --configuration $(buildConfiguration) --version-suffix $(build.buildNumber)'
       publishWebProjects: false

--- a/build/jobs/package.yml
+++ b/build/jobs/package.yml
@@ -18,7 +18,7 @@ steps:
     inputs:
       command: publish
       projects: 'test/**/*.csproj'
-      arguments: '--version-suffix $(build.buildnumber) -o "$(build.binariesdirectory)/IntegrationTests" --configuration $(buildConfiguration) --no-build'
+      arguments: '--version-suffix $(build.buildNumber) -o "$(build.binariesdirectory)/IntegrationTests" --configuration $(buildConfiguration) --no-build'
       publishWebProjects: false
       zipAfterPublish: false
 
@@ -29,12 +29,12 @@ steps:
       command: pack
       configuration: '$(buildConfiguration)'
       packDirectory: '$(build.artifactStagingDirectory)/nupkgs'
-      versioningScheme: 'byEnvVar'
-      versionEnvVar: 'nuget_version'
       nobuild: true
+      versioningScheme: byEnvVar
+      versionEnvVar: 'nuget_version'
       zipAfterPublish: true
-    env:
-      nuget_version: 1.0.0-$(build.buildNumber)
+    env:	
+      nuget_version: $(nuGetVersion)
 
   # Publish artifacts
   - task: PublishBuildArtifacts@1

--- a/build/jobs/update-semver.yml
+++ b/build/jobs/update-semver.yml
@@ -1,0 +1,31 @@
+steps:
+- task: UseDotNet@2
+  displayName: 'Use .NET Core sdk (for GitVersion)'
+  inputs:
+    packageType: sdk
+    version: 2.1.x
+    
+- task: GitVersion@5
+  displayName: 'GitVersion'
+  inputs:
+    configFilePath: '$(Build.SourcesDirectory)/GitVersion.yml'
+
+# Can set these: https://github.com/GitTools/actions/blob/master/gitversion/execute/action.yml
+- powershell: |
+    Write-Host "##vso[task.setvariable variable=semVer]$(GitVersion.semVer)"
+    Write-Host "##vso[task.setvariable variable=informationalVersion]$(GitVersion.informationalVersion)"
+    Write-Host "##vso[task.setvariable variable=majorMinorPatch]$(GitVersion.majorMinorPatch)"
+    Write-Host "##vso[task.setvariable variable=nuGetVersion]$(GitVersion.semVer)"
+    Write-Host "##vso[task.setvariable variable=assemblySemVer]$(GitVersion.assemblySemVer)"
+    Write-Host "##vso[task.setvariable variable=assemblySemFileVer]$(GitVersion.assemblySemFileVer)"
+  name: SetVariablesFromGitVersion
+
+- powershell: |
+    Write-Host '----------Variables to use for build----------'
+    Write-Host 'semVer: $(semVer)'
+    Write-Host 'informationalVersion: $(informationalVersion)'
+    Write-Host 'majorMinorPatch: $(majorMinorPatch)'
+    Write-Host 'assemblySemVer: $(assemblySemVer)'
+    Write-Host 'assemblySemFileVer: $(assemblySemFileVer)'
+    Write-Host 'nuGetVersion: $(nuGetVersion)'
+  name: PrintVariablesFromGitVersion

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -1,7 +1,6 @@
 # DESCRIPTION: 	
 # Builds, tests, and packages the solution for all PR requests.	
 
-name: pr$(system.pullRequest.pullRequestNumber)-$(Date:yyyyMMdd)$(Rev:-r)
 trigger: none
 
 variables:
@@ -9,9 +8,25 @@ variables:
 - template: build-variables.yml
 
 stages:
+- stage: UpdateVersion
+  displayName: 'Determine Semver'
+  dependsOn: []
+  jobs:
+  - job: Semver
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+    - template: ./jobs/update-semver.yml
+    - script: echo %Action%%BuildVersion%
+      displayName: 'Set build version'
+      env:
+        Action: '##vso[build.updatebuildnumber]'
+        BuildVersion: $(GitVersion.semVer)
+
 - stage: BuildUnitTests
   displayName: 'Build and run unit tests'
-  dependsOn: []
+  dependsOn:
+  - UpdateVersion
   jobs:
   - job: Windows
     pool:
@@ -29,7 +44,8 @@ stages:
 
 - stage: DockerBuild  
   displayName: 'Build images'
-  dependsOn: []
+  dependsOn:
+  - UpdateVersion
   jobs:
   - template: ./jobs/docker-build-all.yml
     parameters: 

--- a/docs/Versioning.md
+++ b/docs/Versioning.md
@@ -1,0 +1,35 @@
+# Semantic Versioning for FHIR Server
+
+This guide gives an overview of the Semantic versioning implementation in use with this project.
+To achieve semantic versioning consistently and relaiably the [GitVersion](https://github.com/GitTools/GitVersion) library is used.
+
+## Git Version
+
+### Overview
+GitVersion is a software library and build task that uses Git history to calculate the version that should be used for the current build. The following sections explain how it is configured and the commands available to assist in versioning.
+
+### Setup
+A [configuration](https://github.com/microsoft/fhir-server/blob/master/GitVersion.yml) file is included in the root directory that is used to setup the version strategy and specify how versioning should be calculated against the default and other branches. Currently, all commits to main will be treated as a release, all commits to other branches (including pull requests) will be treated as pre-release (e.g. `1.2.0-my-branch+1`).
+
+The configured GitVersion versioning strategy is [mainline development](https://gitversion.net/docs/reference/versioning-modes/mainline-development), which increments the patch version on every commit to the main branch. Our current development workflow assumes that the main branch will stage a release on every commit, some releases however will be not be approved.
+
+When a release is approved this should result in the assets being published to the nuget feed and a tag being created against the code to mark the release.
+
+### Commands
+Several commands are available during the squash-merge to allow incrementing the major/minor release numbers.
+
+For a major feature or major breaking changes, the following commands can be added to the commit message:
+```
++semver: breaking
+or
++semver: major
+```
+
+Smaller changes can choose to increment the minor version:
+```
++semver: feature
+or
++semver: minor
+```
+
+For bug fixes or other incremental changes, nothing needs to be added, this will happen automatically.


### PR DESCRIPTION
## Description
Adds semver with [GitVersioning](https://github.com/GitTools/GitVersion)

This package allows controlling versioning through Git, version bumps can be utilized through `+semver: major|minor|feature|breaking` syntax in commit messages. 

![image](https://user-images.githubusercontent.com/197221/99157655-c43d8400-267f-11eb-887e-e8b2a93f7e55.png)

For all incremental bug fixes, changes and updates, nothing needs to be changed, GitVersion will increment the patch version automatically based on commits in main.

For breaking changes you can use the following syntax in the commit message:
```
+semver: breaking
or
+semver: major
```

Features can use:
```
+semver: feature
or
+semver: minor
```
Refs #1402

Also see https://github.com/microsoft/healthcare-shared-components/pull/125