### PR TITLE
Do not call DeleteSearchParameter if isDeleted

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/DeleteSearchParameterBehavior.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/DeleteSearchParameterBehavior.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
 
             var response = await next();
 
-            if (searchParamResource != null)
+            if (searchParamResource != null && searchParamResource.IsDeleted == false)
             {
                 // Once the SearchParameter resource is removed from the data store, we can update the in
                 // memory SearchParameterDefinitionManager, and remove the status metadata from the data store


### PR DESCRIPTION
## Description
We attempted to delete a search parameter from the SearchParameter even if it had been previously deleted.  This adds a check to avoid that.

## Related issues
Addresses [issue [AB#79136](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/79136)].

## Testing
Added a unit test

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
Skip, just a bug fix