### PR TITLE
PR resource names include build number

### DIFF
--- a/build/ci-pipeline.yml
+++ b/build/ci-pipeline.yml
@@ -18,11 +18,6 @@ stages:
       vmImage: 'ubuntu-latest'
     steps:
     - template: ./jobs/update-semver.yml
-    - script: echo %Action%%BuildVersion%
-      displayName: 'Set build version'
-      env:
-        Action: '##vso[build.updatebuildnumber]'
-        BuildVersion: $(GitVersion.semVer)
 
 - stage: BuildUnitTests
   displayName: 'Build and run unit tests'

--- a/build/ci-pipeline.yml
+++ b/build/ci-pipeline.yml
@@ -27,6 +27,8 @@ stages:
     assemblySemVer: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.assemblySemVer']]
     assemblySemFileVer: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.assemblySemFileVer']]
     informationalVersion: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.informationalVersion']]
+    majorMinorPatch: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.majorMinorPatch']]
+    nuGetVersion: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.nuGetVersion']]
   jobs:
   - job: Windows
     pool:

--- a/build/ci-pipeline.yml
+++ b/build/ci-pipeline.yml
@@ -23,6 +23,10 @@ stages:
   displayName: 'Build and run unit tests'
   dependsOn:
   - UpdateVersion
+  variables:
+    assemblySemVer: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.assemblySemVer']]
+    assemblySemFileVer: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.assemblySemFileVer']]
+    informationalVersion: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.informationalVersion']]
   jobs:
   - job: Windows
     pool:

--- a/build/ci-variables.yml
+++ b/build/ci-variables.yml
@@ -3,6 +3,7 @@ variables:
     resourceGroupRoot: 'msh-fhir-ci'
     appServicePlanName: '$(resourceGroupRoot)-linux'
     DeploymentEnvironmentName: '$(resourceGroupRoot)'
+    ResourceGroupName: '$(resourceGroupRoot)'
     CrucibleEnvironmentUrl: 'https://crucible.mshapis.com/'
     TestEnvironmentName: 'OSS CI'
     ImageTag: '$(build.BuildNumber)'

--- a/build/jobs/add-aad-test-environment.yml
+++ b/build/jobs/add-aad-test-environment.yml
@@ -37,7 +37,7 @@ jobs:
         }
 
         # If a deleted keyvault exists, remove it first
-        $environmentName = "$(DeploymentEnvironmentName)" -replace "\.", "-" 
+        $environmentName = "$(DeploymentEnvironmentName)" -replace "\.", "" 
         if (Get-AzKeyVault -VaultName "${environmentName}-ts" -Location "westus" -InRemovedState)
         {
             Remove-AzKeyVault -VaultName "${environmentName}-ts" -InRemovedState -Location "westus" -Force

--- a/build/jobs/add-aad-test-environment.yml
+++ b/build/jobs/add-aad-test-environment.yml
@@ -37,9 +37,10 @@ jobs:
         }
 
         # If a deleted keyvault exists, remove it first
-        if (Get-AzKeyVault -VaultName "$(DeploymentEnvironmentName)-ts" -Location "westus" -InRemovedState)
+        $environmentName = "$(DeploymentEnvironmentName)" -replace "\.", "-" 
+        if (Get-AzKeyVault -VaultName "${environmentName}-ts" -Location "westus" -InRemovedState)
         {
-            Remove-AzKeyVault -VaultName "$(DeploymentEnvironmentName)-ts" -InRemovedState -Location "westus" -Force
+            Remove-AzKeyVault -VaultName "${environmentName}-ts" -InRemovedState -Location "westus" -Force
         }
  
         $response = Invoke-RestMethod -Method 'Post' -Uri $adTokenUrl -ContentType "application/x-www-form-urlencoded" -Body $body
@@ -48,4 +49,4 @@ jobs:
         Import-Module $(System.DefaultWorkingDirectory)/samples/scripts/PowerShell/FhirServer/FhirServer.psd1
         Import-Module $(System.DefaultWorkingDirectory)/release/scripts/PowerShell/FhirServerRelease/FhirServerRelease.psd1
 
-        $output = Add-AadTestAuthEnvironment -TestAuthEnvironmentPath $(System.DefaultWorkingDirectory)/testauthenvironment.json -EnvironmentName $(ResourceGroupName) -TenantAdminCredential $adminCredential
+        $output = Add-AadTestAuthEnvironment -TestAuthEnvironmentPath $(System.DefaultWorkingDirectory)/testauthenvironment.json -EnvironmentName $environmentName -ResourceGroupName $(ResourceGroupName) -TenantAdminCredential $adminCredential

--- a/build/jobs/add-aad-test-environment.yml
+++ b/build/jobs/add-aad-test-environment.yml
@@ -48,4 +48,4 @@ jobs:
         Import-Module $(System.DefaultWorkingDirectory)/samples/scripts/PowerShell/FhirServer/FhirServer.psd1
         Import-Module $(System.DefaultWorkingDirectory)/release/scripts/PowerShell/FhirServerRelease/FhirServerRelease.psd1
 
-        $output = Add-AadTestAuthEnvironment -TestAuthEnvironmentPath $(System.DefaultWorkingDirectory)/testauthenvironment.json -EnvironmentName $(DeploymentEnvironmentName) -TenantAdminCredential $adminCredential
+        $output = Add-AadTestAuthEnvironment -TestAuthEnvironmentPath $(System.DefaultWorkingDirectory)/testauthenvironment.json -EnvironmentName $(ResourceGroupName) -TenantAdminCredential $adminCredential

--- a/build/jobs/build.yml
+++ b/build/jobs/build.yml
@@ -12,7 +12,7 @@ steps:
   displayName: 'dotnet build $(buildConfiguration)'
   inputs:
     command: build
-    arguments: "--configuration $(buildConfiguration) /p:AssemblyVersion=$(assemblySemVer) /p:FileVersion=$(assemblySemFileVer) /p:InformationalVersion=$(informationalVersion) /warnaserror"
+    arguments: '--configuration $(buildConfiguration) /p:AssemblyVersion="$(assemblySemVer)" /p:FileVersion="$(assemblySemFileVer)" /p:InformationalVersion="$(informationalVersion)" /p:Version="$(majorMinorPatch)" /warnaserror'
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test UnitTests'

--- a/build/jobs/build.yml
+++ b/build/jobs/build.yml
@@ -10,16 +10,16 @@ steps:
 
 - powershell: |
     Write-Host '----------Variables to use for build----------'
-    Write-Host "$[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.GitVersion.AssemblySemVer']]"
-    Write-Host "$[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.GitVersion.AssemblySemFileVer']]"
-    Write-Host "$[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.GitVersion.InformationalVersion']]"
+    Write-Host $[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.assemblySemVer']]
+    Write-Host $[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.assemblySemFileVer']]
+    Write-Host $[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.informationalVersion']]
   name: PrintVariablesFromGitVersion
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet build $(buildConfiguration)'
   inputs:
     command: build
-    arguments: "--configuration $(buildConfiguration) /p:AssemblyVersion=$[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.GitVersion.AssemblySemVer']] /p:FileVersion=$[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.GitVersion.AssemblySemFileVer']] /p:InformationalVersion=$[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.GitVersion.InformationalVersion']] /warnaserror"
+    arguments: "--configuration $(buildConfiguration) /p:AssemblyVersion=$[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.assemblySemVer']] /p:FileVersion=$[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.assemblySemFileVer']] /p:InformationalVersion=$[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.informationalVersion']] /warnaserror"
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test UnitTests'

--- a/build/jobs/build.yml
+++ b/build/jobs/build.yml
@@ -8,18 +8,11 @@ steps:
   inputs:
     useGlobalJson: true
 
-- powershell: |
-    Write-Host '----------Variables to use for build----------'
-    Write-Host $[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.assemblySemVer']]
-    Write-Host $[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.assemblySemFileVer']]
-    Write-Host $[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.informationalVersion']]
-  name: PrintVariablesFromGitVersion
-
 - task: DotNetCoreCLI@2
   displayName: 'dotnet build $(buildConfiguration)'
   inputs:
     command: build
-    arguments: "--configuration $(buildConfiguration) /p:AssemblyVersion=$[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.assemblySemVer']] /p:FileVersion=$[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.assemblySemFileVer']] /p:InformationalVersion=$[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.informationalVersion']] /warnaserror"
+    arguments: "--configuration $(buildConfiguration) /p:AssemblyVersion=$(assemblySemVer) /p:FileVersion=$(assemblySemFileVer) /p:InformationalVersion=$(informationalVersion) /warnaserror"
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test UnitTests'

--- a/build/jobs/build.yml
+++ b/build/jobs/build.yml
@@ -3,8 +3,6 @@ parameters:
   packageArtifacts: true
 
 steps:
-- template: update-semver.yml
-
 - task: UseDotNet@2
   displayName: 'Use .NET Core sdk'
   inputs:
@@ -14,7 +12,7 @@ steps:
   displayName: 'dotnet build $(buildConfiguration)'
   inputs:
     command: build
-    arguments: '--configuration $(buildConfiguration) /p:AssemblyVersion="$(assemblySemVer)" /p:FileVersion="$(assemblySemFileVer)" /p:InformationalVersion="$(informationalVersion)" /warnaserror'
+    arguments: "--configuration $(buildConfiguration) /p:AssemblyVersion=$[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.GitVersion.AssemblySemVer']] /p:FileVersion=$[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.GitVersion.AssemblySemFileVer']] /p:InformationalVersion=$[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.GitVersion.InformationalVersion']] /warnaserror"
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test UnitTests'

--- a/build/jobs/build.yml
+++ b/build/jobs/build.yml
@@ -8,6 +8,13 @@ steps:
   inputs:
     useGlobalJson: true
 
+- powershell: |
+    Write-Host '----------Variables to use for build----------'
+    Write-Host "$[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.GitVersion.AssemblySemVer']]"
+    Write-Host "$[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.GitVersion.AssemblySemFileVer']]"
+    Write-Host "$[stageDependencies.UpdateVersion.Semver.outputs['GitVersion.GitVersion.InformationalVersion']]"
+  name: PrintVariablesFromGitVersion
+
 - task: DotNetCoreCLI@2
   displayName: 'dotnet build $(buildConfiguration)'
   inputs:

--- a/build/jobs/cleanup.yml
+++ b/build/jobs/cleanup.yml
@@ -10,7 +10,7 @@ jobs:
       azureSubscription: $(ConnectedServiceName)
       azurePowerShellVersion: latestVersion
       ScriptType: InlineScript
-      Inline: 'Get-AzResourceGroup -Name $(DeploymentEnvironmentName) | Remove-AzResourceGroup -Verbose -Force'
+      Inline: 'Get-AzResourceGroup -Name $(ResourceGroupName) | Remove-AzResourceGroup -Verbose -Force'
 
 - job: cleanupAad
   displayName: 'Cleanup Azure Active Directory'

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -54,7 +54,7 @@ jobs:
         $additionalProperties["SqlServer__AllowDatabaseCreation"] = "true"
         $additionalProperties["ASPNETCORE_FORWARDEDHEADERS_ENABLED"] = "true"
 
-        $webAppName = "${{ parameters.webAppName }}" -replace "\.", ""
+        $webAppName = "${{ parameters.webAppName }}"
         $templateParameters = @{
             fhirVersion = "${{ parameters.version }}"
             appServicePlanName = "${{ parameters.appServicePlanName }}"

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -54,7 +54,7 @@ jobs:
         $additionalProperties["SqlServer__AllowDatabaseCreation"] = "true"
         $additionalProperties["ASPNETCORE_FORWARDEDHEADERS_ENABLED"] = "true"
 
-        $webAppName = ${{ parameters.webAppName }} -replace "\.", "-"
+        $webAppName = "${{ parameters.webAppName }}" -replace "\.", "-"
         $templateParameters = @{
             fhirVersion = "${{ parameters.version }}"
             appServicePlanName = "${{ parameters.appServicePlanName }}"

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -54,7 +54,7 @@ jobs:
         $additionalProperties["SqlServer__AllowDatabaseCreation"] = "true"
         $additionalProperties["ASPNETCORE_FORWARDEDHEADERS_ENABLED"] = "true"
 
-        $webAppName = "${{ parameters.webAppName }}" -replace "\.", "-"
+        $webAppName = "${{ parameters.webAppName }}" -replace "\.", ""
         $templateParameters = @{
             fhirVersion = "${{ parameters.version }}"
             appServicePlanName = "${{ parameters.appServicePlanName }}"

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -74,7 +74,12 @@ jobs:
             $templateParameters["sqlAdminPassword"] = "$(-join((((33,35,37,38,42,43,45,46,95) + (48..57) + (65..90) + (97..122) | Get-Random -Count 20) + ((33,35,37,38,42,43,45,46,95) | Get-Random -Count 1) + ((48..57) | Get-Random -Count 1) + ((65..90) | Get-Random -Count 1) + ((97..122) | Get-Random -Count 1) | Get-Random -Count 24) | % {[char]$_}))"
             $templateParameters["sqlSchemaAutomaticUpdatesEnabled"] = if ("${{ parameters.schemaAutomaticUpdatesEnabled }}" -eq "true") { $true } else { $false }
         }
+
+        Write-Host "Provisioning Resource Group"
+        Write-Host "${{ parameters.webAppName }}"
+        Write-Host "${{ parameters.resourceGroup }}"
         New-AzResourceGroupDeployment -Name "${{ parameters.webAppName }}" -ResourceGroupName "${{ parameters.resourceGroup }}" -TemplateFile $(System.DefaultWorkingDirectory)/samples/templates/default-azuredeploy-docker.json -TemplateParameterObject $templateParameters -Verbose
         
+        Write-Host "Setting Key Vault access"
         Set-AzKeyVaultAccessPolicy -VaultName "${{ parameters.webAppName }}" -ObjectId 4d4d503d-9ca8-462e-9e18-b35fc8b5285b -PermissionsToSecrets list,get
 

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -54,11 +54,12 @@ jobs:
         $additionalProperties["SqlServer__AllowDatabaseCreation"] = "true"
         $additionalProperties["ASPNETCORE_FORWARDEDHEADERS_ENABLED"] = "true"
 
+        $webAppName = ${{ parameters.webAppName }} -replace "\.", "-"
         $templateParameters = @{
             fhirVersion = "${{ parameters.version }}"
             appServicePlanName = "${{ parameters.appServicePlanName }}"
             appServicePlanSku = "B3"
-            serviceName = "${{ parameters.webAppName }}"
+            serviceName = $webAppName
             securityAuthenticationAuthority = "https://login.microsoftonline.com/$(tenant-id)"
             securityAuthenticationAudience = "${{ parameters.testEnvironmentUrl }}"
             additionalFhirServerConfigProperties = $additionalProperties 
@@ -76,10 +77,10 @@ jobs:
         }
 
         Write-Host "Provisioning Resource Group"
-        Write-Host "${{ parameters.webAppName }}"
+        Write-Host $webAppName
         Write-Host "${{ parameters.resourceGroup }}"
-        New-AzResourceGroupDeployment -Name "${{ parameters.webAppName }}" -ResourceGroupName "${{ parameters.resourceGroup }}" -TemplateFile $(System.DefaultWorkingDirectory)/samples/templates/default-azuredeploy-docker.json -TemplateParameterObject $templateParameters -Verbose
+        New-AzResourceGroupDeployment -Name $webAppName -ResourceGroupName "${{ parameters.resourceGroup }}" -TemplateFile $(System.DefaultWorkingDirectory)/samples/templates/default-azuredeploy-docker.json -TemplateParameterObject $templateParameters -Verbose
         
         Write-Host "Setting Key Vault access"
-        Set-AzKeyVaultAccessPolicy -VaultName "${{ parameters.webAppName }}" -ObjectId 4d4d503d-9ca8-462e-9e18-b35fc8b5285b -PermissionsToSecrets list,get
+        Set-AzKeyVaultAccessPolicy -VaultName $webAppName -ObjectId 4d4d503d-9ca8-462e-9e18-b35fc8b5285b -PermissionsToSecrets list,get
 

--- a/build/jobs/run-tests.yml
+++ b/build/jobs/run-tests.yml
@@ -59,7 +59,7 @@ jobs:
       azurePowerShellVersion: latestVersion
       ScriptType: inlineScript
       Inline: |
-        $keyVault = "$(DeploymentEnvironmentName)-ts" -replace "\.", "" 
+        $keyVault = "$(DeploymentEnvironmentName)-ts"
         $secrets = Get-AzKeyVaultSecret -VaultName $keyVault
         
         foreach($secret in $secrets)
@@ -121,7 +121,7 @@ jobs:
       azurePowerShellVersion: latestVersion
       ScriptType: inlineScript
       Inline: |
-        $keyVault = "$(DeploymentEnvironmentName)-ts" -replace "\.", "" 
+        $keyVault = "$(DeploymentEnvironmentName)-ts"
         $secrets = Get-AzKeyVaultSecret -VaultName $keyVault
         
         foreach($secret in $secrets)

--- a/build/jobs/run-tests.yml
+++ b/build/jobs/run-tests.yml
@@ -59,19 +59,20 @@ jobs:
       azurePowerShellVersion: latestVersion
       ScriptType: inlineScript
       Inline: |
-        $secrets = Get-AzKeyVaultSecret -VaultName $(DeploymentEnvironmentName)-ts
+        $keyVault = "$(DeploymentEnvironmentName)-ts" -replace "\.", "" 
+        $secrets = Get-AzKeyVaultSecret -VaultName $keyVault
         
         foreach($secret in $secrets)
         {
             $environmentVariableName = $secret.Name.Replace("--","_")
 
-            $secretValue = Get-AzKeyVaultSecret -VaultName $(DeploymentEnvironmentName)-ts -Name $secret.Name
+            $secretValue = Get-AzKeyVaultSecret -VaultName $keyVault -Name $secret.Name
             Write-Host "##vso[task.setvariable variable=$($environmentVariableName)]$($secretValue.SecretValueText)"
         }
 
-        $storageAccounts = Get-AzStorageAccount -ResourceGroupName $(DeploymentEnvironmentName)
+        $storageAccounts = Get-AzStorageAccount -ResourceGroupName $(ResourceGroupName)
         foreach ($storageAccount in $storageAccounts) {
-            $accKey = Get-AzStorageAccountKey -ResourceGroupName $(DeploymentEnvironmentName) -Name $storageAccount.StorageAccountName | Where-Object {$_.KeyName -eq "key1"}
+            $accKey = Get-AzStorageAccountKey -ResourceGroupName $(ResourceGroupName) -Name $storageAccount.StorageAccountName | Where-Object {$_.KeyName -eq "key1"}
 
             $storageSecretName = "$($storageAccount.StorageAccountName)_secret"
             Write-Host "##vso[task.setvariable variable=$($storageSecretName)]$($accKey.Value)"
@@ -120,19 +121,20 @@ jobs:
       azurePowerShellVersion: latestVersion
       ScriptType: inlineScript
       Inline: |
-        $secrets = Get-AzKeyVaultSecret -VaultName $(DeploymentEnvironmentName)-ts
+        $keyVault = "$(DeploymentEnvironmentName)-ts" -replace "\.", "" 
+        $secrets = Get-AzKeyVaultSecret -VaultName $keyVault
         
         foreach($secret in $secrets)
         {
             $environmentVariableName = $secret.Name.Replace("--","_")
 
-            $secretValue = Get-AzKeyVaultSecret -VaultName $(DeploymentEnvironmentName)-ts -Name $secret.Name
+            $secretValue = Get-AzKeyVaultSecret -VaultName $keyVault -Name $secret.Name
             Write-Host "##vso[task.setvariable variable=$($environmentVariableName)]$($secretValue.SecretValueText)"
         }
 
-        $storageAccounts = Get-AzStorageAccount -ResourceGroupName $(DeploymentEnvironmentName)
+        $storageAccounts = Get-AzStorageAccount -ResourceGroupName $(ResourceGroupName)
         foreach ($storageAccount in $storageAccounts) {
-            $accKey = Get-AzStorageAccountKey -ResourceGroupName $(DeploymentEnvironmentName) -Name $storageAccount.StorageAccountName | Where-Object {$_.KeyName -eq "key1"}
+            $accKey = Get-AzStorageAccountKey -ResourceGroupName $(ResourceGroupName) -Name $storageAccount.StorageAccountName | Where-Object {$_.KeyName -eq "key1"}
 
             $storageSecretName = "$($storageAccount.StorageAccountName)_secret"
             Write-Host "##vso[task.setvariable variable=$($storageSecretName)]$($accKey.Value)"

--- a/build/jobs/update-semver.yml
+++ b/build/jobs/update-semver.yml
@@ -18,8 +18,6 @@ steps:
     Write-Host "##vso[task.setvariable variable=nuGetVersion]$(GitVersion.semVer)"
     Write-Host "##vso[task.setvariable variable=assemblySemVer]$(GitVersion.assemblySemVer)"
     Write-Host "##vso[task.setvariable variable=assemblySemFileVer]$(GitVersion.assemblySemFileVer)"
-    $buildName = "$(GitVersion.NuGetVersionV2)" -replace "\.", "-"
-    Write-Host "##vso[task.setvariable variable=DeploymentEnvironmentName]fhir-${buildName}"
   name: SetVariablesFromGitVersion
 
 - powershell: |
@@ -30,5 +28,4 @@ steps:
     Write-Host 'assemblySemVer: $(assemblySemVer)'
     Write-Host 'assemblySemFileVer: $(assemblySemFileVer)'
     Write-Host 'nuGetVersion: $(nuGetVersion)'
-    Write-Host 'DeploymentEnvironmentName: $(DeploymentEnvironmentName)'
   name: PrintVariablesFromGitVersion

--- a/build/jobs/update-semver.yml
+++ b/build/jobs/update-semver.yml
@@ -15,8 +15,8 @@ steps:
 - powershell: |
     Write-Host "##vso[task.setvariable variable=semVer]$(GitVersion.semVer)"
     Write-Host "##vso[task.setvariable variable=informationalVersion;isOutput=true]$(GitVersion.informationalVersion)"
-    Write-Host "##vso[task.setvariable variable=majorMinorPatch]$(GitVersion.majorMinorPatch)"
-    Write-Host "##vso[task.setvariable variable=nuGetVersion]$(GitVersion.semVer)"
+    Write-Host "##vso[task.setvariable variable=majorMinorPatch;isOutput=true]$(GitVersion.majorMinorPatch)"
+    Write-Host "##vso[task.setvariable variable=nuGetVersion;isOutput=true]$(GitVersion.semVer)"
     Write-Host "##vso[task.setvariable variable=assemblySemVer;isOutput=true]$(GitVersion.assemblySemVer)"
     Write-Host "##vso[task.setvariable variable=assemblySemFileVer;isOutput=true]$(GitVersion.assemblySemFileVer)"
   name: SetVariablesFromGitVersion

--- a/build/jobs/update-semver.yml
+++ b/build/jobs/update-semver.yml
@@ -18,6 +18,8 @@ steps:
     Write-Host "##vso[task.setvariable variable=nuGetVersion]$(GitVersion.semVer)"
     Write-Host "##vso[task.setvariable variable=assemblySemVer]$(GitVersion.assemblySemVer)"
     Write-Host "##vso[task.setvariable variable=assemblySemFileVer]$(GitVersion.assemblySemFileVer)"
+    $buildName = ${{ build.BuildNumber }} -replace ".", "-"
+    Write-Host "##vso[task.setvariable variable=DeploymentEnvironmentName]fhir-${buildName}"
   name: SetVariablesFromGitVersion
 
 - powershell: |
@@ -28,4 +30,5 @@ steps:
     Write-Host 'assemblySemVer: $(assemblySemVer)'
     Write-Host 'assemblySemFileVer: $(assemblySemFileVer)'
     Write-Host 'nuGetVersion: $(nuGetVersion)'
+    Write-Host 'DeploymentEnvironmentName: $(DeploymentEnvironmentName)'
   name: PrintVariablesFromGitVersion

--- a/build/jobs/update-semver.yml
+++ b/build/jobs/update-semver.yml
@@ -18,8 +18,7 @@ steps:
     Write-Host "##vso[task.setvariable variable=nuGetVersion]$(GitVersion.semVer)"
     Write-Host "##vso[task.setvariable variable=assemblySemVer]$(GitVersion.assemblySemVer)"
     Write-Host "##vso[task.setvariable variable=assemblySemFileVer]$(GitVersion.assemblySemFileVer)"
-    $buildName = "$(build.BuildNumber)" -replace ".", "-"
-    Write-Host "##vso[task.setvariable variable=DeploymentEnvironmentName]fhir-${buildName}"
+    Write-Host "##vso[task.setvariable variable=DeploymentEnvironmentName]fhir-$(GitVersion.NuGetVersionV2)"
   name: SetVariablesFromGitVersion
 
 - powershell: |

--- a/build/jobs/update-semver.yml
+++ b/build/jobs/update-semver.yml
@@ -18,7 +18,7 @@ steps:
     Write-Host "##vso[task.setvariable variable=nuGetVersion]$(GitVersion.semVer)"
     Write-Host "##vso[task.setvariable variable=assemblySemVer]$(GitVersion.assemblySemVer)"
     Write-Host "##vso[task.setvariable variable=assemblySemFileVer]$(GitVersion.assemblySemFileVer)"
-    $buildName = $(build.BuildNumber) -replace ".", "-"
+    $buildName = "$(build.BuildNumber)" -replace ".", "-"
     Write-Host "##vso[task.setvariable variable=DeploymentEnvironmentName]fhir-${buildName}"
   name: SetVariablesFromGitVersion
 

--- a/build/jobs/update-semver.yml
+++ b/build/jobs/update-semver.yml
@@ -18,7 +18,8 @@ steps:
     Write-Host "##vso[task.setvariable variable=nuGetVersion]$(GitVersion.semVer)"
     Write-Host "##vso[task.setvariable variable=assemblySemVer]$(GitVersion.assemblySemVer)"
     Write-Host "##vso[task.setvariable variable=assemblySemFileVer]$(GitVersion.assemblySemFileVer)"
-    Write-Host "##vso[task.setvariable variable=DeploymentEnvironmentName]fhir-$(GitVersion.NuGetVersionV2)"
+    $buildName = "$(GitVersion.NuGetVersionV2)" -replace "\.", "-"
+    Write-Host "##vso[task.setvariable variable=DeploymentEnvironmentName]fhir-${buildName}"
   name: SetVariablesFromGitVersion
 
 - powershell: |

--- a/build/jobs/update-semver.yml
+++ b/build/jobs/update-semver.yml
@@ -14,11 +14,11 @@ steps:
 # Can set these: https://github.com/GitTools/actions/blob/master/gitversion/execute/action.yml
 - powershell: |
     Write-Host "##vso[task.setvariable variable=semVer]$(GitVersion.semVer)"
-    Write-Host "##vso[task.setvariable variable=informationalVersion]$(GitVersion.informationalVersion)"
+    Write-Host "##vso[task.setvariable variable=informationalVersion;isOutput=true]$(GitVersion.informationalVersion)"
     Write-Host "##vso[task.setvariable variable=majorMinorPatch]$(GitVersion.majorMinorPatch)"
     Write-Host "##vso[task.setvariable variable=nuGetVersion]$(GitVersion.semVer)"
-    Write-Host "##vso[task.setvariable variable=assemblySemVer]$(GitVersion.assemblySemVer)"
-    Write-Host "##vso[task.setvariable variable=assemblySemFileVer]$(GitVersion.assemblySemFileVer)"
+    Write-Host "##vso[task.setvariable variable=assemblySemVer;isOutput=true]$(GitVersion.assemblySemVer)"
+    Write-Host "##vso[task.setvariable variable=assemblySemFileVer;isOutput=true]$(GitVersion.assemblySemFileVer)"
   name: SetVariablesFromGitVersion
 
 - powershell: |

--- a/build/jobs/update-semver.yml
+++ b/build/jobs/update-semver.yml
@@ -29,3 +29,9 @@ steps:
     Write-Host 'assemblySemFileVer: $(assemblySemFileVer)'
     Write-Host 'nuGetVersion: $(nuGetVersion)'
   name: PrintVariablesFromGitVersion
+  
+- powershell: |
+    $buildNumber = "$(GitVersion.semVer)" -replace "\.", "" 
+    Write-Host "##vso[build.updatebuildnumber]$buildNumber" 
+    Write-Host "Updated  build number to '$buildNumber"
+  name: SetBuildVersion

--- a/build/jobs/update-semver.yml
+++ b/build/jobs/update-semver.yml
@@ -18,7 +18,7 @@ steps:
     Write-Host "##vso[task.setvariable variable=nuGetVersion]$(GitVersion.semVer)"
     Write-Host "##vso[task.setvariable variable=assemblySemVer]$(GitVersion.assemblySemVer)"
     Write-Host "##vso[task.setvariable variable=assemblySemFileVer]$(GitVersion.assemblySemFileVer)"
-    $buildName = ${{ build.BuildNumber }} -replace ".", "-"
+    $buildName = $(build.BuildNumber) -replace ".", "-"
     Write-Host "##vso[task.setvariable variable=DeploymentEnvironmentName]fhir-${buildName}"
   name: SetVariablesFromGitVersion
 

--- a/build/jobs/update-semver.yml
+++ b/build/jobs/update-semver.yml
@@ -7,6 +7,7 @@ steps:
     
 - task: GitVersion@5
   displayName: 'GitVersion'
+  name: GitVersion
   inputs:
     configFilePath: '$(Build.SourcesDirectory)/GitVersion.yml'
 
@@ -29,9 +30,3 @@ steps:
     Write-Host 'assemblySemFileVer: $(assemblySemFileVer)'
     Write-Host 'nuGetVersion: $(nuGetVersion)'
   name: PrintVariablesFromGitVersion
-  
-- powershell: |
-    $buildNumber = "$(GitVersion.semVer)" -replace "\.", "" 
-    Write-Host "##vso[build.updatebuildnumber]$buildNumber" 
-    Write-Host "Updated  build number to '$buildNumber"
-  name: SetBuildVersion

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -18,7 +18,7 @@ stages:
     steps:
     - template: ./jobs/update-semver.yml
     - bash: |
-        envName = "${$(GitVersion.semver)//\./}"
+        envName = "${$(GitVersion.semver)//.}"
         echo "##vso[task.setvariable variable=environmentName]$envName"
     - script: echo %Action%%BuildVersion%
       displayName: 'Set build version'

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -21,7 +21,7 @@ stages:
         $buildNumber = "$(GitVersion.semVer)" -replace "\.", "" 
         Write-Host "##vso[build.updatebuildnumber]$buildNumber" 
         Write-Host "Updated  build number to '$buildNumber"
-      name: "Set build version"
+      name: SetBuildVersion
 
 - stage: BuildUnitTests
   displayName: 'Build and run unit tests'

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -17,11 +17,6 @@ stages:
       vmImage: 'ubuntu-latest'
     steps:
     - template: ./jobs/update-semver.yml
-    - powershell: |
-        $buildNumber = "$(GitVersion.semVer)" -replace "\.", "" 
-        Write-Host "##vso[build.updatebuildnumber]$buildNumber" 
-        Write-Host "Updated  build number to '$buildNumber"
-      name: SetBuildVersion
 
 - stage: BuildUnitTests
   displayName: 'Build and run unit tests'

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -18,7 +18,8 @@ stages:
     steps:
     - template: ./jobs/update-semver.yml
     - bash: |
-        envName = "${$(GitVersion.semver)//.}"
+        semver = $(GitVersion.semver)
+        envName = "${semver//.}"
         echo "##vso[task.setvariable variable=environmentName]$envName"
     - script: echo %Action%%BuildVersion%
       displayName: 'Set build version'

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -53,7 +53,8 @@ stages:
 
 - stage: provisionEnvironment
   displayName: Provision Environment
-  dependsOn: []
+  dependsOn:
+  - UpdateVersion
   jobs:
   - job: provision
     steps:
@@ -64,6 +65,12 @@ stages:
         azurePowerShellVersion: latestVersion
         ScriptType: inlineScript
         Inline: |
+          try
+          {
+            Get-AzResourceGroup -Name $(ResourceGroupName) | Remove-AzResourceGroup -Verbose -Force
+          }
+          catch
+          {}
           New-AzResourceGroup -Name "$(ResourceGroupName)" -Location "$(ResourceGroupRegion)" -Force
 
 - stage: aadTestEnvironment

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -17,11 +17,14 @@ stages:
       vmImage: 'ubuntu-latest'
     steps:
     - template: ./jobs/update-semver.yml
+    - bash: |
+        envName = "${$(GitVersion.semver)//\./}"
+        echo "##vso[task.setvariable variable=environmentName]$envName"
     - script: echo %Action%%BuildVersion%
       displayName: 'Set build version'
       env:
         Action: '##vso[build.updatebuildnumber]'
-        BuildVersion: $(GitVersion.semVer)
+        BuildVersion: $(environmentName)
 
 - stage: BuildUnitTests
   displayName: 'Build and run unit tests'

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -16,7 +16,12 @@ stages:
     pool:
       vmImage: 'ubuntu-latest'
     steps:
-    - template: ./jobs/update-semver.yml
+    - template: ./jobs/update-semver.yml  
+    - powershell: |
+        $buildNumber = "$(GitVersion.semVer)" -replace "\.", "" 
+        Write-Host "##vso[build.updatebuildnumber]$buildNumber" 
+        Write-Host "Updated  build number to '$buildNumber"
+      name: SetBuildVersion
 
 - stage: BuildUnitTests
   displayName: 'Build and run unit tests'

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -64,7 +64,7 @@ stages:
         azurePowerShellVersion: latestVersion
         ScriptType: inlineScript
         Inline: |
-          New-AzResourceGroup -Name "$(DeploymentEnvironmentName)" -Location "$(ResourceGroupRegion)" -Force
+          New-AzResourceGroup -Name "$(ResourceGroupName)" -Location "$(ResourceGroupRegion)" -Force
 
 - stage: aadTestEnvironment
   displayName: Setup AAD Test Environment
@@ -143,7 +143,7 @@ stages:
       appServicePlanName: $(appServicePlanName)
       appServicePlanResourceGroup: $(appServicePlanResourceGroup)
       subscription: $(ConnectedServiceName)
-      resourceGroup: $(DeploymentEnvironmentName)
+      resourceGroup: $(ResourceGroupName)
       testEnvironmentUrl: $(TestEnvironmentUrl)
       imageTag: $(ImageTag)
 
@@ -161,7 +161,7 @@ stages:
       appServicePlanName: $(appServicePlanName)
       appServicePlanResourceGroup: $(appServicePlanResourceGroup)
       subscription: $(ConnectedServiceName)
-      resourceGroup: $(DeploymentEnvironmentName)
+      resourceGroup: $(ResourceGroupName)
       testEnvironmentUrl: $(TestEnvironmentUrl)
       imageTag: $(ImageTag)
       schemaAutomaticUpdatesEnabled: true
@@ -179,7 +179,7 @@ stages:
       appServicePlanName: $(appServicePlanName)
       appServicePlanResourceGroup: $(appServicePlanResourceGroup)
       subscription: $(ConnectedServiceName)
-      resourceGroup: $(DeploymentEnvironmentName)
+      resourceGroup: $(ResourceGroupName)
       testEnvironmentUrl: $(TestEnvironmentUrl)
       imageTag: $(ImageTag)
 
@@ -197,7 +197,7 @@ stages:
       appServicePlanName: $(appServicePlanName)
       appServicePlanResourceGroup: $(appServicePlanResourceGroup)
       subscription: $(ConnectedServiceName)
-      resourceGroup: $(DeploymentEnvironmentName)
+      resourceGroup: $(ResourceGroupName)
       testEnvironmentUrl: $(TestEnvironmentUrl)
       imageTag: $(ImageTag)
       schemaAutomaticUpdatesEnabled: true
@@ -215,7 +215,7 @@ stages:
       appServicePlanName: $(appServicePlanName)
       appServicePlanResourceGroup: $(appServicePlanResourceGroup)
       subscription: $(ConnectedServiceName)
-      resourceGroup: $(DeploymentEnvironmentName)
+      resourceGroup: $(ResourceGroupName)
       testEnvironmentUrl: $(TestEnvironmentUrl)
       imageTag: $(ImageTag)
 
@@ -233,7 +233,7 @@ stages:
       appServicePlanName: $(appServicePlanName)
       appServicePlanResourceGroup: $(appServicePlanResourceGroup)
       subscription: $(ConnectedServiceName)
-      resourceGroup: $(DeploymentEnvironmentName)
+      resourceGroup: $(ResourceGroupName)
       testEnvironmentUrl: $(TestEnvironmentUrl)
       imageTag: $(ImageTag)
       schemaAutomaticUpdatesEnabled: true

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -18,8 +18,8 @@ stages:
     steps:
     - template: ./jobs/update-semver.yml
     - bash: |
-        semver = $(GitVersion.semver)
-        envName = "${semver//.}"
+        semver=$(GitVersion.semver)
+        envName="${semver//.}"
         echo "##vso[task.setvariable variable=environmentName]$envName"
     - script: echo %Action%%BuildVersion%
       displayName: 'Set build version'

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -53,8 +53,7 @@ stages:
 
 - stage: provisionEnvironment
   displayName: Provision Environment
-  dependsOn:
-  - UpdateVersion
+  dependsOn: []
   jobs:
   - job: provision
     steps:

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -22,9 +22,6 @@ stages:
       env:
         Action: '##vso[build.updatebuildnumber]'
         BuildVersion: $(GitVersion.semVer)
-    - powershell: |
-        $buildName = "$(GitVersion.NuGetVersionV2)" -replace "\.", "-"
-        Write-Host "##vso[task.setvariable variable=DeploymentEnvironmentName]fhir-${buildName}"
 
 - stage: BuildUnitTests
   displayName: 'Build and run unit tests'

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -27,6 +27,10 @@ stages:
   displayName: 'Build and run unit tests'
   dependsOn:
   - UpdateVersion
+  variables:
+    assemblySemVer: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.assemblySemVer']]
+    assemblySemFileVer: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.assemblySemFileVer']]
+    informationalVersion: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.informationalVersion']]
   jobs:
   - job: Windows
     pool:

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -31,6 +31,8 @@ stages:
     assemblySemVer: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.assemblySemVer']]
     assemblySemFileVer: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.assemblySemFileVer']]
     informationalVersion: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.informationalVersion']]
+    majorMinorPatch: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.majorMinorPatch']]
+    nuGetVersion: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.nuGetVersion']]
   jobs:
   - job: Windows
     pool:

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -22,6 +22,9 @@ stages:
       env:
         Action: '##vso[build.updatebuildnumber]'
         BuildVersion: $(GitVersion.semVer)
+    - powershell: |
+        $buildName = "$(GitVersion.NuGetVersionV2)" -replace "\.", "-"
+        Write-Host "##vso[task.setvariable variable=DeploymentEnvironmentName]fhir-${buildName}"
 
 - stage: BuildUnitTests
   displayName: 'Build and run unit tests'

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -17,15 +17,11 @@ stages:
       vmImage: 'ubuntu-latest'
     steps:
     - template: ./jobs/update-semver.yml
-    - bash: |
-        semver=$(GitVersion.semver)
-        envName="${semver//.}"
-        echo "##vso[task.setvariable variable=environmentName]$envName"
-    - script: echo %Action%%BuildVersion%
-      displayName: 'Set build version'
-      env:
-        Action: '##vso[build.updatebuildnumber]'
-        BuildVersion: $(environmentName)
+    - powershell: |
+        $buildNumber = "$(GitVersion.semVer)" -replace "\.", "" 
+        Write-Host "##vso[build.updatebuildnumber]$buildNumber" 
+        Write-Host "Updated  build number to '$buildNumber"
+      name: "Set build version"
 
 - stage: BuildUnitTests
   displayName: 'Build and run unit tests'

--- a/build/pr-variables.yml
+++ b/build/pr-variables.yml
@@ -4,7 +4,7 @@ variables:
     appServicePlanName: '$(resourceGroupRoot)-$(prNumber)-asp'
     prNumber: $(system.pullRequest.pullRequestNumber)
     ResourceGroupName: '$(resourceGroupRoot)-$(prNumber)'
-    DeploymentEnvironmentName: $[join('f',replace(build.BuildNumber,'.',''))]
+    DeploymentEnvironmentName: 'f$(build.BuildNumber)'
     CrucibleEnvironmentUrl: ''
     TestEnvironmentName: 'OSS PR$(prNumber)'
     ImageTag: '$(build.BuildNumber)'

--- a/build/pr-variables.yml
+++ b/build/pr-variables.yml
@@ -3,7 +3,8 @@ variables:
     resourceGroupRoot: 'msh-fhir-pr'
     appServicePlanName: '$(resourceGroupRoot)-$(prNumber)-asp'
     prNumber: $(system.pullRequest.pullRequestNumber)
-    DeploymentEnvironmentName: '$(resourceGroupRoot)-$(prNumber)'
+    ResourceGroupName: '$(resourceGroupRoot)-$(prNumber)'
+    DeploymentEnvironmentName: '$(build.BuildNumber)'
     CrucibleEnvironmentUrl: ''
     TestEnvironmentName: 'OSS PR$(prNumber)'
     ImageTag: '$(build.BuildNumber)'

--- a/build/pr-variables.yml
+++ b/build/pr-variables.yml
@@ -4,7 +4,7 @@ variables:
     appServicePlanName: '$(resourceGroupRoot)-$(prNumber)-asp'
     prNumber: $(system.pullRequest.pullRequestNumber)
     ResourceGroupName: '$(resourceGroupRoot)-$(prNumber)'
-    DeploymentEnvironmentName: "fhir-$(replace(build.BuildNumber,'.','-'))"
+    DeploymentEnvironmentName: 'fhir'
     CrucibleEnvironmentUrl: ''
     TestEnvironmentName: 'OSS PR$(prNumber)'
     ImageTag: '$(build.BuildNumber)'

--- a/build/pr-variables.yml
+++ b/build/pr-variables.yml
@@ -4,7 +4,7 @@ variables:
     appServicePlanName: '$(resourceGroupRoot)-$(prNumber)-asp'
     prNumber: $(system.pullRequest.pullRequestNumber)
     ResourceGroupName: '$(resourceGroupRoot)-$(prNumber)'
-    DeploymentEnvironmentName: 'f$(build.BuildNumber)'
+    DeploymentEnvironmentName: $[join('f',replace($(build.BuildNumber),'.',''))]
     CrucibleEnvironmentUrl: ''
     TestEnvironmentName: 'OSS PR$(prNumber)'
     ImageTag: '$(build.BuildNumber)'

--- a/build/pr-variables.yml
+++ b/build/pr-variables.yml
@@ -4,7 +4,7 @@ variables:
     appServicePlanName: '$(resourceGroupRoot)-$(prNumber)-asp'
     prNumber: $(system.pullRequest.pullRequestNumber)
     ResourceGroupName: '$(resourceGroupRoot)-$(prNumber)'
-    DeploymentEnvironmentName: 'fhir-$(GitVersion.NuGetVersionV2)'
+    DeploymentEnvironmentName: 'fhir-$(build.BuildNumber)'
     CrucibleEnvironmentUrl: ''
     TestEnvironmentName: 'OSS PR$(prNumber)'
     ImageTag: '$(build.BuildNumber)'

--- a/build/pr-variables.yml
+++ b/build/pr-variables.yml
@@ -4,7 +4,7 @@ variables:
     appServicePlanName: '$(resourceGroupRoot)-$(prNumber)-asp'
     prNumber: $(system.pullRequest.pullRequestNumber)
     ResourceGroupName: '$(resourceGroupRoot)-$(prNumber)'
-    DeploymentEnvironmentName: '$(build.BuildNumber)'
+    DeploymentEnvironmentName: $[replace(variables['build.BuildNumber'],'.','-')]
     CrucibleEnvironmentUrl: ''
     TestEnvironmentName: 'OSS PR$(prNumber)'
     ImageTag: '$(build.BuildNumber)'

--- a/build/pr-variables.yml
+++ b/build/pr-variables.yml
@@ -4,7 +4,7 @@ variables:
     appServicePlanName: '$(resourceGroupRoot)-$(prNumber)-asp'
     prNumber: $(system.pullRequest.pullRequestNumber)
     ResourceGroupName: '$(resourceGroupRoot)-$(prNumber)'
-    DeploymentEnvironmentName: "fhir-$(replace(variables('build.BuildNumber'),'.','-'))"
+    DeploymentEnvironmentName: "fhir-$(replace(variables['build.BuildNumber'],'.','-'))"
     CrucibleEnvironmentUrl: ''
     TestEnvironmentName: 'OSS PR$(prNumber)'
     ImageTag: '$(build.BuildNumber)'

--- a/build/pr-variables.yml
+++ b/build/pr-variables.yml
@@ -4,7 +4,7 @@ variables:
     appServicePlanName: '$(resourceGroupRoot)-$(prNumber)-asp'
     prNumber: $(system.pullRequest.pullRequestNumber)
     ResourceGroupName: '$(resourceGroupRoot)-$(prNumber)'
-    DeploymentEnvironmentName: $[replace(variables['build.BuildNumber'],'.','-')]
+    DeploymentEnvironmentName: "fhir-$[replace(variables('build.BuildNumber'),'.','-')]"
     CrucibleEnvironmentUrl: ''
     TestEnvironmentName: 'OSS PR$(prNumber)'
     ImageTag: '$(build.BuildNumber)'

--- a/build/pr-variables.yml
+++ b/build/pr-variables.yml
@@ -4,7 +4,7 @@ variables:
     appServicePlanName: '$(resourceGroupRoot)-$(prNumber)-asp'
     prNumber: $(system.pullRequest.pullRequestNumber)
     ResourceGroupName: '$(resourceGroupRoot)-$(prNumber)'
-    DeploymentEnvironmentName: 'fhir'
+    DeploymentEnvironmentName: 'fhir-$(GitVersion.NuGetVersionV2)'
     CrucibleEnvironmentUrl: ''
     TestEnvironmentName: 'OSS PR$(prNumber)'
     ImageTag: '$(build.BuildNumber)'

--- a/build/pr-variables.yml
+++ b/build/pr-variables.yml
@@ -4,7 +4,7 @@ variables:
     appServicePlanName: '$(resourceGroupRoot)-$(prNumber)-asp'
     prNumber: $(system.pullRequest.pullRequestNumber)
     ResourceGroupName: '$(resourceGroupRoot)-$(prNumber)'
-    DeploymentEnvironmentName: "fhir-$[replace(variables('build.BuildNumber'),'.','-')]"
+    DeploymentEnvironmentName: "fhir-$(replace(variables('build.BuildNumber'),'.','-'))"
     CrucibleEnvironmentUrl: ''
     TestEnvironmentName: 'OSS PR$(prNumber)'
     ImageTag: '$(build.BuildNumber)'

--- a/build/pr-variables.yml
+++ b/build/pr-variables.yml
@@ -4,7 +4,7 @@ variables:
     appServicePlanName: '$(resourceGroupRoot)-$(prNumber)-asp'
     prNumber: $(system.pullRequest.pullRequestNumber)
     ResourceGroupName: '$(resourceGroupRoot)-$(prNumber)'
-    DeploymentEnvironmentName: 'fhir-$(build.BuildNumber)'
+    DeploymentEnvironmentName: 'f$(build.BuildNumber)'
     CrucibleEnvironmentUrl: ''
     TestEnvironmentName: 'OSS PR$(prNumber)'
     ImageTag: '$(build.BuildNumber)'

--- a/build/pr-variables.yml
+++ b/build/pr-variables.yml
@@ -4,7 +4,7 @@ variables:
     appServicePlanName: '$(resourceGroupRoot)-$(prNumber)-asp'
     prNumber: $(system.pullRequest.pullRequestNumber)
     ResourceGroupName: '$(resourceGroupRoot)-$(prNumber)'
-    DeploymentEnvironmentName: "fhir-$(replace(variables['build.BuildNumber'],'.','-'))"
+    DeploymentEnvironmentName: "fhir-$(replace(build.BuildNumber,'.','-'))"
     CrucibleEnvironmentUrl: ''
     TestEnvironmentName: 'OSS PR$(prNumber)'
     ImageTag: '$(build.BuildNumber)'

--- a/build/pr-variables.yml
+++ b/build/pr-variables.yml
@@ -4,7 +4,7 @@ variables:
     appServicePlanName: '$(resourceGroupRoot)-$(prNumber)-asp'
     prNumber: $(system.pullRequest.pullRequestNumber)
     ResourceGroupName: '$(resourceGroupRoot)-$(prNumber)'
-    DeploymentEnvironmentName: $[join('f',replace($(build.BuildNumber),'.',''))]
+    DeploymentEnvironmentName: $[join('f',replace(build.BuildNumber,'.',''))]
     CrucibleEnvironmentUrl: ''
     TestEnvironmentName: 'OSS PR$(prNumber)'
     ImageTag: '$(build.BuildNumber)'

--- a/build/remove-environment.yml
+++ b/build/remove-environment.yml
@@ -5,6 +5,8 @@ trigger: none
 pr: none
 
 variables:
+- name: ResourceGroupName
+  value: 'msh-fhir-pr-$(pr_number)'
 - name: DeploymentEnvironmentName
   value: 'msh-fhir-pr-$(pr_number)'
 - template: build-variables.yml


### PR DESCRIPTION
## Description
Changes the names of the resources created for testing a PR to include the build number in addition to the PR number. 

## Related issues
Previously we have encountered an error where resource names were conflicting with existing resources. This would require a new PR to be created as the names of the resources was based only on the PR number. This change will change the names of the resources on each build, allowing a rerun of the build to fix this issue.

## Testing
Running the PR.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)