### PR TITLE
Added comments to one of public class - CodableConceptInfo

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Models/CodableConceptInfo.cs
+++ b/src/Microsoft.Health.Fhir.Core/Models/CodableConceptInfo.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Health.Fhir.Core.Models
         }
 
         /// <summary>
-        /// Gets the collection of Coding.
+        /// Gets the Coding collection.
         /// </summary>
         public ICollection<Coding> Coding { get; }
     }

--- a/src/Microsoft.Health.Fhir.Core/Models/CodableConceptInfo.cs
+++ b/src/Microsoft.Health.Fhir.Core/Models/CodableConceptInfo.cs
@@ -12,11 +12,18 @@ namespace Microsoft.Health.Fhir.Core.Models
 {
     public class CodableConceptInfo
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CodableConceptInfo"/> class.
+        /// </summary>
         public CodableConceptInfo()
         {
             Coding = new List<Coding>();
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CodableConceptInfo"/> class.
+        /// </summary>
+        /// <param name="coding">The Coding collection.</param>
         public CodableConceptInfo(IEnumerable<Coding> coding)
         {
             EnsureArg.IsNotNull(coding);
@@ -24,6 +31,9 @@ namespace Microsoft.Health.Fhir.Core.Models
             Coding = coding.ToList();
         }
 
+        /// <summary>
+        /// Gets the collection of Coding.
+        /// </summary>
         public ICollection<Coding> Coding { get; }
     }
 }


### PR DESCRIPTION
## Added comments to CodableConceptInfo class.
I think we should add comments to our public methods/classes etc.
For now, I've just added comments to single class. If we are good to go with this proposed change then I can go ahead and pick other public facing methods and improve the coding standards.

## Related issues : No issues related.

## Testing : No testing required as it is just adding comments to public classes.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
