### PR TITLE
Fix invalid storage bug

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -100,6 +100,20 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
             {
                 ExportJobConfiguration exportJobConfiguration = _exportJobConfiguration;
 
+                // Add a request context so that bundle issues can be added by the SearchOptionFactory
+                var fhirRequestContext = new FhirRequestContext(
+                    method: "Export",
+                    uriString: "$export",
+                    baseUriString: "$export",
+                    correlationId: _exportJobRecord.Id,
+                    requestHeaders: new Dictionary<string, StringValues>(),
+                    responseHeaders: new Dictionary<string, StringValues>())
+                {
+                    IsBackgroundTask = true,
+                };
+
+                _contextAccessor.FhirRequestContext = fhirRequestContext;
+
                 string connectionHash = string.IsNullOrEmpty(_exportJobConfiguration.StorageAccountConnection) ?
                     string.Empty :
                     Health.Core.Extensions.StringExtensions.ComputeHash(_exportJobConfiguration.StorageAccountConnection);
@@ -127,20 +141,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
                 // Connect to export destination using appropriate client.
                 await _exportDestinationClient.ConnectAsync(exportJobConfiguration, cancellationToken, _exportJobRecord.StorageAccountContainerName);
-
-                // Add a request context so that bundle issues can be added by the SearchOptionFactory
-                var fhirRequestContext = new FhirRequestContext(
-                    method: "Export",
-                    uriString: "$export",
-                    baseUriString: "$export",
-                    correlationId: _exportJobRecord.Id,
-                    requestHeaders: new Dictionary<string, StringValues>(),
-                    responseHeaders: new Dictionary<string, StringValues>())
-                {
-                    IsBackgroundTask = true,
-                };
-
-                _contextAccessor.FhirRequestContext = fhirRequestContext;
 
                 // If we are resuming a job, we can detect that by checking the progress info from the job record.
                 // If it is null, then we know we are processing a new job.
@@ -239,9 +239,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
         private async Task UpdateJobRecordAsync(CancellationToken cancellationToken)
         {
-            foreach (OperationOutcomeIssue issue in _contextAccessor.FhirRequestContext.BundleIssues)
+            if (_contextAccessor?.FhirRequestContext?.BundleIssues != null)
             {
-                _exportJobRecord.Issues.Add(issue);
+                foreach (OperationOutcomeIssue issue in _contextAccessor.FhirRequestContext.BundleIssues)
+                {
+                    _exportJobRecord.Issues.Add(issue);
+                }
             }
 
             using (IScoped<IFhirOperationDataStore> fhirOperationDataStore = _fhirOperationDataStoreFactory())


### PR DESCRIPTION
## Description
Fixes export bug where a job hangs if the storage account is invalid.

## Related issues
Addresses #1640.

## Testing
Manual testing and new unit test.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
