### PR TITLE
Change semver VM

### DIFF
--- a/build/ci-pipeline.yml
+++ b/build/ci-pipeline.yml
@@ -15,7 +15,7 @@ stages:
   jobs:
   - job: Semver
     pool:
-      vmImage: 'ubuntu-latest'
+      vmImage: $(WindowsVmImage)
     steps:
     - template: ./jobs/update-semver.yml
     - script: echo %Action%%BuildVersion%

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -14,7 +14,7 @@ stages:
   jobs:
   - job: Semver
     pool:
-      vmImage: 'ubuntu-latest'
+      vmImage: $(WindowsVmImage)
     steps:
     - template: ./jobs/update-semver.yml
     - script: echo %Action%%BuildVersion%


### PR DESCRIPTION
## Description
Changes the semver build step to use a windows VM.

## Related issues
The semver step has been failing since the change to use Ubuntu 20.04

## Testing
PR build

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip (deployment)
