### PR TITLE
Fix template samples

### DIFF
--- a/build/ci-deploy.yml
+++ b/build/ci-deploy.yml
@@ -77,7 +77,7 @@ stages:
       resourceGroup: $(DeploymentEnvironmentName)
       testEnvironmentUrl: $(TestEnvironmentUrl)
       imageTag: $(ImageTag)
-      schemaAutomaticUpdatesEnabled: false
+      schemaAutomaticUpdatesEnabled: 'tool'
 
 - stage: deployR4
   displayName: 'Deploy R4 Site'
@@ -114,7 +114,7 @@ stages:
       resourceGroup: $(DeploymentEnvironmentName)
       testEnvironmentUrl: $(TestEnvironmentUrl)
       imageTag: $(ImageTag)
-      schemaAutomaticUpdatesEnabled: false
+      schemaAutomaticUpdatesEnabled: 'tool'
 
 - stage: deployR5
   displayName: 'Deploy R5 Site'
@@ -151,4 +151,4 @@ stages:
       resourceGroup: $(DeploymentEnvironmentName)
       testEnvironmentUrl: $(TestEnvironmentUrl)
       imageTag: $(ImageTag)
-      schemaAutomaticUpdatesEnabled: false
+      schemaAutomaticUpdatesEnabled: 'tool'

--- a/build/jobs/deploy-aks.yml
+++ b/build/jobs/deploy-aks.yml
@@ -19,8 +19,8 @@ parameters:
 - name: dnsSuffix
   type: string
 - name: schemaAutomaticUpdatesEnabled
-  type: boolean
-  default: false
+  type: string
+  default: 'tool'
 - name: reindexEnabled
   type: boolean
   default: false

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -20,8 +20,8 @@ parameters:
 - name: imageTag
   type: string
 - name: schemaAutomaticUpdatesEnabled
-  type: boolean
-  default: false
+  type: string
+  default: 'tool'
 - name: reindexEnabled
   type: boolean
   default: false
@@ -78,7 +78,7 @@ jobs:
             # Set SQL Variables
             $templateParameters["solutionType"] = "FhirServerSqlServer"
             $templateParameters["sqlAdminPassword"] = "$(-join((((33,35,37,38,42,43,45,46,95) + (48..57) + (65..90) + (97..122) | Get-Random -Count 20) + ((33,35,37,38,42,43,45,46,95) | Get-Random -Count 1) + ((48..57) | Get-Random -Count 1) + ((65..90) | Get-Random -Count 1) + ((97..122) | Get-Random -Count 1) | Get-Random -Count 24) | % {[char]$_}))"
-            $templateParameters["sqlSchemaAutomaticUpdatesEnabled"] = if ("${{ parameters.schemaAutomaticUpdatesEnabled }}" -eq "true") { $true } else { $false }
+            $templateParameters["sqlSchemaAutomaticUpdatesEnabled"] = "${{parameters.schemaAutomaticUpdatesEnabled}}"
         }
 
         Write-Host "Provisioning Resource Group"

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -128,7 +128,7 @@ stages:
       testEnvironmentUrl: $(TestEnvironmentUrl)
       imageTag: $(ImageTag)
       dnsSuffix: $(aksDnsSuffix)
-      schemaAutomaticUpdatesEnabled: true
+      schemaAutomaticUpdatesEnabled: 'auto'
 
 - stage: deployAksR4SqlContainer
   displayName: 'Deploy R4 SqlContainer in AKS'
@@ -147,7 +147,7 @@ stages:
       testEnvironmentUrl: $(TestEnvironmentUrl)
       imageTag: $(ImageTag)
       dnsSuffix: $(aksDnsSuffix)
-      schemaAutomaticUpdatesEnabled: true
+      schemaAutomaticUpdatesEnabled: 'auto'
 
 - stage: deployStu3
   displayName: 'Deploy STU3 Site'
@@ -184,7 +184,7 @@ stages:
       resourceGroup: $(ResourceGroupName)
       testEnvironmentUrl: $(TestEnvironmentUrl)
       imageTag: $(ImageTag)
-      schemaAutomaticUpdatesEnabled: true
+      schemaAutomaticUpdatesEnabled: 'auto'
 
 - stage: deployR4
   displayName: 'Deploy R4 Site'
@@ -221,7 +221,7 @@ stages:
       resourceGroup: $(ResourceGroupName)
       testEnvironmentUrl: $(TestEnvironmentUrl)
       imageTag: $(ImageTag)
-      schemaAutomaticUpdatesEnabled: true
+      schemaAutomaticUpdatesEnabled: 'auto'
 
 - stage: deployR5
   displayName: 'Deploy R5 Site'
@@ -258,7 +258,7 @@ stages:
       resourceGroup: $(ResourceGroupName)
       testEnvironmentUrl: $(TestEnvironmentUrl)
       imageTag: $(ImageTag)
-      schemaAutomaticUpdatesEnabled: true
+      schemaAutomaticUpdatesEnabled: 'auto'
 
 - stage: testAksR4Cosmos
   displayName: 'R4 CosmosDb AKS Tests'

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -147,7 +147,6 @@
         "sqlSchemaAutomaticUpdatesEnabled": {
             "type": "string",
 			"allowedValues":["false", "true"],
-			"minLength":"1",
             "defaultValue": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), 'false', '')]",
             "metadata": {
                 "description": "Determine whether the sql schema should be automatically upgraded on server startup. If false, sql schema will not be initialized or upgraded on the server startup. The schema migration tool will be required to perform initialize or upgrade. If true, sql schema will be upgraded to the maximum supported version."

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -146,8 +146,8 @@
         },
         "sqlSchemaAutomaticUpdatesEnabled": {
             "type": "string",
-            "allowedValues":["false", "true"],
-            "defaultValue": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), 'false', '')]",
+            "allowedValues":["auto", "tool"],
+            "defaultValue": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), 'tool', '')]",
             "metadata": {
                 "description": "Determine whether the sql schema should be automatically upgraded on server startup. If false, sql schema will not be initialized or upgraded on the server startup. The schema migration tool will be required to perform initialize or upgrade. If true, sql schema will be upgraded to the maximum supported version."
             }
@@ -219,7 +219,7 @@
             "FhirServer__Security__Authentication__Audience": "[parameters('securityAuthenticationAudience')]",
             "CosmosDb__ContinuationTokenSizeLimitInKb": "1",
             "SqlServer__Initialize": "[equals(parameters('solutionType'),'FhirServerSqlServer')]",
-            "SqlServer__SchemaOptions__AutomaticUpdatesEnabled": "[parameters('sqlSchemaAutomaticUpdatesEnabled')]",
+            "SqlServer__SchemaOptions__AutomaticUpdatesEnabled": "[if(equals(parameters('sqlSchemaAutomaticUpdatesEnabled'),'auto'), true(), false())]",
             "DataStore": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), 'CosmosDb', 'SqlServer')]",
             "FhirServer__Operations__Export__Enabled": "[parameters('enableExport')]",
             "FhirServer__Operations__Export__StorageAccountUri": "[if(parameters('enableExport'), concat('https://', variables('storageAccountName'), variables('blobStorageUri')), 'null')]",

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -145,8 +145,9 @@
             }
         },
         "sqlSchemaAutomaticUpdatesEnabled": {
-            "type": "bool",
-            "defaultValue": false,
+            "type": "string",
+            "allowedValues":["false", "true"],
+            "defaultValue": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), 'false', '')]",
             "metadata": {
                 "description": "Determine whether the sql schema should be automatically upgraded on server startup. If false, sql schema will not be initialized or upgraded on the server startup. The schema migration tool will be required to perform initialize or upgrade. If true, sql schema will be upgraded to the maximum supported version."
             }

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -145,9 +145,8 @@
             }
         },
         "sqlSchemaAutomaticUpdatesEnabled": {
-            "type": "string",
-            "allowedValues":["false", "true"],
-            "defaultValue": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), 'false', '')]",
+            "type": "bool",
+            "defaultValue": false,
             "metadata": {
                 "description": "Determine whether the sql schema should be automatically upgraded on server startup. If false, sql schema will not be initialized or upgraded on the server startup. The schema migration tool will be required to perform initialize or upgrade. If true, sql schema will be upgraded to the maximum supported version."
             }

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -145,11 +145,12 @@
             }
         },
         "sqlSchemaAutomaticUpdatesEnabled": {
-            "type": "bool",
-            "defaultValue": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), false(), true())]",
+            "type": "string",
+			"allowedValues":["false", "true"],
+			"minLength":"1",
+            "defaultValue": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), 'false', '')]",
             "metadata": {
                 "description": "Determine whether the sql schema should be automatically upgraded on server startup. If false, sql schema will not be initialized or upgraded on the server startup. The schema migration tool will be required to perform initialize or upgrade. If true, sql schema will be upgraded to the maximum supported version."
-            }
         },
         "fhirVersion": {
             "type": "string",

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -146,10 +146,11 @@
         },
         "sqlSchemaAutomaticUpdatesEnabled": {
             "type": "string",
-			"allowedValues":["false", "true"],
+            "allowedValues":["false", "true"],
             "defaultValue": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), 'false', '')]",
             "metadata": {
                 "description": "Determine whether the sql schema should be automatically upgraded on server startup. If false, sql schema will not be initialized or upgraded on the server startup. The schema migration tool will be required to perform initialize or upgrade. If true, sql schema will be upgraded to the maximum supported version."
+            }
         },
         "fhirVersion": {
             "type": "string",

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -146,7 +146,7 @@
         },
         "sqlSchemaAutomaticUpdatesEnabled": {
             "type": "bool",
-            "defaultValue": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), bool('false'), '')]",
+            "defaultValue": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), false(), true())]",
             "metadata": {
                 "description": "Determine whether the sql schema should be automatically upgraded on server startup. If false, sql schema will not be initialized or upgraded on the server startup. The schema migration tool will be required to perform initialize or upgrade. If true, sql schema will be upgraded to the maximum supported version."
             }

--- a/samples/templates/default-azuredeploy.json
+++ b/samples/templates/default-azuredeploy.json
@@ -153,8 +153,8 @@
         },
         "sqlSchemaAutomaticUpdatesEnabled": {
             "type": "string",
-            "allowedValues":["false", "true"],
-            "defaultValue": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), 'false', '')]",
+            "allowedValues":["auto", "tool"],
+            "defaultValue": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), 'tool', '')]",
             "metadata": {
                 "description": "Determine whether the sql schema should be automatically upgraded on server startup. If false, sql schema will not be initialized or upgraded on the server startup. The schema migration tool will be required to perform initialize or upgrade. If true, sql schema will be upgraded to the maximum supported version."
             }
@@ -222,7 +222,7 @@
             "FhirServer:Security:Authentication:Audience": "[parameters('securityAuthenticationAudience')]",
             "CosmosDb:ContinuationTokenSizeLimitInKb": "1",
             "SqlServer:Initialize": "[equals(parameters('solutionType'),'FhirServerSqlServer')]",
-            "SqlServer:SchemaOptions:AutomaticUpdatesEnabled": "[parameters('sqlSchemaAutomaticUpdatesEnabled')]",
+            "SqlServer:SchemaOptions:AutomaticUpdatesEnabled": "[if(equals(parameters('sqlSchemaAutomaticUpdatesEnabled'),'auto'), true(), false())]",
             "DataStore": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), 'CosmosDb', 'SqlServer')]",
             "FhirServer:Operations:Export:Enabled": "[parameters('enableExport')]",
             "FhirServer:Operations:Export:StorageAccountUri": "[if(parameters('enableExport'), concat('https://', variables('storageAccountName'), variables('blobStorageUri')), 'null')]",

--- a/samples/templates/default-azuredeploy.json
+++ b/samples/templates/default-azuredeploy.json
@@ -152,9 +152,8 @@
             }
         },
         "sqlSchemaAutomaticUpdatesEnabled": {
-            "type": "string",
-            "allowedValues":["false", "true"],
-            "defaultValue": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), 'false', '')]",
+            "type": "bool",
+            "defaultValue": false,
             "metadata": {
                 "description": "Determine whether the sql schema should be automatically upgraded on server startup. If false, sql schema will not be initialized or upgraded on the server startup. The schema migration tool will be required to perform initialize or upgrade. If true, sql schema will be upgraded to the maximum supported version."
             }

--- a/samples/templates/default-azuredeploy.json
+++ b/samples/templates/default-azuredeploy.json
@@ -152,12 +152,13 @@
             }
         },
         "sqlSchemaAutomaticUpdatesEnabled": {
-            "type": "bool",
-            "defaultValue": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), false(), true())]",
+            "type": "string",
+			"allowedValues":["false", "true"],
+			"minLength":"1",
+            "defaultValue": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), 'false', '')]",
             "metadata": {
                 "description": "Determine whether the sql schema should be automatically upgraded on server startup. If false, sql schema will not be initialized or upgraded on the server startup. The schema migration tool will be required to perform initialize or upgrade. If true, sql schema will be upgraded to the maximum supported version."
             }
-        },
         "fhirVersion": {
             "type": "string",
             "defaultValue": "R4",

--- a/samples/templates/default-azuredeploy.json
+++ b/samples/templates/default-azuredeploy.json
@@ -153,7 +153,7 @@
         },
         "sqlSchemaAutomaticUpdatesEnabled": {
             "type": "bool",
-            "defaultValue": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), bool('false'), '')]",
+            "defaultValue": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), false(), true())]",
             "metadata": {
                 "description": "Determine whether the sql schema should be automatically upgraded on server startup. If false, sql schema will not be initialized or upgraded on the server startup. The schema migration tool will be required to perform initialize or upgrade. If true, sql schema will be upgraded to the maximum supported version."
             }
@@ -232,7 +232,7 @@
         "combinedFhirServerConfigProperties": "[union(variables('staticFhirServerConfigProperties'), parameters('additionalFhirServerConfigProperties'))]",
         "computedSqlServerReference": "[concat('Microsoft.Sql/servers/', variables('serviceName'))]",
         "storageAccountName": "[concat(substring(replace(variables('serviceName'), '-', ''), 0, min(11, length(replace(variables('serviceName'), '-', '')))), uniquestring(resourceGroup().id, variables('serviceName')))]",
-        "azureContainerRegistryUri":"[if(variables('isMAG'), '.azurecr.us', '.azurecr.io')]",
+        "azureContainerRegistryUri": "[if(variables('isMAG'), '.azurecr.us', '.azurecr.io')]",
         "azureContainerRegistryName": "[concat(substring(replace(variables('serviceName'), '-', ''), 0, min(11, length(replace(variables('serviceName'), '-', '')))), uniquestring(resourceGroup().id, variables('serviceName')))]"
     },
     "resources": [

--- a/samples/templates/default-azuredeploy.json
+++ b/samples/templates/default-azuredeploy.json
@@ -154,7 +154,6 @@
         "sqlSchemaAutomaticUpdatesEnabled": {
             "type": "string",
 			"allowedValues":["false", "true"],
-			"minLength":"1",
             "defaultValue": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), 'false', '')]",
             "metadata": {
                 "description": "Determine whether the sql schema should be automatically upgraded on server startup. If false, sql schema will not be initialized or upgraded on the server startup. The schema migration tool will be required to perform initialize or upgrade. If true, sql schema will be upgraded to the maximum supported version."

--- a/samples/templates/default-azuredeploy.json
+++ b/samples/templates/default-azuredeploy.json
@@ -152,8 +152,9 @@
             }
         },
         "sqlSchemaAutomaticUpdatesEnabled": {
-            "type": "bool",
-            "defaultValue": false,
+            "type": "string",
+            "allowedValues":["false", "true"],
+            "defaultValue": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), 'false', '')]",
             "metadata": {
                 "description": "Determine whether the sql schema should be automatically upgraded on server startup. If false, sql schema will not be initialized or upgraded on the server startup. The schema migration tool will be required to perform initialize or upgrade. If true, sql schema will be upgraded to the maximum supported version."
             }

--- a/samples/templates/default-azuredeploy.json
+++ b/samples/templates/default-azuredeploy.json
@@ -153,11 +153,12 @@
         },
         "sqlSchemaAutomaticUpdatesEnabled": {
             "type": "string",
-			"allowedValues":["false", "true"],
+            "allowedValues":["false", "true"],
             "defaultValue": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), 'false', '')]",
             "metadata": {
                 "description": "Determine whether the sql schema should be automatically upgraded on server startup. If false, sql schema will not be initialized or upgraded on the server startup. The schema migration tool will be required to perform initialize or upgrade. If true, sql schema will be upgraded to the maximum supported version."
             }
+        },
         "fhirVersion": {
             "type": "string",
             "defaultValue": "R4",


### PR DESCRIPTION
## Description
Mixing bool and string force template engine to throw error.
So switch to 'auto' / 'tool' string values

## Related issues
Addresses [#1660].

## Testing
Manually

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip (it's a change in samples)
