### PR TITLE
Adds support for connecting to an existing MS SQL Server when deploying via Helm

### DIFF
--- a/samples/kubernetes/helm/fhir-server/Chart.yaml
+++ b/samples/kubernetes/helm/fhir-server/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.0
+version: 0.4.0

--- a/samples/kubernetes/helm/fhir-server/templates/deployment.yaml
+++ b/samples/kubernetes/helm/fhir-server/templates/deployment.yaml
@@ -126,6 +126,36 @@ spec:
             - name: SqlServer__ConnectionString
               value: "Server=tcp:$(DATABASESERVERNAME),1433;Initial Catalog=$(DATABASENAME);Persist Security Info=False;User ID=$(DATABASEUSERNAME);Password=$(DATABASEPASSWORD);MultipleActiveResultSets=False;Connection Timeout=30"
             {{- end }}
+            {{- if eq .Values.database.dataStore "ExistingSqlServer" }}
+            - name: DataStore
+              value: "SqlServer"
+            - name: SqlServer__AllowDatabaseCreation
+              value: "true"
+            - name: SqlServer__Initialize
+              value: "true"
+            - name: SqlServer__SchemaOptions__AutomaticUpdatesEnabled
+              value: {{ .Values.database.sql.schema.automaticUpdatesEnabled | quote }}
+            - name: DATABASEUSERNAME
+              value: {{ .Values.database.existingSqlServer.userName }}
+            - name: DATABASEPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  {{- if .Values.database.existingSqlServer.existingSecret }}
+                  name: {{ .Values.database.existingSqlServer.existingSecret }}
+                  key: DATABASEPASSWORD
+                  {{- else }}
+                  name: {{ include "fhir-server.fullname" . }}-existing-mssql
+                  key: DATABASEPASSWORD
+                  {{- end }}
+            - name: DATABASENAME
+              value: {{ .Values.database.existingSqlServer.databaseName }}
+            - name: DATABASESERVERNAME
+              value: {{ .Values.database.existingSqlServer.serverName }}
+            - name: DATABASESERVERPORT
+              value: {{ .Values.database.existingSqlServer.port | quote }}
+            - name: SqlServer__ConnectionString
+              value: "Server=tcp:$(DATABASESERVERNAME),$(DATABASESERVERPORT);Initial Catalog=$(DATABASENAME);Persist Security Info=False;User ID=$(DATABASEUSERNAME);Password=$(DATABASEPASSWORD);MultipleActiveResultSets=False;Connection Timeout=30"
+            {{- end }}
             {{- if eq .Values.database.dataStore "CosmosDb" }}
             - name: DataStore
               value: "CosmosDb"

--- a/samples/kubernetes/helm/fhir-server/templates/existingsqlserversecret.yaml
+++ b/samples/kubernetes/helm/fhir-server/templates/existingsqlserversecret.yaml
@@ -1,0 +1,11 @@
+{{- if and (eq .Values.database.dataStore "ExistingSqlServer") (not .Values.database.existingSqlServer.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "fhir-server.fullname" . }}-existing-mssql
+  labels:
+    {{- include "fhir-server.labels" . | nindent 4 }}
+type: Opaque
+data:
+  DATABASEPASSWORD: {{ .Values.database.existingSqlServer.password | b64enc | quote}}
+{{- end }}

--- a/samples/kubernetes/helm/fhir-server/values.yaml
+++ b/samples/kubernetes/helm/fhir-server/values.yaml
@@ -39,7 +39,7 @@ service:
   port: 80
 
 database:
-  # options: SqlServer, SqlContainer, CosmosDb
+  # options: ExistingSqlServer, SqlServer, SqlContainer, CosmosDb
   dataStore: "SqlServer"
   resourceGroup: ""
   location: ""
@@ -86,6 +86,15 @@ database:
       runAsUser: 10001
       runAsGroup: 10001
       fsGroup: 10001
+  existingSqlServer:
+    userName: sa
+    databaseName: FHIR
+    serverName: mymssql-mssql-linux.default
+    password: fhir
+    # name of a pre-created secret to retrieve the SQL Server's password.
+    # the secret must have a key named `DATABASEPASSWORD` with the password as its value.
+    existingSecret: ""
+    port: 1433
 
 appInsights:
   secretKey: "instrumentationKey"


### PR DESCRIPTION
## Description

Adds a new option to the Helm chart which allows using an existing/arbitrary SQL Server instance as a data store.

## Related issues
Addresses #1455 

## Testing

```sh
# setup a test cluster
kind create cluster
# install a "pre-existing" SQL Server
helm repo add stable https://charts.helm.sh/stable
helm install mymssql stable/mssql-linux --set acceptEula.value=Y --set edition.value=Developer
# get the SA password
export SQL_SERVER_PW=$(kubectl get secret --namespace default mymssql-mssql-linux-secret -o jsonpath="{.data.sapassword}" | base64 --decode)
# install the fhir-server using the new options for connecting to an existing SQL DB
helm upgrade --install \
  --set database.sql.schema.automaticUpdatesEnabled=true \
  --set database.dataStore=ExistingSqlServer \
  --set database.existingSqlServer.password=$SQL_SERVER_PW \
  --set database.existingSqlServer.serverName=mymssql-mssql-linux.default \
  fhir-server samples/kubernetes/helm/fhir-server/
```

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
