### PR TITLE
Make sure we return BadRequest for `/?_type=` case.

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -108,6 +108,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                 }
                 else if (string.Equals(query.Item1, KnownQueryParameterNames.Type, StringComparison.OrdinalIgnoreCase))
                 {
+                    if (string.IsNullOrWhiteSpace(query.Item2))
+                    {
+                        throw new BadRequestException(string.Format(Core.Resources.InvalidTypeParameter, query.Item2));
+                    }
+
                     var types = query.Item2.SplitByOrSeparator();
                     var badTypes = types.Where(type => !ModelInfoProvider.IsKnownResource(type)).ToHashSet();
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -222,6 +222,15 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenEmptyTypeOfResource_WhenSearching_ThenBadRequestShouldBeReturned()
+        {
+            using FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.SearchAsync($"?_type="));
+
+            Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
         public async Task GivenSomeInvalidTypeOfResources_WhenSearchingAcrossAllResourceTypes_ThenSearchHasProperOutcome()
         {
             Patient[] patients = await Client.CreateResourcesAsync<Patient>(3);


### PR DESCRIPTION
## Description
Return BadRequest in case of `/?type=` request.

## Related issues
Addresses [#1562].

## Testing
Manual and unit test

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip (it's a small fix)
