### PR TITLE
Turn off splitting canonical for Uri search queries

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Data/R4/unsupported-search-parameters.json
+++ b/src/Microsoft.Health.Fhir.Core/Data/R4/unsupported-search-parameters.json
@@ -55,6 +55,7 @@
         "http://hl7.org/fhir/SearchParameter/OperationDefinition-output-profile",
         "http://hl7.org/fhir/SearchParameter/PlanDefinition-composed-of",
         "http://hl7.org/fhir/SearchParameter/PlanDefinition-depends-on",
+        "http://hl7.org/fhir/SearchParameter/PlanDefinition-definition",
         "http://hl7.org/fhir/SearchParameter/PlanDefinition-derived-from",
         "http://hl7.org/fhir/SearchParameter/PlanDefinition-predecessor",
         "http://hl7.org/fhir/SearchParameter/PlanDefinition-successor",
@@ -91,7 +92,6 @@
         "http://hl7.org/fhir/SearchParameter/Observation-component-value-quantity",
         "http://hl7.org/fhir/SearchParameter/Observation-value-quantity",
         "http://hl7.org/fhir/SearchParameter/Patient-deceased",
-        "http://hl7.org/fhir/SearchParameter/PlanDefinition-definition",
         "http://hl7.org/fhir/SearchParameter/ServiceRequest-occurrence"
     ]
 }

--- a/src/Microsoft.Health.Fhir.Core/Data/R4/unsupported-search-parameters.json
+++ b/src/Microsoft.Health.Fhir.Core/Data/R4/unsupported-search-parameters.json
@@ -55,7 +55,6 @@
         "http://hl7.org/fhir/SearchParameter/OperationDefinition-output-profile",
         "http://hl7.org/fhir/SearchParameter/PlanDefinition-composed-of",
         "http://hl7.org/fhir/SearchParameter/PlanDefinition-depends-on",
-        "http://hl7.org/fhir/SearchParameter/PlanDefinition-definition",
         "http://hl7.org/fhir/SearchParameter/PlanDefinition-derived-from",
         "http://hl7.org/fhir/SearchParameter/PlanDefinition-predecessor",
         "http://hl7.org/fhir/SearchParameter/PlanDefinition-successor",
@@ -92,6 +91,7 @@
         "http://hl7.org/fhir/SearchParameter/Observation-component-value-quantity",
         "http://hl7.org/fhir/SearchParameter/Observation-value-quantity",
         "http://hl7.org/fhir/SearchParameter/Patient-deceased",
+        "http://hl7.org/fhir/SearchParameter/PlanDefinition-definition",
         "http://hl7.org/fhir/SearchParameter/ServiceRequest-occurrence"
     ]
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/SearchParameterExpressionParser.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/SearchParameterExpressionParser.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
                     (SearchParamType.Reference, referenceSearchValueParser.Parse),
                     (SearchParamType.String, StringSearchValue.Parse),
                     (SearchParamType.Token, TokenSearchValue.Parse),
-                    (SearchParamType.Uri, str => UriSearchValue.Parse(str, true, ModelInfoProvider.Instance)),
+                    (SearchParamType.Uri, str => UriSearchValue.Parse(str, false, ModelInfoProvider.Instance)),
                 }
                 .ToDictionary(entry => entry.type, entry => CreateParserWithErrorHandling(entry.parser));
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CanonicalSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CanonicalSearchTests.cs
@@ -39,12 +39,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             }
             else
             {
-                // Canonical components stripped from indexing and in search request
-                Assert.Collection(
-                    result.Resource.Entry,
-                    x => Assert.Equal(Fixture.ObservationProfileV1, x.Resource.Meta.Profile.First()),
-                    x => Assert.Equal(Fixture.ObservationProfileV2, x.Resource.Meta.Profile.First()),
-                    x => Assert.Equal(Fixture.ObservationProfileUriAlternate, x.Resource.Meta.Profile.First()));
+                // Canonical components stripped from indexing (Canonical => Uri)
+                Assert.Empty(result.Resource.Entry);
             }
         }
 
@@ -87,12 +83,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             }
             else
             {
-                // Canonical components stripped from indexing and in search request
-                Assert.Collection(
-                    result.Resource.Entry,
-                    x => Assert.Equal(Fixture.ObservationProfileV1, x.Resource.Meta.Profile.First()),
-                    x => Assert.Equal(Fixture.ObservationProfileV2, x.Resource.Meta.Profile.First()),
-                    x => Assert.Equal(Fixture.ObservationProfileUriAlternate, x.Resource.Meta.Profile.First()));
+                // Canonical components stripped from indexing
+                Assert.Empty(result.Resource.Entry);
             }
         }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/UriSearchTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/UriSearchTestFixture.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Client;
@@ -20,19 +21,24 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
         public IReadOnlyList<ValueSet> ValueSets { get; private set; }
 
+        public string FixtureTag { get; set; }
+
         protected override async Task OnInitializedAsync()
         {
             // Prepare the resources used for URI search tests.
-            await TestFhirClient.DeleteAllResources(ResourceType.ValueSet);
+            FixtureTag = Guid.NewGuid().ToString();
 
             ValueSets = await TestFhirClient.CreateResourcesAsync<ValueSet>(
                 vs => AddValueSet(vs, "http://somewhere.com/test/system"),
-                vs => AddValueSet(vs, "urn://localhost/test"));
+                vs => AddValueSet(vs, "urn://localhost/test"),
+                vs => AddValueSet(vs, "http://example.org/rdf#54135-9"));
 
             void AddValueSet(ValueSet vs, string url)
             {
                 vs.Status = PublicationStatus.Active;
                 vs.Url = url;
+                vs.Meta = new Meta();
+                vs.Meta.Tag.Add(new Coding(null, FixtureTag));
             }
         }
     }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/UriSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/UriSearchTests.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Linq;
+using System.Web;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Xunit;
@@ -22,16 +23,17 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [Theory]
         [InlineData("", "http://somewhere.com/test/system", 0)]
         [InlineData("", "http://somewhere.COM/test/system")]
+        [InlineData("", "http://example.org/rdf#54135-9", 2)]
         [InlineData("", "urn://localhost/test", 1)]
         [InlineData(":above", "system", 0)]
         [InlineData(":above", "test")]
         [InlineData(":above", "urn://localhost/test")]
-        [InlineData(":below", "http", 0)]
+        [InlineData(":below", "http", 0, 2)]
         [InlineData(":below", "test")]
         [InlineData(":below", "urn")]
         public async Task GivenAUriSearchParam_WhenSearched_ThenCorrectBundleShouldBeReturned(string modifier, string queryValue, params int[] expectedIndices)
         {
-            Bundle bundle = await Client.SearchAsync(ResourceType.ValueSet, $"url{modifier}={queryValue}");
+            Bundle bundle = await Client.SearchAsync(ResourceType.ValueSet, $"url{modifier}={HttpUtility.UrlEncode(queryValue)}&_tag={Fixture.FixtureTag}");
 
             ValueSet[] expected = expectedIndices.Select(i => Fixture.ValueSets[i]).ToArray();
 


### PR DESCRIPTION
## Description

Splitting Canonical Components for incoming URI queries may break existing searches.

The example for the provided E2E tests is that the following search should continue to work:
```
/ValueSet?url=http://example.org/rdf#54135-9
```
With the previous code the `#54135-9` would be removed from the search query.

## Related issues
Refs #882

## Testing
Updates tests

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch