### PR TITLE
Adds semver change to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,9 +10,9 @@ Describe how this change was tested.
 ## FHIR Team Checklist
 - [ ] **Update the title** of the PR to be succinct and less than 50 characters
 - [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
-- [ ] Tag the PR with the type of update: **Bug**, **Enhancement**, or **New-Feature**
+- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
 - [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
 - Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)
 
 ### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
-Patch|Skip|Feature|Breaking
+Patch|Skip|Feature|Breaking (reason)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,3 +13,6 @@ Describe how this change was tested.
 - [ ] Tag the PR with the type of update: **Bug**, **Enhancement**, or **New-Feature**
 - [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
 - Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)
+
+### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
+Patch|Skip|Feature|Breaking


### PR DESCRIPTION
## Description
Adds the proposed Semver change to the PR description so we can review with the PR change content

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip (documentation)