### PR TITLE
Adds mock for IModelInfoProvider/IStructureDefinitionSummaryProvider

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionBuilder.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionBuilder.cs
@@ -141,7 +141,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
                 using JsonReader jsonReader = new JsonTextReader(reader);
                 try
                 {
-                    bundle = new BundleWrapper(FhirJsonNode.Read(jsonReader).ToTypedElement(_modelInfoProvider.StructureDefinitionSummaryProvider));
+                    ISourceNode sourceNode = FhirJsonNode.Read(jsonReader);
+                    bundle = new BundleWrapper(sourceNode.ToTypedElement(_modelInfoProvider.StructureDefinitionSummaryProviderForSourceNode(sourceNode)));
                 }
                 catch (FormatException ex)
                 {

--- a/src/Microsoft.Health.Fhir.Core/Models/IModelInfoProvider.cs
+++ b/src/Microsoft.Health.Fhir.Core/Models/IModelInfoProvider.cs
@@ -32,5 +32,7 @@ namespace Microsoft.Health.Fhir.Core.Models
         Type GetTypeForFhirType(string resourceType);
 
         EvaluationContext GetEvaluationContext(Func<string, ITypedElement> elementResolver = null);
+
+        IStructureDefinitionSummaryProvider StructureDefinitionSummaryProviderForSourceNode(ISourceNode sourceNode);
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core/VersionSpecificModelInfoProvider.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/VersionSpecificModelInfoProvider.cs
@@ -71,5 +71,13 @@ namespace Microsoft.Health.Fhir.Core
                 ElementResolver = elementResolver,
             };
         }
+
+        public IStructureDefinitionSummaryProvider StructureDefinitionSummaryProviderForSourceNode(ISourceNode sourceNode)
+        {
+            // SourceNode is not required when we have access to the full generated StructureDefinitionSummaryProvider
+            // but it is required when looking at generic FHIR data.
+
+            return StructureDefinitionSummaryProvider;
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Microsoft.Health.Fhir.SqlServer.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Microsoft.Health.Fhir.SqlServer.UnitTests.csproj
@@ -8,8 +8,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.Health.Fhir.R4.Core\Microsoft.Health.Fhir.R4.Core.csproj" />
     <ProjectReference Include="..\Microsoft.Health.Fhir.SqlServer\Microsoft.Health.Fhir.SqlServer.csproj" />
-    <ProjectReference Include="..\Microsoft.Health.Fhir.Core\Microsoft.Health.Fhir.Core.csproj" />
+    <ProjectReference Include="..\Microsoft.Health.Fhir.Tests.Common\Microsoft.Health.Fhir.Tests.Common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Health.Fhir.Tests.Common/MockModelInfoProviderBuilder.cs
+++ b/src/Microsoft.Health.Fhir.Tests.Common/MockModelInfoProviderBuilder.cs
@@ -1,0 +1,82 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EnsureThat;
+using Hl7.Fhir.ElementModel;
+using Microsoft.Health.Fhir.Core.Models;
+using NSubstitute;
+
+namespace Microsoft.Health.Fhir.Tests.Common
+{
+    public class MockModelInfoProviderBuilder
+    {
+        private readonly IModelInfoProvider _mock;
+        private readonly HashSet<string> _knownTypes;
+
+        private MockModelInfoProviderBuilder(IModelInfoProvider mock, HashSet<string> knownTypes)
+        {
+            EnsureArg.IsNotNull(mock, nameof(mock));
+            EnsureArg.IsNotNull(knownTypes, nameof(knownTypes));
+
+            _mock = mock;
+            _knownTypes = knownTypes;
+        }
+
+        public static MockModelInfoProviderBuilder Create(FhirSpecification version)
+        {
+            IModelInfoProvider provider = Substitute.For<IModelInfoProvider>();
+            provider.Version.Returns(version);
+
+            // Adds normative types by default
+            var seenTypes = new HashSet<string>
+            {
+                "Binary", "Bundle", "CapabilityStatement",  "CodeSystem", "Observation", "OperationOutcome", "Patient", "StructureDefinition", "ValueSet",
+            };
+
+            provider.GetResourceTypeNames().Returns(_ => seenTypes.Where(x => !string.IsNullOrEmpty(x)).ToArray());
+            provider.IsKnownResource(Arg.Any<string>()).Returns(x => provider.GetResourceTypeNames().Contains(x[0]));
+
+            // Simulate inherited behavior
+            // Some code depends on "InheritedResource".BaseType
+            // This adds the ability to resolve "Resource" as the base type
+            provider.GetTypeForFhirType(Arg.Any<string>()).Returns(p => p.ArgAt<string>(0) == "Resource" ? typeof(ResourceObj) : typeof(InheritedResourceObj));
+            provider.GetFhirTypeNameForType(Arg.Any<Type>()).Returns(p => p.ArgAt<Type>(0) == typeof(ResourceObj) ? "Resource" : null);
+
+            // IStructureDefinitionSummaryProvider allows the execution of FHIRPath queries
+            provider.StructureDefinitionSummaryProviderForSourceNode(Arg.Any<ISourceNode>())
+                .Returns(p => new MockStructureDefinitionSummaryProvider(p.ArgAt<ISourceNode>(0), seenTypes));
+
+            return new MockModelInfoProviderBuilder(provider, seenTypes);
+        }
+
+        public MockModelInfoProviderBuilder AddKnownTypes(params string[] knownResourceTypes)
+        {
+            EnsureArg.IsNotNull(knownResourceTypes, nameof(knownResourceTypes));
+
+            foreach (var item in knownResourceTypes)
+            {
+                _knownTypes.Add(item);
+            }
+
+            return this;
+        }
+
+        public IModelInfoProvider Build()
+        {
+            return _mock;
+        }
+
+        private class ResourceObj
+        {
+        }
+
+        private class InheritedResourceObj : ResourceObj
+        {
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Tests.Common/MockStructureDefinitionSummaryProvider.cs
+++ b/src/Microsoft.Health.Fhir.Tests.Common/MockStructureDefinitionSummaryProvider.cs
@@ -1,0 +1,120 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EnsureThat;
+using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Specification;
+using Hl7.Fhir.Utility;
+
+namespace Microsoft.Health.Fhir.Tests.Common
+{
+    /// <summary>
+    /// Provides an implementation of IStructureDefinitionSummaryProvider that can be used to execute FHIRPath without the need for version specific references.
+    /// </summary>
+    public class MockStructureDefinitionSummaryProvider : IStructureDefinitionSummaryProvider
+    {
+        private readonly ISourceNode _node;
+
+        public MockStructureDefinitionSummaryProvider(ISourceNode node, HashSet<string> seenTypes)
+        {
+            EnsureArg.IsNotNull(node, nameof(node));
+            EnsureArg.IsNotNull(seenTypes, nameof(seenTypes));
+
+            SeenTypes = seenTypes;
+            _node = node;
+        }
+
+        public HashSet<string> SeenTypes { get; }
+
+        public IStructureDefinitionSummary Provide(string canonical)
+        {
+            return new MockElementDefinitionSummary(SeenTypes, _node);
+        }
+
+        private class MockElementDefinitionSummary : IElementDefinitionSummary, IStructureDefinitionSummary, IAnnotated, IResourceTypeSupplier
+        {
+            private readonly ISourceNode[] _items;
+            private Dictionary<string, IElementDefinitionSummary> _list;
+            private readonly string _resourceTypeIndicator;
+
+            public MockElementDefinitionSummary(HashSet<string> seenTypes, ISourceNode item)
+                : this(seenTypes, new[] { item }, false)
+            {
+            }
+
+            public MockElementDefinitionSummary(HashSet<string> seenTypes, ISourceNode[] items, bool isCollection)
+            {
+                EnsureArg.IsNotNull(seenTypes, nameof(seenTypes));
+                EnsureArg.IsNotNull(items, nameof(items));
+
+                SeenTypes = seenTypes;
+                IsCollection = isCollection;
+                _items = items;
+
+                _resourceTypeIndicator = items.First().GetResourceTypeIndicator();
+                if (!string.IsNullOrEmpty(_resourceTypeIndicator))
+                {
+                    SeenTypes.Add(_resourceTypeIndicator);
+                }
+            }
+
+            public string ElementName => _items.First().Name;
+
+            public HashSet<string> SeenTypes { get; }
+
+            public bool IsCollection { get; }
+
+            public bool IsRequired { get; }
+
+            public bool InSummary { get; }
+
+            public bool IsChoiceElement { get; }
+
+            public string TypeName => _resourceTypeIndicator;
+
+            public bool IsAbstract { get; }
+
+            public bool IsResource => SeenTypes.Contains(TypeName);
+
+            public string DefaultTypeName => TypeName;
+
+            public string ResourceType => TypeName;
+
+            public ITypeSerializationInfo[] Type => new ITypeSerializationInfo[] { this };
+
+            public string NonDefaultNamespace { get; }
+
+            public XmlRepresentation Representation { get; }
+
+            public int Order { get; }
+
+            public IReadOnlyCollection<IElementDefinitionSummary> GetElements()
+            {
+                if (_list == null)
+                {
+                    _list = new Dictionary<string, IElementDefinitionSummary>();
+
+                    foreach (var item in _items.SelectMany(x => x.Children()).GroupBy(x => x.Name))
+                    {
+                        if (!_list.ContainsKey(item.Key))
+                        {
+                            _list.Add(item.Key, new MockElementDefinitionSummary(SeenTypes, item.ToArray(), item.Count() > _items.Length));
+                        }
+                    }
+                }
+
+                return _list.Values;
+            }
+
+            public IEnumerable<object> Annotations(Type type)
+            {
+                return new[] { this };
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
Adds a Builder and mock for IModelInfoProvider and IStructureDefinitionSummaryProvider. This contains enough functionality to mock and build the SearchParameterDefinitionManager without Poco references.

Removes dependency from SqlTests => R4