### PR TITLE
Added support for common parameters in system search

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/ChainedExpression.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/ChainedExpression.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Linq;
 using EnsureThat;
 using Microsoft.Health.Fhir.Core.Models;
 
@@ -16,26 +17,28 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// <summary>
         /// Initializes a new instance of the <see cref="ChainedExpression"/> class.
         /// </summary>
-        /// <param name="resourceType">The resource type that supports this search expression.</param>
+        /// <param name="resourceTypes">The resource type that supports this search expression.</param>
         /// <param name="referenceSearchParameter">The search parameter that establishes the reference</param>
-        /// <param name="targetResourceType">The target resource type.</param>
+        /// <param name="targetResourceTypes">The target resource type.</param>
         /// <param name="reversed">If this is a reversed chained expression.</param>
         /// <param name="expression">The search expression.</param>
         public ChainedExpression(
-            string resourceType,
+            string[] resourceTypes,
             SearchParameterInfo referenceSearchParameter,
-            string targetResourceType,
+            string[] targetResourceTypes,
             bool reversed,
             Expression expression)
         {
-            EnsureArg.IsTrue(ModelInfoProvider.IsKnownResource(resourceType), nameof(resourceType));
+            EnsureArg.IsNotNull(resourceTypes, nameof(resourceTypes));
+            EnsureArg.IsTrue(resourceTypes.All(x => ModelInfoProvider.IsKnownResource(x)), nameof(resourceTypes));
             EnsureArg.IsNotNull(referenceSearchParameter, nameof(referenceSearchParameter));
-            EnsureArg.IsTrue(ModelInfoProvider.IsKnownResource(targetResourceType), nameof(targetResourceType));
+            EnsureArg.IsNotNull(targetResourceTypes, nameof(targetResourceTypes));
+            EnsureArg.IsTrue(targetResourceTypes.All(x => ModelInfoProvider.IsKnownResource(x)), nameof(targetResourceTypes));
             EnsureArg.IsNotNull(expression, nameof(expression));
 
-            ResourceType = resourceType;
+            ResourceTypes = resourceTypes;
             ReferenceSearchParameter = referenceSearchParameter;
-            TargetResourceType = targetResourceType;
+            TargetResourceTypes = targetResourceTypes;
             Reversed = reversed;
             Expression = expression;
         }
@@ -43,7 +46,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// <summary>
         /// Gets the resource type which is being searched.
         /// </summary>
-        public string ResourceType { get; }
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1819:Properties should not return arrays", Justification = "Array property")]
+        public string[] ResourceTypes { get; }
 
         /// <summary>
         /// Gets the parameter name.
@@ -53,7 +57,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// <summary>
         /// Gets the target resource type.
         /// </summary>
-        public string TargetResourceType { get; }
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1819:Properties should not return arrays", Justification = "Array property")]
+        public string[] TargetResourceTypes { get; }
 
         /// <summary>
         /// Get if the expression is reversed.
@@ -74,7 +79,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
 
         public override string ToString()
         {
-            return $"({(Reversed ? "Reverse " : string.Empty)}Chain {ReferenceSearchParameter.Name}:{TargetResourceType} {Expression})";
+            return $"({(Reversed ? "Reverse " : string.Empty)}Chain {ReferenceSearchParameter.Name}:{string.Join(", ", TargetResourceTypes)} {Expression})";
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Expression.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Expression.cs
@@ -58,21 +58,21 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// <summary>
         /// Creates a <see cref="ChainedExpression"/> that represents chained operation.
         /// </summary>
-        /// <param name="resourceType">The resource type.</param>
+        /// <param name="resourceTypes">The resource type.</param>
         /// <param name="referenceSearchParameter">The search parameter that establishes the reference between resources</param>
-        /// <param name="targetResourceType">The target resource type.</param>
+        /// <param name="targetResourceTypes">The target resource type.</param>
         /// <param name="reversed">If this is a reversed chained expression.</param>
         /// <param name="expression">The expression.</param>
         /// <returns>A <see cref="ChainedExpression"/> that represents chained operation on <paramref name="targetResourceType"/> through <paramref name="referenceSearchParameter"/>.</returns>
-        public static ChainedExpression Chained(string resourceType, SearchParameterInfo referenceSearchParameter, string targetResourceType, bool reversed, Expression expression)
+        public static ChainedExpression Chained(string[] resourceTypes, SearchParameterInfo referenceSearchParameter, string[] targetResourceTypes, bool reversed, Expression expression)
         {
-            return new ChainedExpression(resourceType, referenceSearchParameter, targetResourceType, reversed, expression);
+            return new ChainedExpression(resourceTypes, referenceSearchParameter, targetResourceTypes, reversed, expression);
         }
 
         /// <summary>
         /// Creates a <see cref="IncludeExpression"/> that represents an include operation.
         /// </summary>
-        /// <param name="resourceType">The resource that supports the reference.</param>
+        /// <param name="resourceTypes">The resource that supports the reference.</param>
         /// <param name="referenceSearchParameter">The search parameter that establishes the reference between resources</param>
         /// <param name="sourceResourceType">The source resource type (used in revinclude).</param>
         /// <param name="targetResourceType">The target resource type (used in include).</param>
@@ -81,9 +81,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// <param name="reversed">If this is a reversed include (revinclude) expression.</param>
         /// <param name="iterate">If this is include has :iterate (:recurse) modifier.</param>
         /// <returns>A <see cref="IncludeExpression"/> that represents an include on <param name="targetResourceType"> through <paramref name="referenceSearchParameter"/>.</param></returns>
-        public static IncludeExpression Include(string resourceType, SearchParameterInfo referenceSearchParameter, string sourceResourceType, string targetResourceType, IEnumerable<string> referencedTypes, bool wildCard, bool reversed, bool iterate)
+        public static IncludeExpression Include(string[] resourceTypes, SearchParameterInfo referenceSearchParameter, string sourceResourceType, string targetResourceType, IEnumerable<string> referencedTypes, bool wildCard, bool reversed, bool iterate)
         {
-            return new IncludeExpression(resourceType, referenceSearchParameter, sourceResourceType, targetResourceType, referencedTypes, wildCard, reversed, iterate);
+            return new IncludeExpression(resourceTypes, referenceSearchParameter, sourceResourceType, targetResourceType, referencedTypes, wildCard, reversed, iterate);
         }
 
         /// <summary>

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/ExpressionRewriter.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/ExpressionRewriter.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
                 return expression;
             }
 
-            return new ChainedExpression(resourceType: expression.ResourceType, referenceSearchParameter: expression.ReferenceSearchParameter, targetResourceType: expression.TargetResourceType, reversed: expression.Reversed, expression: visitedExpression);
+            return new ChainedExpression(resourceTypes: expression.ResourceTypes, referenceSearchParameter: expression.ReferenceSearchParameter, targetResourceTypes: expression.TargetResourceTypes, reversed: expression.Reversed, expression: visitedExpression);
         }
 
         public virtual Expression VisitMissingField(MissingFieldExpression expression, TContext context)

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/IncludeExpression.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/IncludeExpression.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// <summary>
         /// Initializes a new instance of the <see cref="IncludeExpression"/> class.
         /// </summary>
-        /// <param name="resourceType">The resource that supports the reference.</param>
+        /// <param name="resourceTypes">The resource that supports the reference.</param>
         /// <param name="referenceSearchParameter">THe search parameter that establishes the reference relationship.</param>
         /// <param name="sourceResourceType">The source type of the reference.</param>
         /// <param name="targetResourceType">The target type of the reference.</param>
@@ -29,9 +29,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// <param name="wildCard">If this is a wildcard reference include (include all referenced resources).</param>
         /// <param name="reversed">If this is a reversed include (revinclude) expression.</param>
         /// <param name="iterate"> If :iterate (:recurse) modifer was applied.</param>
-        public IncludeExpression(string resourceType, SearchParameterInfo referenceSearchParameter, string sourceResourceType, string targetResourceType, IEnumerable<string> referencedTypes, bool wildCard, bool reversed, bool iterate)
+        public IncludeExpression(string[] resourceTypes, SearchParameterInfo referenceSearchParameter, string sourceResourceType, string targetResourceType, IEnumerable<string> referencedTypes, bool wildCard, bool reversed, bool iterate)
         {
-            EnsureArg.IsNotNullOrWhiteSpace(resourceType, nameof(resourceType));
+            EnsureArg.IsNotNull(resourceTypes, nameof(resourceTypes));
 
             if (!wildCard)
             {
@@ -43,7 +43,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
                 EnsureArg.IsNotNull(sourceResourceType, nameof(sourceResourceType));
             }
 
-            ResourceType = resourceType;
+            ResourceTypes = resourceTypes;
             ReferenceSearchParameter = referenceSearchParameter;
             SourceResourceType = sourceResourceType;
             TargetResourceType = targetResourceType;
@@ -58,7 +58,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// <summary>
         /// Gets the resource type which is being searched.
         /// </summary>
-        public string ResourceType { get; }
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1819:Properties should not return arrays", Justification = "Array property")]
+        public string[] ResourceTypes { get; }
 
         /// <summary>
         /// Gets the reference search parameter for the relationship.

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/IncludeExpression.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/IncludeExpression.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// <param name="iterate"> If :iterate (:recurse) modifer was applied.</param>
         public IncludeExpression(string[] resourceTypes, SearchParameterInfo referenceSearchParameter, string sourceResourceType, string targetResourceType, IEnumerable<string> referencedTypes, bool wildCard, bool reversed, bool iterate)
         {
-            EnsureArg.IsNotNull(resourceTypes, nameof(resourceTypes));
+            EnsureArg.HasItems(resourceTypes, nameof(resourceTypes));
 
             if (!wildCard)
             {

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/ExpressionParser.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/ExpressionParser.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using EnsureThat;
 using Hl7.Fhir.Utility;
 using Microsoft.Health.Fhir.Core.Features.Definition;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.ValueSets;
 
@@ -53,19 +54,19 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
         /// <summary>
         /// Parses the input into a corresponding search expression.
         /// </summary>
-        /// <param name="resourceType">The resource type.</param>
+        /// <param name="resourceTypes">The resource type.</param>
         /// <param name="key">The query key.</param>
         /// <param name="value">The query value.</param>
         /// <returns>An instance of search expression representing the search.</returns>
-        public Expression Parse(string resourceType, string key, string value)
+        public Expression Parse(string[] resourceTypes, string key, string value)
         {
             EnsureArg.IsNotNullOrWhiteSpace(key, nameof(key));
             EnsureArg.IsNotNullOrWhiteSpace(value, nameof(value));
 
-            return ParseImpl(resourceType, key.AsSpan(), value);
+            return ParseImpl(resourceTypes, key.AsSpan(), value);
         }
 
-        public IncludeExpression ParseInclude(string resourceType, string includeValue, bool isReversed, bool iterate)
+        public IncludeExpression ParseInclude(string[] resourceTypes, string includeValue, bool isReversed, bool iterate)
         {
             var valueSpan = includeValue.AsSpan();
             if (!TrySplit(SearchSplitChar, ref valueSpan, out ReadOnlySpan<char> originalType))
@@ -73,7 +74,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
                 throw new InvalidSearchOperationException(isReversed ? Core.Resources.RevIncludeMissingType : Core.Resources.IncludeMissingType);
             }
 
-            if (resourceType.Equals(KnownResourceTypes.DomainResource, StringComparison.InvariantCultureIgnoreCase))
+            if (resourceTypes.Length == 1 && resourceTypes[0].Equals(KnownResourceTypes.DomainResource, StringComparison.InvariantCultureIgnoreCase))
             {
                 throw new InvalidSearchOperationException(Core.Resources.IncludeCannotBeAgainstBase);
             }
@@ -105,7 +106,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
             if (wildCard)
             {
                 referencedTypes = new List<string>();
-                var searchParameters = _searchParameterDefinitionManager.GetSearchParameters(resourceType)
+                var searchParameters = resourceTypes.SelectMany(t => _searchParameterDefinitionManager.GetSearchParameters(t))
                     .Where(p => p.Type == ValueSets.SearchParamType.Reference);
 
                 foreach (var p in searchParameters)
@@ -120,10 +121,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
                 }
             }
 
-            return new IncludeExpression(resourceType, refSearchParameter, originalType.ToString(), targetType, referencedTypes, wildCard, isReversed, iterate);
+            return new IncludeExpression(resourceTypes, refSearchParameter, originalType.ToString(), targetType, referencedTypes, wildCard, isReversed, iterate);
         }
 
-        private Expression ParseImpl(string resourceType, ReadOnlySpan<char> key, string value)
+        private Expression ParseImpl(string[] resourceTypes, ReadOnlySpan<char> key, string value)
         {
             if (TryConsume(ReverseChainParameter.AsSpan(), ref key))
             {
@@ -140,31 +141,37 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
                 string typeString = type.ToString();
                 SearchParameterInfo refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter(typeString, refParam.ToString());
 
-                return ParseChainedExpression(typeString, refSearchParameter, resourceType, key, value, true);
+                return ParseChainedExpression(new[] { typeString }, refSearchParameter, resourceTypes, key, value, true);
             }
 
             if (TrySplit(ChainParameter, ref key, out ReadOnlySpan<char> chainedInput))
             {
-                ReadOnlySpan<char> targetTypeName;
+                string[] targetType = Array.Empty<string>();
 
                 if (TrySplit(SearchSplitChar, ref chainedInput, out ReadOnlySpan<char> refParamName))
                 {
-                    targetTypeName = chainedInput;
+                    targetType = new[] { chainedInput.ToString() };
                 }
                 else
                 {
                     refParamName = chainedInput;
-                    targetTypeName = ReadOnlySpan<char>.Empty;
                 }
 
                 if (refParamName.IsEmpty)
                 {
-                    throw new SearchParameterNotSupportedException(resourceType, key.ToString());
+                    throw new SearchParameterNotSupportedException(resourceTypes[0], key.ToString());
                 }
 
-                SearchParameterInfo refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter(resourceType, refParamName.ToString());
+                SearchParameterInfo refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter(resourceTypes[0], refParamName.ToString());
+                foreach (var resourceType in resourceTypes)
+                {
+                    if (refSearchParameter != _searchParameterDefinitionManager.GetSearchParameter(resourceType, refParamName.ToString()))
+                    {
+                        throw new BadRequestException(string.Format(Core.Resources.SearchParameterMustBeCommon, refParamName.ToString(), resourceTypes[0], resourceType));
+                    }
+                }
 
-                return ParseChainedExpression(resourceType, refSearchParameter, targetTypeName.ToString(), key, value, false);
+                return ParseChainedExpression(resourceTypes, refSearchParameter, targetType, key, value, false);
             }
 
             ReadOnlySpan<char> modifier;
@@ -180,12 +187,19 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
             }
 
             // Check to see if the search parameter is supported for this type or not.
-            SearchParameterInfo searchParameter = _searchParameterDefinitionManager.GetSearchParameter(resourceType, paramName.ToString());
+            SearchParameterInfo searchParameter = _searchParameterDefinitionManager.GetSearchParameter(resourceTypes[0], paramName.ToString());
+            foreach (var resourceType in resourceTypes)
+            {
+                if (searchParameter != _searchParameterDefinitionManager.GetSearchParameter(resourceType, paramName.ToString()))
+                {
+                    throw new BadRequestException(string.Format(Core.Resources.SearchParameterMustBeCommon, paramName.ToString(), resourceTypes[0], resourceType));
+                }
+            }
 
             return ParseSearchValueExpression(searchParameter, modifier.ToString(), value);
         }
 
-        private Expression ParseChainedExpression(string resourceType, SearchParameterInfo searchParameter, string targetResourceType, ReadOnlySpan<char> remainingKey, string value, bool reversed)
+        private Expression ParseChainedExpression(string[] resourceTypes, SearchParameterInfo searchParameter, string[] targetResourceTypes, ReadOnlySpan<char> remainingKey, string value, bool reversed)
         {
             // We have more paths after this so this is a chained expression.
             // Since this is chained expression, the expression must be a reference type.
@@ -196,33 +210,36 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
             }
 
             // Check to see if the client has specifically specified the target resource type to scope to.
-            if (!string.IsNullOrEmpty(targetResourceType))
+            if (targetResourceTypes.Any())
             {
                 // A target resource type is specified.
-                if (!ModelInfoProvider.IsKnownResource(targetResourceType))
+                foreach (var targetResourceType in targetResourceTypes)
                 {
-                    throw new InvalidSearchOperationException(string.Format(Core.Resources.ResourceNotSupported, targetResourceType));
+                    if (!ModelInfoProvider.IsKnownResource(targetResourceType))
+                    {
+                        throw new InvalidSearchOperationException(string.Format(Core.Resources.ResourceNotSupported, targetResourceType));
+                    }
                 }
             }
 
+            var possibleTargetResourceTypes = targetResourceTypes.Any()
+                ? targetResourceTypes.Intersect(searchParameter.TargetResourceTypes)
+                : searchParameter.TargetResourceTypes;
+
             ChainedExpression chainedExpression = null;
 
-            foreach (var possibleTargetResourceType in searchParameter.TargetResourceTypes)
+            foreach (var possibleTargetResourceType in possibleTargetResourceTypes)
             {
-                if (!string.IsNullOrEmpty(targetResourceType) && targetResourceType != possibleTargetResourceType)
-                {
-                    continue;
-                }
-
-                var multipleChainType = reversed ? resourceType : possibleTargetResourceType;
+                var wrappedTargetResourceType = new[] { possibleTargetResourceType };
+                var multipleChainType = reversed ? resourceTypes : wrappedTargetResourceType;
 
                 ChainedExpression expression;
                 try
                 {
                     expression = Expression.Chained(
-                        resourceType,
+                        resourceTypes,
                         searchParameter,
-                        possibleTargetResourceType,
+                        wrappedTargetResourceType,
                         reversed,
                         ParseImpl(
                             multipleChainType,

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/IExpressionParser.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/IExpressionParser.cs
@@ -7,8 +7,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
 {
     public interface IExpressionParser
     {
-        Expression Parse(string resourceType, string key, string value);
+        Expression Parse(string[] resourceTypes, string key, string value);
 
-        IncludeExpression ParseInclude(string resourceType, string value, bool isReversed, bool iterate);
+        IncludeExpression ParseInclude(string[] resourceTypes, string value, bool isReversed, bool iterate);
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -935,6 +935,15 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Search parameter &apos;{0}&apos; is not common for &apos;{1}&apos; and &apos;{2}&apos;..
+        /// </summary>
+        internal static string SearchParameterMustBeCommon {
+            get {
+                return ResourceManager.GetString("SearchParameterMustBeCommon", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} So it cannot be marked enabled..
         /// </summary>
         internal static string SearchParameterNoLongerSupported {

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -503,4 +503,8 @@
   <data name="CustomSearchCreateError" xml:space="preserve">
     <value>An error occurred creating the custom search parameter.  The issue must be resolved and the parameter resubmitted to become functional.</value>
   </data>
+  <data name="SearchParameterMustBeCommon" xml:space="preserve">
+    <value>Search parameter '{0}' is not common for '{1}' and '{2}'.</value>
+    <comment>{0}: the invalid search parameter. {1}: first resource type. {2} other resource type.</comment>
+  </data>
 </root>

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/ExpressionRewriterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/ExpressionRewriterTests.cs
@@ -25,8 +25,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions
             var simpleExpression2 = Expression.Equals(FieldName.Number, null, 5M);
             VerifyVisit(simpleExpression1);
             VerifyVisit(Expression.SearchParameter(new SearchParameterInfo("my-param"), simpleExpression1));
-            VerifyVisit(Expression.Chained("Observation", new SearchParameterInfo("subject"), "Patient", false, simpleExpression1));
-            VerifyVisit(Expression.Chained("Patient", new SearchParameterInfo("subject"), "Observation", true, simpleExpression1));
+            VerifyVisit(Expression.Chained(new[] { "Observation" }, new SearchParameterInfo("subject"), new[] { "Patient" }, false, simpleExpression1));
+            VerifyVisit(Expression.Chained(new[] { "Patient" }, new SearchParameterInfo("subject"), new[] { "Observation" }, true, simpleExpression1));
             VerifyVisit(Expression.CompartmentSearch("Patient", "x"));
             VerifyVisit(Expression.Missing(FieldName.Quantity, null));
             VerifyVisit(Expression.MissingSearchParameter(new SearchParameterInfo("my-param"), true));
@@ -53,8 +53,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions
 
             VerifyVisit($"(Param my-param {expectedAndString1})", Expression.SearchParameter(new SearchParameterInfo("my-param"), simpleExpression1));
 
-            VerifyVisit($"(Chain subject:Patient {expectedAndString1})", Expression.Chained("Observation", new SearchParameterInfo("subject"), "Patient", false, simpleExpression1));
-            VerifyVisit($"(Reverse Chain subject:Observation {expectedAndString1})", Expression.Chained("Patient", new SearchParameterInfo("subject"), "Observation", true, simpleExpression1));
+            VerifyVisit($"(Chain subject:Patient {expectedAndString1})", Expression.Chained(new[] { "Observation" }, new SearchParameterInfo("subject"), new[] { "Patient" }, false, simpleExpression1));
+            VerifyVisit($"(Reverse Chain subject:Observation {expectedAndString1})", Expression.Chained(new[] { "Patient" }, new SearchParameterInfo("subject"), new[] { "Observation" }, true, simpleExpression1));
             VerifyVisit($"(Or {expectedAndString1} {expectedAndString2})", Expression.Or(simpleExpression1, simpleExpression2));
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/ExpressionToStringTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/ExpressionToStringTests.cs
@@ -35,9 +35,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions
 
             VerifyExpression("(Compartment Patient 'x')", Expression.CompartmentSearch("Patient", "x"));
 
-            VerifyExpression("(Chain subject:Patient (FieldGreaterThan DateTimeEnd 2000-01-01T00:00:00.0000000))", Expression.Chained("Observation", new SearchParameterInfo("subject"), "Patient", false, Expression.GreaterThan(FieldName.DateTimeEnd, null, new DateTime(2000, 1, 1))));
+            VerifyExpression("(Chain subject:Patient (FieldGreaterThan DateTimeEnd 2000-01-01T00:00:00.0000000))", Expression.Chained(new[] { "Observation" }, new SearchParameterInfo("subject"), new[] { "Patient" }, false, Expression.GreaterThan(FieldName.DateTimeEnd, null, new DateTime(2000, 1, 1))));
 
-            VerifyExpression("(Reverse Chain subject:Observation (FieldGreaterThan DateTimeEnd 2000-01-01T00:00:00.0000000))", Expression.Chained("Patient", new SearchParameterInfo("subject"), "Observation", true, Expression.GreaterThan(FieldName.DateTimeEnd, null, new DateTime(2000, 1, 1))));
+            VerifyExpression("(Reverse Chain subject:Observation (FieldGreaterThan DateTimeEnd 2000-01-01T00:00:00.0000000))", Expression.Chained(new[] { "Patient" }, new SearchParameterInfo("subject"), new[] { "Observation" }, true, Expression.GreaterThan(FieldName.DateTimeEnd, null, new DateTime(2000, 1, 1))));
         }
 
         private static void VerifyExpression(string expected, Expression expression)

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/Parsers/ExpressionParserTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/Parsers/ExpressionParserTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
             Expression expectedExpression = SetupExpression(searchParameter, value);
 
             // Parse the expression.
-            Expression expression = _expressionParser.Parse(sourceResourceType.ToString(), key, value);
+            Expression expression = _expressionParser.Parse(new[] { sourceResourceType.ToString() }, key, value);
 
             ValidateChainedExpression(
                 expression,
@@ -82,7 +82,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
             SetupReferenceSearchParameter(sourceResourceType, param1, targetResourceTypes);
 
             // Parse the expression.
-            Assert.Throws<InvalidSearchOperationException>(() => _expressionParser.Parse(sourceResourceType.ToString(), key, value));
+            Assert.Throws<InvalidSearchOperationException>(() => _expressionParser.Parse(new[] { sourceResourceType.ToString() }, key, value));
         }
 
         [Fact]
@@ -112,7 +112,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
                 .ToArray();
 
             // Parse the expression.
-            Expression expression = _expressionParser.Parse(sourceResourceType.ToString(), key, value);
+            Expression expression = _expressionParser.Parse(new[] { sourceResourceType.ToString() }, key, value);
 
             ValidateChainedExpression(
                 expression,
@@ -150,7 +150,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
             Expression expectedExpression = SetupExpression(searchParameter, value);
 
             // Parse the expression.
-            Expression expression = _expressionParser.Parse(sourceResourceType.ToString(), key, value);
+            Expression expression = _expressionParser.Parse(new[] { sourceResourceType.ToString() }, key, value);
 
             ValidateChainedExpression(
                 expression,
@@ -183,7 +183,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
             Expression expectedExpression = SetupExpression(searchParameter, value);
 
             // Parse the expression.
-            Expression expression = _expressionParser.Parse(sourceResourceType.ToString(), key, value);
+            Expression expression = _expressionParser.Parse(new[] { sourceResourceType.ToString() }, key, value);
 
             ValidateChainedExpression(
                 expression,
@@ -217,7 +217,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
             _searchParameterExpressionParser.Parse(searchParameter, SearchModifierCode.Missing, value).Returns(expression);
 
             // Parse the expression.
-            Expression actualExpression = _expressionParser.Parse(resourceType.ToString(), key, value);
+            Expression actualExpression = _expressionParser.Parse(new[] { resourceType.ToString() }, key, value);
 
             // The mock requires the modifier to match so if we get the same expression instance
             // then it means we got the modifier correctly.
@@ -238,7 +238,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
             SetupSearchParameter(sourceResourceType, param1);
 
             // Parse the expression.
-            Assert.Throws<InvalidSearchOperationException>(() => _expressionParser.Parse(sourceResourceType.ToString(), key, value));
+            Assert.Throws<InvalidSearchOperationException>(() => _expressionParser.Parse(new[] { sourceResourceType.ToString() }, key, value));
         }
 
         [Fact]
@@ -255,7 +255,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
             SetupReferenceSearchParameter(sourceResourceType, param1, targetResourceType);
 
             // Parse the expression.
-            Assert.Throws<InvalidSearchOperationException>(() => _expressionParser.Parse(sourceResourceType.ToString(), key, "Error"));
+            Assert.Throws<InvalidSearchOperationException>(() => _expressionParser.Parse(new[] { sourceResourceType.ToString() }, key, "Error"));
         }
 
         [Fact]
@@ -273,7 +273,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
             SetupReferenceSearchParameter(sourceResourceType, param1, targetResourceType);
 
             // Parse the expression.
-            Assert.Throws<InvalidSearchOperationException>(() => _expressionParser.Parse(sourceResourceType.ToString(), key, "Error"));
+            Assert.Throws<InvalidSearchOperationException>(() => _expressionParser.Parse(new[] { sourceResourceType.ToString() }, key, "Error"));
         }
 
         [Fact]
@@ -284,7 +284,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
             SetupSearchParameter(resourceType, "param1");
 
             // Parse the expression.
-            Assert.Throws<InvalidSearchOperationException>(() => _expressionParser.Parse(resourceType.ToString(), "param1:param2:param3", "Error"));
+            Assert.Throws<InvalidSearchOperationException>(() => _expressionParser.Parse(new[] { resourceType.ToString() }, "param1:param2:param3", "Error"));
         }
 
         [Fact]
@@ -293,7 +293,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
             ResourceType resourceType = ResourceType.Location;
             string invalidParameterName = "...";
 
-            Assert.Throws<SearchParameterNotSupportedException>(() => _expressionParser.Parse(resourceType.ToString(), invalidParameterName, "value"));
+            Assert.Throws<SearchParameterNotSupportedException>(() => _expressionParser.Parse(new[] { resourceType.ToString() }, invalidParameterName, "value"));
         }
 
         private SearchParameterInfo SetupSearchParameter(ResourceType resourceType, string paramName)

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchExpressionTestHelper.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchExpressionTestHelper.cs
@@ -36,9 +36,25 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         {
             ChainedExpression chainedExpression = Assert.IsType<ChainedExpression>(expression);
 
-            Assert.Equal(resourceType.ToString(), chainedExpression.ResourceType);
+            Assert.Collection(chainedExpression.ResourceTypes, x => Assert.Equal(resourceType.ToString(), x));
             Assert.Equal(referenceSearchParam, chainedExpression.ReferenceSearchParameter);
-            Assert.Equal(targetResourceType, chainedExpression.TargetResourceType);
+            Assert.Collection(chainedExpression.TargetResourceTypes, x => Assert.Equal(targetResourceType, x));
+
+            childExpressionValidator(chainedExpression.Expression);
+        }
+
+        public static void ValidateChainedExpression(
+            Expression expression,
+            Hl7.Fhir.Model.ResourceType resourceType,
+            SearchParameterInfo referenceSearchParam,
+            string[] targetResourceTypes,
+            Action<Expression> childExpressionValidator)
+        {
+            ChainedExpression chainedExpression = Assert.IsType<ChainedExpression>(expression);
+
+            Assert.Collection(chainedExpression.ResourceTypes, x => Assert.Equal(resourceType.ToString(), x));
+            Assert.Equal(referenceSearchParam, chainedExpression.ReferenceSearchParameter);
+            Assert.Collection(chainedExpression.TargetResourceTypes, targetResourceTypes.Select<string, Action<string>>(t => x => Assert.Equal(t, x)).ToArray());
 
             childExpressionValidator(chainedExpression.Expression);
         }
@@ -52,9 +68,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         {
             ChainedExpression chainedExpression = Assert.IsType<ChainedExpression>(expression);
 
-            Assert.Equal(resourceType.ToString(), chainedExpression.ResourceType);
+            Assert.Collection(chainedExpression.ResourceTypes, x => Assert.Equal(resourceType.ToString(), x));
             Assert.Equal(referenceSearchParam, chainedExpression.ReferenceSearchParameter);
-            Assert.Equal(targetResourceType.ToString(), chainedExpression.TargetResourceType.ToString());
+            Assert.Collection(chainedExpression.TargetResourceTypes, x => Assert.Equal(targetResourceType.ToString(), x));
 
             childExpressionValidator(chainedExpression.Expression);
         }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchOptionsFactoryTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchOptionsFactoryTests.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             const string paramName1 = "address-city";
             const string value1 = "Seattle";
 
-            _expressionParser.Parse(resourceType.ToString(), paramName1, value1).Returns(
+            _expressionParser.Parse(Arg.Is<string[]>(x => x.Length == 1 && x[0] == resourceType.ToString()), paramName1, value1).Returns(
                 x => throw new SearchParameterNotSupportedException(typeof(Patient), paramName1));
 
             var queryParameters = new[]

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -216,27 +216,49 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
 
             // If the resource type is not specified, then the common
             // search parameters should be used.
-            ResourceType parsedResourceType = ResourceType.DomainResource;
-
-            if (!string.IsNullOrWhiteSpace(resourceType) &&
-                !Enum.TryParse(resourceType, out parsedResourceType))
-            {
-                throw new ResourceNotSupportedException(resourceType);
-            }
+            ResourceType[] parsedResourceTypes = new[] { ResourceType.DomainResource };
 
             var searchExpressions = new List<Expression>();
-
-            if (!string.IsNullOrWhiteSpace(resourceType))
+            if (string.IsNullOrWhiteSpace(resourceType))
             {
+                var resourceTypes = searchParams.Parameters
+                    .Where(q => q.Item1 == KnownQueryParameterNames.Type)
+                    .SelectMany(q => q.Item2.SplitByOrSeparator())
+                    .Where(type => ModelInfoProvider.IsKnownResource(type))
+                    .Select(x =>
+                    {
+                        if (!Enum.TryParse(x, out ResourceType parsedType))
+                        {
+                            // Should never get here
+                            throw new ResourceNotSupportedException(x);
+                        }
+
+                        return parsedType;
+                    })
+                    .Distinct();
+
+                if (resourceTypes.Any())
+                {
+                    parsedResourceTypes = resourceTypes.ToArray();
+                }
+            }
+            else
+            {
+                if (!Enum.TryParse(resourceType, out parsedResourceTypes[0]))
+                {
+                    throw new ResourceNotSupportedException(resourceType);
+                }
+
                 searchExpressions.Add(Expression.SearchParameter(_resourceTypeSearchParameter, Expression.StringEquals(FieldName.TokenCode, null, resourceType, false)));
             }
 
+            var resourceTypesString = parsedResourceTypes.Select(x => x.ToString()).ToArray();
             searchExpressions.AddRange(searchParams.Parameters.Select(
                     q =>
                     {
                         try
                         {
-                            return _expressionParser.Parse(parsedResourceType.ToString(), q.Item1, q.Item2);
+                            return _expressionParser.Parse(resourceTypesString, q.Item1, q.Item2);
                         }
                         catch (SearchParameterNotSupportedException)
                         {
@@ -250,14 +272,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             if (searchParams.Include?.Count > 0)
             {
                 searchExpressions.AddRange(searchParams.Include.Select(
-                    q => _expressionParser.ParseInclude(parsedResourceType.ToString(), q, false /* not reversed */, false /* no iterate */))
+                    q => _expressionParser.ParseInclude(resourceTypesString, q, false /* not reversed */, false /* no iterate */))
                     .Where(item => item != null));
             }
 
             if (searchParams.RevInclude?.Count > 0)
             {
                 searchExpressions.AddRange(searchParams.RevInclude.Select(
-                    q => _expressionParser.ParseInclude(parsedResourceType.ToString(), q, true /* reversed */, false /* no iterate */))
+                    q => _expressionParser.ParseInclude(resourceTypesString, q, true /* reversed */, false /* no iterate */))
                     .Where(item => item != null));
             }
 
@@ -314,7 +336,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                 {
                     try
                     {
-                        SearchParameterInfo searchParameterInfo = _searchParameterDefinitionManager.GetSearchParameter(parsedResourceType.ToString(), sorting.Item1);
+                        SearchParameterInfo searchParameterInfo = resourceTypesString.Select(t => _searchParameterDefinitionManager.GetSearchParameter(t, sorting.Item1)).Distinct().First();
                         sortings.Add((searchParameterInfo, sorting.Item2.ToCoreSortOrder()));
                     }
                     catch (SearchParameterNotSupportedException)
@@ -323,7 +345,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                         _contextAccessor.FhirRequestContext.BundleIssues.Add(new OperationOutcomeIssue(
                             OperationOutcomeConstants.IssueSeverity.Warning,
                             OperationOutcomeConstants.IssueType.NotSupported,
-                            string.Format(CultureInfo.InvariantCulture, Core.Resources.SearchParameterNotSupported, sorting.Item1, parsedResourceType.ToString())));
+                            string.Format(CultureInfo.InvariantCulture, Core.Resources.SearchParameterNotSupported, sorting.Item1, string.Join(", ", resourceTypesString))));
                     }
                 }
 
@@ -374,7 +396,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                     }
 
                     var reversed = RevIncludeIterateModifiers.Contains(p.Item1);
-                    var expression = _expressionParser.ParseInclude(includeResourceType, p.Item2, reversed, true);
+                    var expression = _expressionParser.ParseInclude(new[] { includeResourceType }, p.Item2, reversed, true);
 
                     // Reversed Iterate expressions (not wildcard) must specify target type if there is more than one possible target type
                     if (expression.Reversed && expression.Iterate && expression.TargetResourceType == null && expression.ReferenceSearchParameter?.TargetResourceTypes?.Count > 1)

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/IncludeRewriterTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/IncludeRewriterTests.cs
@@ -76,10 +76,10 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             // [base]/MedicationDispense?_include=MedicationDispense:prescription&_include=MedicationDispense:patient&_id=smart-MedicationDispense-567
 
             var refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationDispense", "prescription");
-            var includeMedicationDispensePrescription = new IncludeExpression("MedicationDispense", refSearchParameter, "MedicationDispense", null, null, false, false, false);
+            var includeMedicationDispensePrescription = new IncludeExpression(new[] { "MedicationDispense" }, refSearchParameter, "MedicationDispense", null, null, false, false, false);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationDispense", "patient");
-            var includeMedicationDispensePatient = new IncludeExpression("MedicationDispense", refSearchParameter, "MedicationDispense", null, null, false, false, false);
+            var includeMedicationDispensePatient = new IncludeExpression(new[] { "MedicationDispense" }, refSearchParameter, "MedicationDispense", null, null, false, false, false);
 
             Expression denormalizedExpression = Expression.And(new List<Expression>
                 {
@@ -108,14 +108,14 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[2].Kind);
             var includeExpression = (IncludeExpression)orderedExpressions[2].NormalizedPredicate;
-            Assert.Equal("MedicationDispense", includeExpression.ResourceType);
+            Assert.Equal("MedicationDispense", includeExpression.ResourceTypes[0]);
             Assert.Equal("prescription", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[3].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[4].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[4].NormalizedPredicate;
-            Assert.Equal("MedicationDispense", includeExpression.ResourceType);
+            Assert.Equal("MedicationDispense", includeExpression.ResourceTypes[0]);
             Assert.Equal("patient", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[5].Kind);
@@ -130,10 +130,10 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             // [base]/MedicationDispense?_include:iterate=Patient:general-practitioner&_include=MedicationRequest:patient&_id=12345
 
             var refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("Patient", "general-practitioner");
-            var includeIteratePatientGeneralPractitioner = new IncludeExpression("Patient", refSearchParameter, "Patient", null, null, false, false, true);
+            var includeIteratePatientGeneralPractitioner = new IncludeExpression(new[] { "Patient" }, refSearchParameter, "Patient", null, null, false, false, true);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationDispense", "patient");
-            var includeMedicationDispensePatient = new IncludeExpression("MedicationDispense", refSearchParameter, "MedicationDispense", null, null, false, false, false);
+            var includeMedicationDispensePatient = new IncludeExpression(new[] { "MedicationDispense" }, refSearchParameter, "MedicationDispense", null, null, false, false, false);
 
             Expression denormalizedExpression = Expression.And(new List<Expression>
                 {
@@ -162,14 +162,14 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[2].Kind);
             var includeExpression = (IncludeExpression)orderedExpressions[2].NormalizedPredicate;
-            Assert.Equal("MedicationDispense", includeExpression.ResourceType);
+            Assert.Equal("MedicationDispense", includeExpression.ResourceTypes[0]);
             Assert.Equal("patient", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[3].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[4].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[4].NormalizedPredicate;
-            Assert.Equal("Patient", includeExpression.ResourceType);
+            Assert.Equal("Patient", includeExpression.ResourceTypes[0]);
             Assert.Equal("general-practitioner", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[5].Kind);
@@ -184,10 +184,10 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             // [base]/MedicationRequest?_include=MedicationRequest:patient&_revinclude=MedicationDispense:prescription&_id=12345
 
             var refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationRequest", "patient");
-            var includeMedicationRequestPatient = new IncludeExpression("MedicationRequest", refSearchParameter, "MedicationRequest", null, null, false, false, false);
+            var includeMedicationRequestPatient = new IncludeExpression(new[] { "MedicationRequest" }, refSearchParameter, "MedicationRequest", null, null, false, false, false);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationDispense", "prescription");
-            var revincludeMedicationDispensePrescription = new IncludeExpression("MedicationDispense", refSearchParameter, "MedicationDispense", null, null, false, true, false);
+            var revincludeMedicationDispensePrescription = new IncludeExpression(new[] { "MedicationDispense" }, refSearchParameter, "MedicationDispense", null, null, false, true, false);
 
             Expression denormalizedExpression = Expression.And(new List<Expression>
                 {
@@ -216,14 +216,14 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[2].Kind);
             var includeExpression = (IncludeExpression)orderedExpressions[2].NormalizedPredicate;
-            Assert.Equal("MedicationRequest", includeExpression.ResourceType);
+            Assert.Equal("MedicationRequest", includeExpression.ResourceTypes[0]);
             Assert.Equal("patient", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[3].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[4].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[4].NormalizedPredicate;
-            Assert.Equal("MedicationDispense", includeExpression.ResourceType);
+            Assert.Equal("MedicationDispense", includeExpression.ResourceTypes[0]);
             Assert.Equal("prescription", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[5].Kind);
@@ -238,10 +238,10 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             // [base]/MedicationRequest?_revinclude:iterate=MedicationDispense:patient&_include=MedicationRequest:patient&_id=12345
 
             var refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationDispense", "patient");
-            var revincludeIterateMedicationDispensePatient = new IncludeExpression("MedicationDispense", refSearchParameter, "MedicationDispense", null, null, false, true, true);
+            var revincludeIterateMedicationDispensePatient = new IncludeExpression(new[] { "MedicationDispense" }, refSearchParameter, "MedicationDispense", null, null, false, true, true);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationRequest", "patient");
-            var includeMedicationRequestPatient = new IncludeExpression("MedicationRequest", refSearchParameter, "MedicationRequest", null, null, false, false, false);
+            var includeMedicationRequestPatient = new IncludeExpression(new[] { "MedicationRequest" }, refSearchParameter, "MedicationRequest", null, null, false, false, false);
 
             Expression denormalizedExpression = Expression.And(new List<Expression>
                 {
@@ -270,14 +270,14 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[2].Kind);
             var includeExpression = (IncludeExpression)orderedExpressions[2].NormalizedPredicate;
-            Assert.Equal("MedicationRequest", includeExpression.ResourceType);
+            Assert.Equal("MedicationRequest", includeExpression.ResourceTypes[0]);
             Assert.Equal("patient", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[3].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[4].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[4].NormalizedPredicate;
-            Assert.Equal("MedicationDispense", includeExpression.ResourceType);
+            Assert.Equal("MedicationDispense", includeExpression.ResourceTypes[0]);
             Assert.Equal("patient", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[5].Kind);
@@ -292,10 +292,10 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             // [base]/Patient?_revinclude=MedicationDispense:patient&_revinclude=MedicationRequest:patient&_id=patientId
 
             var refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationDispense", "patient");
-            var revincludeMedicationDispensePatient = new IncludeExpression("MedicationDispense", refSearchParameter, "MedicationDispense", null, null, false, true, false);
+            var revincludeMedicationDispensePatient = new IncludeExpression(new[] { "MedicationDispense" }, refSearchParameter, "MedicationDispense", null, null, false, true, false);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationRequest", "patient");
-            var revincludeMedicationRequestPatient = new IncludeExpression("MedicationRequest", refSearchParameter, "MedicationRequest", null, null, false, true, false);
+            var revincludeMedicationRequestPatient = new IncludeExpression(new[] { "MedicationRequest" }, refSearchParameter, "MedicationRequest", null, null, false, true, false);
 
             Expression denormalizedExpression = Expression.And(new List<Expression>
                 {
@@ -324,14 +324,14 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[2].Kind);
             var includeExpression = (IncludeExpression)orderedExpressions[2].NormalizedPredicate;
-            Assert.Equal("MedicationDispense", includeExpression.ResourceType);
+            Assert.Equal("MedicationDispense", includeExpression.ResourceTypes[0]);
             Assert.Equal("patient", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[3].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[4].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[4].NormalizedPredicate;
-            Assert.Equal("MedicationRequest", includeExpression.ResourceType);
+            Assert.Equal("MedicationRequest", includeExpression.ResourceTypes[0]);
             Assert.Equal("patient", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[5].Kind);
@@ -346,10 +346,10 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             // [base]/MedicationDispense?_include=MedicationDispense:prescription&_include=MedicationDispense:subject:Patient&_id=smart-MedicationDispense-567
 
             var refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationDispense", "prescription");
-            var includeMedicationDispensePrescription = new IncludeExpression("MedicationDispense", refSearchParameter, "MedicationDispense", null, null, false, false, false);
+            var includeMedicationDispensePrescription = new IncludeExpression(new[] { "MedicationDispense" }, refSearchParameter, "MedicationDispense", null, null, false, false, false);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationDispense", "subject");
-            var includeMedicationDispensePatient = new IncludeExpression("MedicationDispense", refSearchParameter, "MedicationDispense", "Patient", null, false, false, false);
+            var includeMedicationDispensePatient = new IncludeExpression(new[] { "MedicationDispense" }, refSearchParameter, "MedicationDispense", "Patient", null, false, false, false);
 
             Expression denormalizedExpression = Expression.And(new List<Expression>
                 {
@@ -378,14 +378,14 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[2].Kind);
             var includeExpression = (IncludeExpression)orderedExpressions[2].NormalizedPredicate;
-            Assert.Equal("MedicationDispense", includeExpression.ResourceType);
+            Assert.Equal("MedicationDispense", includeExpression.ResourceTypes[0]);
             Assert.Equal("prescription", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[3].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[4].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[4].NormalizedPredicate;
-            Assert.Equal("MedicationDispense", includeExpression.ResourceType);
+            Assert.Equal("MedicationDispense", includeExpression.ResourceTypes[0]);
             Assert.Equal("subject", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[5].Kind);
@@ -400,10 +400,10 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             // [base]/MedicationDispense?_include:iterate=Patient:general-practitioner:Practitioner&_include=MedicationRequest:patient&_id=12345
 
             var refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("Patient", "general-practitioner");
-            var includeIteratePatientGeneralPractitioner = new IncludeExpression("Patient", refSearchParameter, "Patient", "Practitioner", null, false, false, true);
+            var includeIteratePatientGeneralPractitioner = new IncludeExpression(new[] { "Patient" }, refSearchParameter, "Patient", "Practitioner", null, false, false, true);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationDispense", "patient");
-            var includeMedicationDispensePatient = new IncludeExpression("MedicationDispense", refSearchParameter, "MedicationDispense", null, null, false, false, false);
+            var includeMedicationDispensePatient = new IncludeExpression(new[] { "MedicationDispense" }, refSearchParameter, "MedicationDispense", null, null, false, false, false);
 
             Expression denormalizedExpression = Expression.And(new List<Expression>
                 {
@@ -432,14 +432,14 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[2].Kind);
             var includeExpression = (IncludeExpression)orderedExpressions[2].NormalizedPredicate;
-            Assert.Equal("MedicationDispense", includeExpression.ResourceType);
+            Assert.Equal("MedicationDispense", includeExpression.ResourceTypes[0]);
             Assert.Equal("patient", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[3].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[4].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[4].NormalizedPredicate;
-            Assert.Equal("Patient", includeExpression.ResourceType);
+            Assert.Equal("Patient", includeExpression.ResourceTypes[0]);
             Assert.Equal("general-practitioner", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[5].Kind);
@@ -454,10 +454,10 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             // [base]/MedicationRequest?_include=MedicationRequest:patient&_revinclude=MedicationDispense:prescription:MedicationRequest&_id=12345
 
             var refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationRequest", "patient");
-            var includeMedicationRequestPatient = new IncludeExpression("MedicationRequest", refSearchParameter, "MedicationRequest", null, null, false, false, false);
+            var includeMedicationRequestPatient = new IncludeExpression(new[] { "MedicationRequest" }, refSearchParameter, "MedicationRequest", null, null, false, false, false);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationDispense", "prescription");
-            var revincludeMedicationDispensePrescription = new IncludeExpression("MedicationDispense", refSearchParameter, "MedicationDispense", "MedicationRequest", null, false, true, false);
+            var revincludeMedicationDispensePrescription = new IncludeExpression(new[] { "MedicationDispense" }, refSearchParameter, "MedicationDispense", "MedicationRequest", null, false, true, false);
 
             Expression denormalizedExpression = Expression.And(new List<Expression>
                 {
@@ -486,14 +486,14 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[2].Kind);
             var includeExpression = (IncludeExpression)orderedExpressions[2].NormalizedPredicate;
-            Assert.Equal("MedicationRequest", includeExpression.ResourceType);
+            Assert.Equal("MedicationRequest", includeExpression.ResourceTypes[0]);
             Assert.Equal("patient", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[3].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[4].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[4].NormalizedPredicate;
-            Assert.Equal("MedicationDispense", includeExpression.ResourceType);
+            Assert.Equal("MedicationDispense", includeExpression.ResourceTypes[0]);
             Assert.Equal("prescription", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[5].Kind);
@@ -508,10 +508,10 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             // [base]/MedicationRequest?_revinclude:iterate=MedicationDispense:patient&_include=MedicationRequest:subject:Patient&_id=12345
 
             var refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationDispense", "patient");
-            var revincludeIterateMedicationDispensePatient = new IncludeExpression("MedicationDispense", refSearchParameter, "MedicationDispense", null, null, false, true, true);
+            var revincludeIterateMedicationDispensePatient = new IncludeExpression(new[] { "MedicationDispense" }, refSearchParameter, "MedicationDispense", null, null, false, true, true);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationRequest", "subject");
-            var includeMedicationRequestPatient = new IncludeExpression("MedicationRequest", refSearchParameter, "MedicationRequest", "Patient", null, false, false, false);
+            var includeMedicationRequestPatient = new IncludeExpression(new[] { "MedicationRequest" }, refSearchParameter, "MedicationRequest", "Patient", null, false, false, false);
 
             Expression denormalizedExpression = Expression.And(new List<Expression>
                 {
@@ -540,14 +540,14 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[2].Kind);
             var includeExpression = (IncludeExpression)orderedExpressions[2].NormalizedPredicate;
-            Assert.Equal("MedicationRequest", includeExpression.ResourceType);
+            Assert.Equal("MedicationRequest", includeExpression.ResourceTypes[0]);
             Assert.Equal("subject", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[3].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[4].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[4].NormalizedPredicate;
-            Assert.Equal("MedicationDispense", includeExpression.ResourceType);
+            Assert.Equal("MedicationDispense", includeExpression.ResourceTypes[0]);
             Assert.Equal("patient", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[5].Kind);
@@ -562,10 +562,10 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             // [base]/Patient?_revinclude=MedicationDispense:subject:Patient&_revinclude=MedicationRequest:patient&_id=patientId
 
             var refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationDispense", "subject");
-            var revincludeMedicationDispensePatient = new IncludeExpression("MedicationDispense", refSearchParameter, "MedicationDispense", "Patient", null, false, true, false);
+            var revincludeMedicationDispensePatient = new IncludeExpression(new[] { "MedicationDispense" }, refSearchParameter, "MedicationDispense", "Patient", null, false, true, false);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationRequest", "patient");
-            var revincludeMedicationRequestPatient = new IncludeExpression("MedicationRequest", refSearchParameter, "MedicationRequest", null, null, false, true, false);
+            var revincludeMedicationRequestPatient = new IncludeExpression(new[] { "MedicationRequest" }, refSearchParameter, "MedicationRequest", null, null, false, true, false);
 
             Expression denormalizedExpression = Expression.And(new List<Expression>
                 {
@@ -594,14 +594,14 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[2].Kind);
             var includeExpression = (IncludeExpression)orderedExpressions[2].NormalizedPredicate;
-            Assert.Equal("MedicationDispense", includeExpression.ResourceType);
+            Assert.Equal("MedicationDispense", includeExpression.ResourceTypes[0]);
             Assert.Equal("subject", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[3].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[4].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[4].NormalizedPredicate;
-            Assert.Equal("MedicationRequest", includeExpression.ResourceType);
+            Assert.Equal("MedicationRequest", includeExpression.ResourceTypes[0]);
             Assert.Equal("patient", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[5].Kind);
@@ -616,10 +616,10 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             // [base]/Practitioner?_revinclude:iterate=MedicationRequest:patient&_revinclude=Patient:general-practitioner&_id=12345
 
             var refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationRequest", "patient");
-            var revincludeIterateMedicationRequestPatient = new IncludeExpression("MedicationRequest", refSearchParameter, "MedicationRequest", null, null, false, true, true);
+            var revincludeIterateMedicationRequestPatient = new IncludeExpression(new[] { "MedicationRequest" }, refSearchParameter, "MedicationRequest", null, null, false, true, true);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("Patient", "general-practitioner");
-            var revincludePatientGeneralPractitioner = new IncludeExpression("Patient", refSearchParameter, "Patient", null, null, false, true, false);
+            var revincludePatientGeneralPractitioner = new IncludeExpression(new[] { "Patient" }, refSearchParameter, "Patient", null, null, false, true, false);
 
             Expression denormalizedExpression = Expression.And(new List<Expression>
                 {
@@ -648,14 +648,14 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[2].Kind);
             var includeExpression = (IncludeExpression)orderedExpressions[2].NormalizedPredicate;
-            Assert.Equal("Patient", includeExpression.ResourceType);
+            Assert.Equal("Patient", includeExpression.ResourceTypes[0]);
             Assert.Equal("general-practitioner", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[3].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[4].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[4].NormalizedPredicate;
-            Assert.Equal("MedicationRequest", includeExpression.ResourceType);
+            Assert.Equal("MedicationRequest", includeExpression.ResourceTypes[0]);
             Assert.Equal("patient", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[5].Kind);
@@ -670,10 +670,10 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             // [base]/MedicationRequest?_include:iterate=MedicationDispense:patient&_revinclude=MedicationDispense:prescription&_id=12345
 
             var refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationDispense", "patient");
-            var includeIterateMedicationDispensePatient = new IncludeExpression("MedicationDispense", refSearchParameter, "MedicationDispense", null, null, false, false, true);
+            var includeIterateMedicationDispensePatient = new IncludeExpression(new[] { "MedicationDispense" }, refSearchParameter, "MedicationDispense", null, null, false, false, true);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationDispense", "prescription");
-            var revincludeMedicationDispensePrescription = new IncludeExpression("MedicationDispense", refSearchParameter, "MedicationDispense", null, null, false, true, false);
+            var revincludeMedicationDispensePrescription = new IncludeExpression(new[] { "MedicationDispense" }, refSearchParameter, "MedicationDispense", null, null, false, true, false);
 
             Expression denormalizedExpression = Expression.And(new List<Expression>
                 {
@@ -702,14 +702,14 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[2].Kind);
             var includeExpression = (IncludeExpression)orderedExpressions[2].NormalizedPredicate;
-            Assert.Equal("MedicationDispense", includeExpression.ResourceType);
+            Assert.Equal("MedicationDispense", includeExpression.ResourceTypes[0]);
             Assert.Equal("prescription", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[3].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[4].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[4].NormalizedPredicate;
-            Assert.Equal("MedicationDispense", includeExpression.ResourceType);
+            Assert.Equal("MedicationDispense", includeExpression.ResourceTypes[0]);
             Assert.Equal("patient", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[5].Kind);
@@ -727,13 +727,13 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             // [base]/MedicationDispense?_include=MedicationDispense:prescription&_include:iterate=MedicationRequest:patient&_include:iterate=Patient:general-practitioner&_id=12345
 
             var refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationDispense", "prescription");
-            var includeMedicationDispensePrescription = new IncludeExpression("MedicationDispense", refSearchParameter, "MedicationDispense", null, null, false, false, false);
+            var includeMedicationDispensePrescription = new IncludeExpression(new[] { "MedicationDispense" }, refSearchParameter, "MedicationDispense", null, null, false, false, false);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationRequest", "patient");
-            var includeIterateMedicationRequestPatient = new IncludeExpression("MedicationRequest", refSearchParameter, "MedicationRequest", null, null, false, false, true);
+            var includeIterateMedicationRequestPatient = new IncludeExpression(new[] { "MedicationRequest" }, refSearchParameter, "MedicationRequest", null, null, false, false, true);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("Patient", "general-practitioner");
-            var includeIteratePatientGeneralPractitioner = new IncludeExpression("Patient", refSearchParameter, "Patient", null, null, false, false, true);
+            var includeIteratePatientGeneralPractitioner = new IncludeExpression(new[] { "Patient" }, refSearchParameter, "Patient", null, null, false, false, true);
 
             Expression denormalizedExpression = Expression.And(new List<Expression>
                 {
@@ -763,21 +763,21 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[2].Kind);
             var includeExpression = (IncludeExpression)orderedExpressions[2].NormalizedPredicate;
-            Assert.Equal("MedicationDispense", includeExpression.ResourceType);
+            Assert.Equal("MedicationDispense", includeExpression.ResourceTypes[0]);
             Assert.Equal("prescription", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[3].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[4].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[4].NormalizedPredicate;
-            Assert.Equal("MedicationRequest", includeExpression.ResourceType);
+            Assert.Equal("MedicationRequest", includeExpression.ResourceTypes[0]);
             Assert.Equal("patient", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[5].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[6].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[6].NormalizedPredicate;
-            Assert.Equal("Patient", includeExpression.ResourceType);
+            Assert.Equal("Patient", includeExpression.ResourceTypes[0]);
             Assert.Equal("general-practitioner", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[7].Kind);
@@ -792,13 +792,13 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             // [base]/MedicationDispense?_include=MedicationDispense:prescription&_include:iterate=Patient:general-practitioner&_include:iterate=MedicationRequest:patient&_id=12345
 
             var refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationDispense", "prescription");
-            var includeMedicationDispensePrescription = new IncludeExpression("MedicationDispense", refSearchParameter, "MedicationDispense", null, null, false, false, false);
+            var includeMedicationDispensePrescription = new IncludeExpression(new[] { "MedicationDispense" }, refSearchParameter, "MedicationDispense", null, null, false, false, false);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationRequest", "patient");
-            var includeIterateMedicationRequestPatient = new IncludeExpression("MedicationRequest", refSearchParameter, "MedicationRequest", null, null, false, false, true);
+            var includeIterateMedicationRequestPatient = new IncludeExpression(new[] { "MedicationRequest" }, refSearchParameter, "MedicationRequest", null, null, false, false, true);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("Patient", "general-practitioner");
-            var includeIteratePatientGeneralPractitioner = new IncludeExpression("Patient", refSearchParameter, "Patient", null, null, false, false, true);
+            var includeIteratePatientGeneralPractitioner = new IncludeExpression(new[] { "Patient" }, refSearchParameter, "Patient", null, null, false, false, true);
 
             Expression denormalizedExpression = Expression.And(new List<Expression>
                 {
@@ -828,21 +828,21 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[2].Kind);
             var includeExpression = (IncludeExpression)orderedExpressions[2].NormalizedPredicate;
-            Assert.Equal("MedicationDispense", includeExpression.ResourceType);
+            Assert.Equal("MedicationDispense", includeExpression.ResourceTypes[0]);
             Assert.Equal("prescription", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[3].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[4].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[4].NormalizedPredicate;
-            Assert.Equal("MedicationRequest", includeExpression.ResourceType);
+            Assert.Equal("MedicationRequest", includeExpression.ResourceTypes[0]);
             Assert.Equal("patient", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[5].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[6].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[6].NormalizedPredicate;
-            Assert.Equal("Patient", includeExpression.ResourceType);
+            Assert.Equal("Patient", includeExpression.ResourceTypes[0]);
             Assert.Equal("general-practitioner", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[7].Kind);
@@ -857,13 +857,13 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             // [base]/MedicationDispense?_include:iterate=MedicationRequest:patient&_include=MedicationDispense:prescription&_include:iterate=Patient:general-practitioner&_id=12345
 
             var refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationDispense", "prescription");
-            var includeMedicationDispensePrescription = new IncludeExpression("MedicationDispense", refSearchParameter, "MedicationDispense", null, null, false, false, false);
+            var includeMedicationDispensePrescription = new IncludeExpression(new[] { "MedicationDispense" }, refSearchParameter, "MedicationDispense", null, null, false, false, false);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationRequest", "patient");
-            var includeIterateMedicationRequestPatient = new IncludeExpression("MedicationRequest", refSearchParameter, "MedicationRequest", null, null, false, false, true);
+            var includeIterateMedicationRequestPatient = new IncludeExpression(new[] { "MedicationRequest" }, refSearchParameter, "MedicationRequest", null, null, false, false, true);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("Patient", "general-practitioner");
-            var includeIteratePatientGeneralPractitioner = new IncludeExpression("Patient", refSearchParameter, "Patient", null, null, false, false, true);
+            var includeIteratePatientGeneralPractitioner = new IncludeExpression(new[] { "Patient" }, refSearchParameter, "Patient", null, null, false, false, true);
 
             Expression denormalizedExpression = Expression.And(new List<Expression>
                 {
@@ -893,21 +893,21 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[2].Kind);
             var includeExpression = (IncludeExpression)orderedExpressions[2].NormalizedPredicate;
-            Assert.Equal("MedicationDispense", includeExpression.ResourceType);
+            Assert.Equal("MedicationDispense", includeExpression.ResourceTypes[0]);
             Assert.Equal("prescription", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[3].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[4].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[4].NormalizedPredicate;
-            Assert.Equal("MedicationRequest", includeExpression.ResourceType);
+            Assert.Equal("MedicationRequest", includeExpression.ResourceTypes[0]);
             Assert.Equal("patient", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[5].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[6].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[6].NormalizedPredicate;
-            Assert.Equal("Patient", includeExpression.ResourceType);
+            Assert.Equal("Patient", includeExpression.ResourceTypes[0]);
             Assert.Equal("general-practitioner", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[7].Kind);
@@ -922,13 +922,13 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             // [base]/MedicationDispense?_include:iterate=MedicationRequest:patient&_include:iterate=Patient:general-practitioner&_include=MedicationDispense:prescription&_id=12345
 
             var refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationDispense", "prescription");
-            var includeMedicationDispensePrescription = new IncludeExpression("MedicationDispense", refSearchParameter, "MedicationDispense", null, null, false, false, false);
+            var includeMedicationDispensePrescription = new IncludeExpression(new[] { "MedicationDispense" }, refSearchParameter, "MedicationDispense", null, null, false, false, false);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationRequest", "patient");
-            var includeIterateMedicationRequestPatient = new IncludeExpression("MedicationRequest", refSearchParameter, "MedicationRequest", null, null, false, false, true);
+            var includeIterateMedicationRequestPatient = new IncludeExpression(new[] { "MedicationRequest" }, refSearchParameter, "MedicationRequest", null, null, false, false, true);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("Patient", "general-practitioner");
-            var includeIteratePatientGeneralPractitioner = new IncludeExpression("Patient", refSearchParameter, "Patient", null, null, false, false, true);
+            var includeIteratePatientGeneralPractitioner = new IncludeExpression(new[] { "Patient" }, refSearchParameter, "Patient", null, null, false, false, true);
 
             Expression denormalizedExpression = Expression.And(new List<Expression>
                 {
@@ -958,21 +958,21 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[2].Kind);
             var includeExpression = (IncludeExpression)orderedExpressions[2].NormalizedPredicate;
-            Assert.Equal("MedicationDispense", includeExpression.ResourceType);
+            Assert.Equal("MedicationDispense", includeExpression.ResourceTypes[0]);
             Assert.Equal("prescription", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[3].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[4].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[4].NormalizedPredicate;
-            Assert.Equal("MedicationRequest", includeExpression.ResourceType);
+            Assert.Equal("MedicationRequest", includeExpression.ResourceTypes[0]);
             Assert.Equal("patient", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[5].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[6].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[6].NormalizedPredicate;
-            Assert.Equal("Patient", includeExpression.ResourceType);
+            Assert.Equal("Patient", includeExpression.ResourceTypes[0]);
             Assert.Equal("general-practitioner", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[7].Kind);
@@ -987,13 +987,13 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             // [base]/MedicationDispense?_include:iterate=Patient:general-practitioner&_include=MedicationDispense:prescription&_include:iterate=MedicationRequest:patient&_id=12345
 
             var refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationDispense", "prescription");
-            var includeMedicationDispensePrescription = new IncludeExpression("MedicationDispense", refSearchParameter, "MedicationDispense", null, null, false, false, false);
+            var includeMedicationDispensePrescription = new IncludeExpression(new[] { "MedicationDispense" }, refSearchParameter, "MedicationDispense", null, null, false, false, false);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationRequest", "patient");
-            var includeIterateMedicationRequestPatient = new IncludeExpression("MedicationRequest", refSearchParameter, "MedicationRequest", null, null, false, false, true);
+            var includeIterateMedicationRequestPatient = new IncludeExpression(new[] { "MedicationRequest" }, refSearchParameter, "MedicationRequest", null, null, false, false, true);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("Patient", "general-practitioner");
-            var includeIteratePatientGeneralPractitioner = new IncludeExpression("Patient", refSearchParameter, "Patient", null, null, false, false, true);
+            var includeIteratePatientGeneralPractitioner = new IncludeExpression(new[] { "Patient" }, refSearchParameter, "Patient", null, null, false, false, true);
 
             Expression denormalizedExpression = Expression.And(new List<Expression>
                 {
@@ -1023,21 +1023,21 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[2].Kind);
             var includeExpression = (IncludeExpression)orderedExpressions[2].NormalizedPredicate;
-            Assert.Equal("MedicationDispense", includeExpression.ResourceType);
+            Assert.Equal("MedicationDispense", includeExpression.ResourceTypes[0]);
             Assert.Equal("prescription", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[3].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[4].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[4].NormalizedPredicate;
-            Assert.Equal("MedicationRequest", includeExpression.ResourceType);
+            Assert.Equal("MedicationRequest", includeExpression.ResourceTypes[0]);
             Assert.Equal("patient", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[5].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[6].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[6].NormalizedPredicate;
-            Assert.Equal("Patient", includeExpression.ResourceType);
+            Assert.Equal("Patient", includeExpression.ResourceTypes[0]);
             Assert.Equal("general-practitioner", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[7].Kind);
@@ -1052,13 +1052,13 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             // [base]/MedicationDispense?_include:iterate=Patient:general-practitioner&_include:iterate=MedicationRequest:patient&_include=MedicationDispense:prescription&_id=12345
 
             var refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationDispense", "prescription");
-            var includeMedicationDispensePrescription = new IncludeExpression("MedicationDispense", refSearchParameter, "MedicationDispense", null, null, false, false, false);
+            var includeMedicationDispensePrescription = new IncludeExpression(new[] { "MedicationDispense" }, refSearchParameter, "MedicationDispense", null, null, false, false, false);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationRequest", "patient");
-            var includeIterateMedicationRequestPatient = new IncludeExpression("MedicationRequest", refSearchParameter, "MedicationRequest", null, null, false, false, true);
+            var includeIterateMedicationRequestPatient = new IncludeExpression(new[] { "MedicationRequest" }, refSearchParameter, "MedicationRequest", null, null, false, false, true);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("Patient", "general-practitioner");
-            var includeIteratePatientGeneralPractitioner = new IncludeExpression("Patient", refSearchParameter, "Patient", null, null, false, false, true);
+            var includeIteratePatientGeneralPractitioner = new IncludeExpression(new[] { "Patient" }, refSearchParameter, "Patient", null, null, false, false, true);
 
             Expression denormalizedExpression = Expression.And(new List<Expression>
                 {
@@ -1088,21 +1088,21 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[2].Kind);
             var includeExpression = (IncludeExpression)orderedExpressions[2].NormalizedPredicate;
-            Assert.Equal("MedicationDispense", includeExpression.ResourceType);
+            Assert.Equal("MedicationDispense", includeExpression.ResourceTypes[0]);
             Assert.Equal("prescription", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[3].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[4].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[4].NormalizedPredicate;
-            Assert.Equal("MedicationRequest", includeExpression.ResourceType);
+            Assert.Equal("MedicationRequest", includeExpression.ResourceTypes[0]);
             Assert.Equal("patient", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[5].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[6].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[6].NormalizedPredicate;
-            Assert.Equal("Patient", includeExpression.ResourceType);
+            Assert.Equal("Patient", includeExpression.ResourceTypes[0]);
             Assert.Equal("general-practitioner", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[7].Kind);
@@ -1119,13 +1119,13 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             // [base]/MedicationDispense?_include:iterate=Patient:general-practitioner&_include:iterate=MedicationRequest:patient&_include=MedicationDispense:prescription&_id=smart-MedicationDispense-567
 
             var refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("Patient", "general-practitioner");
-            var includeIteratePatientGeneralPractitioner = new IncludeExpression("Patient", refSearchParameter, "Patient", null, null, false, false, true);
+            var includeIteratePatientGeneralPractitioner = new IncludeExpression(new[] { "Patient" }, refSearchParameter, "Patient", null, null, false, false, true);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationRequest", "patient");
-            var includeIterateMedicationRequestPatient = new IncludeExpression("MedicationRequest", refSearchParameter, "MedicationRequest", null, null, false, false, true);
+            var includeIterateMedicationRequestPatient = new IncludeExpression(new[] { "MedicationRequest" }, refSearchParameter, "MedicationRequest", null, null, false, false, true);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationDispense", "prescription");
-            var includeMedicationDispensePrescription = new IncludeExpression("MedicationDispense", refSearchParameter, "MedicationDispense", null, null, false, false, false);
+            var includeMedicationDispensePrescription = new IncludeExpression(new[] { "MedicationDispense" }, refSearchParameter, "MedicationDispense", null, null, false, false, false);
 
             Expression denormalizedExpression = Expression.And(new List<Expression>
                 {
@@ -1155,21 +1155,21 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[2].Kind);
             var includeExpression = (IncludeExpression)orderedExpressions[2].NormalizedPredicate;
-            Assert.Equal("MedicationDispense", includeExpression.ResourceType);
+            Assert.Equal("MedicationDispense", includeExpression.ResourceTypes[0]);
             Assert.Equal("prescription", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[3].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[4].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[4].NormalizedPredicate;
-            Assert.Equal("MedicationRequest", includeExpression.ResourceType);
+            Assert.Equal("MedicationRequest", includeExpression.ResourceTypes[0]);
             Assert.Equal("patient", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[5].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[6].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[6].NormalizedPredicate;
-            Assert.Equal("Patient", includeExpression.ResourceType);
+            Assert.Equal("Patient", includeExpression.ResourceTypes[0]);
             Assert.Equal("general-practitioner", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[7].Kind);
@@ -1184,13 +1184,13 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             // [base]/Organization?_revinclude:iterate=MedicationDispense:prescription&_revinclude:iterate=MedicationRequest:patient&_revinclude=Patient:organization&_id=organization-id
 
             var refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationDispense", "prescription");
-            var includeIteratePatientGeneralPractitioner = new IncludeExpression("MedicationDispense", refSearchParameter, "MedicationDispense", null, null, false, true, true);
+            var includeIteratePatientGeneralPractitioner = new IncludeExpression(new[] { "MedicationDispense" }, refSearchParameter, "MedicationDispense", null, null, false, true, true);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationRequest", "patient");
-            var includeIterateMedicationRequestPatient = new IncludeExpression("MedicationRequest", refSearchParameter, "MedicationRequest", null, null, false, true, true);
+            var includeIterateMedicationRequestPatient = new IncludeExpression(new[] { "MedicationRequest" }, refSearchParameter, "MedicationRequest", null, null, false, true, true);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("Patient", "organization");
-            var includeMedicationDispensePrescription = new IncludeExpression("Patient", refSearchParameter, "Patient", null, null, false, true, false);
+            var includeMedicationDispensePrescription = new IncludeExpression(new[] { "Patient" }, refSearchParameter, "Patient", null, null, false, true, false);
 
             Expression denormalizedExpression = Expression.And(new List<Expression>
                 {
@@ -1220,21 +1220,21 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[2].Kind);
             var includeExpression = (IncludeExpression)orderedExpressions[2].NormalizedPredicate;
-            Assert.Equal("Patient", includeExpression.ResourceType);
+            Assert.Equal("Patient", includeExpression.ResourceTypes[0]);
             Assert.Equal("organization", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[3].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[4].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[4].NormalizedPredicate;
-            Assert.Equal("MedicationRequest", includeExpression.ResourceType);
+            Assert.Equal("MedicationRequest", includeExpression.ResourceTypes[0]);
             Assert.Equal("patient", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[5].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[6].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[6].NormalizedPredicate;
-            Assert.Equal("MedicationDispense", includeExpression.ResourceType);
+            Assert.Equal("MedicationDispense", includeExpression.ResourceTypes[0]);
             Assert.Equal("prescription", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[7].Kind);
@@ -1249,13 +1249,13 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             // [base]/Organization?_include:iterate=MedicationDispense:prescription&_revinclude:iterate=MedicationDispense:patient&_revinclude=Patient:organization&_id=organization-id
 
             var refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationDispense", "prescription");
-            var includeIteratePatientGeneralPractitioner = new IncludeExpression("MedicationDispense", refSearchParameter, "MedicationDispense", null, null, false, false, true);
+            var includeIteratePatientGeneralPractitioner = new IncludeExpression(new[] { "MedicationDispense" }, refSearchParameter, "MedicationDispense", null, null, false, false, true);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationDispense", "patient");
-            var includeIterateMedicationRequestPatient = new IncludeExpression("MedicationDispense", refSearchParameter, "MedicationDispense", null, null, false, true, true);
+            var includeIterateMedicationRequestPatient = new IncludeExpression(new[] { "MedicationDispense" }, refSearchParameter, "MedicationDispense", null, null, false, true, true);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("Patient", "organization");
-            var includeMedicationDispensePrescription = new IncludeExpression("Patient", refSearchParameter, "Patient", null, null, false, true, false);
+            var includeMedicationDispensePrescription = new IncludeExpression(new[] { "Patient" }, refSearchParameter, "Patient", null, null, false, true, false);
 
             Expression denormalizedExpression = Expression.And(new List<Expression>
                 {
@@ -1285,21 +1285,21 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[2].Kind);
             var includeExpression = (IncludeExpression)orderedExpressions[2].NormalizedPredicate;
-            Assert.Equal("Patient", includeExpression.ResourceType);
+            Assert.Equal("Patient", includeExpression.ResourceTypes[0]);
             Assert.Equal("organization", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[3].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[4].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[4].NormalizedPredicate;
-            Assert.Equal("MedicationDispense", includeExpression.ResourceType);
+            Assert.Equal("MedicationDispense", includeExpression.ResourceTypes[0]);
             Assert.Equal("patient", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[5].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[6].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[6].NormalizedPredicate;
-            Assert.Equal("MedicationDispense", includeExpression.ResourceType);
+            Assert.Equal("MedicationDispense", includeExpression.ResourceTypes[0]);
             Assert.Equal("prescription", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[7].Kind);
@@ -1315,16 +1315,16 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             // [base]/MedicationDispense?_id=12345&_include:iterate=Device:location&_include:iterate=Location:endpoint&_include=MedicationDispense:performer&_include:iterate=Patient:general-practitioner
 
             var refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("Device", "location");
-            var includeIterateDeviceLocation = new IncludeExpression("Device", refSearchParameter, "Device", null, null, false, false, true);
+            var includeIterateDeviceLocation = new IncludeExpression(new[] { "Device" }, refSearchParameter, "Device", null, null, false, false, true);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("Location", "endpoint");
-            var includeIterateLocationEndpoint = new IncludeExpression("Location", refSearchParameter, "Location", null, null, false, false, true);
+            var includeIterateLocationEndpoint = new IncludeExpression(new[] { "Location" }, refSearchParameter, "Location", null, null, false, false, true);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationDispense", "performer");
-            var includeMedicationDispensePerformer = new IncludeExpression("MedicationDispense", refSearchParameter, "MedicationDispense", null, null, false, false, false);
+            var includeMedicationDispensePerformer = new IncludeExpression(new[] { "MedicationDispense" }, refSearchParameter, "MedicationDispense", null, null, false, false, false);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("Patient", "general-practitioner");
-            var includeIteratePatientPractitioner = new IncludeExpression("Patient", refSearchParameter, "Patient", null, null, false, false, true);
+            var includeIteratePatientPractitioner = new IncludeExpression(new[] { "Patient" }, refSearchParameter, "Patient", null, null, false, false, true);
 
             Expression denormalizedExpression = Expression.And(new List<Expression>
                 {
@@ -1356,28 +1356,28 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[2].Kind);
             var includeExpression = (IncludeExpression)orderedExpressions[2].NormalizedPredicate;
-            Assert.Equal("MedicationDispense", includeExpression.ResourceType);
+            Assert.Equal("MedicationDispense", includeExpression.ResourceTypes[0]);
             Assert.Equal("performer", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[3].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[4].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[4].NormalizedPredicate;
-            Assert.Equal("Device", includeExpression.ResourceType);
+            Assert.Equal("Device", includeExpression.ResourceTypes[0]);
             Assert.Equal("location", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[5].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[6].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[6].NormalizedPredicate;
-            Assert.Equal("Location", includeExpression.ResourceType);
+            Assert.Equal("Location", includeExpression.ResourceTypes[0]);
             Assert.Equal("endpoint", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[7].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[8].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[8].NormalizedPredicate;
-            Assert.Equal("Patient", includeExpression.ResourceType);
+            Assert.Equal("Patient", includeExpression.ResourceTypes[0]);
             Assert.Equal("general-practitioner", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[9].Kind);
@@ -1392,16 +1392,16 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             // [base]/MedicationDispense?_id=12345&_include:iterate=Location:endpoint&_include=MedicationDispense:performer&_include:iterate=Patient:general-practitioner&_include:iterate=Device:location
 
             var refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("Device", "location");
-            var includeIterateDeviceLocation = new IncludeExpression("Device", refSearchParameter, "Device", null, null, false, false, true);
+            var includeIterateDeviceLocation = new IncludeExpression(new[] { "Device" }, refSearchParameter, "Device", null, null, false, false, true);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("Location", "endpoint");
-            var includeIterateLocationEndpoint = new IncludeExpression("Location", refSearchParameter, "Location", null, null, false, false, true);
+            var includeIterateLocationEndpoint = new IncludeExpression(new[] { "Location" }, refSearchParameter, "Location", null, null, false, false, true);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationDispense", "performer");
-            var includeMedicationDispensePerformer = new IncludeExpression("MedicationDispense", refSearchParameter, "MedicationDispense", null, null, false, false, false);
+            var includeMedicationDispensePerformer = new IncludeExpression(new[] { "MedicationDispense" }, refSearchParameter, "MedicationDispense", null, null, false, false, false);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("Patient", "general-practitioner");
-            var includeIteratePatientPractitioner = new IncludeExpression("Patient", refSearchParameter, "Patient", null, null, false, false, true);
+            var includeIteratePatientPractitioner = new IncludeExpression(new[] { "Patient" }, refSearchParameter, "Patient", null, null, false, false, true);
 
             Expression denormalizedExpression = Expression.And(new List<Expression>
                 {
@@ -1432,28 +1432,28 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[2].Kind);
             var includeExpression = (IncludeExpression)orderedExpressions[2].NormalizedPredicate;
-            Assert.Equal("MedicationDispense", includeExpression.ResourceType);
+            Assert.Equal("MedicationDispense", includeExpression.ResourceTypes[0]);
             Assert.Equal("performer", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[3].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[4].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[4].NormalizedPredicate;
-            Assert.Equal("Patient", includeExpression.ResourceType);
+            Assert.Equal("Patient", includeExpression.ResourceTypes[0]);
             Assert.Equal("general-practitioner", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[9].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[6].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[6].NormalizedPredicate;
-            Assert.Equal("Device", includeExpression.ResourceType);
+            Assert.Equal("Device", includeExpression.ResourceTypes[0]);
             Assert.Equal("location", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[7].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[8].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[8].NormalizedPredicate;
-            Assert.Equal("Location", includeExpression.ResourceType);
+            Assert.Equal("Location", includeExpression.ResourceTypes[0]);
             Assert.Equal("endpoint", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[9].Kind);
@@ -1470,13 +1470,13 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             // [base]/MedicationDispense?_include:iterate=Patient:general-practitioner&_include:iterate=MedicationRequest:patient&_include=MedicationDispense:*&_id=12345
 
             var refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("Patient", "general-practitioner");
-            var includeIteratePatientGeneralPractitioner = new IncludeExpression("Patient", refSearchParameter, "Patient", null, null, false, false, true);
+            var includeIteratePatientGeneralPractitioner = new IncludeExpression(new[] { "Patient" }, refSearchParameter, "Patient", null, null, false, false, true);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationRequest", "patient");
-            var includeIterateMedicationRequestPatient = new IncludeExpression("MedicationRequest", refSearchParameter, "MedicationRequest", null, null, false, false, true);
+            var includeIterateMedicationRequestPatient = new IncludeExpression(new[] { "MedicationRequest" }, refSearchParameter, "MedicationRequest", null, null, false, false, true);
 
             var referencedTypes = new List<string> { "Location", "MedicationRequest", "Patient", "Practitioner", "Organization" }; // partial list of referenced types
-            var includeMedicationDispenseWildcard = new IncludeExpression("MedicationDispense", null, "MedicationDispense", null, referencedTypes, true, false, false);
+            var includeMedicationDispenseWildcard = new IncludeExpression(new[] { "MedicationDispense" }, null, "MedicationDispense", null, referencedTypes, true, false, false);
 
             Expression denormalizedExpression = Expression.And(new List<Expression>
                 {
@@ -1506,21 +1506,21 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[2].Kind);
             var includeExpression = (IncludeExpression)orderedExpressions[2].NormalizedPredicate;
-            Assert.Equal("MedicationDispense", includeExpression.ResourceType);
+            Assert.Equal("MedicationDispense", includeExpression.ResourceTypes[0]);
             Assert.True(includeExpression.WildCard);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[3].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[4].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[4].NormalizedPredicate;
-            Assert.Equal("MedicationRequest", includeExpression.ResourceType);
+            Assert.Equal("MedicationRequest", includeExpression.ResourceTypes[0]);
             Assert.Equal("patient", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[5].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[6].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[6].NormalizedPredicate;
-            Assert.Equal("Patient", includeExpression.ResourceType);
+            Assert.Equal("Patient", includeExpression.ResourceTypes[0]);
             Assert.Equal("general-practitioner", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[7].Kind);
@@ -1535,10 +1535,10 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             // [base]/MedicationRequest?_include:iterate=MedicationDispense:patient&_revinclude=MedicationDispense:*&_id=12345
 
             var refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationDispense", "patient");
-            var includeIterateMedicationRequestPatient = new IncludeExpression("MedicationDispense", refSearchParameter, "MedicationDispense", null, null, false, false, true);
+            var includeIterateMedicationRequestPatient = new IncludeExpression(new[] { "MedicationDispense" }, refSearchParameter, "MedicationDispense", null, null, false, false, true);
 
             var referencedTypes = new List<string> { "Location", "MedicationRequest", "Patient", "Practitioner", "Organization" }; // partial list of referenced types
-            var revIncludeMedicationDispenseWildcard = new IncludeExpression("MedicationDispense", null, "MedicationDispense", null, referencedTypes, true, true, false);
+            var revIncludeMedicationDispenseWildcard = new IncludeExpression(new[] { "MedicationDispense" }, null, "MedicationDispense", null, referencedTypes, true, true, false);
 
             Expression denormalizedExpression = Expression.And(new List<Expression>
                 {
@@ -1567,14 +1567,14 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[2].Kind);
             var includeExpression = (IncludeExpression)orderedExpressions[2].NormalizedPredicate;
-            Assert.Equal("MedicationDispense", includeExpression.ResourceType);
+            Assert.Equal("MedicationDispense", includeExpression.ResourceTypes[0]);
             Assert.True(includeExpression.WildCard);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[3].Kind);
 
             Assert.Equal(TableExpressionKind.Include, orderedExpressions[4].Kind);
             includeExpression = (IncludeExpression)orderedExpressions[4].NormalizedPredicate;
-            Assert.Equal("MedicationDispense", includeExpression.ResourceType);
+            Assert.Equal("MedicationDispense", includeExpression.ResourceTypes[0]);
             Assert.Equal("patient", includeExpression.ReferenceSearchParameter.Name);
 
             Assert.Equal(TableExpressionKind.IncludeLimit, orderedExpressions[5].Kind);
@@ -1589,19 +1589,19 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             // [base]/MedicationDispense?_include=MedicationDispense:prescription&_include:iterate=MedicationRequest:patient&_include:iterate=Patient:general-practitioner&_revinclude:iterate=DiagnosticReport:performer:Practitioner&_include:iterate=DiagnosticReport:patient&_id=12345
 
             var refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationDispense", "prescription");
-            var includeMedicationDispense = new IncludeExpression("MedicationDispense", refSearchParameter, "MedicationDispense", null, null, false, false, false);
+            var includeMedicationDispense = new IncludeExpression(new[] { "MedicationDispense" }, refSearchParameter, "MedicationDispense", null, null, false, false, false);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("MedicationRequest", "patient");
-            var includeIterateMedicationRequestPatient = new IncludeExpression("MedicationRequest", refSearchParameter, "MedicationRequest", null, null, false, false, true);
+            var includeIterateMedicationRequestPatient = new IncludeExpression(new[] { "MedicationRequest" }, refSearchParameter, "MedicationRequest", null, null, false, false, true);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("Patient", "general-practitioner");
-            var includeIteratePatientPractitioner = new IncludeExpression("Patient", refSearchParameter, "Patient", null, null, false, false, true);
+            var includeIteratePatientPractitioner = new IncludeExpression(new[] { "Patient" }, refSearchParameter, "Patient", null, null, false, false, true);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("DiagnosticReport", "performer");
-            var revIncludeIterateDiagnosticReportPerformer = new IncludeExpression("DiagnosticReport", refSearchParameter, "DiagnosticReport", "Practitioner", null, false, true, true);
+            var revIncludeIterateDiagnosticReportPerformer = new IncludeExpression(new[] { "DiagnosticReport" }, refSearchParameter, "DiagnosticReport", "Practitioner", null, false, true, true);
 
             refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter("DiagnosticReport", "patient");
-            var includeIterateDiagnosticReportPatient = new IncludeExpression("DiagnosticReport", refSearchParameter, "DiagnosticReport", null, null, false, false, true);
+            var includeIterateDiagnosticReportPatient = new IncludeExpression(new[] { "DiagnosticReport" }, refSearchParameter, "DiagnosticReport", null, null, false, false, true);
 
             Expression denormalizedExpression = Expression.And(new List<Expression>
                 {

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/RemoveIncludesRewriterTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/RemoveIncludesRewriterTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
         [Fact]
         public void GivenAnExpressionWithIncludes_WhenVisitedByRemoveIncludesRewriter_IncludesAreRemoved()
         {
-            IncludeExpression includeExpression = Expression.Include("a", new SearchParameterInfo("p", "Token"), "Observation", "Patient", null, false, false, false);
+            IncludeExpression includeExpression = Expression.Include(new[] { "a" }, new SearchParameterInfo("p", "Token"), "Observation", "Patient", null, false, false, false);
 
             BinaryExpression fieldExpression = Expression.Equals(FieldName.Number, null, 1);
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -398,10 +398,14 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                         AppendHistoryClause(delimited, referenceSourceTableAlias);
 
                         delimited.BeginDelimitedElement().Append(VLatest.ReferenceSearchParam.ResourceTypeId, referenceSourceTableAlias)
-                            .Append(" = ").Append(Parameters.AddParameter(VLatest.ReferenceSearchParam.ResourceTypeId, Model.GetResourceTypeId(chainedExpression.ResourceType)));
+                            .Append(" IN (")
+                            .Append(string.Join(", ", chainedExpression.ResourceTypes.Select(x => Parameters.AddParameter(VLatest.ReferenceSearchParam.ResourceTypeId, Model.GetResourceTypeId(x)))))
+                            .Append(")");
 
                         delimited.BeginDelimitedElement().Append(VLatest.ReferenceSearchParam.ReferenceResourceTypeId, referenceSourceTableAlias)
-                            .Append(" = ").Append(Parameters.AddParameter(VLatest.ReferenceSearchParam.ReferenceResourceTypeId, Model.GetResourceTypeId(chainedExpression.TargetResourceType)));
+                            .Append(" IN (")
+                            .Append(string.Join(", ", chainedExpression.TargetResourceTypes.Select(x => Parameters.AddParameter(VLatest.ReferenceSearchParam.ReferenceResourceTypeId, Model.GetResourceTypeId(x)))))
+                            .Append(")");
 
                         if (tableExpression.ChainLevel == 1)
                         {
@@ -475,21 +479,23 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                         table = !includeExpression.Reversed ? referenceSourceTableAlias : referenceTargetResourceTableAlias;
 
                         // For RevIncludeIterate we expect to have a TargetType specified if the target reference can be of multiple types
-                        var resourceId = Model.GetResourceTypeId(includeExpression.ResourceType);
+                        var resourceIds = includeExpression.ResourceTypes.Select(x => Model.GetResourceTypeId(x)).ToArray();
                         if (includeExpression.Reversed && includeExpression.Iterate)
                         {
                             if (includeExpression.TargetResourceType != null)
                             {
-                                resourceId = Model.GetResourceTypeId(includeExpression.TargetResourceType);
+                                resourceIds = new[] { Model.GetResourceTypeId(includeExpression.TargetResourceType) };
                             }
                             else if (includeExpression.ReferenceSearchParameter?.TargetResourceTypes?.Count > 0)
                             {
-                                resourceId = Model.GetResourceTypeId(includeExpression.ReferenceSearchParameter.TargetResourceTypes.ToList().First());
+                                resourceIds = new[] { Model.GetResourceTypeId(includeExpression.ReferenceSearchParameter.TargetResourceTypes.ToList().First()) };
                             }
                         }
 
                         delimited.BeginDelimitedElement().Append(VLatest.ReferenceSearchParam.ResourceTypeId, table)
-                            .Append(" = ").Append(Parameters.AddParameter(VLatest.ReferenceSearchParam.ResourceTypeId, resourceId));
+                             .Append(" IN (")
+                             .Append(string.Join(", ", resourceIds))
+                             .Append(")");
 
                         // Get FROM ctes
                         string fromCte = _cteMainSelect;

--- a/src/Microsoft.Health.Fhir.Stu3.Core.UnitTests/Features/Search/SearchOptionsFactoryTests.cs
+++ b/src/Microsoft.Health.Fhir.Stu3.Core.UnitTests/Features/Search/SearchOptionsFactoryTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
             Expression expression = Substitute.For<Expression>();
 
-            _expressionParser.Parse(resourceType.ToString(), paramName, value).Returns(expression);
+            _expressionParser.Parse(Arg.Is<string[]>(x => x.Length == 1 && x[0] == resourceType.ToString()), paramName, value).Returns(expression);
 
             SearchOptions options = CreateSearchOptions(
                 resourceType: resourceType.ToString(),
@@ -55,8 +55,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             Expression expression1 = Substitute.For<Expression>();
             Expression expression2 = Substitute.For<Expression>();
 
-            _expressionParser.Parse(resourceType.ToString(), paramName1, value1).Returns(expression1);
-            _expressionParser.Parse(resourceType.ToString(), paramName2, value2).Returns(expression2);
+            _expressionParser.Parse(Arg.Is<string[]>(x => x.Length == 1 && x[0] == resourceType.ToString()), paramName1, value1).Returns(expression1);
+            _expressionParser.Parse(Arg.Is<string[]>(x => x.Length == 1 && x[0] == resourceType.ToString()), paramName2, value2).Returns(expression2);
 
             var queryParameters = new[]
             {
@@ -93,10 +93,10 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             Expression expression1 = Substitute.For<Expression>();
             Expression expression3 = Substitute.For<Expression>();
 
-            _expressionParser.Parse(resourceType.ToString(), paramName1, value1).Returns(expression1);
-            _expressionParser.Parse(resourceType.ToString(), paramName2, value2)
-                .Returns(x => throw new SearchParameterNotSupportedException(x.ArgAt<string>(0), x.ArgAt<string>(1)));
-            _expressionParser.Parse(resourceType.ToString(), paramName3, value3).Returns(expression3);
+            _expressionParser.Parse(Arg.Is<string[]>(x => x.Length == 1 && x[0] == resourceType.ToString()), paramName1, value1).Returns(expression1);
+            _expressionParser.Parse(Arg.Is<string[]>(x => x.Length == 1 && x[0] == resourceType.ToString()), paramName2, value2)
+                .Returns(x => throw new SearchParameterNotSupportedException(x.ArgAt<string[]>(0)[0], x.ArgAt<string>(1)));
+            _expressionParser.Parse(Arg.Is<string[]>(x => x.Length == 1 && x[0] == resourceType.ToString()), paramName3, value3).Returns(expression3);
 
             var queryParameters = new[]
             {
@@ -137,8 +137,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             Expression expression1 = Substitute.For<Expression>();
             Expression expression2 = Substitute.For<Expression>();
 
-            _expressionParser.Parse(resourceType.ToString(), paramName1, value1).Returns(expression1);
-            _expressionParser.Parse(resourceType.ToString(), paramName2, value2).Returns(expression2);
+            _expressionParser.Parse(Arg.Is<string[]>(x => x.Length == 1 && x[0] == resourceType.ToString()), paramName1, value1).Returns(expression1);
+            _expressionParser.Parse(Arg.Is<string[]>(x => x.Length == 1 && x[0] == resourceType.ToString()), paramName2, value2).Returns(expression2);
 
             var queryParameters = new[]
             {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -243,6 +243,41 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         }
 
         [Fact]
+        public async Task GivenVariousTypesOfResources_WhenSearchingAcrossAllResourceTypesUsingCommonSearchParameter_ThenOnlyResourcesMatchingTypeAndCommonSearchParameterShouldBeReturned()
+        {
+            // Create various resources.
+            var suffix = Guid.NewGuid().ToString("N").Substring(0, 4);
+            Patient nonMatchingPatient = (await Client.CreateAsync(new Patient() { Name = new List<HumanName>() { new HumanName() { Family = $"Adams{suffix}" } } })).Resource;
+            Practitioner nonMatchingPractitioner = (await Client.CreateAsync(new Practitioner() { Name = new List<HumanName>() { new HumanName() { Family = $"Wilson{suffix}" } } })).Resource;
+            Patient matchingPatient = (await Client.CreateAsync(new Patient() { Name = new List<HumanName>() { new HumanName() { Family = $"Smith{suffix}" } } })).Resource;
+            Practitioner matchingPractitioner = (await Client.CreateAsync(new Practitioner() { Name = new List<HumanName>() { new HumanName() { Family = $"Smith{suffix}" } } })).Resource;
+
+            var query = $"?_type=Patient,Practitioner&family={matchingPatient.Name[0].Family}";
+            await ExecuteAndValidateBundle(query, matchingPatient, matchingPractitioner);
+            Bundle bundle = await Client.SearchPostAsync(null, default, ("_type", "Patient,Practitioner"), ("family", matchingPatient.Name[0].Family));
+            ValidateBundle(bundle, query, matchingPatient, matchingPractitioner);
+
+            query = $"?_type=Patient,Practitioner&family={nonMatchingPatient.Name[0].Family}";
+            await ExecuteAndValidateBundle(query, nonMatchingPatient);
+            bundle = await Client.SearchPostAsync(null, default, ("_type", "Patient,Practitioner"), ("family", nonMatchingPatient.Name[0].Family));
+            ValidateBundle(bundle, query, nonMatchingPatient);
+
+            query = $"?_type=Patient,Practitioner&family={nonMatchingPractitioner.Name[0].Family}";
+            await ExecuteAndValidateBundle(query, nonMatchingPractitioner);
+            bundle = await Client.SearchPostAsync(null, default, ("_type", "Patient,Practitioner"), ("family", nonMatchingPractitioner.Name[0].Family));
+            ValidateBundle(bundle, query, nonMatchingPractitioner);
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenVariousTypesOfResources_WhenSearchingAcrossAllResourceTypesUsingNonCommonSearchParameter_ThenExceptionShouldBeThrown()
+        {
+            using FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.SearchAsync($"?_type=Encounter,Procedure&subject=Patient/123"));
+
+            Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
+        }
+
+        [Fact]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenResources_WhenSearchedWithCount_ThenNumberOfResourcesReturnedShouldNotExceedCount()
         {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -243,6 +243,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         }
 
         [Fact]
+        [Trait(Traits.Priority, Priority.One)]
         public async Task GivenVariousTypesOfResources_WhenSearchingAcrossAllResourceTypesUsingCommonSearchParameter_ThenOnlyResourcesMatchingTypeAndCommonSearchParameterShouldBeReturned()
         {
             // Create various resources.


### PR DESCRIPTION
## Description
Added support for common search parameters when searching with `_type`.

#### From the spec: https://www.hl7.org/fhir/search.html#_type
> If multiple types are specified, any search parameters shared across the entire set of specified resources may be used (see search parameter registry). 

#### Example query:
```http
GET /?_type=Encounter,Procedure&patient=Patient/123
```

## Testing
Unit, E2E and manual (SqlServer)

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- [ ] Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Feature (Added new way to search)
