### PR TITLE
Remove queryStatus when complete

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobQueryStatusConverter.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobQueryStatusConverter.cs
@@ -12,7 +12,8 @@ using Newtonsoft.Json.Linq;
 namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
 {
     /// <summary>
-    /// Class to hold metadata for one query of a reindex job
+    /// JsonConverter to handle change <see cref="ReindexJobRecord.QueryList"> from ConcurrentBag to ConcurrentDictionary.
+    /// For backcompat and fact what we don't need values in dictionary and only key uniqueness, we read and write it as array and not dictionary.
     /// </summary>
     public class ReindexJobQueryStatusConverter : JsonConverter<ConcurrentDictionary<ReindexJobQueryStatus, byte>>
     {

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobQueryStatusConverter.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobQueryStatusConverter.cs
@@ -1,0 +1,44 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
+{
+    /// <summary>
+    /// Class to hold metadata for one query of a reindex job
+    /// </summary>
+    public class ReindexJobQueryStatusConverter : JsonConverter<ConcurrentDictionary<ReindexJobQueryStatus, byte>>
+    {
+        public override ConcurrentDictionary<ReindexJobQueryStatus, byte> ReadJson(JsonReader reader, Type objectType, [AllowNull] ConcurrentDictionary<ReindexJobQueryStatus, byte> existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            var queryStatusDictionary = new ConcurrentDictionary<ReindexJobQueryStatus, byte>();
+
+            JArray queryStatusArray = JArray.Load(reader);
+            foreach (var queryStatusJObject in queryStatusArray)
+            {
+                var queryStatus = queryStatusJObject.ToObject<ReindexJobQueryStatus>();
+                queryStatusDictionary.TryAdd(queryStatus, 1);
+            }
+
+            return queryStatusDictionary;
+        }
+
+        public override void WriteJson(JsonWriter writer, [AllowNull] ConcurrentDictionary<ReindexJobQueryStatus, byte> value, JsonSerializer serializer)
+        {
+            var queryStatusArray = new JArray();
+            foreach (var queryStatus in value?.Keys)
+            {
+                queryStatusArray.Add(JObject.FromObject(queryStatus));
+            }
+
+            queryStatusArray.WriteTo(writer);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobRecord.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobRecord.cs
@@ -49,8 +49,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
         [JsonProperty(JobRecordProperties.Error)]
         public IList<OperationOutcomeIssue> Error { get; private set; } = new List<OperationOutcomeIssue>();
 
+        /// <summary>
+        /// Use Concurrent dictionary to allow access to specific items in the list
+        /// Ignore the byte value field, effective using the dictionary as a hashset
+        /// </summary>
         [JsonProperty(JobRecordProperties.QueryList)]
-        public ConcurrentBag<ReindexJobQueryStatus> QueryList { get; private set; } = new ConcurrentBag<ReindexJobQueryStatus>();
+        [JsonConverter(typeof(ReindexJobQueryStatusConverter))]
+
+        public ConcurrentDictionary<ReindexJobQueryStatus, byte> QueryList { get; private set; } = new ConcurrentDictionary<ReindexJobQueryStatus, byte>();
 
         [JsonProperty(JobRecordProperties.Count)]
         public int Count { get; set; }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                             Status = OperationStatus.Queued,
                         };
 
-                        _reindexJobRecord.QueryList.Add(query);
+                        _reindexJobRecord.QueryList.TryAdd(query, 1);
                     }
 
                     await UpdateJobAsync(cancellationToken);
@@ -150,16 +150,16 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                 var queryCancellationTokens = new Dictionary<ReindexJobQueryStatus, CancellationTokenSource>();
 
                 // while not all queries are finished
-                while (_reindexJobRecord.QueryList.Where(q =>
+                while (_reindexJobRecord.QueryList.Keys.Where(q =>
                     q.Status == OperationStatus.Queued ||
                     q.Status == OperationStatus.Running).Any())
                 {
-                    if (_reindexJobRecord.QueryList.Where(q => q.Status == OperationStatus.Queued).Any())
+                    if (_reindexJobRecord.QueryList.Keys.Where(q => q.Status == OperationStatus.Queued).Any())
                     {
                         // grab the next query from the list which is labeled as queued and run it
-                        var query = _reindexJobRecord.QueryList.Where(q => q.Status == OperationStatus.Queued).OrderBy(q => q.LastModified).FirstOrDefault();
+                        var query = _reindexJobRecord.QueryList.Keys.Where(q => q.Status == OperationStatus.Queued).OrderBy(q => q.LastModified).FirstOrDefault();
                         CancellationTokenSource queryTokensSource = new CancellationTokenSource();
-                        queryCancellationTokens.Add(query, queryTokensSource);
+                        queryCancellationTokens.TryAdd(query, queryTokensSource);
 
 #pragma warning disable CS4014 // Suppressed as we want to continue execution and begin processing the next query while this continues to run
                         queryTasks.Add(ProcessQueryAsync(query, jobSemaphore, queryTokensSource.Token));
@@ -169,7 +169,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     }
 
                     // reset stale queries to pending
-                    var staleQueries = _reindexJobRecord.QueryList.Where(
+                    var staleQueries = _reindexJobRecord.QueryList.Keys.Where(
                         q => q.Status == OperationStatus.Running && q.LastModified < Clock.UtcNow - _reindexJobConfiguration.JobHeartbeatTimeoutThreshold);
                     foreach (var staleQuery in staleQueries)
                     {
@@ -304,7 +304,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                             LastModified = Clock.UtcNow,
                             Status = OperationStatus.Queued,
                         };
-                        _reindexJobRecord.QueryList.Add(nextQuery);
+                        _reindexJobRecord.QueryList.TryAdd(nextQuery, 1);
                     }
 
                     await UpdateJobAsync(cancellationToken);
@@ -324,6 +324,15 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     {
                         _reindexJobRecord.Progress += results.Results.Count();
                         query.Status = OperationStatus.Completed;
+
+                        // Remove oldest completed queryStatus object if count > 10
+                        // to ensure reindex job document doesn't grow too large
+                        if (_reindexJobRecord.QueryList.Keys.Where(q => q.Status == OperationStatus.Completed).Count() > 10)
+                        {
+                            var queryStatusToRemove = _reindexJobRecord.QueryList.Keys.Where(q => q.Status == OperationStatus.Completed).OrderBy(q => q.LastModified).FirstOrDefault();
+                            _reindexJobRecord.QueryList.TryRemove(queryStatusToRemove, out var removedByte);
+                        }
+
                         await UpdateJobAsync(cancellationToken);
                     }
                     finally
@@ -366,7 +375,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
         private async Task CheckJobCompletionStatus(CancellationToken cancellationToken)
         {
             // If any query still in progress then we are not done
-            if (_reindexJobRecord.QueryList.Where(q =>
+            if (_reindexJobRecord.QueryList.Keys.Where(q =>
                 q.Status == OperationStatus.Queued ||
                 q.Status == OperationStatus.Running).Any())
             {
@@ -375,7 +384,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             else
             {
                 // all queries marked as complete, reindex job is done, check success or failure
-                if (_reindexJobRecord.QueryList.All(q => q.Status == OperationStatus.Completed))
+                if (_reindexJobRecord.QueryList.Keys.All(q => q.Status == OperationStatus.Completed))
                 {
                     await UpdateParametersAndCompleteJob(cancellationToken);
                 }


### PR DESCRIPTION
## Description
When doing longer running perf tests for Reindexing the job failed.  The query status was growing unchecked and also experienced a duplicate key issue.

Changes here are to avoid duplicate key problem, and to remove completed query status from the Reindex document.

## Related issues
Addresses [issue [AB#80045](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/80045)].

## Testing
Unit tests and E2E tests were updated and run.

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
Skip, just a bug fix