### PR TITLE
Reindex bug fixes

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
@@ -112,5 +112,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations
         public const string RollingFileSizeInMB = "rollingFileSizeInMB";
 
         public const string Issues = "issues";
+
+        public const string TotalResourcesToReindex = "totalResourcesToReindex";
+
+        public const string ResourcesSuccessfullyReindexed = "resourcesSuccessfullyReindexed";
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -127,7 +127,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                             OperationOutcomeConstants.IssueSeverity.Information,
                             OperationOutcomeConstants.IssueType.Informational,
                             Resources.NoResourcesNeedToBeReindexed));
-                        _reindexJobRecord.CanceledTime = DateTimeOffset.UtcNow;
                         await UpdateParametersAndCompleteJob(cancellationToken);
                         return;
                     }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -71,7 +71,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
 
             try
             {
-                if (_reindexJobRecord.Status != OperationStatus.Running)
+                if (_reindexJobRecord.Status != OperationStatus.Running ||
+                    _reindexJobRecord.StartTime == null)
                 {
                     // update job record to running
                     _reindexJobRecord.Status = OperationStatus.Running;
@@ -127,7 +128,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                             OperationOutcomeConstants.IssueType.Informational,
                             Resources.NoResourcesNeedToBeReindexed));
                         _reindexJobRecord.CanceledTime = DateTimeOffset.UtcNow;
-                        await CompleteJobAsync(OperationStatus.Canceled, cancellationToken);
+                        await UpdateParametersAndCompleteJob(cancellationToken);
                         return;
                     }
 
@@ -263,6 +264,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     {
                         await CompleteJobAsync(OperationStatus.Failed, cancellationToken);
                     }
+                    else
+                    {
+                        _reindexJobRecord.Status = OperationStatus.Queued;
+                        await UpdateJobAsync(cancellationToken);
+                    }
                 }
                 finally
                 {
@@ -372,24 +378,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                 // all queries marked as complete, reindex job is done, check success or failure
                 if (_reindexJobRecord.QueryList.All(q => q.Status == OperationStatus.Completed))
                 {
-                    (bool success, string error) = await _reindexUtilities.UpdateSearchParameterStatus(_reindexJobRecord.SearchParams, cancellationToken);
-
-                    if (success)
-                    {
-                        await CompleteJobAsync(OperationStatus.Completed, cancellationToken);
-                        _logger.LogInformation($"Reindex job successfully completed, id {_reindexJobRecord.Id}.");
-                    }
-                    else
-                    {
-                        var issue = new OperationOutcomeIssue(
-                            OperationOutcomeConstants.IssueSeverity.Error,
-                            OperationOutcomeConstants.IssueType.Exception,
-                            error);
-                        _reindexJobRecord.Error.Add(issue);
-                        _logger.LogError(error);
-
-                        await CompleteJobAsync(OperationStatus.Failed, cancellationToken);
-                    }
+                    await UpdateParametersAndCompleteJob(cancellationToken);
                 }
                 else
                 {
@@ -464,10 +453,35 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
 
                 // update the complete total
                 SearchResult countOnlyResults = await ExecuteReindexQueryAsync(queryForCount, countOnly: true, cancellationToken);
-                totalCount += countOnlyResults.TotalCount.Value;
+                if (countOnlyResults != null)
+                {
+                    totalCount += countOnlyResults.TotalCount.Value;
+                }
             }
 
             _reindexJobRecord.Count = totalCount;
+        }
+
+        private async Task UpdateParametersAndCompleteJob(CancellationToken cancellationToken)
+        {
+            (bool success, string error) = await _reindexUtilities.UpdateSearchParameterStatus(_reindexJobRecord.SearchParams, cancellationToken);
+
+            if (success)
+            {
+                await CompleteJobAsync(OperationStatus.Completed, cancellationToken);
+                _logger.LogInformation($"Reindex job successfully completed, id {_reindexJobRecord.Id}.");
+            }
+            else
+            {
+                var issue = new OperationOutcomeIssue(
+                    OperationOutcomeConstants.IssueSeverity.Error,
+                    OperationOutcomeConstants.IssueType.Exception,
+                    error);
+                _reindexJobRecord.Error.Add(issue);
+                _logger.LogError(error);
+
+                await CompleteJobAsync(OperationStatus.Failed, cancellationToken);
+            }
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -629,7 +629,7 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No resources were found matching the type of the updated search parameters needing to be reindexed.  ReindexJob cancelled..
+        ///   Looks up a localized string similar to No resources were found matching the type of the updated search parameters needing to be reindexed.  ReindexJob marked completed..
         /// </summary>
         internal static string NoResourcesNeedToBeReindexed {
             get {

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -526,7 +526,7 @@
     <comment>{0} the uri identifying the custom search parameter.</comment>
   </data>
   <data name="NoResourcesNeedToBeReindexed" xml:space="preserve">
-    <value>No resources were found matching the type of the updated search parameters needing to be reindexed.  ReindexJob cancelled.</value>
+    <value>No resources were found matching the type of the updated search parameters needing to be reindexed.  ReindexJob marked completed.</value>
   </data>
   <data name="ProvenanceHeaderMalformed" xml:space="preserve">
     <value>X-Provenance header is malformed and can't be parsed</value>

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ReindexControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ReindexControllerTests.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
                 Arg.Is<GetReindexRequest>(r => r.JobId == "id"), Arg.Any<CancellationToken>());
 
             var parametersResource = (((FhirResult)result).Result as ResourceElement).ResourceInstance as Parameters;
-            Assert.Equal("Queued", parametersResource.Parameter[3].Value.ToString());
+            Assert.Equal("Queued", parametersResource.Parameter[5].Value.ToString());
         }
 
         [Theory]
@@ -113,7 +113,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
             _mediator.ClearReceivedCalls();
 
             var parametersResource = (((FhirResult)result).Result as ResourceElement).ResourceInstance as Parameters;
-            Assert.Equal("Queued", parametersResource.Parameter[3].Value.ToString());
+            Assert.Equal("Queued", parametersResource.Parameter[5].Value.ToString());
         }
 
         private ReindexController GetController(ReindexJobConfiguration reindexConfig)

--- a/src/Microsoft.Health.Fhir.Shared.Core/Extensions/ReindexJobRecordExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Extensions/ReindexJobRecordExtensions.cs
@@ -26,6 +26,17 @@ namespace Microsoft.Health.Fhir.Core.Extensions
             parametersResource.Parameter = new List<Parameters.ParameterComponent>();
             parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = JobRecordProperties.Id, Value = new FhirString(job.Id) });
 
+            if (job.Error != null && job.Error.Count > 0)
+            {
+                var outputMessages = new List<Parameters.ParameterComponent>();
+                foreach (var error in job.Error)
+                {
+                    outputMessages.Add(new Parameters.ParameterComponent() { Name = error.Code, Value = new FhirString(error.Diagnostics) });
+                }
+
+                parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = JobRecordProperties.Output, Part = outputMessages });
+            }
+
             if (job.StartTime.HasValue)
             {
                 parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = JobRecordProperties.StartTime, Value = new FhirDateTime(job.StartTime.Value) });
@@ -37,6 +48,8 @@ namespace Microsoft.Health.Fhir.Core.Extensions
             }
 
             parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = JobRecordProperties.QueuedTime, Value = new FhirDateTime(job.QueuedTime) });
+            parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = JobRecordProperties.TotalResourcesToReindex, Value = new FhirDecimal(job.Count) });
+            parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = JobRecordProperties.ResourcesSuccessfullyReindexed, Value = new FhirDecimal(job.Progress) });
             parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = JobRecordProperties.Progress, Value = new FhirDecimal(job.PercentComplete) });
             parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = JobRecordProperties.Status, Value = new FhirString(job.Status.ToString()) });
             parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = JobRecordProperties.MaximumConcurrency, Value = new FhirDecimal(job.MaximumConcurrency) });

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
 
                     if (badTypes.Count != 0)
                     {
-                        _contextAccessor.FhirRequestContext.BundleIssues.Add(
+                        _contextAccessor.FhirRequestContext?.BundleIssues.Add(
                             new OperationOutcomeIssue(
                                 OperationOutcomeConstants.IssueSeverity.Warning,
                                 OperationOutcomeConstants.IssueType.NotSupported,
@@ -192,7 +192,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                 {
                     searchOptions.MaxItemCount = _featureConfiguration.MaxItemCountPerSearch;
 
-                    _contextAccessor.FhirRequestContext.BundleIssues.Add(
+                    _contextAccessor.FhirRequestContext?.BundleIssues.Add(
                         new OperationOutcomeIssue(
                             OperationOutcomeConstants.IssueSeverity.Information,
                             OperationOutcomeConstants.IssueType.Informational,
@@ -352,7 +352,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                     catch (SearchParameterNotSupportedException)
                     {
                         sortingsValid = false;
-                        _contextAccessor.FhirRequestContext.BundleIssues.Add(new OperationOutcomeIssue(
+                        _contextAccessor.FhirRequestContext?.BundleIssues.Add(new OperationOutcomeIssue(
                             OperationOutcomeConstants.IssueSeverity.Warning,
                             OperationOutcomeConstants.IssueType.NotSupported,
                             string.Format(CultureInfo.InvariantCulture, Core.Resources.SearchParameterNotSupported, sorting.Item1, string.Join(", ", resourceTypesString))));
@@ -372,7 +372,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
 
                         foreach (var errorMessage in errorMessages)
                         {
-                            _contextAccessor.FhirRequestContext.BundleIssues.Add(new OperationOutcomeIssue(
+                            _contextAccessor.FhirRequestContext?.BundleIssues.Add(new OperationOutcomeIssue(
                                 OperationOutcomeConstants.IssueSeverity.Warning,
                                 OperationOutcomeConstants.IssueType.NotSupported,
                                 errorMessage));
@@ -418,7 +418,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                     // See https://www.hl7.org/fhir/search.html#revinclude.
                     if (expression.Iterate && expression.CircularReference)
                     {
-                        _contextAccessor.FhirRequestContext.BundleIssues.Add(
+                        _contextAccessor.FhirRequestContext?.BundleIssues.Add(
                         new OperationOutcomeIssue(
                             OperationOutcomeConstants.IssueSeverity.Information,
                             OperationOutcomeConstants.IssueType.Informational,

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/SearchParameter.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/SearchParameter.json
@@ -32,7 +32,7 @@
         }
     ],
     "description": "A server defined search that may match any of the string fields in the HumanName, including family, give, prefix, suffix, suffix, and/or text",
-    "code": "name",
+    "code": "foo",
     "base": [ "Patient" ],
     "type": "string",
     "expression": "Patient.name",

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -188,7 +188,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
         }
 
         [Fact]
-        public async Task GivenNoMatchingResources_WhenRunningReindexJob_ThenJobIsCanceled()
+        public async Task GivenNoMatchingResources_WhenRunningReindexJob_ThenJobIsCompleted()
         {
             var searchParam = _supportedSearchParameterDefinitionManager.GetSearchParameter(new Uri("http://hl7.org/fhir/SearchParameter/Measure-name"));
             searchParam.IsSearchable = false;
@@ -213,7 +213,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                 var reindexJobWrapper = await _fhirOperationDataStore.GetReindexJobByIdAsync(response.Job.JobRecord.Id, cancellationTokenSource.Token);
 
                 int delayCount = 0;
-                while (reindexJobWrapper.JobRecord.Status != OperationStatus.Canceled
+                while (reindexJobWrapper.JobRecord.Status != OperationStatus.Completed
                     && delayCount < 10)
                 {
                     await Task.Delay(1000);
@@ -222,6 +222,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                 }
 
                 Assert.True(delayCount <= 9);
+                Assert.True(searchParam.IsSearchable);
             }
             finally
             {


### PR DESCRIPTION
## Description
Fix reindex behavior to properly update parameters when a job has no resources to reindex.  Handle null refs and update SearchParameters.json test file

## Related issues
Addresses [issue [AB#79555](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/79555)].

## Testing
E2E tests and integeration tests were updated, as well as manual tests.

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
Skip, a bug fix