### PR TITLE
x86 webapp should use corresponding extension

### DIFF
--- a/samples/templates/default-azuredeploy.json
+++ b/samples/templates/default-azuredeploy.json
@@ -288,7 +288,7 @@
                     "name": "MSDeploy",
                     "dependsOn": [
                         "[variables('appServiceResourceId')]",
-                        "[concat(variables('appServiceResourceId'), '/siteextensions/AspNetCoreRuntime.5.0.x64')]",
+                        "[concat(variables('appServiceResourceId'), '/siteextensions/AspNetCoreRuntime.5.0.x86')]",
                         "[resourceId('Microsoft.KeyVault/vaults/secrets', variables('serviceName'), 'CosmosDb--Host')]"
                     ],
                     "properties": {
@@ -297,7 +297,7 @@
                 },
                 {
                     "type": "siteextensions",
-                    "name": "AspNetCoreRuntime.5.0.x64",
+                    "name": "AspNetCoreRuntime.5.0.x86",
                     "apiVersion": "2018-11-01",
                     "location": "[resourceGroup().location]",
                     "properties": {


### PR DESCRIPTION
## Description
Provisioning with the current template results in a server error. This sets the installed .net extension back to x86.

![image](https://user-images.githubusercontent.com/197221/108426736-fca9ac80-71f0-11eb-8dc2-1fff96e2611e.png)

## Related issues
Addresses [AB#79680](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/79680).

## Testing
Deployed template.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
