### PR TITLE
Add index hint to SQL query

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -133,20 +133,23 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
             StringBuilder.Append("FROM ").Append(VLatest.Resource).Append(" ").Append(resourceTableAlias);
 
-            if (expression.TableExpressions.Count > 0)
+            if (expression.TableExpressions.Count == 0 &&
+                !_isHistorySearch &&
+                expression.DenormalizedExpressions.Any(e => e.AcceptVisitor(ExpressionContainsParameterVisitor.Instance, SearchParameterNames.ResourceType)))
             {
-                StringBuilder.AppendLine().Append("INNER JOIN ").AppendLine(TableExpressionName(_tableExpressionCounter));
-                StringBuilder.Append("ON ").Append(VLatest.Resource.ResourceSurrogateId, resourceTableAlias).Append(" = ").Append(TableExpressionName(_tableExpressionCounter)).AppendLine(".Sid1");
-            }
-            else if (!_isHistorySearch)
-            {
-                // If not joining with any other CTEs and this is not a history search, make sure the optimizer does not decide to do a scan on the clustered index
+                // If this is a simple search over a resource type (like GET /Observation)
+                // make sure the optimizer does not decide to do a scan on the clustered index, since we have an index specifically for this common case
                 StringBuilder.Append(" WITH(INDEX(").Append(VLatest.Resource.IX_Resource_ResourceTypeId_ResourceSurrgateId).AppendLine("))");
             }
             else
             {
-                // History search will likely resort to a table scan until we add ResourceTypeId as the leading column to the clustered index Resource table.
                 StringBuilder.AppendLine();
+            }
+
+            if (expression.TableExpressions.Count > 0)
+            {
+                StringBuilder.AppendLine().Append("INNER JOIN ").AppendLine(TableExpressionName(_tableExpressionCounter));
+                StringBuilder.Append("ON ").Append(VLatest.Resource.ResourceSurrogateId, resourceTableAlias).Append(" = ").Append(TableExpressionName(_tableExpressionCounter)).AppendLine(".Sid1");
             }
 
             using (var delimitedClause = StringBuilder.BeginDelimitedWhereClause())
@@ -170,15 +173,15 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                 if (searchParamInfo == null || searchParamInfo.Name == KnownQueryParameterNames.LastUpdated)
                 {
                     StringBuilder
-                    .Append(VLatest.Resource.ResourceSurrogateId, resourceTableAlias).Append(" ")
-                    .AppendLine(sortOrder == SortOrder.Ascending ? "ASC" : "DESC");
+                        .Append(VLatest.Resource.ResourceSurrogateId, resourceTableAlias).Append(" ")
+                        .AppendLine(sortOrder == SortOrder.Ascending ? "ASC" : "DESC");
                 }
                 else
                 {
                     StringBuilder
-                    .Append($"{TableExpressionName(_tableExpressionCounter)}.SortValue ")
-                    .Append(sortOrder == SortOrder.Ascending ? "ASC" : "DESC").Append(", ")
-                    .Append(VLatest.Resource.ResourceSurrogateId, resourceTableAlias).AppendLine(" ASC ");
+                        .Append($"{TableExpressionName(_tableExpressionCounter)}.SortValue ")
+                        .Append(sortOrder == SortOrder.Ascending ? "ASC" : "DESC").Append(", ")
+                        .Append(VLatest.Resource.ResourceSurrogateId, resourceTableAlias).AppendLine(" ASC ");
                 }
             }
 
@@ -333,7 +336,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
                     // For reverse chaning, if there is a parameter on the _id search parameter, we need another join to get the resource ID of the reference source (all we have is the surrogate ID at this point)
 
-                    bool denormalizedHandledBySecondJoin = tableExpression.DenormalizedPredicate != null && chainedExpression.Reversed && tableExpression.DenormalizedPredicate.AcceptVisitor(DenormalizedExpressionContainsIdParameterVisitor.Instance, null);
+                    bool denormalizedHandledBySecondJoin = tableExpression.DenormalizedPredicate != null && chainedExpression.Reversed && tableExpression.DenormalizedPredicate.AcceptVisitor(ExpressionContainsParameterVisitor.Instance, SearchParameterNames.Id);
 
                     if (denormalizedHandledBySecondJoin)
                     {
@@ -462,7 +465,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                         }
 
                         delimited.BeginDelimitedElement().Append(VLatest.ReferenceSearchParam.ResourceTypeId, table)
-                        .Append(" = ").Append(Parameters.AddParameter(VLatest.ReferenceSearchParam.ResourceTypeId, resourceId));
+                            .Append(" = ").Append(Parameters.AddParameter(VLatest.ReferenceSearchParam.ResourceTypeId, resourceId));
 
                         // Get FROM ctes
                         string fromCte = _cteMainSelect;
@@ -600,8 +603,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     if (isRev)
                     {
                         StringBuilder.Append("CASE WHEN count(*) over() > ")
-                        .Append(Parameters.AddParameter(context.IncludeCount))
-                        .AppendLine(" THEN 1 ELSE 0 END AS IsPartial ");
+                            .Append(Parameters.AddParameter(context.IncludeCount))
+                            .AppendLine(" THEN 1 ELSE 0 END AS IsPartial ");
                     }
                     else
                     {
@@ -707,15 +710,15 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
             StringBuilder.Append("Sid1, IsMatch, ");
             StringBuilder.Append("CASE WHEN count(*) over() > ")
-                         .Append(Parameters.AddParameter(context.IncludeCount))
-                         .AppendLine(" THEN 1 ELSE 0 END AS IsPartial ");
+                .Append(Parameters.AddParameter(context.IncludeCount))
+                .AppendLine(" THEN 1 ELSE 0 END AS IsPartial ");
 
             StringBuilder.Append("FROM ").AppendLine(cteToLimit);
             StringBuilder.Append($"),{Environment.NewLine}");
 
             // the 'original' include cte is not in the union, but this new layer is instead
             _includeCteIds.Add(TableExpressionName(_tableExpressionCounter));
-         }
+        }
 
         private SearchParameterQueryGeneratorContext GetContext(string tableAlias = null)
         {
@@ -733,7 +736,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                 string columnToSelect = (tableExpression.Kind == TableExpressionKind.Chain ? tableExpression.ChainLevel - 1 : tableExpression.ChainLevel) == 0 ? "Sid1" : "Sid2";
 
                 StringBuilder.Append(VLatest.Resource.ResourceSurrogateId, tableAlias).Append(" IN (SELECT ").Append(columnToSelect)
-                             .Append(" FROM ").Append(TableExpressionName(predecessorIndex)).Append(")");
+                    .Append(" FROM ").Append(TableExpressionName(predecessorIndex)).Append(")");
             }
         }
 
@@ -807,18 +810,18 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
         }
 
         /// <summary>
-        /// A visitor to determine if there are any references to the _id search parameter in an expression
+        /// A visitor to determine if there are any references to a search parameter in an expression.
         /// </summary>
-        private class DenormalizedExpressionContainsIdParameterVisitor : DefaultExpressionVisitor<object, bool>
+        private class ExpressionContainsParameterVisitor : DefaultExpressionVisitor<string, bool>
         {
-            public static readonly DenormalizedExpressionContainsIdParameterVisitor Instance = new DenormalizedExpressionContainsIdParameterVisitor();
+            public static readonly ExpressionContainsParameterVisitor Instance = new ExpressionContainsParameterVisitor();
 
-            private DenormalizedExpressionContainsIdParameterVisitor()
-            : base((acc, curr) => acc || curr)
+            private ExpressionContainsParameterVisitor()
+                : base((acc, curr) => acc || curr)
             {
             }
 
-            public override bool VisitSearchParameter(SearchParameterExpression expression, object context) => expression.Parameter.Name == SearchParameterNames.Id;
+            public override bool VisitSearchParameter(SearchParameterExpression expression, string context) => string.Equals(expression.Parameter.Name, context, StringComparison.Ordinal);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             else if (!_isHistorySearch)
             {
                 // If not joining with any other CTEs and this is not a history search, make sure the optimizer does not decide to do a scan on the clustered index
-                StringBuilder.AppendLine(" WITH(INDEX(IX_Resource_ResourceTypeId_ResourceSurrgateId))");
+                StringBuilder.Append(" WITH(INDEX(").Append(VLatest.Resource.IX_Resource_ResourceTypeId_ResourceSurrgateId).AppendLine("))");
             }
             else
             {


### PR DESCRIPTION
Adds an index hint to the SQL we generate for what it probably the simplest search: find resources of a particular type, like `GET /Observation`. We've seen instances where the optimizer decides to perform a clustered index scan over the `Resource` table, which will likely result in very poor performance. For these exact queries, we add a hint that will force it to use an existing filtered nonclustered index that exists for this very scenario:

```sql
CREATE UNIQUE NONCLUSTERED INDEX IX_Resource_ResourceTypeId_ResourceSurrgateId ON dbo.Resource
(
    ResourceTypeId,
    ResourceSurrogateId
)
WHERE IsHistory = 0 AND IsDeleted = 0
```

Address part of #1452 (does not address timeout handling)