### PR TITLE
Improves performace of count queries

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     selectingFromResourceTable = false;
                     StringBuilder.AppendLine("SELECT COUNT(DISTINCT Sid1)");
                 }
-                else if (expression.TableExpressions.Count == 0)
+                else
                 {
                     // We will be counting over the Resource table.
                     selectingFromResourceTable = true;

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -67,6 +67,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
             if (expression.TableExpressions.Count > 0)
             {
+                if (expression.DenormalizedExpressions.Count > 0)
+                {
+                    throw new InvalidOperationException("Expected no predicates on the Resource table because of the presence of TableExpressions");
+                }
+
                 StringBuilder.Append("WITH ");
 
                 StringBuilder.AppendDelimited($",{Environment.NewLine}", expression.TableExpressions, (sb, tableExpression) =>
@@ -85,14 +90,29 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             }
 
             string resourceTableAlias = "r";
+            bool selectingFromResourceTable;
             var (searchParamInfo, sortOrder) = searchOptions.Sort.Count == 0 ? default : searchOptions.Sort[0];
 
             if (searchOptions.CountOnly)
             {
-                StringBuilder.AppendLine("SELECT COUNT(DISTINCT ").Append(VLatest.Resource.ResourceSurrogateId, resourceTableAlias).Append(")");
+                if (expression.TableExpressions.Count > 0)
+                {
+                    // The last CTE has all the surrogate IDs that match the results.
+                    // We just need to count those and don't need to join with the Resource table
+                    selectingFromResourceTable = false;
+                    StringBuilder.AppendLine("SELECT COUNT(DISTINCT Sid1)");
+                }
+                else if (expression.TableExpressions.Count == 0)
+                {
+                    // We will be counting over the Resource table.
+                    selectingFromResourceTable = true;
+                    StringBuilder.AppendLine("SELECT COUNT(*)");
+                }
             }
             else
             {
+                selectingFromResourceTable = true;
+
                 // DISTINCT is used since different ctes may return the same resources due to _include and _include:iterate search parameters
                 StringBuilder.Append("SELECT DISTINCT ");
 
@@ -131,58 +151,67 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                 StringBuilder.AppendLine();
             }
 
-            StringBuilder.Append("FROM ").Append(VLatest.Resource).Append(" ").Append(resourceTableAlias);
+            if (selectingFromResourceTable)
+            {
+                StringBuilder.Append("FROM ").Append(VLatest.Resource).Append(" ").Append(resourceTableAlias);
 
-            if (expression.TableExpressions.Count == 0 &&
-                !_isHistorySearch &&
-                expression.DenormalizedExpressions.Any(e => e.AcceptVisitor(ExpressionContainsParameterVisitor.Instance, SearchParameterNames.ResourceType)))
-            {
-                // If this is a simple search over a resource type (like GET /Observation)
-                // make sure the optimizer does not decide to do a scan on the clustered index, since we have an index specifically for this common case
-                StringBuilder.Append(" WITH(INDEX(").Append(VLatest.Resource.IX_Resource_ResourceTypeId_ResourceSurrgateId).AppendLine("))");
-            }
-            else
-            {
-                StringBuilder.AppendLine();
-            }
-
-            if (expression.TableExpressions.Count > 0)
-            {
-                StringBuilder.AppendLine().Append("INNER JOIN ").AppendLine(TableExpressionName(_tableExpressionCounter));
-                StringBuilder.Append("ON ").Append(VLatest.Resource.ResourceSurrogateId, resourceTableAlias).Append(" = ").Append(TableExpressionName(_tableExpressionCounter)).AppendLine(".Sid1");
-            }
-
-            using (var delimitedClause = StringBuilder.BeginDelimitedWhereClause())
-            {
-                foreach (var denormalizedPredicate in expression.DenormalizedExpressions)
+                if (expression.TableExpressions.Count == 0 &&
+                    !_isHistorySearch &&
+                    expression.DenormalizedExpressions.Any(e => e.AcceptVisitor(ExpressionContainsParameterVisitor.Instance, SearchParameterNames.ResourceType)) &&
+                    !expression.DenormalizedExpressions.Any(e => e.AcceptVisitor(ExpressionContainsParameterVisitor.Instance, SearchParameterNames.Id)))
                 {
-                    delimitedClause.BeginDelimitedElement();
-                    denormalizedPredicate.AcceptVisitor(DispatchingDenormalizedSearchParameterQueryGenerator.Instance, GetContext());
-                }
-
-                if (expression.TableExpressions.Count == 0)
-                {
-                    AppendHistoryClause(delimitedClause);
-                    AppendDeletedClause(delimitedClause);
-                }
-            }
-
-            if (!searchOptions.CountOnly)
-            {
-                StringBuilder.Append("ORDER BY ");
-                if (searchParamInfo == null || searchParamInfo.Name == KnownQueryParameterNames.LastUpdated)
-                {
-                    StringBuilder
-                        .Append(VLatest.Resource.ResourceSurrogateId, resourceTableAlias).Append(" ")
-                        .AppendLine(sortOrder == SortOrder.Ascending ? "ASC" : "DESC");
+                    // If this is a simple search over a resource type (like GET /Observation)
+                    // make sure the optimizer does not decide to do a scan on the clustered index, since we have an index specifically for this common case
+                    StringBuilder.Append(" WITH(INDEX(").Append(VLatest.Resource.IX_Resource_ResourceTypeId_ResourceSurrgateId).AppendLine("))");
                 }
                 else
                 {
-                    StringBuilder
-                        .Append($"{TableExpressionName(_tableExpressionCounter)}.SortValue ")
-                        .Append(sortOrder == SortOrder.Ascending ? "ASC" : "DESC").Append(", ")
-                        .Append(VLatest.Resource.ResourceSurrogateId, resourceTableAlias).AppendLine(" ASC ");
+                    StringBuilder.AppendLine();
                 }
+
+                if (expression.TableExpressions.Count > 0)
+                {
+                    StringBuilder.AppendLine().Append("INNER JOIN ").AppendLine(TableExpressionName(_tableExpressionCounter));
+                    StringBuilder.Append("ON ").Append(VLatest.Resource.ResourceSurrogateId, resourceTableAlias).Append(" = ").Append(TableExpressionName(_tableExpressionCounter)).AppendLine(".Sid1");
+                }
+
+                using (var delimitedClause = StringBuilder.BeginDelimitedWhereClause())
+                {
+                    foreach (var denormalizedPredicate in expression.DenormalizedExpressions)
+                    {
+                        delimitedClause.BeginDelimitedElement();
+                        denormalizedPredicate.AcceptVisitor(DispatchingDenormalizedSearchParameterQueryGenerator.Instance, GetContext());
+                    }
+
+                    if (expression.TableExpressions.Count == 0)
+                    {
+                        AppendHistoryClause(delimitedClause);
+                        AppendDeletedClause(delimitedClause);
+                    }
+                }
+
+                if (!searchOptions.CountOnly)
+                {
+                    StringBuilder.Append("ORDER BY ");
+                    if (searchParamInfo == null || searchParamInfo.Name == KnownQueryParameterNames.LastUpdated)
+                    {
+                        StringBuilder
+                            .Append(VLatest.Resource.ResourceSurrogateId, resourceTableAlias).Append(" ")
+                            .AppendLine(sortOrder == SortOrder.Ascending ? "ASC" : "DESC");
+                    }
+                    else
+                    {
+                        StringBuilder
+                            .Append($"{TableExpressionName(_tableExpressionCounter)}.SortValue ")
+                            .Append(sortOrder == SortOrder.Ascending ? "ASC" : "DESC").Append(", ")
+                            .Append(VLatest.Resource.ResourceSurrogateId, resourceTableAlias).AppendLine(" ASC ");
+                    }
+                }
+            }
+            else
+            {
+                // this is selecting only from the last CTE (for a count)
+                StringBuilder.Append("FROM ").AppendLine(TableExpressionName(_tableExpressionCounter));
             }
 
             StringBuilder.Append("OPTION(RECOMPILE)");
@@ -220,7 +249,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                             StringBuilder.Append("SELECT ").Append(VLatest.Resource.ResourceSurrogateId, null).Append(" AS Sid1, ")
                                 .Append(cte).AppendLine(".SortValue")
                                 .Append("FROM ").AppendLine(tableExpression.SearchParameterQueryGenerator.Table)
-                            .Append("INNER JOIN ").AppendLine(cte);
+                                .Append("INNER JOIN ").AppendLine(cte);
 
                             using (var delimited = StringBuilder.BeginDelimitedOnClause())
                             {
@@ -493,9 +522,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                         }
 
                         delimited.BeginDelimitedElement().Append(VLatest.ReferenceSearchParam.ResourceTypeId, table)
-                             .Append(" IN (")
-                             .Append(string.Join(", ", resourceIds))
-                             .Append(")");
+                            .Append(" IN (")
+                            .Append(string.Join(", ", resourceIds))
+                            .Append(")");
 
                         // Get FROM ctes
                         string fromCte = _cteMainSelect;

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -207,7 +207,12 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                     if (searchOptions.CountOnly)
                     {
                         await reader.ReadAsync(cancellationToken);
-                        return new SearchResult(reader.GetInt32(0), searchOptions.UnsupportedSearchParams);
+                        var searchResult = new SearchResult(reader.GetInt32(0), searchOptions.UnsupportedSearchParams);
+
+                        // call NextResultAsync to get the info messages
+                        await reader.NextResultAsync(cancellationToken);
+
+                        return searchResult;
                     }
 
                     var resources = new List<SearchResultEntry>(searchOptions.MaxItemCount);


### PR DESCRIPTION
For the SQL provider, we were adding an unnecessary `JOIN` with the `Resource` table in many `_summary=count` queries. Removing the join improves the efficiency in a significant way. Here are two examples:

|                                                                      | Count  | BEFORE_READS | AFTER_READS |   |
|----------------------------------------------------------------------|--------|--------------|-------------|---|
| /Observation?status=final&_summary=count                             | 543671 | 20334        | 3170        |   |
| /Patient?name=john&_summary=count                                    | 26     | 108          | 4           |   |

For the first query, the difference between the SQL is:
![image](https://user-images.githubusercontent.com/339432/103913420-8173b780-50d6-11eb-8e4b-ad19e483c024.png)

(We would get further improvements by eliminating `DISTINCT` when possible)
