### PR TITLE
HealthCheck need to handle error due to customer CMK settings

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Health/CosmosHealthCheckTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Health/CosmosHealthCheckTests.cs
@@ -4,8 +4,12 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using AngleSharp.Common;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -14,6 +18,7 @@ using Microsoft.Health.Abstractions.Exceptions;
 using Microsoft.Health.Fhir.CosmosDb.Configs;
 using Microsoft.Health.Fhir.CosmosDb.Features.Storage;
 using NSubstitute;
+using NSubstitute.ClearExtensions;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
 
@@ -53,6 +58,38 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Health
         public async Task GivenCosmosDbCannotBeQueried_WhenHealthIsChecked_ThenUnhealthyStateShouldBeReturned()
         {
             _testProvider.PerformTest(default, default, _cosmosCollectionConfiguration).ThrowsForAnyArgs<HttpRequestException>();
+            HealthCheckResult result = await _healthCheck.CheckHealthAsync(new HealthCheckContext());
+
+            Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        }
+
+        [Fact]
+        public async Task GivenCosmosAccessIsForbidden_IsClientCmkError_WhenHealthIsChecked_ThenHealthyStateShouldBeReturned()
+        {
+            foreach (int clientCmkIssue in new List<int>(Enum.GetValues(typeof(KnownCosmosDbCmkSubStatusValueClientIssue)).Cast<int>()).Concat(3))
+            {
+                _testProvider.ClearSubstitute();
+                _testProvider.PerformTest(default, default, _cosmosCollectionConfiguration)
+                    .ThrowsForAnyArgs(new CosmosException("An error message", HttpStatusCode.Forbidden, subStatusCode: clientCmkIssue, activityId: null, requestCharge: 0));
+
+                HealthCheckResult result = await _healthCheck.CheckHealthAsync(new HealthCheckContext());
+
+                Assert.Equal(HealthStatus.Healthy, result.Status);
+                Assert.Contains("customer-managed key is not available", result.Description);
+            }
+        }
+
+        [Fact]
+        public async Task GivenCosmosAccessIsForbidden_IsNotClientCmkError_WhenHealthIsChecked_ThenUnhealthyStateShouldBeReturned()
+        {
+            _testProvider.PerformTest(default, default, _cosmosCollectionConfiguration)
+                .ThrowsForAnyArgs(new CosmosException(
+                    "An error message",
+                    HttpStatusCode.Forbidden,
+                    subStatusCode: (int)KnownCosmosDbCmkSubStatusValueServerSideIssue.KeyVaultInternalServerError,
+                    activityId: null,
+                    requestCharge: 0));
+
             HealthCheckResult result = await _healthCheck.CheckHealthAsync(new HealthCheckContext());
 
             Assert.Equal(HealthStatus.Unhealthy, result.Status);

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/CosmosResponseProcessorTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/CosmosResponseProcessorTests.cs
@@ -90,7 +90,6 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Storage
         [InlineData(KnownCosmosDbCmkSubStatusValue.KeyVaultServiceUnavailable)]
         [InlineData(KnownCosmosDbCmkSubStatusValue.KeyVaultWrapUnwrapFailure)]
         [InlineData(KnownCosmosDbCmkSubStatusValue.InvalidKeyVaultKeyUri)]
-        [InlineData(KnownCosmosDbCmkSubStatusValue.InvalidInputBytes)]
         [InlineData(KnownCosmosDbCmkSubStatusValue.KeyVaultInternalServerError)]
         [InlineData(KnownCosmosDbCmkSubStatusValue.KeyVaultDnsNotResolved)]
         public async Task GivenAnExceptionWithCmkSubStatus_WhenProcessing_ThenExceptionShouldThrow(KnownCosmosDbCmkSubStatusValue subStatusValue)

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Health/CosmosHealthCheck.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Health/CosmosHealthCheck.cs
@@ -64,6 +64,10 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Health
 
                 return HealthCheckResult.Healthy("Successfully connected to the data store.");
             }
+            catch (CosmosException ex) when (ex.IsCmkClientError())
+            {
+                return HealthCheckResult.Healthy($"Connection to the data store was unsuccesful, however this is expected because the client's customer-managed key is not available. Error: {ex.Message}");
+            }
             catch (Exception ex) when (ex.IsRequestRateExceeded())
             {
                 return HealthCheckResult.Healthy("Connection to the data store was successful, however, the rate limit has been exceeded.");

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Health/CosmosHealthCheck.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Health/CosmosHealthCheck.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
@@ -66,7 +67,10 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Health
             }
             catch (CosmosException ex) when (ex.IsCmkClientError())
             {
-                return HealthCheckResult.Healthy($"Connection to the data store was unsuccesful, however this is expected because the client's customer-managed key is not available. Error: {ex.Message}");
+                return HealthCheckResult.Unhealthy(
+                    "Connection to the data store was unsuccesful because of the client's customer-managed key is not available.",
+                    exception: ex,
+                    new Dictionary<string, object>() { { "IsCustomerManagedKeyError", true } });
             }
             catch (Exception ex) when (ex.IsRequestRateExceeded())
             {

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Health/CosmosHealthCheck.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Health/CosmosHealthCheck.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Health
             catch (CosmosException ex) when (ex.IsCmkClientError())
             {
                 return HealthCheckResult.Unhealthy(
-                    "Connection to the data store was unsuccesful because of the client's customer-managed key is not available.",
+                    "Connection to the data store was unsuccesful because the client's customer-managed key is not available.",
                     exception: ex,
                     new Dictionary<string, object>() { { "IsCustomerManagedKeyError", true } });
             }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosExceptionExtensions.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosExceptionExtensions.cs
@@ -63,6 +63,9 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
         /// <returns>True iff the error is due to client CMK setting.</returns>
         public static bool IsCmkClientError(this CosmosException exception)
         {
+            // NOTE: It has been confirmed that a SubStatusCode of value '3', although not listed in
+            // https://docs.microsoft.com/en-us/rest/api/cosmos-db/http-status-codes-for-cosmosdb#substatus-codes-for-end-user-issues
+            // as a possible CMK SubStatusCode by Cosmos DB, has been acknowledged as a possible value in some scenarios if the custtomer has disabled their key.
             return exception.StatusCode == HttpStatusCode.Forbidden
                 && (Enum.IsDefined(typeof(KnownCosmosDbCmkSubStatusValueClientIssue), exception.SubStatusCode) || exception.SubStatusCode == 3);
         }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosExceptionExtensions.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosExceptionExtensions.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Globalization;
 using System.Net;
 using Microsoft.Azure.Cosmos;
@@ -53,6 +54,17 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
             return int.TryParse(cosmosHeaders.Get(CosmosDbHeaders.SubStatus), NumberStyles.Integer, CultureInfo.InvariantCulture, out int subStatusCode)
                 ? subStatusCode
                 : (int?)null;
+        }
+
+        /// <summary>
+        /// Determines if the error is due to a client customer-managed key error
+        /// </summary>
+        /// <param name="exception">The exception object</param>
+        /// <returns>True iff the error is due to client CMK setting.</returns>
+        public static bool IsCmkClientError(this CosmosException exception)
+        {
+            return exception.StatusCode == HttpStatusCode.Forbidden
+                && (Enum.IsDefined(typeof(KnownCosmosDbCmkSubStatusValueClientIssue), exception.SubStatusCode) || exception.SubStatusCode == 3);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosResponseProcessor.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosResponseProcessor.cs
@@ -163,9 +163,6 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
                 case KnownCosmosDbCmkSubStatusValue.InvalidKeyVaultKeyUri:
                     errorMessage = Resources.InvalidKeyVaultKeyUri;
                     break;
-                case KnownCosmosDbCmkSubStatusValue.InvalidInputBytes:
-                    errorMessage = Resources.InvalidInputBytes;
-                    break;
                 case KnownCosmosDbCmkSubStatusValue.KeyVaultInternalServerError:
                     errorMessage = Resources.KeyVaultInternalServerError;
                     break;

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/KnownCosmosDbCmkSubStatusValue.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/KnownCosmosDbCmkSubStatusValue.cs
@@ -11,15 +11,14 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
     public enum KnownCosmosDbCmkSubStatusValue
     {
         // Customer-Managed Key (CMK) values
-        AadClientCredentialsGrantFailure = 4000,
-        AadServiceUnavailable = 4001,
-        KeyVaultAuthenticationFailure = 4002,
-        KeyVaultKeyNotFound = 4003,
-        KeyVaultServiceUnavailable = 4004,
-        KeyVaultWrapUnwrapFailure = 4005,
-        InvalidKeyVaultKeyUri = 4006,
-        InvalidInputBytes = 4007,
-        KeyVaultInternalServerError = 4008,
-        KeyVaultDnsNotResolved = 4009,
+        AadClientCredentialsGrantFailure = KnownCosmosDbCmkSubStatusValueServerSideIssue.AadClientCredentialsGrantFailure,
+        AadServiceUnavailable = KnownCosmosDbCmkSubStatusValueServerSideIssue.AadServiceUnavailable,
+        KeyVaultAuthenticationFailure = KnownCosmosDbCmkSubStatusValueClientIssue.KeyVaultAuthenticationFailure,
+        KeyVaultKeyNotFound = KnownCosmosDbCmkSubStatusValueClientIssue.KeyVaultKeyNotFound,
+        KeyVaultServiceUnavailable = KnownCosmosDbCmkSubStatusValueServerSideIssue.KeyVaultServiceUnavailable,
+        KeyVaultWrapUnwrapFailure = KnownCosmosDbCmkSubStatusValueClientIssue.KeyVaultWrapUnwrapFailure,
+        InvalidKeyVaultKeyUri = KnownCosmosDbCmkSubStatusValueClientIssue.InvalidKeyVaultKeyUri,
+        KeyVaultInternalServerError = KnownCosmosDbCmkSubStatusValueServerSideIssue.KeyVaultInternalServerError,
+        KeyVaultDnsNotResolved = KnownCosmosDbCmkSubStatusValueClientIssue.KeyVaultDnsNotResolved,
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/KnownCosmosDbCmkSubStatusValueClientIssue.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/KnownCosmosDbCmkSubStatusValueClientIssue.cs
@@ -1,0 +1,20 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
+{
+    /// <summary>
+    /// Cosmos DB customer-managed key (CMK) sub status values to denote client-side (end-user) issues
+    /// </summary>
+    public enum KnownCosmosDbCmkSubStatusValueClientIssue
+    {
+        // Customer-Managed Key (CMK) values
+        KeyVaultAuthenticationFailure = 4002,
+        KeyVaultKeyNotFound = 4003,
+        KeyVaultWrapUnwrapFailure = 4005,
+        InvalidKeyVaultKeyUri = 4006,
+        KeyVaultDnsNotResolved = 4009,
+    }
+}

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/KnownCosmosDbCmkSubStatusValueServerSideIssue.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/KnownCosmosDbCmkSubStatusValueServerSideIssue.cs
@@ -1,0 +1,19 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
+{
+    /// <summary>
+    /// Cosmos DB customer-managed key (CMK) sub status values to denote server-side issues
+    /// </summary>
+    public enum KnownCosmosDbCmkSubStatusValueServerSideIssue
+    {
+        // Customer-Managed Key (CMK) values
+        AadClientCredentialsGrantFailure = 4000,
+        AadServiceUnavailable = 4001,
+        KeyVaultServiceUnavailable = 4004,
+        KeyVaultInternalServerError = 4008,
+    }
+}


### PR DESCRIPTION
## Description
- Update the HealthCheck to not report unhealthy when the error received is expected due to a customer's CMK settings.
 - Also, remove 4007 from the known list of Cosmos DB CMK sub status value.  After reading https://docs.microsoft.com/en-us/rest/api/cosmos-db/http-status-codes-for-cosmosdb#http-substatus-codes, this is not a CMK-related issue

## Related issues
Addresses [#77750](https://microsofthealth.visualstudio.com/Health/_workitems/edit/77750)

## Testing
All existing unit tests passed, and I added new unit test coverage
