### PR TITLE
Fixes namespace and packages for smart tests

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -26,7 +26,7 @@ branches:
     is-release-branch: false
   hotfix:
     regex: ^hotfix(es)?[/-]
-    tag: beta
+    tag: useBranchName
     increment: Patch
     prevent-increment-of-merged-branch-version: false
     track-merge-target: false

--- a/samples/apps/SmartLauncher/Startup.cs
+++ b/samples/apps/SmartLauncher/Startup.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Health.Internal.SmartLauncher
             }
 
             app.UseDefaultFiles();
-            app.UseStaticFiles(new StaticFileOptions { FileProvider = new EmbeddedFileProvider(Assembly.GetExecutingAssembly(), "SmartLauncher.wwwroot") });
+            app.UseStaticFiles(new StaticFileOptions { FileProvider = new EmbeddedFileProvider(Assembly.GetExecutingAssembly(), "Microsoft.Health.Internal.SmartLauncher.wwwroot") });
 
             app.Map("/config", a =>
             {

--- a/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/Microsoft.Health.Fhir.Stu3.Tests.E2E.csproj
+++ b/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/Microsoft.Health.Fhir.Stu3.Tests.E2E.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Microsoft.Health.Test.Utilities" Version="1.0.79" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="selenium.webdriver" Version="3.141.0" />
+    <PackageReference Include="selenium.chrome.webdriver" Version="85.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.7.0" />


### PR DESCRIPTION
## Description
Smart tests fail to run because the static file provider is using the wrong namespace.

## Testing
Testing locally 

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)