### PR TITLE
Add x-ms-retry-after-ms header when throttling requests

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Headers/KnownHeaders.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Headers/KnownHeaders.cs
@@ -5,9 +5,10 @@
 
 namespace Microsoft.Health.Fhir.Api.Features.Headers
 {
-    public static class KnownFhirHeaders
+    internal static class KnownHeaders
     {
         public const string IfNoneExist = "If-None-Exist";
         public const string PartiallyIndexedParamsHeaderName = "x-ms-use-partial-indices";
+        public const string RetryAfterMilliseconds = "x-ms-retry-after-ms";
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Features/Throttling/ThrottlingMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Throttling/ThrottlingMiddleware.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Api.Configs;
 using Microsoft.Health.Fhir.Api.Features.ActionResults;
+using Microsoft.Health.Fhir.Api.Features.Headers;
 using Microsoft.Health.Fhir.Core.Configs;
 
 namespace Microsoft.Health.Fhir.Api.Features.Throttling
@@ -23,8 +24,14 @@ namespace Microsoft.Health.Fhir.Api.Features.Throttling
     /// <summary>
     /// Middleware to limit the number of concurrent requests that an instance of the server handles simultaneously.
     /// </summary>
-    public class ThrottlingMiddleware
+    public sealed class ThrottlingMiddleware : IDisposable
     {
+        private const int MinRetryAfterMilliseconds = 20;
+        private const int MaxRetryAfterMilliseconds = 60000;
+        private const double RetryAfterGrowthRate = 1.2;
+        private const double RetryAfterDecayRate = 1.1;
+        private const int SamplePeriodMilliseconds = 500;
+
         private readonly ILogger<ThrottlingMiddleware> _logger;
         private readonly ThrottlingConfiguration _configuration;
         private readonly HashSet<(string method, string path)> _excludedEndpoints;
@@ -32,6 +39,11 @@ namespace Microsoft.Health.Fhir.Api.Features.Throttling
 
         private int _requestsInFlight = 0;
         private RequestDelegate _next;
+        private int _currentPeriodSuccessCount;
+        private int _currentPeriodRejectedCount;
+        private int _currentRetryAfterMilliseconds = MinRetryAfterMilliseconds;
+
+        private bool _disposed;
 
         public ThrottlingMiddleware(
             RequestDelegate next,
@@ -53,6 +65,50 @@ namespace Microsoft.Health.Fhir.Api.Features.Throttling
                 foreach (var excludedEndpoint in _configuration.ExcludedEndpoints)
                 {
                     _excludedEndpoints.Add((excludedEndpoint.Method, excludedEndpoint.Path));
+                }
+            }
+
+#pragma warning disable 4014 // Intentional fire and forget behavior
+            SamplingLoop();
+#pragma warning restore 4014
+        }
+
+        public void Dispose() => _disposed = true;
+
+        /// <summary>
+        /// Samples the success rate (i.e. requests not throttled) over a period, and adjusts the value we return as the retry after header.
+        /// This is an extremely simple approach that exponentially grows or decays the value depending on whether the success rate is
+        /// less than or greater than 99%, respectively.
+        /// The value as high as necessary to keep the success rate over 99%, but we want it to decrease when the request rate backs off,
+        /// so overall latency for clients is not unnecessarily high.
+        /// </summary>
+        public async Task SamplingLoop()
+        {
+            while (!_disposed)
+            {
+                await Task.Delay(SamplePeriodMilliseconds);
+
+                var successCount = Interlocked.Exchange(ref _currentPeriodSuccessCount, 0);
+                var failureCount = Interlocked.Exchange(ref _currentPeriodRejectedCount, 0);
+
+                var totalCount = successCount + failureCount;
+                double successRate = totalCount == 0 ? 100.0 : successCount * 100.0 / totalCount;
+
+                if (successRate >= 99)
+                {
+                    // see if we should lower the value
+                    if (_currentRetryAfterMilliseconds > MinRetryAfterMilliseconds)
+                    {
+                        _currentRetryAfterMilliseconds = (int)(_currentRetryAfterMilliseconds / RetryAfterDecayRate);
+                    }
+                }
+                else
+                {
+                    // see if we should raise the value.
+                    if (_currentRetryAfterMilliseconds < MaxRetryAfterMilliseconds)
+                    {
+                        _currentRetryAfterMilliseconds = (int)(_currentRetryAfterMilliseconds * RetryAfterGrowthRate);
+                    }
                 }
             }
         }
@@ -78,13 +134,18 @@ namespace Microsoft.Health.Fhir.Api.Features.Throttling
                 if (Interlocked.Increment(ref _requestsInFlight) <= _configuration.ConcurrentRequestLimit)
                 {
                     // Still within the concurrent request limit, let the request through.
+                    Interlocked.Increment(ref _currentPeriodSuccessCount);
                     await _next(context);
                 }
                 else
                 {
                     // Exceeded the concurrent request limit, return 429.
+                    Interlocked.Increment(ref _currentPeriodRejectedCount);
                     context.Response.StatusCode = (int)HttpStatusCode.TooManyRequests;
                     _logger.LogWarning($"{Resources.TooManyConcurrentRequests}. Limit is {_configuration.ConcurrentRequestLimit}.");
+
+                    // note we are aligning with Cosmos DB and not returning the standard header (which is in seconds)
+                    context.Response.Headers[KnownHeaders.RetryAfterMilliseconds] = _currentRetryAfterMilliseconds.ToString();
 
                     // Output an OperationOutcome in the body.
                     var result = TooManyRequestsActionResult.TooManyRequests;

--- a/src/Microsoft.Health.Fhir.Api/Microsoft.Health.Fhir.Api.csproj
+++ b/src/Microsoft.Health.Fhir.Api/Microsoft.Health.Fhir.Api.csproj
@@ -44,7 +44,4 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Features\Headers\" />
-  </ItemGroup>
 </Project>

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/FhirRequestContextRouteDataPopulatingFilterAttributeTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/FhirRequestContextRouteDataPopulatingFilterAttributeTests.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
         public void GivenPartialIndexHeader_WhenSearchReqeust_ThenFhirContextPropertySet()
         {
             _httpContext.Request.Headers.Add(
-                KnownFhirHeaders.PartiallyIndexedParamsHeaderName,
+                KnownHeaders.PartiallyIndexedParamsHeaderName,
                 new Microsoft.Extensions.Primitives.StringValues(new string[] { "true" }));
 
             _filterAttribute.OnActionExecuting(_actionExecutingContext);

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Throttling/ThrottlingMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Throttling/ThrottlingMiddlewareTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
@@ -22,7 +23,7 @@ using Xunit;
 
 namespace Microsoft.Health.Fhir.Shared.Api.UnitTests.Features.Throttling
 {
-    public class ThrottlingMiddlewareTests
+    public class ThrottlingMiddlewareTests : IDisposable
     {
         private HttpContext _httpContext = new DefaultHttpContext();
         private ThrottlingMiddleware _middleware;
@@ -159,5 +160,7 @@ namespace Microsoft.Health.Fhir.Shared.Api.UnitTests.Features.Throttling
             _provider = _collection.BuildServiceProvider();
             _httpContext.RequestServices = _provider;
         }
+
+        public void Dispose() => _middleware?.Dispose();
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Throttling/ThrottlingMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Throttling/ThrottlingMiddlewareTests.cs
@@ -23,7 +23,7 @@ using Xunit;
 
 namespace Microsoft.Health.Fhir.Shared.Api.UnitTests.Features.Throttling
 {
-    public class ThrottlingMiddlewareTests : IDisposable
+    public class ThrottlingMiddlewareTests : IAsyncLifetime
     {
         private HttpContext _httpContext = new DefaultHttpContext();
         private ThrottlingMiddleware _middleware;
@@ -161,6 +161,8 @@ namespace Microsoft.Health.Fhir.Shared.Api.UnitTests.Features.Throttling
             _httpContext.RequestServices = _provider;
         }
 
-        public void Dispose() => _middleware?.Dispose();
+        public Task InitializeAsync() => Task.CompletedTask;
+
+        async Task IAsyncLifetime.DisposeAsync() => await _middleware.DisposeAsync();
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         [AuditEventType(AuditEventSubType.Create)]
         public async Task<IActionResult> ConditionalCreate([FromBody] Resource resource)
         {
-            StringValues conditionalCreateHeader = HttpContext.Request.Headers[KnownFhirHeaders.IfNoneExist];
+            StringValues conditionalCreateHeader = HttpContext.Request.Headers[KnownHeaders.IfNoneExist];
 
             Tuple<string, string>[] conditionalParameters = QueryHelpers.ParseQuery(conditionalCreateHeader)
                 .SelectMany(query => query.Value, (query, value) => Tuple.Create(query.Key, value)).ToArray();

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/ActionConstraints/ConditionalConstraintAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/ActionConstraints/ConditionalConstraintAttribute.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Health.Fhir.Api.Features.ActionConstraints
 
         public bool Accept(ActionConstraintContext context)
         {
-            StringValues conditionalCreateHeader = context.RouteContext.HttpContext.Request.Headers[KnownFhirHeaders.IfNoneExist];
+            StringValues conditionalCreateHeader = context.RouteContext.HttpContext.Request.Headers[KnownHeaders.IfNoneExist];
 
             if (!string.IsNullOrEmpty(conditionalCreateHeader))
             {

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/FhirRequestContextRouteDataPopulatingFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/FhirRequestContextRouteDataPopulatingFilterAttribute.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
                 }
             }
 
-            if (context.HttpContext.Request.Headers.TryGetValue(KnownFhirHeaders.PartiallyIndexedParamsHeaderName, out var headerValues))
+            if (context.HttpContext.Request.Headers.TryGetValue(KnownHeaders.PartiallyIndexedParamsHeaderName, out var headerValues))
             {
                 fhirRequestContext.IncludePartiallyIndexedSearchParams = true;
             }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
@@ -17,6 +17,7 @@ using Microsoft.Health.Api.Features.Audit;
 using Microsoft.Health.Fhir.Api.Features.ActionResults;
 using Microsoft.Health.Fhir.Api.Features.Bundle;
 using Microsoft.Health.Fhir.Api.Features.Exceptions;
+using Microsoft.Health.Fhir.Api.Features.Headers;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Context;
@@ -32,7 +33,6 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
     [AttributeUsage(AttributeTargets.Class)]
     internal class OperationOutcomeExceptionFilterAttribute : ActionFilterAttribute
     {
-        private const string RetryAfterHeaderName = "x-ms-retry-after-ms";
         private const string ValidateController = "Validate";
 
         private readonly IFhirRequestContextAccessor _fhirRequestContextAccessor;
@@ -163,7 +163,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
                         if (ex.RetryAfter != null)
                         {
                             healthExceptionResult.Headers.Add(
-                                RetryAfterHeaderName,
+                                KnownHeaders.RetryAfterMilliseconds,
                                 ex.RetryAfter.Value.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
                         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
@@ -292,7 +292,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
             AddHeaderIfNeeded(HeaderNames.IfMatch, entry.Request.IfMatch, httpContext);
             AddHeaderIfNeeded(HeaderNames.IfModifiedSince, entry.Request.IfModifiedSince?.ToString(), httpContext);
             AddHeaderIfNeeded(HeaderNames.IfNoneMatch, entry.Request.IfNoneMatch, httpContext);
-            AddHeaderIfNeeded(KnownFhirHeaders.IfNoneExist, entry.Request.IfNoneExist, httpContext);
+            AddHeaderIfNeeded(KnownHeaders.IfNoneExist, entry.Request.IfNoneExist, httpContext);
 
             if (requestMethod == HTTPVerb.POST ||
                 requestMethod == HTTPVerb.PUT)

--- a/src/Microsoft.Health.Fhir.Shared.Api/Microsoft.Health.Fhir.Shared.Api.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Microsoft.Health.Fhir.Shared.Api.projitems
@@ -48,7 +48,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Formatters\JsonArrayPool.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Formatters\NonFhirResourceXmlOutputFormatter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Headers\FhirResultExtensions.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Features\Headers\KnownFhirHeaders.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Bundle\BundleHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Bundle\TransactionBundleValidator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Bundle\TransactionExceptionHandler.cs" />


### PR DESCRIPTION
## Description

When we throttle requests based on the maximum number of concurrent requests, we should return a response header indicating how long the client should wait before retrying.

Note that we are not using the standard `Retry-After` header, but instead `x-ms-retry-after-ms`, which we already return when Cosmos DB throttles.

The approach is very simple. It is based on observing the success rate of requests over time and adjusting it up or down to try to keep the success rate at 99% without returning an unnecessarily large value. Growth and decay are both exponential at different rates, with the growth rate being faster.

In a future, change ([AB#79045](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/79045)), we'll add queuing before rejecting requests to increase throughput.

## Related issues
Addresses [AB#78885](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/78885) .

## Testing
Testing was based on a simulator where I adjusted various constants.

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
