### PR TITLE
Release docker compose: Update image and set automatic updates to schema to true

### DIFF
--- a/release/docker-compose.yaml
+++ b/release/docker-compose.yaml
@@ -1,13 +1,14 @@
 version: "3"
 services:
   fhir-api:
-    image: "healthplatformregistry.azurecr.io/r4_fhir-server"
+    image: "mcr.microsoft.com/healthcareapis/r4-fhir-server"
     restart: on-failure
     environment:
       FHIRServer__Security__Enabled: "false"
       SqlServer__ConnectionString: "Server=tcp:sql,1433;Initial Catalog=FHIR;Persist Security Info=False;User ID=sa;Password=${SAPASSWORD};MultipleActiveResultSets=False;Connection Timeout=30;"
       SqlServer__AllowDatabaseCreation: "true"
       SqlServer__Initialize: "true"
+      SqlServer__SchemaOptions__AutomaticUpdatesEnabled: "true"
       DataStore: "SqlServer"
     ports:     
       - "8080:8080"


### PR DESCRIPTION
## Description
It seems that the docker image is no longer present in the ACR specified. `mcr.microsoft.com/healthcareapis/r4-fhir-server` seems to work. Please confirm this is appropriate.

DB schema was not being initialized. Added:

```
SqlServer__SchemaOptions__AutomaticUpdatesEnabled: "true"
```

## Related issues
Closes #1575

## Testing
FHIR server comes up and metadata endpoint works without error.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
