### PR TITLE
Change order of file creation during export

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportFileManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportFileManager.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                 _approxMaxFileSizeInBytes > 0 &&
                 fileInfo.CommittedBytes >= _approxMaxFileSizeInBytes)
             {
-                await CreateNewFileAndUpdateMappings(resourceType, fileInfo.Sequence + 1, cancellationToken);
+                fileInfo = await CreateNewFileAndUpdateMappings(resourceType, fileInfo.Sequence + 1, cancellationToken);
             }
 
             await _exportDestinationClient.WriteFilePartAsync(fileInfo.FileUri, partId, data, cancellationToken);

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportFileManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportFileManager.cs
@@ -75,9 +75,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
             }
 
             ExportFileInfo fileInfo = await GetFile(resourceType, cancellationToken);
-            await _exportDestinationClient.WriteFilePartAsync(fileInfo.FileUri, partId, data, cancellationToken);
-
-            fileInfo.IncrementCount(data.Length);
 
             // We need to create a new file if the current file has exceeded a certain limit.
             // File size limits are valid only for schema versions starting from 2.
@@ -87,6 +84,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
             {
                 await CreateNewFileAndUpdateMappings(resourceType, fileInfo.Sequence + 1, cancellationToken);
             }
+
+            await _exportDestinationClient.WriteFilePartAsync(fileInfo.FileUri, partId, data, cancellationToken);
+            fileInfo.IncrementCount(data.Length);
         }
 
         private async Task<ExportFileInfo> GetFile(string resourceType, CancellationToken cancellationToken)


### PR DESCRIPTION
## Description
While exporting data we create a new file once we reach a certain file size limit for each resource type. If there are no new resources of that type to be exported, we would have created a file for nothing. This PR changes the order of creating new files in order to prevent generating an (ultimately) empty file.

## Related issues
Addresses #1620 

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
