### PR TITLE
Fix export _type

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportJobTaskTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportJobTaskTests.cs
@@ -985,11 +985,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
                 _cancellationToken)
                 .Returns(x =>
                 {
-                    string[] types =
-                    {
-                        x.ArgAt<IReadOnlyList<Tuple<string, string>>>(1)[3].Item2,
-                        x.ArgAt<IReadOnlyList<Tuple<string, string>>>(1)[4].Item2,
-                    };
+                    string[] types = x.ArgAt<IReadOnlyList<Tuple<string, string>>>(1)[3].Item2.Split(',');
                     SearchResultEntry[] entries = new SearchResultEntry[types.Length];
 
                     for (int index = 0; index < types.Length; index++)
@@ -1082,7 +1078,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
                     bool typeParameterIncluded = false;
                     bool continuationTokenParameterIncluded = false;
-                    var types = new List<string>();
+                    var types = new string[0];
 
                     foreach (Tuple<string, string> parameter in queryParameterList)
                     {
@@ -1093,7 +1089,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
                         else if (parameter.Item1 == Core.Features.KnownQueryParameterNames.Type)
                         {
                             typeParameterIncluded = true;
-                            types.Add(parameter.Item2);
+                            types = parameter.Item2.Split(',');
                         }
                     }
 
@@ -1105,9 +1101,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
                         throw new Exception();
                     }
 
-                    SearchResultEntry[] entries = new SearchResultEntry[types.Count];
+                    SearchResultEntry[] entries = new SearchResultEntry[types.Length];
 
-                    for (int index = 0; index < types.Count; index++)
+                    for (int index = 0; index < types.Length; index++)
                     {
                         entries[index] = CreateSearchResultEntry(searchCallsMade.ToString(CultureInfo.InvariantCulture), types[index]);
                     }
@@ -1440,11 +1436,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
                 .Returns(x =>
                 {
                     string parentId = x.ArgAt<string>(1);
-                    string[] resourceTypes =
-                    {
-                        x.ArgAt<IReadOnlyList<Tuple<string, string>>>(3)[2].Item2,
-                        x.ArgAt<IReadOnlyList<Tuple<string, string>>>(3)[3].Item2,
-                    };
+                    string[] resourceTypes = x.ArgAt<IReadOnlyList<Tuple<string, string>>>(3)[2].Item2.Split(',');
 
                     SearchResultEntry[] entries = new SearchResultEntry[resourceTypes.Length];
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -291,12 +291,19 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                 }
                 else if (_exportJobRecord.ExportType == ExportJobType.All && requestedResourceTypes != null)
                 {
+                    List<string> resources = new List<string>();
+
                     foreach (var resource in requestedResourceTypes)
                     {
                         if (!filteredResources.Contains(resource))
                         {
-                            queryParametersList.Add(Tuple.Create(KnownQueryParameterNames.Type, resource));
+                            resources.Add(resource);
                         }
+                    }
+
+                    if (resources.Count > 0)
+                    {
+                        queryParametersList.Add(Tuple.Create(KnownQueryParameterNames.Type, resources.JoinByOrSeparator()));
                     }
                 }
 
@@ -481,12 +488,19 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
             {
                 if (requestedResourceTypes != null)
                 {
+                    List<string> resources = new List<string>();
+
                     foreach (var resource in requestedResourceTypes)
                     {
                         if (!filteredResources.Contains(resource))
                         {
-                            queryParametersList.Add(Tuple.Create(KnownQueryParameterNames.Type, resource));
+                            resources.Add(resource);
                         }
+                    }
+
+                    if (resources.Count > 0)
+                    {
+                        queryParametersList.Add(Tuple.Create(KnownQueryParameterNames.Type, resources.JoinByOrSeparator()));
                     }
                 }
 


### PR DESCRIPTION
## Description
When using _type with multiple resources no resources are exported.

## Related issues
Addresses #1596 

## Testing
New unit tests

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch (Bug)
