### PR TITLE
Fix convert data tests

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/ConvertData/ContainerRegistryTemplateProviderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/ConvertData/ContainerRegistryTemplateProviderTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Conver
             var convertDataConfig = new ConvertDataConfiguration
             {
                 Enabled = true,
-                OperationTimeout = TimeSpan.FromMilliseconds(50),
+                OperationTimeout = TimeSpan.FromSeconds(1),
             };
             convertDataConfig.ContainerRegistryServers.Add("test.azurecr.io");
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/ConvertData/ConvertDataEngineTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/ConvertData/ConvertDataEngineTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Conver
             _config = new ConvertDataConfiguration
             {
                 Enabled = true,
-                OperationTimeout = TimeSpan.FromMilliseconds(50),
+                OperationTimeout = TimeSpan.FromSeconds(1),
             };
             _config.ContainerRegistryServers.Add("test.azurecr.io");
         }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/ConvertData/ConvertDataRequestHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/ConvertData/ConvertDataRequestHandlerTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Conver
             var convertDataConfig = new ConvertDataConfiguration
             {
                 Enabled = true,
-                OperationTimeout = TimeSpan.FromMilliseconds(100),
+                OperationTimeout = TimeSpan.FromSeconds(1),
             };
             convertDataConfig.ContainerRegistryServers.Add("test.azurecr.io");
 


### PR DESCRIPTION
## Description
Set the convert data process timeout in unit tests to a longer value since sometimes it executes longer than current threshold (50ms) and failed in the test case. The current threshold in service is 30 seconds. 

## Related issues
Addresses [issue #].

## Testing
Run unit tests and no timeout failure occurs.