### PR TITLE
Added missing strings to Resources.resx

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -1007,7 +1007,7 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The _type parameter must be included when using the _typeFilter parameter. .
+        ///   Looks up a localized string similar to The _type parameter must be included when using the _typeFilter parameter..
         /// </summary>
         internal static string TypeFilterWithoutTypeIsUnsupported {
             get {

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -503,4 +503,12 @@
   <data name="CustomSearchCreateError" xml:space="preserve">
     <value>An error occurred creating the custom search parameter.  The issue must be resolved and the parameter resubmitted to become functional.</value>
   </data>
+  <data name="TypeFilterUnparseable" xml:space="preserve">
+    <value>The _typeFilter segment '{0}' could not be parsed.</value>
+    <comment>Error message for a bad _typeFilter parameter on an export job. {0} is the segment that couldn't be parsed.</comment>
+  </data>
+  <data name="TypeFilterWithoutTypeIsUnsupported" xml:space="preserve">
+    <value>The _type parameter must be included when using the _typeFilter parameter.</value>
+    <comment>Export job parameter exception messsage</comment>
+  </data>
 </root>


### PR DESCRIPTION
## Description
Added 2 missing strings to `Resources.resx` (accidentally removed by #1449).

## Testing
Solution builds.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- [ ] Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip (Fixing build)
