### PR TITLE
Refine status code for ACR access token errors.

### DIFF
--- a/src/Microsoft.Health.Fhir.Azure/ContainerRegistry/AzureContainerRegistryAccessTokenProvider.cs
+++ b/src/Microsoft.Health.Fhir.Azure/ContainerRegistry/AzureContainerRegistryAccessTokenProvider.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Health.Fhir.Azure.ContainerRegistry
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to get AAD access token from managed identity.");
-                throw new AzureContainerRegistryTokenException(Resources.CannotGetAcrAccessToken, ex);
+                throw new AzureContainerRegistryTokenException(Resources.CannotGetAcrAccessToken, HttpStatusCode.Unauthorized);
             }
 
             try
@@ -84,7 +84,7 @@ namespace Microsoft.Health.Fhir.Azure.ContainerRegistry
             catch (HttpRequestException ex)
             {
                 _logger.LogError(ex, "Failed to get ACR access token with AAD access token.");
-                throw new AzureContainerRegistryTokenException(Resources.CannotGetAcrAccessToken, ex);
+                throw new AzureContainerRegistryTokenException(Resources.CannotGetAcrAccessToken, HttpStatusCode.BadRequest, ex);
             }
         }
 
@@ -122,7 +122,7 @@ namespace Microsoft.Health.Fhir.Azure.ContainerRegistry
             else if (!refreshTokenResponse.IsSuccessStatusCode)
             {
                 _logger.LogError($"Failed to exchange ACR refresh token with AAD access token. Status code: {refreshTokenResponse.StatusCode}.");
-                throw new AzureContainerRegistryTokenException(Resources.CannotGetAcrAccessToken);
+                throw new AzureContainerRegistryTokenException(Resources.CannotGetAcrAccessToken, refreshTokenResponse.StatusCode);
             }
 
             var refreshTokenText = await refreshTokenResponse.Content.ReadAsStringAsync();
@@ -131,7 +131,7 @@ namespace Microsoft.Health.Fhir.Azure.ContainerRegistry
             if (string.IsNullOrEmpty(refreshToken))
             {
                 _logger.LogError("ACR refresh token is empty.");
-                throw new AzureContainerRegistryTokenException(Resources.CannotGetAcrAccessToken);
+                throw new AzureContainerRegistryTokenException(Resources.CannotGetAcrAccessToken, refreshTokenResponse.StatusCode);
             }
 
             _logger.LogInformation("Successfully exchanged ACR refresh token.");
@@ -169,7 +169,7 @@ namespace Microsoft.Health.Fhir.Azure.ContainerRegistry
             else if (!accessTokenResponse.IsSuccessStatusCode)
             {
                 _logger.LogError($"Failed to get ACR access token with ACR refresh token. Status code: {accessTokenResponse.StatusCode}.");
-                throw new AzureContainerRegistryTokenException(Resources.CannotGetAcrAccessToken);
+                throw new AzureContainerRegistryTokenException(Resources.CannotGetAcrAccessToken, accessTokenResponse.StatusCode);
             }
 
             var accessTokenText = await accessTokenResponse.Content.ReadAsStringAsync();
@@ -178,7 +178,7 @@ namespace Microsoft.Health.Fhir.Azure.ContainerRegistry
             if (string.IsNullOrEmpty(accessToken))
             {
                 _logger.LogError("ACR access token is empty.");
-                throw new AzureContainerRegistryTokenException(Resources.CannotGetAcrAccessToken);
+                throw new AzureContainerRegistryTokenException(Resources.CannotGetAcrAccessToken, accessTokenResponse.StatusCode);
             }
 
             _logger.LogInformation("Successfully retrieved ACR access token.");

--- a/src/Microsoft.Health.Fhir.Azure/ContainerRegistry/AzureContainerRegistryAccessTokenProvider.cs
+++ b/src/Microsoft.Health.Fhir.Azure/ContainerRegistry/AzureContainerRegistryAccessTokenProvider.cs
@@ -65,10 +65,10 @@ namespace Microsoft.Health.Fhir.Azure.ContainerRegistry
             {
                 aadToken = await _aadTokenProvider.GetAccessTokenForResourceAsync(aadResourceUri, cancellationToken);
             }
-            catch (Exception ex)
+            catch (AccessTokenProviderException ex)
             {
                 _logger.LogError(ex, "Failed to get AAD access token from managed identity.");
-                throw new AzureContainerRegistryTokenException(Resources.CannotGetAcrAccessToken, HttpStatusCode.Unauthorized);
+                throw new AzureContainerRegistryTokenException(Resources.CannotGetAcrAccessToken, HttpStatusCode.Unauthorized, ex);
             }
 
             try

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/Models/AzureContainerRegistryTokenException.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/Models/AzureContainerRegistryTokenException.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Diagnostics;
+using System.Net;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Models;
 
@@ -11,27 +12,31 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.ConvertData.Models
 {
     public class AzureContainerRegistryTokenException : FhirException
     {
-        public AzureContainerRegistryTokenException(string message)
+        public AzureContainerRegistryTokenException(string message, HttpStatusCode statusCode)
             : base(message)
         {
             Debug.Assert(!string.IsNullOrEmpty(message), "Exception message should not be empty.");
 
+            StatusCode = statusCode;
             Issues.Add(new OperationOutcomeIssue(
                 OperationOutcomeConstants.IssueSeverity.Error,
                 OperationOutcomeConstants.IssueType.Exception,
                 message));
         }
 
-        public AzureContainerRegistryTokenException(string message, System.Exception innerException)
+        public AzureContainerRegistryTokenException(string message, HttpStatusCode statusCode, System.Exception innerException)
             : base(message, innerException)
         {
             Debug.Assert(!string.IsNullOrEmpty(message), "Exception message should not be empty.");
             Debug.Assert(innerException != null, "Inner exception should not be null.");
 
+            StatusCode = statusCode;
             Issues.Add(new OperationOutcomeIssue(
                 OperationOutcomeConstants.IssueSeverity.Error,
                 OperationOutcomeConstants.IssueType.Exception,
                 message));
         }
+
+        public HttpStatusCode StatusCode { get; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
@@ -135,7 +135,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
                     case FhirTransactionFailedException fhirTransactionFailedException:
                         operationOutcomeResult.StatusCode = fhirTransactionFailedException.ResponseStatusCode;
                         break;
-                    case AzureContainerRegistryTokenException _:
+                    case AzureContainerRegistryTokenException azureContainerRegistryTokenException:
+                        operationOutcomeResult.StatusCode = azureContainerRegistryTokenException.StatusCode;
+                        break;
                     case FetchTemplateCollectionFailedException _:
                     case ConvertDataUnhandledException _:
                         operationOutcomeResult.StatusCode = HttpStatusCode.InternalServerError;


### PR DESCRIPTION
## Description
Refine status code to reflect the real status code in exchange ACR tokens with AAD token.

## Related issues
Addresses [issue #AB78902](https://microsofthealth.visualstudio.com/Health/_workitems/edit/78902).

## Testing
Manually tested against different ACR configuration.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip
