### PR TITLE
Fixes SkippableFact in CustomSearch tests

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             _fixture = fixture;
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task GivenANewSearchParam_WhenReindexingComplete_ThenResourcesSearchedWithNewParamReturned()
         {
             var patientName = Guid.NewGuid().ToString().ComputeHash().Substring(28).ToLower();
@@ -93,7 +93,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             await DeleteSearchParameterAndVerify(searchParamPosted.Resource);
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task GivenASearchParam_WhenUpdatingParam_ThenResourcesIndexedWithUpdatedParam()
         {
             var patientName = Guid.NewGuid().ToString().ComputeHash().Substring(28).ToLower();


### PR DESCRIPTION
Adding this to main branch.

* Make the test a skippable fact

## Testing
Fixes unit tests

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
