### PR TITLE
Ensures custom search tests are run serially

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -18,6 +18,8 @@ using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 {
+    [CollectionDefinition(Categories.CustomSearch, DisableParallelization = true)]
+    [Collection(Categories.CustomSearch)]
     [Trait(Traits.Category, Categories.CustomSearch)]
     [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb, Format.Json)]
     public class CustomSearchParamTests : SearchTestsBase<HttpIntegrationTestFixture>


### PR DESCRIPTION
## Description
Currently, custom search tests are failing in [the PaaS PR where we are enabling reindexing for Cosmos](https://microsofthealth.visualstudio.com/Health/_git/health-paas/pullrequest/14830). This is likely due to the tests running in parallel. 

A bit more evidence:

One test is failing with the error `Changes to seach parameters is not allowed while a reindex job is ongoing`, indicating that the tests are attempting to run more than one reindexing operation at the same time.

Investigating a bit further, one of the reindex job documents found in a database in the PR's environment has the error message: `The search parameter with definition URL 'http://hl7.org/fhir/SearchParameter/Patient-foo' is not supported. So it cannot be marked enabled.`. Looking at the `Patient-foo`  search parameter document, we can see that it was deleted, indicating that one test could be attempting to clean up the parameter while another test is attempting to use it.

## Related issues
Addresses [AB#79847](https://microsofthealth.visualstudio.com/Health/_workitems/edit/79847).

## Testing
Custom search tests pass in OSS as before.

## FHIR Team Checklist
- ✅ **Update the title** of the PR to be succinct and less than 50 characters
- ✅ **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- ✅ Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- ✅ Tag the PR with **Azure API for FHIR** if this will release to the managed service
- ✅ Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
