### PR TITLE
Implements search for SQL reindexing

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -859,7 +859,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             {
                 delimited.BeginDelimitedElement();
 
-                StringBuilder.Append(VLatest.Resource.SearchParamHash, tableAlias).Append(" != ").Append(Parameters.AddParameter(_searchParameterHash));
+                StringBuilder.Append("(").Append(VLatest.Resource.SearchParamHash, tableAlias).Append(" != ").Append(Parameters.AddParameter(_searchParameterHash)).Append(" OR ").Append(VLatest.Resource.SearchParamHash, tableAlias).Append(" IS NULL)");
             }
         }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlSearchType.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlSearchType.cs
@@ -7,12 +7,22 @@ using System;
 
 namespace Microsoft.Health.Fhir.SqlServer.Features.Search
 {
+    /// <summary>
+    /// Enum to specify the type of search to carry out.
+    /// </summary>
+    /// <remarks>
+    /// With the exception of None, the flags attribute requires enumeration constants to be powers of two, that is, 1, 2, 4, 8.
+    /// </remarks>
     [Flags]
     internal enum SqlSearchType
     {
-        // The flags attribute requires enumeration constants to be powers of two, that is, 1, 2, 4, 8
+        // Default value, set if we do not need to consider history or reindexing
         None = 0,
+
+        // Set if we are including previous resource versions or deleted resources
         History = 1,
+
+        // Set if the search parameter hash value needs to be considered in a search
         Reindex = 2,
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlSearchType.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlSearchType.cs
@@ -20,9 +20,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
         None = 0,
 
         // Set if we are including previous resource versions or deleted resources
-        History = 1,
+        History = 1 << 0,
 
         // Set if the search parameter hash value needs to be considered in a search
-        Reindex = 2,
+        Reindex = 1 << 1,
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlSearchType.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlSearchType.cs
@@ -1,0 +1,18 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.Health.Fhir.SqlServer.Features.Search
+{
+    [Flags]
+    internal enum SqlSearchType
+    {
+        // The flags attribute requires enumeration constants to be powers of two, that is, 1, 2, 4, 8
+        None = 0,
+        History = 1,
+        Reindex = 2,
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
             // If we should include the total count of matching search results
             if (searchOptions.IncludeTotal == TotalType.Accurate && !searchOptions.CountOnly)
             {
-                searchResult = await SearchImpl(searchOptions, false, false, null, cancellationToken);
+                searchResult = await SearchImpl(searchOptions, SqlSearchType.None, null, cancellationToken);
 
                 // If this is the first page and there aren't any more pages
                 if (searchOptions.ContinuationToken == null && searchResult.ContinuationToken == null)
@@ -111,7 +111,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                         searchOptions.CountOnly = true;
 
                         // And perform a second read.
-                        var countOnlySearchResult = await SearchImpl(searchOptions, false, false, null, cancellationToken);
+                        var countOnlySearchResult = await SearchImpl(searchOptions, SqlSearchType.None, null, cancellationToken);
 
                         searchResult.TotalCount = countOnlySearchResult.TotalCount;
                     }
@@ -124,7 +124,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
             }
             else
             {
-                searchResult = await SearchImpl(searchOptions, false, false, null, cancellationToken);
+                searchResult = await SearchImpl(searchOptions, SqlSearchType.None, null, cancellationToken);
             }
 
             return searchResult;
@@ -132,10 +132,10 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
 
         protected override async Task<SearchResult> SearchHistoryInternalAsync(SearchOptions searchOptions, CancellationToken cancellationToken)
         {
-            return await SearchImpl(searchOptions, true, false, null, cancellationToken);
+            return await SearchImpl(searchOptions, SqlSearchType.History, null, cancellationToken);
         }
 
-        private async Task<SearchResult> SearchImpl(SearchOptions searchOptions, bool isHistorySearch, bool isReindexSearch, string currentSearchParameterHash, CancellationToken cancellationToken)
+        private async Task<SearchResult> SearchImpl(SearchOptions searchOptions, SqlSearchType searchType, string currentSearchParameterHash, CancellationToken cancellationToken)
         {
             Expression searchExpression = searchOptions.Expression;
 
@@ -201,9 +201,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                     stringBuilder,
                     new SqlQueryParameterManager(sqlCommandWrapper.Parameters),
                     _model,
-                    isHistorySearch,
+                    searchType,
                     _schemaInformation,
-                    isReindexSearch,
                     currentSearchParameterHash);
 
                 expression.AcceptVisitor(queryGenerator, searchOptions);
@@ -424,7 +423,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
 
         protected async override Task<SearchResult> SearchForReindexInternalAsync(SearchOptions searchOptions, string searchParameterHash, CancellationToken cancellationToken)
         {
-            return await SearchImpl(searchOptions, false, true, searchParameterHash, cancellationToken);
+            return await SearchImpl(searchOptions, SqlSearchType.Reindex, searchParameterHash, cancellationToken);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -424,7 +424,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
 
         protected async override Task<SearchResult> SearchForReindexInternalAsync(SearchOptions searchOptions, string searchParameterHash, CancellationToken cancellationToken)
         {
-            // TODO: Update SearchImpl to search for both historical and non historical values at the same time (this implementation is not complete and will only look for non-historical resources).
             return await SearchImpl(searchOptions, false, true, searchParameterHash, cancellationToken);
         }
     }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
             // If we should include the total count of matching search results
             if (searchOptions.IncludeTotal == TotalType.Accurate && !searchOptions.CountOnly)
             {
-                searchResult = await SearchImpl(searchOptions, false, cancellationToken);
+                searchResult = await SearchImpl(searchOptions, false, false, null, cancellationToken);
 
                 // If this is the first page and there aren't any more pages
                 if (searchOptions.ContinuationToken == null && searchResult.ContinuationToken == null)
@@ -111,7 +111,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                         searchOptions.CountOnly = true;
 
                         // And perform a second read.
-                        var countOnlySearchResult = await SearchImpl(searchOptions, false, cancellationToken);
+                        var countOnlySearchResult = await SearchImpl(searchOptions, false, false, null, cancellationToken);
 
                         searchResult.TotalCount = countOnlySearchResult.TotalCount;
                     }
@@ -124,7 +124,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
             }
             else
             {
-                searchResult = await SearchImpl(searchOptions, false, cancellationToken);
+                searchResult = await SearchImpl(searchOptions, false, false, null, cancellationToken);
             }
 
             return searchResult;
@@ -132,10 +132,10 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
 
         protected override async Task<SearchResult> SearchHistoryInternalAsync(SearchOptions searchOptions, CancellationToken cancellationToken)
         {
-            return await SearchImpl(searchOptions, true, cancellationToken);
+            return await SearchImpl(searchOptions, true, false, null, cancellationToken);
         }
 
-        private async Task<SearchResult> SearchImpl(SearchOptions searchOptions, bool historySearch, CancellationToken cancellationToken)
+        private async Task<SearchResult> SearchImpl(SearchOptions searchOptions, bool isHistorySearch, bool isReindexSearch, string currentSearchParameterHash, CancellationToken cancellationToken)
         {
             Expression searchExpression = searchOptions.Expression;
 
@@ -197,7 +197,14 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
 
                 EnableTimeAndIoMessageLogging(stringBuilder, sqlConnectionWrapper);
 
-                var queryGenerator = new SqlQueryGenerator(stringBuilder, new SqlQueryParameterManager(sqlCommandWrapper.Parameters), _model, historySearch, _schemaInformation);
+                var queryGenerator = new SqlQueryGenerator(
+                    stringBuilder,
+                    new SqlQueryParameterManager(sqlCommandWrapper.Parameters),
+                    _model,
+                    isHistorySearch,
+                    _schemaInformation,
+                    isReindexSearch,
+                    currentSearchParameterHash);
 
                 expression.AcceptVisitor(queryGenerator, searchOptions);
 
@@ -418,7 +425,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
         protected async override Task<SearchResult> SearchForReindexInternalAsync(SearchOptions searchOptions, string searchParameterHash, CancellationToken cancellationToken)
         {
             // TODO: Update SearchImpl to search for both historical and non historical values at the same time (this implementation is not complete and will only look for non-historical resources).
-            return await SearchImpl(searchOptions, false, cancellationToken);
+            return await SearchImpl(searchOptions, false, true, searchParameterHash, cancellationToken);
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexSearchTests.cs
@@ -1,0 +1,130 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Health.Fhir.Core.Features;
+using Microsoft.Health.Fhir.Core.Features.Definition;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Microsoft.Health.Fhir.Core.Features.Search;
+using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.Core.UnitTests.Extensions;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Microsoft.Health.Fhir.Tests.Integration.Persistence;
+using NSubstitute;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
+{
+    [FhirStorageTestsFixtureArgumentSets(DataStore.All)]
+
+    public class ReindexSearchTests : IClassFixture<FhirStorageTestsFixture>
+    {
+        private readonly IScoped<IFhirDataStore> _scopedDataStore;
+        private readonly IScoped<ISearchService> _searchService;
+        private readonly SearchParameterDefinitionManager _searchParameterDefinitionManager;
+
+        private readonly ISearchIndexer _searchIndexer = Substitute.For<ISearchIndexer>();
+
+        public ReindexSearchTests(FhirStorageTestsFixture fixture)
+        {
+            _scopedDataStore = fixture.DataStore.CreateMockScope();
+            _searchService = fixture.SearchService.CreateMockScope();
+            _searchParameterDefinitionManager = fixture.SearchParameterDefinitionManager;
+        }
+
+        [Fact]
+        public async Task GivenResourceWithMatchingHash_WhenPerformingReindexSearch_ThenResourceShouldNotBeReturned()
+        {
+            ResourceWrapper testPatient = null;
+
+            try
+            {
+                UpsertOutcome outcome = await UpsertPatientData();
+                testPatient = outcome.Wrapper;
+
+                var patientHash = testPatient.SearchParameterHash;
+
+                var queryParametersList = new List<Tuple<string, string>>()
+                {
+                    Tuple.Create(KnownQueryParameterNames.Count, "100"),
+                    Tuple.Create(KnownQueryParameterNames.Type, "Patient"),
+                };
+
+                // Pass in the same hash value
+                SearchResult searchResult = await _searchService.Value.SearchForReindexAsync(queryParametersList, patientHash, false, CancellationToken.None);
+
+                // A reindex search should return all the resources that have a different hash value than the one specified
+                Assert.Empty(searchResult.Results);
+            }
+            finally
+            {
+                if (testPatient != null)
+                {
+                    await _scopedDataStore.Value.HardDeleteAsync(testPatient.ToResourceKey(), CancellationToken.None);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task GivenResourceWithDifferentHash_WhenPerformingReindexSearch_ThenResourceShouldBeReturned()
+        {
+            ResourceWrapper testPatient = null;
+
+            try
+            {
+                UpsertOutcome outcome = await UpsertPatientData();
+                testPatient = outcome.Wrapper;
+
+                var queryParametersList = new List<Tuple<string, string>>()
+                {
+                    Tuple.Create(KnownQueryParameterNames.Count, "100"),
+                    Tuple.Create(KnownQueryParameterNames.Type, "Patient"),
+                };
+
+                // Pass in a different hash value
+                SearchResult searchResult = await _searchService.Value.SearchForReindexAsync(queryParametersList, "differentHash", false, CancellationToken.None);
+
+                // A reindex search should return all the resources that have a different hash value than the one specified.
+                Assert.Single(searchResult.Results);
+            }
+            finally
+            {
+                if (testPatient != null)
+                {
+                    await _scopedDataStore.Value.HardDeleteAsync(testPatient.ToResourceKey(), CancellationToken.None);
+                }
+            }
+        }
+
+        private async Task<UpsertOutcome> UpsertPatientData()
+        {
+            var json = Samples.GetJson("Patient");
+            var rawResource = new RawResource(json, FhirResourceFormat.Json, isMetaSet: false);
+            var resourceRequest = new ResourceRequest(WebRequestMethods.Http.Put);
+            var compartmentIndices = Substitute.For<CompartmentIndices>();
+            var resourceElement = Deserializers.ResourceDeserializer.DeserializeRaw(rawResource, "v1", DateTimeOffset.UtcNow);
+            var searchIndices = _searchIndexer.Extract(resourceElement);
+
+            var wrapper = new ResourceWrapper(
+                resourceElement,
+                rawResource,
+                resourceRequest,
+                false,
+                searchIndices,
+                compartmentIndices,
+                new List<KeyValuePair<string, string>>(),
+                _searchParameterDefinitionManager.GetSearchParameterHashForResourceType("Patient"));
+
+            return await _scopedDataStore.Value.UpsertAsync(wrapper, null, true, true, CancellationToken.None);
+        }
+    }
+}

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Microsoft.Health.Fhir.Shared.Tests.Integration.projitems
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Microsoft.Health.Fhir.Shared.Tests.Integration.projitems
@@ -14,6 +14,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\Export\CreateExportRequestHandlerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\FhirOperationTestConstants.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\Reindex\ReindexJobTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\Reindex\ReindexSearchTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SearchParameterStatusDataStoreTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlServerSchemaUpgradeTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\CosmosDbFhirStorageTestHelper.cs" />


### PR DESCRIPTION
## Description

During a reindexing operation, we carry out a set of searches to retrieve the resources that need to be reindexed. These queries rely on the search parameter hash value to determine if a resource's search indices are up to date or not. 

This PR adds the ability to search for resources that need to be reindexed, or, in other words, resources that have a hash value that differs from the latest hash for their resource type.

## Example

Here is an example of a SQL query that is generated during reindexing:
```
SET STATISTICS IO ON;
SET STATISTICS TIME ON;

SELECT DISTINCT TOP (101) r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(1 AS bit) AS IsMatch, CAST(0 AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource
FROM dbo.Resource r WITH(INDEX(IX_Resource_ResourceTypeId_ResourceSurrgateId))
WHERE ResourceTypeId = 103
    AND IsHistory = 0
    AND IsDeleted = 0
    AND SearchParamHash != 2F5C6AB1905CB44F005FCB608BE0274A1160D02DC27BF6846460402CDEB27723
ORDER BY r.ResourceSurrogateId ASC
OPTION(RECOMPILE)

```

## Notes

Note 1: reindexing search parameters that impact multiple resource types is currently broken. There is a bug to track this (please see [AB#79638](https://microsofthealth.visualstudio.com/Health/_workitems/edit/79638)).

Note 2: this is being merged into a feature branch. There are still work items TBD before this is merged to main:
- Reindexing should not update the version of the resources that are reindexed (this will be fixed in [AB#73395](https://microsofthealth.visualstudio.com/Health/_workitems/edit/73395) and [AB#79121](https://microsofthealth.visualstudio.com/Health/_workitems/edit/79121))
- Storing a resource's search indices in an efficient way could give us performance improvements (this is being tracked in [AB#79648](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Resolute/Stories/?workitem=79648))

## Related issues
Addresses [AB#73616](https://microsofthealth.visualstudio.com/Health/_workitems/edit/73616).

## Testing
Adds new search specific integration tests.

## FHIR Team Checklist
- ✅ **Update the title** of the PR to be succinct and less than 50 characters
- ✅ **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- ✅ Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- ✅ Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)
