### PR TITLE
Added support for type modifier on reference search parameter

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/ExpressionParser.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/ExpressionParser.cs
@@ -265,31 +265,25 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
 
         private Expression ParseSearchValueExpression(SearchParameterInfo searchParameter, string modifier, string value)
         {
-            SearchModifierCode? parsedModifier = null;
-            string targetTypeModifier = null;
-            if (!string.IsNullOrEmpty(modifier))
-            {
-                parsedModifier = ParseSearchParamModifier();
+            SearchModifier parsedModifier = ParseSearchParamModifier();
+            return _searchParameterExpressionParser.Parse(searchParameter, parsedModifier, value);
 
-                if (parsedModifier == SearchModifierCode.Type)
+            SearchModifier ParseSearchParamModifier()
+            {
+                if (string.IsNullOrEmpty(modifier))
                 {
-                    targetTypeModifier = modifier;
+                    return null;
                 }
-            }
 
-            return _searchParameterExpressionParser.Parse(searchParameter, parsedModifier, targetTypeModifier, value);
-
-            SearchModifierCode? ParseSearchParamModifier()
-            {
                 if (SearchParamModifierMapping.TryGetValue(modifier, out SearchModifierCode searchModifierCode))
                 {
-                    return searchModifierCode;
+                    return new SearchModifier(searchModifierCode);
                 }
 
                 // Modifier on a Reference Search Parameter can be used to restrict target type
                 if (searchParameter.Type == SearchParamType.Reference && searchParameter.TargetResourceTypes.Contains(modifier, StringComparer.OrdinalIgnoreCase))
                 {
-                    return SearchModifierCode.Type;
+                    return new SearchModifier(SearchModifierCode.Type, modifier);
                 }
 
                 throw new InvalidSearchOperationException(

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/ExpressionParser.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/ExpressionParser.cs
@@ -271,7 +271,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
             {
                 parsedModifier = ParseSearchParamModifier();
 
-                if (parsedModifier == null)
+                if (parsedModifier == SearchModifierCode.Type)
                 {
                     targetTypeModifier = modifier;
                 }
@@ -289,7 +289,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
                 // Modifier on a Reference Search Parameter can be used to restrict target type
                 if (searchParameter.Type == SearchParamType.Reference && searchParameter.TargetResourceTypes.Contains(modifier, StringComparer.OrdinalIgnoreCase))
                 {
-                    return null;
+                    return SearchModifierCode.Type;
                 }
 
                 throw new InvalidSearchOperationException(

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/ISearchParameterExpressionParser.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/ISearchParameterExpressionParser.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
         Expression Parse(
             SearchParameterInfo searchParameter,
             SearchModifierCode? modifier,
+            string targetTypeModifier,
             string value);
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/ISearchParameterExpressionParser.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/ISearchParameterExpressionParser.cs
@@ -4,7 +4,6 @@
 // -------------------------------------------------------------------------------------------------
 
 using Microsoft.Health.Fhir.Core.Models;
-using Microsoft.Health.Fhir.ValueSets;
 
 namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
 {
@@ -12,8 +11,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
     {
         Expression Parse(
             SearchParameterInfo searchParameter,
-            SearchModifierCode? modifier,
-            string targetTypeModifier,
+            SearchModifier modifier,
             string value);
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/SearchParameterExpressionParser.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/SearchParameterExpressionParser.cs
@@ -192,6 +192,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
                 return helper.Build(
                     searchParameter.Name,
                     modifier,
+                    targetTypeModifier,
                     comparator,
                     componentIndex,
                     searchValue);
@@ -212,6 +213,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
                     return helper.Build(
                         searchParameter.Name,
                         modifier,
+                        targetTypeModifier,
                         comparator,
                         componentIndex,
                         searchValue);

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/SearchParameterExpressionParser.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/SearchParameterExpressionParser.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
             {
                 // This is a single value expression.
                 ISearchValue searchValue = parser(valueSpan.ToString());
-                searchValue = ApplyTargetTypeModifier(searchValue);
+                searchValue = ApplyTargetTypeModifier(modifier, searchValue);
 
                 return helper.Build(
                     searchParameter.Name,
@@ -198,7 +198,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
                 Expression[] expressions = parts.Select(part =>
                 {
                     ISearchValue searchValue = parser(part);
-                    searchValue = ApplyTargetTypeModifier(searchValue);
+                    searchValue = ApplyTargetTypeModifier(modifier, searchValue);
 
                     return helper.Build(
                         searchParameter.Name,
@@ -211,7 +211,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
                 return Expression.Or(expressions);
             }
 
-            ISearchValue ApplyTargetTypeModifier(ISearchValue source)
+            ISearchValue ApplyTargetTypeModifier(SearchModifier modifier, ISearchValue source)
             {
                 var referenceSearchValue = source as ReferenceSearchValue;
                 if (referenceSearchValue == null || modifier?.SearchModifierCode != SearchModifierCode.Type)

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/SearchValueExpressionBuilderHelper.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/SearchValueExpressionBuilderHelper.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
 
         private string _searchParameterName;
         private SearchModifierCode? _modifier;
+        private string _targetTypeModifier;
         private SearchComparator _comparator;
         private int? _componentIndex;
 
@@ -28,6 +29,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         public Expression Build(
             string searchParameterName,
             SearchModifierCode? modifier,
+            string targetTypeModifier,
             SearchComparator comparator,
             int? componentIndex,
             ISearchValue searchValue)
@@ -37,12 +39,17 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
                 modifier == null || Enum.IsDefined(typeof(SearchModifierCode), modifier.Value),
                 "Invalid modifier.");
             Debug.Assert(
+                (modifier != SearchModifierCode.Type && targetTypeModifier == null) ||
+                (modifier == SearchModifierCode.Type && !string.IsNullOrWhiteSpace(targetTypeModifier)),
+                "Target type needs to be specified for Type modifier.");
+            Debug.Assert(
                 Enum.IsDefined(typeof(SearchComparator), comparator),
                 "Invalid comparator.");
             EnsureArg.IsNotNull(searchValue, nameof(searchValue));
 
             _searchParameterName = searchParameterName;
             _modifier = modifier;
+            _targetTypeModifier = targetTypeModifier;
             _comparator = comparator;
             _componentIndex = componentIndex;
 
@@ -172,7 +179,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         {
             EnsureArg.IsNotNull(reference, nameof(reference));
 
-            if (_modifier != null)
+            if (_modifier != null && _modifier != SearchModifierCode.Type)
             {
                 ThrowModifierNotSupported();
             }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchModifier.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchModifier.cs
@@ -1,0 +1,77 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using EnsureThat;
+using Microsoft.Health.Fhir.ValueSets;
+
+namespace Microsoft.Health.Fhir.Core.Features.Search
+{
+    /// <summary>
+    /// Defines a search modifier applied to search parameter
+    /// </summary>
+    public sealed class SearchModifier : IEquatable<SearchModifier>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SearchModifier"/> class.
+        /// </summary>
+        /// <param name="searchModifierCode"><see cref="SearchModifierCode"/></param>
+        /// <param name="resourceType">Resource type used to constrain abstract modifier code (e.g. <see cref="SearchModifierCode.Type"/>)</param>
+        public SearchModifier(SearchModifierCode searchModifierCode, string resourceType = null)
+        {
+            EnsureArg.EnumIsDefined(searchModifierCode, nameof(searchModifierCode));
+            if (searchModifierCode == SearchModifierCode.Type)
+            {
+                EnsureArg.IsNotEmptyOrWhiteSpace(resourceType, nameof(resourceType));
+            }
+            else
+            {
+                EnsureArg.Is(resourceType, null, nameof(resourceType));
+            }
+
+            SearchModifierCode = searchModifierCode;
+            ResourceType = resourceType;
+        }
+
+        /// <summary>
+        /// <see cref="SearchModifierCode"/>
+        /// </summary>
+        public SearchModifierCode SearchModifierCode { get; }
+
+        /// <summary>
+        /// Resource type used to constrain abstract modifier code (e.g. <see cref="SearchModifierCode.Type"/>)
+        /// </summary>
+        public string ResourceType { get; }
+
+        public static bool operator ==(SearchModifier lhs, SearchModifier rhs)
+            => (object)lhs == rhs || (lhs?.Equals(rhs) ?? false);
+
+        public static bool operator !=(SearchModifier lhs, SearchModifier rhs)
+            => !(lhs == rhs);
+
+        public override bool Equals(object other)
+            => Equals(other as SearchModifier);
+
+        public bool Equals([AllowNull] SearchModifier other)
+        {
+            return !(other is null) &&
+                SearchModifierCode == other.SearchModifierCode &&
+                string.Equals(ResourceType, other.ResourceType, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public override int GetHashCode()
+        {
+            int h1 = SearchModifierCode.GetHashCode();
+            int h2 = ResourceType?.GetHashCode(StringComparison.OrdinalIgnoreCase) ?? 0;
+            return ((h1 << 5) + h1) ^ h2;
+        }
+
+        public override string ToString()
+        {
+            return SearchModifierCode == SearchModifierCode.Type ? ResourceType : SearchModifierCode.ToString();
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchModifier.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchModifier.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
         /// <param name="resourceType">Resource type used to constrain abstract modifier code (e.g. <see cref="SearchModifierCode.Type"/>)</param>
         public SearchModifier(SearchModifierCode searchModifierCode, string resourceType = null)
         {
-            EnsureArg.EnumIsDefined(searchModifierCode, nameof(searchModifierCode));
             if (searchModifierCode == SearchModifierCode.Type)
             {
                 EnsureArg.IsNotEmptyOrWhiteSpace(resourceType, nameof(resourceType));

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/Parsers/ExpressionParserTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/Parsers/ExpressionParserTests.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
 
             Expression expression = Substitute.For<Expression>();
 
-            _searchParameterExpressionParser.Parse(searchParameter, SearchModifierCode.Missing, null, value).Returns(expression);
+            _searchParameterExpressionParser.Parse(searchParameter, new SearchModifier(SearchModifierCode.Missing), value).Returns(expression);
 
             // Parse the expression.
             Expression actualExpression = _expressionParser.Parse(resourceType.ToString(), key, value);
@@ -329,7 +329,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
         {
             Expression expectedExpression = Substitute.For<Expression>();
 
-            _searchParameterExpressionParser.Parse(searchParameter, null, null, value).Returns(expectedExpression);
+            _searchParameterExpressionParser.Parse(searchParameter, null, value).Returns(expectedExpression);
 
             return expectedExpression;
         }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/Parsers/ExpressionParserTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/Parsers/ExpressionParserTests.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
 
             Expression expression = Substitute.For<Expression>();
 
-            _searchParameterExpressionParser.Parse(searchParameter, SearchModifierCode.Missing, value).Returns(expression);
+            _searchParameterExpressionParser.Parse(searchParameter, SearchModifierCode.Missing, null, value).Returns(expression);
 
             // Parse the expression.
             Expression actualExpression = _expressionParser.Parse(resourceType.ToString(), key, value);
@@ -329,7 +329,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
         {
             Expression expectedExpression = Substitute.For<Expression>();
 
-            _searchParameterExpressionParser.Parse(searchParameter, null, value).Returns(expectedExpression);
+            _searchParameterExpressionParser.Parse(searchParameter, null, null, value).Returns(expectedExpression);
 
             return expectedExpression;
         }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/Parsers/SearchValueExpressionBuilderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/Parsers/SearchValueExpressionBuilderTests.cs
@@ -66,6 +66,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
             Expression expression = _parser.Parse(
                 CreateSearchParameter(SearchParamType.String),
                 SearchModifierCode.Missing,
+                null,
                 isMissingString);
 
             ValidateMissingParamExpression(expression, DefaultParamName, expectedIsMissing);
@@ -75,7 +76,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
         public void GivenMissingModifierWithAnInvalidValue_WhenBuilding_ThenInvalidSearchOperationExceptionShouldBeThrown()
         {
             Assert.Throws<InvalidSearchOperationException>(
-                () => _parser.Parse(CreateSearchParameter(SearchParamType.String), SearchModifierCode.Missing, "test"));
+                () => _parser.Parse(CreateSearchParameter(SearchParamType.String), SearchModifierCode.Missing, null, "test"));
         }
 
         [Fact]
@@ -88,6 +89,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
             // Parse the expression.
             Validate(
                 CreateSearchParameter(SearchParamType.String),
+                null,
                 null,
                 value,
                 e => ValidateMultiaryExpression(
@@ -107,6 +109,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
             Assert.Throws<InvalidSearchOperationException>(() => _parser.Parse(
                 CreateSearchParameter(searchParameterType),
                 null,
+                null,
                 value));
         }
 
@@ -120,7 +123,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
                 components: components);
             SearchParameterInfo searchParameter = searchParameter1;
 
-            Assert.Throws<InvalidSearchOperationException>(() => _parser.Parse(searchParameter, null, "a$b$c"));
+            Assert.Throws<InvalidSearchOperationException>(() => _parser.Parse(searchParameter, null, null, "a$b$c"));
         }
 
         [Fact]
@@ -148,6 +151,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
 
             Validate(
                 searchParameter,
+                null,
                 null,
                 $"{system}|{code}${quantity}|{quantitySystem}|{quantityCode}",
                 outer => ValidateMultiaryExpression(
@@ -196,6 +200,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
             Validate(
                 searchParameter,
                 null,
+                null,
                 $"gt{quantity1}|{quantitySystem1}|{quantityCode1}$le{quantity2}|{quantitySystem2}|{quantityCode2}",
                 outer => ValidateMultiaryExpression(
                     outer,
@@ -235,7 +240,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
                 }.ToInfo());
 
             Assert.Throws<InvalidSearchOperationException>(
-                () => _parser.Parse(CreateSearchParameter(SearchParamType.Composite), modifier, "10|s|c$10|s|c"));
+                () => _parser.Parse(CreateSearchParameter(SearchParamType.Composite), modifier, null, "10|s|c$10|s|c"));
         }
 
         [Theory]
@@ -251,6 +256,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
 
             Validate(
                 CreateSearchParameter(SearchParamType.Date),
+                null,
                 null,
                 input,
                 e => ValidateMultiaryExpression(
@@ -274,6 +280,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
             Validate(
                 CreateSearchParameter(SearchParamType.Date),
                 null,
+                null,
                 "eq" + dateTimeInput,
                 e => ValidateMultiaryExpression(
                     e,
@@ -295,6 +302,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
 
             Validate(
                 CreateSearchParameter(SearchParamType.Date),
+                null,
                 null,
                 "ne" + dateTimeInput,
                 e => ValidateMultiaryExpression(
@@ -343,6 +351,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
             Validate(
                 CreateSearchParameter(SearchParamType.Date),
                 null,
+                null,
                 prefix + dateTimeInput,
                 e => ValidateDateTimeBinaryOperatorExpression(
                     e,
@@ -372,6 +381,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
                 Validate(
                     CreateSearchParameter(SearchParamType.Date),
                     null,
+                    null,
                     "ap" + dateTimeInput,
                     e => ValidateMultiaryExpression(
                         e,
@@ -386,7 +396,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
         public void GivenADateWithInvalidModifier_WhenBuilding_ThenInvalidSearchOperationExceptionShouldBeThrown(SearchModifierCode modifier)
         {
             Assert.Throws<InvalidSearchOperationException>(
-                () => _parser.Parse(CreateSearchParameter(SearchParamType.Date), modifier, "1980"));
+                () => _parser.Parse(CreateSearchParameter(SearchParamType.Date), modifier, null, "1980"));
         }
 
         [Theory]
@@ -404,6 +414,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
         {
             Validate(
                 CreateSearchParameter(SearchParamType.Number),
+                null,
                 null,
                 $"{prefix}15.0",
                 e => ValidateMultiaryExpression(
@@ -427,6 +438,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
             Validate(
                 CreateSearchParameter(SearchParamType.Number),
                 null,
+                null,
                 $"{prefix}{expected}",
                 e => ValidateBinaryExpression(e, FieldName.Number, binaryOperator, expected));
         }
@@ -436,7 +448,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
         public void GivenANumberWithInvalidModifier_WhenBuilding_ThenInvalidSearchOperationExceptionShouldBeThrown(SearchModifierCode modifier)
         {
             Assert.Throws<InvalidSearchOperationException>(
-                () => _parser.Parse(CreateSearchParameter(SearchParamType.Number), modifier, "123"));
+                () => _parser.Parse(CreateSearchParameter(SearchParamType.Number), modifier, null, "123"));
         }
 
         [Theory]
@@ -457,6 +469,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
 
             Validate(
                 CreateSearchParameter(SearchParamType.Quantity),
+                null,
                 null,
                 $"{prefix}6.05|{system}|{code}",
                 e => ValidateMultiaryExpression(
@@ -489,6 +502,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
             Validate(
                 CreateSearchParameter(SearchParamType.Quantity),
                 null,
+                null,
                 $"{prefix}{expected}|{system}|{code}",
                 e => ValidateMultiaryExpression(
                     e,
@@ -506,6 +520,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
 
             Validate(
                 CreateSearchParameter(SearchParamType.Quantity),
+                null,
                 null,
                 $"gt{expected}||{code}",
                 e => ValidateMultiaryExpression(
@@ -526,6 +541,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
             Validate(
                 CreateSearchParameter(SearchParamType.Quantity),
                 null,
+                null,
                 $"le{expected}|{system}{suffix}",
                 e => ValidateMultiaryExpression(
                     e,
@@ -542,6 +558,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
             Validate(
                 CreateSearchParameter(SearchParamType.Quantity),
                 null,
+                null,
                 $"gt{expected}",
                 e => ValidateBinaryExpression(e, FieldName.Quantity, BinaryOperator.GreaterThan, expected));
         }
@@ -551,7 +568,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
         public void GivenAQuantityWithInvalidModifier_WhenBuilding_ThenInvalidSearchOperationExceptionShouldBeThrown(SearchModifierCode modifier)
         {
             Assert.Throws<InvalidSearchOperationException>(
-                () => _parser.Parse(CreateSearchParameter(SearchParamType.Quantity), modifier, "1"));
+                () => _parser.Parse(CreateSearchParameter(SearchParamType.Quantity), modifier, null, "1"));
         }
 
         [Fact]
@@ -563,6 +580,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
 
             Validate(
                 CreateSearchParameter(SearchParamType.Reference),
+                null,
                 null,
                 resourceId,
                 e => ValidateStringExpression(e, FieldName.ReferenceResourceId, StringOperator.Equals, resourceId, false));
@@ -580,7 +598,29 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
             Validate(
                 CreateSearchParameter(SearchParamType.Reference),
                 null,
+                null,
                 reference,
+                e => ValidateMultiaryExpression(
+                    e,
+                    MultiaryOperator.And,
+                    e1 => ValidateMissingFieldExpression(e1, FieldName.ReferenceBaseUri),
+                    e1 => ValidateStringExpression(e1, FieldName.ReferenceResourceType, StringOperator.Equals, resourceType.ToString(), false),
+                    e1 => ValidateStringExpression(e1, FieldName.ReferenceResourceId, StringOperator.Equals, resourceId, false)));
+        }
+
+        [Fact]
+        public void GivenAReferenceUsingResourceIdWithTargetTypeModifierTargetingInternalResource_WhenBuilt_ThenCorrectExpressionShouldBeCreated()
+        {
+            const ResourceType resourceType = ResourceType.Patient;
+            const string resourceId = "123";
+
+            _referenceSearchValueParser.Parse(resourceId).Returns(new ReferenceSearchValue(ReferenceKind.Internal, null, null, resourceId));
+
+            Validate(
+                CreateSearchParameter(SearchParamType.Reference),
+                null,
+                resourceType.ToString(),
+                resourceId.ToString(),
                 e => ValidateMultiaryExpression(
                     e,
                     MultiaryOperator.And,
@@ -603,6 +643,32 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
             Validate(
                 CreateSearchParameter(SearchParamType.Reference),
                 null,
+                null,
+                reference,
+                e => ValidateMultiaryExpression(
+                    e,
+                    MultiaryOperator.And,
+                    e1 => ValidateStringExpression(e1, FieldName.ReferenceResourceType, StringOperator.Equals, resourceType.ToString(), false),
+                    e1 => ValidateStringExpression(e1, FieldName.ReferenceResourceId, StringOperator.Equals, resourceId, false)));
+        }
+
+        [Theory]
+        [InlineData(ReferenceKind.InternalOrExternal, true)]
+        [InlineData(ReferenceKind.InternalOrExternal, false)]
+        [InlineData(ReferenceKind.External, true)]
+        [InlineData(ReferenceKind.External, false)]
+        public void GivenAReferenceUsingResourceIdWithTargetTypeModifier_WhenBuilt_ThenCorrectExpressionShouldBeCreated(ReferenceKind referenceLocations, bool withResourceType)
+        {
+            const ResourceType resourceType = ResourceType.Patient;
+            const string resourceId = "123";
+            string reference = $"{(withResourceType ? resourceType + "/" : null)}{resourceId}";
+
+            _referenceSearchValueParser.Parse(reference).Returns(new ReferenceSearchValue(referenceLocations, null, withResourceType ? resourceType.ToString() : null, resourceId));
+
+            Validate(
+                CreateSearchParameter(SearchParamType.Reference),
+                null,
+                resourceType.ToString(),
                 reference,
                 e => ValidateMultiaryExpression(
                     e,
@@ -625,6 +691,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
             Validate(
                 CreateSearchParameter(SearchParamType.Reference),
                 null,
+                null,
                 reference,
                 e => ValidateMultiaryExpression(
                     e,
@@ -641,7 +708,18 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
             _referenceSearchValueParser.Parse(Arg.Any<string>()).Returns(new ReferenceSearchValue(ReferenceKind.InternalOrExternal, null, null, "123"));
 
             Assert.Throws<InvalidSearchOperationException>(
-                () => _parser.Parse(CreateSearchParameter(SearchParamType.Reference), modifier, "Patient/test"));
+                () => _parser.Parse(CreateSearchParameter(SearchParamType.Reference), modifier, null, "Patient/test"));
+        }
+
+        [Theory]
+        [InlineData("Patient", "Group", "test")]
+        [InlineData("InvalidModifier", null, "test")]
+        public void GivenAReferenceWithInvalidTargetTypeModifier_WhenBuilding_ThenInvalidSearchOperationExceptionShouldBeThrown(string targetTypeModifier, string resourceType, string resourceId)
+        {
+            _referenceSearchValueParser.Parse(Arg.Any<string>()).Returns(new ReferenceSearchValue(ReferenceKind.InternalOrExternal, null, resourceType, resourceId));
+
+            Assert.Throws<InvalidSearchOperationException>(
+                () => _parser.Parse(CreateSearchParameter(SearchParamType.Reference), null, targetTypeModifier, $"{resourceType}{(string.IsNullOrEmpty(resourceType) ? null : "/")}{resourceId}"));
         }
 
         [Fact]
@@ -651,6 +729,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
 
             Validate(
                 CreateSearchParameter(SearchParamType.String),
+                null,
                 null,
                 input,
                 e => ValidateStringExpression(e, FieldName.String, StringOperator.StartsWith, input, true));
@@ -664,6 +743,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
             Validate(
                 CreateSearchParameter(SearchParamType.String),
                 SearchModifierCode.Exact,
+                null,
                 input,
                 e => ValidateStringExpression(e, FieldName.String, StringOperator.Equals, input, false));
         }
@@ -676,6 +756,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
             Validate(
                 CreateSearchParameter(SearchParamType.String),
                 SearchModifierCode.Contains,
+                null,
                 input,
                 e => ValidateStringExpression(e, FieldName.String, StringOperator.Contains, input, true));
         }
@@ -691,7 +772,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
         public void GivenAStringWithInvalidModifier_WhenBuilding_ThenInvalidSearchOperationExceptionShouldBeThrown(SearchModifierCode modifier)
         {
             Assert.Throws<InvalidSearchOperationException>(
-                () => _parser.Parse(CreateSearchParameter(SearchParamType.String), modifier, "test"));
+                () => _parser.Parse(CreateSearchParameter(SearchParamType.String), modifier, null, "test"));
         }
 
         [Fact]
@@ -702,6 +783,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
             Validate(
                 CreateSearchParameter(SearchParamType.Token),
                 SearchModifierCode.Text,
+                null,
                 input,
                 e => ValidateStringExpression(e, FieldName.TokenText, StringOperator.StartsWith, input, true));
         }
@@ -716,7 +798,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
                 Type = searchParameterType,
             };
 
-            Assert.Throws<InvalidSearchOperationException>(() => _parser.Parse(searchParameter.ToInfo(), SearchModifierCode.Text, "test"));
+            Assert.Throws<InvalidSearchOperationException>(() => _parser.Parse(searchParameter.ToInfo(), SearchModifierCode.Text, null, "test"));
         }
 
         [Fact]
@@ -726,6 +808,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
 
             Validate(
                 CreateSearchParameter(SearchParamType.Token),
+                null,
                 null,
                 code,
                 e => ValidateStringExpression(e, FieldName.TokenCode, StringOperator.Equals, code, false));
@@ -738,6 +821,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
 
             Validate(
                 CreateSearchParameter(SearchParamType.Token),
+                null,
                 null,
                 $"|{code}",
                 e => ValidateMultiaryExpression(
@@ -757,6 +841,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
             Validate(
                 CreateSearchParameter(SearchParamType.Token),
                 null,
+                null,
                 $"{system}|{code}",
                 e => ValidateStringExpression(e, FieldName.TokenSystem, StringOperator.Equals, system, false));
         }
@@ -769,6 +854,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
 
             Validate(
                 CreateSearchParameter(SearchParamType.Token),
+                null,
                 null,
                 $"{system}|{code}",
                 e =>
@@ -789,7 +875,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
         public void GivenATokenWithInvalidModifier_WhenBuilding_ThenInvalidSearchOperationExceptionShouldBeThrown(SearchModifierCode modifier)
         {
             Assert.Throws<InvalidSearchOperationException>(
-                () => _parser.Parse(CreateSearchParameter(SearchParamType.Token), modifier, "test"));
+                () => _parser.Parse(CreateSearchParameter(SearchParamType.Token), modifier, null, "test"));
         }
 
         [Fact]
@@ -799,6 +885,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
 
             Validate(
                 CreateSearchParameter(SearchParamType.Uri),
+                null,
                 null,
                 input,
                 e => ValidateStringExpression(e, FieldName.Uri, StringOperator.Equals, input, false));
@@ -812,6 +899,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
             Validate(
                 CreateSearchParameter(SearchParamType.Uri),
                 SearchModifierCode.Above,
+                null,
                 input,
                 e => ValidateMultiaryExpression(
                     e,
@@ -828,6 +916,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
             Validate(
                 CreateSearchParameter(SearchParamType.Uri),
                 SearchModifierCode.Below,
+                null,
                 input,
                 e => ValidateMultiaryExpression(
                     e,
@@ -847,7 +936,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
         public void GivenAUriWithInvalidModifier_WhenBuilding_ThenInvalidSearchOperationExceptionShouldBeThrown(SearchModifierCode modifier)
         {
             Assert.Throws<InvalidSearchOperationException>(
-                () => _parser.Parse(CreateSearchParameter(SearchParamType.Uri), modifier, "test"));
+                () => _parser.Parse(CreateSearchParameter(SearchParamType.Uri), modifier, null, "test"));
         }
 
         private SearchParameterInfo CreateSearchParameter(SearchParamType searchParameterType)
@@ -862,10 +951,11 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
         private void Validate(
             SearchParameterInfo searchParameter,
             SearchModifierCode? modifier,
+            string targetTypeModifier,
             string value,
             Action<Expression> valueValidator)
         {
-            Expression expression = _parser.Parse(searchParameter, modifier, value);
+            Expression expression = _parser.Parse(searchParameter, modifier, targetTypeModifier, value);
             Assert.NotNull(expression);
             ValidateSearchParameterExpression(expression, DefaultParamName, valueValidator);
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ReferenceSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ReferenceSearchTests.cs
@@ -27,7 +27,10 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [InlineData("organization=Organization/ijk", 2)] // This is specified in the resource as "ijk", without the type, but the type can only be Organization
         [InlineData("organization=ijk", 2)]
         [InlineData("general-practitioner=Practitioner/p1", 3)]
+        [InlineData("general-practitioner:Practitioner=Practitioner/p1", 3)]
+        [InlineData("general-practitioner:Practitioner=p1", 3)]
         [InlineData("general-practitioner=Practitioner/p2")] // This is specified in the resource as "p2", without the type, but because the parameter can reference several types and we don't resolve references, this search does not succeed
+        [InlineData("general-practitioner:Practitioner=p2")] // This is specified in the resource as "p2", without the type, but because the parameter can reference several types and we don't resolve references, this search does not succeed
         [InlineData("general-practitioner=p2", 4)]
         public async Task GivenAReferenceSearchParam_WhenSearched_ThenCorrectBundleShouldBeReturned(string query, params int[] matchIndices)
         {


### PR DESCRIPTION
## Description
Added support for type modifer when searching by reference. It was previously only supported for chained reference, but not when reference is the last search parameter.

#### From the spec: https://www.hl7.org/fhir/search.html#reference
> A modifier is also defined to allow the client to be explicit about the intended type

#### Example query
```http
GET /Encounter?subject:Patient=Patient/123
```

## Testing
Unit + manual (SqlServer)

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- [ ] Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch (Modifier was previously supported if it was in the middle of the chain, but not the end)
