### PR TITLE
Adds data layer for SQL reindexing

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/IFhirOperationDataStore.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/IFhirOperationDataStore.cs
@@ -50,29 +50,37 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations
         Task<ExportJobOutcome> UpdateExportJobAsync(ExportJobRecord jobRecord, WeakETag eTag, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Commits a new reindex job record to the data store
-        /// </summary>
-        /// <param name="jobRecord">The reindex job record</param>
-        /// <param name="cancellationToken">The cancellation token</param>
-        /// <returns>A newly created reindex job record</returns>
-        Task<ReindexJobWrapper> CreateReindexJobAsync(ReindexJobRecord jobRecord, CancellationToken cancellationToken);
-
-        /// <summary>
         /// Acquires export jobs.
         /// </summary>
         /// <param name="maximumNumberOfConcurrentJobsAllowed">The maximum number of concurrent jobs allowed.</param>
         /// <param name="jobHeartbeatTimeoutThreshold">The job heartbeat timeout threshold.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>A list of acquired export job.</returns>
+        /// <returns>A list of acquired export jobs.</returns>
         Task<IReadOnlyCollection<ExportJobOutcome>> AcquireExportJobsAsync(ushort maximumNumberOfConcurrentJobsAllowed, TimeSpan jobHeartbeatTimeoutThreshold, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Commits a new reindex job record to the data store.
+        /// </summary>
+        /// <param name="jobRecord">The reindex job record.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A newly created reindex job record.</returns>
+        Task<ReindexJobWrapper> CreateReindexJobAsync(ReindexJobRecord jobRecord, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Gets a reindex job by id.
+        /// </summary>
+        /// <param name="jobId">The id of the job.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The reindex job details.</returns>
+        Task<ReindexJobWrapper> GetReindexJobByIdAsync(string jobId, CancellationToken cancellationToken);
 
         /// <summary>
         /// Updates an existing reindex job record in the data store.
         /// </summary>
-        /// <param name="jobRecord">The updated job record</param>
-        /// <param name="eTag">current eTag value</param>
-        /// <param name="cancellationToken">the cancellation token</param>
-        /// <returns>An instance of the updated job record</returns>
+        /// <param name="jobRecord">The updated job record.</param>
+        /// <param name="eTag">current eTag value.</param>
+        /// <param name="cancellationToken">the cancellation token.</param>
+        /// <returns>An instance of the updated job record.</returns>
         Task<ReindexJobWrapper> UpdateReindexJobAsync(ReindexJobRecord jobRecord, WeakETag eTag, CancellationToken cancellationToken);
 
         /// <summary>
@@ -85,18 +93,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations
         Task<IReadOnlyCollection<ReindexJobWrapper>> AcquireReindexJobsAsync(ushort maximumNumberOfConcurrentJobsAllowed, TimeSpan jobHeartbeatTimeoutThreshold, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Gets a reindex job by id
+        /// Queries the datastore for any reindex job documents with a status of running, queued or paused.
         /// </summary>
-        /// <param name="jobId">The id of the job.</param>
-        /// <param name="cancellationToken">The cancellation token</param>
-        /// <returns>The reindex job details.</returns>
-        Task<ReindexJobWrapper> GetReindexJobByIdAsync(string jobId, CancellationToken cancellationToken);
-
-        /// <summary>
-        /// Queries the datastore for any reindex job documents with a status of running, queued or paused
-        /// </summary>
-        /// <param name="cancellationToken">The cancellation token</param>
-        /// <returns>True if any found, along with id of the job</returns>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>True if any found, along with the id of the job.</returns>
         Task<(bool, string)> CheckActiveReindexJobsAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirOperationDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirOperationDataStore.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,7 +23,6 @@ using Microsoft.Health.SqlServer;
 using Microsoft.Health.SqlServer.Features.Client;
 using Microsoft.Health.SqlServer.Features.Storage;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 {
@@ -44,7 +44,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
             _jsonSerializerSettings = new JsonSerializerSettings
             {
-                ContractResolver = new CamelCasePropertyNamesContractResolver(),
                 Converters = new List<JsonConverter>
                 {
                     new EnumLiteralJsonConverter(),
@@ -195,9 +194,147 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             }
         }
 
-        public Task<IReadOnlyCollection<ReindexJobWrapper>> AcquireReindexJobsAsync(ushort maximumNumberOfConcurrentJobsAllowed, TimeSpan jobHeartbeatTimeoutThreshold, CancellationToken cancellationToken)
+        public async Task<ReindexJobWrapper> CreateReindexJobAsync(ReindexJobRecord jobRecord, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            using (SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken, true))
+            using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateSqlCommand())
+            {
+                VLatest.CreateReindexJob.PopulateCommand(
+                    sqlCommandWrapper,
+                    jobRecord.Id,
+                    jobRecord.Status.ToString(),
+                    JsonConvert.SerializeObject(jobRecord, _jsonSerializerSettings));
+
+                var rowVersion = (int?)await sqlCommandWrapper.ExecuteScalarAsync(cancellationToken);
+
+                if (rowVersion == null)
+                {
+                    throw new OperationFailedException(string.Format(Core.Resources.OperationFailed, OperationsConstants.Reindex, "Failed to create reindex job because no row version was returned."), HttpStatusCode.InternalServerError);
+                }
+
+                return new ReindexJobWrapper(jobRecord, WeakETag.FromVersionId(rowVersion.ToString()));
+            }
+        }
+
+        public async Task<ReindexJobWrapper> GetReindexJobByIdAsync(string id, CancellationToken cancellationToken)
+        {
+            EnsureArg.IsNotNullOrWhiteSpace(id, nameof(id));
+
+            using (SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken, true))
+            using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateSqlCommand())
+            {
+                VLatest.GetReindexJobById.PopulateCommand(sqlCommandWrapper, id);
+
+                using (SqlDataReader sqlDataReader = await sqlCommandWrapper.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken))
+                {
+                    if (!sqlDataReader.Read())
+                    {
+                        throw new JobNotFoundException(string.Format(Core.Resources.JobNotFound, id));
+                    }
+
+                    (string rawJobRecord, byte[] rowVersion) = sqlDataReader.ReadRow(VLatest.ReindexJob.RawJobRecord, VLatest.ReindexJob.JobVersion);
+
+                    return CreateReindexJobWrapper(rawJobRecord, rowVersion);
+                }
+            }
+        }
+
+        public async Task<ReindexJobWrapper> UpdateReindexJobAsync(ReindexJobRecord jobRecord, WeakETag eTag, CancellationToken cancellationToken)
+        {
+            EnsureArg.IsNotNull(jobRecord, nameof(jobRecord));
+
+            byte[] rowVersionAsBytes = GetRowVersionAsBytes(eTag);
+
+            using (SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken, true))
+            using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateSqlCommand())
+            {
+                VLatest.UpdateReindexJob.PopulateCommand(
+                    sqlCommandWrapper,
+                    jobRecord.Id,
+                    jobRecord.Status.ToString(),
+                    JsonConvert.SerializeObject(jobRecord, _jsonSerializerSettings),
+                    rowVersionAsBytes);
+
+                try
+                {
+                    var rowVersion = (byte[])await sqlCommandWrapper.ExecuteScalarAsync(cancellationToken);
+
+                    if (rowVersion.NullIfEmpty() == null)
+                    {
+                        throw new OperationFailedException(string.Format(Core.Resources.OperationFailed, OperationsConstants.Reindex, "Failed to create reindex job because no row version was returned."), HttpStatusCode.InternalServerError);
+                    }
+
+                    return new ReindexJobWrapper(jobRecord, GetRowVersionAsEtag(rowVersion));
+                }
+                catch (SqlException e)
+                {
+                    if (e.Number == SqlErrorCodes.PreconditionFailed)
+                    {
+                        throw new JobConflictException();
+                    }
+                    else if (e.Number == SqlErrorCodes.NotFound)
+                    {
+                        throw new JobNotFoundException(string.Format(Core.Resources.JobNotFound, jobRecord.Id));
+                    }
+                    else
+                    {
+                        _logger.LogError(e, "Error from SQL database on reindex job update.");
+                        throw;
+                    }
+                }
+            }
+        }
+
+        public async Task<IReadOnlyCollection<ReindexJobWrapper>> AcquireReindexJobsAsync(ushort maximumNumberOfConcurrentJobsAllowed, TimeSpan jobHeartbeatTimeoutThreshold, CancellationToken cancellationToken)
+        {
+            using (SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken, true))
+            using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateSqlCommand())
+            {
+                var jobHeartbeatTimeoutThresholdInSeconds = Convert.ToInt64(jobHeartbeatTimeoutThreshold.TotalSeconds);
+
+                VLatest.AcquireReindexJobs.PopulateCommand(
+                    sqlCommandWrapper,
+                    jobHeartbeatTimeoutThresholdInSeconds,
+                    maximumNumberOfConcurrentJobsAllowed);
+
+                var acquiredJobs = new List<ReindexJobWrapper>();
+
+                using (SqlDataReader sqlDataReader = await sqlCommandWrapper.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken))
+                {
+                    while (await sqlDataReader.ReadAsync(cancellationToken))
+                    {
+                        (string rawJobRecord, byte[] rowVersion) = sqlDataReader.ReadRow(VLatest.ReindexJob.RawJobRecord, VLatest.ReindexJob.JobVersion);
+
+                        acquiredJobs.Add(CreateReindexJobWrapper(rawJobRecord, rowVersion));
+                    }
+                }
+
+                return acquiredJobs;
+            }
+        }
+
+        public async Task<(bool, string)> CheckActiveReindexJobsAsync(CancellationToken cancellationToken)
+        {
+            using (SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken, true))
+            using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateSqlCommand())
+            {
+                VLatest.CheckActiveReindexJobs.PopulateCommand(sqlCommandWrapper);
+
+                var activeJobs = new List<string>();
+
+                using (SqlDataReader sqlDataReader = await sqlCommandWrapper.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken))
+                {
+                    while (await sqlDataReader.ReadAsync(cancellationToken))
+                    {
+                        string id = sqlDataReader.ReadRow(VLatest.ReindexJob.Id);
+
+                        activeJobs.Add(id);
+                    }
+                }
+
+                // Currently, there can only be one active reindex job at a time.
+                return (activeJobs.Count > 0, activeJobs.Count > 0 ? activeJobs.FirstOrDefault() : string.Empty);
+            }
         }
 
         private ExportJobOutcome CreateExportJobOutcome(string rawJobRecord, byte[] rowVersionAsBytes)
@@ -236,24 +373,13 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             return versionAsBytes;
         }
 
-        public Task<ReindexJobWrapper> CreateReindexJobAsync(ReindexJobRecord jobRecord, CancellationToken cancellationToken)
+        private ReindexJobWrapper CreateReindexJobWrapper(string rawJobRecord, byte[] rowVersionAsBytes)
         {
-            throw new NotImplementedException();
-        }
+            var reindexJobRecord = JsonConvert.DeserializeObject<ReindexJobRecord>(rawJobRecord, _jsonSerializerSettings);
 
-        public Task<ReindexJobWrapper> UpdateReindexJobAsync(ReindexJobRecord jobRecord, WeakETag eTag, CancellationToken cancellationToken)
-        {
-            throw new NotImplementedException();
-        }
+            WeakETag etag = GetRowVersionAsEtag(rowVersionAsBytes);
 
-        public Task<ReindexJobWrapper> GetReindexJobByIdAsync(string jobId, CancellationToken cancellationToken)
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task<(bool, string)> CheckActiveReindexJobsAsync(CancellationToken cancellationToken)
-        {
-            throw new NotImplementedException();
+            return new ReindexJobWrapper(reindexJobRecord, etag);
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/FhirOperationDataStoreExportTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/FhirOperationDataStoreExportTests.cs
@@ -24,14 +24,14 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
 {
     [Collection(FhirOperationTestConstants.FhirOperationTests)]
     [FhirStorageTestsFixtureArgumentSets(DataStore.All)]
-    public class FhirOperationDataStoreTests : IClassFixture<FhirStorageTestsFixture>, IAsyncLifetime
+    public class FhirOperationDataStoreExportTests : IClassFixture<FhirStorageTestsFixture>, IAsyncLifetime
     {
         private readonly IFhirOperationDataStore _operationDataStore;
         private readonly IFhirStorageTestHelper _testHelper;
 
         private readonly CreateExportRequest _exportRequest = new CreateExportRequest(new Uri("http://localhost/ExportJob"), ExportJobType.All);
 
-        public FhirOperationDataStoreTests(FhirStorageTestsFixture fixture)
+        public FhirOperationDataStoreExportTests(FhirStorageTestsFixture fixture)
         {
             _operationDataStore = fixture.OperationDataStore;
             _testHelper = fixture.TestHelper;
@@ -48,7 +48,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
         }
 
         [Fact]
-        public async Task GivenANewExportRequest_WhenCreatingExportJob_ThenGetsJobCreated()
+        public async Task GivenANewExportRequest_WhenCreatingAnExportJob_ThenAnExportJobGetsCreated()
         {
             var jobRecord = new ExportJobRecord(_exportRequest.RequestUri, _exportRequest.RequestType, ExportFormatTags.ResourceName, _exportRequest.ResourceType, null, "hash");
 
@@ -61,7 +61,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
         }
 
         [Fact]
-        public async Task GivenAMatchingJob_WhenGettingById_ThenTheMatchingJobShouldBeReturned()
+        public async Task GivenAMatchingExportJob_WhenGettingById_ThenTheMatchingExportJobShouldBeReturned()
         {
             var jobRecord = await InsertNewExportJobRecordAsync();
 
@@ -71,7 +71,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
         }
 
         [Fact]
-        public async Task GivenNoMatchingJob_WhenGettingById_ThenJobNotFoundExceptionShouldBeThrown()
+        public async Task GivenNoMatchingExportJob_WhenGettingById_ThenJobNotFoundExceptionShouldBeThrown()
         {
             var jobRecord = await InsertNewExportJobRecordAsync();
 
@@ -79,7 +79,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
         }
 
         [Fact]
-        public async Task GivenAMatchingJob_WhenGettingByHash_ThenTheMatchingJobShouldBeReturned()
+        public async Task GivenAMatchingExportJob_WhenGettingByHash_ThenTheMatchingExportJobShouldBeReturned()
         {
             var jobRecord = await InsertNewExportJobRecordAsync();
 
@@ -89,7 +89,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
         }
 
         [Fact]
-        public async Task GivenNoMatchingJob_WhenGettingByHash_ThenNoMatchingJobShouldBeReturned()
+        public async Task GivenNoMatchingExportJob_WhenGettingByHash_ThenNoMatchingExportJobShouldBeReturned()
         {
             var jobRecord = await InsertNewExportJobRecordAsync();
 
@@ -99,7 +99,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
         }
 
         [Fact]
-        public async Task GivenThereIsNoRunningJob_WhenAcquiringJobs_ThenAvailableJobsShouldBeReturned()
+        public async Task GivenThereIsNoRunningExportJob_WhenAcquiringExportJobs_ThenAvailableExportJobsShouldBeReturned()
         {
             ExportJobRecord jobRecord = await InsertNewExportJobRecordAsync();
 
@@ -119,7 +119,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
         [InlineData(OperationStatus.Completed)]
         [InlineData(OperationStatus.Failed)]
         [InlineData(OperationStatus.Running)]
-        public async Task GivenJobIsNotInQueuedState_WhenAcquiringJobs_ThenNoJobShouldBeReturned(OperationStatus operationStatus)
+        public async Task GivenExportJobIsNotInQueuedState_WhenAcquiringExportJobs_ThenNoExportJobShouldBeReturned(OperationStatus operationStatus)
         {
             ExportJobRecord jobRecord = await InsertNewExportJobRecordAsync(jr => jr.Status = operationStatus);
 
@@ -133,9 +133,9 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
         [InlineData(1, 0)]
         [InlineData(2, 1)]
         [InlineData(3, 2)]
-        public async Task GivenNumberOfRunningJobs_WhenAcquiringJobs_ThenAvailableJobsShouldBeReturned(ushort limit, int expectedNumberOfJobsReturned)
+        public async Task GivenNumberOfRunningExportJobs_WhenAcquiringExportJobs_ThenAvailableExportJobsShouldBeReturned(ushort limit, int expectedNumberOfJobsReturned)
         {
-            await CreateRunningJob();
+            await CreateRunningExportJob();
             ExportJobRecord jobRecord1 = await InsertNewExportJobRecordAsync(); // Queued
             await InsertNewExportJobRecordAsync(jr => jr.Status = OperationStatus.Canceled);
             await InsertNewExportJobRecordAsync(jr => jr.Status = OperationStatus.Completed);
@@ -165,9 +165,9 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
         }
 
         [Fact]
-        public async Task GivenThereIsRunningJobThatExpired_WhenAcquiringJobs_ThenTheExpiredJobShouldBeReturned()
+        public async Task GivenThereIsARunningExportJobThatExpired_WhenAcquiringExportJobs_ThenTheExpiredExportJobShouldBeReturned()
         {
-            ExportJobOutcome jobOutcome = await CreateRunningJob();
+            ExportJobOutcome jobOutcome = await CreateRunningExportJob();
 
             await Task.Delay(1200);
 
@@ -180,7 +180,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
         }
 
         [Fact]
-        public async Task GivenThereAreQueuedJobs_WhenSimultaneouslyAcquiringJobs_ThenCorrectJobsShouldBeReturned()
+        public async Task GivenThereAreQueuedExportJobs_WhenSimultaneouslyAcquiringExportJobs_ThenCorrectExportJobsShouldBeReturned()
         {
             ExportJobRecord[] jobRecords = new[]
             {
@@ -217,9 +217,9 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
         }
 
         [Fact]
-        public async Task GivenARunningJob_WhenUpdatingTheJob_ThenTheJobShouldBeUpdated()
+        public async Task GivenARunningExportJob_WhenUpdatingTheExportJob_ThenTheExportJobShouldBeUpdated()
         {
-            ExportJobOutcome jobOutcome = await CreateRunningJob();
+            ExportJobOutcome jobOutcome = await CreateRunningExportJob();
             ExportJobRecord job = jobOutcome.JobRecord;
 
             job.Status = OperationStatus.Completed;
@@ -231,9 +231,9 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
         }
 
         [Fact]
-        public async Task GivenAnOldVersionOfAJob_WhenUpdatingTheJob_ThenJobConflictExceptionShouldBeThrown()
+        public async Task GivenAnOldVersionOfAnExportJob_WhenUpdatingTheExportJob_ThenJobConflictExceptionShouldBeThrown()
         {
-            ExportJobOutcome jobOutcome = await CreateRunningJob();
+            ExportJobOutcome jobOutcome = await CreateRunningExportJob();
             ExportJobRecord job = jobOutcome.JobRecord;
 
             // Update the job for a first time. This should not fail.
@@ -246,9 +246,9 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
         }
 
         [Fact]
-        public async Task GivenANonexistentJob_WhenUpdatingTheJob_ThenJobNotFoundExceptionShouldBeThrown()
+        public async Task GivenANonexistentExportJob_WhenUpdatingTheExportJob_ThenJobNotFoundExceptionShouldBeThrown()
         {
-            ExportJobOutcome jobOutcome = await CreateRunningJob();
+            ExportJobOutcome jobOutcome = await CreateRunningExportJob();
 
             ExportJobRecord job = jobOutcome.JobRecord;
             WeakETag jobVersion = jobOutcome.ETag;
@@ -259,9 +259,9 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
         }
 
         [Fact]
-        public async Task GivenThereIsARunningJob_WhenSimultaneousUpdateCallsOccur_ThenJobConflictExceptionShouldBeThrown()
+        public async Task GivenThereIsARunningExportJob_WhenSimultaneousUpdateCallsOccur_ThenJobConflictExceptionShouldBeThrown()
         {
-            ExportJobOutcome runningJobOutcome = await CreateRunningJob();
+            ExportJobOutcome runningJobOutcome = await CreateRunningExportJob();
 
             var completionSource = new TaskCompletionSource<bool>();
 
@@ -285,7 +285,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
             }
         }
 
-        private async Task<ExportJobOutcome> CreateRunningJob()
+        private async Task<ExportJobOutcome> CreateRunningExportJob()
         {
             // Create a queued job.
             await InsertNewExportJobRecordAsync();

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Microsoft.Health.Fhir.Shared.Tests.Integration.projitems
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Microsoft.Health.Fhir.Shared.Tests.Integration.projitems
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\FhirOperationDataStoreReindexTests.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\FhirOperationDataStoreTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\FhirOperationDataStoreExportTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\Export\CreateExportRequestHandlerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\FhirOperationTestConstants.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\Reindex\ReindexJobTests.cs" />

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestHelper.cs
@@ -46,6 +46,11 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             await DeleteAllRecordsAsync(ReindexJobPartitionKey, cancellationToken);
         }
 
+        public async Task DeleteReindexJobRecordAsync(string id, CancellationToken cancellationToken = default)
+        {
+            await _documentClient.DeleteItemStreamAsync(id, new PartitionKey(ReindexJobPartitionKey), cancellationToken: cancellationToken);
+        }
+
         private async Task DeleteAllRecordsAsync(string partitionKey, CancellationToken cancellationToken)
         {
             var query = _documentClient.GetItemQueryIterator<JObject>(

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/IFhirStorageTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/IFhirStorageTestHelper.cs
@@ -41,6 +41,14 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         Task DeleteAllReindexJobRecordsAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Deletes the specified reindex job record from the database.
+        /// </summary>
+        /// <param name="id">The id of the job to delete.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A task.</returns>
+        Task DeleteReindexJobRecordAsync(string id, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Gets a token representing the state of the database.
         /// </summary>
         /// <returns>The state token</returns>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
@@ -178,9 +178,29 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             }
         }
 
-        public Task DeleteAllReindexJobRecordsAsync(CancellationToken cancellationToken = default)
+        public async Task DeleteAllReindexJobRecordsAsync(CancellationToken cancellationToken = default)
         {
-            throw new NotImplementedException();
+            using (var connection = await _sqlConnectionFactory.GetSqlConnectionAsync())
+            {
+                var command = new SqlCommand("DELETE FROM dbo.ReindexJob", connection);
+
+                await command.Connection.OpenAsync(cancellationToken);
+                await command.ExecuteNonQueryAsync(cancellationToken);
+            }
+        }
+
+        public async Task DeleteReindexJobRecordAsync(string id, CancellationToken cancellationToken = default)
+        {
+            using (var connection = await _sqlConnectionFactory.GetSqlConnectionAsync())
+            {
+                var command = new SqlCommand("DELETE FROM dbo.ReindexJob WHERE Id = @id", connection);
+
+                var parameter = new SqlParameter { ParameterName = "@id", Value = id };
+                command.Parameters.Add(parameter);
+
+                await command.Connection.OpenAsync(cancellationToken);
+                await command.ExecuteNonQueryAsync(cancellationToken);
+            }
         }
 
         async Task<object> IFhirStorageTestHelper.GetSnapshotToken()


### PR DESCRIPTION
## Description
Implements the data layer for  SQL reindexing. This is the C# code that interfaces with the new reindexing schema changes added in #1570.

## Related issues
Addresses [AB#73857](https://microsofthealth.visualstudio.com/Health/_workitems/edit/73857).

## Testing
There were already existing integration tests that tested the Cosmos DB reindexing layer functionality. I updated these tests to cover SQL as well, and I added a few additional tests for more coverage.

## FHIR Team Checklist
- ✅ **Update the title** of the PR to be succinct and less than 50 characters
- ✅ **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- ✅ Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- ✅ Tag the PR with **Azure API for FHIR** if this will release to the managed service
- ✅ Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
