### PR TITLE
Gracefully handle Cosmos DB throttling on startup

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Headers/HeaderDictionaryExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Headers/HeaderDictionaryExtensions.cs
@@ -17,13 +17,15 @@ namespace Microsoft.Health.Fhir.Api.Features.Headers
         /// </summary>
         /// <param name="responseHeaders">The response headers</param>
         /// <param name="retryAfterTimeSpan">The time</param>
-        public static void AddRetryAfterHeaders(this IHeaderDictionary responseHeaders, TimeSpan retryAfterTimeSpan)
+        public static void AddRetryAfterHeaders(this IHeaderDictionary responseHeaders, TimeSpan? retryAfterTimeSpan)
         {
+            retryAfterTimeSpan ??= TimeSpan.FromSeconds(1); // in case this is missing, provide some value so we that the header is always there
+
             responseHeaders.Add(
                 KnownHeaders.RetryAfterMilliseconds,
-                ((int)retryAfterTimeSpan.TotalMilliseconds).ToString(CultureInfo.InvariantCulture));
+                ((int)retryAfterTimeSpan.Value.TotalMilliseconds).ToString(CultureInfo.InvariantCulture));
 
-            int retryAfterSeconds = retryAfterTimeSpan == default ? 0 : Math.Max(1, (int)Math.Round(retryAfterTimeSpan.TotalSeconds));
+            int retryAfterSeconds = retryAfterTimeSpan == default ? 0 : Math.Max(1, (int)Math.Round(retryAfterTimeSpan.Value.TotalSeconds));
 
             responseHeaders.Add(
                 KnownHeaders.RetryAfter,

--- a/src/Microsoft.Health.Fhir.Api/Features/Throttling/ThrottlingMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Throttling/ThrottlingMiddleware.cs
@@ -292,10 +292,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Throttling
 
             context.Response.StatusCode = StatusCodes.Status429TooManyRequests;
 
-            if (exception.RetryAfter.HasValue)
-            {
-                context.Response.Headers.AddRetryAfterHeaders(exception.RetryAfter.Value);
-            }
+            context.Response.Headers.AddRetryAfterHeaders(exception.RetryAfter);
 
             Memory<byte> body = CreateThrottledBody(exception.Message);
 

--- a/src/Microsoft.Health.Fhir.Api/Features/Throttling/ThrottlingMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Throttling/ThrottlingMiddleware.cs
@@ -13,6 +13,7 @@ using EnsureThat;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Health.Abstractions.Exceptions;
 using Microsoft.Health.Fhir.Api.Configs;
 using Microsoft.Health.Fhir.Api.Features.Headers;
 using Microsoft.Health.Fhir.Core.Configs;
@@ -22,6 +23,8 @@ namespace Microsoft.Health.Fhir.Api.Features.Throttling
     /// <summary>
     /// Middleware to limit the number of concurrent requests that an instance of the server handles simultaneously.
     /// Also provides request queuing up to a maximum queue size and wait time in the queue.
+    /// Also handles unhandled <see cref="RequestRateExceededException"/> thrown downstream and returns a 429 response.
+    /// These can happen during startup before the MVC handler has been reached.
     /// </summary>
     public sealed class ThrottlingMiddleware : IAsyncDisposable, IDisposable
     {
@@ -34,7 +37,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Throttling
 
         // hard-coding these to minimize resource consumption when throttling
         private const string ThrottledContentType = "application/json; charset=utf-8";
-        private static readonly ReadOnlyMemory<byte> _throttledBody = Encoding.UTF8.GetBytes($@"{{""severity"":""Error"",""code"":""Throttled"",""diagnostics"":""{Resources.TooManyConcurrentRequests}""}}").AsMemory();
+        private static readonly ReadOnlyMemory<byte> _throttledBody = CreateThrottledBody(Resources.TooManyConcurrentRequests);
 
         private readonly RequestDelegate _next;
         private readonly ILogger<ThrottlingMiddleware> _logger;
@@ -51,6 +54,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Throttling
         private readonly int _concurrentRequestLimit;
         private readonly int _maxQueueSize;
         private readonly int _maxMillisecondsInQueue;
+        private bool _throttlingEnabled;
 
         public ThrottlingMiddleware(
             RequestDelegate next,
@@ -62,6 +66,8 @@ namespace Microsoft.Health.Fhir.Api.Features.Throttling
             _logger = EnsureArg.IsNotNull(logger, nameof(logger));
             ThrottlingConfiguration configuration = EnsureArg.IsNotNull(throttlingConfiguration?.Value, nameof(throttlingConfiguration));
             EnsureArg.IsNotNull(securityConfiguration?.Value, nameof(securityConfiguration));
+
+            _throttlingEnabled = throttlingConfiguration.Value.Enabled;
 
             _securityEnabled = securityConfiguration.Value.Enabled;
 
@@ -123,92 +129,105 @@ namespace Microsoft.Health.Fhir.Api.Features.Throttling
 
         public async Task Invoke(HttpContext context)
         {
-            if (_excludedEndpoints.Contains((context.Request.Method, context.Request.Path.Value)))
+            try
             {
-                // Endpoint is exempt from concurrent request limits.
-                await _next(context);
-                return;
-            }
-
-            if (_securityEnabled && !context.User.Identity.IsAuthenticated)
-            {
-                // Ignore Unauthenticated users if security is enabled
-                await _next(context);
-                return;
-            }
-
-            bool canRun = false;
-            bool queueSizeExceeded = false;
-            LinkedListNode<TaskCompletionSource<object>> queueNode = null;
-
-            for (int i = 0; i < 2; i++)
-            {
-                // we do two loop iterations only when we need to queue up the request.
-                lock (_queue)
+                if (!_throttlingEnabled)
                 {
-                    if (_requestsInFlight < _concurrentRequestLimit)
-                    {
-                        canRun = true;
-                        _requestsInFlight++;
-                        break;
-                    }
-
-                    if (_queue.Count >= _maxQueueSize)
-                    {
-                        queueSizeExceeded = true;
-                        break;
-                    }
-
-                    if (queueNode != null)
-                    {
-                        _queue.AddLast(queueNode);
-                        break;
-                    }
+                    await _next(context);
+                    return;
                 }
 
-                // allocate outside of the lock
-                queueNode = new LinkedListNode<TaskCompletionSource<object>>(new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously));
-            }
-
-            if (canRun)
-            {
-                // No throttling or no queueing necessary. Execute the request.
-                await RunRequest(context);
-            }
-            else if (queueSizeExceeded)
-            {
-                await Return429(context);
-            }
-            else
-            {
-                Debug.Assert(queueNode != null);
-
-                // start the timeout clock now while we wait for other requests ahead of us to finish.
-                if (await Task.WhenAny(queueNode.Value.Task, Task.Delay(_maxMillisecondsInQueue, context.RequestAborted)) != queueNode.Value.Task)
+                if (_excludedEndpoints.Contains((context.Request.Method, context.Request.Path.Value)))
                 {
-                    // timed out or request canceled
+                    // Endpoint is exempt from concurrent request limits.
+                    await _next(context);
+                    return;
+                }
+
+                if (_securityEnabled && !context.User.Identity.IsAuthenticated)
+                {
+                    // Ignore Unauthenticated users if security is enabled
+                    await _next(context);
+                    return;
+                }
+
+                bool canRun = false;
+                bool queueSizeExceeded = false;
+                LinkedListNode<TaskCompletionSource<object>> queueNode = null;
+
+                for (int i = 0; i < 2; i++)
+                {
+                    // we do two loop iterations only when we need to queue up the request.
                     lock (_queue)
                     {
-                        if (queueNode.List != null)
+                        if (_requestsInFlight < _concurrentRequestLimit)
                         {
-                            _queue.Remove(queueNode);
-                        }
-                        else
-                        {
-                            // this was a race condition and the request is actually ready to go now.
                             canRun = true;
+                            _requestsInFlight++;
+                            break;
+                        }
+
+                        if (_queue.Count >= _maxQueueSize)
+                        {
+                            queueSizeExceeded = true;
+                            break;
+                        }
+
+                        if (queueNode != null)
+                        {
+                            _queue.AddLast(queueNode);
+                            break;
                         }
                     }
 
-                    if (!canRun)
-                    {
-                        await Return429(context);
-                        return;
-                    }
+                    // allocate outside of the lock
+                    queueNode = new LinkedListNode<TaskCompletionSource<object>>(new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously));
                 }
 
-                // the request has been dequeued and we can now execute.
-                await RunRequest(context);
+                if (canRun)
+                {
+                    // No throttling or no queueing necessary. Execute the request.
+                    await RunRequest(context);
+                }
+                else if (queueSizeExceeded)
+                {
+                    await Return429(context);
+                }
+                else
+                {
+                    Debug.Assert(queueNode != null);
+
+                    // start the timeout clock now while we wait for other requests ahead of us to finish.
+                    if (await Task.WhenAny(queueNode.Value.Task, Task.Delay(_maxMillisecondsInQueue, context.RequestAborted)) != queueNode.Value.Task)
+                    {
+                        // timed out or request canceled
+                        lock (_queue)
+                        {
+                            if (queueNode.List != null)
+                            {
+                                _queue.Remove(queueNode);
+                            }
+                            else
+                            {
+                                // this was a race condition and the request is actually ready to go now.
+                                canRun = true;
+                            }
+                        }
+
+                        if (!canRun)
+                        {
+                            await Return429(context);
+                            return;
+                        }
+                    }
+
+                    // the request has been dequeued and we can now execute.
+                    await RunRequest(context);
+                }
+            }
+            catch (RequestRateExceededException e)
+            {
+                await Return429FromRequestRateExceededException(e, context);
             }
         }
 
@@ -266,6 +285,27 @@ namespace Microsoft.Health.Fhir.Api.Features.Throttling
 
             await context.Response.Body.WriteAsync(_throttledBody);
         }
+
+        private async Task Return429FromRequestRateExceededException(RequestRateExceededException exception, HttpContext context)
+        {
+            _logger.LogWarning($"Returning 429 from unhandled {nameof(RequestRateExceededException)}");
+
+            context.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+
+            if (exception.RetryAfter.HasValue)
+            {
+                context.Response.Headers.AddRetryAfterHeaders(exception.RetryAfter.Value);
+            }
+
+            Memory<byte> body = CreateThrottledBody(exception.Message);
+
+            context.Response.ContentLength = body.Length;
+            context.Response.ContentType = ThrottledContentType;
+
+            await context.Response.Body.WriteAsync(body);
+        }
+
+        private static Memory<byte> CreateThrottledBody(string message) => Encoding.UTF8.GetBytes($@"{{""severity"":""Error"",""code"":""Throttled"",""diagnostics"":""{message}""}}").AsMemory();
 
         public async ValueTask DisposeAsync()
         {

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/FhirCosmosClientInitializerTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/FhirCosmosClientInitializerTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.CosmosDb.Configs;
 using Microsoft.Health.Fhir.CosmosDb.Features.Storage;
 using NSubstitute;
@@ -30,6 +31,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Storage
             _initializer = new FhirCosmosClientInitializer(
                 clientTestProvider,
                 () => new[] { new TestRequestHandler() },
+                new RetryExceptionPolicyFactory(_cosmosDataStoreConfiguration, Substitute.For<IFhirRequestContextAccessor>()),
                 NullLogger<FhirCosmosClientInitializer>.Instance);
 
             _collectionInitializers = new List<ICollectionInitializer> { _collectionInitializer1, _collectionInitializer2 };

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CollectionInitializer.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CollectionInitializer.cs
@@ -3,68 +3,104 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
+using System.Net;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Logging;
+using Microsoft.Health.Abstractions.Exceptions;
 using Microsoft.Health.Fhir.CosmosDb.Configs;
 using Microsoft.Health.Fhir.CosmosDb.Features.Storage.Versioning;
+using Polly;
 
 namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
 {
     public class CollectionInitializer : ICollectionInitializer
     {
-        private readonly string _collectionId;
+        private readonly CosmosCollectionConfiguration _cosmosCollectionConfiguration;
         private readonly CosmosDataStoreConfiguration _cosmosDataStoreConfiguration;
-        private readonly int? _initialCollectionThroughput;
         private readonly IUpgradeManager _upgradeManager;
+        private readonly RetryExceptionPolicyFactory _retryExceptionPolicyFactory;
+        private readonly ICosmosClientTestProvider _clientTestProvider;
         private readonly ILogger<CollectionInitializer> _logger;
 
-        public CollectionInitializer(string collectionId, CosmosDataStoreConfiguration cosmosDataStoreConfiguration, int? initialCollectionThroughput, IUpgradeManager upgradeManager, ILogger<CollectionInitializer> logger)
+        public CollectionInitializer(
+            CosmosCollectionConfiguration cosmosCollectionConfiguration,
+            CosmosDataStoreConfiguration cosmosDataStoreConfiguration,
+            IUpgradeManager upgradeManager,
+            RetryExceptionPolicyFactory retryExceptionPolicyFactory,
+            ICosmosClientTestProvider clientTestProvider,
+            ILogger<CollectionInitializer> logger)
         {
-            EnsureArg.IsNotNull(collectionId, nameof(collectionId));
+            EnsureArg.IsNotNull(cosmosCollectionConfiguration, nameof(cosmosCollectionConfiguration));
+            EnsureArg.IsNotNull(cosmosCollectionConfiguration.CollectionId, nameof(CosmosCollectionConfiguration.CollectionId));
+            EnsureArg.IsNotNull(clientTestProvider, nameof(clientTestProvider));
             EnsureArg.IsNotNull(cosmosDataStoreConfiguration, nameof(cosmosDataStoreConfiguration));
             EnsureArg.IsNotNull(upgradeManager, nameof(upgradeManager));
+            EnsureArg.IsNotNull(retryExceptionPolicyFactory, nameof(retryExceptionPolicyFactory));
             EnsureArg.IsNotNull(logger, nameof(logger));
 
-            _collectionId = collectionId;
+            _cosmosCollectionConfiguration = cosmosCollectionConfiguration;
             _cosmosDataStoreConfiguration = cosmosDataStoreConfiguration;
-            _initialCollectionThroughput = initialCollectionThroughput;
             _upgradeManager = upgradeManager;
+            _retryExceptionPolicyFactory = retryExceptionPolicyFactory;
+            _clientTestProvider = clientTestProvider;
             _logger = logger;
         }
 
         public async Task<Container> InitializeCollection(CosmosClient client)
         {
             Database database = client.GetDatabase(_cosmosDataStoreConfiguration.DatabaseId);
-            Container containerClient = database.GetContainer(_collectionId);
+            Container containerClient = database.GetContainer(_cosmosCollectionConfiguration.CollectionId);
 
-            _logger.LogInformation("Finding Container: {collectionId}", _collectionId);
-            var existingContainer = await database.TryGetContainerAsync(_collectionId);
+            _logger.LogInformation("Finding Container: {collectionId}", _cosmosCollectionConfiguration.CollectionId);
 
-            if (existingContainer == null)
+            AsyncPolicy retryPolicy = _retryExceptionPolicyFactory.GetRetryPolicy();
+
+            ContainerResponse container = await retryPolicy.ExecuteAsync(async () =>
             {
-                _logger.LogInformation("Creating Cosmos Container if not exits: {collectionId}", _collectionId);
-
-                var containerResponse = await database.CreateContainerIfNotExistsAsync(
-                    _collectionId,
-                    $"/{KnownDocumentProperties.PartitionKey}",
-                    _initialCollectionThroughput);
-
-                containerResponse.Resource.DefaultTimeToLive = -1;
-
-                existingContainer = await containerClient.ReplaceContainerAsync(containerResponse);
-
-                if (_initialCollectionThroughput.HasValue)
+                var existingContainer = await database.TryGetContainerAsync(_cosmosCollectionConfiguration.CollectionId);
+                if (existingContainer == null)
                 {
-                    ThroughputProperties throughputProperties = ThroughputProperties.CreateManualThroughput(_initialCollectionThroughput.Value);
-                    await containerClient.ReplaceThroughputAsync(throughputProperties);
+                    _logger.LogInformation("Creating Cosmos Container if not exits: {collectionId}", _cosmosCollectionConfiguration.CollectionId);
+
+                    var containerResponse = await database.CreateContainerIfNotExistsAsync(
+                        _cosmosCollectionConfiguration.CollectionId,
+                        $"/{KnownDocumentProperties.PartitionKey}",
+                        _cosmosCollectionConfiguration.InitialCollectionThroughput);
+
+                    containerResponse.Resource.DefaultTimeToLive = -1;
+
+                    existingContainer = await containerClient.ReplaceContainerAsync(containerResponse);
+
+                    if (_cosmosCollectionConfiguration.InitialCollectionThroughput.HasValue)
+                    {
+                        ThroughputProperties throughputProperties = ThroughputProperties.CreateManualThroughput(_cosmosCollectionConfiguration.InitialCollectionThroughput.Value);
+                        await containerClient.ReplaceThroughputAsync(throughputProperties);
+                    }
                 }
-            }
+
+                return existingContainer;
+            });
+
+            await retryPolicy.ExecuteAsync(async () =>
+            {
+                try
+                {
+                    await _clientTestProvider.PerformTest(container, _cosmosDataStoreConfiguration, _cosmosCollectionConfiguration);
+                }
+                catch (CosmosException e) when (e.StatusCode == HttpStatusCode.TooManyRequests)
+                {
+                    // This is the very first interaction with the collection, and we might get this exception
+                    // when it calls GetCachedContainerPropertiesAsync, which does not use our request handler.
+                    throw new RequestRateExceededException(e.RetryAfter);
+                }
+            });
 
             await _upgradeManager.SetupContainerAsync(containerClient);
 
-            return existingContainer;
+            return container;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosContainerProvider.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosContainerProvider.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
                 {
                     _initializationOperation.EnsureInitialized().GetAwaiter().GetResult();
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is not RequestRateExceededException)
                 {
                     _logger.LogCritical(ex, "Couldn't create a ContainerScope because EnsureInitialized failed.");
                     throw new ServiceUnavailableException();

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/FhirCosmosClientInitializer.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/FhirCosmosClientInitializer.cs
@@ -7,11 +7,13 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Cosmos.Fluent;
 using Microsoft.Extensions.Logging;
+using Microsoft.Health.Abstractions.Exceptions;
 using Microsoft.Health.Fhir.CosmosDb.Configs;
 using Microsoft.IO;
 using Newtonsoft.Json;
@@ -24,18 +26,22 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
         private readonly ICosmosClientTestProvider _testProvider;
         private readonly ILogger<FhirCosmosClientInitializer> _logger;
         private readonly Func<IEnumerable<RequestHandler>> _requestHandlerFactory;
+        private readonly RetryExceptionPolicyFactory _retryExceptionPolicyFactory;
 
         public FhirCosmosClientInitializer(
             ICosmosClientTestProvider testProvider,
             Func<IEnumerable<RequestHandler>> requestHandlerFactory,
+            RetryExceptionPolicyFactory retryExceptionPolicyFactory,
             ILogger<FhirCosmosClientInitializer> logger)
         {
             EnsureArg.IsNotNull(testProvider, nameof(testProvider));
             EnsureArg.IsNotNull(requestHandlerFactory, nameof(requestHandlerFactory));
+            EnsureArg.IsNotNull(retryExceptionPolicyFactory, nameof(retryExceptionPolicyFactory));
             EnsureArg.IsNotNull(logger, nameof(logger));
 
             _testProvider = testProvider;
             _requestHandlerFactory = requestHandlerFactory;
+            _retryExceptionPolicyFactory = retryExceptionPolicyFactory;
             _logger = logger;
         }
 
@@ -92,13 +98,15 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
             _logger.LogInformation("Opening CosmosClient connection to {CollectionId}", cosmosCollectionConfiguration.CollectionId);
             try
             {
-                await _testProvider.PerformTest(client.GetContainer(configuration.DatabaseId, cosmosCollectionConfiguration.CollectionId), configuration, cosmosCollectionConfiguration);
+                await _retryExceptionPolicyFactory.GetRetryPolicy().ExecuteAsync(async () =>
+                    await _testProvider.PerformTest(client.GetContainer(configuration.DatabaseId, cosmosCollectionConfiguration.CollectionId), configuration, cosmosCollectionConfiguration));
 
                 _logger.LogInformation("Established CosmosClient connection to {CollectionId}", cosmosCollectionConfiguration.CollectionId);
             }
             catch (Exception e)
             {
-                _logger.LogCritical(e, "Failed to connect to CosmosClient collection {CollectionId}", cosmosCollectionConfiguration.CollectionId);
+                LogLevel logLevel = e is RequestRateExceededException ? LogLevel.Warning : LogLevel.Critical;
+                _logger.Log(logLevel, e, "Failed to connect to CosmosClient collection {CollectionId}", cosmosCollectionConfiguration.CollectionId);
                 throw;
             }
         }
@@ -118,9 +126,11 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
                 {
                     _logger.LogInformation("CreateDatabaseIfNotExists {DatabaseId}", cosmosDataStoreConfiguration.DatabaseId);
 
-                    await client.CreateDatabaseIfNotExistsAsync(
-                        cosmosDataStoreConfiguration.DatabaseId,
-                        cosmosDataStoreConfiguration.InitialDatabaseThroughput.HasValue ? ThroughputProperties.CreateManualThroughput(cosmosDataStoreConfiguration.InitialDatabaseThroughput.Value) : null);
+                    await _retryExceptionPolicyFactory.GetRetryPolicy().ExecuteAsync(
+                        async () =>
+                            await client.CreateDatabaseIfNotExistsAsync(
+                                cosmosDataStoreConfiguration.DatabaseId,
+                                cosmosDataStoreConfiguration.InitialDatabaseThroughput.HasValue ? ThroughputProperties.CreateManualThroughput(cosmosDataStoreConfiguration.InitialDatabaseThroughput.Value) : null));
                 }
 
                 foreach (var collectionInitializer in collectionInitializers)
@@ -132,7 +142,8 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
             }
             catch (Exception ex)
             {
-                _logger.LogCritical(ex, "Cosmos DB Database {DatabaseId} and collections initialization failed", cosmosDataStoreConfiguration.DatabaseId);
+                LogLevel logLevel = ex is RequestRateExceededException ? LogLevel.Warning : LogLevel.Critical;
+                _logger.Log(logLevel, ex, "Cosmos DB Database {DatabaseId} and collections initialization failed", cosmosDataStoreConfiguration.DatabaseId);
                 throw;
             }
         }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
@@ -139,15 +139,18 @@ namespace Microsoft.Extensions.DependencyInjection
                 {
                     var config = sp.GetService<CosmosDataStoreConfiguration>();
                     var upgradeManager = sp.GetService<CollectionUpgradeManager>();
+                    var retryExceptionPolicyFactory = sp.GetService<RetryExceptionPolicyFactory>();
                     var loggerFactory = sp.GetService<ILoggerFactory>();
+                    var cosmosClientTestProvider = sp.GetService<ICosmosClientTestProvider>();
                     var namedCosmosCollectionConfiguration = sp.GetService<IOptionsMonitor<CosmosCollectionConfiguration>>();
                     var cosmosCollectionConfiguration = namedCosmosCollectionConfiguration.Get(Constants.CollectionConfigurationName);
 
                     return new CollectionInitializer(
-                        cosmosCollectionConfiguration.CollectionId,
+                        cosmosCollectionConfiguration,
                         config,
-                        cosmosCollectionConfiguration.InitialCollectionThroughput,
                         upgradeManager,
+                        retryExceptionPolicyFactory,
+                        cosmosClientTestProvider,
                         loggerFactory.CreateLogger<CollectionInitializer>());
                 })
                 .Singleton()

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
@@ -162,11 +162,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
                 {
                     case RequestRateExceededException ex:
                         healthExceptionResult = CreateOperationOutcomeResult(ex.Message, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Throttled, HttpStatusCode.TooManyRequests);
-
-                        if (ex.RetryAfter != null)
-                        {
-                            healthExceptionResult.Headers.AddRetryAfterHeaders(ex.RetryAfter.Value);
-                        }
+                        healthExceptionResult.Headers.AddRetryAfterHeaders(ex.RetryAfter);
 
                         break;
                     case UnsupportedMediaTypeException unsupportedMediaTypeException:

--- a/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
@@ -50,12 +50,12 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.AddOptions();
             services.AddMvc(options =>
-            {
-                options.EnableEndpointRouting = false;
-                options.RespectBrowserAcceptHeader = true;
-            })
-            .AddNewtonsoftJson()
-            .AddRazorRuntimeCompilation();
+                {
+                    options.EnableEndpointRouting = false;
+                    options.RespectBrowserAcceptHeader = true;
+                })
+                .AddNewtonsoftJson()
+                .AddRazorRuntimeCompilation();
 
             var fhirServerConfiguration = new FhirServerConfiguration();
 
@@ -172,14 +172,10 @@ namespace Microsoft.Extensions.DependencyInjection
                     app.UseFhirRequestContextAuthentication();
 
                     app.UseMiddleware<SearchPostReroutingMiddleware>();
-                    var throttlingConfig = app.ApplicationServices.GetService<IOptions<ThrottlingConfiguration>>();
 
-                    if (throttlingConfig?.Value?.Enabled == true)
-                    {
-                        // Throttling needs to come after Audit and ApiNotifications so we can audit it and track it for API metrics.
-                        // It should also be after authentication
-                        app.UseThrottling();
-                    }
+                    // Throttling needs to come after Audit and ApiNotifications so we can audit it and track it for API metrics.
+                    // It should also be after authentication
+                    app.UseThrottling();
 
                     next(app);
                 };

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
@@ -116,9 +116,10 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
             var responseProcessor = new CosmosResponseProcessor(fhirRequestContextAccessor, Substitute.For<IMediator>(), NullLogger<CosmosResponseProcessor>.Instance);
             var handler = new FhirCosmosResponseHandler(() => new NonDisposingScope(_container), _cosmosDataStoreConfiguration, fhirRequestContextAccessor, responseProcessor);
-            var documentClientInitializer = new FhirCosmosClientInitializer(testProvider, () => new[] { handler }, NullLogger<FhirCosmosClientInitializer>.Instance);
+            var retryExceptionPolicyFactory = new RetryExceptionPolicyFactory(_cosmosDataStoreConfiguration, Substitute.For<IFhirRequestContextAccessor>());
+            var documentClientInitializer = new FhirCosmosClientInitializer(testProvider, () => new[] { handler }, retryExceptionPolicyFactory, NullLogger<FhirCosmosClientInitializer>.Instance);
             _cosmosClient = documentClientInitializer.CreateCosmosClient(_cosmosDataStoreConfiguration);
-            var fhirCollectionInitializer = new CollectionInitializer(_cosmosCollectionConfiguration.CollectionId, _cosmosDataStoreConfiguration, _cosmosCollectionConfiguration.InitialCollectionThroughput, upgradeManager, NullLogger<CollectionInitializer>.Instance);
+            var fhirCollectionInitializer = new CollectionInitializer(_cosmosCollectionConfiguration, _cosmosDataStoreConfiguration, upgradeManager, retryExceptionPolicyFactory, Substitute.For<ICosmosClientTestProvider>(), NullLogger<CollectionInitializer>.Instance);
 
             // Cosmos DB emulators throws errors when multiple collections are initialized concurrently.
             // Use the semaphore to only allow one initialization at a time.
@@ -150,7 +151,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 _cosmosDataStoreConfiguration,
                 optionsMonitor,
                 cosmosDocumentQueryFactory,
-                new RetryExceptionPolicyFactory(_cosmosDataStoreConfiguration, Substitute.For<IFhirRequestContextAccessor>()),
+                retryExceptionPolicyFactory,
                 NullLogger<CosmosFhirDataStore>.Instance,
                 options);
 
@@ -158,7 +159,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 documentClient,
                 _cosmosDataStoreConfiguration,
                 optionsMonitor,
-                new RetryExceptionPolicyFactory(_cosmosDataStoreConfiguration, Substitute.For<IFhirRequestContextAccessor>()),
+                retryExceptionPolicyFactory,
                 new CosmosQueryFactory(responseProcessor, new NullFhirCosmosQueryLogger()),
                 NullLogger<CosmosFhirOperationDataStore>.Instance);
 


### PR DESCRIPTION
## Description
Improves the handling of Cosmos DB throttling when the service starts up. 
Adding retries, avoiding logging RequestRateExceededExceptions as critical, and handling this exception in ThrottlingMiddleware.

## Testing
Manual testing with an added unit test.

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
