### PR TITLE
Bump converter package to 3.3.115.8

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Microsoft.Health.Fhir.Core.csproj
+++ b/src/Microsoft.Health.Fhir.Core/Microsoft.Health.Fhir.Core.csproj
@@ -44,7 +44,7 @@
     <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="$(HealthcareSharedPackageVersion)" />
     <PackageReference Include="Hl7.Fhir.Serialization" Version="$(Hl7FhirVersion)" />
     <PackageReference Include="Hl7.FhirPath" Version="$(Hl7FhirVersion)" />
-    <PackageReference Include="Microsoft.Health.Fhir.Liquid.Converter" Version="3.2.117.10" />
+    <PackageReference Include="Microsoft.Health.Fhir.Liquid.Converter" Version="3.3.115.8" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.4.0" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.13" />
     <PackageReference Include="Polly" Version="7.2.1" />


### PR DESCRIPTION
## Description
Bump converter package to 3.3.115.8

## Related issues

## Testing
Unit tests, e2e tests and manual deployment tests.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip
