### PR TITLE
Fix UpsertResource backwards compatibility

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/ConformanceProviderBase.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/ConformanceProviderBase.cs
@@ -21,6 +21,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
 
         public abstract Task<ResourceElement> GetCapabilityStatementAsync(CancellationToken cancellationToken = default(CancellationToken));
 
+        internal void ClearCache()
+        {
+            _evaluatedQueries.Clear();
+        }
+
         public async Task<bool> SatisfiesAsync(IEnumerable<CapabilityQuery> queries, CancellationToken cancellationToken = default(CancellationToken))
         {
             EnsureArg.IsNotNull(queries, nameof(queries));

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaVersionConstants.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaVersionConstants.cs
@@ -10,5 +10,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema
         public const int Min = (int)SchemaVersion.V4;
         public const int Max = (int)SchemaVersion.V7;
         public const int SearchParameterStatusSchemaVersion = (int)SchemaVersion.V6;
+        public const int SupportForReferencesWithMissingTypeVersion = (int)SchemaVersion.V7;
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
         private readonly SqlServerDataStoreConfiguration _configuration;
         private readonly SqlServerFhirModel _model;
         private readonly SearchParameterToSearchValueTypeMap _searchParameterTypeMap;
+        private readonly V6.UpsertResourceTvpGenerator<ResourceMetadata> _upsertResourceTvpGeneratorV6;
         private readonly VLatest.UpsertResourceTvpGenerator<ResourceMetadata> _upsertResourceTvpGeneratorVLatest;
         private readonly RecyclableMemoryStreamManager _memoryStreamManager;
         private readonly CoreFeatureConfiguration _coreFeatures;
@@ -50,6 +51,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             SqlServerDataStoreConfiguration configuration,
             SqlServerFhirModel model,
             SearchParameterToSearchValueTypeMap searchParameterTypeMap,
+            V6.UpsertResourceTvpGenerator<ResourceMetadata> upsertResourceTvpGeneratorV6,
             VLatest.UpsertResourceTvpGenerator<ResourceMetadata> upsertResourceTvpGeneratorVLatest,
             IOptions<CoreFeatureConfiguration> coreFeatures,
             SqlConnectionWrapperFactory sqlConnectionWrapperFactory,
@@ -59,6 +61,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             EnsureArg.IsNotNull(configuration, nameof(configuration));
             EnsureArg.IsNotNull(model, nameof(model));
             EnsureArg.IsNotNull(searchParameterTypeMap, nameof(searchParameterTypeMap));
+            EnsureArg.IsNotNull(upsertResourceTvpGeneratorV6, nameof(upsertResourceTvpGeneratorV6));
             EnsureArg.IsNotNull(upsertResourceTvpGeneratorVLatest, nameof(upsertResourceTvpGeneratorVLatest));
             EnsureArg.IsNotNull(coreFeatures, nameof(coreFeatures));
             EnsureArg.IsNotNull(sqlConnectionWrapperFactory, nameof(sqlConnectionWrapperFactory));
@@ -68,6 +71,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             _configuration = configuration;
             _model = model;
             _searchParameterTypeMap = searchParameterTypeMap;
+            _upsertResourceTvpGeneratorV6 = upsertResourceTvpGeneratorV6;
             _upsertResourceTvpGeneratorVLatest = upsertResourceTvpGeneratorVLatest;
             _coreFeatures = coreFeatures.Value;
             _sqlConnectionWrapperFactory = sqlConnectionWrapperFactory;
@@ -79,12 +83,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
         public async Task<UpsertOutcome> UpsertAsync(ResourceWrapper resource, WeakETag weakETag, bool allowCreate, bool keepHistory, CancellationToken cancellationToken)
         {
-            int etag = 0;
-            if (weakETag != null && !int.TryParse(weakETag.VersionId, out etag))
-            {
-                // Set the etag to a sentinel value to enable expected failure paths when updating with both existing and nonexistent resources.
-                etag = -1;
-            }
+            int? eTag = weakETag == null
+                ? (int?)null
+                : (int.TryParse(weakETag.VersionId, out var parsedETag) ? parsedETag : -1); // Set the etag to a sentinel value to enable expected failure paths when updating with both existing and nonexistent resources.
 
             var resourceMetadata = new ResourceMetadata(
                 resource.CompartmentIndices,
@@ -99,18 +100,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
                 stream.Seek(0, 0);
 
-                VLatest.UpsertResource.PopulateCommand(
-                sqlCommandWrapper,
-                baseResourceSurrogateId: ResourceSurrogateIdHelper.LastUpdatedToResourceSurrogateId(resource.LastModified.UtcDateTime),
-                resourceTypeId: _model.GetResourceTypeId(resource.ResourceTypeName),
-                resourceId: resource.ResourceId,
-                eTag: weakETag == null ? null : (int?)etag,
-                allowCreate: allowCreate,
-                isDeleted: resource.IsDeleted,
-                keepHistory: keepHistory,
-                requestMethod: resource.Request.Method,
-                rawResource: stream,
-                tableValuedParameters: _upsertResourceTvpGeneratorVLatest.Generate(resourceMetadata));
+                PopulateUpsertResourceCommand(sqlCommandWrapper, resource, resourceMetadata, allowCreate, keepHistory, eTag, stream);
 
                 try
                 {
@@ -145,6 +135,43 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                             throw;
                     }
                 }
+            }
+        }
+
+        private void PopulateUpsertResourceCommand(SqlCommandWrapper sqlCommandWrapper, ResourceWrapper resource, ResourceMetadata resourceMetadata, bool allowCreate, bool keepHistory, int? eTag, RecyclableMemoryStream stream)
+        {
+            long baseResourceSurrogateId = ResourceSurrogateIdHelper.LastUpdatedToResourceSurrogateId(resource.LastModified.UtcDateTime);
+            short resourceTypeId = _model.GetResourceTypeId(resource.ResourceTypeName);
+
+            if (_schemaInformation.Current >= 7)
+            {
+                VLatest.UpsertResource.PopulateCommand(
+                    sqlCommandWrapper,
+                    baseResourceSurrogateId: baseResourceSurrogateId,
+                    resourceTypeId: resourceTypeId,
+                    resourceId: resource.ResourceId,
+                    eTag: eTag,
+                    allowCreate: allowCreate,
+                    isDeleted: resource.IsDeleted,
+                    keepHistory: keepHistory,
+                    requestMethod: resource.Request.Method,
+                    rawResource: stream,
+                    tableValuedParameters: _upsertResourceTvpGeneratorVLatest.Generate(resourceMetadata));
+            }
+            else
+            {
+                V6.UpsertResource.PopulateCommand(
+                    sqlCommandWrapper,
+                    baseResourceSurrogateId: baseResourceSurrogateId,
+                    resourceTypeId: resourceTypeId,
+                    resourceId: resource.ResourceId,
+                    eTag: eTag,
+                    allowCreate: allowCreate,
+                    isDeleted: resource.IsDeleted,
+                    keepHistory: keepHistory,
+                    requestMethod: resource.Request.Method,
+                    rawResource: stream,
+                    tableValuedParameters: _upsertResourceTvpGeneratorV6.Generate(resourceMetadata));
             }
         }
 
@@ -211,9 +238,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                             searchIndices: null,
                             compartmentIndices: null,
                             lastModifiedClaims: null)
-                            {
-                                IsHistory = isHistory,
-                            };
+                        {
+                            IsHistory = isHistory,
+                        };
                     }
                 }
             }
@@ -256,8 +283,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             EnsureArg.IsNotNull(builder, nameof(builder));
 
             builder.AddDefaultResourceInteractions()
-                   .AddDefaultSearchParameters()
-                   .AddDefaultRestSearchParams();
+                .AddDefaultSearchParameters()
+                .AddDefaultRestSearchParams();
 
             if (_coreFeatures.SupportsBatch)
             {

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -20,6 +20,7 @@ using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Features.Conformance;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.SqlServer.Features.Schema;
 using Microsoft.Health.Fhir.SqlServer.Features.Schema.Model;
 using Microsoft.Health.Fhir.ValueSets;
 using Microsoft.Health.SqlServer.Configs;
@@ -143,7 +144,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             long baseResourceSurrogateId = ResourceSurrogateIdHelper.LastUpdatedToResourceSurrogateId(resource.LastModified.UtcDateTime);
             short resourceTypeId = _model.GetResourceTypeId(resource.ResourceTypeName);
 
-            if (_schemaInformation.Current >= 7)
+            if (_schemaInformation.Current >= SchemaVersionConstants.SupportForReferencesWithMissingTypeVersion)
             {
                 VLatest.UpsertResource.PopulateCommand(
                     sqlCommandWrapper,

--- a/src/Microsoft.Health.Fhir.SqlServer/Microsoft.Health.Fhir.SqlServer.csproj
+++ b/src/Microsoft.Health.Fhir.SqlServer/Microsoft.Health.Fhir.SqlServer.csproj
@@ -12,11 +12,14 @@
     <EmbeddedResource Include="Features\Schema\Migrations\6.diff.sql" />
     <EmbeddedResource Include="Features\Schema\Migrations\6.sql">
       <InputToImmutableSqlGenerator>true</InputToImmutableSqlGenerator>
+      <InputToMutableSqlGenerator>true</InputToMutableSqlGenerator>
+      <MutableClassVersion>6</MutableClassVersion>
     </EmbeddedResource>
     <EmbeddedResource Include="Features\Schema\Migrations\7.diff.sql" />
     <EmbeddedResource Include="Features\Schema\Migrations\7.sql">
       <InputToImmutableSqlGenerator>true</InputToImmutableSqlGenerator>
       <InputToMutableSqlGenerator>true</InputToMutableSqlGenerator>
+      <MutableClassVersion>Latest</MutableClassVersion>
     </EmbeddedResource>
 
   </ItemGroup>
@@ -61,7 +64,7 @@
         <Namespace>Microsoft.Health.Fhir.SqlServer.Features.Schema.Model</Namespace>
         <Args>@(ImmutableSqlGeneratorInputs->'&quot;%(FullPath)&quot;', ' ')</Args>
       </Generated>
-      <Generated Include="Features\Schema\Model\VLatest.Generated.cs">
+      <Generated Include="Features\Schema\Model\V%(MutableSqlGeneratorInputs.MutableClassVersion).Generated.cs">
         <Generator>MutableSqlModelGenerator</Generator>
         <Namespace>Microsoft.Health.Fhir.SqlServer.Features.Schema.Model</Namespace>
         <Args>@(MutableSqlGeneratorInputs->'&quot;%(FullPath)&quot;', ' ')</Args>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Microsoft.Health.Fhir.Shared.Tests.Integration.projitems
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Microsoft.Health.Fhir.Shared.Tests.Integration.projitems
@@ -27,6 +27,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlDataReaderExtensionsTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlServerFhirStorageTestHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlServerFhirStorageTestsFixture.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlServerSqlCompatibilityTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlServerTransactionScopeTests.cs" />
   </ItemGroup>
 </Project>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -6,14 +6,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using MediatR;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Health.Abstractions.Features.Transactions;
 using Microsoft.Health.Core.Internal;
 using Microsoft.Health.Fhir.Core;
@@ -21,26 +18,13 @@ using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Conformance;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
-using Microsoft.Health.Fhir.Core.Features.Resources;
-using Microsoft.Health.Fhir.Core.Features.Resources.Create;
-using Microsoft.Health.Fhir.Core.Features.Resources.Delete;
-using Microsoft.Health.Fhir.Core.Features.Resources.Get;
-using Microsoft.Health.Fhir.Core.Features.Resources.Upsert;
 using Microsoft.Health.Fhir.Core.Features.Search;
-using Microsoft.Health.Fhir.Core.Features.Search.Parameters;
 using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
-using Microsoft.Health.Fhir.Core.Features.Security.Authorization;
-using Microsoft.Health.Fhir.Core.Messages.Create;
-using Microsoft.Health.Fhir.Core.Messages.Delete;
-using Microsoft.Health.Fhir.Core.Messages.Get;
-using Microsoft.Health.Fhir.Core.Messages.Upsert;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.CosmosDb.Features.Storage;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
-using Microsoft.Health.Fhir.Tests.Common.Mocks;
 using Microsoft.Health.Test.Utilities;
-using NSubstitute;
 using Xunit;
 using Task = System.Threading.Tasks.Task;
 
@@ -53,65 +37,21 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
     public partial class FhirStorageTests : IClassFixture<FhirStorageTestsFixture>
     {
         private readonly FhirStorageTestsFixture _fixture;
-        private readonly CapabilityStatement _conformance;
-        private readonly ISearchService _searchService;
+        private readonly CapabilityStatement _capabilityStatement;
         private readonly ResourceDeserializer _deserializer;
-        private readonly FhirJsonParser _fhirJsonParser = new FhirJsonParser();
+        private readonly FhirJsonParser _fhirJsonParser;
         private readonly IFhirDataStore _dataStore;
-        private readonly ISearchParameterUtilities _searchParameterUtilities;
+        private ConformanceProviderBase _conformanceProvider;
 
         public FhirStorageTests(FhirStorageTestsFixture fixture)
         {
             _fixture = fixture;
-            _searchService = Substitute.For<ISearchService>();
+            _capabilityStatement = fixture.CapabilityStatement;
+            _deserializer = fixture.Deserializer;
             _dataStore = fixture.DataStore;
-
-            _conformance = CapabilityStatementMock.GetMockedCapabilityStatement();
-
-            CapabilityStatementMock.SetupMockResource(_conformance, ResourceType.Observation, null);
-            var observationResource = _conformance.Rest[0].Resource.Find(r => r.Type == ResourceType.Observation);
-            observationResource.UpdateCreate = true;
-            observationResource.Versioning = CapabilityStatement.ResourceVersionPolicy.Versioned;
-
-            CapabilityStatementMock.SetupMockResource(_conformance, ResourceType.Organization, null);
-            var organizationResource = _conformance.Rest[0].Resource.Find(r => r.Type == ResourceType.Organization);
-            organizationResource.UpdateCreate = true;
-            organizationResource.Versioning = CapabilityStatement.ResourceVersionPolicy.NoVersion;
-
-            var provider = Substitute.For<ConformanceProviderBase>();
-            provider.GetCapabilityStatementAsync().Returns(_conformance.ToTypedElement().ToResourceElement());
-
-            // TODO: FhirRepository instantiate ResourceDeserializer class directly
-            // which will try to deserialize the raw resource. We should mock it as well.
-            var rawResourceFactory = Substitute.For<RawResourceFactory>(new FhirJsonSerializer());
-
-            var resourceWrapperFactory = Substitute.For<IResourceWrapperFactory>();
-            resourceWrapperFactory
-                .Create(Arg.Any<ResourceElement>(), Arg.Any<bool>(), Arg.Any<bool>())
-                .Returns(x =>
-                {
-                    ResourceElement resource = x.ArgAt<ResourceElement>(0);
-
-                    return new ResourceWrapper(resource, rawResourceFactory.Create(resource, keepMeta: true), new ResourceRequest(HttpMethod.Post, "http://fhir"), x.ArgAt<bool>(1), null, null, null);
-                });
-
-            var collection = new ServiceCollection();
-
-            var resourceIdProvider = new ResourceIdProvider();
-
-            _searchParameterUtilities = Substitute.For<ISearchParameterUtilities>();
-
-            collection.AddSingleton(typeof(IRequestHandler<CreateResourceRequest, UpsertResourceResponse>), new CreateResourceHandler(_dataStore, new Lazy<IConformanceProvider>(() => provider), resourceWrapperFactory, resourceIdProvider, new ResourceReferenceResolver(_searchService, new TestQueryStringParser()), DisabledFhirAuthorizationService.Instance, _searchParameterUtilities));
-            collection.AddSingleton(typeof(IRequestHandler<UpsertResourceRequest, UpsertResourceResponse>), new UpsertResourceHandler(_dataStore, new Lazy<IConformanceProvider>(() => provider), resourceWrapperFactory, resourceIdProvider, DisabledFhirAuthorizationService.Instance, ModelInfoProvider.Instance));
-            collection.AddSingleton(typeof(IRequestHandler<GetResourceRequest, GetResourceResponse>), new GetResourceHandler(_dataStore, new Lazy<IConformanceProvider>(() => provider), resourceWrapperFactory, resourceIdProvider, DisabledFhirAuthorizationService.Instance));
-            collection.AddSingleton(typeof(IRequestHandler<DeleteResourceRequest, DeleteResourceResponse>), new DeleteResourceHandler(_dataStore, new Lazy<IConformanceProvider>(() => provider), resourceWrapperFactory, resourceIdProvider, DisabledFhirAuthorizationService.Instance));
-
-            ServiceProvider services = collection.BuildServiceProvider();
-
-            Mediator = new Mediator(type => services.GetService(type));
-
-            _deserializer = new ResourceDeserializer(
-                (FhirResourceFormat.Json, new Func<string, string, DateTimeOffset, ResourceElement>((str, version, lastUpdated) => _fhirJsonParser.Parse(str).ToResourceElement())));
+            _fhirJsonParser = fixture.JsonParser;
+            _conformanceProvider = fixture.ConformanceProvider;
+            Mediator = fixture.Mediator;
         }
 
         protected Mediator Mediator { get; }
@@ -236,8 +176,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         [InlineData("InvalidVersion")]
         public async Task GivenANonexistentResource_WhenUpsertingWithCreateEnabledAndIntegerETagHeader_TheServerShouldReturnResourceNotFoundResponse(string versionId)
         {
-            SetAllowCreate(true);
-
             await Assert.ThrowsAsync<ResourceNotFoundException>(async () =>
                 await Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight"), WeakETag.FromVersionId(versionId)));
         }
@@ -249,10 +187,13 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         [InlineData("InvalidVersion")]
         public async Task GivenANonexistentResource_WhenUpsertingWithCreateDisabledAndIntegerETagHeader_TheServerShouldReturnResourceNotFoundResponse(string versionId)
         {
-            SetAllowCreate(false);
-
-            await Assert.ThrowsAsync<ResourceNotFoundException>(async () =>
-                await Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight"), WeakETag.FromVersionId(versionId)));
+            await SetAllowCreateForOperation(
+                false,
+                async () =>
+                {
+                    await Assert.ThrowsAsync<ResourceNotFoundException>(async () =>
+                        await Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight"), WeakETag.FromVersionId(versionId)));
+                });
         }
 
         [Fact]
@@ -282,27 +223,29 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         [Fact]
         public async Task GivenANonexistentResource_WhenUpsertingWithCreateDisabled_ThenAMethodNotAllowedExceptionIsThrown()
         {
-            SetAllowCreate(false);
-            var ex = await Assert.ThrowsAsync<MethodNotAllowedException>(() => Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight")));
+            await SetAllowCreateForOperation(
+                false,
+                async () =>
+                {
+                    var ex = await Assert.ThrowsAsync<MethodNotAllowedException>(() => Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight")));
 
-            Assert.Equal(Resources.ResourceCreationNotAllowed, ex.Message);
+                    Assert.Equal(Resources.ResourceCreationNotAllowed, ex.Message);
+                });
         }
 
         [Fact]
         [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb)]
         public async Task GivenANonexistentResourceAndCosmosDb_WhenUpsertingWithCreateDisabledAndInvalidETagHeader_ThenAResourceNotFoundIsThrown()
         {
-            SetAllowCreate(false);
-
-            await Assert.ThrowsAsync<ResourceNotFoundException>(() => Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight"), WeakETag.FromVersionId("invalidVersion")));
+            await SetAllowCreateForOperation(
+                false,
+                async () => await Assert.ThrowsAsync<ResourceNotFoundException>(() => Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight"), WeakETag.FromVersionId("invalidVersion"))));
         }
 
         [Fact]
         [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb)]
         public async Task GivenANonexistentResourceAndCosmosDb_WhenUpsertingWithCreateEnabledAndInvalidETagHeader_ThenResourceNotFoundIsThrown()
         {
-            SetAllowCreate(true);
-
             await Assert.ThrowsAsync<ResourceNotFoundException>(() => Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight"), WeakETag.FromVersionId("invalidVersion")));
         }
 
@@ -747,11 +690,23 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             await Assert.ThrowsAsync<TException>(action);
         }
 
-        private void SetAllowCreate(bool allowCreate)
+        private async Task SetAllowCreateForOperation(bool allowCreate, Func<Task> operation)
         {
-            var observation = _conformance.Rest[0].Resource.Find(r => r.Type == ResourceType.Observation);
+            var observation = _capabilityStatement.Rest[0].Resource.Find(r => r.Type == ResourceType.Observation);
+            var originalValue = observation.UpdateCreate;
             observation.UpdateCreate = allowCreate;
             observation.Versioning = CapabilityStatement.ResourceVersionPolicy.Versioned;
+            _conformanceProvider.ClearCache();
+
+            try
+            {
+                await operation();
+            }
+            finally
+            {
+                observation.UpdateCreate = originalValue;
+                _conformanceProvider.ClearCache();
+            }
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTestsFixture.cs
@@ -4,35 +4,73 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Threading.Tasks;
+using System.Net.Http;
+using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
+using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Health.Abstractions.Features.Transactions;
+using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Core.Features.Conformance;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Microsoft.Health.Fhir.Core.Features.Resources;
+using Microsoft.Health.Fhir.Core.Features.Resources.Create;
+using Microsoft.Health.Fhir.Core.Features.Resources.Delete;
+using Microsoft.Health.Fhir.Core.Features.Resources.Get;
+using Microsoft.Health.Fhir.Core.Features.Resources.Upsert;
+using Microsoft.Health.Fhir.Core.Features.Search;
+using Microsoft.Health.Fhir.Core.Features.Search.Parameters;
 using Microsoft.Health.Fhir.Core.Features.Search.Registry;
+using Microsoft.Health.Fhir.Core.Features.Security.Authorization;
+using Microsoft.Health.Fhir.Core.Messages.Create;
+using Microsoft.Health.Fhir.Core.Messages.Delete;
+using Microsoft.Health.Fhir.Core.Messages.Get;
+using Microsoft.Health.Fhir.Core.Messages.Upsert;
+using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Microsoft.Health.Fhir.Tests.Common.Mocks;
+using NSubstitute;
 using Xunit;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 {
     public class FhirStorageTestsFixture : IAsyncLifetime, IDisposable
     {
         private readonly IServiceProvider _fixture;
+        private readonly ResourceIdProvider _resourceIdProvider;
 
         public FhirStorageTestsFixture(DataStore dataStore)
-        {
-            switch (dataStore)
+            : this(dataStore switch
             {
-                case Common.FixtureParameters.DataStore.CosmosDb:
-                    _fixture = new CosmosDbFhirStorageTestsFixture();
-                    break;
-                case Common.FixtureParameters.DataStore.SqlServer:
-                    _fixture = new SqlServerFhirStorageTestsFixture();
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(dataStore), dataStore, null);
-            }
+                Common.FixtureParameters.DataStore.CosmosDb => new CosmosDbFhirStorageTestsFixture(),
+                Common.FixtureParameters.DataStore.SqlServer => new SqlServerFhirStorageTestsFixture(),
+                _ => throw new ArgumentOutOfRangeException(nameof(dataStore), dataStore, null),
+            })
+        {
         }
+
+        internal FhirStorageTestsFixture(IServiceProvider fixture)
+        {
+            _fixture = fixture;
+
+            // This step has to be done in the constructor because it uses an AsyncLocal and the tests run with the same
+            // execution context as the fixture constructor, but not the same as InitializeAsync().
+            _resourceIdProvider = new ResourceIdProvider();
+        }
+
+        public Mediator Mediator { get; private set; }
+
+        public CapabilityStatement CapabilityStatement { get; private set; }
+
+        public ConformanceProviderBase ConformanceProvider { get; private set; }
+
+        public FhirJsonParser JsonParser { get; } = new FhirJsonParser();
+
+        public ResourceDeserializer Deserializer { get; private set; }
 
         public IFhirDataStore DataStore => _fixture.GetRequiredService<IFhirDataStore>();
 
@@ -46,20 +84,67 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
         public FilebasedSearchParameterStatusDataStore FilebasedSearchParameterStatusDataStore => _fixture.GetRequiredService<FilebasedSearchParameterStatusDataStore>();
 
-        void IDisposable.Dispose()
+        public void Dispose()
         {
             (_fixture as IDisposable)?.Dispose();
         }
 
-        async Task IAsyncLifetime.InitializeAsync()
+        public async Task InitializeAsync()
         {
             if (_fixture is IAsyncLifetime asyncLifetime)
             {
                 await asyncLifetime.InitializeAsync();
             }
+
+            ISearchService searchService = Substitute.For<ISearchService>();
+
+            CapabilityStatement = CapabilityStatementMock.GetMockedCapabilityStatement();
+
+            CapabilityStatementMock.SetupMockResource(CapabilityStatement, ResourceType.Observation, null);
+            var observationResource = CapabilityStatement.Rest[0].Resource.Find(r => r.Type == ResourceType.Observation);
+            observationResource.UpdateCreate = true;
+            observationResource.Versioning = CapabilityStatement.ResourceVersionPolicy.Versioned;
+
+            CapabilityStatementMock.SetupMockResource(CapabilityStatement, ResourceType.Organization, null);
+            var organizationResource = CapabilityStatement.Rest[0].Resource.Find(r => r.Type == ResourceType.Organization);
+            organizationResource.UpdateCreate = true;
+            organizationResource.Versioning = CapabilityStatement.ResourceVersionPolicy.NoVersion;
+
+            ConformanceProvider = Substitute.For<ConformanceProviderBase>();
+            ConformanceProvider.GetCapabilityStatementAsync().Returns(CapabilityStatement.ToTypedElement().ToResourceElement());
+
+            // TODO: FhirRepository instantiate ResourceDeserializer class directly
+            // which will try to deserialize the raw resource. We should mock it as well.
+            var rawResourceFactory = Substitute.For<RawResourceFactory>(new FhirJsonSerializer());
+
+            var resourceWrapperFactory = Substitute.For<IResourceWrapperFactory>();
+            resourceWrapperFactory
+                .Create(Arg.Any<ResourceElement>(), Arg.Any<bool>(), Arg.Any<bool>())
+                .Returns(x =>
+                {
+                    ResourceElement resource = x.ArgAt<ResourceElement>(0);
+
+                    return new ResourceWrapper(resource, rawResourceFactory.Create(resource, keepMeta: true), new ResourceRequest(HttpMethod.Post, "http://fhir"), x.ArgAt<bool>(1), null, null, null);
+                });
+
+            var collection = new ServiceCollection();
+
+            ISearchParameterUtilities searchParameterUtilities = Substitute.For<ISearchParameterUtilities>();
+
+            collection.AddSingleton(typeof(IRequestHandler<CreateResourceRequest, UpsertResourceResponse>), new CreateResourceHandler(DataStore, new Lazy<IConformanceProvider>(() => ConformanceProvider), resourceWrapperFactory, _resourceIdProvider, new ResourceReferenceResolver(searchService, new TestQueryStringParser()), DisabledFhirAuthorizationService.Instance, searchParameterUtilities));
+            collection.AddSingleton(typeof(IRequestHandler<UpsertResourceRequest, UpsertResourceResponse>), new UpsertResourceHandler(DataStore, new Lazy<IConformanceProvider>(() => ConformanceProvider), resourceWrapperFactory, _resourceIdProvider, DisabledFhirAuthorizationService.Instance, ModelInfoProvider.Instance));
+            collection.AddSingleton(typeof(IRequestHandler<GetResourceRequest, GetResourceResponse>), new GetResourceHandler(DataStore, new Lazy<IConformanceProvider>(() => ConformanceProvider), resourceWrapperFactory, _resourceIdProvider, DisabledFhirAuthorizationService.Instance));
+            collection.AddSingleton(typeof(IRequestHandler<DeleteResourceRequest, DeleteResourceResponse>), new DeleteResourceHandler(DataStore, new Lazy<IConformanceProvider>(() => ConformanceProvider), resourceWrapperFactory, _resourceIdProvider, DisabledFhirAuthorizationService.Instance));
+
+            ServiceProvider services = collection.BuildServiceProvider();
+
+            Mediator = new Mediator(type => services.GetService(type));
+
+            Deserializer = new ResourceDeserializer(
+                (FhirResourceFormat.Json, new Func<string, string, DateTimeOffset, ResourceElement>((str, version, lastUpdated) => JsonParser.Parse(str).ToResourceElement())));
         }
 
-        async Task IAsyncLifetime.DisposeAsync()
+        public async Task DisposeAsync()
         {
             if (_fixture is IAsyncLifetime asyncLifetime)
             {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/ISqlServerFhirStorageTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/ISqlServerFhirStorageTestHelper.cs
@@ -5,7 +5,6 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Health.Fhir.SqlServer.Features.Schema;
 using Microsoft.Health.SqlServer.Features.Schema;
 
 namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
@@ -13,13 +12,14 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
     public interface ISqlServerFhirStorageTestHelper
     {
         /// <summary>
-        /// Creates and initializes a new SQL database.
+        /// Creates and initializes a new SQL database if it does not already exist.
         /// </summary>
         /// <param name="databaseName">The name of the database to create.</param>
+        /// <param name="maximumSupportedSchemaVersion">The maximum supported schema version.</param>
         /// <param name="forceIncrementalSchemaUpgrade">True if diff SQL files should be applied to upgrade the schema.</param>
         /// <param name="schemaInitializer">The schema initializer to use for database initialization. If this is not provided, a new one is created.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        Task CreateAndInitializeDatabase(string databaseName, bool forceIncrementalSchemaUpgrade, SchemaInitializer schemaInitializer = null, CancellationToken cancellationToken = default);
+        Task CreateAndInitializeDatabase(string databaseName, int maximumSupportedSchemaVersion, bool forceIncrementalSchemaUpgrade, SchemaInitializer schemaInitializer = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Deletes the specified SQL database.

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             _searchParameterDefinitionManager.StartAsync(CancellationToken.None).Wait();
         }
 
-        public async Task CreateAndInitializeDatabase(string databaseName, bool forceIncrementalSchemaUpgrade, SchemaInitializer schemaInitializer = null, CancellationToken cancellationToken = default)
+        public async Task CreateAndInitializeDatabase(string databaseName, int maximumSupportedSchemaVersion, bool forceIncrementalSchemaUpgrade, SchemaInitializer schemaInitializer = null, CancellationToken cancellationToken = default)
         {
             var testConnectionString = new SqlConnectionStringBuilder(_initialConnectionString) { InitialCatalog = databaseName }.ToString();
             schemaInitializer = schemaInitializer ?? CreateSchemaInitializer(testConnectionString);
@@ -66,7 +66,11 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 using (SqlCommand command = connection.CreateCommand())
                 {
                     command.CommandTimeout = 600;
-                    command.CommandText = $"CREATE DATABASE {databaseName}";
+                    command.CommandText = @$"
+                        IF NOT EXISTS (SELECT * FROM sys.databases WHERE name = '{databaseName}')
+                        BEGIN
+                          CREATE DATABASE {databaseName};
+                        END";
                     await command.ExecuteNonQueryAsync(cancellationToken);
                 }
             }
@@ -91,7 +95,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 });
 
             await schemaInitializer.InitializeAsync(forceIncrementalSchemaUpgrade, cancellationToken);
-            _sqlServerFhirModel.Initialize(SchemaVersionConstants.Max, true);
+            _sqlServerFhirModel.Initialize(maximumSupportedSchemaVersion, true);
         }
 
         public async Task DeleteDatabase(string databaseName, CancellationToken cancellationToken = default)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Numerics;
 using System.Threading.Tasks;
+using Microsoft.Health.Fhir.SqlServer.Features.Schema;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Xunit;
 
@@ -30,10 +31,10 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             try
             {
                 // Create two databases, one where we apply the the maximum supported version's snapshot SQL schema file
-                await _testHelper.CreateAndInitializeDatabase(snapshotDatabaseName, forceIncrementalSchemaUpgrade: false);
+                await _testHelper.CreateAndInitializeDatabase(snapshotDatabaseName, SchemaVersionConstants.Max, forceIncrementalSchemaUpgrade: false);
 
                 // And one where we apply .diff.sql files to upgrade the schema version to the maximum supported version.
-                await _testHelper.CreateAndInitializeDatabase(diffDatabaseName, forceIncrementalSchemaUpgrade: true);
+                await _testHelper.CreateAndInitializeDatabase(diffDatabaseName, SchemaVersionConstants.Max, forceIncrementalSchemaUpgrade: true);
 
                 bool isEqual = _testHelper.CompareDatabaseSchemas(snapshotDatabaseName, diffDatabaseName);
                 Assert.True(isEqual);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerSqlCompatibilityTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerSqlCompatibilityTests.cs
@@ -1,0 +1,73 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Microsoft.Health.Fhir.SqlServer.Features.Schema;
+using Microsoft.Health.Fhir.Tests.Common;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
+{
+    public class SqlServerSqlCompatibilityTests
+    {
+        /// <summary>
+        /// A basic smoke test verifying that the code is compatible with schema versions
+        /// all the way back to <see cref="SchemaVersionConstants.Min"/>. Ensures that the code can
+        /// insert insert a resource using every schema version, and that we can read resources
+        /// that were inserted into with earlier schemas.
+        /// </summary>
+        [Fact]
+        public async Task GivenADatabaseWithAnEarlierSupportedSchema_WhenUpserting_OperationSucceeds()
+        {
+            string databaseName = $"FHIRCOMPATIBILITYTEST_{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}";
+            var insertedElements = new List<string>();
+
+            FhirStorageTestsFixture fhirStorageTestsFixture = null;
+            try
+            {
+                for (int i = SchemaVersionConstants.Min; i <= SchemaVersionConstants.Max; i++)
+                {
+                    try
+                    {
+                        fhirStorageTestsFixture = new FhirStorageTestsFixture(new SqlServerFhirStorageTestsFixture(i, databaseName));
+                        await fhirStorageTestsFixture.InitializeAsync(); // this will either create the database or upgrade the schema.
+
+                        Mediator mediator = fhirStorageTestsFixture.Mediator;
+
+                        foreach (string id in insertedElements)
+                        {
+                            // verify that we can read entries from previous versions
+                            var readResult = (await mediator.GetResourceAsync(new ResourceKey("Observation", id))).ToResourceElement(fhirStorageTestsFixture.Deserializer);
+                            Assert.Equal(id, readResult.Id);
+                        }
+
+                        // add a new entry
+
+                        var saveResult = await mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight"));
+                        var deserialized = saveResult.RawResourceElement.ToResourceElement(Deserializers.ResourceDeserializer);
+                        var result = (await mediator.GetResourceAsync(new ResourceKey(deserialized.InstanceType, deserialized.Id, deserialized.VersionId))).ToResourceElement(fhirStorageTestsFixture.Deserializer);
+
+                        Assert.NotNull(result);
+                        Assert.Equal(deserialized.Id, result.Id);
+                        insertedElements.Add(result.Id);
+                    }
+                    catch (Exception e)
+                    {
+                        throw new InvalidOperationException($"Failure using schema version {i}", e);
+                    }
+                }
+            }
+            finally
+            {
+                await fhirStorageTestsFixture?.DisposeAsync();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
Fixes an earlier compatibility break where the code was only able to insert into a database with the latest schema version.

Added an integration smoke test for this scenario. The test refactoring to accomplish this is a bit messy.

## Related issues
Addresses #1594.

## Testing
Introduced a new integration test.

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch 
