### PR TITLE
Check for conditional item duplicates (prototype)

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Persistence/ConditionalCreateConcurrencyBehavior.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Persistence/ConditionalCreateConcurrencyBehavior.cs
@@ -1,0 +1,89 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EnsureThat;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Core.Features.Search;
+using Microsoft.Health.Fhir.Core.Messages.Create;
+using Microsoft.Health.Fhir.Core.Messages.Upsert;
+
+namespace Microsoft.Health.Fhir.Core.Features.Persistence
+{
+    /// <summary>
+    /// Intercepts ConditionalCreateResourceRequests and checks to ensure no duplicate items were created
+    /// </summary>
+    public class ConditionalCreateConcurrencyBehavior
+        : IPipelineBehavior<ConditionalCreateResourceRequest, UpsertResourceResponse>, IPipelineBehavior<ConditionalUpsertResourceRequest, UpsertResourceResponse>
+    {
+        private readonly ISearchService _searchService;
+        private readonly IFhirDataStore _dataStore;
+        private readonly ILogger<ConditionalCreateConcurrencyBehavior> _logger;
+
+        public ConditionalCreateConcurrencyBehavior(ISearchService searchService, IFhirDataStore dataStore, ILogger<ConditionalCreateConcurrencyBehavior> logger)
+        {
+            EnsureArg.IsNotNull(searchService, nameof(searchService));
+            EnsureArg.IsNotNull(dataStore, nameof(dataStore));
+            EnsureArg.IsNotNull(logger, nameof(logger));
+
+            _searchService = searchService;
+            _dataStore = dataStore;
+            _logger = logger;
+        }
+
+        public async Task<UpsertResourceResponse> Handle(ConditionalCreateResourceRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<UpsertResourceResponse> next)
+        {
+            EnsureArg.IsNotNull(request, nameof(request));
+            EnsureArg.IsNotNull(next, nameof(next));
+
+            return await Execute(request.Resource.InstanceType, request.ConditionalParameters, next);
+        }
+
+        public async Task<UpsertResourceResponse> Handle(ConditionalUpsertResourceRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<UpsertResourceResponse> next)
+        {
+            EnsureArg.IsNotNull(request, nameof(request));
+            EnsureArg.IsNotNull(next, nameof(next));
+
+            return await Execute(request.Resource.InstanceType, request.ConditionalParameters, next);
+        }
+
+        private async Task<UpsertResourceResponse> Execute(string resourceType, IReadOnlyList<Tuple<string, string>> conditions, RequestHandlerDelegate<UpsertResourceResponse> next)
+        {
+            EnsureArg.IsNotNullOrEmpty(resourceType, nameof(resourceType));
+            EnsureArg.IsNotNull(conditions, nameof(conditions));
+            EnsureArg.IsNotNull(next, nameof(next));
+
+            UpsertResourceResponse response = await next();
+
+            // Check for duplicates
+            if (response?.Outcome.Outcome == SaveOutcomeType.Created)
+            {
+                IReadOnlyCollection<SearchResultEntry> matchedResults = await _searchService.ConditionalSearchAsync(resourceType, conditions, default);
+
+                SearchResultEntry[] orderedResults = matchedResults
+                    .OrderBy(x => x.Resource.ResourceId)
+                    .ToArray();
+
+                if (orderedResults.Length > 1 && !string.Equals(response.Outcome.RawResourceElement.Id, orderedResults.First().Resource.ResourceId, StringComparison.Ordinal))
+                {
+                    _logger.LogWarning("{ItemsFound} items found after creating with conditional Create/Update, reverting", orderedResults.Length);
+
+                    // remove current item and return conflict.
+                    await _dataStore.HardDeleteAsync(new ResourceKey(resourceType, response.Outcome.RawResourceElement.Id), default);
+
+                    throw new ResourceConflictException(Core.Resources.ResourceConflict);
+                }
+            }
+
+            return response;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Persistence/ResourceConflictException.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Persistence/ResourceConflictException.cs
@@ -20,5 +20,15 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
                     OperationOutcomeConstants.IssueType.Conflict,
                     string.Format(Core.Resources.ResourceVersionConflict, etag?.VersionId)));
         }
+
+        public ResourceConflictException(string message)
+        {
+            Debug.Assert(message != null, "Message should not be null");
+
+            Issues.Add(new OperationOutcomeIssue(
+                OperationOutcomeConstants.IssueSeverity.Error,
+                OperationOutcomeConstants.IssueType.Conflict,
+                message));
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Health.Fhir.Core {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -706,6 +706,15 @@ namespace Microsoft.Health.Fhir.Core {
         internal static string RequestedActionNotAllowed {
             get {
                 return ResourceManager.GetString("RequestedActionNotAllowed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A conditional create or update is currently being attempted with the same parameters..
+        /// </summary>
+        internal static string ResourceConflict {
+            get {
+                return ResourceManager.GetString("ResourceConflict", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -515,4 +515,7 @@
     <value>Search parameter '{0}' is not common for '{1}' and '{2}'.</value>
     <comment>{0}: the invalid search parameter. {1}: first resource type. {2} other resource type.</comment>
   </data>
+  <data name="ResourceConflict" xml:space="preserve">
+    <value>A conditional create or update is currently being attempted with the same parameters.</value>
+  </data>
 </root>

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/PersistenceModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/PersistenceModule.cs
@@ -36,6 +36,10 @@ namespace Microsoft.Health.Fhir.Api.Modules
 
             services.AddScoped<TransactionBundleValidator>();
             services.AddScoped<ResourceReferenceResolver>();
+
+            services.Add<ConditionalCreateConcurrencyBehavior>()
+                .Transient()
+                .AsImplementedInterfaces();
         }
     }
 }


### PR DESCRIPTION
## Description
Wanting to gather additional feedback, I'm not happy with this implementation.

Adds a behavior that checks for duplicates when conditional items are created.

## Related issues
Addresses [# Issue Number]

## Testing
Adds test

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
