### PR TITLE
Added logs for cancel export request flow

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/CancelExportRequestHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/CancelExportRequestHandlerTests.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Health.Core.Internal;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Extensions;
@@ -39,7 +40,16 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
         public CancelExportRequestHandlerTests()
         {
             var collection = new ServiceCollection();
-            collection.Add(sp => new CancelExportRequestHandler(_fhirOperationDataStore, DisabledFhirAuthorizationService.Instance, _retryCount, _sleepDurationProvider)).Singleton().AsSelf().AsImplementedInterfaces();
+            collection
+                .Add(sp => new CancelExportRequestHandler(
+                    _fhirOperationDataStore,
+                    DisabledFhirAuthorizationService.Instance,
+                    _retryCount,
+                    _sleepDurationProvider,
+                    NullLogger<CancelExportRequestHandler>.Instance))
+                .Singleton()
+                .AsSelf()
+                .AsImplementedInterfaces();
 
             ServiceProvider provider = collection.BuildServiceProvider();
             _mediator = new Mediator(type => provider.GetService(type));

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CancelExportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CancelExportRequestHandler.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
             }
             catch (Exception ex)
             {
-                _logger.LogWarning($"Unable to cancel export job {request.JobId}. Exception: {ex}");
+                _logger.LogError(ex, $"Unable to cancel export job {request.JobId}");
                 throw;
             }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CancelExportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CancelExportRequestHandler.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using MediatR;
+using Microsoft.Extensions.Logging;
 using Microsoft.Health.Core;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export.Models;
@@ -27,22 +28,26 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
         private readonly IFhirOperationDataStore _fhirOperationDataStore;
         private readonly IFhirAuthorizationService _authorizationService;
+        private readonly ILogger<CancelExportRequestHandler> _logger;
         private readonly AsyncRetryPolicy _retryPolicy;
 
-        public CancelExportRequestHandler(IFhirOperationDataStore fhirOperationDataStore, IFhirAuthorizationService authorizationService)
-            : this(fhirOperationDataStore, authorizationService, DefaultRetryCount, DefaultSleepDurationProvider)
+        public CancelExportRequestHandler(IFhirOperationDataStore fhirOperationDataStore, IFhirAuthorizationService authorizationService, ILogger<CancelExportRequestHandler> logger)
+            : this(fhirOperationDataStore, authorizationService, DefaultRetryCount, DefaultSleepDurationProvider, logger)
         {
         }
 
-        public CancelExportRequestHandler(IFhirOperationDataStore fhirOperationDataStore, IFhirAuthorizationService authorizationService, int retryCount, Func<int, TimeSpan> sleepDurationProvider)
+        public CancelExportRequestHandler(IFhirOperationDataStore fhirOperationDataStore, IFhirAuthorizationService authorizationService, int retryCount, Func<int, TimeSpan> sleepDurationProvider, ILogger<CancelExportRequestHandler> logger)
         {
             EnsureArg.IsNotNull(fhirOperationDataStore, nameof(fhirOperationDataStore));
             EnsureArg.IsNotNull(authorizationService, nameof(authorizationService));
             EnsureArg.IsGte(retryCount, 0, nameof(retryCount));
             EnsureArg.IsNotNull(sleepDurationProvider, nameof(sleepDurationProvider));
+            EnsureArg.IsNotNull(logger, nameof(logger));
 
             _fhirOperationDataStore = fhirOperationDataStore;
             _authorizationService = authorizationService;
+            _logger = logger;
+
             _retryPolicy = Policy.Handle<JobConflictException>()
                 .WaitAndRetryAsync(retryCount, sleepDurationProvider);
         }
@@ -56,26 +61,38 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                 throw new UnauthorizedFhirActionException();
             }
 
-            return await _retryPolicy.ExecuteAsync(async () =>
+            CancelExportResponse cancelResponse;
+            try
             {
-                ExportJobOutcome outcome = await _fhirOperationDataStore.GetExportJobByIdAsync(request.JobId, cancellationToken);
-
-                // If the job is already completed for any reason, return conflict status.
-                if (outcome.JobRecord.Status.IsFinished())
+                cancelResponse = await _retryPolicy.ExecuteAsync(async () =>
                 {
-                    return new CancelExportResponse(HttpStatusCode.Conflict);
-                }
+                    ExportJobOutcome outcome = await _fhirOperationDataStore.GetExportJobByIdAsync(request.JobId, cancellationToken);
 
-                // Try to cancel the job.
-                outcome.JobRecord.Status = OperationStatus.Canceled;
-                outcome.JobRecord.CanceledTime = Clock.UtcNow;
+                    // If the job is already completed for any reason, return conflict status.
+                    if (outcome.JobRecord.Status.IsFinished())
+                    {
+                        return new CancelExportResponse(HttpStatusCode.Conflict);
+                    }
 
-                outcome.JobRecord.FailureDetails = new JobFailureDetails(Resources.UserRequestedCancellation, HttpStatusCode.NoContent);
+                    // Try to cancel the job.
+                    outcome.JobRecord.Status = OperationStatus.Canceled;
+                    outcome.JobRecord.CanceledTime = Clock.UtcNow;
 
-                await _fhirOperationDataStore.UpdateExportJobAsync(outcome.JobRecord, outcome.ETag, cancellationToken);
+                    outcome.JobRecord.FailureDetails = new JobFailureDetails(Resources.UserRequestedCancellation, HttpStatusCode.NoContent);
 
-                return new CancelExportResponse(HttpStatusCode.Accepted);
-            });
+                    _logger.LogInformation($"Attempting to cancel export job {request.JobId}");
+                    await _fhirOperationDataStore.UpdateExportJobAsync(outcome.JobRecord, outcome.ETag, cancellationToken);
+
+                    return new CancelExportResponse(HttpStatusCode.Accepted);
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"Unable to cancel export job {request.JobId}. Exception: {ex}");
+                throw;
+            }
+
+            return cancelResponse;
         }
     }
 }


### PR DESCRIPTION
## Description
Added some logging in the CancelExportRequest handler.

## Related issues
Addresses [issue [AB#79190](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/79190)].

## Testing
No functionality change. Existing tests.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
