### PR TITLE
Removes unused nuget feed

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -7,7 +7,6 @@
     <!-- When <clear /> is present, previously defined sources are ignored -->
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="Hl7.Fhir" value="https://www.myget.org/F/fhir-net-api/api/v3/index.json" />
     <add key="Microsoft Health OSS" value="https://microsofthealthoss.pkgs.visualstudio.com/FhirServer/_packaging/Public/nuget/v3/index.json" />
   </packageSources>
   <activePackageSource>


### PR DESCRIPTION
## Description
Nuget config should only contain nuget feeds that are official or that we control.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip (config)
