### PR TITLE
"Handling" parameter in search

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/KnownHeaders.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/KnownHeaders.cs
@@ -12,5 +12,6 @@ namespace Microsoft.Health.Fhir.Core.Features
         public const string RetryAfterMilliseconds = "x-ms-retry-after-ms";
         public const string RetryAfter = "Retry-After";
         public const string ProvenanceHeader = "X-Provenance";
+        public const string Prefer = "Prefer";
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/KnownQueryParameterNames.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/KnownQueryParameterNames.cs
@@ -46,6 +46,8 @@ namespace Microsoft.Health.Fhir.Core.Features
 
         public const string Elements = "_elements";
 
+        public const string Handling = "handling";
+
         /// <summary>
         /// The total query parameter.
         /// </summary>

--- a/src/Microsoft.Health.Fhir.Core/Features/KnownQueryParameterNames.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/KnownQueryParameterNames.cs
@@ -46,8 +46,6 @@ namespace Microsoft.Health.Fhir.Core.Features
 
         public const string Elements = "_elements";
 
-        public const string Handling = "handling";
-
         /// <summary>
         /// The total query parameter.
         /// </summary>

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -530,11 +530,11 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The &apos;handling&apos; parameter value &apos;{0}&apos; is invalid. The supported values are: {1}..
+        ///   Looks up a localized string similar to The &apos;handling&apos; value &apos;{0}&apos; is invalid. The supported values are: {1}..
         /// </summary>
-        internal static string InvalidHandlingParameter {
+        internal static string InvalidHandlingValue {
             get {
-                return ResourceManager.GetString("InvalidHandlingParameter", resourceCulture);
+                return ResourceManager.GetString("InvalidHandlingValue", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -530,6 +530,15 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The &apos;handling&apos; parameter value &apos;{0}&apos; is invalid. The supported values are: {1}..
+        /// </summary>
+        internal static string InvalidHandlingParameter {
+            get {
+                return ResourceManager.GetString("InvalidHandlingParameter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The count must be greater than zero..
         /// </summary>
         internal static string InvalidSearchCountSpecified {
@@ -1138,6 +1147,15 @@ namespace Microsoft.Health.Fhir.Core {
         internal static string UnsupportedTotalParameter {
             get {
                 return ResourceManager.GetString("UnsupportedTotalParameter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unsupported search parameter(s): `{0}`.
+        /// </summary>
+        internal static string UnsuppotedSearchParameters {
+            get {
+                return ResourceManager.GetString("UnsuppotedSearchParameters", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -1151,7 +1151,7 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unsupported search parameter(s): `{0}`.
+        ///   Looks up a localized string similar to Unsupported search parameter(s): `{0}`..
         /// </summary>
         internal static string UnsuppotedSearchParameters {
             get {

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -1151,15 +1151,6 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unsupported search parameter(s): `{0}`..
-        /// </summary>
-        internal static string UnsuppotedSearchParameters {
-            get {
-                return ResourceManager.GetString("UnsuppotedSearchParameters", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Resource id is required for updates..
         /// </summary>
         internal static string UpdateRequestsRequireId {

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -534,4 +534,12 @@
   <data name="ProvenanceHeaderShouldntHaveTarget" xml:space="preserve">
     <value>X-Provenance header shall not have a specified `Provenance.target`</value>
   </data>
+  <data name="InvalidHandlingParameter" xml:space="preserve">
+    <value>The 'handling' parameter value '{0}' is invalid. The supported values are: {1}.</value>
+    <comment>{0}: the invalid handling parameter value. {1}: the supported handling parameter values.</comment>
+  </data>
+  <data name="UnsuppotedSearchParameters" xml:space="preserve">
+    <value>Unsupported search parameter(s): `{0}`</value>
+    <comment>{0}: collection comma-separated unknown or unsupported search parameters</comment>
+  </data>
 </root>

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -539,7 +539,7 @@
     <comment>{0}: the invalid handling value. {1}: the supported handling values.</comment>
   </data>
   <data name="UnsuppotedSearchParameters" xml:space="preserve">
-    <value>Unsupported search parameter(s): `{0}`</value>
-    <comment>{0}: collection comma-separated unknown or unsupported search parameters</comment>
+    <value>Unsupported search parameter(s): `{0}`.</value>
+    <comment>{0}: collection comma-separated unknown or unsupported search parameters.</comment>
   </data>
 </root>

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -538,8 +538,4 @@
     <value>The 'handling' value '{0}' is invalid. The supported values are: {1}.</value>
     <comment>{0}: the invalid handling value. {1}: the supported handling values.</comment>
   </data>
-  <data name="UnsuppotedSearchParameters" xml:space="preserve">
-    <value>Unsupported search parameter(s): `{0}`.</value>
-    <comment>{0}: collection comma-separated unknown or unsupported search parameters.</comment>
-  </data>
 </root>

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -534,9 +534,9 @@
   <data name="ProvenanceHeaderShouldntHaveTarget" xml:space="preserve">
     <value>X-Provenance header shall not have a specified `Provenance.target`</value>
   </data>
-  <data name="InvalidHandlingParameter" xml:space="preserve">
-    <value>The 'handling' parameter value '{0}' is invalid. The supported values are: {1}.</value>
-    <comment>{0}: the invalid handling parameter value. {1}: the supported handling parameter values.</comment>
+  <data name="InvalidHandlingValue" xml:space="preserve">
+    <value>The 'handling' value '{0}' is invalid. The supported values are: {1}.</value>
+    <comment>{0}: the invalid handling value. {1}: the supported handling values.</comment>
   </data>
   <data name="UnsuppotedSearchParameters" xml:space="preserve">
     <value>Unsupported search parameter(s): `{0}`</value>

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -358,8 +358,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                 if (throwForUnsupported)
                 {
                     throw new BadRequestException(string.Format(
-                        Core.Resources.UnsuppotedSearchParameters,
-                        string.Join(",", unsupportedSearchParameters.Select(x => x.Item1))));
+                            Core.Resources.SearchParameterNotSupported,
+                            string.Join(",", unsupportedSearchParameters.Select(x => x.Item1)),
+                            string.Join(",", resourceTypesString)));
                 }
                 else
                 {
@@ -368,7 +369,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                         _contextAccessor.FhirRequestContext?.BundleIssues.Add(new OperationOutcomeIssue(
                               OperationOutcomeConstants.IssueSeverity.Warning,
                               OperationOutcomeConstants.IssueType.NotSupported,
-                              string.Format(CultureInfo.InvariantCulture, Core.Resources.SearchParameterNotSupported, unsupported.Item1, string.Join(", ", resourceTypesString))));
+                              string.Format(CultureInfo.InvariantCulture, Core.Resources.SearchParameterNotSupported, unsupported.Item1, string.Join(",", resourceTypesString))));
                     }
                 }
             }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -78,6 +78,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             var searchParams = new SearchParams();
             var unsupportedSearchParameters = new List<Tuple<string, string>>();
             bool setDefaultBundleTotal = true;
+            bool throwForUnsupportedParams = false;
 
             // Extract the continuation token, filter out the other known query parameters that's not search related.
             foreach (Tuple<string, string> query in queryParameters ?? Enumerable.Empty<Tuple<string, string>>())
@@ -102,9 +103,24 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
 
                     setDefaultBundleTotal = false;
                 }
-                else if (query.Item1 == KnownQueryParameterNames.Format)
+                else if (query.Item1 == KnownQueryParameterNames.Format || query.Item1 == KnownQueryParameterNames.Pretty)
                 {
-                    // TODO: We need to handle format parameter.
+                    // _format and _pretty are not search parameters, so we can ignore them.
+                }
+                else if (string.Equals(query.Item1, KnownQueryParameterNames.Handling, StringComparison.OrdinalIgnoreCase))
+                {
+                    if (string.IsNullOrWhiteSpace(query.Item2) || !Enum.TryParse<SearchParameterHandling>(query.Item2, true, out var handling))
+                    {
+                        throw new BadRequestException(string.Format(
+                            Core.Resources.InvalidHandlingParameter,
+                            query.Item2,
+                            Enum.GetNames<SearchParameterHandling>()));
+                    }
+
+                    if (handling == SearchParameterHandling.Strict)
+                    {
+                        throwForUnsupportedParams = true;
+                    }
                 }
                 else if (string.Equals(query.Item1, KnownQueryParameterNames.Type, StringComparison.OrdinalIgnoreCase))
                 {
@@ -331,8 +347,22 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
 
             if (unsupportedSearchParameters.Any())
             {
-                // TODO: Client can specify whether exception should be raised or not when it encounters unknown search parameters.
-                // For now, we will ignore any unknown search parameters.
+                if (throwForUnsupportedParams)
+                {
+                    throw new BadRequestException(string.Format(
+                        Core.Resources.UnsuppotedSearchParameters,
+                        string.Join(",", unsupportedSearchParameters.Select(x => x.Item1))));
+                }
+                else
+                {
+                    foreach (var unsupported in unsupportedSearchParameters)
+                    {
+                        _contextAccessor.FhirRequestContext?.BundleIssues.Add(new OperationOutcomeIssue(
+                              OperationOutcomeConstants.IssueSeverity.Warning,
+                              OperationOutcomeConstants.IssueType.NotSupported,
+                              string.Format(CultureInfo.InvariantCulture, Core.Resources.SearchParameterNotSupported, unsupported.Item1, string.Join(", ", resourceTypesString))));
+                    }
+                }
             }
 
             searchOptions.UnsupportedSearchParams = unsupportedSearchParameters;

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -332,7 +332,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             if (unsupportedSearchParameters.Any())
             {
                 bool throwForUnsupported = false;
-                if (_contextAccessor.FhirRequestContext.RequestHeaders.TryGetValue(KnownHeaders.Prefer, out var values))
+                if (_contextAccessor.FhirRequestContext.RequestHeaders != null &&
+                    _contextAccessor.FhirRequestContext.RequestHeaders.TryGetValue(KnownHeaders.Prefer, out var values))
                 {
                     var handlingValue = values.FirstOrDefault(x => x.StartsWith("handling=", StringComparison.OrdinalIgnoreCase));
                     if (handlingValue != default)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -811,15 +811,22 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         public async Task GivenASearchRequestWithInvalidParametersAndStrictHandling_WhenHandled_ReturnsBadRequest()
         {
             using FhirException ex = await Assert.ThrowsAsync<FhirException>(() =>
-            Client.SearchAsync("/Patient?Cookie=Chip&Ramen=Spicy", Tuple.Create(KnownHeaders.Prefer, "handling=strict")));
+                Client.SearchAsync("/Patient?Cookie=Chip&Ramen=Spicy", Tuple.Create(KnownHeaders.Prefer, "handling=strict")));
             Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
+        }
+
+        [Fact]
+        public async Task GivenASearchRequestWithValidParametersAndStrictHandling_WhenHandled_ReturnsSearchResults()
+        {
+            var response = await Client.SearchAsync("/Patient?name=ronda", Tuple.Create(KnownHeaders.Prefer, "handling=strict"));
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
 
         [Fact]
         public async Task GivenASearchRequestWithInvalidHandling_WhenHandled_ReturnsBadRequest()
         {
             using FhirException ex = await Assert.ThrowsAsync<FhirException>(() =>
-            Client.SearchAsync("/Patient?Cookie=Chip&Ramen=Spicy", Tuple.Create(KnownHeaders.Prefer, "handling=foo")));
+                Client.SearchAsync("/Patient?Cookie=Chip&Ramen=Spicy", Tuple.Create(KnownHeaders.Prefer, "handling=foo")));
             Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
         }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -778,23 +778,33 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [Fact]
         public async Task GivenASearchRequestWithInvalidParameters_WhenHandled_ReturnsSearchResults()
         {
-            var response = await Client.SearchAsync("/Patient?Cookie=Chip&Ramen=Spicy");
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Equal(KnownResourceTypes.OperationOutcome, response.Resource.Entry.First().Resource.TypeName);
-            Assert.Equal(Bundle.SearchEntryMode.Outcome, response.Resource.Entry.First().Search.Mode);
-            var outcome = response.Resource.Entry.First().Resource as OperationOutcome;
-            Assert.Equal(2, outcome.Issue.Count);
+            string[] expectedDiagnostics =
+            {
+                string.Format(Core.Resources.SearchParameterNotSupported, "Cookie", "Patient"),
+                string.Format(Core.Resources.SearchParameterNotSupported, "Ramen", "Patient"),
+            };
+            OperationOutcome.IssueType[] expectedCodeTypes = { OperationOutcome.IssueType.NotSupported, OperationOutcome.IssueType.NotSupported };
+            OperationOutcome.IssueSeverity[] expectedIssueSeverities = { OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueSeverity.Warning };
+
+            Bundle bundle = await Client.SearchAsync("/Patient?Cookie=Chip&Ramen=Spicy");
+            OperationOutcome outcome = GetAndValidateOperationOutcome(bundle);
+            ValidateOperationOutcome(expectedDiagnostics, expectedIssueSeverities, expectedCodeTypes, outcome);
         }
 
         [Fact]
         public async Task GivenASearchRequestWithInvalidParametersAndLenientHandling_WhenHandled_ReturnsSearchResults()
         {
-            var response = await Client.SearchAsync("/Patient?Cookie=Chip&Ramen=Spicy", Tuple.Create(KnownHeaders.Prefer, "handling=lenient"));
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Equal(KnownResourceTypes.OperationOutcome, response.Resource.Entry.First().Resource.TypeName);
-            Assert.Equal(Bundle.SearchEntryMode.Outcome, response.Resource.Entry.First().Search.Mode);
-            var outcome = response.Resource.Entry.First().Resource as OperationOutcome;
-            Assert.Equal(2, outcome.Issue.Count);
+            string[] expectedDiagnostics =
+            {
+                string.Format(Core.Resources.SearchParameterNotSupported, "Cookie", "Patient"),
+                string.Format(Core.Resources.SearchParameterNotSupported, "Ramen", "Patient"),
+            };
+            OperationOutcome.IssueType[] expectedCodeTypes = { OperationOutcome.IssueType.NotSupported, OperationOutcome.IssueType.NotSupported };
+            OperationOutcome.IssueSeverity[] expectedIssueSeverities = { OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueSeverity.Warning };
+
+            Bundle bundle = await Client.SearchAsync("/Patient?Cookie=Chip&Ramen=Spicy", Tuple.Create(KnownHeaders.Prefer, "handling=lenient"));
+            OperationOutcome outcome = GetAndValidateOperationOutcome(bundle);
+            ValidateOperationOutcome(expectedDiagnostics, expectedIssueSeverities, expectedCodeTypes, outcome);
         }
 
         [Fact]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -787,9 +787,9 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         }
 
         [Fact]
-        public async Task GivenASearchRequestWithInvalidParametersAndLatientHandling_WhenHandled_ReturnsSearchResults()
+        public async Task GivenASearchRequestWithInvalidParametersAndLenientHandling_WhenHandled_ReturnsSearchResults()
         {
-            var response = await Client.SearchAsync("/Patient?Cookie=Chip&Ramen=Spicy&handling=lenient");
+            var response = await Client.SearchAsync("/Patient?Cookie=Chip&Ramen=Spicy", Tuple.Create(KnownHeaders.Prefer, "handling=lenient"));
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal(KnownResourceTypes.OperationOutcome, response.Resource.Entry.First().Resource.TypeName);
             Assert.Equal(Bundle.SearchEntryMode.Outcome, response.Resource.Entry.First().Search.Mode);
@@ -800,14 +800,16 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [Fact]
         public async Task GivenASearchRequestWithInvalidParametersAndStrictHandling_WhenHandled_ReturnsBadRequest()
         {
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.SearchAsync("/Patient?Cookie=Chip&Ramen=Spicy&handling=strict"));
+            using FhirException ex = await Assert.ThrowsAsync<FhirException>(() =>
+            Client.SearchAsync("/Patient?Cookie=Chip&Ramen=Spicy", Tuple.Create(KnownHeaders.Prefer, "handling=strict")));
             Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
         }
 
         [Fact]
         public async Task GivenASearchRequestWithInvalidHandling_WhenHandled_ReturnsBadRequest()
         {
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.SearchAsync("/Patient?Cookie=Chip&Ramen=Spicy&handling=foo"));
+            using FhirException ex = await Assert.ThrowsAsync<FhirException>(() =>
+            Client.SearchAsync("/Patient?Cookie=Chip&Ramen=Spicy", Tuple.Create(KnownHeaders.Prefer, "handling=foo")));
             Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
         }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CanonicalSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CanonicalSearchTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         {
             Skip.IfNot(Fixture.TestFhirServer.Metadata.SupportsSearchParameter("Observation", "_profile"), _skipReason);
 
-            FhirResponse<Bundle> result = await Fixture.TestFhirClient.SearchAsync($"Observation?_profile={Fixture.ObservationProfileUri}&_order=_lastModified");
+            FhirResponse<Bundle> result = await Fixture.TestFhirClient.SearchAsync($"Observation?_profile={Fixture.ObservationProfileUri}");
 
             if (ModelInfoProvider.Version == FhirSpecification.Stu3)
             {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [Fact]
         public async Task GivenAnIncludeSearchExpressionWithMissingModifier_WhenSearched_ThenCorrectBundleShouldBeReturned()
         {
-            string query = $"_tag={Fixture.Tag}&_include=DiagnosticReport:patient:Patient&code=429858000&organization:missing=true";
+            string query = $"_tag={Fixture.Tag}&_include=DiagnosticReport:patient:Patient&code=429858000&specimen:missing=true";
 
             Bundle bundle = await Client.SearchAsync(ResourceType.DiagnosticReport, query);
 


### PR DESCRIPTION
## Description
Adds support for Prefer header with handling= parameter.
Throw exception if handling set to strict, adds operation outcome if there is unsupported parameters to search bundle.

For strict:
![image](https://user-images.githubusercontent.com/1523833/110520392-41738580-80c3-11eb-8386-46499bd7adf5.png)
OperationOutcome in bundle:
![image](https://user-images.githubusercontent.com/1523833/110520459-56e8af80-80c3-11eb-9e33-727093dc784c.png)


## Related issues
Addresses [#1050 ]
Addresses [#612 ].

## Testing
Manual and unit tests

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch 
