### PR TITLE
Fix AnonymizedExportTests when run locally

### DIFF
--- a/Microsoft.Health.Fhir.sln
+++ b/Microsoft.Health.Fhir.sln
@@ -30,9 +30,9 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{404C6C33-DB00-4182-BD90-F10A8B17C321}"
 	ProjectSection(SolutionItems) = preProject
 		Directory.Build.props = Directory.Build.props
+		GitVersion.yml = GitVersion.yml
 		global.json = global.json
 		testauthenvironment.json = testauthenvironment.json
-		GitVersion.yml = GitVersion.yml
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{B5F2D2DF-D0C7-4861-8259-F6A041DB9854}"
@@ -164,6 +164,7 @@ Global
 		test\Microsoft.Health.Fhir.Shared.Tests.Crucible\Microsoft.Health.Fhir.Shared.Tests.Crucible.projitems*{7f2b9209-2c50-42ed-961b-a09cc8a26a07}*SharedItemsImports = 5
 		test\Microsoft.Health.Fhir.Shared.Tests.E2E.Common\Microsoft.Health.Fhir.Shared.Tests.E2E.Common.projitems*{7f2b9209-2c50-42ed-961b-a09cc8a26a07}*SharedItemsImports = 5
 		test\Microsoft.Health.Fhir.Shared.Tests.E2E\Microsoft.Health.Fhir.Shared.Tests.E2E.projitems*{7f2b9209-2c50-42ed-961b-a09cc8a26a07}*SharedItemsImports = 5
+		test\Microsoft.Health.Fhir.Shared.Tests.Smart\Microsoft.Health.Fhir.Shared.Tests.Smart.projitems*{7f2b9209-2c50-42ed-961b-a09cc8a26a07}*SharedItemsImports = 5
 		src\Microsoft.Health.Fhir.Shared.Api\Microsoft.Health.Fhir.Shared.Api.projitems*{85428d07-39a0-473f-b3bd-0f2c98a1a5f5}*SharedItemsImports = 5
 		test\Microsoft.Health.Fhir.Shared.Tests.Integration\Microsoft.Health.Fhir.Shared.Tests.Integration.projitems*{8ae4a7fd-c963-4004-8086-83e4615ac357}*SharedItemsImports = 13
 		src\Microsoft.Health.Fhir.Shared.Web\Microsoft.Health.Fhir.Shared.Web.projitems*{8b173ba3-2018-4bb7-b32a-d4a9fc7984eb}*SharedItemsImports = 5
@@ -409,7 +410,7 @@ Global
 		{A955963B-D766-492D-94FD-98A8B9EA8931} = {85F39C13-BC62-49A0-9C06-3BBA724D35ED}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		RESX_SortFileContentOnSave = True
 		SolutionGuid = {E370FB31-CF95-47D1-B1E1-863A77973FF8}
+		RESX_SortFileContentOnSave = True
 	EndGlobalSection
 EndGlobal

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Microsoft.Health.Fhir.Shared.Tests.E2E.projitems
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Microsoft.Health.Fhir.Shared.Tests.E2E.projitems
@@ -46,6 +46,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rest\PatchTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\ReadTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\RemoteTestFhirServer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Rest\RequiresIsolatedDatabaseAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\Search\BasicSearchTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\Search\ChainingSearchTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\Search\CompositeSearchTestFixture.cs" />

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/InProcTestFhirServer.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/InProcTestFhirServer.cs
@@ -4,18 +4,25 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Reflection;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.CosmosDb.Features.Storage;
+using Microsoft.Health.Fhir.Shared.Tests.E2E.Rest;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Web;
 using Newtonsoft.Json.Linq;
@@ -28,6 +35,9 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
     /// </summary>
     public class InProcTestFhirServer : TestFhirServer
     {
+        private readonly Func<Task> _cleanupDatabase;
+        private readonly IConfiguration _builtConfiguration;
+
         public InProcTestFhirServer(DataStore dataStore, Type startupType)
             : base(new Uri("http://localhost/"))
         {
@@ -44,6 +54,54 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             // For local development we will use the Azure Storage Emulator for export.
             configuration["FhirServer:Operations:Export:StorageAccountConnection"] = "UseDevelopmentStorage=true";
+
+            if (startupType.IsDefined(typeof(RequiresIsolatedDatabaseAttribute)))
+            {
+                // Alter the configuration so that the server will create a new, isolated database/container.
+                // Ensure tha the database/container is deleted at the end of the test run (when this instance is disposed)
+
+                if (dataStore == DataStore.SqlServer)
+                {
+                    var connectionStringBuilder = new SqlConnectionStringBuilder(configuration["SqlServer:ConnectionString"]);
+                    var databaseName = connectionStringBuilder.InitialCatalog += "_" + startupType.Name;
+                    configuration["SqlServer:ConnectionString"] = connectionStringBuilder.ToString();
+
+                    _cleanupDatabase = async () =>
+                    {
+                        connectionStringBuilder.InitialCatalog = "master";
+                        await using var connection = new SqlConnection(connectionStringBuilder.ToString());
+
+                        await connection.OpenAsync();
+                        SqlConnection.ClearAllPools();
+
+                        await using SqlCommand command = connection.CreateCommand();
+                        command.CommandTimeout = 600;
+                        command.CommandText = $"DROP DATABASE IF EXISTS {databaseName}";
+                        await command.ExecuteNonQueryAsync();
+                    };
+                }
+                else if (dataStore == DataStore.CosmosDb)
+                {
+                    var collectionId = configuration["FhirServer:CosmosDb:CollectionId"] = $"fhir{ModelInfoProvider.Version}_{startupType.Name}";
+
+                    _cleanupDatabase = async () =>
+                    {
+                        string ValueOrFallback(string configKey, string fallbackValue)
+                        {
+                            string value = _builtConfiguration[configKey];
+                            return string.IsNullOrEmpty(value) ? fallbackValue : value;
+                        }
+
+                        var host = ValueOrFallback("CosmosDb:Host", CosmosDbLocalEmulator.Host);
+                        var key = ValueOrFallback("CosmosDb:Key", CosmosDbLocalEmulator.Key);
+                        var databaseId = ValueOrFallback("CosmosDb:DatabaseId", null) ?? throw new InvalidOperationException("expected CosmosDb:DatabaseId to be set in configuration");
+
+                        using var client = new CosmosClient(host, key);
+                        Container container = client.GetContainer(databaseId, collectionId);
+                        await container.DeleteContainerAsync();
+                    };
+                }
+            }
 
             var builder = WebHost.CreateDefaultBuilder()
                 .UseContentRoot(Path.GetDirectoryName(startupType.Assembly.Location))
@@ -69,6 +127,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
                 });
 
             Server = new TestServer(builder);
+
+            _builtConfiguration = Server.Services.GetRequiredService<IConfiguration>();
         }
 
         public TestServer Server { get; }
@@ -78,10 +138,16 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             return Server.CreateHandler();
         }
 
-        public override void Dispose()
+        public override async ValueTask DisposeAsync()
         {
             Server?.Dispose();
-            base.Dispose();
+
+            if (_cleanupDatabase != null)
+            {
+                await _cleanupDatabase();
+            }
+
+            await base.DisposeAsync();
         }
 
         /// <summary>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Metric/StartupWithMetricHandler.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Metric/StartupWithMetricHandler.cs
@@ -13,6 +13,7 @@ using Microsoft.Health.Fhir.CosmosDb.Features.Metrics;
 
 namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Metric
 {
+    [RequiresIsolatedDatabase]
     public class StartupWithMetricHandler : StartupBaseForCustomProviders
     {
         public StartupWithMetricHandler(IConfiguration configuration)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/RequiresIsolatedDatabaseAttribute.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/RequiresIsolatedDatabaseAttribute.cs
@@ -1,0 +1,19 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.Health.Fhir.Web;
+
+namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
+{
+    /// <summary>
+    /// An attribute to be placed on a custom <see cref="Startup"/> type for in-proc E2E tests, when
+    /// the tests require that the in-proc server operates on an isolated database.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class RequiresIsolatedDatabaseAttribute : Attribute
+    {
+    }
+}

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/StartupForExportTestProvider.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/StartupForExportTestProvider.cs
@@ -15,6 +15,7 @@ using Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Metric;
 
 namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
 {
+    [RequiresIsolatedDatabase]
     public class StartupForExportTestProvider : StartupBaseForCustomProviders
     {
         public StartupForExportTestProvider(IConfiguration configuration)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TestFhirServer.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TestFhirServer.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
     /// Represents a FHIR server for end-to-end testing.
     /// Creates and caches <see cref="TestFhirClient"/> instances that target the server.
     /// </summary>
-    public abstract class TestFhirServer : IDisposable
+    public abstract class TestFhirServer : IAsyncDisposable
     {
         private readonly ConcurrentDictionary<(ResourceFormat format, TestApplication clientApplication, TestUser user), Lazy<TestFhirClient>> _cache = new ConcurrentDictionary<(ResourceFormat format, TestApplication clientApplication, TestUser user), Lazy<TestFhirClient>>();
         private static readonly AsyncLocal<SessionTokenContainer> _asyncLocalSessionTokenContainer = new AsyncLocal<SessionTokenContainer>();
@@ -203,7 +203,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             SecurityEnabled = localSecurityEnabled;
         }
 
-        public virtual void Dispose()
+        public virtual ValueTask DisposeAsync()
         {
             foreach (Lazy<TestFhirClient> cacheValue in _cache.Values)
             {
@@ -212,6 +212,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
                     cacheValue.Value.HttpClient.Dispose();
                 }
             }
+
+            return default;
         }
 
         /// <summary>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TestFhirServer.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TestFhirServer.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
     public abstract class TestFhirServer : IAsyncDisposable
     {
         private readonly ConcurrentDictionary<(ResourceFormat format, TestApplication clientApplication, TestUser user), Lazy<TestFhirClient>> _cache = new ConcurrentDictionary<(ResourceFormat format, TestApplication clientApplication, TestUser user), Lazy<TestFhirClient>>();
-        private static readonly AsyncLocal<SessionTokenContainer> _asyncLocalSessionTokenContainer = new AsyncLocal<SessionTokenContainer>();
+        private readonly SessionTokenContainer _sessionTokenContainer = new SessionTokenContainer();
 
         private readonly Dictionary<string, AuthenticationHttpMessageHandler> _authenticationHandlers = new Dictionary<string, AuthenticationHttpMessageHandler>();
 
@@ -54,15 +54,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         protected internal Uri AuthorizeUri { get; set; }
 
         public Uri BaseAddress { get; }
-
-        public static void CreateSession()
-        {
-            if (_asyncLocalSessionTokenContainer.Value == null)
-            {
-                // Ensure that we are able to preserve session tokens across requests in this execution context and its children.
-                _asyncLocalSessionTokenContainer.Value = new SessionTokenContainer();
-            }
-        }
 
         public TestFhirClient GetTestFhirClient(ResourceFormat format, bool reusable = true, AuthenticationHttpMessageHandler authenticationHandler = null)
         {
@@ -93,7 +84,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             HttpMessageHandler innerHandler = authenticationHandler ?? CreateMessageHandler();
 
-            var sessionMessageHandler = new SessionMessageHandler(innerHandler, _asyncLocalSessionTokenContainer);
+            var sessionMessageHandler = new SessionMessageHandler(innerHandler, _sessionTokenContainer);
 
             var httpClient = new HttpClient(sessionMessageHandler) { BaseAddress = BaseAddress };
 
@@ -221,14 +212,15 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         /// </summary>
         private class SessionMessageHandler : DelegatingHandler
         {
-            private readonly AsyncLocal<SessionTokenContainer> _asyncLocalSessionTokenContainer;
+            private readonly SessionTokenContainer _sessionTokenContainer;
             private readonly AsyncRetryPolicy<HttpResponseMessage> _polly;
 
-            public SessionMessageHandler(HttpMessageHandler innerHandler, AsyncLocal<SessionTokenContainer> asyncLocalSessionTokenContainer)
+            public SessionMessageHandler(HttpMessageHandler innerHandler, SessionTokenContainer sessionTokenContainer)
                 : base(innerHandler)
             {
-                _asyncLocalSessionTokenContainer = asyncLocalSessionTokenContainer;
-                EnsureArg.IsNotNull(asyncLocalSessionTokenContainer, nameof(asyncLocalSessionTokenContainer));
+                EnsureArg.IsNotNull(sessionTokenContainer, nameof(sessionTokenContainer));
+                _sessionTokenContainer = sessionTokenContainer;
+
                 _polly = Policy.Handle<HttpRequestException>(x =>
                     {
                         if (x.InnerException is IOException || x.InnerException is SocketException)
@@ -244,13 +236,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
-                SessionTokenContainer sessionTokenContainer = _asyncLocalSessionTokenContainer.Value;
-                if (sessionTokenContainer == null)
-                {
-                    throw new InvalidOperationException($"{nameof(SessionTokenContainer)} has not been set for the execution context");
-                }
-
-                string latestValue = sessionTokenContainer.SessionToken;
+                string latestValue = _sessionTokenContainer.SessionToken;
 
                 if (!string.IsNullOrEmpty(latestValue))
                 {
@@ -268,7 +254,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
                 if (response.Headers.TryGetValues("x-ms-session-token", out var tokens))
                 {
-                    sessionTokenContainer.SessionToken = tokens.SingleOrDefault();
+                    _sessionTokenContainer.SessionToken = tokens.SingleOrDefault();
                 }
 
                 return response;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TestFhirServerFactory.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TestFhirServerFactory.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Health.Fhir.Smart.Tests.E2E;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Xunit;
 
@@ -82,7 +81,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             {
                 if (cacheValue.IsValueCreated)
                 {
-                    (await cacheValue.Value).Dispose();
+                    await (await cacheValue.Value).DisposeAsync();
                 }
             }
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TestFhirServerFactory.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TestFhirServerFactory.cs
@@ -20,12 +20,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
     {
         private readonly ConcurrentDictionary<(DataStore dataStore, Type startupType), Lazy<Task<TestFhirServer>>> _cache = new ConcurrentDictionary<(DataStore dataStore, Type startupType), Lazy<Task<TestFhirServer>>>();
 
-        public TestFhirServerFactory()
-        {
-            // allow cosmos DB session consistency
-            TestFhirServer.CreateSession();
-        }
-
         public async Task<TestFhirServer> GetTestFhirServerAsync(DataStore dataStore, Type startupType)
         {
             return await _cache.GetOrAdd(


### PR DESCRIPTION
## Description
AnonymizedExportTests currently fail when run run locally (which is the only time they really do anything) _and_  when run with other tests in the E2E assembly (So `dotnet test` fails). 

It took me some time to figure out why, but it turns out that the export operations were getting picked up by a different `TestServer` than the one associated with the test class' fixture (which uses a custom `Startup` type).

In this PR, I'm introducing a `RequiresIsolatedDatabaseAttribute` that can be placed on the custom `Startup` classes where this is needed. When an `InProcTestFhirServer` is created for the `Startup` type, we look for the attribute, and if present, we alter the config so that a new database/container will be created. At the end of the test run, we delete the database.

As a result of this, we also needed to make a more subtle change. We were flowing the session tokens between tests using an `AsyncLocal` to maintain proper session consistency with Cosmos DB across requests, ensuring that a client would always read its own writes. But the session token from one database is incompatible with another database, so I moved away from `AsyncLocal` and instead maintain the latest session token in the `TestFhirServer` instance.

## Related issues
Addresses #1517 

## Testing
E2E tests, run locally

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch (only a change to tests)
