### PR TITLE
Add Retry-After header on 429

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Headers/HeaderDictionaryExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Headers/HeaderDictionaryExtensions.cs
@@ -1,0 +1,33 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Globalization;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.Health.Fhir.Api.Features.Headers
+{
+    internal static class HeaderDictionaryExtensions
+    {
+        /// <summary>
+        /// Adds x-ms-retry-after-ms and Retry-After response headers. The former is used by Cosmos DB and is expressed in ms, the latter is the W3C standard header and expressed in
+        /// seconds. The seconds will be >= 1 unless the timespan is really 0.
+        /// </summary>
+        /// <param name="responseHeaders">The response headers</param>
+        /// <param name="retryAfterTimeSpan">The time</param>
+        public static void AddRetryAfterHeaders(this IHeaderDictionary responseHeaders, TimeSpan retryAfterTimeSpan)
+        {
+            responseHeaders.Add(
+                KnownHeaders.RetryAfterMilliseconds,
+                ((int)retryAfterTimeSpan.TotalMilliseconds).ToString(CultureInfo.InvariantCulture));
+
+            int retryAfterSeconds = retryAfterTimeSpan == default ? 0 : Math.Max(1, (int)Math.Round(retryAfterTimeSpan.TotalSeconds));
+
+            responseHeaders.Add(
+                KnownHeaders.RetryAfter,
+                retryAfterSeconds.ToString(CultureInfo.InvariantCulture));
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Api/Features/Headers/KnownHeaders.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Headers/KnownHeaders.cs
@@ -10,5 +10,6 @@ namespace Microsoft.Health.Fhir.Api.Features.Headers
         public const string IfNoneExist = "If-None-Exist";
         public const string PartiallyIndexedParamsHeaderName = "x-ms-use-partial-indices";
         public const string RetryAfterMilliseconds = "x-ms-retry-after-ms";
+        public const string RetryAfter = "Retry-After";
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Features/Throttling/ThrottlingMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Throttling/ThrottlingMiddleware.cs
@@ -259,8 +259,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Throttling
 
             context.Response.StatusCode = StatusCodes.Status429TooManyRequests;
 
-            // note we are aligning with Cosmos DB and not returning the standard header (which is in seconds)
-            context.Response.Headers[KnownHeaders.RetryAfterMilliseconds] = _currentRetryAfterMilliseconds.ToString();
+            context.Response.Headers.AddRetryAfterHeaders(TimeSpan.FromMilliseconds(_currentRetryAfterMilliseconds));
 
             context.Response.ContentLength = _throttledBody.Length;
             context.Response.ContentType = ThrottledContentType;

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
@@ -164,6 +164,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
 
                         if (ex.RetryAfter != null)
                         {
+                            healthExceptionResult.Headers.AddRetryAfterHeaders(ex.RetryAfter.Value);
                             healthExceptionResult.Headers.Add(
                                 KnownHeaders.RetryAfterMilliseconds,
                                 ex.RetryAfter.Value.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
@@ -165,9 +165,6 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
                         if (ex.RetryAfter != null)
                         {
                             healthExceptionResult.Headers.AddRetryAfterHeaders(ex.RetryAfter.Value);
-                            healthExceptionResult.Headers.Add(
-                                KnownHeaders.RetryAfterMilliseconds,
-                                ex.RetryAfter.Value.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
                         }
 
                         break;


### PR DESCRIPTION
## Description
Based on customer feedback, we're adding the standard `Retry-After` header in addition to the existing `x-ms-retry-after-ms` header.

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
