### PR TITLE
Added support for reverse chaining with multiple target types

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/ExpressionParser.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/ExpressionParser.cs
@@ -257,6 +257,18 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
                 {
                     chainedExpression = expression;
                 }
+                else if (reversed)
+                {
+                    chainedExpression = Expression.Chained(
+                        resourceTypes,
+                        searchParameter,
+                        chainedExpression.TargetResourceTypes.Append(possibleTargetResourceType).ToArray(),
+                        reversed,
+                        ParseImpl(
+                            multipleChainType,
+                            remainingKey,
+                            value));
+                }
                 else
                 {
                     // If the target resource type is ambiguous, we throw an error.

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
@@ -121,6 +121,16 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         }
 
         [Fact]
+        public async Task GivenAReverseChainSearchExpressionWithMultipleTargetTypes_WhenSearched_ThenCorrectBundleShouldBeReturned()
+        {
+            string query = $"?_tag={Fixture.Tag}&_type=Patient,Device&_has:Observation:subject:code=429858000";
+
+            Bundle bundle = await Client.SearchAsync(query);
+
+            ValidateBundle(bundle, Fixture.SmithPatient, Fixture.TrumanPatient);
+        }
+
+        [Fact]
         public async Task GivenANestedReverseChainSearchExpressionOverASimpleParameter_WhenSearched_ThenCorrectBundleShouldBeReturned()
         {
             string query = $"_tag={Fixture.Tag}&_has:Observation:patient:_has:DiagnosticReport:result:code=429858000";


### PR DESCRIPTION
## Description
Added support for the queries similar this:
```http
GET /?_type=Patient,Device&_has:Observation:subject:code=429858000
```

Requires this to be merged first: #1547 

## Testing
E2E and manual (SqlServer)

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- [ ] Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Feature (Added new way to search)
