### PR TITLE
Updates PR best practices to promote useful documentation

### DIFF
--- a/docs/CodeReviewRulesOfThumb.md
+++ b/docs/CodeReviewRulesOfThumb.md
@@ -74,6 +74,15 @@ External contributor authors:
 - Longer discussions with external contributors will be handled on a case-by-case basis
 - The FHIR team will reach out to you if we believe it would be helpful to move discussions to a different platform
 
+## Advocate for useful documentation
+ 
+- Don't be afraid to ask the author to add comments for additional clarity
+    - This will help pass on knowledge
+    - If you need to ask a clarifying question on a PR, it could indicate that a comment would be useful
+- Check that the classes you are reviewing have a class-level comment
+    - Ensure that the documentation adds value (sometimes, this involves explaining why something is needed or when it is used, rather than what it does)
+    - Suggest moving lengthy `///<summary></summary>` comments to the `///<remarks></remarks>` section
+
 ## Positive reinforcement is important!
 
 - If you think it is appropriate and would like to add an emoji, the team has expressed that we like them 🙂


### PR DESCRIPTION
## Description
During the team's meeting on improving documentation today, we noted that reviewers should play a role in advocating for useful documentation. I added a section to this document summarizing a few discussion points that seem relevant to our team's PR best practices.

## FHIR Team Checklist
- ✅ **Update the title** of the PR to be succinct and less than 50 characters
- ✅ **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- ✅ Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- ✅ Tag the PR with **Azure API for FHIR** if this will release to the managed service
- ✅ Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)
