### PR TITLE
Returns Bad Request when a request has both _elements and _summary parameters

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -268,6 +268,15 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The &apos;_elements&apos; parameter is supported only when &apos;_summary&apos; is SummaryType.False or &apos;_summary&apos; is not specified at all..
+        /// </summary>
+        internal static string ElementsAndSummaryParametersAreIncompatible {
+            get {
+                return ResourceManager.GetString("ElementsAndSummaryParametersAreIncompatible", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Error validating roles:
         ///{0}.
         /// </summary>
@@ -391,15 +400,6 @@ namespace Microsoft.Health.Fhir.Core {
         internal static string IncludeMissingType {
             get {
                 return ResourceManager.GetString("IncludeMissingType", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The parameters &apos;{0}&apos; and &apos;{1}&apos; are not compatible..
-        /// </summary>
-        internal static string IncompatibleSearchParameters {
-            get {
-                return ResourceManager.GetString("IncompatibleSearchParameters", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Health.Fhir.Core {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -391,6 +391,15 @@ namespace Microsoft.Health.Fhir.Core {
         internal static string IncludeMissingType {
             get {
                 return ResourceManager.GetString("IncludeMissingType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The parameters &apos;{0}&apos; and &apos;{1}&apos; are not compatible..
+        /// </summary>
+        internal static string IncompatibleSearchParameters {
+            get {
+                return ResourceManager.GetString("IncompatibleSearchParameters", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -461,4 +461,7 @@
     <value>The '_type' parameter contains unknown resource(s): {0}</value>
     <comment>{0}: Single or list of unknown resources.</comment>
   </data>
+  <data name="IncompatibleSearchParameters" xml:space="preserve">
+    <value>The parameters '{0}' and '{1}' are not compatible.</value>
+  </data>
 </root>

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -461,7 +461,7 @@
     <value>The '_type' parameter contains unknown resource(s): {0}</value>
     <comment>{0}: Single or list of unknown resources.</comment>
   </data>
-  <data name="IncompatibleSearchParameters" xml:space="preserve">
-    <value>The parameters '{0}' and '{1}' are not compatible.</value>
+  <data name="ElementsAndSummaryParametersAreIncompatible" xml:space="preserve">
+    <value>The '_elements' parameter is supported only when '_summary' is SummaryType.False or '_summary' is not specified at all.</value>
   </data>
 </root>

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             if (searchParams.Elements?.Any() == true && searchParams.Summary != null && searchParams.Summary != SummaryType.False)
             {
                 // The search parameters _elements and _summarize cannot be specified for the same request.
-                throw new BadRequestException(string.Format(Core.Resources.IncompatibleSearchParameters, KnownQueryParameterNames.Summary, KnownQueryParameterNames.Elements));
+                throw new BadRequestException(string.Format(Core.Resources.ElementsAndSummaryParametersAreIncompatible, KnownQueryParameterNames.Summary, KnownQueryParameterNames.Elements));
             }
 
             // Check to see if only the count should be returned

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -205,6 +205,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
 
             searchOptions.IncludeCount = _featureConfiguration.DefaultIncludeCountPerSearch;
 
+            if (searchParams.Elements?.Any() == true && searchParams.Summary != null && searchParams.Summary != SummaryType.False)
+            {
+                // The search parameters _elements and _summarize cannot be specified for the same request.
+                throw new BadRequestException(string.Format(Core.Resources.IncompatibleSearchParameters, KnownQueryParameterNames.Summary, KnownQueryParameterNames.Elements));
+            }
+
             // Check to see if only the count should be returned
             searchOptions.CountOnly = searchParams.Summary == SummaryType.Count;
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -8,11 +8,13 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Net;
+using System.Threading.Tasks;
 using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.FhirPath;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Client;
 using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Core.Features;
 using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Tests.Common;
@@ -425,22 +427,10 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenListOfResources_WhenSearchedWithElements_ThenOnlySpecifiedPropertiesShouldBeReturned()
         {
-            const int numberOfResources = 3;
-            string[] elements = new[] { "gender", "birthDate" };
-
+            string[] elements = { "gender", "birthDate" };
             var tag = new Coding(string.Empty, Guid.NewGuid().ToString());
 
-            Patient patient = Samples.GetDefaultPatient().ToPoco<Patient>();
-            var patients = new Patient[numberOfResources];
-
-            for (int i = 0; i < numberOfResources; i++)
-            {
-                patient.Meta = new Meta();
-                patient.Meta.Tag.Add(tag);
-
-                FhirResponse<Patient> createdPatient = await Client.CreateAsync(patient);
-                patients[i] = MaskingNode.ForElements(new ScopedNode(createdPatient.Resource.ToTypedElement()), elements).ToPoco<Patient>();
-            }
+            Patient[] patients = await CreateTestPatientElements(tag, elements);
 
             Bundle bundle = await Client.SearchAsync($"Patient?_tag={tag.Code}&_elements={string.Join(',', elements)}");
 
@@ -476,24 +466,44 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenListOfResources_WhenSearchedWithInvalidElements_ThenOnlyValidSpecifiedPropertiesShouldBeReturned()
         {
-            const int numberOfResources = 3;
-            string[] elements = new[] { "gender", "birthDate" };
-
+            string[] elements = { "gender", "birthDate" };
             var tag = new Coding(string.Empty, Guid.NewGuid().ToString());
 
-            Patient patient = Samples.GetDefaultPatient().ToPoco<Patient>();
-            var patients = new Patient[numberOfResources];
-
-            for (int i = 0; i < numberOfResources; i++)
-            {
-                patient.Meta = new Meta();
-                patient.Meta.Tag.Add(tag);
-
-                FhirResponse<Patient> createdPatient = await Client.CreateAsync(patient);
-                patients[i] = MaskingNode.ForElements(new ScopedNode(createdPatient.Resource.ToTypedElement()), elements).ToPoco<Patient>();
-            }
+            Patient[] patients = await CreateTestPatientElements(tag, elements);
 
             Bundle bundle = await Client.SearchAsync($"Patient?_tag={tag.Code}&_elements=invalidProperty,{string.Join(',', elements)}");
+
+            ValidateBundle(bundle, patients);
+        }
+
+        [InlineData("id", "count")]
+        [InlineData("id,active", "true")]
+        [InlineData("id,active", "data")]
+        [InlineData("id,active", "text")]
+        [Theory]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenListOfResources_WhenSearchedWithElementsAndSummaryNotFalse_ThenExceptionShouldBeThrown(string elementsValues, string summaryValue)
+        {
+            using FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.SearchAsync($"Patient?_elements={elementsValues}&_summary={summaryValue}"));
+
+            const HttpStatusCode expectedStatusCode = HttpStatusCode.BadRequest;
+            Assert.Equal(expectedStatusCode, ex.StatusCode);
+
+            var expectedErrorMessage = $"{expectedStatusCode}: " + string.Format(Core.Resources.IncompatibleSearchParameters, KnownQueryParameterNames.Summary, KnownQueryParameterNames.Elements);
+
+            Assert.Equal(expectedErrorMessage, ex.Message);
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenListOfResources_WhenSearchedWithElementsAndFalseSummary_ThenOnlySpecifiedPropertiesShouldBeReturned()
+        {
+            string[] elements = { "gender", "birthDate" };
+            var tag = new Coding(string.Empty, Guid.NewGuid().ToString());
+
+            Patient[] patients = await CreateTestPatientElements(tag, elements);
+
+            Bundle bundle = await Client.SearchAsync($"Patient?_tag={tag.Code}&_elements={string.Join(',', elements)}&_summary=false");
 
             ValidateBundle(bundle, patients);
         }
@@ -687,6 +697,26 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         {
             System.Net.Http.HttpResponseMessage httpResponseMessage = await Client.HttpClient.GetAsync(uri);
             Assert.Equal(HttpStatusCode.BadRequest, httpResponseMessage.StatusCode);
+        }
+
+        private async Task<Patient[]> CreateTestPatientElements(Coding tag, string[] elements)
+        {
+            const int numberOfResources = 3;
+
+            Patient patient = Samples.GetDefaultPatient().ToPoco<Patient>();
+            var patients = new Patient[numberOfResources];
+
+            for (int i = 0; i < numberOfResources; i++)
+            {
+                patient.Meta = new Meta();
+                patient.Meta.Tag.Add(tag);
+
+                FhirResponse<Patient> createdPatient = await Client.CreateAsync(patient);
+                patients[i] = MaskingNode.ForElements(new ScopedNode(createdPatient.Resource.ToTypedElement()), elements)
+                    .ToPoco<Patient>();
+            }
+
+            return patients;
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -489,7 +489,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             const HttpStatusCode expectedStatusCode = HttpStatusCode.BadRequest;
             Assert.Equal(expectedStatusCode, ex.StatusCode);
 
-            var expectedErrorMessage = $"{expectedStatusCode}: " + string.Format(Core.Resources.IncompatibleSearchParameters, KnownQueryParameterNames.Summary, KnownQueryParameterNames.Elements);
+            var expectedErrorMessage = $"{expectedStatusCode}: " + string.Format(Core.Resources.ElementsAndSummaryParametersAreIncompatible, KnownQueryParameterNames.Summary, KnownQueryParameterNames.Elements);
 
             Assert.Equal(expectedErrorMessage, ex.Message);
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -430,7 +430,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             string[] elements = { "gender", "birthDate" };
             var tag = new Coding(string.Empty, Guid.NewGuid().ToString());
 
-            Patient[] patients = await CreateTestPatientElements(tag, elements);
+            Patient[] patients = await CreatePatientsWithSpecifiedElements(tag, elements);
 
             Bundle bundle = await Client.SearchAsync($"Patient?_tag={tag.Code}&_elements={string.Join(',', elements)}");
 
@@ -469,7 +469,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             string[] elements = { "gender", "birthDate" };
             var tag = new Coding(string.Empty, Guid.NewGuid().ToString());
 
-            Patient[] patients = await CreateTestPatientElements(tag, elements);
+            Patient[] patients = await CreatePatientsWithSpecifiedElements(tag, elements);
 
             Bundle bundle = await Client.SearchAsync($"Patient?_tag={tag.Code}&_elements=invalidProperty,{string.Join(',', elements)}");
 
@@ -482,7 +482,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [InlineData("id,active", "text")]
         [Theory]
         [Trait(Traits.Priority, Priority.One)]
-        public async Task GivenListOfResources_WhenSearchedWithElementsAndSummaryNotFalse_ThenExceptionShouldBeThrown(string elementsValues, string summaryValue)
+        public async Task GivenListOfResources_WhenSearchedWithElementsAndSummaryNotSetToFalse_ThenExceptionShouldBeThrown(string elementsValues, string summaryValue)
         {
             using FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.SearchAsync($"Patient?_elements={elementsValues}&_summary={summaryValue}"));
 
@@ -496,12 +496,12 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
-        public async Task GivenListOfResources_WhenSearchedWithElementsAndFalseSummary_ThenOnlySpecifiedPropertiesShouldBeReturned()
+        public async Task GivenListOfResources_WhenSearchedWithElementsAndSummarySetToFalse_ThenOnlySpecifiedPropertiesShouldBeReturned()
         {
             string[] elements = { "gender", "birthDate" };
             var tag = new Coding(string.Empty, Guid.NewGuid().ToString());
 
-            Patient[] patients = await CreateTestPatientElements(tag, elements);
+            Patient[] patients = await CreatePatientsWithSpecifiedElements(tag, elements);
 
             Bundle bundle = await Client.SearchAsync($"Patient?_tag={tag.Code}&_elements={string.Join(',', elements)}&_summary=false");
 
@@ -699,7 +699,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             Assert.Equal(HttpStatusCode.BadRequest, httpResponseMessage.StatusCode);
         }
 
-        private async Task<Patient[]> CreateTestPatientElements(Coding tag, string[] elements)
+        private async Task<Patient[]> CreatePatientsWithSpecifiedElements(Coding tag, string[] elements)
         {
             const int numberOfResources = 3;
 


### PR DESCRIPTION
## Description
Prior to this fix, when making a search request with both the `_elements` and `_summary` parameters, an internal server error was returned. Now, an operation outcome is returned specifying a bad request and an error message.

![image](https://user-images.githubusercontent.com/54082711/100003149-7826c980-2d7a-11eb-80ce-22209a22d35c.png)

## Related issues
Addresses [#AB76836](https://microsofthealth.visualstudio.com/Health/_workitems/edit/76836) and #1384.

## Testing
Added two E2E tests to cover this case.
