### PR TITLE
Adding mediator to notify about exceptions

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Extensions/ExceptionExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Api/Extensions/ExceptionExtensions.cs
@@ -8,7 +8,7 @@ using EnsureThat;
 
 namespace Microsoft.Health.Fhir.Api.Extensions
 {
-    public static class ExceptionExtensions
+    internal static class ExceptionExtensions
     {
         public static Exception GetInnerMostException(this Exception input)
         {

--- a/src/Microsoft.Health.Fhir.Api/Extensions/ExceptionExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Api/Extensions/ExceptionExtensions.cs
@@ -1,0 +1,27 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using EnsureThat;
+
+namespace Microsoft.Health.Fhir.Api.Extensions
+{
+    public static class ExceptionExtensions
+    {
+        public static Exception GetInnerMostException(this Exception input)
+        {
+            EnsureArg.IsNotNull(input, nameof(input));
+
+            Exception current = input;
+
+            while (current.InnerException != null)
+            {
+                current = current.InnerException;
+            }
+
+            return current;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Api/Features/ExceptionNotifications/ExceptionNotification.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/ExceptionNotifications/ExceptionNotification.cs
@@ -1,0 +1,98 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Net;
+using Microsoft.Health.Fhir.Core.Features.Metrics;
+
+namespace Microsoft.Health.Fhir.Api.Features.ExceptionNotifications
+{
+    /// <summary>
+    /// A MediatR message containing information about exceptions with the context of the current request.
+    /// Consume these using MediatR to collect stats about exceptions.
+    /// </summary>
+    public class ExceptionNotification : IMetricsNotification
+    {
+        /// <summary>
+        /// The FHIR operation being performed.
+        /// </summary>
+        public string FhirOperation { get; set; }
+
+        /// <summary>
+        /// The type of FHIR resource associated with this context.
+        /// </summary>
+        public string ResourceType { get; set; }
+
+        /// <summary>
+        /// The response HTTP status code to the request.
+        /// </summary>
+        public HttpStatusCode StatusCode { get; set; }
+
+        /// <summary>
+        /// The amount of time elapsed to process the request.
+        /// </summary>
+        public TimeSpan Latency { get; set; }
+
+        /// <summary>
+        /// The correlation id associated with the current request.
+        /// </summary>
+        public string CorrelationId { get; set; }
+
+        /// <summary>
+        /// The the outer exception type.
+        /// </summary>
+        public string OuterExceptionType { get; set; }
+
+        /// <summary>
+        /// The the outer method that caused the exception.
+        /// </summary>
+        public string OuterMethod { get; set; }
+
+        /// <summary>
+        /// The Message property for the exception.
+        /// </summary>
+        public string ExceptionMessage { get; set; }
+
+        /// <summary>
+        /// The StackTrace property for the exception.
+        /// </summary>
+        public string StackTrace { get; set; }
+
+        /// <summary>
+        /// The InnerMostExceptionType for the exception.
+        /// </summary>
+        public string InnerMostExceptionType { get; set; }
+
+        /// <summary>
+        /// The InnerMostExceptionMessage property for the exception.
+        /// </summary>
+        public string InnerMostExceptionMessage { get; set; }
+
+        /// <summary>
+        /// The HResult property for the exception.
+        /// </summary>
+        public int HResult { get; set; }
+
+        /// <summary>
+        /// The Source property for the exception.
+        /// </summary>
+        public string Source { get; set; }
+
+        /// <summary>
+        /// The TargetSite property for the exception.
+        /// </summary>
+        public string TargetSite { get; set; }
+
+        /// <summary>
+        /// The IsRequestEntityTooLarge extension property for the exception.
+        /// </summary>
+        public bool IsRequestEntityTooLarge { get; set; }
+
+        /// <summary>
+        /// The IsRequestRateExceeded extension property for the exception.
+        /// </summary>
+        public bool IsRequestRateExceeded { get; set; }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Api/Features/ExceptionNotifications/ExceptionNotificationMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/ExceptionNotifications/ExceptionNotificationMiddleware.cs
@@ -1,0 +1,87 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Net;
+using System.Threading;
+using EnsureThat;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Health.Fhir.Api.Extensions;
+using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Core.Features.Context;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Fhir.Api.Features.ExceptionNotifications
+{
+    public class ExceptionNotificationMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly ILogger<ExceptionNotificationMiddleware> _logger;
+        private readonly IMediator _mediator;
+        private readonly IFhirRequestContextAccessor _fhirRequestContextAccessor;
+
+        public ExceptionNotificationMiddleware(
+            RequestDelegate next,
+            ILogger<ExceptionNotificationMiddleware> logger,
+            IFhirRequestContextAccessor fhirRequestContextAccessor,
+            IMediator mediator)
+        {
+            EnsureArg.IsNotNull(next, nameof(next));
+            EnsureArg.IsNotNull(logger, nameof(logger));
+            EnsureArg.IsNotNull(fhirRequestContextAccessor, nameof(fhirRequestContextAccessor));
+            EnsureArg.IsNotNull(mediator, nameof(mediator));
+
+            _next = next;
+            _logger = logger;
+            _fhirRequestContextAccessor = fhirRequestContextAccessor;
+            _mediator = mediator;
+        }
+
+        public async Task Invoke(HttpContext context)
+        {
+            try
+            {
+                await _next(context);
+            }
+            catch (Exception exception)
+            {
+                var exceptionNotification = new ExceptionNotification();
+
+                try
+                {
+                    IFhirRequestContext fhirRequestContext = _fhirRequestContextAccessor.FhirRequestContext;
+                    var innerMostException = exception.GetInnerMostException();
+
+                    exceptionNotification.CorrelationId = fhirRequestContext?.CorrelationId;
+                    exceptionNotification.FhirOperation = fhirRequestContext?.AuditEventType;
+                    exceptionNotification.OuterExceptionType = exception.GetType().ToString();
+                    exceptionNotification.ResourceType = fhirRequestContext?.ResourceType;
+                    exceptionNotification.StatusCode = (HttpStatusCode)context.Response.StatusCode;
+                    exceptionNotification.ExceptionMessage = exception.Message;
+                    exceptionNotification.StackTrace = exception.StackTrace;
+                    exceptionNotification.InnerMostExceptionType = innerMostException.GetType().ToString();
+                    exceptionNotification.InnerMostExceptionMessage = innerMostException.Message;
+                    exceptionNotification.HResult = exception.HResult;
+                    exceptionNotification.Source = exception.Source;
+                    exceptionNotification.OuterMethod = exception.TargetSite?.Name;
+                    exceptionNotification.IsRequestEntityTooLarge = exception.IsRequestEntityTooLarge();
+                    exceptionNotification.IsRequestRateExceeded = exception.IsRequestRateExceeded();
+
+                    await _mediator.Publish(exceptionNotification, CancellationToken.None);
+                }
+                catch (Exception e)
+                {
+                    // Failures in publishing exception notifications should not cause the API to return an error.
+                    _logger.LogWarning(e, "Failure while publishing Exception notification.");
+                }
+
+                // Rethrowing the exception so the BaseExceptionMiddleware can handle it. We are only notifying there is an exception at this point.
+                throw;
+            }
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Api/Features/ExceptionNotifications/ExceptionNotificationMiddlewareExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/ExceptionNotifications/ExceptionNotificationMiddlewareExtensions.cs
@@ -1,0 +1,17 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Builder;
+
+namespace Microsoft.Health.Fhir.Api.Features.ExceptionNotifications
+{
+    public static class ExceptionNotificationMiddlewareExtensions
+    {
+        public static IApplicationBuilder UseExceptionNotificationMiddleware(this IApplicationBuilder builder)
+        {
+            return builder.UseMiddleware<ExceptionNotificationMiddleware>();
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Exceptions/ExceptionNotificationMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Exceptions/ExceptionNotificationMiddlewareTests.cs
@@ -1,0 +1,83 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Health.Fhir.Api.Features.ExceptionNotifications;
+using Microsoft.Health.Fhir.Core.Features.Context;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Shared.Api.UnitTests.Features.Exceptions
+{
+    public class ExceptionNotificationMiddlewareTests
+    {
+        private readonly DefaultHttpContext _context;
+        private readonly IFhirRequestContextAccessor _fhirRequestContextAccessor;
+        private readonly IMediator _mediator = Substitute.For<IMediator>();
+
+        public ExceptionNotificationMiddlewareTests()
+        {
+            _fhirRequestContextAccessor = Substitute.For<IFhirRequestContextAccessor>();
+            _context = new DefaultHttpContext();
+        }
+
+        [Fact]
+        public async Task GivenAnHttpContextWithException_WhenExecutingExceptionNotificationMiddleware_MediatRShouldEmitNotification()
+        {
+            var exceptionMessage = "Test exception";
+            var exceptionNotificationMiddleware = CreateExceptionNotificationMiddleware(innerHttpContext => throw new Exception(exceptionMessage));
+
+            try
+            {
+                await exceptionNotificationMiddleware.Invoke(_context);
+            }
+            catch (Exception e)
+            {
+                await _mediator.ReceivedWithAnyArgs(1).Publish(Arg.Any<ExceptionNotification>(), Arg.Any<CancellationToken>());
+                Assert.Equal(exceptionMessage, e.Message);
+            }
+        }
+
+        [Fact]
+        public async Task GivenAnHttpContextWithNoException_WhenExecutingExceptionNotificationMiddleware_MediatRShouldNotEmitNotification()
+        {
+            var exceptionNotificationMiddleware = CreateExceptionNotificationMiddleware(innerHttpContext => Task.CompletedTask);
+
+            await exceptionNotificationMiddleware.Invoke(_context);
+
+            await _mediator.DidNotReceiveWithAnyArgs().Publish(Arg.Any<object>(), Arg.Any<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task WhenMediatRFails_OriginalExceptionStillThrown()
+        {
+            var exceptionMessage = "Test exception";
+            var mediatorExceptionMessage = "Mediator Failure";
+
+            var exceptionNotificationMiddleware = CreateExceptionNotificationMiddleware(innerHttpContext => throw new Exception(exceptionMessage));
+            _mediator.WhenForAnyArgs(async x => await x.Publish(Arg.Any<ExceptionNotificationMiddleware>(), Arg.Any<CancellationToken>())).Throw(new System.Exception(mediatorExceptionMessage));
+
+            try
+            {
+                await exceptionNotificationMiddleware.Invoke(_context);
+            }
+            catch (Exception e)
+            {
+                await _mediator.DidNotReceiveWithAnyArgs().Publish(Arg.Any<object>(), Arg.Any<CancellationToken>());
+                Assert.Equal(exceptionMessage, e.Message);
+            }
+        }
+
+        private ExceptionNotificationMiddleware CreateExceptionNotificationMiddleware(RequestDelegate nextDelegate)
+        {
+            return Substitute.ForPartsOf<ExceptionNotificationMiddleware>(nextDelegate, NullLogger<ExceptionNotificationMiddleware>.Instance, _fhirRequestContextAccessor, _mediator);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Exceptions/ExceptionNotificationMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Exceptions/ExceptionNotificationMiddlewareTests.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Health.Fhir.Shared.Api.UnitTests.Features.Exceptions
 
         private ExceptionNotificationMiddleware CreateExceptionNotificationMiddleware(RequestDelegate nextDelegate)
         {
-            return Substitute.ForPartsOf<ExceptionNotificationMiddleware>(nextDelegate, NullLogger<ExceptionNotificationMiddleware>.Instance, _fhirRequestContextAccessor, _mediator);
+            return new ExceptionNotificationMiddleware(nextDelegate, NullLogger<ExceptionNotificationMiddleware>.Instance, _fhirRequestContextAccessor, _mediator);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Microsoft.Health.Fhir.Shared.Api.UnitTests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Microsoft.Health.Fhir.Shared.Api.UnitTests.projitems
@@ -25,6 +25,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Context\FhirRequestContextBeforeAuthenticationMiddlewareTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Context\FhirRequestContextMiddlewareTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Exceptions\BaseExceptionMiddlewareTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Exceptions\ExceptionNotificationMiddlewareTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Filters\FhirRequestContextRouteDataPopulatingFilterAttributeTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Filters\FilterTestsHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Filters\OperationOutcomeExceptionFilterTests.cs" />

--- a/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
@@ -151,9 +151,6 @@ namespace Microsoft.Extensions.DependencyInjection
                     }
                     else
                     {
-                        // This middleware creates notifications for each exception that is encountered with the context of the current request.
-                        app.UseExceptionNotificationMiddleware();
-
                         // This middleware will capture issues within other middleware that prevent the ExceptionHandler from completing.
                         // This should be the first middleware added because they execute in order.
                         app.UseBaseException();
@@ -163,6 +160,9 @@ namespace Microsoft.Extensions.DependencyInjection
 
                         // This middleware will capture any handled error with the status code between 400 and 599 that hasn't had a body or content-type set. (i.e. 404 on unknown routes)
                         app.UseStatusCodePagesWithReExecute(KnownRoutes.CustomError, "?statusCode={0}");
+
+                        // This middleware creates notifications for each exception that is encountered with the context of the current request.
+                        app.UseExceptionNotificationMiddleware();
                     }
 
                     // The audit module needs to come after the exception handler because we need to catch the response before it gets converted to custom error.

--- a/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
@@ -19,6 +19,7 @@ using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Api.Configs;
 using Microsoft.Health.Fhir.Api.Features.ApiNotifications;
 using Microsoft.Health.Fhir.Api.Features.Context;
+using Microsoft.Health.Fhir.Api.Features.ExceptionNotifications;
 using Microsoft.Health.Fhir.Api.Features.Exceptions;
 using Microsoft.Health.Fhir.Api.Features.Operations.Export;
 using Microsoft.Health.Fhir.Api.Features.Operations.Reindex;
@@ -150,6 +151,9 @@ namespace Microsoft.Extensions.DependencyInjection
                     }
                     else
                     {
+                        // This middleware creates notifications for each exception that is encountered with the context of the current request.
+                        app.UseExceptionNotificationMiddleware();
+
                         // This middleware will capture issues within other middleware that prevent the ExceptionHandler from completing.
                         // This should be the first middleware added because they execute in order.
                         app.UseBaseException();


### PR DESCRIPTION
## Description
Adding a middleware and mediator to notify about exceptions in the FHIR service for special logging purposes. The notifications have some information for the current exception and the current request when applicable. 

## Related issues
No related issues. New feature.

## Testing
Unit tests were added. I also wrote a handler to make sure the notifications were being emitted correctly.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
