### PR TITLE
Improve performance of DateTime searches in Cosmos DB

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/DateTimeEqualityRewriterTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/DateTimeEqualityRewriterTests.cs
@@ -1,0 +1,131 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
+{
+    public class DateTimeEqualityRewriterTests
+    {
+        private static readonly DateTime _start = new(2021, 1, 1, 0, 0, 0);
+        private static readonly DateTime _end = new(2021, 1, 1, 23, 59, 59);
+
+        [Fact]
+        public void GivenStartAndEndExpressions_WhenRewritten_AnUpperBoundOnStartIsAdded()
+        {
+            MultiaryExpression inputExpression =
+                Expression.And(
+                    Expression.GreaterThanOrEqual(FieldName.DateTimeStart, null, _start),
+                    Expression.LessThanOrEqual(FieldName.DateTimeEnd, null, _end));
+
+            Expression rewrittenExpression = inputExpression.AcceptVisitor(DateTimeEqualityRewriter.Instance);
+
+            Assert.Equal(
+                "(And (FieldGreaterThanOrEqual DateTimeStart 2021-01-01T00:00:00.0000000) (FieldLessThanOrEqual DateTimeStart 2021-01-01T23:59:59.0000000) (FieldLessThanOrEqual DateTimeEnd 2021-01-01T23:59:59.0000000))",
+                rewrittenExpression.ToString());
+        }
+
+        [Fact]
+        public void GivenStartAndEndExpressionsOredTogether_WhenRewritten_AreIgnored()
+        {
+            MultiaryExpression inputExpression =
+                Expression.Or(
+                    Expression.GreaterThanOrEqual(FieldName.DateTimeStart, null, _start),
+                    Expression.LessThanOrEqual(FieldName.DateTimeEnd, null, _end));
+
+            Expression rewrittenExpression = inputExpression.AcceptVisitor(DateTimeEqualityRewriter.Instance);
+
+            Assert.Same(inputExpression, rewrittenExpression);
+        }
+
+        [Fact]
+        public void GivenStartAndEndExpressionsInReverseOrder_WhenRewritten_AnUpperBoundOnStartIsAdded()
+        {
+            MultiaryExpression inputExpression =
+                Expression.And(
+                    Expression.LessThanOrEqual(FieldName.DateTimeEnd, null, _end),
+                    Expression.GreaterThanOrEqual(FieldName.DateTimeStart, null, _start));
+
+            Expression rewrittenExpression = inputExpression.AcceptVisitor(DateTimeEqualityRewriter.Instance);
+
+            Assert.Equal(
+                "(And (FieldGreaterThanOrEqual DateTimeStart 2021-01-01T00:00:00.0000000) (FieldLessThanOrEqual DateTimeStart 2021-01-01T23:59:59.0000000) (FieldLessThanOrEqual DateTimeEnd 2021-01-01T23:59:59.0000000))",
+                rewrittenExpression.ToString());
+        }
+
+        [Fact]
+        public void GivenStartAndEndExclusiveExpressions_WhenRewritten_AnUpperBoundOnStartIsAdded()
+        {
+            MultiaryExpression inputExpression =
+                Expression.And(
+                    Expression.GreaterThan(FieldName.DateTimeStart, null, _start),
+                    Expression.LessThan(FieldName.DateTimeEnd, null, _end));
+
+            Expression rewrittenExpression = inputExpression.AcceptVisitor(DateTimeEqualityRewriter.Instance);
+
+            Assert.Equal(
+                "(And (FieldGreaterThan DateTimeStart 2021-01-01T00:00:00.0000000) (FieldLessThan DateTimeStart 2021-01-01T23:59:59.0000000) (FieldLessThan DateTimeEnd 2021-01-01T23:59:59.0000000))",
+                rewrittenExpression.ToString());
+        }
+
+        [Fact]
+        public void GivenTwoStartExpressions_WhenRewritten_AreIgnored()
+        {
+            MultiaryExpression inputExpression =
+                Expression.And(
+                    Expression.GreaterThan(FieldName.DateTimeStart, null, _start),
+                    Expression.LessThan(FieldName.DateTimeStart, null, _end));
+
+            Expression rewrittenExpression = inputExpression.AcceptVisitor(DateTimeEqualityRewriter.Instance);
+
+            Assert.Same(inputExpression, rewrittenExpression);
+        }
+
+        [Fact]
+        public void GiveThreeUnrelatedExpressions_WhenRewritten_AreIgnored()
+        {
+            MultiaryExpression inputExpression =
+                Expression.And(
+                    Expression.Equals(FieldName.Number, null, 1),
+                    Expression.Equals(FieldName.Number, null, 2),
+                    Expression.Equals(FieldName.Number, null, 3));
+
+            Expression rewrittenExpression = inputExpression.AcceptVisitor(DateTimeEqualityRewriter.Instance);
+
+            Assert.Same(inputExpression, rewrittenExpression);
+        }
+
+        [Fact]
+        public void GivenStartAndEndExpressionsAndAnUnrelatedExpression_WhenRewritten_AnUpperBoundOnStartIsAdded()
+        {
+            MultiaryExpression inputExpression =
+                Expression.And(
+                    Expression.GreaterThanOrEqual(FieldName.DateTimeStart, null, _start),
+                    Expression.LessThanOrEqual(FieldName.DateTimeEnd, null, _end),
+                    Expression.Equals(FieldName.Number, null, 1));
+
+            Expression rewrittenExpression = inputExpression.AcceptVisitor(DateTimeEqualityRewriter.Instance);
+
+            Assert.Equal(
+                "(And (FieldGreaterThanOrEqual DateTimeStart 2021-01-01T00:00:00.0000000) (FieldLessThanOrEqual DateTimeStart 2021-01-01T23:59:59.0000000) (FieldLessThanOrEqual DateTimeEnd 2021-01-01T23:59:59.0000000) (FieldEqual Number 1))",
+                rewrittenExpression.ToString());
+        }
+
+        [Fact]
+        public void GivenStartAndEndExpressionsOnDifferentComponents_WhenRewritten_AreIgnored()
+        {
+            MultiaryExpression inputExpression =
+                Expression.And(
+                    Expression.GreaterThanOrEqual(FieldName.DateTimeStart, 1, _start),
+                    Expression.LessThanOrEqual(FieldName.DateTimeEnd, 2, _end));
+
+            Expression rewrittenExpression = inputExpression.AcceptVisitor(DateTimeEqualityRewriter.Instance);
+
+            Assert.Same(inputExpression, rewrittenExpression);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
@@ -57,6 +57,12 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
             SearchOptions searchOptions,
             CancellationToken cancellationToken)
         {
+            // we're going to mutate searchOptions, so clone it first so the caller of this method does not see the changes.
+            searchOptions = searchOptions.Clone();
+
+            // rewrite DateTime range expressions to be more efficient
+            searchOptions.Expression = searchOptions.Expression.AcceptVisitor(DateTimeEqualityRewriter.Instance);
+
             // pull out the _include and _revinclude expressions.
             bool hasIncludeOrRevIncludeExpressions = ExtractIncludeExpressions(
                 searchOptions.Expression,
@@ -66,8 +72,6 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
 
             if (hasIncludeOrRevIncludeExpressions)
             {
-                // we're going to mutate searchOptions, so clone it first so the caller of this method does not see the changes.
-                searchOptions = searchOptions.Clone();
                 searchOptions.Expression = expressionWithoutIncludes;
 
                 if (includeExpressions.Any(e => e.Iterate) || revIncludeExpressions.Any(e => e.Iterate))

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
             searchOptions = searchOptions.Clone();
 
             // rewrite DateTime range expressions to be more efficient
-            searchOptions.Expression = searchOptions.Expression.AcceptVisitor(DateTimeEqualityRewriter.Instance);
+            searchOptions.Expression = searchOptions.Expression?.AcceptVisitor(DateTimeEqualityRewriter.Instance);
 
             // pull out the _include and _revinclude expressions.
             bool hasIncludeOrRevIncludeExpressions = ExtractIncludeExpressions(


### PR DESCRIPTION
## Description
Searches like `/Patient?birthdate=1948-11-22` currently perform poorly with the Cosmos DB provider. In this change, we are making the following change to the query we generate this this kind of search:
![image](https://user-images.githubusercontent.com/339432/108876876-b1b2df00-75cc-11eb-9969-dd7333817c8e.png)

Today, the database is forced to intersect all patients where the birthdate's start is > queryStart and birthdate's end is < queryEnd, but because there is no correlation between these fields, this results in all patients being processed to perform the intersection. 

The solution is to add an upper bound to start, the same as the end time. 

Since we already do this for the SQL implementation, we are reusing the same visitor.

This makes a major difference. For a database with 44K Synthea patients, here are some before and after numbers, searching for the first ~10 results:

|                                          | Before RUs                                               | After RUs |
|------------------------------------------|----------------------------------------------------------|-----------|
| Observation?date=2011-08-17              | 143283                                                   | 18        |
| /Patient?birthdate=1948-11-22            | 1911                                                     | 15        |
| Observation?date=2007-08-16 (no matches) | Many empty pages with continuation and 5-10K RU per page | 7.85      |

## Related issues
Addresses #1690 

## Testing
Added unit tests and manual testing against a large-ish database

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
