### PR TITLE
Changes to use single nuget package source

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -6,9 +6,7 @@
   <packageSources>
     <!-- When <clear /> is present, previously defined sources are ignored -->
     <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="Hl7.Fhir" value="https://www.myget.org/F/fhir-net-api/api/v3/index.json" />
-    <add key="Microsoft Health OSS" value="https://microsofthealthoss.pkgs.visualstudio.com/FhirServer/_packaging/Public/nuget/v3/index.json" />
+    <add key="Microsoft Health OSS" value="https://microsofthealthoss.pkgs.visualstudio.com/_packaging/Combined/nuget/v3/index.json" />
   </packageSources>
   <activePackageSource>
     <add key="All" value="(Aggregate source)" />


### PR DESCRIPTION
## Description
To comply with new policies, we need to switch to a single nuget source. The feed specified here contains the existing `FhirServer/Public` feed plus the public nuget gallery. 
