### PR TITLE
Personal/quwan/feature anonymized patient group export

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Filters/ValidateExportRequestFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Filters/ValidateExportRequestFilterAttribute.cs
@@ -120,7 +120,10 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
 
         private bool IsValidAnonymizedExportRequestParam(HttpRequest request, string paramName)
         {
-            if (AnonymizedExportRequestPathRegexs.Any(pathRegex => Regex.IsMatch(request.Path, pathRegex)))
+            if (AnonymizedExportRequestPathRegexs.Any(pathRegex => Regex.IsMatch(
+                input: request.Path,
+                pattern: pathRegex,
+                options: RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)))
             {
                 return _supportedQueryParamsForAnonymizedExport.Contains(paramName);
             }

--- a/src/Microsoft.Health.Fhir.Api/Features/Filters/ValidateExportRequestFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Filters/ValidateExportRequestFilterAttribute.cs
@@ -29,9 +29,6 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
             "ndjson",
         };
 
-        // Support anonymization for basic and patient/group export.
-        // The regex of <id> in group export is [A-Za-z0-9\-\.]{1,64}, from HL7 website https://www.hl7.org/fhir/datatypes.html#id.
-
         private const string PreferHeaderName = "Prefer";
         private const string PreferHeaderExpectedValue = "respond-async";
         private readonly HashSet<string> _supportedQueryParams;

--- a/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
@@ -97,6 +97,15 @@ namespace Microsoft.Health.Fhir.Api {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Missing &apos;_anonymizationConfig&apos; for anonymized export.
+        /// </summary>
+        public static string ConfigLocationRequiredForAnonymizedExport {
+            get {
+                return ResourceManager.GetString("ConfigLocationRequiredForAnonymizedExport", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Missing &apos;_container&apos; for anonymized export.
         /// </summary>
         public static string ContainerIsRequiredForAnonymizedExport {
@@ -133,15 +142,6 @@ namespace Microsoft.Health.Fhir.Api {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The maximum length of a custom audit header value is {0}. The supplied custom audit header &apos;{1}&apos; has length of {2}..
-        /// </summary>
-        public static string CustomAuditHeaderTooLarge {
-            get {
-                return ResourceManager.GetString("CustomAuditHeaderTooLarge", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Convert data does not support the following parameter {0} for a POST operation..
         /// </summary>
         public static string ConvertDataParameterNotValid {
@@ -165,6 +165,15 @@ namespace Microsoft.Health.Fhir.Api {
         public static string ConvertDataParameterValueNotValid {
             get {
                 return ResourceManager.GetString("ConvertDataParameterValueNotValid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The maximum length of a custom audit header value is {0}. The supplied custom audit header &apos;{1}&apos; has length of {2}..
+        /// </summary>
+        public static string CustomAuditHeaderTooLarge {
+            get {
+                return ResourceManager.GetString("CustomAuditHeaderTooLarge", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Health.Fhir.Api/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Api/Resources.resx
@@ -349,4 +349,7 @@
     <value>The container registry '{0}' is not configured.</value>
     <comment>{0}: the container registry login server</comment>
   </data>
+  <data name="ConfigLocationRequiredForAnonymizedExport" xml:space="preserve">
+    <value>Missing '_anonymizationConfig' for anonymized export</value>
+  </data>
 </root>

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -421,7 +421,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                             progress.NewSubSearch(result.Resource.ResourceId);
                         }
 
-                        await RunExportCompartmentSearch(exportJobConfiguration, progress.SubSearch, sharedQueryParametersList, cancellationToken, currentBatchId + ":" + resultIndex.ToString("d6"));
+                        await RunExportCompartmentSearch(exportJobConfiguration, progress.SubSearch, sharedQueryParametersList, anonymizer, cancellationToken, currentBatchId + ":" + resultIndex.ToString("d6"));
                         resultIndex++;
 
                         progress.ClearSubSearch();
@@ -467,6 +467,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
             ExportJobConfiguration exportJobConfiguration,
             ExportJobProgress progress,
             List<Tuple<string, string>> sharedQueryParametersList,
+            IAnonymizer anonymizer,
             CancellationToken cancellationToken,
             string batchIdPrefix = "")
         {
@@ -492,7 +493,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
             if (progress.CurrentFilter != null)
             {
-                await ProcessFilterForCompartment(exportJobConfiguration, progress, queryParametersList, batchIdPrefix + "-filter", cancellationToken);
+                await ProcessFilterForCompartment(exportJobConfiguration, progress, queryParametersList, anonymizer, batchIdPrefix + "-filter", cancellationToken);
             }
 
             if (_exportJobRecord.Filters != null)
@@ -504,7 +505,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                         requestedResourceTypes.Contains(filter.ResourceType, StringComparison.OrdinalIgnoreCase))
                     {
                         progress.SetFilter(filter);
-                        await ProcessFilterForCompartment(exportJobConfiguration, progress, queryParametersList, batchIdPrefix + "-filter", cancellationToken);
+                        await ProcessFilterForCompartment(exportJobConfiguration, progress, queryParametersList, anonymizer, batchIdPrefix + "-filter", cancellationToken);
                     }
                 }
             }
@@ -531,7 +532,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                     }
                 }
 
-                await SearchCompartmentWithFilter(exportJobConfiguration, progress, null, queryParametersList, batchIdPrefix, cancellationToken);
+                await SearchCompartmentWithFilter(exportJobConfiguration, progress, null, queryParametersList, anonymizer, batchIdPrefix, cancellationToken);
             }
         }
 
@@ -539,6 +540,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
             ExportJobConfiguration exportJobConfiguration,
             ExportJobProgress exportJobProgress,
             List<Tuple<string, string>> queryParametersList,
+            IAnonymizer anonymizer,
             string batchIdPrefix,
             CancellationToken cancellationToken)
         {
@@ -549,7 +551,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                 filterQueryParametersList.Add(param);
             }
 
-            await SearchCompartmentWithFilter(exportJobConfiguration, exportJobProgress, exportJobProgress.CurrentFilter.ResourceType, filterQueryParametersList, batchIdPrefix + index, cancellationToken);
+            await SearchCompartmentWithFilter(exportJobConfiguration, exportJobProgress, exportJobProgress.CurrentFilter.ResourceType, filterQueryParametersList, anonymizer, batchIdPrefix + index, cancellationToken);
         }
 
         private async Task SearchCompartmentWithFilter(
@@ -557,6 +559,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
             ExportJobProgress progress,
             string resourceType,
             List<Tuple<string, string>> queryParametersList,
+            IAnonymizer anonymizer,
             string batchIdPrefix,
             CancellationToken cancellationToken)
         {
@@ -581,7 +584,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                         cancellationToken);
                 }
 
-                await ProcessSearchResultsAsync(searchResult.Results, currentBatchId, null, cancellationToken);
+                await ProcessSearchResultsAsync(searchResult.Results, currentBatchId, anonymizer, cancellationToken);
 
                 if (searchResult.ContinuationToken == null)
                 {

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ExportControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ExportControllerTests.cs
@@ -108,6 +108,40 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
                 idParameter: "id"));
         }
 
+        [Fact]
+        public async Task GivenAnAnonymizedExportRequest_WhenNoContainerName_ThenRequestNotValidExceptionShouldBeThrown()
+        {
+            string anonymizationConfig = "anonymizationConfig";
+
+            await Assert.ThrowsAsync<RequestNotValidException>(() => _exportEnabledController.ExportResourceTypeById(
+                typeFilter: null,
+                since: null,
+                resourceType: null,
+                containerName: null,
+                formatName: null,
+                anonymizationConfigLocation: anonymizationConfig,
+                anonymizationConfigFileETag: null,
+                typeParameter: ResourceType.Patient.ToString(),
+                idParameter: "id"));
+        }
+
+        [Fact]
+        public async Task GivenAnExportRequestWithAnonymizationConfigEtag_WhenNoAnonymizationConfig_ThenRequestNotValidExceptionShouldBeThrown()
+        {
+            string anonymizationConfigEtag = "anonymizationConfigEtag";
+
+            await Assert.ThrowsAsync<RequestNotValidException>(() => _exportEnabledController.ExportResourceTypeById(
+                typeFilter: null,
+                since: null,
+                resourceType: null,
+                containerName: null,
+                formatName: null,
+                anonymizationConfigLocation: null,
+                anonymizationConfigFileETag: anonymizationConfigEtag,
+                typeParameter: ResourceType.Patient.ToString(),
+                idParameter: "id"));
+        }
+
         private ExportController GetController(ExportJobConfiguration exportConfig)
         {
             var operationConfig = new OperationsConfiguration()

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ExportControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ExportControllerTests.cs
@@ -57,6 +57,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
                 resourceType: null,
                 containerName: null,
                 formatName: null,
+                anonymizationConfigLocation: null,
+                anonymizationConfigFileETag: null,
                 typeParameter: ResourceType.Patient.ToString()));
         }
 
@@ -71,6 +73,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
                 resourceType: null,
                 containerName: null,
                 formatName: null,
+                anonymizationConfigLocation: null,
+                anonymizationConfigFileETag: null,
                 typeParameter: ResourceType.Group.ToString(),
                 idParameter: "id"));
         }
@@ -78,13 +82,30 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
         [Fact]
         public async Task GivenAnExportByResourceTypeRequest_WhenResourceTypeIsNotPatient_ThenRequestNotValidExceptionShouldBeThrown()
         {
-            await Assert.ThrowsAsync<RequestNotValidException>(() => _exportEnabledController.ExportResourceType(null, null, null, null, null, ResourceType.Observation.ToString()));
+            await Assert.ThrowsAsync<RequestNotValidException>(() => _exportEnabledController.ExportResourceType(
+                typeFilter: null,
+                since: null,
+                resourceType: null,
+                containerName: null,
+                formatName: null,
+                anonymizationConfigLocation: null,
+                anonymizationConfigFileETag: null,
+                typeParameter: ResourceType.Observation.ToString()));
         }
 
         [Fact]
         public async Task GivenAnExportResourceTypeIdRequest_WhenResourceTypeIsNotGroup_ThenRequestNotValidExceptionShouldBeThrown()
         {
-            await Assert.ThrowsAsync<RequestNotValidException>(() => _exportEnabledController.ExportResourceTypeById(null, null, null, null, null, ResourceType.Patient.ToString(), "id"));
+            await Assert.ThrowsAsync<RequestNotValidException>(() => _exportEnabledController.ExportResourceTypeById(
+                typeFilter: null,
+                since: null,
+                resourceType: null,
+                containerName: null,
+                formatName: null,
+                anonymizationConfigLocation: null,
+                anonymizationConfigFileETag: null,
+                typeParameter: ResourceType.Patient.ToString(),
+                idParameter: "id"));
         }
 
         private ExportController GetController(ExportJobConfiguration exportConfig)

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/ValidateExportRequestFilterAttributeTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/ValidateExportRequestFilterAttributeTests.cs
@@ -123,6 +123,28 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
             _filter.OnActionExecuting(context);
         }
 
+        [InlineData("/export")]
+        [InlineData("/Location/$export")]
+        [InlineData("/Group/$export")]
+        [InlineData("/Group/!@#/$export")]
+        [Theory]
+        public void GivenARequestWithUnsupportedAnonymizedExportRequestPath_WhenGettingAnExportOperationRequest_ThenARequestNotValidExceptionShouldBeThrown(string queryPath)
+        {
+            var context = CreateContext();
+            context.HttpContext.Request.Headers.Add(HeaderNames.Accept, CorrectAcceptHeaderValue);
+            context.HttpContext.Request.Headers.Add(PreferHeaderName, CorrectPreferHeaderValue);
+
+            var queryParams = new Dictionary<string, StringValues>()
+            {
+                { KnownQueryParameterNames.AnonymizationConfigurationLocation, "paramValue" },
+            };
+
+            context.HttpContext.Request.Query = new QueryCollection(queryParams);
+            context.HttpContext.Request.Path = new PathString(queryPath);
+
+            Assert.Throws<RequestNotValidException>(() => _filter.OnActionExecuting(context));
+        }
+
         [InlineData(KnownQueryParameterNames.Since)]
         [InlineData(KnownQueryParameterNames.Type)]
         [InlineData(KnownQueryParameterNames.Since, KnownQueryParameterNames.Type)]

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/ValidateExportRequestFilterAttributeTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/ValidateExportRequestFilterAttributeTests.cs
@@ -83,8 +83,6 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
         [InlineData("since")]
         [InlineData("_SINCE")]
         [InlineData("queryParam")]
-        [InlineData(KnownQueryParameterNames.AnonymizationConfigurationFileEtag)]
-        [InlineData(KnownQueryParameterNames.AnonymizationConfigurationLocation)]
         [Theory]
         public void GivenARequestWithCorrectHeadersAndUnsupportedQueryParam_WhenGettingAnExportOperationRequest_ThenARequestNotValidExceptionShouldBeThrown(string queryParamName)
         {
@@ -101,7 +99,6 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
             Assert.Throws<RequestNotValidException>(() => _filter.OnActionExecuting(context));
         }
 
-        [InlineData(KnownQueryParameterNames.AnonymizationConfigurationFileEtag)]
         [InlineData(KnownQueryParameterNames.AnonymizationConfigurationLocation)]
         [InlineData(KnownQueryParameterNames.AnonymizationConfigurationLocation, KnownQueryParameterNames.AnonymizationConfigurationFileEtag)]
         [Theory]
@@ -121,28 +118,6 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
             context.HttpContext.Request.Path = new PathString("/$export");
 
             _filter.OnActionExecuting(context);
-        }
-
-        [InlineData("/export")]
-        [InlineData("/Location/$export")]
-        [InlineData("/Group/$export")]
-        [InlineData("/Group/!@#/$export")]
-        [Theory]
-        public void GivenARequestWithUnsupportedAnonymizedExportRequestPath_WhenGettingAnExportOperationRequest_ThenARequestNotValidExceptionShouldBeThrown(string queryPath)
-        {
-            var context = CreateContext();
-            context.HttpContext.Request.Headers.Add(HeaderNames.Accept, CorrectAcceptHeaderValue);
-            context.HttpContext.Request.Headers.Add(PreferHeaderName, CorrectPreferHeaderValue);
-
-            var queryParams = new Dictionary<string, StringValues>()
-            {
-                { KnownQueryParameterNames.AnonymizationConfigurationLocation, "paramValue" },
-            };
-
-            context.HttpContext.Request.Query = new QueryCollection(queryParams);
-            context.HttpContext.Request.Path = new PathString(queryPath);
-
-            Assert.Throws<RequestNotValidException>(() => _filter.OnActionExecuting(context));
         }
 
         [InlineData(KnownQueryParameterNames.Since)]

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ExportController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ExportController.cs
@@ -111,9 +111,17 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             [FromQuery(Name = KnownQueryParameterNames.Container)] string containerName,
             [FromQuery(Name = KnownQueryParameterNames.TypeFilter)] string typeFilter,
             [FromQuery(Name = KnownQueryParameterNames.Format)] string formatName,
+            [FromQuery(Name = KnownQueryParameterNames.AnonymizationConfigurationLocation)] string anonymizationConfigLocation,
+            [FromQuery(Name = KnownQueryParameterNames.AnonymizationConfigurationFileEtag)] string anonymizationConfigFileETag,
             string typeParameter)
         {
             CheckIfExportIsEnabled();
+
+            if (!string.IsNullOrWhiteSpace(anonymizationConfigFileETag) || !string.IsNullOrWhiteSpace(anonymizationConfigFileETag))
+            {
+                CheckIfAnonymizedExportIsEnabled();
+                CheckContainerNameForAnonymizedExport(containerName);
+            }
 
             // Export by ResourceType is supported only for Patient resource type.
             if (!string.Equals(typeParameter, ResourceType.Patient.ToString(), StringComparison.Ordinal))
@@ -121,7 +129,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                 throw new RequestNotValidException(string.Format(Resources.UnsupportedResourceType, typeParameter));
             }
 
-            return await SendExportRequest(ExportJobType.Patient, since, typeFilter, resourceType, containerName: containerName, formatName: formatName);
+            return await SendExportRequest(ExportJobType.Patient, since, typeFilter, resourceType, containerName: containerName, formatName: formatName, anonymizationConfigLocation: anonymizationConfigLocation, anonymizationConfigFileETag: anonymizationConfigFileETag);
         }
 
         [HttpGet]
@@ -134,10 +142,18 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             [FromQuery(Name = KnownQueryParameterNames.Container)] string containerName,
             [FromQuery(Name = KnownQueryParameterNames.TypeFilter)] string typeFilter,
             [FromQuery(Name = KnownQueryParameterNames.Format)] string formatName,
+            [FromQuery(Name = KnownQueryParameterNames.AnonymizationConfigurationLocation)] string anonymizationConfigLocation,
+            [FromQuery(Name = KnownQueryParameterNames.AnonymizationConfigurationFileEtag)] string anonymizationConfigFileETag,
             string typeParameter,
             string idParameter)
         {
             CheckIfExportIsEnabled();
+
+            if (!string.IsNullOrWhiteSpace(anonymizationConfigFileETag) || !string.IsNullOrWhiteSpace(anonymizationConfigFileETag))
+            {
+                CheckIfAnonymizedExportIsEnabled();
+                CheckContainerNameForAnonymizedExport(containerName);
+            }
 
             // Export by ResourceTypeId is supported only for Group resource type.
             if (!string.Equals(typeParameter, ResourceType.Group.ToString(), StringComparison.Ordinal) || string.IsNullOrEmpty(idParameter))
@@ -145,7 +161,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                 throw new RequestNotValidException(string.Format(Resources.UnsupportedResourceType, typeParameter));
             }
 
-            return await SendExportRequest(ExportJobType.Group, since, typeFilter, resourceType, idParameter, containerName: containerName, formatName: formatName);
+            return await SendExportRequest(ExportJobType.Group, since, typeFilter, resourceType, idParameter, containerName: containerName, formatName: formatName, anonymizationConfigLocation: anonymizationConfigLocation, anonymizationConfigFileETag: anonymizationConfigFileETag);
         }
 
         [HttpGet]

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ExportController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ExportController.cs
@@ -251,16 +251,13 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         {
             if (!string.IsNullOrWhiteSpace(anonymizationConfigLocation) || !string.IsNullOrWhiteSpace(anonymizationConfigFileETag))
             {
-                CheckIfAnonymizedExportIsEnabled();
-                CheckContainerNameAndConfigLocationForAnonymizedExport(containerName, anonymizationConfigLocation);
-            }
-        }
+                // Check if anonymizedExport is enabled
+                if (!_features.SupportsAnonymizedExport)
+                {
+                    throw new RequestNotValidException(string.Format(Resources.OperationNotEnabled, OperationsConstants.AnonymizedExport));
+                }
 
-        private void CheckIfAnonymizedExportIsEnabled()
-        {
-            if (!_features.SupportsAnonymizedExport)
-            {
-                throw new RequestNotValidException(string.Format(Resources.OperationNotEnabled, OperationsConstants.AnonymizedExport));
+                CheckContainerNameAndConfigLocationForAnonymizedExport(containerName, anonymizationConfigLocation);
             }
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Client/FhirClient.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Client/FhirClient.cs
@@ -305,12 +305,12 @@ namespace Microsoft.Health.Fhir.Client
             return response.Content.Headers.ContentLocation;
         }
 
-        public async Task<Uri> AnonymizedExportAsync(string anonymizationConfig, string container, string etag = null, CancellationToken cancellationToken = default)
+        public async Task<Uri> AnonymizedExportAsync(string anonymizationConfig, string container, string etag = null, string path = "", CancellationToken cancellationToken = default)
         {
             anonymizationConfig = HttpUtility.UrlEncode(anonymizationConfig);
             etag = HttpUtility.UrlEncode(etag);
             container = HttpUtility.UrlEncode(container);
-            string requestUrl = $"$export?_container={container}&_anonymizationConfig={anonymizationConfig}&_anonymizationConfigEtag={etag}";
+            string requestUrl = $"{path}$export?_container={container}&_anonymizationConfig={anonymizationConfig}&_anonymizationConfigEtag={etag}";
 
             using var message = new HttpRequestMessage(HttpMethod.Get, requestUrl);
             message.Headers.Add("Accept", "application/fhir+json");

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/AnonymizedExportTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/AnonymizedExportTests.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
         [SkippableFact]
         public async Task GivenAValidConfigurationWithETag_WhenExportingGroupAnonymizedData_ResourceShouldBeAnonymized()
         {
-            Skip.If(!_isUsingInProcTestServer, "Not using in-process fhir server.");
+            Skip.IfNot(_isUsingInProcTestServer, "Not using in-process fhir server.");
 
             _metricHandler.ResetCount();
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/AnonymizedExportTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/AnonymizedExportTests.cs
@@ -44,7 +44,6 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
         private readonly MetricHandler _metricHandler;
         private const string RedactResourceIdAnonymizationConfiguration = @"
 {
-    ""fhirVersion"": ""R4"",
     ""fhirPathRules"": [
         {""path"": ""Resource.nodesByName('id')"", ""method"": ""redact""},
         {""path"": ""nodesByType('Human').name"", ""method"": ""redact""}

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/AnonymizedExportTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/AnonymizedExportTests.cs
@@ -59,15 +59,12 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
             _exportConfiguration = ((IOptions<ExportJobConfiguration>)(fixture.TestFhirServer as InProcTestFhirServer)?.Server?.Services?.GetService(typeof(IOptions<ExportJobConfiguration>)))?.Value;
         }
 
-        [Theory]
+        [SkippableTheory]
         [InlineData("")]
         [InlineData("Patient/")]
         public async Task GivenAValidConfigurationWithETag_WhenExportingAnonymizedData_ResourceShouldBeAnonymized(string path)
         {
-            if (!_isUsingInProcTestServer)
-            {
-                return;
-            }
+            Skip.If(!_isUsingInProcTestServer, "Not using in-process fhir server.");
 
             _metricHandler.ResetCount();
 
@@ -94,13 +91,10 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
             Assert.Single(_metricHandler.NotificationMapping[typeof(ExportTaskMetricsNotification)]);
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task GivenAValidConfigurationWithETag_WhenExportingGroupAnonymizedData_ResourceShouldBeAnonymized()
         {
-            if (!_isUsingInProcTestServer)
-            {
-                return;
-            }
+            Skip.If(!_isUsingInProcTestServer, "Not using in-process fhir server.");
 
             _metricHandler.ResetCount();
 
@@ -145,13 +139,10 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
             Assert.Single(_metricHandler.NotificationMapping[typeof(ExportTaskMetricsNotification)]);
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task GivenAValidConfigurationWithETagNoQuotes_WhenExportingAnonymizedData_ResourceShouldBeAnonymized()
         {
-            if (!_isUsingInProcTestServer)
-            {
-                return;
-            }
+            Skip.If(!_isUsingInProcTestServer, "Not using in-process fhir server.");
 
             _metricHandler.ResetCount();
 
@@ -179,13 +170,10 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
             Assert.Single(_metricHandler.NotificationMapping[typeof(ExportTaskMetricsNotification)]);
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task GivenAValidConfigurationWithoutETag_WhenExportingAnonymizedData_ResourceShouldBeAnonymized()
         {
-            if (!_isUsingInProcTestServer)
-            {
-                return;
-            }
+            Skip.If(!_isUsingInProcTestServer, "Not using in-process fhir server.");
 
             _metricHandler.ResetCount();
 
@@ -213,13 +201,10 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
             Assert.Single(_metricHandler.NotificationMapping[typeof(ExportTaskMetricsNotification)]);
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task GivenInvalidConfiguration_WhenExportingAnonymizedData_ThenBadRequestShouldBeReturned()
         {
-            if (!_isUsingInProcTestServer)
-            {
-                return;
-            }
+            Skip.If(!_isUsingInProcTestServer, "Not using in-process fhir server.");
 
             _metricHandler.ResetCount();
 
@@ -236,13 +221,10 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
             Assert.Single(_metricHandler.NotificationMapping[typeof(ExportTaskMetricsNotification)]);
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task GivenAGroupIdNotExisted_WhenExportingGroupAnonymizedData_ThenBadRequestShouldBeReturned()
         {
-            if (!_isUsingInProcTestServer)
-            {
-                return;
-            }
+            Skip.If(!_isUsingInProcTestServer, "Not using in-process fhir server.");
 
             _metricHandler.ResetCount();
 
@@ -260,13 +242,10 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
             Assert.Single(_metricHandler.NotificationMapping[typeof(ExportTaskMetricsNotification)]);
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task GivenInvalidEtagProvided_WhenExportingAnonymizedData_ThenBadRequestShouldBeReturned()
         {
-            if (!_isUsingInProcTestServer)
-            {
-                return;
-            }
+            Skip.If(!_isUsingInProcTestServer, "Not using in-process fhir server.");
 
             _metricHandler.ResetCount();
 
@@ -283,13 +262,10 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
             Assert.Single(_metricHandler.NotificationMapping[typeof(ExportTaskMetricsNotification)]);
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task GivenEtagInWrongFormatProvided_WhenExportingAnonymizedData_ThenBadRequestShouldBeReturned()
         {
-            if (!_isUsingInProcTestServer)
-            {
-                return;
-            }
+            Skip.If(!_isUsingInProcTestServer, "Not using in-process fhir server.");
 
             _metricHandler.ResetCount();
 
@@ -306,13 +282,10 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
             Assert.Single(_metricHandler.NotificationMapping[typeof(ExportTaskMetricsNotification)]);
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task GivenAContainerNotExisted_WhenExportingAnonymizedData_ThenBadRequestShouldBeReturned()
         {
-            if (!_isUsingInProcTestServer)
-            {
-                return;
-            }
+            Skip.If(!_isUsingInProcTestServer, "Not using in-process fhir server.");
 
             _metricHandler.ResetCount();
 
@@ -327,13 +300,10 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
             Assert.Single(_metricHandler.NotificationMapping[typeof(ExportTaskMetricsNotification)]);
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task GivenALargeConfigurationProvided_WhenExportingAnonymizedData_ThenBadRequestShouldBeReturned()
         {
-            if (!_isUsingInProcTestServer)
-            {
-                return;
-            }
+            Skip.If(!_isUsingInProcTestServer, "Not using in-process fhir server.");
 
             _metricHandler.ResetCount();
 
@@ -351,13 +321,10 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
             Assert.Single(_metricHandler.NotificationMapping[typeof(ExportTaskMetricsNotification)]);
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task GivenAnAnonymizedExportRequestWithoutContainerName_WhenExportingAnonymizedData_ThenFhirExceptionShouldBeThrewFromFhirClient()
         {
-            if (!_isUsingInProcTestServer)
-            {
-                return;
-            }
+            Skip.If(!_isUsingInProcTestServer, "Not using in-process fhir server.");
 
             (string fileName, string _) = await UploadConfigurationAsync(RedactResourceIdAnonymizationConfiguration);
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/AnonymizedExportTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/AnonymizedExportTests.cs
@@ -17,8 +17,10 @@ using Microsoft.Azure.Storage.Blob;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Client;
 using Microsoft.Health.Fhir.Core.Configs;
+using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export.Models;
+using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Metric;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
@@ -27,6 +29,7 @@ using Microsoft.Health.Fhir.Tests.E2E.Rest;
 using Microsoft.Health.Test.Utilities;
 using Newtonsoft.Json;
 using Xunit;
+using FhirGroup = Hl7.Fhir.Model.Group;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
@@ -41,6 +44,7 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
         private readonly MetricHandler _metricHandler;
         private const string RedactResourceIdAnonymizationConfiguration = @"
 {
+    ""fhirVersion"": ""R4"",
     ""fhirPathRules"": [
         {""path"": ""Resource.nodesByName('id')"", ""method"": ""redact""},
         {""path"": ""nodesByType('Human').name"", ""method"": ""redact""}
@@ -55,8 +59,10 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
             _exportConfiguration = ((IOptions<ExportJobConfiguration>)(fixture.TestFhirServer as InProcTestFhirServer)?.Server?.Services?.GetService(typeof(IOptions<ExportJobConfiguration>)))?.Value;
         }
 
-        [Fact]
-        public async Task GivenAValidConfigurationWithETag_WhenExportingAnonymizedData_ResourceShouldBeAnonymized()
+        [Theory]
+        [InlineData("")]
+        [InlineData("Patient/")]
+        public async Task GivenAValidConfigurationWithETag_WhenExportingAnonymizedData_ResourceShouldBeAnonymized(string path)
         {
             if (!_isUsingInProcTestServer)
             {
@@ -65,10 +71,13 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
 
             _metricHandler.ResetCount();
 
-            (string fileName, string etag) = await UploadConfigurationAsync(RedactResourceIdAnonymizationConfiguration);
+            var resourceToCreate = Samples.GetDefaultPatient().ToPoco<Patient>();
+            resourceToCreate.Id = Guid.NewGuid().ToString();
+            await _testFhirClient.UpdateAsync(resourceToCreate);
 
+            (string fileName, string etag) = await UploadConfigurationAsync(RedactResourceIdAnonymizationConfiguration);
             string containerName = Guid.NewGuid().ToString("N");
-            Uri contentLocation = await _testFhirClient.AnonymizedExportAsync(fileName, containerName, etag);
+            Uri contentLocation = await _testFhirClient.AnonymizedExportAsync(fileName, containerName, etag, path);
             HttpResponseMessage response = await WaitForCompleteAsync(contentLocation);
             IList<Uri> blobUris = await CheckExportStatus(response);
 
@@ -86,6 +95,57 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
         }
 
         [Fact]
+        public async Task GivenAValidConfigurationWithETag_WhenExportingGroupAnonymizedData_ResourceShouldBeAnonymized()
+        {
+            if (!_isUsingInProcTestServer)
+            {
+                return;
+            }
+
+            _metricHandler.ResetCount();
+
+            var patientToCreate = Samples.GetDefaultPatient().ToPoco<Patient>();
+            patientToCreate.Id = Guid.NewGuid().ToString();
+            var patientReponse = await _testFhirClient.UpdateAsync(patientToCreate);
+            var patientId = patientReponse.Resource.Id;
+
+            var group = new FhirGroup()
+            {
+                Type = FhirGroup.GroupType.Person,
+                Actual = true,
+                Id = Guid.NewGuid().ToString(),
+                Member = new List<FhirGroup.MemberComponent>()
+                {
+                    new FhirGroup.MemberComponent()
+                    {
+                        Entity = new ResourceReference($"{KnownResourceTypes.Patient}/{patientId}"),
+                    },
+                },
+            };
+            var groupReponse = await _testFhirClient.UpdateAsync(group);
+            var groupId = groupReponse.Resource.Id;
+
+            (string fileName, string etag) = await UploadConfigurationAsync(RedactResourceIdAnonymizationConfiguration);
+            string containerName = Guid.NewGuid().ToString("N");
+            Uri contentLocation = await _testFhirClient.AnonymizedExportAsync(fileName, containerName, etag, $"Group/{groupId}/");
+            HttpResponseMessage response = await WaitForCompleteAsync(contentLocation);
+            IList<Uri> blobUris = await CheckExportStatus(response);
+
+            IEnumerable<string> dataFromExport = await DownloadBlobAndParse(blobUris);
+            FhirJsonParser parser = new FhirJsonParser();
+
+            foreach (string content in dataFromExport)
+            {
+                Resource result = parser.Parse<Resource>(content);
+
+                Assert.Contains(result.Meta.Security, c => "REDACTED".Equals(c.Code));
+            }
+
+            Assert.Equal(2, dataFromExport.Count());
+            Assert.Single(_metricHandler.NotificationMapping[typeof(ExportTaskMetricsNotification)]);
+        }
+
+        [Fact]
         public async Task GivenAValidConfigurationWithETagNoQuotes_WhenExportingAnonymizedData_ResourceShouldBeAnonymized()
         {
             if (!_isUsingInProcTestServer)
@@ -94,6 +154,10 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
             }
 
             _metricHandler.ResetCount();
+
+            var resourceToCreate = Samples.GetDefaultPatient().ToPoco<Patient>();
+            resourceToCreate.Id = Guid.NewGuid().ToString();
+            await _testFhirClient.UpdateAsync(resourceToCreate);
 
             (string fileName, string etag) = await UploadConfigurationAsync(RedactResourceIdAnonymizationConfiguration);
             etag = etag.Substring(1, 17);
@@ -124,6 +188,10 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
             }
 
             _metricHandler.ResetCount();
+
+            var resourceToCreate = Samples.GetDefaultPatient().ToPoco<Patient>();
+            resourceToCreate.Id = Guid.NewGuid().ToString();
+            await _testFhirClient.UpdateAsync(resourceToCreate);
 
             (string fileName, string _) = await UploadConfigurationAsync(RedactResourceIdAnonymizationConfiguration);
 


### PR DESCRIPTION
## Description
Support De-identified export for [Patient](https://hl7.org/Fhir/uv/bulkdata/export/index.html#endpoint---all-patients) and [Group](https://hl7.org/Fhir/uv/bulkdata/export/index.html#endpoint---group-of-patients) export.

The behaviors can be viewed at [Using $export command](https://docs.microsoft.com/en-us/azure/healthcare-apis/export-data#using-export-command).

## Examples

 `GET https://<<FHIR service base URL>>/Patient/$export?_container=<<container_name>>&_anonymizationConfig=<<config file name>>&_anonymizationConfigEtag=<<ETag on storage>> `

 `GET https://<<FHIR service base URL>>/Group/[ID]/$export?_container=<<container_name>>&_anonymizationConfig=<<config file name>>&_anonymizationConfigEtag=<<ETag on storage>> `

## Testing
Manual and unit test

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Feature (An extension of De-identified export)
