### PR TITLE
Split out variable for e2e tests agent

### DIFF
--- a/build/build-variables.yml
+++ b/build/build-variables.yml
@@ -26,6 +26,7 @@ variables:
   LinuxVmImage: 'ubuntu-latest'
   # The following is set by a build Pipeline variable:
   # DefaultLinuxPool: 'Azure Pipelines'
+  # SharedLinuxPool: 'Azure Pipelines'
   #-----------------------------------------------------------------------------------------
   # AKS details
   clusterName: "mshealth-oss-aks-cluster"

--- a/build/jobs/cleanup.yml
+++ b/build/jobs/cleanup.yml
@@ -2,7 +2,7 @@ jobs:
 - job: DeleteResourceGroup
   displayName: 'Delete resource group'
   pool:
-    name: '$(DefaultLinuxPool)'
+    name: '$(SharedLinuxPool)'
     vmImage: '$(LinuxVmImage)'
   steps:
   - task: AzurePowerShell@4

--- a/build/jobs/run-tests.yml
+++ b/build/jobs/run-tests.yml
@@ -7,7 +7,7 @@ parameters:
 jobs:
 - job: "integrationTests"
   pool:
-    name: '$(DefaultLinuxPool)'
+    name: '$(SharedLinuxPool)'
     vmImage: '$(LinuxVmImage)'
   steps:
   - task: DownloadBuildArtifacts@0
@@ -48,7 +48,7 @@ jobs:
 - job: 'cosmosE2eTests'
   dependsOn: []
   pool:
-    name: '$(DefaultLinuxPool)'
+    name: '$(SharedLinuxPool)'
     vmImage: '$(LinuxVmImage)'
   steps:
   - template: e2e-setup.yml
@@ -134,7 +134,7 @@ jobs:
 - job: 'sqlE2eTests'
   dependsOn: []
   pool:
-    name: '$(DefaultLinuxPool)'
+    name: '$(SharedLinuxPool)'
     vmImage: '$(LinuxVmImage)'
   steps:
   - template: e2e-setup.yml


### PR DESCRIPTION
## Description
E2E tests consume 9 agents (Stu3, R4, R5) x (Integration, Sql, Cosmos) configurations. We can run these on a separate shared pool that can scale beyond 10 parallel jobs.

After observing this for a while, I think this would be the best balance of the following:

* Free hosted agents have a max parallel job count of 10, but are always available
* Shared agents take ~3-4 mins to spin up on demand, but scale well beyond 10.

By offloading the largest bottleneck we can keep the compilation fast and scale out the running of tests.
