### PR TITLE
Disable image tag support for template collection reference

### DIFF
--- a/docs/ConvertDataOperation.md
+++ b/docs/ConvertDataOperation.md
@@ -24,7 +24,7 @@ Make a call to ```<<FHIR service base URL>>/$convert-data``` with the [Parameter
 | ----------- | ----------- | ----------- |
 | inputData      | Data to be converted. | A valid JSON String|
 | inputDataType   | Data type of input. | ```HL7v2``` |
-| templateCollectionReference | Reference to a template collection. It can be the default templates, or an image on Azure Container Registry that the FHIR server can access. | ```microsofthealth/fhirconverter:default```, \<RegistryServer\>/\<imageName\>@\<imageDigest\>, \<RegistryServer\>/\<imageName\>:\<imageTag\> |
+| templateCollectionReference | Reference to a template collection. It can be the default templates, or an image specified by digest on Azure Container Registry that the FHIR server can access. | ```microsofthealth/fhirconverter:default```, \<RegistryServer\>/\<imageName\>@\<imageDigest\>|
 | rootTemplate | The root template to use while transforming the data. | ```ADT_A01```, ```OML_O21```, ```ORU_R01```, ```VXU_V04``` |
 
 **Sample request:**
@@ -106,8 +106,6 @@ b) Register the ACR on your FHIR server by setting `FhirServer__Operations__Conv
 
 ### 7. Verify
 
-Make a call to the $convert-data API specifying your template reference in the templateCollectionReference parameter. You can use any one of the following two formats to specify the reference. However, we strongly recommend choosing digest because its immutable and stable.
+Make a call to the $convert-data API specifying your template reference in the templateCollectionReference parameter. Currently we only support using digest to specify the reference because it's immutable and stable.
 
 `<RegistryServer>/<imageName>@<imageDigest>`
-
-`<RegistryServer>/<imageName>:<imageTag>` 

--- a/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
@@ -133,15 +133,6 @@ namespace Microsoft.Health.Fhir.Api {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The maximum length of a custom audit header value is {0}. The supplied custom audit header &apos;{1}&apos; has length of {2}..
-        /// </summary>
-        public static string CustomAuditHeaderTooLarge {
-            get {
-                return ResourceManager.GetString("CustomAuditHeaderTooLarge", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Convert data does not support the following parameter {0} for a POST operation..
         /// </summary>
         public static string ConvertDataParameterNotValid {
@@ -165,6 +156,24 @@ namespace Microsoft.Health.Fhir.Api {
         public static string ConvertDataParameterValueNotValid {
             get {
                 return ResourceManager.GetString("ConvertDataParameterValueNotValid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The maximum length of a custom audit header value is {0}. The supplied custom audit header &apos;{1}&apos; has length of {2}..
+        /// </summary>
+        public static string CustomAuditHeaderTooLarge {
+            get {
+                return ResourceManager.GetString("CustomAuditHeaderTooLarge", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Digest must be provided in image reference &apos;{0}&apos;..
+        /// </summary>
+        public static string DigestIsRequiredInReference {
+            get {
+                return ResourceManager.GetString("DigestIsRequiredInReference", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Health.Fhir.Api/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Api/Resources.resx
@@ -349,4 +349,8 @@
     <value>The container registry '{0}' is not configured.</value>
     <comment>{0}: the container registry login server</comment>
   </data>
+  <data name="DigestIsRequiredInReference" xml:space="preserve">
+    <value>Digest must be provided in image reference '{0}'.</value>
+    <comment>{0}: image reference</comment>
+  </data>
 </root>

--- a/src/Microsoft.Health.Fhir.Core/Data/OperationDefinition/convert-data.json
+++ b/src/Microsoft.Health.Fhir.Core/Data/OperationDefinition/convert-data.json
@@ -33,7 +33,7 @@
             "use": "in",
             "min": 1,
             "max": "1",
-            "documentation": "Reference to a template collection which can be the default templates, or an image on Azure Container Registry that the FHIR server can access. Supported values - `microsofthealth/fhirconverter:default`, `<RegistryServer>/<imageName>@<imageDigest>`, `<RegistryServer>/<imageName>:<imageTag>`.",
+            "documentation": "Reference to a template collection which can be the default templates, or an image specified by digest on Azure Container Registry that the FHIR server can access. Supported values - `microsofthealth/fhirconverter:default`, `<RegistryServer>/<imageName>@<imageDigest>`",
             "type": "string"
         },
         {

--- a/src/Microsoft.Health.Fhir.Core/Messages/ConvertData/ConvertDataRequest.cs
+++ b/src/Microsoft.Health.Fhir.Core/Messages/ConvertData/ConvertDataRequest.cs
@@ -58,8 +58,8 @@ namespace Microsoft.Health.Fhir.Core.Messages.ConvertData
 
         /// <summary>
         /// Reference for template collection.
-        /// The format is "<registryServer>/<imageName>:<imageTag>" for template collection stored in container registries.
-        /// Also supports image digest as reference. Will use 'latest' if no tag or digest present.
+        /// It can be the default templates "microsofthealth/fhirconverter:default", or an image on Azure Container Registry with digest "<registryServer>/<imageName>@<imageDigest>".
+        /// Currently we don't support image tags because the content is mutable and may lead to unexpected results.
         /// </summary>
         public string TemplateCollectionReference { get; }
 

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ConvertDataControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ConvertDataControllerTests.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Health.Fhir.Shared.Api.UnitTests.Controllers
 
             parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = ConvertDataProperties.InputData, Value = new FhirString(GetSampleHl7v2Message()) });
             parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = ConvertDataProperties.InputDataType, Value = new FhirString("Hl7v2") });
-            parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = ConvertDataProperties.TemplateCollectionReference, Value = new FhirString("test.azurecr.io/testimage:latest") });
+            parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = ConvertDataProperties.TemplateCollectionReference, Value = new FhirString("test.azurecr.io/testimage@sha256:a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3") });
             parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = ConvertDataProperties.RootTemplate, Value = new FhirString("ADT_A01") });
 
             return parametersResource;

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ConvertDataControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ConvertDataControllerTests.cs
@@ -63,7 +63,9 @@ namespace Microsoft.Health.Fhir.Shared.Api.UnitTests.Controllers
         [Theory]
         [InlineData("abc.azurecr.io")]
         [InlineData("abc.azurecr.io/:tag")]
-        [InlineData("testimage:tag")]
+        [InlineData("testimage/aaa:tag")]
+        [InlineData("testimage@")]
+        [InlineData("testimage@sha256:a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3")]
         public async Task GivenAConvertDataRequest_WithInvalidReference_WhenInvalidBodySent_ThenRequestNotValidThrown(string templateCollectionReference)
         {
             var body = GetConvertDataParamsWithCustomTemplateReference(templateCollectionReference);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/ConvertData/ConvertDataEngineTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/ConvertData/ConvertDataEngineTests.cs
@@ -61,11 +61,8 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Conver
         }
 
         [Theory]
-        [InlineData("fakeacr.azurecr.io/template:default")]
-        [InlineData("test.azurecr-test.io/template:default")]
+        [InlineData("fakeacr.azurecr.io/template@sha256:a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3")]
         [InlineData("test.azurecr.com/template@sha256:592535ef52d742f81e35f4d87b43d9b535ed56cf58c90a14fc5fd7ea0fbb8696")]
-        [InlineData("*****####.com/template:default")]
-        [InlineData("¶Š™œãý£¾.com/template:default")]
         public async Task GivenConvertDataRequest_WithUnconfiguredRegistry_ContainerRegistryNotConfiguredExceptionShouldBeThrown(string templateReference)
         {
             var convertDataEngine = GetDefaultEngine();

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -71,7 +71,6 @@
                 "Enabled": false,
                 "ContainerRegistryServers": [],
                 "TemplateCollectionOptions": {
-                    "ShortCacheTimeSpan": "00:30:00",
                     "LongCacheTimeSpan": "01:00:00",
                     "TemplateCollectionSizeLimitMegabytes": 10
                 },


### PR DESCRIPTION
## Description
Support digest only in template collection reference as image tags are mutable and can lead to unexpected results:

- We have added the pulled image to local cache for 30 minutes and when user modified the same tag, the image will not be refreshed until cache expires
- When another admin/user changes the image tag, the conversion result would be strange. 

The decision is to remove support for image tags for now and request with payload of image tags will result in 400 Bad Request ```Digest must be provided in image reference```

## Related issues
Addresses [AB#78458](https://microsofthealth.visualstudio.com/Health/_workitems/edit/78485).

## Testing
Add cases for image tags and digest.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip (fix bug)
