### PR TITLE
Added support for :not modifier on a Token Search Parameter

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/DefaultExpressionVisitor.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/DefaultExpressionVisitor.cs
@@ -43,6 +43,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
             return result;
         }
 
+        public virtual TOutput VisitNotExpression(NotExpression expression, TContext context) => expression.Expression.AcceptVisitor(this, context);
+
         public virtual TOutput VisitSearchParameter(SearchParameterExpression expression, TContext context) => expression.Expression.AcceptVisitor(this, context);
 
         public virtual TOutput VisitBinary(BinaryExpression expression, TContext context) => default;

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Expression.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Expression.cs
@@ -36,6 +36,16 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         }
 
         /// <summary>
+        /// Creates a <see cref="NotExpression"/> that represents logical NOT operation over <paramref name="expression"/>.
+        /// </summary>
+        /// <param name="expression">The expression.</param>
+        /// <returns>A <see cref="NotExpression"/> that has logical operator NOT over <paramref name="expression"/>.</returns>
+        public static NotExpression Not(Expression expression)
+        {
+            return new NotExpression(expression);
+        }
+
+        /// <summary>
         /// Creates a <see cref="MultiaryExpression"/> that represents logical AND operation over <paramref name="expressions"/>.
         /// </summary>
         /// <param name="expressions">The expressions.</param>

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/ExpressionRewriter.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/ExpressionRewriter.cs
@@ -51,6 +51,17 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
             return expression;
         }
 
+        public virtual Expression VisitNotExpression(NotExpression expression, TContext context)
+        {
+            Expression visitedExpression = expression.Expression.AcceptVisitor(visitor: this, context: context);
+            if (ReferenceEquals(visitedExpression, expression.Expression))
+            {
+                return expression;
+            }
+
+            return new NotExpression(visitedExpression);
+        }
+
         public virtual Expression VisitMultiary(MultiaryExpression expression, TContext context)
         {
             IReadOnlyList<Expression> rewrittenExpressions = VisitArray(expression.Expressions, context);

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/IExpressionVisitor.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/IExpressionVisitor.cs
@@ -48,6 +48,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         TOutput VisitMissingSearchParameter(MissingSearchParameterExpression expression, TContext context);
 
         /// <summary>
+        /// Visits the <see cref="NotExpression"/>.
+        /// </summary>
+        /// <param name="expression">The expression to visit.</param>
+        /// <param name="context">The input</param>
+        TOutput VisitNotExpression(NotExpression expression, TContext context);
+
+        /// <summary>
         /// Visits the <see cref="MultiaryExpression"/>.
         /// </summary>
         /// <param name="expression">The expression to visit.</param>

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/NotExpression.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/NotExpression.cs
@@ -1,0 +1,42 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using EnsureThat;
+
+namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
+{
+    /// <summary>
+    /// Represents a not expression where <see cref="Expression"/> is negated.
+    /// </summary>
+    public class NotExpression : Expression
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NotExpression"/> class.
+        /// </summary>
+        /// <param name="expression">The expression.</param>
+        public NotExpression(Expression expression)
+        {
+            EnsureArg.IsNotNull(expression, nameof(expression));
+            Expression = expression;
+        }
+
+        /// <summary>
+        /// Gets the expression.
+        /// </summary>
+        public Expression Expression { get; }
+
+        public override TOutput AcceptVisitor<TContext, TOutput>(IExpressionVisitor<TContext, TOutput> visitor, TContext context)
+        {
+            EnsureArg.IsNotNull(visitor, nameof(visitor));
+
+            return visitor.VisitNotExpression(this, context);
+        }
+
+        public override string ToString()
+        {
+            return $"(Not {Expression})";
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/SearchParameterExpressionParser.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/SearchParameterExpressionParser.cs
@@ -199,19 +199,38 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
                 }
 
                 // This is a multiple value expression.
-                Expression[] expressions = parts.Select(part =>
+                if (modifier == SearchModifierCode.Not)
                 {
-                    ISearchValue searchValue = parser(part);
+                    Expression[] expressions = parts.Select(part =>
+                    {
+                        ISearchValue searchValue = parser(part);
 
-                    return helper.Build(
-                        searchParameter.Name,
-                        modifier,
-                        comparator,
-                        componentIndex,
-                        searchValue);
-                }).ToArray();
+                        return helper.Build(
+                            searchParameter.Name,
+                            null,
+                            comparator,
+                            componentIndex,
+                            searchValue);
+                    }).ToArray();
 
-                return Expression.Or(expressions);
+                    return Expression.Not(Expression.Or(expressions));
+                }
+                else
+                {
+                    Expression[] expressions = parts.Select(part =>
+                    {
+                        ISearchValue searchValue = parser(part);
+
+                        return helper.Build(
+                            searchParameter.Name,
+                            modifier,
+                            comparator,
+                            componentIndex,
+                            searchValue);
+                    }).ToArray();
+
+                    return Expression.Or(expressions);
+                }
             }
         }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/SearchValueExpressionBuilderHelper.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/SearchValueExpressionBuilderHelper.cs
@@ -245,31 +245,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
 
             if (_modifier == null)
             {
-                // Based on spec http://hl7.org/fhir/search.html#token,
-                // we need to make sure to test if system is missing or not based on how it is supplied.
-                if (token.System == null)
-                {
-                    // If the system is not supplied, then the token code is matched irrespective of the value of system.
-                    _outputExpression = Expression.StringEquals(FieldName.TokenCode, _componentIndex, token.Code, false);
-                }
-                else if (token.System.Length == 0)
-                {
-                    // If the system is empty, then the token is matched if there is no system property.
-                    _outputExpression = Expression.And(
-                        Expression.Missing(FieldName.TokenSystem, _componentIndex),
-                        Expression.StringEquals(FieldName.TokenCode, _componentIndex, token.Code, false));
-                }
-                else if (string.IsNullOrWhiteSpace(token.Code))
-                {
-                    // If the code is empty, then the token is matched if system is matched.
-                    _outputExpression = Expression.StringEquals(FieldName.TokenSystem, _componentIndex, token.System, false);
-                }
-                else
-                {
-                    _outputExpression = Expression.And(
-                        Expression.StringEquals(FieldName.TokenSystem, _componentIndex, token.System, false),
-                        Expression.StringEquals(FieldName.TokenCode, _componentIndex, token.Code, false));
-                }
+                _outputExpression = BuildEqualityExpression();
+            }
+            else if (_modifier == SearchModifierCode.Not)
+            {
+                _outputExpression = Expression.Not(BuildEqualityExpression());
             }
             else if (_modifier == SearchModifierCode.Above ||
                      _modifier == SearchModifierCode.Below ||
@@ -282,6 +262,35 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
             else
             {
                 ThrowModifierNotSupported();
+            }
+
+            Expression BuildEqualityExpression()
+            {
+                // Based on spec http://hl7.org/fhir/search.html#token,
+                // we need to make sure to test if system is missing or not based on how it is supplied.
+                if (token.System == null)
+                {
+                    // If the system is not supplied, then the token code is matched irrespective of the value of system.
+                    return Expression.StringEquals(FieldName.TokenCode, _componentIndex, token.Code, false);
+                }
+                else if (token.System.Length == 0)
+                {
+                    // If the system is empty, then the token is matched if there is no system property.
+                    return Expression.And(
+                        Expression.Missing(FieldName.TokenSystem, _componentIndex),
+                        Expression.StringEquals(FieldName.TokenCode, _componentIndex, token.Code, false));
+                }
+                else if (string.IsNullOrWhiteSpace(token.Code))
+                {
+                    // If the code is empty, then the token is matched if system is matched.
+                    return Expression.StringEquals(FieldName.TokenSystem, _componentIndex, token.System, false);
+                }
+                else
+                {
+                    return Expression.And(
+                        Expression.StringEquals(FieldName.TokenSystem, _componentIndex, token.System, false),
+                        Expression.StringEquals(FieldName.TokenCode, _componentIndex, token.Code, false));
+                }
             }
         }
 

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/ExpressionQueryBuilder.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/ExpressionQueryBuilder.cs
@@ -119,7 +119,15 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries
                     AppendSubquery(parameterName: null, expression.Expression, context);
                     break;
                 default:
-                    AppendSubquery(expression.Parameter.Name, expression.Expression, context);
+                    if (expression.Expression is NotExpression notExpression)
+                    {
+                        AppendSubquery(expression.Parameter.Name, notExpression.Expression, context, true);
+                    }
+                    else
+                    {
+                        AppendSubquery(expression.Parameter.Name, expression.Expression, context);
+                    }
+
                     break;
             }
 
@@ -211,8 +219,9 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries
 
         public object VisitNotExpression(NotExpression expression, Context context)
         {
-            // TODO: This will be removed once it's implemented.
-            throw new SearchOperationNotSupportedException("Modifier ':not' is not supported");
+            string message = $"Not expression should be handled in {nameof(VisitSearchParameter)}";
+            Debug.Fail(message);
+            throw new InvalidOperationException(message);
         }
 
         public object VisitMultiary(MultiaryExpression expression, Context context)

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/ExpressionQueryBuilder.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/ExpressionQueryBuilder.cs
@@ -219,9 +219,10 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries
 
         public object VisitNotExpression(NotExpression expression, Context context)
         {
-            string message = $"Not expression should be handled in {nameof(VisitSearchParameter)}";
-            Debug.Fail(message);
-            throw new InvalidOperationException(message);
+            _queryBuilder.Append("NOT (");
+            expression.Expression.AcceptVisitor(this, context);
+            _queryBuilder.Append(")");
+            return null;
         }
 
         public object VisitMultiary(MultiaryExpression expression, Context context)

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/ExpressionQueryBuilder.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/ExpressionQueryBuilder.cs
@@ -209,6 +209,12 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries
             return null;
         }
 
+        public object VisitNotExpression(NotExpression expression, Context context)
+        {
+            // TODO: This will be removed once it's implemented.
+            throw new SearchOperationNotSupportedException("Modifier ':not' is not supported");
+        }
+
         public object VisitMultiary(MultiaryExpression expression, Context context)
         {
             MultiaryOperator op = expression.MultiaryOperation;

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/Parsers/SearchValueExpressionBuilderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/Parsers/SearchValueExpressionBuilderTests.cs
@@ -706,6 +706,18 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
                 e => ValidateStringExpression(e, FieldName.TokenText, StringOperator.StartsWith, input, true));
         }
 
+        [Fact]
+        public void GivenATokenWithNotModifier_WhenBuilt_ThenCorrectExpressionShouldBeCreated()
+        {
+            const string input = "TestString123";
+
+            Validate(
+                CreateSearchParameter(SearchParamType.Token),
+                SearchModifierCode.Not,
+                input,
+                e => ValidateNotExpression(e, x => ValidateStringExpression(x, FieldName.TokenCode, StringOperator.Equals, input, false)));
+        }
+
         [Theory]
         [MemberData(nameof(GetNoneTokenSearchParamTypeAsMemberData))]
         public void GivenASearchParameterThatDoesNotSupportTextModifier_WhenBuilt_ThenCorrectExpressionShouldBeCreated(SearchParamType searchParameterType)
@@ -784,7 +796,6 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
         [Theory]
         [InlineData(SearchModifierCode.Exact)]
         [InlineData(SearchModifierCode.Contains)]
-        [InlineData(SearchModifierCode.Not)]
         [InlineData(SearchModifierCode.Type)]
         public void GivenATokenWithInvalidModifier_WhenBuilding_ThenInvalidSearchOperationExceptionShouldBeThrown(SearchModifierCode modifier)
         {

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchExpressionTestHelper.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchExpressionTestHelper.cs
@@ -139,6 +139,14 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             Assert.Equal(expectedFieldName, mfExpression.FieldName);
         }
 
+        public static void ValidateNotExpression(
+            Expression expression,
+            Action<Expression> subValidator)
+        {
+            NotExpression notExpression = Assert.IsType<NotExpression>(expression);
+            subValidator(notExpression.Expression);
+        }
+
         public static void ValidateCompartmentSearchExpression(
             Expression expression,
             string compartmentType,

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -221,8 +221,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             var searchExpressions = new List<Expression>();
             if (string.IsNullOrWhiteSpace(resourceType))
             {
+                // Try to parse resource types from _type Search Parameter
+                // This will result in empty array if _type has any modifiers
+                // Which is good, since :not modifier changes the meaning of the
+                // search parameter and we can no longer use it to deduce types
+                // (and should proceed with ResourceType.DomainResource in that case)
                 var resourceTypes = searchParams.Parameters
-                    .Where(q => q.Item1 == KnownQueryParameterNames.Type)
+                    .Where(q => q.Item1 == KnownQueryParameterNames.Type) // <-- Equality comparison to avoid modifiers
                     .SelectMany(q => q.Item2.SplitByOrSeparator())
                     .Where(type => ModelInfoProvider.IsKnownResource(type))
                     .Select(x =>

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/NormalizedPredicateReordererTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/NormalizedPredicateReordererTests.cs
@@ -18,7 +18,8 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
 {
     public class NormalizedPredicateReordererTests
     {
-        private static readonly Expression NormalExpression = new SearchParameterExpression(new SearchParameterInfo("TestParam"), Expression.Equals(FieldName.TokenCode, null, "TestValue"));
+        private static readonly SearchParameterExpression NormalExpression = new SearchParameterExpression(new SearchParameterInfo("TestParam"), Expression.Equals(FieldName.TokenCode, null, "TestValue"));
+        private static readonly SearchParameterExpression NotExpression = new SearchParameterExpression(NormalExpression.Parameter, Expression.Not(NormalExpression.Expression));
 
         [Fact]
         public void GivenExpressionWithSingleTableExpression_WhenReordered_ReturnsOriginalExpression()
@@ -30,7 +31,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
         }
 
         [Fact]
-        public void GivenExpressionWithMulthMultipleTableExpressions_WhenReordered_DenormilizedExpressionReturnedFirst()
+        public void GivenExpressionWithMultipleTableExpressions_WhenReordered_DenormilizedExpressionReturnedFirst()
         {
             var tableExpressions = new List<TableExpression>
             {
@@ -44,7 +45,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
         }
 
         [Fact]
-        public void GivenExpressionWithMulthMultipleTableExpressions_WhenReordered_ReferenceExpressionReturnedBeforeNormal()
+        public void GivenExpressionWithMultipleTableExpressions_WhenReordered_ReferenceExpressionReturnedBeforeNormal()
         {
             var tableExpressions = new List<TableExpression>
             {
@@ -58,7 +59,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
         }
 
         [Fact]
-        public void GivenExpressionWithMulthMultipleTableExpressions_WhenReordered_CompartmentExpressionReturnedBeforeNormal()
+        public void GivenExpressionWithMultipleTableExpressions_WhenReordered_CompartmentExpressionReturnedBeforeNormal()
         {
             var tableExpressions = new List<TableExpression>
             {
@@ -72,11 +73,11 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
         }
 
         [Fact]
-        public void GivenExpressionWithMulthMultipleTableExpressions_WhenReordered_MissingParameterExpressionReturnedBeforeInclude()
+        public void GivenExpressionWithMultipleTableExpressions_WhenReordered_MissingParameterExpressionReturnedBeforeNotExpression()
         {
             var tableExpressions = new List<TableExpression>
             {
-                new TableExpression(new IncludeQueryGenerator(), NormalExpression, null, TableExpressionKind.Include),
+                new TableExpression(null, NotExpression, null, TableExpressionKind.Normal),
                 new TableExpression(null, new MissingSearchParameterExpression(new SearchParameterInfo("TestParam"), true), null, TableExpressionKind.Normal),
             };
 
@@ -86,12 +87,12 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
         }
 
         [Fact]
-        public void GivenExpressionWithMulthMultipleTableExpressions_WhenReordered_IncludeExpressionReturnedLast()
+        public void GivenExpressionWithMultipleTableExpressions_WhenReordered_IncludeExpressionReturnedLast()
         {
             var tableExpressions = new List<TableExpression>
             {
                 new TableExpression(new IncludeQueryGenerator(), NormalExpression, null, TableExpressionKind.Include),
-                new TableExpression(null, NormalExpression, null, TableExpressionKind.Normal),
+                new TableExpression(null, NotExpression, null, TableExpressionKind.Normal),
             };
 
             var inputExpression = SqlRootExpression.WithTableExpressions(tableExpressions);

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/NotExpressionRewriterTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/NotExpressionRewriterTests.cs
@@ -1,0 +1,74 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
+using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions;
+using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
+{
+    public class NotExpressionRewriterTests
+    {
+        [Fact]
+        public void GivenExpressionWithNotExpression_WhenVisited_AllExpressionPrependedToExpressionList()
+        {
+            var subExpression = Expression.StringEquals(FieldName.TokenCode, 0, "TestValue123", false);
+            var tableExpressions = new List<TableExpression>
+            {
+                new TableExpression(null, new SearchParameterExpression(new SearchParameterInfo("TestParam"), Expression.Not(subExpression)), null, TableExpressionKind.Normal),
+            };
+
+            var inputExpression = SqlRootExpression.WithTableExpressions(tableExpressions);
+            var visitedExpression = (SqlRootExpression)inputExpression.AcceptVisitor(NotExpressionRewriter.Instance);
+            Assert.Collection(
+                visitedExpression.TableExpressions,
+                e => { Assert.Equal(TableExpressionKind.All, e.Kind); },
+                e => { ValidateNotExpression(subExpression, e); });
+            Assert.Equal(tableExpressions.Count + 1, visitedExpression.TableExpressions.Count);
+        }
+
+        [Fact]
+        public void GivenExpressionWithNoNotExpression_WhenVisited_OriginalExpressionReturned()
+        {
+            var tableExpressions = new List<TableExpression>
+            {
+                new TableExpression(null, null, null, TableExpressionKind.Normal),
+            };
+
+            var inputExpression = SqlRootExpression.WithTableExpressions(tableExpressions);
+            var visitedExpression = (SqlRootExpression)inputExpression.AcceptVisitor(NotExpressionRewriter.Instance);
+            Assert.Equal(inputExpression, visitedExpression);
+        }
+
+        [Fact]
+        public void GivenExpressionWithNotExpressionLast_WhenVisited_NotExpressionUnwrapped()
+        {
+            var subExpression = Expression.StringEquals(FieldName.TokenCode, 0, "TestValue123", false);
+            var tableExpressions = new List<TableExpression>
+            {
+                new TableExpression(null, null, null, TableExpressionKind.Normal),
+                new TableExpression(null, new SearchParameterExpression(new SearchParameterInfo("TestParam"), Expression.Not(subExpression)), null, TableExpressionKind.Normal),
+            };
+
+            var inputExpression = SqlRootExpression.WithTableExpressions(tableExpressions);
+            var visitedExpression = (SqlRootExpression)inputExpression.AcceptVisitor(NotExpressionRewriter.Instance);
+            Assert.Collection(
+                visitedExpression.TableExpressions,
+                e => { Assert.Equal(tableExpressions[0], e); },
+                e => { ValidateNotExpression(subExpression, e); });
+        }
+
+        private static void ValidateNotExpression(Expression subExpression, TableExpression expressionToValidate)
+        {
+            Assert.Equal(TableExpressionKind.NotExists, expressionToValidate.Kind);
+
+            var spExpression = Assert.IsType<SearchParameterExpression>(expressionToValidate.NormalizedPredicate);
+            Assert.Equal(subExpression, spExpression.Expression);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/NormalizedPredicateReorderer.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/NormalizedPredicateReorderer.cs
@@ -37,6 +37,12 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
                     return -10;
                 }
 
+                var order = t.NormalizedPredicate?.AcceptVisitor(Scout.Instance, context);
+                if (order != 0)
+                {
+                    return order;
+                }
+
                 switch (t.SearchParameterQueryGenerator)
                 {
                     case ReferenceSearchParameterQueryGenerator _:
@@ -51,6 +57,26 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
             }).ToList();
 
             return new SqlRootExpression(reorderedExpressions, expression.DenormalizedExpressions);
+        }
+
+        public override Expression VisitNotExpression(NotExpression expression, object context)
+        {
+            return base.VisitNotExpression(expression, context);
+        }
+
+        private class Scout : DefaultExpressionVisitor<object, int>
+        {
+            internal static readonly Scout Instance = new Scout();
+
+            private Scout()
+                : base((accumulated, current) => current != 0 ? current : accumulated)
+            {
+            }
+
+            public override int VisitNotExpression(NotExpression expression, object context)
+            {
+                return -15;
+            }
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/NormalizedSearchParameterQueryGeneratorFactory.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/NormalizedSearchParameterQueryGeneratorFactory.cs
@@ -149,6 +149,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
             return TokenSearchParameterQueryGenerator.Instance;
         }
 
+        public NormalizedSearchParameterQueryGenerator VisitNotExpression(NotExpression expression, object context)
+        {
+            return expression.Expression.AcceptVisitor(this, context);
+        }
+
         public NormalizedSearchParameterQueryGenerator VisitMultiary(MultiaryExpression expression, object context)
         {
             foreach (var childExpression in expression.Expressions)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/NotExpressionRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/NotExpressionRewriter.cs
@@ -1,0 +1,95 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
+
+namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
+{
+    /// <summary>
+    /// Turns an expression with a :not modifier into a <see cref="TableExpressionKind.NotExists"/>
+    /// table expression with the condition negated
+    /// </summary>
+    internal class NotExpressionRewriter : SqlExpressionRewriterWithInitialContext<object>
+    {
+        internal static readonly NotExpressionRewriter Instance = new NotExpressionRewriter();
+
+        public override Expression VisitSqlRoot(SqlRootExpression expression, object context)
+        {
+            if (expression.TableExpressions.Count == 0)
+            {
+                return expression;
+            }
+
+            List<TableExpression> newTableExpressions = null;
+            for (var i = 0; i < expression.TableExpressions.Count; i++)
+            {
+                TableExpression tableExpression = expression.TableExpressions[i];
+
+                // process only normalized predicates. Ignore Sort as it has its own visitor.
+                if (tableExpression.Kind != TableExpressionKind.Sort && tableExpression.NormalizedPredicate?.AcceptVisitor(Scout.Instance, context) == true)
+                {
+                    EnsureAllocatedAndPopulated(ref newTableExpressions, expression.TableExpressions, i);
+
+                    // If this is the first expression, we need to add another expression before it
+                    if (i == 0)
+                    {
+                        // seed with all resources so that we have something to restrict
+                        newTableExpressions.Add(
+                            new TableExpression(
+                                tableExpression.SearchParameterQueryGenerator,
+                                null,
+                                tableExpression.DenormalizedPredicate,
+                                TableExpressionKind.All));
+                    }
+
+                    newTableExpressions.Add((TableExpression)tableExpression.AcceptVisitor(this, context));
+                }
+                else
+                {
+                    newTableExpressions?.Add(tableExpression);
+                }
+            }
+
+            if (newTableExpressions == null)
+            {
+                return expression;
+            }
+
+            return new SqlRootExpression(newTableExpressions, expression.DenormalizedExpressions);
+        }
+
+        public override Expression VisitTable(TableExpression tableExpression, object context)
+        {
+            var normalizedPredicate = tableExpression.NormalizedPredicate.AcceptVisitor(this, context);
+
+            return new TableExpression(
+                tableExpression.SearchParameterQueryGenerator,
+                normalizedPredicate,
+                tableExpression.DenormalizedPredicate,
+                TableExpressionKind.NotExists);
+        }
+
+        public override Expression VisitNotExpression(NotExpression expression, object context)
+        {
+            return expression.Expression;
+        }
+
+        private class Scout : DefaultExpressionVisitor<object, bool>
+        {
+            internal static readonly Scout Instance = new Scout();
+
+            private Scout()
+                : base((accumulated, current) => current || accumulated)
+            {
+            }
+
+            public override bool VisitNotExpression(NotExpression expression, object context)
+            {
+                return true;
+            }
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SearchParameterQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SearchParameterQueryGenerator.cs
@@ -63,6 +63,13 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             return context;
         }
 
+        public override SearchParameterQueryGeneratorContext VisitNotExpression(NotExpression expression, SearchParameterQueryGeneratorContext context)
+        {
+            Debug.Assert(false, "Not expressions should have been rewritten");
+
+            return base.VisitNotExpression(expression, context);
+        }
+
         public override SearchParameterQueryGeneratorContext VisitMultiary(MultiaryExpression expression, SearchParameterQueryGeneratorContext context)
         {
             if (expression.MultiaryOperation == MultiaryOperator.Or)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SearchParameterQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SearchParameterQueryGenerator.cs
@@ -65,8 +65,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
         public override SearchParameterQueryGeneratorContext VisitNotExpression(NotExpression expression, SearchParameterQueryGeneratorContext context)
         {
-            Debug.Assert(false, "Not expressions should have been rewritten");
-
+            context.StringBuilder.Append("NOT ");
             return base.VisitNotExpression(expression, context);
         }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -182,6 +182,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                                                .AcceptVisitor(StringOverflowRewriter.Instance)
                                                .AcceptVisitor(NumericRangeRewriter.Instance)
                                                .AcceptVisitor(MissingSearchParamVisitor.Instance)
+                                               .AcceptVisitor(NotExpressionRewriter.Instance)
                                                .AcceptVisitor(IncludeDenormalizedRewriter.Instance)
                                                .AcceptVisitor(TopRewriter.Instance, searchOptions)
                                                .AcceptVisitor(IncludeRewriter.Instance)


### PR DESCRIPTION
## Description
Added support for `:not` modifier when searching with token search parameter.

#### From the spec: https://www.hl7.org/fhir/search.html#token
> | Modifier | Use |
> | --- | --- |
> | `:not` | Reverse the code matching described in the paragraph above: return all resources that do not have a matching item. Note that this includes resources that have no value for the parameter - e.g. ?gender:not=male includes all patients that do not have gender = male, including patients that do not have a gender at all |

#### Example query
```http
GET /Encounter?status:not=in-progress
```

## Testing
Unit, E2E and manual (SqlServer)

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- [ ] Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Feature (Added support for new modifier)
