### PR TITLE
Add convert data capability statement.

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Routing/KnownRoutes.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Routing/KnownRoutes.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
         public const string ResourceReindexOperationDefinition = OperationDefinition + "/" + OperationsConstants.ResourceReindex;
 
         public const string ConvertData = "$convert-data";
+        public const string ConvertDataOperationDefinition = OperationDefinition + "/" + OperationsConstants.ConvertData;
 
         public const string CompartmentTypeByResourceType = CompartmentTypeRouteSegment + "/" + IdRouteSegment + "/" + CompartmentResourceTypeRouteSegment;
 

--- a/src/Microsoft.Health.Fhir.Api/Features/Routing/RouteNames.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Routing/RouteNames.cs
@@ -50,5 +50,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
         internal const string GroupExportOperationDefinition = "GroupExportOperationDefinition";
 
         internal const string AnonymizedExportOperationDefinition = "AnonymizedExportOperationDefinition";
+
+        internal const string ConvertDataOperationDefinition = "ConvertDataOperationDefinition";
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Features/Routing/UrlResolver.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Routing/UrlResolver.cs
@@ -283,6 +283,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
                 case OperationsConstants.ResourceReindex:
                     routeName = RouteNames.ResourceReindexOperationDefinition;
                     break;
+                case OperationsConstants.ConvertData:
+                    routeName = RouteNames.ConvertDataOperationDefinition;
+                    break;
                 default:
                     throw new OperationNotImplementedException(string.Format(Resources.OperationNotImplemented, operationName));
             }

--- a/src/Microsoft.Health.Fhir.Core/Data/OperationDefinition/convert-data.json
+++ b/src/Microsoft.Health.Fhir.Core/Data/OperationDefinition/convert-data.json
@@ -1,0 +1,48 @@
+{
+    "resourceType": "OperationDefinition",
+    "id": "convert-data",
+    "url": "[base]/OperationDefinition/convert-data",
+    "version": "1.0.0",
+    "name": "Convert Data",
+    "status": "active",
+    "kind": "operation",
+    "description": "Convert data operation enables data conversion from legacy formats to FHIR format.",
+    "code": "convert-data",
+    "system": true,
+    "type": false,
+    "instance": false,
+    "parameter": [
+        {
+            "name": "inputData",
+            "use": "in",
+            "min": 1,
+            "max": "1",
+            "documentation": "Input data to be converted.",
+            "type": "string"
+        },
+        {
+            "name": "inputDataType",
+            "use": "in",
+            "min": 1,
+            "max": "1",
+            "documentation": "The format of input data. Supported formats - `Hl7v2`.",
+            "type": "string"
+        },
+        {
+            "name": "templateCollectionReference",
+            "use": "in",
+            "min": 1,
+            "max": "1",
+            "documentation": "Reference to a template collection which can be the default templates, or an image on Azure Container Registry that the FHIR server can access. Supported values - `microsofthealth/fhirconverter:default`, `<RegistryServer>/<imageName>@<imageDigest>`, `<RegistryServer>/<imageName>:<imageTag>`.",
+            "type": "string"
+        },
+        {
+            "name": "rootTemplate",
+            "use": "in",
+            "min": 1,
+            "max": "1",
+            "documentation": "The root template to use while transforming the data. Supported values - `ADT_A01`, `OML_O21`, `ORU_R01`, `VXU_V04`.",
+            "type": "string"
+        }
+    ]
+}

--- a/src/Microsoft.Health.Fhir.Core/Data/OperationDefinition/convert-data.json
+++ b/src/Microsoft.Health.Fhir.Core/Data/OperationDefinition/convert-data.json
@@ -41,7 +41,7 @@
             "use": "in",
             "min": 1,
             "max": "1",
-            "documentation": "The root template to use while transforming the data. Supported values - `ADT_A01`, `OML_O21`, `ORU_R01`, `VXU_V04`.",
+            "documentation": "The root template to use while transforming the data. Supported default values - `ADT_A01`, `OML_O21`, `ORU_R01`, `VXU_V04`.",
             "type": "string"
         }
     ]

--- a/src/Microsoft.Health.Fhir.Core/Microsoft.Health.Fhir.Core.csproj
+++ b/src/Microsoft.Health.Fhir.Core/Microsoft.Health.Fhir.Core.csproj
@@ -6,6 +6,7 @@
     <None Remove="Features\Security\roles.schema.json" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="Data\OperationDefinition\convert-data.json" />
     <EmbeddedResource Include="Data\R4\BaseCapabilities.json" />
     <EmbeddedResource Include="Data\R4\compartment.json" />
     <EmbeddedResource Include="Data\R4\search-parameters.json" />

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/OperationDefinitionController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/OperationDefinitionController.cs
@@ -96,6 +96,14 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             return await GetOperationDefinitionAsync(OperationsConstants.AnonymizedExport);
         }
 
+        [HttpGet]
+        [Route(KnownRoutes.ConvertDataOperationDefinition, Name = RouteNames.ConvertDataOperationDefinition)]
+        [AllowAnonymous]
+        public async Task<IActionResult> ConvertDataOperationDefinition()
+        {
+            return await GetOperationDefinitionAsync(OperationsConstants.ConvertData);
+        }
+
         private async Task<IActionResult> GetOperationDefinitionAsync(string operationName)
         {
             CheckIfOperationIsEnabledAndRespond(operationName);
@@ -121,6 +129,9 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                 case OperationsConstants.Reindex:
                 case OperationsConstants.ResourceReindex:
                     operationEnabled = _operationConfiguration.Reindex.Enabled;
+                    break;
+                case OperationsConstants.ConvertData:
+                    operationEnabled = _operationConfiguration.ConvertData.Enabled;
                     break;
                 default:
                     break;


### PR DESCRIPTION
## Description
Add convert data capability statement.

## Related issues
Addresses [issue AB#78432](https://microsofthealth.visualstudio.com/Health/_workitems/edit/78432).

## Testing
Manually test the operation definition API.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip (reason)
