### PR TITLE
Update datetime param table schema

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/8.diff.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/8.diff.sql
@@ -17,8 +17,8 @@ CREATE TYPE dbo.StringSearchParamTableType_2 AS TABLE
 ALTER TABLE dbo.StringSearchParam
 ADD IsMin bit NOT NULL,
     IsMax bit NOT NULL,
-    CONSTRAINT IsMin_Constraint DEFAULT 0 FOR IsMin,
-    CONSTRAINT IsMax_Constraint DEFAULT 0 FOR IsMax;
+    CONSTRAINT string_IsMin_Constraint DEFAULT 0 FOR IsMin,
+    CONSTRAINT string_IsMax_Constraint DEFAULT 0 FOR IsMax;
 
 CREATE NONCLUSTERED INDEX IX_StringSearchParam_SearchParamId_Text
 ON dbo.StringSearchParam
@@ -74,8 +74,91 @@ CREATE TYPE dbo.DateTimeSearchParamTableType_2 AS TABLE
 ALTER TABLE dbo.DateTimeSearchParam
 ADD IsMin bit NOT NULL,
     IsMax bit NOT NULL,
-    CONSTRAINT IsMin_Constraint DEFAULT 0 FOR IsMin,
-    CONSTRAINT IsMax_Constraint DEFAULT 0 FOR IsMax;
+    CONSTRAINT date_IsMin_Constraint DEFAULT 0 FOR IsMin,
+    CONSTRAINT date_IsMax_Constraint DEFAULT 0 FOR IsMax;
+
+CREATE NONCLUSTERED INDEX IX_DateTimeSearchParam_SearchParamId_StartDateTime_EndDateTime
+ON dbo.DateTimeSearchParam
+(
+    SearchParamId,
+    StartDateTime,
+    EndDateTime
+)
+INCLUDE
+(
+    ResourceTypeId,
+    IsLongerThanADay,
+    IsMin,
+    IsMax
+)
+WHERE IsHistory = 0
+WITH 
+(
+    DROP_EXISTING = ON,
+    ONLINE = ON
+)
+
+CREATE NONCLUSTERED INDEX IX_DateTimeSearchParam_SearchParamId_EndDateTime_StartDateTime
+ON dbo.DateTimeSearchParam
+(
+    SearchParamId,
+    EndDateTime,
+    StartDateTime
+)
+INCLUDE
+(
+    ResourceTypeId,
+    IsLongerThanADay,
+    IsMin,
+    IsMax
+)
+WHERE IsHistory = 0
+WITH 
+(
+    DROP_EXISTING = ON,
+    ONLINE = ON
+)
+
+
+CREATE NONCLUSTERED INDEX IX_DateTimeSearchParam_SearchParamId_StartDateTime_EndDateTime_Long
+ON dbo.DateTimeSearchParam
+(
+    SearchParamId,
+    StartDateTime,
+    EndDateTime
+)
+INCLUDE
+(
+    ResourceTypeId,
+    IsMin,
+    IsMax
+)
+WHERE IsHistory = 0 AND IsLongerThanADay = 1
+WITH 
+(
+    DROP_EXISTING = ON,
+    ONLINE = ON
+)
+
+CREATE NONCLUSTERED INDEX IX_DateTimeSearchParam_SearchParamId_EndDateTime_StartDateTime_Long
+ON dbo.DateTimeSearchParam
+(
+    SearchParamId,
+    EndDateTime,
+    StartDateTime
+)
+INCLUDE
+(
+    ResourceTypeId,
+    IsMin,
+    IsMax
+)
+WHERE IsHistory = 0 AND IsLongerThanADay = 1
+WITH 
+(
+    DROP_EXISTING = ON,
+    ONLINE = ON
+)
 
 GO
 
@@ -165,7 +248,7 @@ CREATE PROCEDURE dbo.UpsertResource_3
     @numberSearchParams dbo.NumberSearchParamTableType_1 READONLY,
     @quantitySearchParams dbo.QuantitySearchParamTableType_1 READONLY,
     @uriSearchParams dbo.UriSearchParamTableType_1 READONLY,
-    @dateTimeSearchParms dbo.DateTimeSearchParamTableType_1 READONLY,
+    @dateTimeSearchParms dbo.DateTimeSearchParamTableType_2 READONLY,
     @referenceTokenCompositeSearchParams dbo.ReferenceTokenCompositeSearchParamTableType_2 READONLY,
     @tokenTokenCompositeSearchParams dbo.TokenTokenCompositeSearchParamTableType_1 READONLY,
     @tokenDateTimeCompositeSearchParams dbo.TokenDateTimeCompositeSearchParamTableType_1 READONLY,

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/8.diff.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/8.diff.sql
@@ -61,6 +61,22 @@ WITH
     ONLINE = ON
 )
 
+CREATE TYPE dbo.DateTimeSearchParamTableType_2 AS TABLE
+(
+    SearchParamId smallint NOT NULL,
+    StartDateTime datetimeoffset(7) NOT NULL,
+    EndDateTime datetimeoffset(7) NOT NULL,
+    IsLongerThanADay bit NOT NULL,
+    IsMin bit NOT NULL,
+    IsMax bit NOT NULL
+);
+
+ALTER TABLE dbo.DateTimeSearchParam
+ADD IsMin bit NOT NULL,
+    IsMax bit NOT NULL,
+    CONSTRAINT IsMin_Constraint DEFAULT 0 FOR IsMin,
+    CONSTRAINT IsMax_Constraint DEFAULT 0 FOR IsMax;
+
 GO
 
 /*************************************************************
@@ -394,8 +410,8 @@ AS
     FROM @quantitySearchParams
 
     INSERT INTO dbo.DateTimeSearchParam
-        (ResourceTypeId, ResourceSurrogateId, SearchParamId, StartDateTime, EndDateTime, IsLongerThanADay, IsHistory)
-    SELECT DISTINCT @resourceTypeId, @resourceSurrogateId, SearchParamId, StartDateTime, EndDateTime, IsLongerThanADay, 0
+        (ResourceTypeId, ResourceSurrogateId, SearchParamId, StartDateTime, EndDateTime, IsLongerThanADay, IsHistory, IsMin, IsMax)
+    SELECT DISTINCT @resourceTypeId, @resourceSurrogateId, SearchParamId, StartDateTime, EndDateTime, IsLongerThanADay, 0, IsMin, IsMax
     FROM @dateTimeSearchParms
 
     INSERT INTO dbo.ReferenceTokenCompositeSearchParam

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/8.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/8.sql
@@ -642,7 +642,9 @@ ON dbo.DateTimeSearchParam
 INCLUDE
 (
     ResourceTypeId,
-    IsLongerThanADay
+    IsLongerThanADay,
+    IsMin,
+    IsMax
 )
 WHERE IsHistory = 0
 
@@ -656,7 +658,9 @@ ON dbo.DateTimeSearchParam
 INCLUDE
 (
     ResourceTypeId,
-    IsLongerThanADay
+    IsLongerThanADay,
+    IsMin,
+    IsMax
 )
 WHERE IsHistory = 0
 
@@ -670,7 +674,9 @@ ON dbo.DateTimeSearchParam
 )
 INCLUDE
 (
-    ResourceTypeId
+    ResourceTypeId,
+    IsMin,
+    IsMax
 )
 WHERE IsHistory = 0 AND IsLongerThanADay = 1
 
@@ -683,7 +689,9 @@ ON dbo.DateTimeSearchParam
 )
 INCLUDE
 (
-    ResourceTypeId
+    ResourceTypeId,
+    IsMin,
+    IsMax
 )
 WHERE IsHistory = 0 AND IsLongerThanADay = 1
 
@@ -1242,7 +1250,7 @@ CREATE PROCEDURE dbo.UpsertResource_3
     @numberSearchParams dbo.NumberSearchParamTableType_1 READONLY,
     @quantitySearchParams dbo.QuantitySearchParamTableType_1 READONLY,
     @uriSearchParams dbo.UriSearchParamTableType_1 READONLY,
-    @dateTimeSearchParms dbo.DateTimeSearchParamTableType_1 READONLY,
+    @dateTimeSearchParms dbo.DateTimeSearchParamTableType_2 READONLY,
     @referenceTokenCompositeSearchParams dbo.ReferenceTokenCompositeSearchParamTableType_2 READONLY,
     @tokenTokenCompositeSearchParams dbo.TokenTokenCompositeSearchParamTableType_1 READONLY,
     @tokenDateTimeCompositeSearchParams dbo.TokenDateTimeCompositeSearchParamTableType_1 READONLY,
@@ -1487,8 +1495,8 @@ AS
     FROM @quantitySearchParams
 
     INSERT INTO dbo.DateTimeSearchParam
-        (ResourceTypeId, ResourceSurrogateId, SearchParamId, StartDateTime, EndDateTime, IsLongerThanADay, IsHistory)
-    SELECT DISTINCT @resourceTypeId, @resourceSurrogateId, SearchParamId, StartDateTime, EndDateTime, IsLongerThanADay, 0
+        (ResourceTypeId, ResourceSurrogateId, SearchParamId, StartDateTime, EndDateTime, IsLongerThanADay, IsHistory, IsMin, IsMax)
+    SELECT DISTINCT @resourceTypeId, @resourceSurrogateId, SearchParamId, StartDateTime, EndDateTime, IsLongerThanADay, 0, IsMin, IsMax
     FROM @dateTimeSearchParms
 
     INSERT INTO dbo.ReferenceTokenCompositeSearchParam

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/8.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/8.sql
@@ -602,12 +602,14 @@ GO
     Date Search Param
 **************************************************************/
 
-CREATE TYPE dbo.DateTimeSearchParamTableType_1 AS TABLE
+CREATE TYPE dbo.DateTimeSearchParamTableType_2 AS TABLE
 (
     SearchParamId smallint NOT NULL,
     StartDateTime datetimeoffset(7) NOT NULL,
     EndDateTime datetimeoffset(7) NOT NULL,
-    IsLongerThanADay bit NOT NULL
+    IsLongerThanADay bit NOT NULL,
+    IsMin bit NOT NULL,
+    IsMax bit NOT NULL
 )
 
 CREATE TABLE dbo.DateTimeSearchParam
@@ -618,7 +620,9 @@ CREATE TABLE dbo.DateTimeSearchParam
     StartDateTime datetime2(7) NOT NULL,
     EndDateTime datetime2(7) NOT NULL,
     IsLongerThanADay bit NOT NULL,
-    IsHistory bit NOT NULL
+    IsHistory bit NOT NULL,
+    IsMin bit NOT NULL,
+    IsMax bit NOT NULL
 )
 
 CREATE CLUSTERED INDEX IXC_DateTimeSearchParam

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaVersionConstants.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaVersionConstants.cs
@@ -11,6 +11,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema
         public const int Max = (int)SchemaVersion.V8;
         public const int SearchParameterStatusSchemaVersion = (int)SchemaVersion.V6;
         public const int SupportForReferencesWithMissingTypeVersion = (int)SchemaVersion.V7;
-        public const int KeepTrackOfMinMaxForStringSearchParamVersion = (int)SchemaVersion.V8;
+        public const int AddMinMaxForDateAndStringSearchParamVersion = (int)SchemaVersion.V8;
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             long baseResourceSurrogateId = ResourceSurrogateIdHelper.LastUpdatedToResourceSurrogateId(resource.LastModified.UtcDateTime);
             short resourceTypeId = _model.GetResourceTypeId(resource.ResourceTypeName);
 
-            if (_schemaInformation.Current >= SchemaVersionConstants.KeepTrackOfMinMaxForStringSearchParamVersion)
+            if (_schemaInformation.Current >= SchemaVersionConstants.AddMinMaxForDateAndStringSearchParamVersion)
             {
                 VLatest.UpsertResource.PopulateCommand(
                     sqlCommandWrapper,

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/TvpRowGeneration/DateTimeSearchParameterV2RowGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/TvpRowGeneration/DateTimeSearchParameterV2RowGenerator.cs
@@ -1,0 +1,47 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.Health.Fhir.Core.Features.Search;
+using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
+using Microsoft.Health.Fhir.SqlServer.Features.Schema.Model;
+
+namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.TvpRowGeneration
+{
+    internal class DateTimeSearchParameterV2RowGenerator : SearchParameterRowGenerator<DateTimeSearchValue, DateTimeSearchParamTableTypeV2Row>
+    {
+        private short _lastUpdatedSearchParamId;
+
+        public DateTimeSearchParameterV2RowGenerator(SqlServerFhirModel model)
+            : base(model)
+        {
+        }
+
+        internal override bool TryGenerateRow(short searchParamId, DateTimeSearchValue searchValue, out DateTimeSearchParamTableTypeV2Row row)
+        {
+            if (searchParamId == _lastUpdatedSearchParamId)
+            {
+                // this value is already stored on the Resource table.
+                row = default;
+                return false;
+            }
+
+            row = new DateTimeSearchParamTableTypeV2Row(
+                searchParamId,
+                searchValue.Start,
+                searchValue.End,
+                (searchValue.Start - searchValue.End).Ticks > TimeSpan.TicksPerDay,
+                searchValue.IsMin,
+                searchValue.IsMax);
+
+            return true;
+        }
+
+        protected override void Initialize()
+        {
+            _lastUpdatedSearchParamId = Model.GetSearchParamId(SearchParameterNames.LastUpdatedUri);
+        }
+    }
+}

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -145,14 +146,21 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             // These constraints will not be present in databases that were directly initialized with the latest schema.
             // We need to exclude these constraints from the schema difference comparison.
             bool unexpectedDifference = false;
+            HashSet<string> constraintNames = new HashSet<string>()
+            {
+                "[dbo].[date_IsMin_Constraint]",
+                "[dbo].[date_IsMax_Constraint]",
+                "[dbo].[string_IsMin_Constraint]",
+                "[dbo].[string_IsMax_Constraint]",
+            };
+
             foreach (SchemaDifference schemaDifference in remainingDifferences)
             {
                 if (schemaDifference.TargetObject.ObjectType.Name == "Table")
                 {
                     foreach (SchemaDifference child in schemaDifference.Children)
                     {
-                        if (child.TargetObject.ObjectType.Name == "DefaultConstraint" &&
-                            (child.TargetObject.Name.ToString() == "[dbo].[IsMin_Constraint]" || child.TargetObject.Name.ToString() == "[dbo].[IsMax_Constraint]"))
+                        if (child.TargetObject.ObjectType.Name == "DefaultConstraint" && constraintNames.Contains(child.TargetObject.Name.ToString()))
                         {
                             // Expected
                             continue;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
@@ -12,7 +12,6 @@ using EnsureThat;
 using MediatR;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.SqlServer.Features.Schema;
 using Microsoft.Health.Fhir.SqlServer.Features.Storage;
 using Microsoft.Health.SqlServer;
@@ -131,6 +130,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 ("TableType", "[dbo].[ReferenceSearchParamTableType_1]"),
                 ("TableType", "[dbo].[ReferenceTokenCompositeSearchParamTableType_1]"),
                 ("TableType", "[dbo].[StringSearchParamTableType_1]"),
+                ("TableType", "[dbo].[DateTimeSearchParamTableType_1]"),
             };
 
             var remainingDifferences = result.Differences.Where(


### PR DESCRIPTION
## Description
Update the schema by for dbo.DateTimeSearchParam table to add two bit columns - IsMin and IsMax. This is similar to #1579 which was for the StringSearchParam table.

I am reusing the schema version 8 since this is being merged into a feature branch for now.

## Related issues
Addresses [AB#80140](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/80140)

## Testing
Existing tests. Tested E2E flow on local deployment.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
