### PR TITLE
Change keyvault to use sdk package version

### DIFF
--- a/src/Microsoft.Health.Fhir.R4.Web/Microsoft.Health.Fhir.R4.Web.csproj
+++ b/src/Microsoft.Health.Fhir.R4.Web/Microsoft.Health.Fhir.R4.Web.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="IdentityServer4" Version="4.1.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.16.0" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.16.0" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="4.1.1" />
     <PackageReference Include="prometheus-net.DotNetRuntime" Version="3.4.1" />

--- a/src/Microsoft.Health.Fhir.R5.Web/Microsoft.Health.Fhir.R5.Web.csproj
+++ b/src/Microsoft.Health.Fhir.R5.Web/Microsoft.Health.Fhir.R5.Web.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="IdentityServer4" Version="4.1.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.16.0" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.16.0" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="4.1.1" />
     <PackageReference Include="prometheus-net.DotNetRuntime" Version="3.4.1" />

--- a/src/Microsoft.Health.Fhir.Stu3.Web/Microsoft.Health.Fhir.Stu3.Web.csproj
+++ b/src/Microsoft.Health.Fhir.Stu3.Web/Microsoft.Health.Fhir.Stu3.Web.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="IdentityServer4" Version="4.1.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.16.0" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="$(SdkPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.16.0" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="4.1.1" />
     <PackageReference Include="prometheus-net.DotNetRuntime" Version="3.4.1" />


### PR DESCRIPTION
## Description
Changes the keyvault package to use the sdk package version.

## Related issues

## Testing
Automated testing

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch (Dependency update)
