### PR TITLE
Makes reindex job tests independent of data store

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTestsFixture.cs
@@ -7,8 +7,10 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Health.Abstractions.Features.Transactions;
+using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Features.Search.Registry;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Xunit;
@@ -45,6 +47,12 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         public ISearchParameterStatusDataStore SearchParameterStatusDataStore => _fixture.GetRequiredService<ISearchParameterStatusDataStore>();
 
         public FilebasedSearchParameterStatusDataStore FilebasedSearchParameterStatusDataStore => _fixture.GetRequiredService<FilebasedSearchParameterStatusDataStore>();
+
+        public ISearchService SearchService => _fixture.GetRequiredService<ISearchService>();
+
+        public SearchParameterDefinitionManager SearchParameterDefinitionManager => _fixture.GetRequiredService<SearchParameterDefinitionManager>();
+
+        public SupportedSearchParameterDefinitionManager SupportedSearchParameterDefinitionManager => _fixture.GetRequiredService<SupportedSearchParameterDefinitionManager>();
 
         void IDisposable.Dispose()
         {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
@@ -30,27 +30,22 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
     {
         private readonly string _masterDatabaseName;
         private readonly string _initialConnectionString;
-        private readonly SearchParameterDefinitionManager _searchParameterDefinitionManager;
         private readonly SqlServerFhirModel _sqlServerFhirModel;
         private readonly ISqlConnectionFactory _sqlConnectionFactory;
 
         public SqlServerFhirStorageTestHelper(
             string initialConnectionString,
             string masterDatabaseName,
-            SearchParameterDefinitionManager searchParameterDefinitionManager,
             SqlServerFhirModel sqlServerFhirModel,
             ISqlConnectionFactory sqlConnectionFactory)
         {
-            EnsureArg.IsNotNull(searchParameterDefinitionManager, nameof(searchParameterDefinitionManager));
             EnsureArg.IsNotNull(sqlServerFhirModel, nameof(sqlServerFhirModel));
             EnsureArg.IsNotNull(sqlConnectionFactory, nameof(sqlConnectionFactory));
 
             _masterDatabaseName = masterDatabaseName;
             _initialConnectionString = initialConnectionString;
-            _searchParameterDefinitionManager = searchParameterDefinitionManager;
             _sqlServerFhirModel = sqlServerFhirModel;
             _sqlConnectionFactory = sqlConnectionFactory;
-            _searchParameterDefinitionManager.StartAsync(CancellationToken.None).Wait();
         }
 
         public async Task CreateAndInitializeDatabase(string databaseName, bool forceIncrementalSchemaUpgrade, SchemaInitializer schemaInitializer = null, CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Description
The reindex job tests were setup to use the Cosmos DB search service. This PR moves the search service setup logic to the datastore-specific test fixtures, which will allow the tests to run for SQL as well.

These tests are not yet enabled for SQL - they should be enabled and should pass once SQL reindexing is fully implemented.

## Related issues
Addresses [AB#78696](https://microsofthealth.visualstudio.com/Health/_workitems/edit/78696).

It might be nice to rethink how our integration tests are setup, since manually instantiating services is not very pretty or scalable. Created [AB#78697](https://microsofthealth.visualstudio.com/Health/_workitems/edit/78697) to track this.

## Testing
Manual testing:
- Ensured that the tests continue to pass for Cosmos DB
- Temporarily enabled the tests for SQL to ensure that the tests run without fixture-related issues (although some tests fail, as expected)

## FHIR Team Checklist
- ✅ **Update the title** of the PR to be succinct and less than 50 characters
- ✅ **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- ✅ Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- ✅ Tag the PR with **Azure API for FHIR** if this will release to the managed service
- ✅ Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
