### PR TITLE
Update automaticUpdatesEnabled flag and image name

### DIFF
--- a/docs/Testing-Releases.md
+++ b/docs/Testing-Releases.md
@@ -29,10 +29,11 @@ There are a few different kinds of release assets, both Webdeploy zip files and 
 
 Here are the tags for Docker images that should be noted:
 
-* healthplatformregistry.azurecr.io/${version}_fhir-server:**master** - The latest code that has been merged to the main branch and passed all tests.
-* healthplatformregistry.azurecr.io/${version}_fhir-server:**release** - The latest release, this is the tag we will focus on.
-* healthplatformregistry.azurecr.io/${version}_fhir-server:**build-[release number]** - Allows you to pin or access a specific release.
-* mcr.microsoft.com/healthcareapis/${version}-fhir-server:**latest** - If the image has issues with the above tags, consider this.
+1. mcr.microsoft.com/healthcareapis/${version}-fhir-server:**latest** - This is the image we will focus on.
+2. healthplatformregistry.azurecr.io/${version}_fhir-server:**release** - The latest release, if the mcr latest image as mentioned above has issues, consider this.
+3. healthplatformregistry.azurecr.io/${version}_fhir-server:**master** - The latest code that has been merged to the main branch and passed all tests.
+4. healthplatformregistry.azurecr.io/${version}_fhir-server:**build-[release number]** - Allows you to pin or access a specific release.
+
 
 The current data store used by Azure API for FHIR is Cosmos DB, the following steps will walk through creating a test environment using Containers targeting the "release" label above.
 

--- a/docs/Testing-Releases.md
+++ b/docs/Testing-Releases.md
@@ -32,6 +32,7 @@ Here are the tags for Docker images that should be noted:
 * healthplatformregistry.azurecr.io/${version}_fhir-server:**master** - The latest code that has been merged to the main branch and passed all tests.
 * healthplatformregistry.azurecr.io/${version}_fhir-server:**release** - The latest release, this is the tag we will focus on.
 * healthplatformregistry.azurecr.io/${version}_fhir-server:**build-[release number]** - Allows you to pin or access a specific release.
+* mcr.microsoft.com/healthcareapis/${version}_fhir-server - If the image has issues with the above tags, this is used.
 
 The current data store used by Azure API for FHIR is Cosmos DB, the following steps will walk through creating a test environment using Containers targeting the "release" label above.
 

--- a/docs/Testing-Releases.md
+++ b/docs/Testing-Releases.md
@@ -32,7 +32,7 @@ Here are the tags for Docker images that should be noted:
 * healthplatformregistry.azurecr.io/${version}_fhir-server:**master** - The latest code that has been merged to the main branch and passed all tests.
 * healthplatformregistry.azurecr.io/${version}_fhir-server:**release** - The latest release, this is the tag we will focus on.
 * healthplatformregistry.azurecr.io/${version}_fhir-server:**build-[release number]** - Allows you to pin or access a specific release.
-* mcr.microsoft.com/healthcareapis/${version}_fhir-server - If the image has issues with the above tags, this is used.
+* mcr.microsoft.com/healthcareapis/${version}-fhir-server:**latest** - If the image has issues with the above tags, consider this.
 
 The current data store used by Azure API for FHIR is Cosmos DB, the following steps will walk through creating a test environment using Containers targeting the "release" label above.
 

--- a/samples/docker/README.md
+++ b/samples/docker/README.md
@@ -6,7 +6,7 @@ The following instructions detail how to build and run the FHIR Server in Docker
 
 ## Use CI image
 
-If it is not desirable to clone this repository and build locally an image of the most recent CI build is available from the Azure Container Repository HealthPlatformRegistry. Both of the following methods will generate a R4 server, but a STU3 or R5 server can be created by changing which image is pulled.
+If it is not desirable to clone this repository and build locally an image of the most recent CI build is available from the Microsoft Container Registry(mcr.microsoft.com/healthcareapis). Both of the following methods will generate a R4 server, but a STU3 or R5 server can be created by changing which image is pulled.
 
 Using docker-compose this image can be started with the following steps:
 1. Open a terminal window.
@@ -39,7 +39,7 @@ docker run --net fhir_network --name fhir_sql -e SA_PASSWORD=<SA_PASSWORD> -e AC
 5. Run the command: 
 
 ```bash
-docker run --net fhir_network -e FhirServer__Security__Enabled="false" -e SqlServer__ConnectionString="Server=tcp:fhir_sql,1433;Initial Catalog=FHIR;Persist Security Info=False;User ID=sa;Password=<SA_PASSWORD>;MultipleActiveResultSets=False;Connection Timeout=30;" -e SqlServer__AllowDatabaseCreation="true" -e SqlServer__Initialize="true" -e SqlServer__SchemaOptions__AutomaticUpdatesEnabled="true" -e DataStore="SqlServer" -p 8080:8080 -d healthplatformregistry.azurecr.io/r4_fhir-server azure-fhir-api
+docker run --net fhir_network -e FhirServer__Security__Enabled="false" -e SqlServer__ConnectionString="Server=tcp:fhir_sql,1433;Initial Catalog=FHIR;Persist Security Info=False;User ID=sa;Password=<SA_PASSWORD>;MultipleActiveResultSets=False;Connection Timeout=30;" -e SqlServer__AllowDatabaseCreation="true" -e SqlServer__Initialize="true" -e SqlServer__SchemaOptions__AutomaticUpdatesEnabled="true" -e DataStore="SqlServer" -p 8080:8080 -d mcr.microsoft.com/healthcareapis/r4-fhir-server azure-fhir-api
 ```
 
 6. After giving the container a minute to start up it should be accessible at http://localhost:8080/metadata.
@@ -80,6 +80,7 @@ docker run -d \
     -e SqlServer__ConnectionString="Server=tcp:<sql-server-fqdn>,1433;Initial Catalog=FHIR;Persist Security Info=False;User ID=sa;Password=<sql-sa-password>;MultipleActiveResultSets=False;Connection Timeout=30;" \
     -e SqlServer__AllowDatabaseCreation="true" \
     -e SqlServer__Initialize="true" \
+    -e SqlServer__SchemaOptions__AutomaticUpdatesEnabled="true" \
     -e DataStore="SqlServer" \
     -p 8080:8080
     azure-fhir-api azure-fhir-api

--- a/samples/kubernetes/helm/fhir-server/values.yaml
+++ b/samples/kubernetes/helm/fhir-server/values.yaml
@@ -5,9 +5,9 @@
 replicaCount: 1
 
 image:
-  registry: mcr.microsoft.com/healthcareapis/r4-fhir-server
-  repository: r4_fhir-server
-  tag: master
+  registry: mcr.microsoft.com/healthcareapis
+  repository: r4-fhir-server
+  tag: latest
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/samples/kubernetes/helm/fhir-server/values.yaml
+++ b/samples/kubernetes/helm/fhir-server/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  registry: healthplatformregistry.azurecr.io
+  registry: mcr.microsoft.com/healthcareapis/r4-fhir-server
   repository: r4_fhir-server
   tag: master
   pullPolicy: IfNotPresent
@@ -59,7 +59,7 @@ database:
     edition: 5
     maxPoolSize: 100
     schema:
-      automaticUpdatesEnabled: false
+      automaticUpdatesEnabled: true
   cosmosDb:
     initialCollectionThroughput: "400"
     # databaseId: health


### PR DESCRIPTION
## Description
Update the image name to be consistent with the change [here ](https://github.com/microsoft/fhir-server/pull/1576 )and schema.automaticUpdatesEnabled to true for kubernetes deployment.

## Related issues
Addresses #1297

## Testing
Tested manually by deploying fhir service in aks.
Steps taken:

1. az aks create --resource-group rg-name --name cluster-name --node-count 1 --enable-addons monitoring --generate-ssh-keys
2. az aks install-cli
3. az aks get-credentials --resource-group rg-name --name cluster-name
4. $SQL_PASSWORD = "strong-password"
5. kubectl create secret generic mssql --from-literal=SA_PASSWORD=$SQL_PASSWORD
6. Used [this instruction](https://docs.microsoft.com/en-us/sql/linux/tutorial-sql-server-containers-kubernetes?view=sql-server-ver15) to create sql container
7. helm upgrade --install --set database.dataStore=ExistingSqlServer --set database.existingSqlServer.password=$SQL_PASSWORD --set database.existingSqlServer.serverName=mssql-deployment.default fhir-server fhir-server/samples/kubernetes/helm/fhir-server/
8. Connected to the server run: kubectl port-forward service/fhir-server 8080:80
Hit the server locally using http://localhost:8080



## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
