### PR TITLE
Correct docker image location in release compose file

### DIFF
--- a/release/docker-compose.yaml
+++ b/release/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   fhir-api:
-    image: "healthplatformregistry.azurecr.io/r4_fhir-server"
+    image: "mcr.microsoft.com/healthcareapis/r4-fhir-server"
     restart: on-failure
     environment:
       FHIRServer__Security__Enabled: "false"


### PR DESCRIPTION
It seems that the docker image is no longer present in the ACR specified.

`mcr.microsoft.com/healthcareapis/r4-fhir-server` seems to work.