### PR TITLE
Converts more build tasks to use Linux agents

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,10 @@
 <Project>
 
   <PropertyGroup>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Product>Microsoft Health</Product>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <RepositoryUrl>https://github.com/microsoft/fhir-server/</RepositoryUrl>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
     <!-- allow pre-release dependencies -->
@@ -44,14 +48,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.321" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.321" PrivateAssets="All" />
   </ItemGroup>
 
   <Choose>
     <When Condition="$(MSBuildProjectName)!='SmartLauncher' AND !$(MSBuildProjectName.Contains('Test'))">
       <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.3" />
+        <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.3" PrivateAssets="All" />
       </ItemGroup>
     </When>
   </Choose>

--- a/build/build-variables.yml
+++ b/build/build-variables.yml
@@ -23,6 +23,9 @@ variables:
   TestClientUrl: 'https://$(DeploymentEnvironmentName)-client/'
   ConnectedServiceName: 'Microsoft Health Open Source Subscription'
   WindowsVmImage: 'windows-latest'
+  LinuxVmImage: 'ubuntu-latest'
+  # The following is set by a build Pipeline variable:
+  # DefaultLinuxPool: 'Azure Pipelines'
   #-----------------------------------------------------------------------------------------
   # AKS details
   clusterName: "mshealth-oss-aks-cluster"

--- a/build/ci-pipeline.yml
+++ b/build/ci-pipeline.yml
@@ -15,9 +15,10 @@ stages:
   jobs:
   - job: Semver
     pool:
-      vmImage: $(WindowsVmImage)
+      name: '$(DefaultLinuxPool)'
+      vmImage: '$(LinuxVmImage)'
     steps:
-    - template: ./jobs/update-semver.yml
+    - template: ./jobs/update-semver.yml  
 
 - stage: BuildUnitTests
   displayName: 'Build and run unit tests'
@@ -35,14 +36,15 @@ stages:
       vmImage: $(WindowsVmImage)
     steps:
     - template: ./jobs/build.yml
-
-  - job: Linux
-    pool:
-      vmImage: 'ubuntu-latest'
-    steps:
-    - template: ./jobs/build.yml
       parameters:
         packageArtifacts: false
+  
+  - job: Linux
+    pool:
+      name: '$(DefaultLinuxPool)'
+      vmImage: '$(LinuxVmImage)'
+    steps:
+    - template: ./jobs/build.yml
 
 - stage: DockerBuild  
   displayName: 'Build images'

--- a/build/jobs/add-aad-test-environment.yml
+++ b/build/jobs/add-aad-test-environment.yml
@@ -1,7 +1,7 @@
 jobs:  
 - job: setup
   pool:
-    vmImage: $(WindowsVmImage)
+    vmImage: '$(WindowsVmImage)'
   steps:
   - task: AzureKeyVault@1
     displayName: 'Azure Key Vault: resolute-oss-tenant-info'

--- a/build/jobs/build.yml
+++ b/build/jobs/build.yml
@@ -12,14 +12,15 @@ steps:
   displayName: 'dotnet build $(buildConfiguration)'
   inputs:
     command: build
-    arguments: '--configuration $(buildConfiguration) /p:AssemblyVersion="$(assemblySemVer)" /p:FileVersion="$(assemblySemFileVer)" /p:InformationalVersion="$(informationalVersion)" /p:Version="$(majorMinorPatch)" /warnaserror'
+    arguments: '--configuration $(buildConfiguration) -p:ContinuousIntegrationBuild=true -p:AssemblyVersion="$(assemblySemVer)" -p:FileVersion="$(assemblySemFileVer)" -p:InformationalVersion="$(informationalVersion)" -p:Version="$(majorMinorPatch)" -warnaserror'
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test UnitTests'
   inputs:
     command: test
     projects: '**/*UnitTests/*.csproj'
-    arguments: '--configuration $(buildConfiguration)'
+    arguments: '--configuration $(buildConfiguration) --no-build'
+    testRunTitle: 'Unit Tests'
 
 - ${{ if eq(parameters.packageArtifacts, 'true') }}:
   - template: package.yml

--- a/build/jobs/cleanup.yml
+++ b/build/jobs/cleanup.yml
@@ -2,7 +2,8 @@ jobs:
 - job: DeleteResourceGroup
   displayName: 'Delete resource group'
   pool:
-    vmImage: $(WindowsVmImage)
+    name: '$(DefaultLinuxPool)'
+    vmImage: '$(LinuxVmImage)'
   steps:
   - task: AzurePowerShell@4
     displayName: 'Delete resource group'
@@ -15,7 +16,7 @@ jobs:
 - job: cleanupAad
   displayName: 'Cleanup Azure Active Directory'
   pool:
-    vmImage: $(WindowsVmImage)
+    vmImage: '$(WindowsVmImage)'
   steps:
   - task: AzureKeyVault@1
     displayName: 'Azure Key Vault: resolute-oss-tenant-info'
@@ -58,13 +59,14 @@ jobs:
 - job: deleteImage
   displayName: 'Delete Image'
   pool:
-    vmImage: $(WindowsVmImage)
+    name: '$(DefaultLinuxPool)'
+    vmImage: '$(LinuxVmImage)'
   steps:
   - task: AzureCLI@2
     displayName: 'Delete Image'
     inputs:
       azureSubscription: $(ConnectedServiceName)
-      scriptType: ps
+      scriptType: pscore
       scriptLocation: InlineScript
       inlineScript: |
         az acr repository delete --name $(azureContainerRegistryName) --image 'r4_fhir-server:$(ImageTag)' --yes

--- a/build/jobs/docker-add-tag.yml
+++ b/build/jobs/docker-add-tag.yml
@@ -8,7 +8,8 @@ parameters:
 jobs:
 - job: DockerAddTag
   pool:
-    vmImage: 'ubuntu-latest'
+    name: '$(DefaultLinuxPool)'
+    vmImage: '$(LinuxVmImage)'
   steps:
   - task: AzureCLI@2
     displayName: 'Azure CLI: InlineScript'

--- a/build/jobs/docker-build-push.yml
+++ b/build/jobs/docker-build-push.yml
@@ -10,7 +10,8 @@ parameters:
 jobs:
 - job: '${{parameters.version}}_Docker'
   pool:
-    vmImage: 'ubuntu-latest'
+    name: '$(DefaultLinuxPool)'
+    vmImage: '$(LinuxVmImage)'
   steps:
   - task: DockerCompose@0
     displayName: 'Build FHIR ${{parameters.version}} Server Image'

--- a/build/jobs/package-web.yml
+++ b/build/jobs/package-web.yml
@@ -10,5 +10,5 @@ steps:
     inputs:
       command: publish
       projects: '${{parameters.csproj}}'
-      arguments: '--output $(build.artifactStagingDirectory)/web --configuration $(buildConfiguration) --version-suffix $(build.buildNumber)'
+      arguments: '--output $(build.artifactStagingDirectory)/web --configuration $(buildConfiguration) --version-suffix $(build.buildNumber) --no-build'
       publishWebProjects: false

--- a/build/jobs/package.yml
+++ b/build/jobs/package.yml
@@ -23,18 +23,9 @@ steps:
       zipAfterPublish: false
 
   # Package nugets
-  - task: DotNetCoreCLI@2
-    displayName: 'dotnet pack nugets'
-    inputs:
-      command: pack
-      configuration: '$(buildConfiguration)'
-      packDirectory: '$(build.artifactStagingDirectory)/nupkgs'
-      nobuild: true
-      versioningScheme: byEnvVar
-      versionEnvVar: 'nuget_version'
-      zipAfterPublish: true
-    env:	
-      nuget_version: $(nuGetVersion)
+  - powershell: |
+      & dotnet pack $(Build.SourcesDirectory) --output $(Build.ArtifactStagingDirectory)/nupkgs --no-build --configuration=Release -p:PackageVersion=$(nuGetVersion)
+    name: PackNugets
 
   # Publish artifacts
   - task: PublishBuildArtifacts@1
@@ -68,7 +59,7 @@ steps:
   - task: PublishBuildArtifacts@1
     displayName: 'publish test configuration jsons'
     inputs:
-      pathToPublish: './test/configuration/'
+      pathToPublish: './test/Configuration/'
       artifactName: 'deploy'
       artifactType: 'container'
 

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -29,7 +29,8 @@ parameters:
 jobs:
 - job: provisionEnvironment
   pool:
-    vmImage: $(WindowsVmImage)
+    name: '$(DefaultLinuxPool)'
+    vmImage: '$(LinuxVmImage)'
   steps:
   - task: AzureKeyVault@1
     displayName: 'Azure Key Vault: resolute-oss-tenant-info'
@@ -88,3 +89,6 @@ jobs:
         Write-Host "Setting Key Vault access"
         Set-AzKeyVaultAccessPolicy -VaultName $webAppName -ObjectId 4d4d503d-9ca8-462e-9e18-b35fc8b5285b -PermissionsToSecrets list,get
 
+  - template: ./provision-healthcheck.yml
+    parameters: 
+      webAppName: ${{ parameters.webAppName }}

--- a/build/jobs/provision-healthcheck.yml
+++ b/build/jobs/provision-healthcheck.yml
@@ -1,0 +1,25 @@
+parameters:
+- name: webAppName
+  type: string
+
+steps:
+- powershell: |
+    $healthCheckUrl = "https://${{ parameters.webAppName }}.azurewebsites.net/health/check"
+    $healthStatus = 0
+    Do {
+      Start-Sleep -s 5
+      Write-Host "Checking: $healthCheckUrl"
+
+      try {
+        $healthStatus = (Invoke-WebRequest -URI $healthCheckUrl).statuscode
+        Write-Host "Result: $healthStatus"
+      }
+      catch {
+        Write-Host $PSItem.Exception.Message
+      }
+      finally {
+        $Error.Clear()
+      }
+
+    } While ($healthStatus -ne 200)
+  name: PingHealthCheckEndpoint

--- a/build/jobs/redeploy-webapp.yml
+++ b/build/jobs/redeploy-webapp.yml
@@ -11,7 +11,8 @@ parameters:
 jobs:
 - job: provisionEnvironment
   pool:
-    vmImage: $(WindowsVmImage)
+    name: '$(DefaultLinuxPool)'
+    vmImage: '$(LinuxVmImage)'
   steps:  
   - task: AzureRmWebAppDeployment@4
     displayName: 'Azure App Service Deploy'
@@ -22,3 +23,7 @@ jobs:
       DockerNamespace: $(azureContainerRegistry)
       DockerRepository: '${{ parameters.version }}_fhir-server'
       DockerImageTag: ${{ parameters.imageTag }}
+
+  - template: ./provision-healthcheck.yml
+    parameters: 
+      webAppName: ${{ parameters.webAppName }}

--- a/build/jobs/run-tests.yml
+++ b/build/jobs/run-tests.yml
@@ -7,7 +7,8 @@ parameters:
 jobs:
 - job: "integrationTests"
   pool:
-    vmImage: $(WindowsVmImage)
+    name: '$(DefaultLinuxPool)'
+    vmImage: '$(LinuxVmImage)'
   steps:
   - task: DownloadBuildArtifacts@0
     inputs:
@@ -32,13 +33,12 @@ jobs:
       azureSubscription: $(ConnectedServiceName)
       KeyVaultName: '${{ parameters.keyVaultName }}-sql'
 
-  - task: VSTest@2
+  - task: DotNetCoreCLI@2
     displayName: 'Run Integration Tests'
     inputs:
-      testSelector: testAssemblies
-      testAssemblyVer2: |
-        **\*${{ parameters.version }}.Tests.Integration*.dll
-      searchFolder: '$(System.ArtifactsDirectory)'
+      command: test
+      arguments: '"**\*${{ parameters.version }}.Tests.Integration*.dll"'
+      workingDirectory: "$(System.ArtifactsDirectory)"
       testRunTitle: '${{ parameters.version }} Integration'
     env:
       'CosmosDb:Host': $(CosmosDb--Host)
@@ -48,7 +48,8 @@ jobs:
 - job: 'cosmosE2eTests'
   dependsOn: []
   pool:
-    vmImage: $(WindowsVmImage)
+    name: '$(DefaultLinuxPool)'
+    vmImage: '$(LinuxVmImage)'
   steps:
   - template: e2e-setup.yml
     
@@ -71,12 +72,15 @@ jobs:
         }
 
         $storageAccounts = Get-AzStorageAccount -ResourceGroupName $(ResourceGroupName)
+        $allStorageAccounts = ""
         foreach ($storageAccount in $storageAccounts) {
             $accKey = Get-AzStorageAccountKey -ResourceGroupName $(ResourceGroupName) -Name $storageAccount.StorageAccountName | Where-Object {$_.KeyName -eq "key1"}
 
             $storageSecretName = "$($storageAccount.StorageAccountName)_secret"
             Write-Host "##vso[task.setvariable variable=$($storageSecretName)]$($accKey.Value)"
+            $allStorageAccounts += "$($storageSecretName)|$($accKey.Value)|"
         }
+        Write-Host "##vso[task.setvariable variable=AllStorageAccounts]$($allStorageAccounts)"
 
         Write-Host "##vso[task.setvariable variable=Resource]$(TestEnvironmentUrl)"
         
@@ -93,24 +97,45 @@ jobs:
 
         dotnet dev-certs https
 
-  - task: VSTest@2
-    displayName: 'Run E2E Tests'
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E ${{ parameters.version }} CosmosDB'
     inputs:
-      testSelector: testAssemblies
-      testAssemblyVer2: |
-        **\*${{ parameters.version }}.Tests.E2E*.dll
-      testFiltercriteria: "FullyQualifiedName~CosmosDb"
-      searchFolder: '$(System.ArtifactsDirectory)'
-      rerunFailedTests: true
-      rerunType: 'basedOnTestFailurePercentage'
-      rerunFailedThreshold: '95'
-      rerunMaxAttempts: 3
+      command: test
+      arguments: '"**\*${{ parameters.version }}.Tests.E2E*.dll" --filter "FullyQualifiedName~CosmosDb"'
+      workingDirectory: "$(System.ArtifactsDirectory)"
       testRunTitle: '${{ parameters.version }} CosmosDB'
+    env:
+      'TestEnvironmentUrl': $(TestEnvironmentUrl)
+      'TestEnvironmentUrl_${{ parameters.version }}': $(TestEnvironmentUrl_${{ parameters.version }})
+      'Resource': $(Resource)
+      'AllStorageAccounts': $(AllStorageAccounts)
+      'tenant-admin-service-principal-name': $(tenant-admin-service-principal-name)
+      'tenant-admin-service-principal-password': $(tenant-admin-service-principal-password)
+      'tenant-admin-user-name': $(tenant-admin-user-name)
+      'tenant-admin-user-password': $(tenant-admin-user-password)
+      'tenant-id': $(tenant-id)
+      'app_globalAdminServicePrincipal_id': $(app_globalAdminServicePrincipal_id)
+      'app_globalAdminServicePrincipal_secret': $(app_globalAdminServicePrincipal_secret)
+      'app_nativeClient_id': $(app_nativeClient_id)
+      'app_nativeClient_secret': $(app_nativeClient_secret)
+      'app_wrongAudienceClient_id': $(app_wrongAudienceClient_id)
+      'app_wrongAudienceClient_secret': $(app_wrongAudienceClient_secret)
+      'user_globalAdminUser_id': $(user_globalAdminUser_id)
+      'user_globalAdminUser_secret': $(user_globalAdminUser_secret)
+      'user_globalConverterUser_id': $(user_globalConverterUser_id)
+      'user_globalConverterUser_secret': $(user_globalConverterUser_secret)
+      'user_globalExporterUser_id': $(user_globalExporterUser_id)
+      'user_globalExporterUser_secret': $(user_globalExporterUser_secret)
+      'user_globalReaderUser_id': $(user_globalReaderUser_id)
+      'user_globalReaderUser_secret': $(user_globalReaderUser_secret)
+      'user_globalWriterUser_id': $(user_globalWriterUser_id)
+      'user_globalWriterUser_secret': $(user_globalWriterUser_secret)
 
 - job: 'sqlE2eTests'
   dependsOn: []
   pool:
-    vmImage: $(WindowsVmImage)
+    name: '$(DefaultLinuxPool)'
+    vmImage: '$(LinuxVmImage)'
   steps:
   - template: e2e-setup.yml
     
@@ -133,12 +158,15 @@ jobs:
         }
 
         $storageAccounts = Get-AzStorageAccount -ResourceGroupName $(ResourceGroupName)
+        $allStorageAccounts = ""
         foreach ($storageAccount in $storageAccounts) {
             $accKey = Get-AzStorageAccountKey -ResourceGroupName $(ResourceGroupName) -Name $storageAccount.StorageAccountName | Where-Object {$_.KeyName -eq "key1"}
 
             $storageSecretName = "$($storageAccount.StorageAccountName)_secret"
             Write-Host "##vso[task.setvariable variable=$($storageSecretName)]$($accKey.Value)"
+            $allStorageAccounts += "|$($storageSecretName)|$($accKey.Value)"
         }
+        Write-Host "##vso[task.setvariable variable=AllStorageAccounts]$($allStorageAccounts)"
 
         Write-Host "##vso[task.setvariable variable=Resource]$(TestEnvironmentUrl)"
         
@@ -155,16 +183,36 @@ jobs:
 
         dotnet dev-certs https
 
-  - task: VSTest@2
-    displayName: 'Run E2E Tests'
+  - task: DotNetCoreCLI@2
+    displayName: 'E2E ${{ parameters.version }} SQL'
     inputs:
-      testSelector: testAssemblies
-      testAssemblyVer2: |
-        **\*${{ parameters.version }}.Tests.E2E*.dll
-      testFiltercriteria: "FullyQualifiedName~SqlServer"
-      searchFolder: '$(System.ArtifactsDirectory)'
-      rerunFailedTests: true
-      rerunType: 'basedOnTestFailurePercentage'
-      rerunFailedThreshold: '95'
-      rerunMaxAttempts: 3
+      command: test
+      arguments: '"**\*${{ parameters.version }}.Tests.E2E*.dll" --filter "FullyQualifiedName~SqlServer"'
+      workingDirectory: "$(System.ArtifactsDirectory)"
       testRunTitle: '${{ parameters.version }} SQL'
+    env:
+      'TestEnvironmentUrl_Sql': $(TestEnvironmentUrl_Sql)
+      'TestEnvironmentUrl_${{ parameters.version }}_Sql': $(TestEnvironmentUrl_${{ parameters.version }}_Sql)
+      'Resource': $(Resource)
+      'AllStorageAccounts': $(AllStorageAccounts)
+      'tenant-admin-service-principal-name': $(tenant-admin-service-principal-name)
+      'tenant-admin-service-principal-password': $(tenant-admin-service-principal-password)
+      'tenant-admin-user-name': $(tenant-admin-user-name)
+      'tenant-admin-user-password': $(tenant-admin-user-password)
+      'tenant-id': $(tenant-id)
+      'app_globalAdminServicePrincipal_id': $(app_globalAdminServicePrincipal_id)
+      'app_globalAdminServicePrincipal_secret': $(app_globalAdminServicePrincipal_secret)
+      'app_nativeClient_id': $(app_nativeClient_id)
+      'app_nativeClient_secret': $(app_nativeClient_secret)
+      'app_wrongAudienceClient_id': $(app_wrongAudienceClient_id)
+      'app_wrongAudienceClient_secret': $(app_wrongAudienceClient_secret)
+      'user_globalAdminUser_id': $(user_globalAdminUser_id)
+      'user_globalAdminUser_secret': $(user_globalAdminUser_secret)
+      'user_globalConverterUser_id': $(user_globalConverterUser_id)
+      'user_globalConverterUser_secret': $(user_globalConverterUser_secret)
+      'user_globalExporterUser_id': $(user_globalExporterUser_id)
+      'user_globalExporterUser_secret': $(user_globalExporterUser_secret)
+      'user_globalReaderUser_id': $(user_globalReaderUser_id)
+      'user_globalReaderUser_secret': $(user_globalReaderUser_secret)
+      'user_globalWriterUser_id': $(user_globalWriterUser_id)
+      'user_globalWriterUser_secret': $(user_globalWriterUser_secret)

--- a/build/jobs/update-semver.yml
+++ b/build/jobs/update-semver.yml
@@ -1,32 +1,31 @@
 steps:
+
 - task: UseDotNet@2
   displayName: 'Use .NET Core sdk (for GitVersion)'
   inputs:
     packageType: sdk
-    version: 2.1.x
-    
-- task: GitVersion@5
-  displayName: 'GitVersion'
-  name: GitVersion
+    version: 3.1.x
+  
+- task: UseDotNet@2
   inputs:
-    configFilePath: '$(Build.SourcesDirectory)/GitVersion.yml'
-
-# Can set these: https://github.com/GitTools/actions/blob/master/gitversion/execute/action.yml
+    useGlobalJson: true
+    
 - powershell: |
-    Write-Host "##vso[task.setvariable variable=semVer]$(GitVersion.semVer)"
-    Write-Host "##vso[task.setvariable variable=informationalVersion;isOutput=true]$(GitVersion.informationalVersion)"
-    Write-Host "##vso[task.setvariable variable=majorMinorPatch;isOutput=true]$(GitVersion.majorMinorPatch)"
-    Write-Host "##vso[task.setvariable variable=nuGetVersion;isOutput=true]$(GitVersion.semVer)"
-    Write-Host "##vso[task.setvariable variable=assemblySemVer;isOutput=true]$(GitVersion.assemblySemVer)"
-    Write-Host "##vso[task.setvariable variable=assemblySemFileVer;isOutput=true]$(GitVersion.assemblySemFileVer)"
+    dotnet tool install --global GitVersion.Tool --version 5.5.1
+
+    $gitVersionJson = & 'dotnet-gitversion'  | ConvertFrom-Json
+
+    Write-Host "##vso[task.setvariable variable=semVer]$($gitVersionJson.semVer)"
+    Write-Host "##vso[task.setvariable variable=informationalVersion;isOutput=true]$($gitVersionJson.informationalVersion)"
+    Write-Host "##vso[task.setvariable variable=majorMinorPatch;isOutput=true]$($gitVersionJson.majorMinorPatch)"
+    Write-Host "##vso[task.setvariable variable=nuGetVersion;isOutput=true]$($gitVersionJson.semVer)"
+    Write-Host "##vso[task.setvariable variable=assemblySemVer;isOutput=true]$($gitVersionJson.assemblySemVer)"
+    Write-Host "##vso[task.setvariable variable=assemblySemFileVer;isOutput=true]$($gitVersionJson.assemblySemFileVer)"
+
+    Write-Host "##vso[build.updatebuildnumber]$($gitVersionJson.semVer)"
   name: SetVariablesFromGitVersion
 
 - powershell: |
     Write-Host '----------Variables to use for build----------'
     Write-Host 'semVer: $(semVer)'
-    Write-Host 'informationalVersion: $(informationalVersion)'
-    Write-Host 'majorMinorPatch: $(majorMinorPatch)'
-    Write-Host 'assemblySemVer: $(assemblySemVer)'
-    Write-Host 'assemblySemFileVer: $(assemblySemFileVer)'
-    Write-Host 'nuGetVersion: $(nuGetVersion)'
   name: PrintVariablesFromGitVersion

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -14,11 +14,12 @@ stages:
   jobs:
   - job: Semver
     pool:
-      vmImage: $(WindowsVmImage)
+      name: '$(DefaultLinuxPool)'
+      vmImage: '$(LinuxVmImage)'
     steps:
     - template: ./jobs/update-semver.yml  
     - powershell: |
-        $buildNumber = "$(GitVersion.semVer)" -replace "\.", "" 
+        $buildNumber = "$(semVer)" -replace "\.", "" 
         Write-Host "##vso[build.updatebuildnumber]$buildNumber" 
         Write-Host "Updated  build number to '$buildNumber"
       name: SetBuildVersion
@@ -39,14 +40,16 @@ stages:
       vmImage: $(WindowsVmImage)
     steps:
     - template: ./jobs/build.yml
+      parameters:
+        packageArtifacts: false
 
   - job: Linux
     pool:
-      vmImage: 'ubuntu-latest'
+      name: '$(DefaultLinuxPool)'
+      vmImage: '$(LinuxVmImage)'
     steps:
     - template: ./jobs/build.yml
-      parameters:
-        packageArtifacts: false
+    
 
 - stage: DockerBuild  
   displayName: 'Build images'
@@ -62,6 +65,9 @@ stages:
   dependsOn: []
   jobs:
   - job: provision
+    pool:
+      name: '$(DefaultLinuxPool)'
+      vmImage: '$(LinuxVmImage)'
     steps:
     - task: AzurePowerShell@4
       displayName: Provision Resource Group

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ExportDataValidationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ExportDataValidationTests.cs
@@ -465,9 +465,24 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             else
             {
                 string storageSecret = Environment.GetEnvironmentVariable(storageAccountName + "_secret");
+                string allAccounts = Environment.GetEnvironmentVariable("AllStorageAccounts");
+
                 if (!string.IsNullOrWhiteSpace(storageSecret))
                 {
                     StorageCredentials storageCredentials = new StorageCredentials(storageAccountName, storageSecret);
+                    cloudAccount = new CloudStorageAccount(storageCredentials, useHttps: true);
+                }
+                else if (!string.IsNullOrWhiteSpace(allAccounts))
+                {
+                    var splitAccounts = allAccounts.Split('|').ToList();
+                    var nameIndex = splitAccounts.IndexOf(storageAccountName + "_secret");
+
+                    if (nameIndex < 0)
+                    {
+                        throw new Exception("Unable to create a cloud storage account, key not provided.");
+                    }
+
+                    StorageCredentials storageCredentials = new StorageCredentials(storageAccountName, splitAccounts[nameIndex + 1].Trim());
                     cloudAccount = new CloudStorageAccount(storageCredentials, useHttps: true);
                 }
             }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
@@ -61,6 +61,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             _cosmosCollectionConfiguration = new CosmosCollectionConfiguration
             {
                 CollectionId = Guid.NewGuid().ToString(),
+                InitialCollectionThroughput = 1000,
             };
         }
 


### PR DESCRIPTION
## Description
Moves most build steps to use linux agents.

- Changes GitVersion to use .NET Tool
- Changes E2E tests to use dotnet test
- Changes docker cleanup to use pscore
- Added check to end of deployment step to wait for containers to load
- Increases initial RUs of Integration test Cosmos DB
- Specifies --no-build in package and public steps
- Changes to Linux build for creating packages
- Workaround to provide Storage Account test credentials to concating an 'AllStorageAccounts' string.

Steps not converted:

- Windows Build :)
- Setup AAD
- Cleanup AAD

These changes save a few minutes on the build (~4 mins in the Build and Package Steps). Also 2-3mins in the E2E test steps.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
