### PR TITLE
Makes chaining tests more specific for ci

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [Fact]
         public async Task GivenAChainedSearchExpression_WhenSearched_ThenCorrectBundleShouldBeReturned()
         {
-            string query = $"_tag={Fixture.Tag}&subject:Patient.name=Smith";
+            string query = $"_tag={Fixture.Tag}&subject:Patient.name={Fixture.SmithPatientGivenName}";
 
             Bundle bundle = await Client.SearchAsync(ResourceType.DiagnosticReport, query);
 
@@ -40,7 +40,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [Fact]
         public async Task GivenANestedChainedSearchExpression_WhenSearched_ThenCorrectBundleShouldBeReturned()
         {
-            string query = $"_tag={Fixture.Tag}&result.subject:Patient.name=Smith";
+            string query = $"_tag={Fixture.Tag}&result.subject:Patient.name={Fixture.SmithPatientGivenName}";
 
             Bundle bundle = await Client.SearchAsync(ResourceType.DiagnosticReport, query);
 
@@ -50,7 +50,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [Fact]
         public async Task GivenAMultiNestedChainedSearchExpression_WhenSearched_ThenCorrectBundleShouldBeReturned()
         {
-            string query = $"_tag={Fixture.Tag}&result.subject:Patient.organization.address-city=Seattle";
+            string query = $"_tag={Fixture.Tag}&result.subject:Patient.organization.address-city={Fixture.OrganizationCity}";
 
             Bundle bundle = await Client.SearchAsync(ResourceType.DiagnosticReport, query);
 
@@ -60,7 +60,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [Fact]
         public async Task GivenANestedChainedSearchExpressionWithAnOrFinalCondition_WhenSearched_ThenCorrectBundleShouldBeReturned()
         {
-            string query = $"_tag={Fixture.Tag}&result.subject:Patient.name=Smith,Truman";
+            string query = $"_tag={Fixture.Tag}&result.subject:Patient.name={Fixture.SmithPatientGivenName},{Fixture.TrumanPatientGivenName}";
 
             Bundle bundle = await Client.SearchAsync(ResourceType.DiagnosticReport, query);
 
@@ -104,7 +104,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [Fact]
         public async Task GivenAReverseChainSearchExpressionOverASimpleParameter_WhenSearched_ThenCorrectBundleShouldBeReturned()
         {
-            string query = $"_tag={Fixture.Tag}&_has:Observation:patient:code=429858000";
+            string query = $"_tag={Fixture.Tag}&_has:Observation:patient:code={Fixture.SnomedCode}";
 
             Bundle bundle = await Client.SearchAsync(ResourceType.Patient, query);
 
@@ -114,7 +114,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [Fact]
         public async Task GivenAReverseChainSearchExpressionOverASimpleParameter_WhenSearchedWithPaging_ThenCorrectBundleShouldBeReturned()
         {
-            string query = $"_tag={Fixture.Tag}&_has:Observation:patient:code=429858000&_count=1";
+            string query = $"_tag={Fixture.Tag}&_has:Observation:patient:code={Fixture.SnomedCode}&_count=1";
 
             Bundle bundle = await Client.SearchAsync(ResourceType.Patient, query);
 
@@ -128,7 +128,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [Fact]
         public async Task GivenAReverseChainSearchExpressionWithMultipleTargetTypes_WhenSearched_ThenCorrectBundleShouldBeReturned()
         {
-            string query = $"?_tag={Fixture.Tag}&_type=Patient,Device&_has:Observation:subject:code=429858000";
+            string query = $"?_tag={Fixture.Tag}&_type=Patient,Device&_has:Observation:subject:code={Fixture.SnomedCode}";
 
             Bundle bundle = await Client.SearchAsync(query);
 
@@ -138,7 +138,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [Fact]
         public async Task GivenANestedReverseChainSearchExpressionOverASimpleParameter_WhenSearched_ThenCorrectBundleShouldBeReturned()
         {
-            string query = $"_tag={Fixture.Tag}&_has:Observation:patient:_has:DiagnosticReport:result:code=429858000";
+            string query = $"_tag={Fixture.Tag}&_has:Observation:patient:_has:DiagnosticReport:result:code={Fixture.SnomedCode}";
 
             Bundle bundle = await Client.SearchAsync(ResourceType.Patient, query);
 
@@ -155,6 +155,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             ValidateBundle(bundle, Fixture.AdamsPatient, Fixture.SmithPatient, Fixture.TrumanPatient);
         }
 
+        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
         [Fact]
         public async Task GivenANestedReverseChainSearchExpressionOverTheTypeResourceParameter_WhenSearched_ThenCorrectBundleShouldBeReturned()
         {
@@ -211,7 +212,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [Fact]
         public async Task GivenACombinationOfChainingReverseChainSearchExpressionOverASimpleParameter_WhenSearched_ThenCorrectBundleShouldBeReturned()
         {
-            string query = $"_tag={Fixture.Tag}&code=429858000&patient:Patient._has:Group:member:_tag={Fixture.Tag}";
+            string query = $"_tag={Fixture.Tag}&code={Fixture.SnomedCode}&patient:Patient._has:Group:member:_tag={Fixture.Tag}";
 
             Bundle bundle = await Client.SearchAsync(ResourceType.DiagnosticReport, query);
 
@@ -221,7 +222,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [Fact]
         public async Task GivenACombinationOfChainingReverseChainSearchExpressionOverASimpleParameter_WhenSearchedWithPaging_ThenCorrectBundleShouldBeReturned()
         {
-            string query = $"_tag={Fixture.Tag}&code=429858000&patient:Patient._has:Group:member:_tag={Fixture.Tag}&_count=1";
+            string query = $"_tag={Fixture.Tag}&code={Fixture.SnomedCode}&patient:Patient._has:Group:member:_tag={Fixture.Tag}&_count=1";
 
             Bundle bundle = await Client.SearchAsync(ResourceType.DiagnosticReport, query);
 
@@ -235,7 +236,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [Fact]
         public async Task GivenACombinationOfChainingReverseChainSearchExpressionOverAResourceTableParameter_WhenSearched_ThenCorrectBundleShouldBeReturned()
         {
-            string query = $"_tag={Fixture.Tag}&code=429858000&patient:Patient._has:Group:member:_id={Fixture.PatientGroup.Id}";
+            string query = $"_tag={Fixture.Tag}&code={Fixture.SnomedCode}&patient:Patient._has:Group:member:_id={Fixture.PatientGroup.Id}";
 
             Bundle bundle = await Client.SearchAsync(ResourceType.DiagnosticReport, query);
 
@@ -245,7 +246,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [Fact]
         public async Task GivenACombinationOfChainingReverseChainSearchExpressionOverAResourceTableParameter_WhenSearchedWithPaging_ThenCorrectBundleShouldBeReturned()
         {
-            string query = $"_tag={Fixture.Tag}&code=429858000&patient:Patient._has:Group:member:_id={Fixture.PatientGroup.Id}&_count=1";
+            string query = $"_tag={Fixture.Tag}&code={Fixture.SnomedCode}&patient:Patient._has:Group:member:_id={Fixture.PatientGroup.Id}&_count=1";
 
             Bundle bundle = await Client.SearchAsync(ResourceType.DiagnosticReport, query);
 
@@ -292,6 +293,14 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
             public DiagnosticReport TrumanLoincDiagnosticReport { get; private set; }
 
+            public string SmithPatientGivenName { get; } = Guid.NewGuid().ToString();
+
+            public string TrumanPatientGivenName { get; } = Guid.NewGuid().ToString();
+
+            public string SnomedCode { get; } = Guid.NewGuid().ToString();
+
+            public string OrganizationCity { get; } = Guid.NewGuid().ToString();
+
             public Patient SmithPatient { get; private set; }
 
             public DiagnosticReport SmithSnomedDiagnosticReport { get; private set; }
@@ -307,7 +316,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 Tag = Guid.NewGuid().ToString();
 
                 // Construct an observation pointing to a patient and a diagnostic report pointing to the observation and the patient along with some not matching entries
-                var snomedCode = new CodeableConcept("http://snomed.info/sct", "429858000");
+                var snomedCode = new CodeableConcept("http://snomed.info/sct", SnomedCode);
                 var loincCode = new CodeableConcept("http://loinc.org", "4548-4");
 
                 var meta = new Meta
@@ -318,11 +327,11 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                     },
                 };
 
-                var organization = (await TestFhirClient.CreateAsync(new Organization { Meta = meta, Address = new List<Address> { new Address { City = "Seattle" } } })).Resource;
+                var organization = (await TestFhirClient.CreateAsync(new Organization { Meta = meta, Address = new List<Address> { new() { City = "Seattle" }, new() { City = OrganizationCity} } })).Resource;
 
                 AdamsPatient = (await TestFhirClient.CreateAsync(new Patient { Meta = meta, Name = new List<HumanName> { new HumanName { Family = "Adams" } } })).Resource;
-                SmithPatient = (await TestFhirClient.CreateAsync(new Patient { Meta = meta, Name = new List<HumanName> { new HumanName { Family = "Smith" } }, ManagingOrganization = new ResourceReference($"Organization/{organization.Id}") })).Resource;
-                TrumanPatient = (await TestFhirClient.CreateAsync(new Patient { Meta = meta, Name = new List<HumanName> { new HumanName { Family = "Truman" } } })).Resource;
+                SmithPatient = (await TestFhirClient.CreateAsync(new Patient { Meta = meta, Name = new List<HumanName> { new HumanName { Given = new[] { SmithPatientGivenName }, Family = "Smith" } }, ManagingOrganization = new ResourceReference($"Organization/{organization.Id}") })).Resource;
+                TrumanPatient = (await TestFhirClient.CreateAsync(new Patient { Meta = meta, Name = new List<HumanName> { new HumanName { Given = new[] { TrumanPatientGivenName }, Family = "Truman" } } })).Resource;
 
                 DeviceLoincSubject = (await TestFhirClient.CreateAsync(new Device { Meta = meta })).Resource;
                 DeviceSnomedSubject = (await TestFhirClient.CreateAsync(new Device { Meta = meta })).Resource;


### PR DESCRIPTION
## Description
Makes data more specific for chaining tests in ci:
https://microsofthealthoss.visualstudio.com/FhirServer/_build/results?buildId=9360&view=ms.vss-test-web.build-test-results-tab&runId=1263238&resultId=100080&paneView=debug

## Related issues
Addresses [issue #].

## Testing
Updates tests

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
