### PR TITLE
Increase max limit of _count parameter

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Configs/CoreFeatureConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/CoreFeatureConfiguration.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Health.Fhir.Core.Configs
         /// <summary>
         /// Gets or sets the default value for maximum value for _count in search.
         /// </summary>
-        public int MaxItemCountPerSearch { get; set; } = 100;
+        public int MaxItemCountPerSearch { get; set; } = 1000;
 
         /// <summary>
         /// Gets or sets the default value for _count in search.


### PR DESCRIPTION
## Description
Increase max limit of _count parameter

## Related issues
Addresses [AB#79296](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Resolute/Stories/?workitem=79296)

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
