### PR TITLE
Fix image cleanup script

### DIFF
--- a/build/cleanup-images.yml
+++ b/build/cleanup-images.yml
@@ -32,7 +32,7 @@ jobs:
                 $difference = New-TimeSpan -Start $imageDate.lastUpdateTime -End $currentDate
 
                 if (($tagParts[0] -notlike "*build*") -and (($difference.totalDays -gt 60) -or (($difference.totalDays -gt 7) -and ($tagParts[0] -like "pr*")))) {
-                  az acr repository untag --name $(azureContai | nerRegistryName) --image '${version}_fhir-server:${tag}'
+                  az acr repository untag --name $(azureContainerRegistryName) --image '${version}_fhir-server:${tag}'
                 }
               }
               catch {

--- a/build/cleanup-images.yml
+++ b/build/cleanup-images.yml
@@ -20,6 +20,7 @@ jobs:
         $versions = "stu3","r4","r5"
         
         foreach ($version in $versions) {
+          Write-Host "Untagging ${version} images"
           $repository = "${version}_fhir-server"
           $tagList = az acr repository show-tags --name $(azureContainerRegistryName) --repository $repository | ConvertFrom-Json
 
@@ -32,7 +33,7 @@ jobs:
                 $difference = New-TimeSpan -Start $imageDate.lastUpdateTime -End $currentDate
 
                 if (($tagParts[0] -notlike "*build*") -and (($difference.totalDays -gt 60) -or (($difference.totalDays -gt 7) -and ($tagParts[0] -like "pr*")))) {
-                  az acr repository untag --name $(azureContainerRegistryName) --image '${version}_fhir-server:${tag}'
+                  az acr repository untag --name $(azureContainerRegistryName) --image "${version}_fhir-server:${tag}"
                 }
               }
               catch {
@@ -42,6 +43,7 @@ jobs:
         }
 
         foreach ($version in $versions) {
+          Write-Host "Removing untagged ${version} images"
           $repository = "${version}_fhir-server"
           az acr repository show-manifests --name $(azureContainerRegistryName) --repository $repository --query "[?tags[0]==null].digest" -o tsv `
           | %{ az acr repository delete --name $(azureContainerRegistryName) --image $repository@$_ --yes }

--- a/build/cleanup-images.yml
+++ b/build/cleanup-images.yml
@@ -4,47 +4,26 @@
 variables:
 - template: build-variables.yml
 
-jobs:
-- job: deleteImage
-  displayName: 'Delete Images'
-  pool:
-    vmImage: $(WindowsVmImage)
-  steps:
-  - task: AzureCLI@2
-    displayName: 'Delete Images'
-    inputs:
-      azureSubscription: $(ConnectedServiceName)
-      scriptType: ps
-      scriptLocation: InlineScript
-      inlineScript: |
-        $versions = "stu3","r4","r5"
-        
-        foreach ($version in $versions) {
-          Write-Host "Untagging ${version} images"
-          $repository = "${version}_fhir-server"
-          $tagList = az acr repository show-tags --name $(azureContainerRegistryName) --repository $repository | ConvertFrom-Json
+stages:
+- stage: CleanupStu3
+  displayName: 'Cleanup Stu3'
+  jobs:
+  - template: ./jobs/cleanup-version-images.yml
+    parameters: 
+      tag: 'stu3'
 
-          foreach ($tag in $tagList) {
-            $tagParts = $tag.Split('-')
-              try {
-                $imageName = "${repository}:${tag}"
-                $imageDate = az acr repository show --name $(azureContainerRegistryName) --image $imageName | ConvertFrom-Json
-                $currentDate = Get-Date
-                $difference = New-TimeSpan -Start $imageDate.lastUpdateTime -End $currentDate
+- stage: CleanupR4
+  displayName: 'Cleanup R4'
+  dependsOn: []
+  jobs:
+  - template: ./jobs/cleanup-version-images.yml
+    parameters: 
+      tag: 'r4'
 
-                if (($tagParts[0] -notlike "*build*") -and (($difference.totalDays -gt 60) -or (($difference.totalDays -gt 7) -and ($tagParts[0] -like "pr*")))) {
-                  az acr repository untag --name $(azureContainerRegistryName) --image "${version}_fhir-server:${tag}"
-                }
-              }
-              catch {
-                Write-Host "Error deleting tag ${tag} in ${version} repository"
-              }
-          }
-        }
-
-        foreach ($version in $versions) {
-          Write-Host "Removing untagged ${version} images"
-          $repository = "${version}_fhir-server"
-          az acr repository show-manifests --name $(azureContainerRegistryName) --repository $repository --query "[?tags[0]==null].digest" -o tsv `
-          | %{ az acr repository delete --name $(azureContainerRegistryName) --image $repository@$_ --yes }
-        }
+- stage: CleanupR5
+  displayName: 'Cleanup R5'
+  dependsOn: []
+  jobs:
+  - template: ./jobs/cleanup-version-images.yml
+    parameters: 
+      tag: 'r5'

--- a/build/cleanup-images.yml
+++ b/build/cleanup-images.yml
@@ -10,7 +10,7 @@ stages:
   jobs:
   - template: ./jobs/cleanup-version-images.yml
     parameters: 
-      tag: 'stu3'
+      version: 'stu3'
 
 - stage: CleanupR4
   displayName: 'Cleanup R4'
@@ -18,7 +18,7 @@ stages:
   jobs:
   - template: ./jobs/cleanup-version-images.yml
     parameters: 
-      tag: 'r4'
+      version: 'r4'
 
 - stage: CleanupR5
   displayName: 'Cleanup R5'
@@ -26,4 +26,4 @@ stages:
   jobs:
   - template: ./jobs/cleanup-version-images.yml
     parameters: 
-      tag: 'r5'
+      version: 'r5'

--- a/build/jobs/cleanup-version-images.yml
+++ b/build/jobs/cleanup-version-images.yml
@@ -1,0 +1,44 @@
+parameters:
+- name: version
+  type: string
+
+jobs:
+- job: deleteImage
+  displayName: "Delete ${{ parameters.version }} Images"
+  pool:
+    vmImage: $(WindowsVmImage)
+  steps:
+    - task: AzureCLI@2
+      displayName: 'Delete Images'
+      inputs:
+        azureSubscription: $(ConnectedServiceName)
+        scriptType: ps
+        scriptLocation: InlineScript
+        inlineScript: |
+          $version = ${{ parameters.version }}
+        
+          Write-Host "Untagging ${version} images"
+          $repository = "${version}_fhir-server"
+          $tagList = az acr repository show-tags --name $(azureContainerRegistryName) --repository $repository | ConvertFrom-Json
+
+          foreach ($tag in $tagList) {
+            $tagParts = $tag.Split('-')
+              try {
+                $imageName = "${repository}:${tag}"
+                $imageDate = az acr repository show --name $(azureContainerRegistryName) --image $imageName | ConvertFrom-Json
+                $currentDate = Get-Date
+                $difference = New-TimeSpan -Start $imageDate.lastUpdateTime -End $currentDate
+
+                if (($tagParts[0] -notlike "*build*") -and (($difference.totalDays -gt 60) -or (($difference.totalDays -gt 7) -and ($tagParts[0] -like "*-pr*")))) {
+                  az acr repository untag --name $(azureContainerRegistryName) --image "${version}_fhir-server:${tag}"
+                }
+              }
+              catch {
+                Write-Host "Error deleting tag ${tag} in ${version} repository"
+              }
+          }
+
+          Write-Host "Removing untagged ${version} images"
+          $repository = "${version}_fhir-server"
+          az acr repository show-manifests --name $(azureContainerRegistryName) --repository $repository --query "[?tags[0]==null].digest" -o tsv `
+          | %{ az acr repository delete --name $(azureContainerRegistryName) --image $repository@$_ --yes }

--- a/build/jobs/cleanup-version-images.yml
+++ b/build/jobs/cleanup-version-images.yml
@@ -15,7 +15,7 @@ jobs:
         scriptType: ps
         scriptLocation: InlineScript
         inlineScript: |
-          $version = ${{ parameters.version }}
+          $version = "${{ parameters.version }}"
         
           Write-Host "Untagging ${version} images"
           $repository = "${version}_fhir-server"

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -14,7 +14,7 @@ stages:
   jobs:
   - job: Semver
     pool:
-      vmImage: 'ubuntu-latest'
+      vmImage: $(WindowsVmImage)
     steps:
     - template: ./jobs/update-semver.yml
     - script: echo %Action%%BuildVersion%


### PR DESCRIPTION
## Description
Fixes a breaking typo and other issues in the docker image cleanup script preventing it from running

## Related issues
The image cleanup can't run

## Testing
The script will be run from the branch

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip (build infrastructure)
