### PR TITLE
sqlSchemaAutomaticUpdatesEnabled now set to valid bool

### DIFF
--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -139,7 +139,7 @@
         },
         "sqlSchemaAutomaticUpdatesEnabled": {
             "type": "bool",
-            "defaultValue": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), bool('false'), '')]",
+            "defaultValue": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), bool('false'), bool('true'))]",
             "metadata": {
                 "description": "Determine whether the sql schema should be automatically upgraded on server startup. If false, sql schema will not be initialized or upgraded on the server startup. The schema migration tool will be required to perform initialize or upgrade. If true, sql schema will be upgraded to the maximum supported version."
             }

--- a/samples/templates/default-azuredeploy.json
+++ b/samples/templates/default-azuredeploy.json
@@ -146,7 +146,7 @@
         },
         "sqlSchemaAutomaticUpdatesEnabled": {
             "type": "bool",
-            "defaultValue": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), bool('false'), '')]",
+            "defaultValue": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), bool('false'), bool('true'))]",
             "metadata": {
                 "description": "Determine whether the sql schema should be automatically upgraded on server startup. If false, sql schema will not be initialized or upgraded on the server startup. The schema migration tool will be required to perform initialize or upgrade. If true, sql schema will be upgraded to the maximum supported version."
             }


### PR DESCRIPTION
## Description
When using `solutionType` other than `FhirServerCosmosDB` (currently only other option is `FhirServerSqlServer`) then the flag `sqlSchemaAutomaticUpdatesEnabled` shall be set to true, so that the schema will be updated and the templates are valid.

I am not a hundred percent sure if that flag has been set as empty on purpose, given that one might not want the schema to be automatically applied / patched / whatever. If so, please let me know, so I can at least set it to `false`.

## Related issues
There is no related issue, I stumbled on that problem while trying to deploy the environment.

## Testing
I used Azure-CLI to validate that the template-files are still working.

For the docker-template:
`az deployment group validate --template-file default-azuredeploy-docker.json -g <the-resource-group>`

For the default-template:
`az deployment group validate --template-file default-azuredeploy.json -g <the-resource-group>`

It would ask for a service-name after, which I set to `fire-server`.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- [ ] Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
