### PR TITLE
Limited chained search in Cosmos provider

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Configs/CosmosDataStoreConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Configs/CosmosDataStoreConfiguration.cs
@@ -46,5 +46,10 @@ namespace Microsoft.Health.Fhir.CosmosDb.Configs
         /// This time includes the time to fetch the first page.
         /// </summary>
         public int SearchEnumerationTimeoutInSeconds { get; set; } = 30;
+
+        /// <summary>
+        /// Enables chained searches in CosmosDB
+        /// </summary>
+        public bool EnableChainedSearch { get; set; }
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
             if (searchOptions.CountOnly)
             {
                 int count = await ExecuteCountSearchAsync(
-                    _queryBuilder.BuildSqlQuerySpec(searchOptions, new QueryBuilderOptions(Array.Empty<IncludeExpression>())),
+                    _queryBuilder.BuildSqlQuerySpec(searchOptions),
                     cancellationToken);
 
                 return new SearchResult(count, searchOptions.UnsupportedSearchParams);
@@ -155,7 +155,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
 
                     // And perform a second read.
                     searchResult.TotalCount = await ExecuteCountSearchAsync(
-                        _queryBuilder.BuildSqlQuerySpec(searchOptions,  new QueryBuilderOptions(Array.Empty<IncludeExpression>())),
+                        _queryBuilder.BuildSqlQuerySpec(searchOptions),
                         cancellationToken);
                 }
             }
@@ -410,7 +410,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
                         Sort = Array.Empty<(SearchParameterInfo searchParameterInfo, SortOrder sortOrder)>(),
                     };
 
-                    QueryDefinition includeQuery = _queryBuilder.BuildSqlQuerySpec(includeSearchOptions, new QueryBuilderOptions(Array.Empty<IncludeExpression>()));
+                    QueryDefinition includeQuery = _queryBuilder.BuildSqlQuerySpec(includeSearchOptions);
 
                     (IReadOnlyList<FhirCosmosResourceWrapper> results, string continuationToken) includeResponse = default;
                     do
@@ -465,7 +465,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
                         Sort = Array.Empty<(SearchParameterInfo searchParameterInfo, SortOrder sortOrder)>(),
                     };
 
-                    QueryDefinition revIncludeQuery = _queryBuilder.BuildSqlQuerySpec(revIncludeSearchOptions, new QueryBuilderOptions(Array.Empty<IncludeExpression>()));
+                    QueryDefinition revIncludeQuery = _queryBuilder.BuildSqlQuerySpec(revIncludeSearchOptions);
 
                     (IReadOnlyList<FhirCosmosResourceWrapper> results, string continuationToken) includeResponse = default;
                     do

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/ExpressionQueryBuilder.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/ExpressionQueryBuilder.cs
@@ -198,12 +198,13 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries
 
         public object VisitChained(ChainedExpression expression, Context context)
         {
+            // Chained expressions require additional queries and are handled in the FhirCosmosSearchService.
             throw new SearchOperationNotSupportedException(Resources.ChainedExpressionNotSupported);
         }
 
         public object VisitSortParameter(SortExpression expression, Context context)
         {
-            throw new SearchOperationNotSupportedException(Resources.ChainedExpressionNotSupported);
+            throw new SearchOperationNotSupportedException(Core.Resources.SortNotSupported);
         }
 
         public object VisitMissingField(MissingFieldExpression expression, Context context)

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/ExpressionQueryBuilder.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/ExpressionQueryBuilder.cs
@@ -198,13 +198,11 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries
 
         public object VisitChained(ChainedExpression expression, Context context)
         {
-            // TODO: This will be removed once it's implemented.
             throw new SearchOperationNotSupportedException(Resources.ChainedExpressionNotSupported);
         }
 
         public object VisitSortParameter(SortExpression expression, Context context)
         {
-            // TODO: This will be removed once it's implemented.
             throw new SearchOperationNotSupportedException(Resources.ChainedExpressionNotSupported);
         }
 

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/IQueryBuilder.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/IQueryBuilder.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries
 {
     public interface IQueryBuilder
     {
-        QueryDefinition BuildSqlQuerySpec(SearchOptions searchOptions, IReadOnlyList<IncludeExpression> includes);
+        QueryDefinition BuildSqlQuerySpec(SearchOptions searchOptions, IReadOnlyList<IncludeExpression> includes, bool idsOnly = false);
 
         QueryDefinition GenerateHistorySql(SearchOptions searchOptions);
 

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/IQueryBuilder.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/IQueryBuilder.cs
@@ -10,9 +10,9 @@ using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
 
 namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries
 {
-    public interface IQueryBuilder
+    internal interface IQueryBuilder
     {
-        QueryDefinition BuildSqlQuerySpec(SearchOptions searchOptions, IReadOnlyList<IncludeExpression> includes, bool idsOnly = false);
+        QueryDefinition BuildSqlQuerySpec(SearchOptions searchOptions, QueryBuilderOptions queryOptions);
 
         QueryDefinition GenerateHistorySql(SearchOptions searchOptions);
 

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/IQueryBuilder.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/IQueryBuilder.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries
 {
     internal interface IQueryBuilder
     {
-        QueryDefinition BuildSqlQuerySpec(SearchOptions searchOptions, QueryBuilderOptions queryOptions);
+        QueryDefinition BuildSqlQuerySpec(SearchOptions searchOptions, QueryBuilderOptions queryOptions = null);
 
         QueryDefinition GenerateHistorySql(SearchOptions searchOptions);
 

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/QueryBuilder.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/QueryBuilder.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using EnsureThat;
 using Microsoft.Azure.Cosmos;
@@ -19,9 +20,9 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries
 {
     public class QueryBuilder : IQueryBuilder
     {
-        public QueryDefinition BuildSqlQuerySpec(SearchOptions searchOptions, IReadOnlyList<IncludeExpression> includes)
+        public QueryDefinition BuildSqlQuerySpec(SearchOptions searchOptions, IReadOnlyList<IncludeExpression> includes, bool idsOnly)
         {
-            return new QueryBuilderHelper().BuildSqlQuerySpec(searchOptions, includes);
+            return new QueryBuilderHelper().BuildSqlQuerySpec(searchOptions, includes, idsOnly);
         }
 
         public QueryDefinition GenerateHistorySql(SearchOptions searchOptions)
@@ -47,13 +48,17 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries
                 _queryHelper = new QueryHelper(_queryBuilder, _queryParameterManager, SearchValueConstants.RootAliasName);
             }
 
-            public QueryDefinition BuildSqlQuerySpec(SearchOptions searchOptions, IReadOnlyList<IncludeExpression> includes)
+            public QueryDefinition BuildSqlQuerySpec(SearchOptions searchOptions, IReadOnlyList<IncludeExpression> includes, bool idOnly)
             {
                 EnsureArg.IsNotNull(searchOptions, nameof(searchOptions));
 
                 if (searchOptions.CountOnly)
                 {
                     AppendSelectFromRoot("VALUE COUNT(1)");
+                }
+                else if (idOnly)
+                {
+                    AppendSelectFromRoot($"r.{KnownResourceWrapperProperties.ResourceId}", includes);
                 }
                 else
                 {

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/QueryBuilder.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/QueryBuilder.cs
@@ -20,9 +20,9 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries
 {
     internal class QueryBuilder : IQueryBuilder
     {
-        public QueryDefinition BuildSqlQuerySpec(SearchOptions searchOptions, QueryBuilderOptions queryOptions)
+        public QueryDefinition BuildSqlQuerySpec(SearchOptions searchOptions, QueryBuilderOptions queryOptions = null)
         {
-            return new QueryBuilderHelper().BuildSqlQuerySpec(searchOptions, queryOptions);
+            return new QueryBuilderHelper().BuildSqlQuerySpec(searchOptions, queryOptions ?? new QueryBuilderOptions());
         }
 
         public QueryDefinition GenerateHistorySql(SearchOptions searchOptions)

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/QueryBuilderOptions.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/QueryBuilderOptions.cs
@@ -1,0 +1,29 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
+
+namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries
+{
+    internal class QueryBuilderOptions
+    {
+        public QueryBuilderOptions(IReadOnlyList<IncludeExpression> includes = null, QueryProjection projection = QueryProjection.Default)
+        {
+            Includes = includes;
+            Projection = projection;
+        }
+
+        /// <summary>
+        /// References to project from the search index
+        /// </summary>
+        public IReadOnlyList<IncludeExpression> Includes { get; }
+
+        /// <summary>
+        /// The type of projected fields to return
+        /// </summary>
+        public QueryProjection Projection { get; }
+    }
+}

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/QueryProjection.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/QueryProjection.cs
@@ -1,0 +1,25 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries
+{
+    internal enum QueryProjection
+    {
+        /// <summary>
+        /// Default columns selected
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// Only the ID columns a selected (can be ID + Reference IDs)
+        /// </summary>
+        Id,
+
+        /// <summary>
+        /// Only reference IDs are selected
+        /// </summary>
+        ReferencesOnly,
+    }
+}

--- a/src/Microsoft.Health.Fhir.CosmosDb/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Health.Fhir.CosmosDb {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -84,6 +84,15 @@ namespace Microsoft.Health.Fhir.CosmosDb {
         internal static string ChainedExpressionNotSupported {
             get {
                 return ResourceManager.GetString("ChainedExpressionNotSupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sub-queries in a chained expression cannot return more than {0} results, please use a more selective criteria..
+        /// </summary>
+        internal static string ChainedExpressionSubqueryLimit {
+            get {
+                return ResourceManager.GetString("ChainedExpressionSubqueryLimit", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Health.Fhir.CosmosDb/Resources.resx
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Resources.resx
@@ -165,4 +165,7 @@
   <data name="IncludeIterateNotSupported" xml:space="preserve">
     <value>_include:iterate and _revinclude:iterate are not supported.</value>
   </data>
+  <data name="ChainedExpressionSubqueryLimit" xml:space="preserve">
+    <value>Sub-queries in a chained expression cannot return more than {0} results, please use a more selective criteria.</value>
+  </data>
 </root>

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -116,7 +116,8 @@
         "IndividualBatchActionRetryOptions" : {
             "MaxNumberOfRetries": 18,
             "MaxWaitTimeInSeconds": 90
-        }
+        },
+        "EnableChainedSearch": true
     },
     "DataStore": "CosmosDb",
     "KeyVault": {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Client;
 using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.CosmosDb.Features.Search;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Xunit;
@@ -23,6 +24,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         public ChainingSearchTests(ClassFixture fixture)
             : base(fixture)
         {
+            Client.HttpClient.DefaultRequestHeaders.TryAddWithoutValidation(FhirCosmosSearchService.HeaderEnableChainedSearch, "true");
         }
 
         [Fact]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
@@ -14,7 +14,7 @@ using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 {
-    [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
+    [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.Json)]
     public class ChainingSearchTests : SearchTestsBase<ChainingSearchTests.ClassFixture>
     {
         public ChainingSearchTests(ClassFixture fixture)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         public ChainingSearchTests(ClassFixture fixture)
             : base(fixture)
         {
-            Client.HttpClient.DefaultRequestHeaders.TryAddWithoutValidation(FhirCosmosSearchService.HeaderEnableChainedSearch, "true");
+            Client.HttpClient.DefaultRequestHeaders.TryAddWithoutValidation("x-ms-enable-chained-search", "true");
         }
 
         [Fact]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
@@ -171,7 +171,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 _fhirDataStore,
                 new QueryBuilder(),
                 _searchParameterDefinitionManager,
-                fhirRequestContextAccessor);
+                fhirRequestContextAccessor,
+                new CosmosDataStoreConfiguration());
 
             _fhirStorageTestHelper = new CosmosDbFhirStorageTestHelper(_container);
         }


### PR DESCRIPTION
## Description
Adds limited support for Chained and Reverse Chained FHIR Search in CosmosDB.
Adds a feature flag to enable the feature selectively for more feedback.

**Approach:**
In a chained expression, e.g. `Observation?subject:Patient.name='Jim'` will result in a query run against Patient where name = 'Jim', these ids will then be used to filter Observations by search parameter references in the `Observation.subject` index.

In a reverse chained expression, e.g. `Patient?_has:Group:member:_id=group1` this will result in a query against Group where _id=group1, yielding out the search indexes of `Group.member`. These ids will then be used to filter the parent type `Patient`.

**Limitations:**
Due to not being able to join to other documents, this implementation walks down the search expression and issues sub-queries to resolve the matched resources, this is done for each level of the expression. If any query returns more than 100 results an error will be thrown.

**Examples:**

* Simple chained query, observations who have a Patient with name Smith:
  * `/Observation?subject:Patient.name=Smith`
* Reverse chaining example, Practitioners who have Encounters with Claims created on 2020-04-01
  * `/Practitioner?_has:Encounter:practitioner:_has:Claim:encounter:created=eq2020-04-01`
* Chaining with reverse chaining example, Observations for patients who are in a Group with _id=group1
  * `/Observation?subject:Patient._has:Group:member:_id=group1`

**Questions/considerations:**
- What performance should we expect? 
  - The RUs for all sub-queries will be totaled and returned with the response.
- Should we limit the number and levels in chained search? Each level of each chained query will add a sub-query.  
  - This might be ok, if the sub-queries fail or return 0 results, the chain is short-circuited 

## Related issues
Addresses [issue #].

## Testing
Enables existing tests against cosmosdb

![image](https://user-images.githubusercontent.com/197221/109060798-b47c0580-769a-11eb-8eae-0e32d2afc12d.png)

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
