### PR TITLE
Fix Cosmos DB error handling

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Reindex/ReindexHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Reindex/ReindexHandlerTests.cs
@@ -87,11 +87,12 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
 
             var jobRecord = new ReindexJobRecord(_resourceTypeSearchParameterHashMap, 1);
             var jobWrapper = new ReindexJobWrapper(jobRecord, WeakETag.FromVersionId("id"));
-            _fhirOperationDataStore.GetReindexJobByIdAsync("id", CancellationToken.None).Throws(new RequestRateExceededException(TimeSpan.FromMilliseconds(100)));
+            _fhirOperationDataStore.GetReindexJobByIdAsync("id", CancellationToken.None).Throws(new Exception(null, new RequestRateExceededException(TimeSpan.FromMilliseconds(100))));
 
             var handler = new GetReindexRequestHandler(_fhirOperationDataStore, DisabledFhirAuthorizationService.Instance);
 
-            await Assert.ThrowsAsync<RequestRateExceededException>(() => handler.Handle(request, CancellationToken.None));
+            Exception thrownException = await Assert.ThrowsAsync<Exception>(() => handler.Handle(request, CancellationToken.None));
+            Assert.IsType<RequestRateExceededException>(thrownException.InnerException);
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Core/Extensions/ExceptionExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Extensions/ExceptionExtensions.cs
@@ -1,0 +1,34 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.Health.Abstractions.Exceptions;
+using Microsoft.Health.Fhir.Core.Exceptions;
+
+namespace Microsoft.Health.Fhir.Core.Extensions
+{
+    public static class ExceptionExtensions
+    {
+        /// <summary>
+        /// Determines whether the exception or its inner exception is of type <see cref="RequestRateExceededException"/>.
+        /// It could be the inner exception because the Cosmos DB SDK wraps exceptions that are thrown inside of custom request handlers with a CosmosException.
+        /// </summary>
+        /// <param name="e">The exception</param>
+        public static bool IsRequestRateExceeded(this Exception e)
+        {
+            return e is RequestRateExceededException || e?.InnerException is RequestRateExceededException;
+        }
+
+        /// <summary>
+        /// Determines whether the exception or its inner exception is of type <see cref="RequestEntityTooLargeException"/>.
+        /// It could be the inner exception because the Cosmos DB SDK wraps exceptions that are thrown inside of custom request handlers with a CosmosException.
+        /// </summary>
+        /// <param name="e">The exception</param>
+        public static bool IsRequestEntityTooLarge(this Exception e)
+        {
+            return e is RequestEntityTooLargeException || e?.InnerException is RequestEntityTooLargeException;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/GetReindexRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/GetReindexRequestHandler.cs
@@ -9,8 +9,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using MediatR;
-using Microsoft.Health.Abstractions.Exceptions;
 using Microsoft.Health.Fhir.Core.Exceptions;
+using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models;
 using Microsoft.Health.Fhir.Core.Features.Security;
 using Microsoft.Health.Fhir.Core.Features.Security.Authorization;
@@ -68,7 +68,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             {
                 throw;
             }
-            catch (Exception ex) when (ex.InnerException is RequestRateExceededException)
+            catch (Exception ex) when (ex.IsRequestRateExceeded())
             {
                 throw;
             }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/GetReindexRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/GetReindexRequestHandler.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             {
                 throw;
             }
-            catch (RequestRateExceededException)
+            catch (Exception ex) when (ex.InnerException is RequestRateExceededException)
             {
                 throw;
             }

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Health/CosmosHealthCheckTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Health/CosmosHealthCheckTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Health
         public async Task GivenCosmosDbWithTooManyRequests_WhenHealthIsChecked_ThenHealthyStateShouldBeReturned()
         {
             _testProvider.PerformTest(default, default, _cosmosCollectionConfiguration)
-                .ThrowsForAnyArgs(new RequestRateExceededException(TimeSpan.Zero));
+                .ThrowsForAnyArgs(new Exception(null, new RequestRateExceededException(TimeSpan.Zero)));
 
             HealthCheckResult result = await _healthCheck.CheckHealthAsync(new HealthCheckContext());
 

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Health/CosmosHealthCheck.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Health/CosmosHealthCheck.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Health
 
                 return HealthCheckResult.Healthy("Successfully connected to the data store.");
             }
-            catch (RequestRateExceededException)
+            catch (Exception ex) when (ex.InnerException is RequestRateExceededException)
             {
                 return HealthCheckResult.Healthy("Connection to the data store was successful, however, the rate limit has been exceeded.");
             }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Health/CosmosHealthCheck.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Health/CosmosHealthCheck.cs
@@ -11,8 +11,8 @@ using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.Health.Abstractions.Exceptions;
 using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.CosmosDb.Configs;
 using Microsoft.Health.Fhir.CosmosDb.Features.Storage;
 
@@ -64,7 +64,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Health
 
                 return HealthCheckResult.Healthy("Successfully connected to the data store.");
             }
-            catch (Exception ex) when (ex.InnerException is RequestRateExceededException)
+            catch (Exception ex) when (ex.IsRequestRateExceeded())
             {
                 return HealthCheckResult.Healthy("Connection to the data store was successful, however, the rate limit has been exceeded.");
             }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Queries/CosmosQuery.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Queries/CosmosQuery.cs
@@ -4,7 +4,6 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
@@ -100,12 +99,6 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Queries
                     null,
                     0,
                     fhirException ?? ex);
-
-                if (fhirException != null)
-                {
-                    // rethrow the original exception
-                    ExceptionDispatchInfo.Throw(fhirException);
-                }
 
                 throw;
             }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosDbDistributedLock.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosDbDistributedLock.cs
@@ -234,7 +234,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
 
                         break;
                     }
-                    catch (RequestRateExceededException)
+                    catch (CosmosException ex) when (ex.InnerException is RequestRateExceededException)
                     {
                         await Task.Delay(TimeSpan.FromSeconds(1));
                     }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosDbDistributedLock.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosDbDistributedLock.cs
@@ -10,8 +10,8 @@ using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Logging;
-using Microsoft.Health.Abstractions.Exceptions;
 using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Health.Fhir.Core.Extensions;
 using Newtonsoft.Json;
 
 namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
@@ -234,7 +234,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
 
                         break;
                     }
-                    catch (CosmosException ex) when (ex.InnerException is RequestRateExceededException)
+                    catch (CosmosException ex) when (ex.IsRequestRateExceeded())
                     {
                         await Task.Delay(TimeSpan.FromSeconds(1));
                     }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -191,9 +191,9 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
             }
             catch (CosmosException exception)
             {
-                if (exception.GetSubStatusCode() == HttpStatusCode.RequestEntityTooLarge)
+                if (exception.InnerException is RequestEntityTooLargeException)
                 {
-                    throw new RequestRateExceededException(exception.RetryAfter);
+                    throw;
                 }
 
                 _logger.LogError(exception, "Unhandled Document Client Exception");
@@ -340,7 +340,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
                             results.AddRange(page);
                         }
                     }
-                    catch (RequestRateExceededException)
+                    catch (CosmosException e) when (e.InnerException is RequestRateExceededException)
                     {
                         // return whatever we have when we get a 429
                         break;

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -18,6 +18,7 @@ using Microsoft.Health.Core;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Exceptions;
+using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Conformance;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.CosmosDb.Configs;
@@ -191,7 +192,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
             }
             catch (CosmosException exception)
             {
-                if (exception.InnerException is RequestEntityTooLargeException)
+                if (exception.IsRequestEntityTooLarge())
                 {
                     throw;
                 }
@@ -340,7 +341,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
                             results.AddRange(page);
                         }
                     }
-                    catch (CosmosException e) when (e.InnerException is RequestRateExceededException)
+                    catch (CosmosException e) when (e.IsRequestRateExceeded())
                     {
                         // return whatever we have when we get a 429
                         break;

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Operations/CosmosFhirOperationDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Operations/CosmosFhirOperationDataStore.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Abstractions.Exceptions;
 using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export.Models;
 using Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models;
@@ -101,9 +102,9 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Operations
             }
             catch (CosmosException dce)
             {
-                if (dce.StatusCode == HttpStatusCode.TooManyRequests)
+                if (dce.InnerException is RequestRateExceededException)
                 {
-                    throw new RequestRateExceededException(dce.RetryAfter);
+                    throw;
                 }
 
                 _logger.LogError(dce, "Failed to create an export job.");
@@ -128,11 +129,12 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Operations
             }
             catch (CosmosException dce)
             {
-                if (dce.StatusCode == HttpStatusCode.TooManyRequests)
+                if (dce.InnerException is RequestRateExceededException)
                 {
-                    throw new RequestRateExceededException(dce.RetryAfter);
+                    throw;
                 }
-                else if (dce.StatusCode == HttpStatusCode.NotFound)
+
+                if (dce.StatusCode == HttpStatusCode.NotFound)
                 {
                     throw new JobNotFoundException(string.Format(Core.Resources.JobNotFound, id));
                 }
@@ -169,9 +171,9 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Operations
             }
             catch (CosmosException dce)
             {
-                if (dce.StatusCode == HttpStatusCode.TooManyRequests)
+                if (dce.InnerException is RequestRateExceededException)
                 {
-                    throw new RequestRateExceededException(dce.RetryAfter);
+                    throw;
                 }
 
                 _logger.LogError(dce, "Failed to get an export job by hash.");
@@ -207,9 +209,9 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Operations
             }
             catch (CosmosException dce)
             {
-                if (dce.StatusCode == HttpStatusCode.TooManyRequests)
+                if (dce.InnerException is RequestRateExceededException)
                 {
-                    throw new RequestRateExceededException(dce.RetryAfter);
+                    throw;
                 }
                 else if (dce.StatusCode == HttpStatusCode.PreconditionFailed)
                 {
@@ -244,9 +246,9 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Operations
             }
             catch (CosmosException dce)
             {
-                if (dce.GetSubStatusCode() == HttpStatusCode.RequestEntityTooLarge)
+                if (dce.InnerException is RequestEntityTooLargeException)
                 {
-                    throw new RequestRateExceededException(null);
+                    throw;
                 }
 
                 _logger.LogError(dce, "Failed to acquire export jobs.");
@@ -271,9 +273,9 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Operations
             }
             catch (CosmosException dce)
             {
-                if (dce.StatusCode == HttpStatusCode.TooManyRequests)
+                if (dce.InnerException is RequestRateExceededException)
                 {
-                    throw new RequestRateExceededException(dce.RetryAfter);
+                    throw;
                 }
 
                 _logger.LogError(dce, "Failed to create a reindex job.");
@@ -297,9 +299,9 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Operations
             }
             catch (CosmosException dce)
             {
-                if (dce.GetSubStatusCode() == HttpStatusCode.RequestEntityTooLarge)
+                if (dce.InnerException is RequestEntityTooLargeException)
                 {
-                    throw new RequestRateExceededException(null);
+                    throw;
                 }
 
                 _logger.LogError(dce, "Failed to acquire reindex jobs.");
@@ -328,9 +330,9 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Operations
             }
             catch (CosmosException dce)
             {
-                if (dce.StatusCode == HttpStatusCode.TooManyRequests)
+                if (dce.InnerException is RequestRateExceededException)
                 {
-                    throw new RequestRateExceededException(dce.RetryAfter);
+                    throw;
                 }
 
                 _logger.LogError(dce, "Failed to check if any reindex jobs are active.");
@@ -357,9 +359,9 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Operations
             }
             catch (CosmosException dce)
             {
-                if (dce.StatusCode == HttpStatusCode.TooManyRequests)
+                if (dce.InnerException is RequestRateExceededException)
                 {
-                    throw new RequestRateExceededException(dce.RetryAfter);
+                    throw;
                 }
                 else if (dce.StatusCode == HttpStatusCode.NotFound)
                 {
@@ -399,9 +401,9 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Operations
             }
             catch (CosmosException dce)
             {
-                if (dce.StatusCode == HttpStatusCode.TooManyRequests)
+                if (dce.InnerException is RequestRateExceededException)
                 {
-                    throw new RequestRateExceededException(dce.RetryAfter);
+                    throw;
                 }
                 else if (dce.StatusCode == HttpStatusCode.PreconditionFailed)
                 {

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Operations/CosmosFhirOperationDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Operations/CosmosFhirOperationDataStore.cs
@@ -14,9 +14,8 @@ using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Cosmos.Scripts;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.Health.Abstractions.Exceptions;
 using Microsoft.Health.Extensions.DependencyInjection;
-using Microsoft.Health.Fhir.Core.Exceptions;
+using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export.Models;
 using Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models;
@@ -102,7 +101,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Operations
             }
             catch (CosmosException dce)
             {
-                if (dce.InnerException is RequestRateExceededException)
+                if (dce.IsRequestRateExceeded())
                 {
                     throw;
                 }
@@ -129,7 +128,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Operations
             }
             catch (CosmosException dce)
             {
-                if (dce.InnerException is RequestRateExceededException)
+                if (dce.IsRequestRateExceeded())
                 {
                     throw;
                 }
@@ -171,7 +170,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Operations
             }
             catch (CosmosException dce)
             {
-                if (dce.InnerException is RequestRateExceededException)
+                if (dce.IsRequestRateExceeded())
                 {
                     throw;
                 }
@@ -209,7 +208,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Operations
             }
             catch (CosmosException dce)
             {
-                if (dce.InnerException is RequestRateExceededException)
+                if (dce.IsRequestRateExceeded())
                 {
                     throw;
                 }
@@ -246,7 +245,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Operations
             }
             catch (CosmosException dce)
             {
-                if (dce.InnerException is RequestEntityTooLargeException)
+                if (dce.IsRequestEntityTooLarge())
                 {
                     throw;
                 }
@@ -273,7 +272,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Operations
             }
             catch (CosmosException dce)
             {
-                if (dce.InnerException is RequestRateExceededException)
+                if (dce.IsRequestRateExceeded())
                 {
                     throw;
                 }
@@ -299,7 +298,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Operations
             }
             catch (CosmosException dce)
             {
-                if (dce.InnerException is RequestEntityTooLargeException)
+                if (dce.IsRequestEntityTooLarge())
                 {
                     throw;
                 }
@@ -330,7 +329,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Operations
             }
             catch (CosmosException dce)
             {
-                if (dce.InnerException is RequestRateExceededException)
+                if (dce.IsRequestRateExceeded())
                 {
                     throw;
                 }
@@ -359,7 +358,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Operations
             }
             catch (CosmosException dce)
             {
-                if (dce.InnerException is RequestRateExceededException)
+                if (dce.IsRequestRateExceeded())
                 {
                     throw;
                 }
@@ -401,7 +400,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Operations
             }
             catch (CosmosException dce)
             {
-                if (dce.InnerException is RequestRateExceededException)
+                if (dce.IsRequestRateExceeded())
                 {
                     throw;
                 }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
@@ -184,6 +184,23 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
                 context.Result = healthExceptionResult;
                 context.ExceptionHandled = true;
             }
+            else if (context.Exception.InnerException != null)
+            {
+                Exception outerException = context.Exception;
+                context.Exception = outerException.InnerException;
+
+                try
+                {
+                    OnActionExecuted(context);
+                }
+                finally
+                {
+                    if (!context.ExceptionHandled)
+                    {
+                        context.Exception = outerException;
+                    }
+                }
+            }
         }
 
         private OperationOutcomeResult CreateOperationOutcomeResult(string message, OperationOutcome.IssueSeverity issueSeverity, OperationOutcome.IssueType issueType, HttpStatusCode httpStatusCode)


### PR DESCRIPTION
## Description
Exceptions that we throw inside of a `RequestHandler` are wrapped by the Cosmos DB SDK in a `CosmosException` with status code 500. This means that our error handling for 429s and other conditions where we throw a specific exception have resulted in 500s since we moved to v3 of the Cosmos DB SDK.

The change here is to recognize that the `RequestRateExceededException` and others we throw from within the `RequestHandler` will appear as an inner exception.

## Related issues
Addresses [AB#76850](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/76850)

## Testing
Added unit tests and performed manual testing
