### PR TITLE
Add bundle issues to export record

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportJobTaskTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportJobTaskTests.cs
@@ -18,6 +18,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.Health.Core.Internal;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Exceptions;
+using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export.ExportDestinationClient;
@@ -74,6 +75,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
                 _resourceDeserializer,
                 null,
                 Substitute.For<IMediator>(),
+                Substitute.For<IFhirRequestContextAccessor>(),
                 NullLogger<ExportJobTask>.Instance);
         }
 
@@ -499,6 +501,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
                 _resourceDeserializer,
                 null,
                 Substitute.For<IMediator>(),
+                Substitute.For<IFhirRequestContextAccessor>(),
                 NullLogger<ExportJobTask>.Instance);
 
             await exportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
@@ -531,6 +534,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
                 _resourceDeserializer,
                 null,
                 Substitute.For<IMediator>(),
+                Substitute.For<IFhirRequestContextAccessor>(),
                 NullLogger<ExportJobTask>.Instance);
 
             _searchService.SearchAsync(
@@ -571,6 +575,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
                 _resourceDeserializer,
                 null,
                 Substitute.For<IMediator>(),
+                Substitute.For<IFhirRequestContextAccessor>(),
                 NullLogger<ExportJobTask>.Instance);
 
             await exportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
@@ -614,6 +619,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
                 _resourceDeserializer,
                 null,
                 Substitute.For<IMediator>(),
+                Substitute.For<IFhirRequestContextAccessor>(),
                 NullLogger<ExportJobTask>.Instance);
 
             await exportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
@@ -677,6 +683,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
                 _resourceDeserializer,
                 null,
                 Substitute.For<IMediator>(),
+                Substitute.For<IFhirRequestContextAccessor>(),
                 NullLogger<ExportJobTask>.Instance);
 
             numberOfSuccessfulPages = 5;
@@ -857,6 +864,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
                 _resourceDeserializer,
                 null,
                 Substitute.For<IMediator>(),
+                Substitute.For<IFhirRequestContextAccessor>(),
                 NullLogger<ExportJobTask>.Instance);
 
             await secondExportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
@@ -951,6 +959,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
                 _resourceDeserializer,
                 null,
                 Substitute.For<IMediator>(),
+                Substitute.For<IFhirRequestContextAccessor>(),
                 NullLogger<ExportJobTask>.Instance);
 
             // Reseting the number of calls so that the ressource id of the Patient is the same ('2') as it was when the crash happened.
@@ -1138,6 +1147,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
                 _resourceDeserializer,
                 null,
                 Substitute.For<IMediator>(),
+                Substitute.For<IFhirRequestContextAccessor>(),
                 NullLogger<ExportJobTask>.Instance);
 
             // Reseting the number of calls so that the ressource id of the Patient is the same ('2') as it was when the crash happened.
@@ -1379,6 +1389,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
                 _resourceDeserializer,
                 null,
                 Substitute.For<IMediator>(),
+                Substitute.For<IFhirRequestContextAccessor>(),
                 NullLogger<ExportJobTask>.Instance);
 
             // Reseting the number of calls so that the ressource id of the Patient is the same ('2') as it was when the crash happened.
@@ -1537,6 +1548,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
                 _resourceDeserializer,
                 factory.CreateMockScope(),
                 Substitute.For<IMediator>(),
+                Substitute.For<IFhirRequestContextAccessor>(),
                 NullLogger<ExportJobTask>.Instance);
 
             await anonymizedExportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
@@ -1571,6 +1583,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
                 _resourceDeserializer,
                 factory.CreateMockScope(),
                 Substitute.For<IMediator>(),
+                Substitute.For<IFhirRequestContextAccessor>(),
                 NullLogger<ExportJobTask>.Instance);
 
             await exportJobTask.ExecuteAsync(exportJobRecordWithOneResource, _weakETag, _cancellationToken);
@@ -1607,6 +1620,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
                 _resourceDeserializer,
                 factory.CreateMockScope(),
                 Substitute.For<IMediator>(),
+                Substitute.For<IFhirRequestContextAccessor>(),
                 NullLogger<ExportJobTask>.Instance);
 
             await exportJobTask.ExecuteAsync(exportJobRecordWithOneResource, _weakETag, _cancellationToken);

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/GetExportRequestHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/GetExportRequestHandlerTests.cs
@@ -18,6 +18,7 @@ using Microsoft.Health.Fhir.Core.Features.Operations.Export.Models;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Security.Authorization;
 using Microsoft.Health.Fhir.Core.Messages.Export;
+using Microsoft.Health.Fhir.Core.Models;
 using NSubstitute;
 using Xunit;
 
@@ -71,6 +72,22 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
             Assert.False(string.IsNullOrWhiteSpace(output.Type));
             Assert.NotNull(output.FileUri);
             Assert.True(output.Count >= 0);
+
+            var error = result.JobResult.Error.FirstOrDefault();
+
+            // Check whether required fields are present for Error.
+            Assert.NotNull(error);
+            Assert.False(string.IsNullOrWhiteSpace(error.Type));
+            Assert.NotNull(error.FileUri);
+            Assert.True(error.Count >= 0);
+
+            var issue = result.JobResult.Issues.FirstOrDefault();
+
+            // Check whether required fields are present for Issues.
+            Assert.NotNull(issue);
+            Assert.False(string.IsNullOrWhiteSpace(issue.Diagnostics));
+            Assert.False(string.IsNullOrWhiteSpace(issue.Code));
+            Assert.False(string.IsNullOrWhiteSpace(issue.Severity));
         }
 
         [Theory]
@@ -130,6 +147,13 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
                 var exportFileInfo = new ExportFileInfo("patient", new Uri("https://exportlocation/fileUri"), sequence: 0);
                 exportFileInfo.IncrementCount(100);
                 jobRecord.Output.Add("patient", exportFileInfo);
+
+                var exportErrorInfo = new ExportFileInfo("error", new Uri("https://exportlocation/fileUri"), sequence: 0);
+                exportErrorInfo.IncrementCount(100);
+                jobRecord.Error.Add(exportErrorInfo);
+
+                var exportIssue = new OperationOutcomeIssue("warning", "code", "message");
+                jobRecord.Issues.Add(exportIssue);
             }
 
             var jobOutcome = new ExportJobOutcome(jobRecord, WeakETag.FromVersionId("eTag"));

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                 uriString: "$export",
                 baseUriString: "$export",
                 correlationId: _exportJobRecord.Id,
-                requestHeaders: null,
+                requestHeaders: new Dictionary<string, StringValues>(),
                 responseHeaders: new Dictionary<string, StringValues>());
 
                 _contextAccessor.FhirRequestContext = fhirRequestContext;

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -97,6 +97,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
             _exportJobRecord = exportJobRecord;
             _weakETag = weakETag;
 
+            var existingFhirRequestContext = _contextAccessor.FhirRequestContext;
+
             try
             {
                 ExportJobConfiguration exportJobConfiguration = _exportJobConfiguration;
@@ -217,6 +219,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
                 _exportJobRecord.FailureDetails = new JobFailureDetails(Resources.UnknownError, HttpStatusCode.InternalServerError);
                 await CompleteJobAsync(OperationStatus.Failed, cancellationToken);
+            }
+            finally
+            {
+                _contextAccessor.FhirRequestContext = existingFhirRequestContext;
             }
         }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -15,10 +15,12 @@ using EnsureThat;
 using MediatR;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
 using Microsoft.Health.Core;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Exceptions;
+using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export.ExportDestinationClient;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export.Models;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
@@ -39,6 +41,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
         private readonly IExportDestinationClient _exportDestinationClient;
         private readonly IResourceDeserializer _resourceDeserializer;
         private readonly IMediator _mediator;
+        private readonly IFhirRequestContextAccessor _contextAccessor;
         private readonly ILogger _logger;
 
         // Currently we will have only one file per resource type. In the future we will add the ability to split
@@ -59,6 +62,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
             IResourceDeserializer resourceDeserializer,
             IScoped<IAnonymizerFactory> anonymizerFactory,
             IMediator mediator,
+            IFhirRequestContextAccessor contextAccessor,
             ILogger<ExportJobTask> logger)
         {
             EnsureArg.IsNotNull(fhirOperationDataStoreFactory, nameof(fhirOperationDataStoreFactory));
@@ -69,6 +73,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
             EnsureArg.IsNotNull(exportDestinationClient, nameof(exportDestinationClient));
             EnsureArg.IsNotNull(resourceDeserializer, nameof(resourceDeserializer));
             EnsureArg.IsNotNull(mediator, nameof(mediator));
+            EnsureArg.IsNotNull(contextAccessor, nameof(contextAccessor));
             EnsureArg.IsNotNull(logger, nameof(logger));
 
             _fhirOperationDataStoreFactory = fhirOperationDataStoreFactory;
@@ -80,6 +85,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
             _exportDestinationClient = exportDestinationClient;
             _anonymizerFactory = anonymizerFactory;
             _mediator = mediator;
+            _contextAccessor = contextAccessor;
             _logger = logger;
         }
 
@@ -122,6 +128,17 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
                 // Connect to export destination using appropriate client.
                 await _exportDestinationClient.ConnectAsync(exportJobConfiguration, cancellationToken, _exportJobRecord.StorageAccountContainerName);
+
+                // Add a request context so that bundle issues can be added by the SearchOptionFactory
+                var fhirRequestContext = new FhirRequestContext(
+                method: "Export",
+                uriString: "$export",
+                baseUriString: "$export",
+                correlationId: _exportJobRecord.Id,
+                requestHeaders: null,
+                responseHeaders: new Dictionary<string, StringValues>());
+
+                _contextAccessor.FhirRequestContext = fhirRequestContext;
 
                 // If we are resuming a job, we can detect that by checking the progress info from the job record.
                 // If it is null, then we know we are processing a new job.
@@ -216,12 +233,19 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
         private async Task UpdateJobRecordAsync(CancellationToken cancellationToken)
         {
+            foreach (OperationOutcomeIssue issue in _contextAccessor.FhirRequestContext.BundleIssues)
+            {
+                _exportJobRecord.Issues.Add(issue);
+            }
+
             using (IScoped<IFhirOperationDataStore> fhirOperationDataStore = _fhirOperationDataStoreFactory())
             {
                 ExportJobOutcome updatedExportJobOutcome = await fhirOperationDataStore.Value.UpdateExportJobAsync(_exportJobRecord, _weakETag, cancellationToken);
 
                 _exportJobRecord = updatedExportJobOutcome.JobRecord;
                 _weakETag = updatedExportJobOutcome.ETag;
+
+                _contextAccessor.FhirRequestContext.BundleIssues.Clear();
             }
         }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/GetExportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/GetExportRequestHandler.cs
@@ -53,7 +53,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                     outcome.JobRecord.RequestUri,
                     requiresAccessToken: false,
                     outcome.JobRecord.Output.Values.Select(x => x.ToExportOutputResponse()).OrderBy(x => x.Type, StringComparer.Ordinal).ToList(),
-                    outcome.JobRecord.Error.Select(x => x.ToExportOutputResponse()).ToList());
+                    outcome.JobRecord.Error.Select(x => x.ToExportOutputResponse()).ToList(),
+                    outcome.JobRecord.Issues);
 
                 exportResponse = new GetExportResponse(HttpStatusCode.OK, jobResult);
             }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobRecord.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobRecord.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
         [JsonProperty(JobRecordProperties.Error)]
         public IList<ExportFileInfo> Error { get; private set; } = new List<ExportFileInfo>();
 
-        [JsonProperty(JobRecordProperties.Issue)]
+        [JsonProperty(JobRecordProperties.Issues)]
         public IList<OperationOutcomeIssue> Issues { get; private set; } = new List<OperationOutcomeIssue>();
 
         [JsonProperty(JobRecordProperties.Progress)]

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobRecord.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobRecord.cs
@@ -108,6 +108,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
         [JsonProperty(JobRecordProperties.Error)]
         public IList<ExportFileInfo> Error { get; private set; } = new List<ExportFileInfo>();
 
+        [JsonProperty(JobRecordProperties.Issue)]
+        public IList<OperationOutcomeIssue> Issues { get; private set; } = new List<OperationOutcomeIssue>();
+
         [JsonProperty(JobRecordProperties.Progress)]
         public ExportJobProgress Progress { get; set; }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobResult.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobResult.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
     /// </summary>
     public class ExportJobResult
     {
-        public ExportJobResult(DateTimeOffset transactionTime, Uri requestUri, bool requiresAccessToken, IList<ExportOutputResponse> output, IList<ExportOutputResponse> errors)
+        public ExportJobResult(DateTimeOffset transactionTime, Uri requestUri, bool requiresAccessToken, IList<ExportOutputResponse> output, IList<ExportOutputResponse> errors, IList<Core.Models.OperationOutcomeIssue> issues)
         {
             EnsureArg.IsNotDefault<DateTimeOffset>(transactionTime, nameof(transactionTime));
             EnsureArg.IsNotNull(requestUri, nameof(requestUri));
@@ -28,6 +28,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
             RequiresAccessToken = requiresAccessToken;
             Output = output;
             Error = errors;
+            Issues = issues;
         }
 
         [JsonConstructor]
@@ -49,5 +50,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
 
         [JsonProperty("error")]
         public IList<ExportOutputResponse> Error { get; private set; }
+
+        [JsonProperty("issues")]
+        public IList<Microsoft.Health.Fhir.Core.Models.OperationOutcomeIssue> Issues { get; private set; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
@@ -108,5 +108,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations
         public const string ResourceTypeSearchParameterHashMap = "resourceTypeSearchParameterHashMap";
 
         public const string ExportFormat = "exportFormat";
+
+        public const string Issues = "issues";
     }
 }


### PR DESCRIPTION
## Description
Currently an export job fails if an issue is added to the search bundle as the export job doesn't have a bundle to return. This PR adds a stand in for the bundle that can have issues added to it. These issues are then added to the export job record and can be seen by getting the export job status.

## Related issues
Addresses 77673.

## Testing
New and existing unit tests

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch (Bug fix)
