### PR TITLE
Cleanup aad in beginning of build

### DIFF
--- a/build/jobs/add-aad-test-environment.yml
+++ b/build/jobs/add-aad-test-environment.yml
@@ -1,52 +1,48 @@
-jobs:  
-- job: setup
-  pool:
-    vmImage: '$(WindowsVmImage)'
-  steps:
-  - task: AzureKeyVault@1
-    displayName: 'Azure Key Vault: resolute-oss-tenant-info'
-    inputs:
-      azureSubscription: $(ConnectedServiceName)
-      KeyVaultName: 'resolute-oss-tenant-info'
+steps:
+- task: AzureKeyVault@1
+  displayName: 'Azure Key Vault: resolute-oss-tenant-info'
+  inputs:
+    azureSubscription: $(ConnectedServiceName)
+    KeyVaultName: 'resolute-oss-tenant-info'
 
-  - task: AzurePowerShell@4
-    displayName: Setup Test Environment
-    inputs:
-      azureSubscription: $(ConnectedServiceName)
-      azurePowerShellVersion: latestVersion
-      ScriptType: inlineScript
-      Inline: |
-        Install-Module -Name AzureAD -Force -Verbose -Scope CurrentUser
-        $tenantId = "$(tenant-id)"
+- task: AzurePowerShell@4
+  displayName: Setup AAD Test Environment
+  inputs:
+    azureSubscription: $(ConnectedServiceName)
+    azurePowerShellVersion: latestVersion
+    ScriptType: inlineScript
+    Inline: |
+      Install-Module -Name AzureAD -Force -Verbose -Scope CurrentUser
+      $tenantId = "$(tenant-id)"
 
-        # Get admin token
-        $username = "$(tenant-admin-user-name)"
-        $password_raw = "$(tenant-admin-user-password)"
-        $password =  ConvertTo-SecureString -AsPlainText $password_raw -Force
-        $adminCredential = New-Object PSCredential $username,$password
- 
-        $adTokenUrl = "https://login.microsoftonline.com/$tenantId/oauth2/token"
-        $resource = "https://graph.windows.net/"
- 
-        $body = @{
-            grant_type = "password"
-            username   = $username
-            password   = $password_raw
-            resource   = $resource 
-            client_id  = "1950a258-227b-4e31-a9cf-717495945fc2" # Microsoft Azure PowerShell
-        }
+      # Get admin token
+      $username = "$(tenant-admin-user-name)"
+      $password_raw = "$(tenant-admin-user-password)"
+      $password =  ConvertTo-SecureString -AsPlainText $password_raw -Force
+      $adminCredential = New-Object PSCredential $username,$password
 
-        # If a deleted keyvault exists, remove it first
-        $environmentName = "$(DeploymentEnvironmentName)" -replace "\.", "" 
-        if (Get-AzKeyVault -VaultName "${environmentName}-ts" -Location "westus" -InRemovedState)
-        {
-            Remove-AzKeyVault -VaultName "${environmentName}-ts" -InRemovedState -Location "westus" -Force
-        }
- 
-        $response = Invoke-RestMethod -Method 'Post' -Uri $adTokenUrl -ContentType "application/x-www-form-urlencoded" -Body $body
-        Connect-AzureAD -TenantId $tenantId -AadAccessToken $response.access_token -AccountId $username
+      $adTokenUrl = "https://login.microsoftonline.com/$tenantId/oauth2/token"
+      $resource = "https://graph.windows.net/"
 
-        Import-Module $(System.DefaultWorkingDirectory)/samples/scripts/PowerShell/FhirServer/FhirServer.psd1
-        Import-Module $(System.DefaultWorkingDirectory)/release/scripts/PowerShell/FhirServerRelease/FhirServerRelease.psd1
+      $body = @{
+          grant_type = "password"
+          username   = $username
+          password   = $password_raw
+          resource   = $resource 
+          client_id  = "1950a258-227b-4e31-a9cf-717495945fc2" # Microsoft Azure PowerShell
+      }
 
-        $output = Add-AadTestAuthEnvironment -TestAuthEnvironmentPath $(System.DefaultWorkingDirectory)/testauthenvironment.json -EnvironmentName $environmentName -ResourceGroupName $(ResourceGroupName) -TenantAdminCredential $adminCredential
+      # If a deleted keyvault exists, remove it first
+      $environmentName = "$(DeploymentEnvironmentName)" -replace "\.", "" 
+      if (Get-AzKeyVault -VaultName "${environmentName}-ts" -Location "westus" -InRemovedState)
+      {
+          Remove-AzKeyVault -VaultName "${environmentName}-ts" -InRemovedState -Location "westus" -Force
+      }
+
+      $response = Invoke-RestMethod -Method 'Post' -Uri $adTokenUrl -ContentType "application/x-www-form-urlencoded" -Body $body
+      Connect-AzureAD -TenantId $tenantId -AadAccessToken $response.access_token -AccountId $username
+
+      Import-Module $(System.DefaultWorkingDirectory)/samples/scripts/PowerShell/FhirServer/FhirServer.psd1
+      Import-Module $(System.DefaultWorkingDirectory)/release/scripts/PowerShell/FhirServerRelease/FhirServerRelease.psd1
+
+      $output = Add-AadTestAuthEnvironment -TestAuthEnvironmentPath $(System.DefaultWorkingDirectory)/testauthenvironment.json -EnvironmentName $environmentName -ResourceGroupName $(ResourceGroupName) -TenantAdminCredential $adminCredential

--- a/build/jobs/cleanup-aad.yml
+++ b/build/jobs/cleanup-aad.yml
@@ -1,0 +1,43 @@
+jobs:
+- job: cleanupAad
+  displayName: 'Cleanup Azure Active Directory'
+  pool:
+    vmImage: '$(WindowsVmImage)'
+  steps:
+  - task: AzureKeyVault@1
+    displayName: 'Azure Key Vault: resolute-oss-tenant-info'
+    inputs:
+      azureSubscription: $(ConnectedServiceName)
+      KeyVaultName: 'resolute-oss-tenant-info'
+
+  - task: AzurePowerShell@4
+    displayName: 'Delete AAD apps'
+    inputs:
+      azureSubscription: $(ConnectedServiceName)
+      azurePowerShellVersion: latestVersion
+      ScriptType: InlineScript
+      Inline: |
+        Install-Module AzureAD -Force
+        
+        $username = "$(tenant-admin-user-name)"
+        $clientId = "$(tenant-admin-service-principal-name)"
+        $clientSecret = "$(tenant-admin-service-principal-password)"
+        $tenantId = "$(tenant-id)"
+
+        $adTokenUrl = "https://login.microsoftonline.com/$tenantId/oauth2/token"
+        $resource = "https://graph.windows.net/"
+
+        $body = @{
+            grant_type    = "client_credentials"
+            client_id     = $clientId
+            client_secret = $clientSecret
+            resource      = $resource
+        }
+
+        $response = Invoke-RestMethod -Method 'Post' -Uri $adTokenUrl -ContentType "application/x-www-form-urlencoded" -Body $body
+        Connect-AzureAD -TenantId $tenantId -AadAccessToken $response.access_token -AccountId $username
+
+        Import-Module $(System.DefaultWorkingDirectory)/samples/scripts/PowerShell/FhirServer/FhirServer.psd1
+        Import-Module $(System.DefaultWorkingDirectory)/release/scripts/PowerShell/FhirServerRelease/FhirServerRelease.psd1
+
+        Remove-AadTestAuthEnvironment -TestAuthEnvironmentPath $(System.DefaultWorkingDirectory)/testauthenvironment.json -EnvironmentName $(DeploymentEnvironmentName)

--- a/build/jobs/cleanup-aad.yml
+++ b/build/jobs/cleanup-aad.yml
@@ -1,6 +1,6 @@
 jobs:
 - job: cleanupAad
-  displayName: 'Cleanup Azure Active Directory'
+  displayName: 'Cleanup AAD'
   pool:
     vmImage: '$(WindowsVmImage)'
   steps:

--- a/build/jobs/cleanup.yml
+++ b/build/jobs/cleanup.yml
@@ -13,48 +13,7 @@ jobs:
       ScriptType: InlineScript
       Inline: 'Get-AzResourceGroup -Name $(ResourceGroupName) | Remove-AzResourceGroup -Verbose -Force'
 
-- job: cleanupAad
-  displayName: 'Cleanup Azure Active Directory'
-  pool:
-    vmImage: '$(WindowsVmImage)'
-  steps:
-  - task: AzureKeyVault@1
-    displayName: 'Azure Key Vault: resolute-oss-tenant-info'
-    inputs:
-      azureSubscription: $(ConnectedServiceName)
-      KeyVaultName: 'resolute-oss-tenant-info'
-
-  - task: AzurePowerShell@4
-    displayName: 'Delete AAD apps'
-    inputs:
-      azureSubscription: $(ConnectedServiceName)
-      azurePowerShellVersion: latestVersion
-      ScriptType: InlineScript
-      Inline: |
-        Install-Module AzureAD -Force
-        
-        $username = "$(tenant-admin-user-name)"
-        $clientId = "$(tenant-admin-service-principal-name)"
-        $clientSecret = "$(tenant-admin-service-principal-password)"
-        $tenantId = "$(tenant-id)"
-
-        $adTokenUrl = "https://login.microsoftonline.com/$tenantId/oauth2/token"
-        $resource = "https://graph.windows.net/"
-
-        $body = @{
-            grant_type    = "client_credentials"
-            client_id     = $clientId
-            client_secret = $clientSecret
-            resource      = $resource
-        }
-
-        $response = Invoke-RestMethod -Method 'Post' -Uri $adTokenUrl -ContentType "application/x-www-form-urlencoded" -Body $body
-        Connect-AzureAD -TenantId $tenantId -AadAccessToken $response.access_token -AccountId $username
-
-        Import-Module $(System.DefaultWorkingDirectory)/samples/scripts/PowerShell/FhirServer/FhirServer.psd1
-        Import-Module $(System.DefaultWorkingDirectory)/release/scripts/PowerShell/FhirServerRelease/FhirServerRelease.psd1
-
-        Remove-AadTestAuthEnvironment -TestAuthEnvironmentPath $(System.DefaultWorkingDirectory)/testauthenvironment.json -EnvironmentName $(DeploymentEnvironmentName)
+- template: ./cleanup-aad.yml
 
 - job: deleteImage
   displayName: 'Delete Image'

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -29,7 +29,7 @@ parameters:
 jobs:
 - job: provisionEnvironment
   pool:
-    name: '$(DefaultLinuxPool)'
+    name: '$(SharedLinuxPool)'
     vmImage: '$(LinuxVmImage)'
   steps:
   - task: AzureKeyVault@1

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -83,6 +83,8 @@ stages:
           catch
           {}
           New-AzResourceGroup -Name "$(ResourceGroupName)" -Location "$(ResourceGroupRegion)" -Force
+  - template: ./jobs/cleanup-aad.yml
+
 
 - stage: aadTestEnvironment
   displayName: Setup AAD Test Environment

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -90,7 +90,6 @@ stages:
   displayName: Setup AAD Test Environment
   dependsOn:
   - provisionEnvironment
-  - DockerBuild
   jobs:
   - template: ./jobs/add-aad-test-environment.yml
 
@@ -99,6 +98,7 @@ stages:
   condition: and(succeeded(), eq(variables.enableAks, 'true'))
   dependsOn:
   - DockerBuild
+  - aadTestEnvironment
   jobs:
   - template: ./jobs/deploy-aks.yml
     parameters: 
@@ -118,6 +118,7 @@ stages:
   condition: and(succeeded(), eq(variables.enableAks, 'true'))
   dependsOn:
   - DockerBuild
+  - aadTestEnvironment
   jobs:
   - template: ./jobs/deploy-aks.yml
     parameters: 
@@ -137,6 +138,7 @@ stages:
   condition: and(succeeded(), eq(variables.enableAks, 'true'))
   dependsOn:
   - DockerBuild
+  - aadTestEnvironment
   jobs:
   - template: ./jobs/deploy-aks.yml
     parameters: 
@@ -154,8 +156,8 @@ stages:
 - stage: deployStu3
   displayName: 'Deploy STU3 Site'
   dependsOn:
-  - provisionEnvironment
   - DockerBuild
+  - aadTestEnvironment
   jobs:
   - template: ./jobs/provision-deploy.yml
     parameters: 
@@ -172,8 +174,8 @@ stages:
 - stage: deployStu3Sql
   displayName: 'Deploy STU3 SQL Site'
   dependsOn:
-  - provisionEnvironment
   - DockerBuild
+  - aadTestEnvironment
   jobs:
   - template: ./jobs/provision-deploy.yml
     parameters: 
@@ -191,8 +193,8 @@ stages:
 - stage: deployR4
   displayName: 'Deploy R4 Site'
   dependsOn:
-  - provisionEnvironment
   - DockerBuild
+  - aadTestEnvironment
   jobs:
   - template: ./jobs/provision-deploy.yml
     parameters: 
@@ -209,8 +211,8 @@ stages:
 - stage: deployR4Sql
   displayName: 'Deploy R4 SQL Site'
   dependsOn:
-  - provisionEnvironment
   - DockerBuild
+  - aadTestEnvironment
   jobs:
   - template: ./jobs/provision-deploy.yml
     parameters: 
@@ -228,8 +230,8 @@ stages:
 - stage: deployR5
   displayName: 'Deploy R5 Site'
   dependsOn:
-  - provisionEnvironment
   - DockerBuild
+  - aadTestEnvironment
   jobs:
   - template: ./jobs/provision-deploy.yml
     parameters: 
@@ -246,8 +248,8 @@ stages:
 - stage: deployR5Sql
   displayName: 'Deploy R5 SQL Site'
   dependsOn:
-  - provisionEnvironment
   - DockerBuild
+  - aadTestEnvironment
   jobs:
   - template: ./jobs/provision-deploy.yml
     parameters: 

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -65,6 +65,7 @@ stages:
   dependsOn: []
   jobs:
   - job: provision
+    displayName: 'Create Resource Group'
     pool:
       name: '$(DefaultLinuxPool)'
       vmImage: '$(LinuxVmImage)'
@@ -83,22 +84,29 @@ stages:
           catch
           {}
           New-AzResourceGroup -Name "$(ResourceGroupName)" -Location "$(ResourceGroupRegion)" -Force
-  - template: ./jobs/cleanup-aad.yml
 
-
-- stage: aadTestEnvironment
-  displayName: Setup AAD Test Environment
+- stage: setupEnvironment
+  displayName: Setup Test Environment
   dependsOn:
+  - UpdateVersion
   - provisionEnvironment
   jobs:
-  - template: ./jobs/add-aad-test-environment.yml
+  - template: ./jobs/cleanup-aad.yml
+  - job: setup
+    displayName: 'Setup AAD'
+    dependsOn:
+    - cleanupAad
+    pool:
+      vmImage: '$(WindowsVmImage)'
+    steps:
+    - template: ./jobs/add-aad-test-environment.yml
 
 - stage: deployAksR4Cosmos
   displayName: 'Deploy R4 Cosmos in AKS'
   condition: and(succeeded(), eq(variables.enableAks, 'true'))
   dependsOn:
   - DockerBuild
-  - aadTestEnvironment
+  - setupEnvironment
   jobs:
   - template: ./jobs/deploy-aks.yml
     parameters: 
@@ -118,7 +126,7 @@ stages:
   condition: and(succeeded(), eq(variables.enableAks, 'true'))
   dependsOn:
   - DockerBuild
-  - aadTestEnvironment
+  - setupEnvironment
   jobs:
   - template: ./jobs/deploy-aks.yml
     parameters: 
@@ -138,7 +146,7 @@ stages:
   condition: and(succeeded(), eq(variables.enableAks, 'true'))
   dependsOn:
   - DockerBuild
-  - aadTestEnvironment
+  - setupEnvironment
   jobs:
   - template: ./jobs/deploy-aks.yml
     parameters: 
@@ -157,7 +165,7 @@ stages:
   displayName: 'Deploy STU3 Site'
   dependsOn:
   - DockerBuild
-  - aadTestEnvironment
+  - setupEnvironment
   jobs:
   - template: ./jobs/provision-deploy.yml
     parameters: 
@@ -175,7 +183,7 @@ stages:
   displayName: 'Deploy STU3 SQL Site'
   dependsOn:
   - DockerBuild
-  - aadTestEnvironment
+  - setupEnvironment
   jobs:
   - template: ./jobs/provision-deploy.yml
     parameters: 
@@ -194,7 +202,7 @@ stages:
   displayName: 'Deploy R4 Site'
   dependsOn:
   - DockerBuild
-  - aadTestEnvironment
+  - setupEnvironment
   jobs:
   - template: ./jobs/provision-deploy.yml
     parameters: 
@@ -212,7 +220,7 @@ stages:
   displayName: 'Deploy R4 SQL Site'
   dependsOn:
   - DockerBuild
-  - aadTestEnvironment
+  - setupEnvironment
   jobs:
   - template: ./jobs/provision-deploy.yml
     parameters: 
@@ -231,7 +239,7 @@ stages:
   displayName: 'Deploy R5 Site'
   dependsOn:
   - DockerBuild
-  - aadTestEnvironment
+  - setupEnvironment
   jobs:
   - template: ./jobs/provision-deploy.yml
     parameters: 
@@ -249,7 +257,7 @@ stages:
   displayName: 'Deploy R5 SQL Site'
   dependsOn:
   - DockerBuild
-  - aadTestEnvironment
+  - setupEnvironment
   jobs:
   - template: ./jobs/provision-deploy.yml
     parameters: 
@@ -269,7 +277,7 @@ stages:
   condition: and(succeeded(), eq(variables.enableAks, 'true'))
   dependsOn:
   - BuildUnitTests
-  - aadTestEnvironment
+  - setupEnvironment
   - deployAksR4Cosmos
   jobs:
   - template: ./jobs/run-tests-aks.yml
@@ -285,7 +293,7 @@ stages:
   condition: and(succeeded(), eq(variables.enableAks, 'true'))
   dependsOn:
   - BuildUnitTests
-  - aadTestEnvironment
+  - setupEnvironment
   - deployAksR4Sql
   jobs:
   - template: ./jobs/run-tests-aks.yml
@@ -301,7 +309,7 @@ stages:
   condition: and(succeeded(), eq(variables.enableAks, 'true'))
   dependsOn:
   - BuildUnitTests
-  - aadTestEnvironment
+  - setupEnvironment
   - deployAksR4SqlContainer
   jobs:
   - template: ./jobs/run-tests-aks.yml
@@ -316,7 +324,7 @@ stages:
   displayName: 'Run Stu3 Tests'
   dependsOn:
   - BuildUnitTests
-  - aadTestEnvironment
+  - setupEnvironment
   - deployStu3
   - deployStu3Sql
   jobs:
@@ -329,7 +337,7 @@ stages:
   displayName: 'Run R4 Tests'
   dependsOn:
   - BuildUnitTests
-  - aadTestEnvironment
+  - setupEnvironment
   - deployR4
   - deployR4Sql
   jobs:
@@ -342,7 +350,7 @@ stages:
   displayName: 'Run R5 Tests'
   dependsOn:
   - BuildUnitTests
-  - aadTestEnvironment
+  - setupEnvironment
   - deployR5
   - deployR5Sql
   jobs:


### PR DESCRIPTION
## Description
Performs the AAD cleanup of test applications at the start of the build

## Related issues
Addresses the role conflict exception that occasionally occurs in builds:
![image](https://user-images.githubusercontent.com/197221/109535554-8ff4a480-7a71-11eb-8f1d-fcc76c2b0890.png)


## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
