### PR TITLE
IncludeTests must keep BasePath

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SearchTestsBase.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SearchTestsBase.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -136,7 +137,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         protected void ValidateBundleUrl(Uri expectedBaseAddress, ResourceType expectedResourceType, string expectedQuery, string bundleUrl)
         {
             var uriBuilder = new UriBuilder(expectedBaseAddress);
-            uriBuilder.Path = expectedResourceType.ToString();
+            uriBuilder.Path = Path.Combine(uriBuilder.Path, expectedResourceType.ToString());
             uriBuilder.Query = expectedQuery;
 
             Assert.Equal(HttpUtility.UrlDecode(uriBuilder.Uri.ToString()), HttpUtility.UrlDecode(bundleUrl));


### PR DESCRIPTION
## Description

Include tests do not keep Path when validating expected bundle Url:

```
[xUnit.net 00:00:48.82]     Microsoft.Health.Fhir.Tests.E2E.Rest.Search.IncludeSearchTests(CosmosDb, Json).GivenAnIncludeSearchExpressionWithMultipleDenormalizedParameters_WhenSearched_ThenCorrectBundleShouldBeReturned [FAIL]
  X Microsoft.Health.Fhir.Tests.E2E.Rest.Search.IncludeSearchTests(CosmosDb, Json).GivenAnIncludeSearchExpression_WhenSearched_ThenCorrectBundleShouldBeReturned [76ms]
  Error Message:
   Assert.Equal() Failure

Expected: ···rontend.abc.com/Location?_include=Location:organization:O···
Actual:   ···rontend.abc.com/twpr14207wu2-pr14207.abc.com/Location···
```

Build: https://microsofthealth.visualstudio.com/Health/_build/results?buildId=76709&view=logs&j=35e54f60-58e4-5f8d-a085-64345d1fe23f&t=f2c479e6-e3bd-5e7f-fa2d-146fe3633493
