### PR TITLE
Add support to DELETE custom search parameters

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Extensions/RawResourceExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Extensions/RawResourceExtensions.cs
@@ -1,0 +1,51 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.IO;
+using EnsureThat;
+using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Serialization;
+using Microsoft.Health.Fhir.Core.Exceptions;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Microsoft.Health.Fhir.Core.Models;
+using Newtonsoft.Json;
+
+namespace Microsoft.Health.Fhir.Core.Extensions
+{
+    public static class RawResourceExtensions
+    {
+        /// <summary>
+        /// Converts the RawResource to an ITypedElement
+        /// </summary>
+        /// <param name="rawResource">The RawResource to convert</param>
+        /// <param name="modelInfoProvider">The IModelInfoProvider to use when converting the RawResource</param>
+        /// <returns>An ITypedElement of the RawResource</returns>
+        public static ITypedElement ToITypedElement(this RawResource rawResource, IModelInfoProvider modelInfoProvider)
+        {
+            EnsureArg.IsNotNull(rawResource, nameof(rawResource));
+            EnsureArg.IsNotNull(modelInfoProvider, nameof(modelInfoProvider));
+
+            using TextReader reader = new StringReader(rawResource.Data);
+            using JsonReader jsonReader = new JsonTextReader(reader);
+            try
+            {
+                ISourceNode sourceNode = FhirJsonNode.Read(jsonReader);
+                return modelInfoProvider.ToTypedElement(sourceNode);
+            }
+            catch (FormatException ex)
+            {
+                var issue = new OperationOutcomeIssue(
+                    OperationOutcomeConstants.IssueSeverity.Fatal,
+                    OperationOutcomeConstants.IssueType.Invalid,
+                    ex.Message);
+
+                throw new InvalidDefinitionException(
+                    Core.Resources.SearchParameterDefinitionContainsInvalidEntry,
+                    new OperationOutcomeIssue[] { issue });
+            }
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/BundleWrappers/SearchParameterWrapper.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/BundleWrappers/SearchParameterWrapper.cs
@@ -14,7 +14,7 @@ using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Core.Features.Definition.BundleWrappers
 {
-    public class SearchParameterWrapper
+    internal class SearchParameterWrapper
     {
         private readonly Lazy<string> _url;
         private readonly Lazy<IReadOnlyList<ITypedElement>> _component;

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/BundleWrappers/SearchParameterWrapper.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/BundleWrappers/SearchParameterWrapper.cs
@@ -45,7 +45,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition.BundleWrappers
 
         public string Description => _description.Value;
 
+#pragma warning disable CA1056 // Uri properties should not be strings
         public string Url => _url.Value;
+#pragma warning restore CA1056 // Uri properties should not be strings
 
         public string Type => _type.Value;
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/BundleWrappers/SearchParameterWrapper.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/BundleWrappers/SearchParameterWrapper.cs
@@ -14,7 +14,7 @@ using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Core.Features.Definition.BundleWrappers
 {
-    internal class SearchParameterWrapper
+    public class SearchParameterWrapper
     {
         private readonly Lazy<string> _url;
         private readonly Lazy<IReadOnlyList<ITypedElement>> _component;

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/BundleWrappers/SearchParameterWrapper.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/BundleWrappers/SearchParameterWrapper.cs
@@ -45,9 +45,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition.BundleWrappers
 
         public string Description => _description.Value;
 
-#pragma warning disable CA1056 // Uri properties should not be strings
         public string Url => _url.Value;
-#pragma warning restore CA1056 // Uri properties should not be strings
 
         public string Type => _type.Value;
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/ISearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/ISearchParameterDefinitionManager.cs
@@ -79,5 +79,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         /// </summary>
         /// <param name="searchParameters">An collection containing SearchParameter resources.</param>
         void AddNewSearchParameters(IReadOnlyCollection<ITypedElement> searchParameters);
+
+        /// <summary>
+        /// Allows removal of a custom search parameter.
+        /// </summary>
+        /// <param name="searchParam">The custom search parameter to remove.</param>
+        void DeleteSearchParameter(ITypedElement searchParam);
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionBuilder.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionBuilder.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -12,16 +13,16 @@ using System.Linq;
 using System.Reflection;
 using EnsureThat;
 using Hl7.Fhir.ElementModel;
-using Hl7.Fhir.Serialization;
 using Hl7.Fhir.Utility;
 using Hl7.FhirPath;
 using Microsoft.Health.Fhir.Core.Data;
 using Microsoft.Health.Fhir.Core.Exceptions;
+using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Definition.BundleWrappers;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.ValueSets;
-using Newtonsoft.Json;
 
 namespace Microsoft.Health.Fhir.Core.Features.Definition
 {
@@ -40,8 +41,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
 
         internal static void Build(
             IReadOnlyCollection<ITypedElement> searchParameters,
-            IDictionary<Uri, SearchParameterInfo> uriDictionary,
-            IDictionary<string, IDictionary<string, SearchParameterInfo>> resourceTypeDictionary,
+            ConcurrentDictionary<Uri, SearchParameterInfo> uriDictionary,
+            ConcurrentDictionary<string, ConcurrentDictionary<string, SearchParameterInfo>> resourceTypeDictionary,
             IModelInfoProvider modelInfoProvider)
         {
             EnsureArg.IsNotNull(searchParameters, nameof(searchParameters));
@@ -88,24 +89,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             Assembly assembly = null)
         {
             using Stream stream = modelInfoProvider.OpenVersionedFileStream(embeddedResourceName, embeddedResourceNamespace, assembly);
-            using TextReader reader = new StreamReader(stream);
-            using JsonReader jsonReader = new JsonTextReader(reader);
-            try
-            {
-                ISourceNode sourceNode = FhirJsonNode.Read(jsonReader);
-                return new BundleWrapper(modelInfoProvider.ToTypedElement(sourceNode));
-            }
-            catch (FormatException ex)
-            {
-                var issue = new OperationOutcomeIssue(
-                    OperationOutcomeConstants.IssueSeverity.Fatal,
-                    OperationOutcomeConstants.IssueType.Invalid,
-                    ex.Message);
 
-                throw new InvalidDefinitionException(
-                    Core.Resources.SearchParameterDefinitionContainsInvalidEntry,
-                    new OperationOutcomeIssue[] { issue });
-            }
+            using TextReader reader = new StreamReader(stream);
+            var data = reader.ReadToEnd();
+            var rawResource = new RawResource(data, FhirResourceFormat.Json, true);
+
+            return new BundleWrapper(rawResource.ToITypedElement(modelInfoProvider));
         }
 
         private static List<(string ResourceType, SearchParameterInfo SearchParameter)> ValidateAndGetFlattenedList(
@@ -299,11 +288,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         private static HashSet<SearchParameterInfo> BuildSearchParameterDefinition(
             ILookup<string, SearchParameterInfo> searchParametersLookup,
             string resourceType,
-            IDictionary<string, IDictionary<string, SearchParameterInfo>> resourceTypeDictionary,
+            ConcurrentDictionary<string, ConcurrentDictionary<string, SearchParameterInfo>> resourceTypeDictionary,
             IModelInfoProvider modelInfoProvider)
         {
             HashSet<SearchParameterInfo> results;
-            if (resourceTypeDictionary.TryGetValue(resourceType, out IDictionary<string, SearchParameterInfo> cachedSearchParameters))
+            if (resourceTypeDictionary.TryGetValue(resourceType, out ConcurrentDictionary<string, SearchParameterInfo> cachedSearchParameters))
             {
                 results = new HashSet<SearchParameterInfo>(cachedSearchParameters.Values);
             }
@@ -328,10 +317,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
 
             results.UnionWith(searchParametersLookup[resourceType]);
 
-            Dictionary<string, SearchParameterInfo> searchParameterDictionary = results.ToDictionary(
+            var searchParameterDictionary = new ConcurrentDictionary<string, SearchParameterInfo>(
+                results.ToDictionary(
                 r => r.Name,
                 r => r,
-                StringComparer.Ordinal);
+                StringComparer.Ordinal));
 
             if (!resourceTypeDictionary.TryAdd(resourceType, searchParameterDictionary))
             {

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionBuilder.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionBuilder.cs
@@ -17,7 +17,6 @@ using Hl7.Fhir.Utility;
 using Hl7.FhirPath;
 using Microsoft.Health.Fhir.Core.Data;
 using Microsoft.Health.Fhir.Core.Exceptions;
-using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Definition.BundleWrappers;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Search;
@@ -94,7 +93,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             var data = reader.ReadToEnd();
             var rawResource = new RawResource(data, FhirResourceFormat.Json, true);
 
-            return new BundleWrapper(rawResource.ToITypedElement(modelInfoProvider));
+            return new BundleWrapper(modelInfoProvider.ToTypedElement(rawResource));
         }
 
         private static List<(string ResourceType, SearchParameterInfo SearchParameter)> ValidateAndGetFlattenedList(

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
@@ -156,13 +156,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         public void DeleteSearchParameter(ITypedElement searchParam)
         {
             var searchParamWrapper = new SearchParameterWrapper(searchParam);
+            var searchParameterInfo = GetSearchParameter(new Uri(searchParamWrapper.Url));
 
             if (!UrlLookup.Remove(new Uri(searchParamWrapper.Url)))
             {
                 throw new Exception(string.Format(Resources.CustomSearchParameterNotfound, searchParamWrapper.Url));
             }
 
-            var searchParameterInfo = TypeLookup[searchParamWrapper.Type][searchParamWrapper.Name];
             var allResourceTypes = searchParameterInfo.TargetResourceTypes.Union(searchParameterInfo.BaseResourceTypes);
             foreach (var resourceType in allResourceTypes)
             {

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
@@ -33,14 +33,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
 
             _modelInfoProvider = modelInfoProvider;
             _resourceTypeSearchParameterHashMap = new ConcurrentDictionary<string, string>();
-            TypeLookup = new Dictionary<string, IDictionary<string, SearchParameterInfo>>();
-            UrlLookup = new Dictionary<Uri, SearchParameterInfo>();
+            TypeLookup = new ConcurrentDictionary<string, ConcurrentDictionary<string, SearchParameterInfo>>();
+            UrlLookup = new ConcurrentDictionary<Uri, SearchParameterInfo>();
         }
 
-        internal IDictionary<Uri, SearchParameterInfo> UrlLookup { get; set; }
+        internal ConcurrentDictionary<Uri, SearchParameterInfo> UrlLookup { get; set; }
 
         // TypeLookup key is: Resource type, the inner dictionary key is the Search Parameter name.
-        internal IDictionary<string, IDictionary<string, SearchParameterInfo>> TypeLookup { get; }
+        internal ConcurrentDictionary<string, ConcurrentDictionary<string, SearchParameterInfo>> TypeLookup { get; }
 
         public IEnumerable<SearchParameterInfo> AllSearchParameters => UrlLookup.Values;
 
@@ -68,7 +68,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
 
         public IEnumerable<SearchParameterInfo> GetSearchParameters(string resourceType)
         {
-            if (TypeLookup.TryGetValue(resourceType, out IDictionary<string, SearchParameterInfo> value))
+            if (TypeLookup.TryGetValue(resourceType, out ConcurrentDictionary<string, SearchParameterInfo> value))
             {
                 return value.Values;
             }
@@ -78,7 +78,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
 
         public SearchParameterInfo GetSearchParameter(string resourceType, string name)
         {
-            if (TypeLookup.TryGetValue(resourceType, out IDictionary<string, SearchParameterInfo> lookup) &&
+            if (TypeLookup.TryGetValue(resourceType, out ConcurrentDictionary<string, SearchParameterInfo> lookup) &&
                 lookup.TryGetValue(name, out SearchParameterInfo searchParameter))
             {
                 return searchParameter;
@@ -91,7 +91,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         {
             searchParameter = null;
 
-            return TypeLookup.TryGetValue(resourceType, out IDictionary<string, SearchParameterInfo> searchParameters) &&
+            return TypeLookup.TryGetValue(resourceType, out ConcurrentDictionary<string, SearchParameterInfo> searchParameters) &&
                 searchParameters.TryGetValue(name, out searchParameter);
         }
 
@@ -143,11 +143,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
 
         private void CalculateSearchParameterHash()
         {
-            foreach (KeyValuePair<string, IDictionary<string, SearchParameterInfo>> kvp in TypeLookup)
+            foreach (string resourceName in TypeLookup.Keys)
             {
-                string searchParamHash = SearchHelperUtilities.CalculateSearchParameterHash(kvp.Value.Values);
+                string searchParamHash = SearchHelperUtilities.CalculateSearchParameterHash(TypeLookup[resourceName].Values);
                 _resourceTypeSearchParameterHashMap.AddOrUpdate(
-                    kvp.Key,
+                    resourceName,
                     searchParamHash,
                     (resourceType, existingValue) => searchParamHash);
             }
@@ -156,9 +156,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         public void DeleteSearchParameter(ITypedElement searchParam)
         {
             var searchParamWrapper = new SearchParameterWrapper(searchParam);
-            var searchParameterInfo = GetSearchParameter(new Uri(searchParamWrapper.Url));
+            SearchParameterInfo searchParameterInfo = null;
 
-            if (!UrlLookup.Remove(new Uri(searchParamWrapper.Url)))
+            if (!UrlLookup.TryRemove(new Uri(searchParamWrapper.Url), out searchParameterInfo))
             {
                 throw new Exception(string.Format(Resources.CustomSearchParameterNotfound, searchParamWrapper.Url));
             }
@@ -166,10 +166,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             var allResourceTypes = searchParameterInfo.TargetResourceTypes.Union(searchParameterInfo.BaseResourceTypes);
             foreach (var resourceType in allResourceTypes)
             {
-                if (TypeLookup.ContainsKey(resourceType))
-                {
-                    TypeLookup[resourceType].Remove(searchParameterInfo.Name);
-                }
+                TypeLookup[resourceType].TryRemove(searchParameterInfo.Name, out var removedParam);
             }
 
             CalculateSearchParameterHash();

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchableSearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchableSearchParameterDefinitionManager.cs
@@ -116,5 +116,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         {
             _inner.UpdateSearchParameterHashMap(updatedSearchParamHashMap);
         }
+
+        public void DeleteSearchParameter(ITypedElement searchParam)
+        {
+            _inner.DeleteSearchParameter(searchParam);
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SupportedSearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SupportedSearchParameterDefinitionManager.cs
@@ -91,5 +91,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         {
             _inner.UpdateSearchParameterHashMap(updatedSearchParamHashMap);
         }
+
+        public void DeleteSearchParameter(ITypedElement searchParam)
+        {
+            _inner.DeleteSearchParameter(searchParam);
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                         _reindexJobRecord.Error.Add(new OperationOutcomeIssue(
                             OperationOutcomeConstants.IssueSeverity.Information,
                             OperationOutcomeConstants.IssueType.Informational,
-                            Resources.NoResourcesNeedbeReindexed));
+                            Resources.NoResourcesNeedToBeReindexed));
                         _reindexJobRecord.CanceledTime = DateTimeOffset.UtcNow;
                         await CompleteJobAsync(OperationStatus.Canceled, cancellationToken);
                         return;

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -120,6 +120,17 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
 
                     await CalculateTotalCount(cancellationToken);
 
+                    if (_reindexJobRecord.Count == 0)
+                    {
+                        _reindexJobRecord.Error.Add(new OperationOutcomeIssue(
+                            OperationOutcomeConstants.IssueSeverity.Information,
+                            OperationOutcomeConstants.IssueType.Informational,
+                            Resources.NoResourcesNeedbeReindexed));
+                        _reindexJobRecord.CanceledTime = DateTimeOffset.UtcNow;
+                        await CompleteJobAsync(OperationStatus.Canceled, cancellationToken);
+                        return;
+                    }
+
                     // Generate separate queries for each resource type and add them to query list.
                     foreach (string resourceType in _reindexJobRecord.Resources)
                     {
@@ -280,7 +291,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     results = await ExecuteReindexQueryAsync(query, countOnly: false, cancellationToken);
 
                     // if continuation token then update next query
-                    if (!string.IsNullOrEmpty(results.ContinuationToken))
+                    if (!string.IsNullOrEmpty(results?.ContinuationToken))
                     {
                         var encodedContinuationToken = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(results.ContinuationToken));
                         var nextQuery = new ReindexJobQueryStatus(query.ResourceType, encodedContinuationToken)

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/CreateSearchParameterBehavior.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/CreateSearchParameterBehavior.cs
@@ -14,6 +14,7 @@ using Microsoft.Health.Fhir.Core.Models;
 namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
 {
     public class CreateSearchParameterBehavior<TCreateResourceRequest, TUpsertResourceResponse> : IPipelineBehavior<TCreateResourceRequest, TUpsertResourceResponse>
+        where TCreateResourceRequest : CreateResourceRequest
     {
         private ISearchParameterUtilities _searchParameterUtitliies;
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/CreateSearchParameterBehavior.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/CreateSearchParameterBehavior.cs
@@ -1,0 +1,43 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EnsureThat;
+using MediatR;
+using Microsoft.Health.Fhir.Core.Messages.Create;
+using Microsoft.Health.Fhir.Core.Models;
+
+namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
+{
+    public class CreateSearchParameterBehavior<TCreateResourceRequest, TUpsertResourceResponse> : IPipelineBehavior<TCreateResourceRequest, TUpsertResourceResponse>
+    {
+        private ISearchParameterUtilities _searchParameterUtitliies;
+
+        public CreateSearchParameterBehavior(ISearchParameterUtilities searchParameterUtilities)
+        {
+            EnsureArg.IsNotNull(searchParameterUtilities, nameof(searchParameterUtilities));
+
+            _searchParameterUtitliies = searchParameterUtilities;
+        }
+
+        public async Task<TUpsertResourceResponse> Handle(TCreateResourceRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TUpsertResourceResponse> next)
+        {
+            var response = await next();
+
+            var createRequest = request as CreateResourceRequest;
+
+            if (createRequest.Resource.InstanceType.Equals(KnownResourceTypes.SearchParameter, StringComparison.Ordinal))
+            {
+                // Once the SearchParameter resource is committed to the data store, we can update the in
+                // memory SearchParameterDefinitionManager, and persist the status to the data store
+                await _searchParameterUtitliies.AddSearchParameterAsync(createRequest.Resource.Instance);
+            }
+
+            return response;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/DeleteSearchParameterBehavior.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/DeleteSearchParameterBehavior.cs
@@ -1,0 +1,53 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EnsureThat;
+using MediatR;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Microsoft.Health.Fhir.Core.Messages.Delete;
+using Microsoft.Health.Fhir.Core.Models;
+
+namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
+{
+    public class DeleteSearchParameterBehavior<TDeleteResourceRequest, TDeleteResourceResponse> : IPipelineBehavior<TDeleteResourceRequest, TDeleteResourceResponse>
+    {
+        private ISearchParameterUtilities _searchParameterUtilities;
+        private IFhirDataStore _fhirDataStore;
+
+        public DeleteSearchParameterBehavior(ISearchParameterUtilities searchParameterUtilities, IFhirDataStore fhirDataStore)
+        {
+            EnsureArg.IsNotNull(searchParameterUtilities, nameof(searchParameterUtilities));
+            EnsureArg.IsNotNull(fhirDataStore, nameof(fhirDataStore));
+
+            _searchParameterUtilities = searchParameterUtilities;
+            _fhirDataStore = fhirDataStore;
+        }
+
+        public async Task<TDeleteResourceResponse> Handle(TDeleteResourceRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TDeleteResourceResponse> next)
+        {
+            var deleteRequest = request as DeleteResourceRequest;
+            ResourceWrapper searchParamResource = null;
+
+            if (deleteRequest.ResourceKey.ResourceType.Equals(KnownResourceTypes.SearchParameter, StringComparison.Ordinal))
+            {
+                searchParamResource = await _fhirDataStore.GetAsync(deleteRequest.ResourceKey, cancellationToken);
+            }
+
+            var response = await next();
+
+            if (searchParamResource != null)
+            {
+                // Once the SearchParameter resource is removed from the data store, we can update the in
+                // memory SearchParameterDefinitionManager, and persist the deleted status to the data store
+                await _searchParameterUtilities.DeleteSearchParameterAsync(searchParamResource.RawResource);
+            }
+
+            return response;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/DeleteSearchParameterBehavior.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/DeleteSearchParameterBehavior.cs
@@ -15,6 +15,7 @@ using Microsoft.Health.Fhir.Core.Models;
 namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
 {
     public class DeleteSearchParameterBehavior<TDeleteResourceRequest, TDeleteResourceResponse> : IPipelineBehavior<TDeleteResourceRequest, TDeleteResourceResponse>
+        where TDeleteResourceRequest : DeleteResourceRequest
     {
         private ISearchParameterUtilities _searchParameterUtilities;
         private IFhirDataStore _fhirDataStore;

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/DeleteSearchParameterBehavior.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/DeleteSearchParameterBehavior.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
             if (searchParamResource != null)
             {
                 // Once the SearchParameter resource is removed from the data store, we can update the in
-                // memory SearchParameterDefinitionManager, and persist the deleted status to the data store
+                // memory SearchParameterDefinitionManager, and remove the status metadata from the data store
                 await _searchParameterUtilities.DeleteSearchParameterAsync(searchParamResource.RawResource);
             }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/ISearchParameterUtilities.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/ISearchParameterUtilities.cs
@@ -11,5 +11,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
     public interface ISearchParameterUtilities
     {
         Task AddSearchParameterAsync(ITypedElement searchParam);
+
+        Task DeleteSearchParameterAsync(ITypedElement searchParam);
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/ISearchParameterUtilities.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/ISearchParameterUtilities.cs
@@ -5,6 +5,7 @@
 
 using System.Threading.Tasks;
 using Hl7.Fhir.ElementModel;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
 
 namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
 {
@@ -12,6 +13,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
     {
         Task AddSearchParameterAsync(ITypedElement searchParam);
 
-        Task DeleteSearchParameterAsync(ITypedElement searchParam);
+        Task DeleteSearchParameterAsync(RawResource searchParam);
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterUtilities.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterUtilities.cs
@@ -9,8 +9,10 @@ using System.Threading.Tasks;
 using EnsureThat;
 using Hl7.Fhir.ElementModel;
 using Microsoft.Health.Fhir.Core.Exceptions;
+using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Definition.BundleWrappers;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Search.Registry;
 using Microsoft.Health.Fhir.Core.Models;
 
@@ -20,16 +22,20 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
     {
         private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager;
         private readonly SearchParameterStatusManager _searchParameterStatusManager;
+        private IModelInfoProvider _modelInfoProvider;
 
         public SearchParameterUtilities(
             SearchParameterStatusManager searchParameterStatusManager,
-            ISearchParameterDefinitionManager searchParameterDefinitionManager)
+            ISearchParameterDefinitionManager searchParameterDefinitionManager,
+            IModelInfoProvider modelInfoProvider)
         {
             EnsureArg.IsNotNull(searchParameterStatusManager, nameof(searchParameterStatusManager));
             EnsureArg.IsNotNull(searchParameterDefinitionManager, nameof(searchParameterDefinitionManager));
+            EnsureArg.IsNotNull(modelInfoProvider, nameof(modelInfoProvider));
 
             _searchParameterStatusManager = searchParameterStatusManager;
             _searchParameterDefinitionManager = searchParameterDefinitionManager;
+            _modelInfoProvider = modelInfoProvider;
         }
 
         public async Task AddSearchParameterAsync(ITypedElement searchParam)
@@ -62,10 +68,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
             }
         }
 
-        public async Task DeleteSearchParameterAsync(ITypedElement searchParam)
+        public async Task DeleteSearchParameterAsync(RawResource searchParamResource)
         {
             try
             {
+                var searchParam = searchParamResource.ToITypedElement(_modelInfoProvider);
                 _searchParameterDefinitionManager.DeleteSearchParameter(searchParam);
 
                 var searchParameterWrapper = new SearchParameterWrapper(searchParam);

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterUtilities.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterUtilities.cs
@@ -61,5 +61,35 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
                 throw customSearchException;
             }
         }
+
+        public async Task DeleteSearchParameterAsync(ITypedElement searchParam)
+        {
+            try
+            {
+                _searchParameterDefinitionManager.DeleteSearchParameter(searchParam);
+
+                var searchParameterWrapper = new SearchParameterWrapper(searchParam);
+                await _searchParameterStatusManager.DeleteSearchParameterStatusAsync(searchParameterWrapper.Url);
+            }
+            catch (FhirException fex)
+            {
+                fex.Issues.Add(new OperationOutcomeIssue(
+                    OperationOutcomeConstants.IssueSeverity.Error,
+                    OperationOutcomeConstants.IssueType.Exception,
+                    Core.Resources.CustomSearchDeleteError));
+
+                throw;
+            }
+            catch (Exception ex)
+            {
+                var customSearchException = new ConfigureCustomSearchException(Core.Resources.CustomSearchDeleteError);
+                customSearchException.Issues.Add(new OperationOutcomeIssue(
+                    OperationOutcomeConstants.IssueSeverity.Error,
+                    OperationOutcomeConstants.IssueType.Exception,
+                    ex.Message));
+
+                throw customSearchException;
+            }
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterUtilities.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterUtilities.cs
@@ -73,10 +73,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
             try
             {
                 var searchParam = searchParamResource.ToITypedElement(_modelInfoProvider);
-                _searchParameterDefinitionManager.DeleteSearchParameter(searchParam);
-
                 var searchParameterWrapper = new SearchParameterWrapper(searchParam);
+
                 await _searchParameterStatusManager.DeleteSearchParameterStatusAsync(searchParameterWrapper.Url);
+                _searchParameterDefinitionManager.DeleteSearchParameter(searchParam);
             }
             catch (FhirException fex)
             {

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterUtilities.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterUtilities.cs
@@ -74,6 +74,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
                 var searchParam = _modelInfoProvider.ToTypedElement(searchParamResource);
                 var searchParameterWrapper = new SearchParameterWrapper(searchParam);
 
+                // First we delete the status metadata from the data store as this fuction depends on the
+                // the in memory definition manager.  Once complete we remove the SearchParameter from
+                // the definition manager.
                 await _searchParameterStatusManager.DeleteSearchParameterStatusAsync(searchParameterWrapper.Url);
                 _searchParameterDefinitionManager.DeleteSearchParameter(searchParam);
             }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterUtilities.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterUtilities.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using EnsureThat;
 using Hl7.Fhir.ElementModel;
 using Microsoft.Health.Fhir.Core.Exceptions;
-using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Definition.BundleWrappers;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
@@ -72,7 +71,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
         {
             try
             {
-                var searchParam = searchParamResource.ToITypedElement(_modelInfoProvider);
+                var searchParam = _modelInfoProvider.ToTypedElement(searchParamResource);
                 var searchParameterWrapper = new SearchParameterWrapper(searchParam);
 
                 await _searchParameterStatusManager.DeleteSearchParameterStatusAsync(searchParameterWrapper.Url);

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatus.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatus.cs
@@ -10,5 +10,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
         Disabled = 1,
         Supported = 2,
         Enabled = 3,
+        Deleted = 4,
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
                 if (parameters.TryGetValue(p.Url, out ResourceSearchParameterStatus result))
                 {
                     bool isSearchable = result.Status == SearchParameterStatus.Enabled;
-                    bool isSupported = result.Status != SearchParameterStatus.Disabled;
+                    bool isSupported = result.Status == SearchParameterStatus.Supported || result.Status == SearchParameterStatus.Enabled;
                     bool isPartiallySupported = result.IsPartiallySupported;
 
                     if (result.Status == SearchParameterStatus.Disabled)
@@ -105,7 +105,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
                 var paramInfo = _searchParameterDefinitionManager.GetSearchParameter(searchParamUri);
                 updated.Add(paramInfo);
                 paramInfo.IsSearchable = status == SearchParameterStatus.Enabled;
-                paramInfo.IsSupported = status != SearchParameterStatus.Disabled;
+                paramInfo.IsSupported = status == SearchParameterStatus.Supported || status == SearchParameterStatus.Enabled;
 
                 searchParameterStatusList.Add(new ResourceSearchParameterStatus()
                 {
@@ -125,6 +125,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
             // new search parameters are added as supported, until reindexing occurs, when
             // they will be fully enabled
             await UpdateSearchParameterStatusAsync(searchParamUris, SearchParameterStatus.Supported);
+        }
+
+        internal async Task DeleteSearchParameterStatusAsync(string url)
+        {
+            var searchParamUris = new List<string>() { url };
+            await UpdateSearchParameterStatusAsync(searchParamUris, SearchParameterStatus.Deleted);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
             await _mediator.Publish(new SearchParametersUpdated(updated));
         }
 
-        public async Task AddSearchParameterStatusAsync(IReadOnlyCollection<string> searchParamUris)
+        internal async Task AddSearchParameterStatusAsync(IReadOnlyCollection<string> searchParamUris)
         {
             // new search parameters are added as supported, until reindexing occurs, when
             // they will be fully enabled

--- a/src/Microsoft.Health.Fhir.Core/Models/IModelInfoProvider.cs
+++ b/src/Microsoft.Health.Fhir.Core/Models/IModelInfoProvider.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Specification;
 using Hl7.FhirPath;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
 
 namespace Microsoft.Health.Fhir.Core.Models
 {
@@ -34,5 +35,7 @@ namespace Microsoft.Health.Fhir.Core.Models
         EvaluationContext GetEvaluationContext(Func<string, ITypedElement> elementResolver = null);
 
         ITypedElement ToTypedElement(ISourceNode sourceNode);
+
+        ITypedElement ToTypedElement(RawResource rawResource);
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -277,6 +277,24 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to An error occurred deleting the custom search parameter.  The issue must be resolved and the delete request resubmitted to remove the parameter..
+        /// </summary>
+        internal static string CustomSearchDeleteError {
+            get {
+                return ResourceManager.GetString("CustomSearchDeleteError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Custom Search parameter with Uri: {0} was not found..
+        /// </summary>
+        internal static string CustomSearchParameterNotfound {
+            get {
+                return ResourceManager.GetString("CustomSearchParameterNotfound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The date time string &apos;{0}&apos; is not in a correct format..
         /// </summary>
         internal static string DateTimeStringIsIncorrectlyFormatted {

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -622,9 +622,9 @@ namespace Microsoft.Health.Fhir.Core {
         /// <summary>
         ///   Looks up a localized string similar to No resources were found matching the type of the updated search parameters needing to be reindexed.  ReindexJob cancelled..
         /// </summary>
-        internal static string NoResourcesNeedbeReindexed {
+        internal static string NoResourcesNeedToBeReindexed {
             get {
-                return ResourceManager.GetString("NoResourcesNeedbeReindexed", resourceCulture);
+                return ResourceManager.GetString("NoResourcesNeedToBeReindexed", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -620,6 +620,15 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No resources were found matching the type of the updated search parameters needing to be reindexed.  ReindexJob cancelled..
+        /// </summary>
+        internal static string NoResourcesNeedbeReindexed {
+            get {
+                return ResourceManager.GetString("NoResourcesNeedbeReindexed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No search parameters found needing to be indexed.  Job cancelled..
         /// </summary>
         internal static string NoSearchParametersNeededToBeIndexed {

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -515,4 +515,11 @@
     <value>Search parameter '{0}' is not common for '{1}' and '{2}'.</value>
     <comment>{0}: the invalid search parameter. {1}: first resource type. {2} other resource type.</comment>
   </data>
+  <data name="CustomSearchDeleteError" xml:space="preserve">
+    <value>An error occurred deleting the custom search parameter.  The issue must be resolved and the delete request resubmitted to remove the parameter.</value>
+  </data>
+  <data name="CustomSearchParameterNotfound" xml:space="preserve">
+    <value>Custom Search parameter with Uri: {0} was not found.</value>
+    <comment>{0} the uri identifying the custom search parameter.</comment>
+  </data>
 </root>

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -522,4 +522,7 @@
     <value>Custom Search parameter with Uri: {0} was not found.</value>
     <comment>{0} the uri identifying the custom search parameter.</comment>
   </data>
+  <data name="NoResourcesNeedbeReindexed" xml:space="preserve">
+    <value>No resources were found matching the type of the updated search parameters needing to be reindexed.  ReindexJob cancelled.</value>
+  </data>
 </root>

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -522,7 +522,7 @@
     <value>Custom Search parameter with Uri: {0} was not found.</value>
     <comment>{0} the uri identifying the custom search parameter.</comment>
   </data>
-  <data name="NoResourcesNeedbeReindexed" xml:space="preserve">
+  <data name="NoResourcesNeedToBeReindexed" xml:space="preserve">
     <value>No resources were found matching the type of the updated search parameters needing to be reindexed.  ReindexJob cancelled.</value>
   </data>
 </root>

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/SearchModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/SearchModule.cs
@@ -140,8 +140,8 @@ namespace Microsoft.Health.Fhir.Api.Modules
             services.AddSingleton<SearchParameterFilterAttribute>();
             services.AddSingleton<ISearchParameterUtilities, SearchParameterUtilities>();
 
-            services.AddTransient(typeof(IPipelineBehavior<,>), typeof(CreateSearchParameterBehavior<,>));
-            services.AddTransient(typeof(IPipelineBehavior<,>), typeof(DeleteSearchParameterBehavior<,>));
+            services.AddTransient(typeof(IPipelineBehavior<CreateResourceRequest, UpsertResourceResponse>), typeof(CreateSearchParameterBehavior<CreateResourceRequest, UpsertResourceResponse>));
+            services.AddTransient(typeof(IPipelineBehavior<DeleteResourceRequest, DeleteResourceResponse>), typeof(DeleteSearchParameterBehavior<DeleteResourceRequest, DeleteResourceResponse>));
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/SearchModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/SearchModule.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using EnsureThat;
+using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Health.Extensions.DependencyInjection;
@@ -19,6 +20,9 @@ using Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers;
 using Microsoft.Health.Fhir.Core.Features.Search.Parameters;
 using Microsoft.Health.Fhir.Core.Features.Search.Registry;
 using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
+using Microsoft.Health.Fhir.Core.Messages.Create;
+using Microsoft.Health.Fhir.Core.Messages.Delete;
+using Microsoft.Health.Fhir.Core.Messages.Upsert;
 using Microsoft.Health.Fhir.Shared.Core.Features.Search.Parameters;
 
 namespace Microsoft.Health.Fhir.Api.Modules
@@ -135,6 +139,9 @@ namespace Microsoft.Health.Fhir.Api.Modules
             services.AddSingleton<ISearchParameterValidator, SearchParameterValidator>();
             services.AddSingleton<SearchParameterFilterAttribute>();
             services.AddSingleton<ISearchParameterUtilities, SearchParameterUtilities>();
+
+            services.AddTransient(typeof(IPipelineBehavior<,>), typeof(CreateSearchParameterBehavior<,>));
+            services.AddTransient(typeof(IPipelineBehavior<,>), typeof(DeleteSearchParameterBehavior<,>));
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Definition/SearchParameterDefinitionBuilderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Definition/SearchParameterDefinitionBuilderTests.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using Hl7.Fhir.Model;
@@ -25,13 +26,13 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Definition
         private readonly string _invalidEntriesFile = "SearchParametersWithInvalidEntries.json";
         private readonly string _invalidDefinitionsFile = "SearchParametersWithInvalidDefinitions.json";
         private readonly string _validEntriesFile = "SearchParameters.json";
-        private readonly Dictionary<Uri, SearchParameterInfo> _uriDictionary;
-        private readonly Dictionary<string, IDictionary<string, SearchParameterInfo>> _resourceTypeDictionary;
+        private readonly ConcurrentDictionary<Uri, SearchParameterInfo> _uriDictionary;
+        private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, SearchParameterInfo>> _resourceTypeDictionary;
 
         public SearchParameterDefinitionBuilderTests()
         {
-            _uriDictionary = new Dictionary<Uri, SearchParameterInfo>();
-            _resourceTypeDictionary = new Dictionary<string, IDictionary<string, SearchParameterInfo>>();
+            _uriDictionary = new ConcurrentDictionary<Uri, SearchParameterInfo>();
+            _resourceTypeDictionary = new ConcurrentDictionary<string, ConcurrentDictionary<string, SearchParameterInfo>>();
         }
 
         [Theory]
@@ -78,8 +79,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Definition
             Bundle staticBundle = Definitions.GetDefinition("SearchParameters");
 
             Assert.Equal(
-                staticBundle.Entry.Select(entry => entry.FullUrl),
-                _uriDictionary.Values.Select(value => value.Url.ToString()));
+                staticBundle.Entry.Select(entry => entry.FullUrl).OrderBy(s => s, StringComparer.OrdinalIgnoreCase),
+                _uriDictionary.Values.Select(value => value.Url.ToString()).OrderBy(s => s, StringComparer.OrdinalIgnoreCase));
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/ResourceHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/ResourceHandlerTests.cs
@@ -24,7 +24,6 @@ using Microsoft.Health.Fhir.Core.Features.Resources.Delete;
 using Microsoft.Health.Fhir.Core.Features.Resources.Get;
 using Microsoft.Health.Fhir.Core.Features.Resources.Upsert;
 using Microsoft.Health.Fhir.Core.Features.Search;
-using Microsoft.Health.Fhir.Core.Features.Search.Parameters;
 using Microsoft.Health.Fhir.Core.Features.Security;
 using Microsoft.Health.Fhir.Core.Features.Security.Authorization;
 using Microsoft.Health.Fhir.Core.Models;
@@ -53,7 +52,6 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Resources
         private readonly ResourceDeserializer _deserializer;
         private readonly FhirJsonParser _fhirJsonParser = new FhirJsonParser();
         private IFhirAuthorizationService _authorizationService;
-        private readonly ISearchParameterUtilities _searchParameterUtilities;
 
         public ResourceHandlerTests()
         {
@@ -95,17 +93,15 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Resources
             _authorizationService = Substitute.For<IFhirAuthorizationService>();
             _authorizationService.CheckAccess(Arg.Any<DataActions>()).Returns(ci => ci.Arg<DataActions>());
 
-            _searchParameterUtilities = Substitute.For<ISearchParameterUtilities>();
-
             var referenceResolver = new ResourceReferenceResolver(_searchService, new TestQueryStringParser());
             _resourceIdProvider = new ResourceIdProvider();
             collection.Add(x => _mediator).Singleton().AsSelf();
-            collection.Add(x => new CreateResourceHandler(_fhirDataStore, lazyConformanceProvider, _resourceWrapperFactory, _resourceIdProvider, referenceResolver, _authorizationService, _searchParameterUtilities)).Singleton().AsSelf().AsImplementedInterfaces();
+            collection.Add(x => new CreateResourceHandler(_fhirDataStore, lazyConformanceProvider, _resourceWrapperFactory, _resourceIdProvider, referenceResolver, _authorizationService)).Singleton().AsSelf().AsImplementedInterfaces();
             collection.Add(x => new UpsertResourceHandler(_fhirDataStore, lazyConformanceProvider, _resourceWrapperFactory, _resourceIdProvider, _authorizationService, ModelInfoProvider.Instance)).Singleton().AsSelf().AsImplementedInterfaces();
             collection.Add(x => new ConditionalCreateResourceHandler(_fhirDataStore, lazyConformanceProvider, _resourceWrapperFactory, _searchService, x.GetService<IMediator>(), _resourceIdProvider, _authorizationService)).Singleton().AsSelf().AsImplementedInterfaces();
             collection.Add(x => new ConditionalUpsertResourceHandler(_fhirDataStore, lazyConformanceProvider, _resourceWrapperFactory, _searchService, x.GetService<IMediator>(), _resourceIdProvider, _authorizationService)).Singleton().AsSelf().AsImplementedInterfaces();
             collection.Add(x => new GetResourceHandler(_fhirDataStore, lazyConformanceProvider, _resourceWrapperFactory, _resourceIdProvider, _authorizationService)).Singleton().AsSelf().AsImplementedInterfaces();
-            collection.Add(x => new DeleteResourceHandler(_fhirDataStore, lazyConformanceProvider, _resourceWrapperFactory, _resourceIdProvider, _authorizationService, _searchParameterUtilities)).Singleton().AsSelf().AsImplementedInterfaces();
+            collection.Add(x => new DeleteResourceHandler(_fhirDataStore, lazyConformanceProvider, _resourceWrapperFactory, _resourceIdProvider, _authorizationService)).Singleton().AsSelf().AsImplementedInterfaces();
 
             ServiceProvider provider = collection.BuildServiceProvider();
             _mediator = new Mediator(type => provider.GetService(type));
@@ -129,24 +125,6 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Resources
 
             Assert.NotNull(deserializedResource.Id);
             Assert.NotEqual("id1", deserializedResource.Id);
-
-            // Ensure for non-SearchParameter, that we do not call Add SearchParameter
-            await _searchParameterUtilities.DidNotReceive().AddSearchParameterAsync(Arg.Any<ITypedElement>());
-        }
-
-        [Fact]
-        public async Task GivenAFhirMediator_WhenCreatingASearchParameterResource_ThenAddNewSearchParameterShouldBeCalled()
-        {
-            var searchParameter = new SearchParameter() { Id = "Id" };
-            var resource = searchParameter.ToTypedElement().ToResourceElement();
-
-            var wrapper = CreateResourceWrapper(resource, false);
-
-            _fhirDataStore.UpsertAsync(Arg.Any<ResourceWrapper>(), Arg.Any<WeakETag>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(x => new UpsertOutcome(x.Arg<ResourceWrapper>(), SaveOutcomeType.Created));
-
-            await _mediator.CreateResourceAsync(resource);
-
-            await _searchParameterUtilities.Received().AddSearchParameterAsync(Arg.Any<ITypedElement>());
         }
 
         [Fact]
@@ -412,29 +390,6 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Resources
             Assert.NotNull(result);
             Assert.Equal(patient.Scalar<string>(birthDateProp), result.Scalar<string>(birthDateProp));
             Assert.Equal(patient.Scalar<string>(genderDateProp), result.Scalar<string>(genderDateProp));
-        }
-
-        [Fact]
-        public async Task GivenAFhirMediator_WhenDeletingDeletingSearchParameter_ThenSearchParameterUtilitiesCalled()
-        {
-            _authorizationService.CheckAccess(Arg.Any<DataActions>()).Returns(DataActions.Delete | DataActions.HardDelete);
-
-            ResourceKey resourceKey = new ResourceKey<SearchParameter>("id1");
-
-            var searchParam = Samples.GetJsonSample("SearchParameter");
-
-            var searchParamWrapper = CreateResourceWrapper(searchParam, false);
-
-            _fhirDataStore.GetAsync(resourceKey, Arg.Any<CancellationToken>()).Returns(searchParamWrapper);
-
-            ResourceKey resultKey = (await _mediator.DeleteResourceAsync(resourceKey, true)).ResourceKey;
-
-            await _fhirDataStore.Received(1).GetAsync(resourceKey, Arg.Any<CancellationToken>());
-            await _searchParameterUtilities.Received(1).DeleteSearchParameterAsync(searchParamWrapper.RawResource);
-
-            Assert.NotNull(resultKey);
-            Assert.Equal(resourceKey.Id, resultKey.Id);
-            Assert.Null(resultKey.VersionId);
         }
 
         private ResourceWrapper CreateResourceWrapper(ResourceElement resource, bool isDeleted)

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
                 .IsSearchParameterSupported(Arg.Is(_searchParameterInfos[4]))
                 .Returns((true, false));
 
-            _searchParameterUtilties = new SearchParameterUtilities(_manager, _searchParameterDefinitionManager);
+            _searchParameterUtilties = new SearchParameterUtilities(_manager, _searchParameterDefinitionManager, ModelInfoProvider.Instance);
         }
 
         public async Task InitializeAsync()

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
@@ -164,7 +164,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             await _manager.EnsureInitialized();
             _fhirRequestContext.IncludePartiallyIndexedSearchParams = true;
             var searchableDefinitionManager = new SearchableSearchParameterDefinitionManager(_searchParameterDefinitionManager, _fhirRequestContextAccessor);
-            var paramList = searchableDefinitionManager.AllSearchParameters;
+            var paramList = searchableDefinitionManager.AllSearchParameters.OrderBy(p => p.Name);
 
             Assert.Collection(
                 paramList,

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
@@ -50,6 +50,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\LightweightReferenceToElementResolverTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchIndexerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchParameters\SearchConverterForAllSearchTypes.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchParameters\SearchParameterBehaviorTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchParameters\SearchParameterDefinitionManagerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchParameters\SearchParameterFixtureData.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchParameters\SearchParameterValidatorTests.cs" />

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Create/CreateResourceHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Create/CreateResourceHandler.cs
@@ -15,7 +15,6 @@ using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Conformance;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
-using Microsoft.Health.Fhir.Core.Features.Search.Parameters;
 using Microsoft.Health.Fhir.Core.Features.Security;
 using Microsoft.Health.Fhir.Core.Features.Security.Authorization;
 using Microsoft.Health.Fhir.Core.Messages.Create;
@@ -28,7 +27,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Create
     {
         private readonly ResourceReferenceResolver _referenceResolver;
         private readonly Dictionary<string, (string resourceId, string resourceType)> _referenceIdDictionary;
-        private ISearchParameterUtilities _searchParameterUtitliies;
 
         public CreateResourceHandler(
             IFhirDataStore fhirDataStore,
@@ -36,16 +34,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Create
             IResourceWrapperFactory resourceWrapperFactory,
             ResourceIdProvider resourceIdProvider,
             ResourceReferenceResolver referenceResolver,
-            IFhirAuthorizationService authorizationService,
-            ISearchParameterUtilities searchParameterUtitliies)
+            IFhirAuthorizationService authorizationService)
             : base(fhirDataStore, conformanceProvider, resourceWrapperFactory, resourceIdProvider, authorizationService)
         {
             EnsureArg.IsNotNull(referenceResolver, nameof(referenceResolver));
-            EnsureArg.IsNotNull(searchParameterUtitliies, nameof(searchParameterUtitliies));
 
             _referenceResolver = referenceResolver;
             _referenceIdDictionary = new Dictionary<string, (string resourceId, string resourceType)>();
-            _searchParameterUtitliies = searchParameterUtitliies;
         }
 
         public async Task<UpsertResourceResponse> Handle(CreateResourceRequest message, CancellationToken cancellationToken)
@@ -76,16 +71,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Create
 
             resource.VersionId = result.Wrapper.Version;
 
-            var response = new UpsertResourceResponse(new SaveOutcome(new RawResourceElement(result.Wrapper), SaveOutcomeType.Created));
-
-            if (message.Resource.InstanceType.Equals(KnownResourceTypes.SearchParameter, StringComparison.Ordinal))
-            {
-                // Once the SearchParameter resource is committed to the data store, we can update the in
-                // memory SearchParameterDefinitionManager, and persist the status to the data store
-                await _searchParameterUtitliies.AddSearchParameterAsync(message.Resource.Instance);
-            }
-
-            return response;
+            return new UpsertResourceResponse(new SaveOutcome(new RawResourceElement(result.Wrapper), SaveOutcomeType.Created));
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeleteResourceHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeleteResourceHandler.cs
@@ -15,6 +15,7 @@ using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Security;
 using Microsoft.Health.Fhir.Core.Features.Security.Authorization;
 using Microsoft.Health.Fhir.Core.Messages.Delete;
+using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Core.Features.Resources.Delete
 {
@@ -70,6 +71,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Delete
                     cancellationToken: cancellationToken);
 
                 version = result?.Wrapper.Version;
+            }
+
+            if (message.ResourceKey.ResourceType.Equals(KnownResourceTypes.SearchParameter, StringComparison.Ordinal))
+            {
+                // Once the SearchParameter resource is committed to the data store, we can update the in
+                // memory SearchParameterDefinitionManager, and persist the status to the data store
+                var searchParamResource = await FhirDataStore.GetAsync(message.ResourceKey, cancellationToken);
+                await _searchParameterUtitliies.Delete(message.Resource.Instance);
             }
 
             if (string.IsNullOrWhiteSpace(version))

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeleteResourceHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeleteResourceHandler.cs
@@ -12,7 +12,6 @@ using MediatR;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Features.Conformance;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
-using Microsoft.Health.Fhir.Core.Features.Search.Parameters;
 using Microsoft.Health.Fhir.Core.Features.Security;
 using Microsoft.Health.Fhir.Core.Features.Security.Authorization;
 using Microsoft.Health.Fhir.Core.Messages.Delete;
@@ -22,19 +21,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Delete
 {
     public class DeleteResourceHandler : BaseResourceHandler, IRequestHandler<DeleteResourceRequest, DeleteResourceResponse>
     {
-        private ISearchParameterUtilities _searchParameterUtilities;
-
         public DeleteResourceHandler(
             IFhirDataStore fhirDataStore,
             Lazy<IConformanceProvider> conformanceProvider,
             IResourceWrapperFactory resourceWrapperFactory,
             ResourceIdProvider resourceIdProvider,
-            IFhirAuthorizationService authorizationService,
-            ISearchParameterUtilities searchParameterUtilities)
+            IFhirAuthorizationService authorizationService)
             : base(fhirDataStore, conformanceProvider, resourceWrapperFactory, resourceIdProvider, authorizationService)
         {
-            EnsureArg.IsNotNull(searchParameterUtilities, nameof(searchParameterUtilities));
-            _searchParameterUtilities = searchParameterUtilities;
         }
 
         public async Task<DeleteResourceResponse> Handle(DeleteResourceRequest message, CancellationToken cancellationToken)
@@ -55,13 +49,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Delete
             }
 
             string version = null;
-
-            ResourceWrapper searchParamResource = null;
-
-            if (message.ResourceKey.ResourceType.Equals(KnownResourceTypes.SearchParameter, StringComparison.Ordinal))
-            {
-                searchParamResource = await FhirDataStore.GetAsync(message.ResourceKey, cancellationToken);
-            }
 
             if (message.HardDelete)
             {
@@ -84,13 +71,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Delete
                     cancellationToken: cancellationToken);
 
                 version = result?.Wrapper.Version;
-            }
-
-            if (message.ResourceKey.ResourceType.Equals(KnownResourceTypes.SearchParameter, StringComparison.Ordinal))
-            {
-                // Once the SearchParameter resource is committed to the data store, we can update the in
-                // memory SearchParameterDefinitionManager, and persist the status to the data store
-                await _searchParameterUtilities.DeleteSearchParameterAsync(searchParamResource!.RawResource);
             }
 
             if (string.IsNullOrWhiteSpace(version))

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/IncludeRewriterTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/IncludeRewriterTests.cs
@@ -1634,7 +1634,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             {
                 IModelInfoProvider modelInfoProvider = MockModelInfoProviderBuilder
                     .Create(FhirSpecification.R4)
-                    .AddKnownTypes("Device", "DiagnosticReport", "MedicationRequest", "MedicationDispense", "Location", "Practitioner", "Organization")
+                    .AddKnownTypes("Device", "DiagnosticReport", "MedicationRequest", "MedicationDispense", "Location", "Practitioner", "Organization", "Bundle")
                     .Build();
 
                 SearchParameterDefinitionManager = new SearchParameterDefinitionManager(modelInfoProvider);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -109,9 +109,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         private async Task DeleteSearchParameterAndVerify(SearchParameter searchParam)
         {
             await Client.DeleteAsync(searchParam);
-            var searchParamBundle = await Client.SearchAsync(ResourceType.SearchParameter, $"url={searchParam.Url}");
-
-            Assert.Empty(searchParamBundle.Resource.Entry);
+            var ex = await Assert.ThrowsAsync<FhirException>(() => Client.ReadAsync<SearchParameter>(ResourceType.SearchParameter, searchParam.Id));
+            Assert.Contains("Gone", ex.Message);
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             {
                 searchParamPosted = await Client.CreateAsync(searchParam);
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 // if the SearchParameter exists, we should delete it and recreate it
                 var searchParamBundle = await Client.SearchAsync(ResourceType.SearchParameter, $"url={searchParam.Url}");
@@ -60,7 +60,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 }
                 else
                 {
-                    throw ex;
+                    throw;
                 }
             }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -247,8 +247,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                 IsSearchable = false,
             };
 
-            _searchParameterDefinitionManager.UrlLookup.Add(searchParam.Url, searchParam);
-            _searchParameterDefinitionManager.TypeLookup["Patient"].Add(searchParamName, searchParam);
+            _searchParameterDefinitionManager.UrlLookup.TryAdd(searchParam.Url, searchParam);
+            _searchParameterDefinitionManager.TypeLookup["Patient"].TryAdd(searchParamName, searchParam);
 
             await UpsertPatientData("searchIndicesPatient1");
             await UpsertPatientData("searchIndicesPatient2");

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -188,7 +188,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
         }
 
         [Fact]
-        public async Task GivenNoMatchingResources_WhenRunningReindexJob_ThenJobIsCompleted()
+        public async Task GivenNoMatchingResources_WhenRunningReindexJob_ThenJobIsCanceled()
         {
             var searchParam = _supportedSearchParameterDefinitionManager.GetSearchParameter(new Uri("http://hl7.org/fhir/SearchParameter/Measure-name"));
             searchParam.IsSearchable = false;
@@ -213,7 +213,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                 var reindexJobWrapper = await _fhirOperationDataStore.GetReindexJobByIdAsync(response.Job.JobRecord.Id, cancellationTokenSource.Token);
 
                 int delayCount = 0;
-                while (reindexJobWrapper.JobRecord.Status != OperationStatus.Completed
+                while (reindexJobWrapper.JobRecord.Status != OperationStatus.Canceled
                     && delayCount < 10)
                 {
                     await Task.Delay(1000);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTestsFixture.cs
@@ -21,7 +21,6 @@ using Microsoft.Health.Fhir.Core.Features.Resources.Delete;
 using Microsoft.Health.Fhir.Core.Features.Resources.Get;
 using Microsoft.Health.Fhir.Core.Features.Resources.Upsert;
 using Microsoft.Health.Fhir.Core.Features.Search;
-using Microsoft.Health.Fhir.Core.Features.Search.Parameters;
 using Microsoft.Health.Fhir.Core.Features.Search.Registry;
 using Microsoft.Health.Fhir.Core.Features.Security.Authorization;
 using Microsoft.Health.Fhir.Core.Messages.Create;
@@ -129,9 +128,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
             var collection = new ServiceCollection();
 
-            ISearchParameterUtilities searchParameterUtilities = Substitute.For<ISearchParameterUtilities>();
-
-            collection.AddSingleton(typeof(IRequestHandler<CreateResourceRequest, UpsertResourceResponse>), new CreateResourceHandler(DataStore, new Lazy<IConformanceProvider>(() => ConformanceProvider), resourceWrapperFactory, _resourceIdProvider, new ResourceReferenceResolver(searchService, new TestQueryStringParser()), DisabledFhirAuthorizationService.Instance, searchParameterUtilities));
+            collection.AddSingleton(typeof(IRequestHandler<CreateResourceRequest, UpsertResourceResponse>), new CreateResourceHandler(DataStore, new Lazy<IConformanceProvider>(() => ConformanceProvider), resourceWrapperFactory, _resourceIdProvider, new ResourceReferenceResolver(searchService, new TestQueryStringParser()), DisabledFhirAuthorizationService.Instance));
             collection.AddSingleton(typeof(IRequestHandler<UpsertResourceRequest, UpsertResourceResponse>), new UpsertResourceHandler(DataStore, new Lazy<IConformanceProvider>(() => ConformanceProvider), resourceWrapperFactory, _resourceIdProvider, DisabledFhirAuthorizationService.Instance, ModelInfoProvider.Instance));
             collection.AddSingleton(typeof(IRequestHandler<GetResourceRequest, GetResourceResponse>), new GetResourceHandler(DataStore, new Lazy<IConformanceProvider>(() => ConformanceProvider), resourceWrapperFactory, _resourceIdProvider, DisabledFhirAuthorizationService.Instance));
             collection.AddSingleton(typeof(IRequestHandler<DeleteResourceRequest, DeleteResourceResponse>), new DeleteResourceHandler(DataStore, new Lazy<IConformanceProvider>(() => ConformanceProvider), resourceWrapperFactory, _resourceIdProvider, DisabledFhirAuthorizationService.Instance));


### PR DESCRIPTION
## Description
Adds the support to the DeleteResourceHandler to remove custom search parameter from the SearchParameterDefinitionManager collections.

## Related issues
Addresses [issue [AB#76347](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/76347)].

## Testing
Unit test added. E2E Test updated with DELETE.  Manual testing performed.

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
