### PR TITLE
Re-enable AKS in PR builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,4 @@ For more information see the [Code of Conduct FAQ](https://opensource.microsoft.
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
 FHIR&reg; is the registered trademark of HL7 and is used with the permission of HL7. 
+

--- a/build/jobs/deploy-aks.yml
+++ b/build/jobs/deploy-aks.yml
@@ -51,7 +51,7 @@ jobs:
         corsMethods=`cat $corsPath | jq -r '.FhirServer.Cors.Methods | @csv' | tr -d '"'`
         corsHeaders=`cat $corsPath | jq -r '.FhirServer.Cors.Headers | @csv' | tr -d '"'`
         corsMaxAge=`cat $corsPath | jq -r '.FhirServer.Cors.MaxAge'`        
-        repositoryName=`echo $(azureContainerRegistry)/${{parameters.version}}_fhir-server | tr '[:upper:]' '[:lower:]'`
+        repositoryName=`echo ${{parameters.version}}_fhir-server | tr '[:upper:]' '[:lower:]'`
         releaseName=`echo "$(DeploymentEnvironmentName)-${{parameters.version}}-${{parameters.dataStore}}" | tr '[:upper:]' '[:lower:]'`
         hostName=`echo "${releaseName}.${{parameters.dnsSuffix}}" | tr '[:upper:]' '[:lower:]'`
         tenantId="$(tenant-id)"
@@ -75,6 +75,7 @@ jobs:
 
         cat <<EOF > release-values.yaml
         image:
+          registry: $(azureContainerRegistry)
           repository: $repositoryName
           tag: ${{parameters.imageTag}}
         resources:

--- a/build/jobs/deploy-aks.yml
+++ b/build/jobs/deploy-aks.yml
@@ -125,7 +125,7 @@ jobs:
           enabled: ${{ parameters.reindexEnabled }}
         security:
           enabled: true
-          enableAadSmartOnFhirProxy: false
+          enableAadSmartOnFhirProxy: true
           authority: https://login.microsoftonline.com/${tenantId}
           audience: ${{ parameters.testEnvironmentUrl }}
         EOF

--- a/build/pr-variables.yml
+++ b/build/pr-variables.yml
@@ -8,4 +8,3 @@ variables:
     CrucibleEnvironmentUrl: ''
     TestEnvironmentName: 'OSS PR$(prNumber)'
     ImageTag: '$(build.BuildNumber)'
-    enableAks: true

--- a/build/pr-variables.yml
+++ b/build/pr-variables.yml
@@ -8,3 +8,4 @@ variables:
     CrucibleEnvironmentUrl: ''
     TestEnvironmentName: 'OSS PR$(prNumber)'
     ImageTag: '$(build.BuildNumber)'
+    enableAks: true


### PR DESCRIPTION
## Description
AKS has been disabled for a few months. This is to test if the build steps still work.

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip (Deployment)
