### PR TITLE
Fixes smartlauncher references for e2e tests

### DIFF
--- a/Microsoft.Health.Fhir.sln
+++ b/Microsoft.Health.Fhir.sln
@@ -133,6 +133,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Fhir.Stu3.
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Client", "Client", "{83B3EE6D-693E-4E86-A925-28B1A108268E}"
 EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Microsoft.Health.Fhir.Shared.Tests.Smart", "test\Microsoft.Health.Fhir.Shared.Tests.Smart\Microsoft.Health.Fhir.Shared.Tests.Smart.shproj", "{A955963B-D766-492D-94FD-98A8B9EA8931}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		test\Microsoft.Health.Fhir.Shared.Tests.E2E.Common\Microsoft.Health.Fhir.Shared.Tests.E2E.Common.projitems*{0478b687-7105-40f6-a2dc-81057890e944}*SharedItemsImports = 13
@@ -404,6 +406,7 @@ Global
 		{4640D17C-7229-4D90-A330-0423DFC3FFC5} = {83B3EE6D-693E-4E86-A925-28B1A108268E}
 		{743EA25C-A6F5-4B41-BC56-69D9A89386A3} = {83B3EE6D-693E-4E86-A925-28B1A108268E}
 		{83B3EE6D-693E-4E86-A925-28B1A108268E} = {7457B218-2651-49B5-BED8-22233889516A}
+		{A955963B-D766-492D-94FD-98A8B9EA8931} = {85F39C13-BC62-49A0-9C06-3BBA724D35ED}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		RESX_SortFileContentOnSave = True

--- a/samples/apps/SmartLauncher/Models/SmartLauncherConfig.cs
+++ b/samples/apps/SmartLauncher/Models/SmartLauncherConfig.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-namespace SmartLauncher
+namespace Microsoft.Health.Internal.SmartLauncher.Models
 {
     public class SmartLauncherConfig
     {

--- a/samples/apps/SmartLauncher/Program.cs
+++ b/samples/apps/SmartLauncher/Program.cs
@@ -6,7 +6,7 @@
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 
-namespace SmartLauncher
+namespace Microsoft.Health.Internal.SmartLauncher
 {
     public class Program
     {

--- a/samples/apps/SmartLauncher/SmartLauncher.csproj
+++ b/samples/apps/SmartLauncher/SmartLauncher.csproj
@@ -4,7 +4,8 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
     <UserSecretsId>SmartLauncher_3d9536f4-982c-4334-83df-890fb8ae70e6</UserSecretsId>
-    <IsPackable>false</IsPackable>
+    <AssemblyName>Microsoft.Health.Internal.SmartLauncher</AssemblyName>
+    <RootNamespace>Microsoft.Health.Internal.SmartLauncher</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/apps/SmartLauncher/Startup.cs
+++ b/samples/apps/SmartLauncher/Startup.cs
@@ -11,9 +11,10 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Health.Internal.SmartLauncher.Models;
 using Newtonsoft.Json;
 
-namespace SmartLauncher
+namespace Microsoft.Health.Internal.SmartLauncher
 {
     public class Startup
     {

--- a/test/Microsoft.Health.Fhir.R4.Tests.E2E/Microsoft.Health.Fhir.R4.Tests.E2E.csproj
+++ b/test/Microsoft.Health.Fhir.R4.Tests.E2E/Microsoft.Health.Fhir.R4.Tests.E2E.csproj
@@ -33,6 +33,7 @@
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\samples\apps\SmartLauncher\SmartLauncher.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Health.Extensions.Xunit\Microsoft.Health.Extensions.Xunit.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Health.Fhir.Core\Microsoft.Health.Fhir.Core.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Health.Fhir.CosmosDb\Microsoft.Health.Fhir.CosmosDb.csproj" />
@@ -42,7 +43,6 @@
     <ProjectReference Include="..\..\src\Microsoft.Health.Fhir.R4.Core\Microsoft.Health.Fhir.R4.Core.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Health.Fhir.Tests.Common\Microsoft.Health.Fhir.Tests.Common.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Health.Fhir.R4.Web\Microsoft.Health.Fhir.R4.Web.csproj" />
-    <ProjectReference Include="..\..\samples\apps\SmartLauncher\SmartLauncher.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Update="xunit.runner.json">
@@ -73,4 +73,5 @@
       <BuiltProjectOutputGroupOutput Include="$(ProjectRuntimeConfigFilePath)" FinalOutputPath="$(ProjectRuntimeConfigFilePath)" />
     </ItemGroup>
   </Target>
+  <Import Project="..\Microsoft.Health.Fhir.Shared.Tests.Smart\Microsoft.Health.Fhir.Shared.Tests.Smart.projitems" Label="Shared" />
 </Project>

--- a/test/Microsoft.Health.Fhir.R5.Tests.E2E/Microsoft.Health.Fhir.R5.Tests.E2E.csproj
+++ b/test/Microsoft.Health.Fhir.R5.Tests.E2E/Microsoft.Health.Fhir.R5.Tests.E2E.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\samples\apps\SmartLauncher\SmartLauncher.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Health.Extensions.Xunit\Microsoft.Health.Extensions.Xunit.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Health.Fhir.Core\Microsoft.Health.Fhir.Core.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Health.Fhir.CosmosDb\Microsoft.Health.Fhir.CosmosDb.csproj" />
@@ -36,7 +37,6 @@
     <ProjectReference Include="..\..\src\Microsoft.Health.Fhir.R5.Core\Microsoft.Health.Fhir.R5.Core.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Health.Fhir.Tests.Common\Microsoft.Health.Fhir.Tests.Common.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Health.Fhir.R5.Web\Microsoft.Health.Fhir.R5.Web.csproj" />
-    <ProjectReference Include="..\..\samples\apps\SmartLauncher\SmartLauncher.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Update="xunit.runner.json">
@@ -66,4 +66,5 @@
       <BuiltProjectOutputGroupOutput Include="$(ProjectRuntimeConfigFilePath)" FinalOutputPath="$(ProjectRuntimeConfigFilePath)" />
     </ItemGroup>
   </Target>
+  <Import Project="..\Microsoft.Health.Fhir.Shared.Tests.Smart\Microsoft.Health.Fhir.Shared.Tests.Smart.projitems" Label="Shared" />
 </Project>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/AuditTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/AuditTests.cs
@@ -14,6 +14,7 @@ using Hl7.Fhir.Model;
 using Microsoft.Health.Api.Features.Audit;
 using Microsoft.Health.Fhir.Client;
 using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Smart.Tests.E2E;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.E2E.Common;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BatchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BatchTests.cs
@@ -9,6 +9,7 @@ using System.Net;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Client;
 using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Smart.Tests.E2E;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.E2E.Common;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TestFhirServerFactory.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TestFhirServerFactory.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Health.Fhir.Smart.Tests.E2E;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Xunit;
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Smart/Microsoft.Health.Fhir.Shared.Tests.Smart.projitems
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Smart/Microsoft.Health.Fhir.Shared.Tests.Smart.projitems
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>08829356-360B-4EBF-8DA6-8D19294697C0</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>Microsoft.Health.Fhir.Shared.Tests.Smart</Import_RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)SmartProxy\SmartProxyBadRequestTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SmartProxy\SmartProxyTestFixture.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SmartProxy\SmartProxyTests.cs" />
+  </ItemGroup>
+</Project>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Smart/Microsoft.Health.Fhir.Shared.Tests.Smart.shproj
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Smart/Microsoft.Health.Fhir.Shared.Tests.Smart.shproj
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup Label="Globals">
+        <ProjectGuid>{A955963B-D766-492D-94FD-98A8B9EA8931}</ProjectGuid>
+    </PropertyGroup>
+    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+    <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+    <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+    <Import Project="Microsoft.Health.Fhir.Shared.Tests.Smart.projitems" Label="Shared" />
+    <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+</Project>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Smart/SmartProxy/SmartProxyBadRequestTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Smart/SmartProxy/SmartProxyBadRequestTests.cs
@@ -12,7 +12,7 @@ using Microsoft.Health.Fhir.Tests.E2E.Common;
 using Microsoft.Health.Fhir.Tests.E2E.Rest;
 using Xunit;
 
-namespace Microsoft.Health.Fhir.Tests.E2E.SmartProxy
+namespace Microsoft.Health.Fhir.Smart.Tests.E2E.SmartProxy
 {
     [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb, Format.All)]
     public class SmartProxyBadRequestTests : IClassFixture<HttpIntegrationTestFixture>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Smart/SmartProxy/SmartProxyTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Smart/SmartProxy/SmartProxyTestFixture.cs
@@ -12,11 +12,13 @@ using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Microsoft.Health.Fhir.Tests.E2E;
 using Microsoft.Health.Fhir.Tests.E2E.Common;
 using Microsoft.Health.Fhir.Tests.E2E.Rest;
+using Microsoft.Health.Internal.SmartLauncher;
 using Xunit;
 
-namespace Microsoft.Health.Fhir.Tests.E2E.SmartProxy
+namespace Microsoft.Health.Fhir.Smart.Tests.E2E.SmartProxy
 {
     public class SmartProxyTestFixture : IDisposable, IAsyncLifetime
     {
@@ -56,7 +58,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.SmartProxy
                             { "DefaultSmartAppUrl", "/sampleapp/launch.html" },
                         });
                     })
-                    .UseStartup<SmartLauncher.Startup>()
+                    .UseStartup<Startup>()
                     .UseUrls(baseUrl);
 
                 WebServer = builder.Build();

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Smart/SmartProxy/SmartProxyTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Smart/SmartProxy/SmartProxyTests.cs
@@ -14,6 +14,7 @@ using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Client;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Fhir.Tests.E2E;
 using Microsoft.Health.Fhir.Tests.E2E.Common;
 using Microsoft.Health.Test.Utilities;
 using Newtonsoft.Json.Linq;
@@ -22,7 +23,7 @@ using OpenQA.Selenium.Chrome;
 using Xunit;
 using Task = System.Threading.Tasks.Task;
 
-namespace Microsoft.Health.Fhir.Tests.E2E.SmartProxy
+namespace Microsoft.Health.Fhir.Smart.Tests.E2E.SmartProxy
 {
     [Trait(Traits.Category, Categories.SmartOnFhir)]
     public class SmartProxyTests : IClassFixture<SmartProxyTestFixture>

--- a/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/Microsoft.Health.Fhir.Stu3.Tests.E2E.csproj
+++ b/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/Microsoft.Health.Fhir.Stu3.Tests.E2E.csproj
@@ -22,7 +22,6 @@
     <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="1.0.79" />
     <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.79" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="selenium.chrome.webdriver" Version="85.0.0" />
     <PackageReference Include="selenium.webdriver" Version="3.141.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
@@ -30,6 +29,7 @@
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\samples\apps\SmartLauncher\SmartLauncher.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Health.Extensions.Xunit\Microsoft.Health.Extensions.Xunit.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Health.Fhir.Core\Microsoft.Health.Fhir.Core.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Health.Fhir.CosmosDb\Microsoft.Health.Fhir.CosmosDb.csproj" />
@@ -39,7 +39,6 @@
     <ProjectReference Include="..\..\src\Microsoft.Health.Fhir.Stu3.Core\Microsoft.Health.Fhir.Stu3.Core.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Health.Fhir.Tests.Common\Microsoft.Health.Fhir.Tests.Common.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Health.Fhir.Stu3.Web\Microsoft.Health.Fhir.Stu3.Web.csproj" />
-    <ProjectReference Include="..\..\samples\apps\SmartLauncher\SmartLauncher.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Update="xunit.runner.json">
@@ -71,4 +70,5 @@
       <BuiltProjectOutputGroupOutput Include="$(ProjectRuntimeConfigFilePath)" FinalOutputPath="$(ProjectRuntimeConfigFilePath)" />
     </ItemGroup>
   </Target>
+  <Import Project="..\Microsoft.Health.Fhir.Shared.Tests.Smart\Microsoft.Health.Fhir.Shared.Tests.Smart.projitems" Label="Shared" />
 </Project>


### PR DESCRIPTION
## Description
- Fixes SMART sample app to be packaged with internal namespace
- Moves SMART E2E tests to a shared project so they are run in all versions of FHIR (was previously only in the STU3 assembly)

## Testing
SMART E2E tests now run in all versions of FHIR
