### PR TITLE
Group export: Handle empty groups correctly

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -682,12 +682,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                 if (patientIds.Count == 0)
                 {
                     _logger.LogInformation($"Group {groupId} does not have any patient ids as members.");
-                    SearchResult emptySearchResult = new SearchResult(
-                        results: new List<SearchResultEntry>(),
-                        continuationToken: null,
-                        sortOrder: null,
-                        unsupportedSearchParameters: new List<Tuple<string, string>>());
-                    return emptySearchResult;
+                    return SearchResult.Empty();
                 }
 
                 queryParametersList.Add(Tuple.Create(KnownQueryParameterNames.Id, string.Join(',', patientIds)));

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -677,7 +677,19 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
         {
             if (!queryParametersList.Exists((Tuple<string, string> parameter) => parameter.Item1 == KnownQueryParameterNames.Id || parameter.Item1 == KnownQueryParameterNames.ContinuationToken))
             {
-                var patientIds = await _groupMemberExtractor.GetGroupPatientIds(groupId, groupMembershipTime, cancellationToken);
+                HashSet<string> patientIds = await _groupMemberExtractor.GetGroupPatientIds(groupId, groupMembershipTime, cancellationToken);
+
+                if (patientIds.Count == 0)
+                {
+                    _logger.LogInformation($"Group {groupId} does not have any patient ids as members.");
+                    SearchResult emptySearchResult = new SearchResult(
+                        results: new List<SearchResultEntry>(),
+                        continuationToken: null,
+                        sortOrder: null,
+                        unsupportedSearchParameters: new List<Tuple<string, string>>());
+                    return emptySearchResult;
+                }
+
                 queryParametersList.Add(Tuple.Create(KnownQueryParameterNames.Id, string.Join(',', patientIds)));
             }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchResult.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchResult.cs
@@ -68,5 +68,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
         public string ContinuationToken { get; }
 
         public IReadOnlyList<(SearchParameterInfo searchParameterInfo, SortOrder sortOrder)> SortOrder { get; }
+
+        public static SearchResult Empty(IReadOnlyList<Tuple<string, string>> unsupportedSearchParams = null)
+        {
+            return new SearchResult(totalCount: 0, unsupportedSearchParams ?? new List<Tuple<string, string>>());
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchServiceTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchServiceTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
             _searchOptionsFactory.Create(resourceType, _queryParameters).Returns(expectedSearchOptions);
 
-            var expectedSearchResult = new SearchResult(new SearchResultEntry[0], null, null, _unsupportedQueryParameters);
+            var expectedSearchResult = SearchResult.Empty(_unsupportedQueryParameters);
 
             _searchService.SearchImplementation = options =>
             {
@@ -78,7 +78,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
             _searchOptionsFactory.Create(compartmentType, compartmentId, resourceType, _queryParameters).Returns(expectedSearchOptions);
 
-            var expectedSearchResult = new SearchResult(new SearchResultEntry[0], null, null, _unsupportedQueryParameters);
+            var expectedSearchResult = SearchResult.Empty(_unsupportedQueryParameters);
 
             _searchService.SearchImplementation = options =>
             {
@@ -98,7 +98,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             const string resourceType = "Observation";
             const string resourceId = "abc";
 
-            _searchService.SearchImplementation = options => new SearchResult(new SearchResultEntry[0], null, null, _unsupportedQueryParameters);
+            _searchService.SearchImplementation = options => SearchResult.Empty(_unsupportedQueryParameters);
 
             await Assert.ThrowsAsync<ResourceNotFoundException>(() => _searchService.SearchHistoryAsync(resourceType, resourceId, null, null, null, null, null, CancellationToken.None));
         }
@@ -113,7 +113,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
             var resourceWrapper =
                 new ResourceWrapper(observation, _rawResourceFactory.Create(observation, keepMeta: true), _resourceRequest, false, null, null, null);
-            _searchService.SearchImplementation = options => new SearchResult(new SearchResultEntry[0], null, null, _unsupportedQueryParameters);
+            _searchService.SearchImplementation = options => SearchResult.Empty(_unsupportedQueryParameters);
 
             _fhirDataStore.GetAsync(Arg.Any<ResourceKey>(), Arg.Any<CancellationToken>()).Returns(resourceWrapper);
 
@@ -140,7 +140,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             _searchService.SearchImplementation = options =>
             {
                 testOptions = options;
-                return new SearchResult(new SearchResultEntry[0], null, null, _unsupportedQueryParameters);
+                return SearchResult.Empty(_unsupportedQueryParameters);
             };
 
             SearchResult searchResult = await _searchService.SearchForReindexAsync(new List<Tuple<string, string>>() { new Tuple<string, string>("_type", resourceType) }, hashValue, countOnly, CancellationToken.None);

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Behaviors/ListSearchPipeBehavior.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Behaviors/ListSearchPipeBehavior.cs
@@ -99,8 +99,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Behavior
         {
             SearchOptions searchOptions = _searchOptionsFactory.Create(request.ResourceType, request.Queries);
 
-            SearchResult emptySearchResult =
-                new SearchResult(new List<SearchResultEntry>(), null, null, searchOptions.UnsupportedSearchParams);
+            SearchResult emptySearchResult = SearchResult.Empty(searchOptions.UnsupportedSearchParams);
 
             ResourceElement bundle = _bundleFactory.CreateSearchBundle(emptySearchResult);
             return new SearchResourceResponse(bundle);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ExportDataValidationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ExportDataValidationTests.cs
@@ -202,6 +202,18 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             IList<Uri> blobUris = await CheckExportStatus(contentLocation);
 
             Assert.Empty(blobUris);
+
+            async Task<string> CreateGroupWithoutPatientIds()
+            {
+                var group = new FhirGroup()
+                {
+                    Type = FhirGroup.GroupType.Person,
+                    Actual = true,
+                };
+
+                var groupResponse = await _testFhirClient.CreateAsync(group);
+                return groupResponse.Resource.Id;
+            }
         }
 
         [Fact(Skip = "Failing CI build")]
@@ -543,18 +555,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             }
 
             return (resourceDictionary, groupId);
-        }
-
-        private async Task<string> CreateGroupWithoutPatientIds()
-        {
-            var group = new FhirGroup()
-            {
-                Type = FhirGroup.GroupType.Person,
-                Actual = true,
-            };
-
-            var groupResponse = await _testFhirClient.CreateAsync(group);
-            return groupResponse.Resource.Id;
         }
     }
 }


### PR DESCRIPTION
## Description
When exporting a group that has no members we end up exporting all patient data. This PR updates the code to handle this scenario correctly and export nothing.

## Related issues
Addresses #1634 

## Testing
Manual testing on local deployment. Added E2E test.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
