### PR TITLE
Add validation for Sql server supported search parameter types

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/IDataStoreSearchParameterValidator.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/IDataStoreSearchParameterValidator.cs
@@ -1,0 +1,25 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Fhir.Core.Models;
+
+namespace Microsoft.Health.Fhir.Core.Features.Search
+{
+    /// <summary>
+    /// Used to validate whether a SearchParameter is supported by the data store
+    /// beyond the standard validation which occurs, specific data store implementations
+    /// may have have additional restrictions
+    /// </summary>
+    public interface IDataStoreSearchParameterValidator
+    {
+        /// <summary>
+        /// Determines whether the SearchParameter is supported.
+        /// </summary>
+        /// <param name="searchParameter">The search parameter to check for support</param>
+        /// <param name="errorMessage">If the method returns <c>false</c>, includes an error message explaining that the SearchParameter is not supported</param>
+        /// <returns>Whether the SearchParameter supported</returns>
+        bool ValidateSearchParameter(SearchParameterInfo searchParameter, out string errorMessage);
+    }
+}

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/CosmosDbSearchParameterValidator.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/CosmosDbSearchParameterValidator.cs
@@ -1,0 +1,21 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Fhir.Core.Features.Search;
+using Microsoft.Health.Fhir.Core.Models;
+
+namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
+{
+    internal class CosmosDbSearchParameterValidator : IDataStoreSearchParameterValidator
+    {
+        // Currently Cosmos DB has not additional validation steps to perform specific to the
+        // data store for validation of a SearchParameter
+        public bool ValidateSearchParameter(SearchParameterInfo searchParameter, out string errorMessage)
+        {
+            errorMessage = null;
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
@@ -218,6 +218,10 @@ namespace Microsoft.Extensions.DependencyInjection
                 .Singleton()
                 .AsImplementedInterfaces();
 
+            fhirServerBuilder.Services.Add<CosmosDbSearchParameterValidator>()
+                .Singleton()
+                .AsImplementedInterfaces();
+
             return fhirServerBuilder;
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
@@ -106,7 +106,10 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
                 .IsSearchParameterSupported(Arg.Is(_searchParameterInfos[4]))
                 .Returns((true, false));
 
-            _searchParameterOperations = new SearchParameterOperations(_manager, _searchParameterDefinitionManager, ModelInfoProvider.Instance, _searchParameterSupportResolver);
+            var searchParameterDataStoreValidator = Substitute.For<IDataStoreSearchParameterValidator>();
+            searchParameterDataStoreValidator.ValidateSearchParameter(Arg.Any<SearchParameterInfo>(), out Arg.Any<string>()).Returns(true, null);
+
+            _searchParameterOperations = new SearchParameterOperations(_manager, _searchParameterDefinitionManager, ModelInfoProvider.Instance, _searchParameterSupportResolver, searchParameterDataStoreValidator);
         }
 
         public async Task InitializeAsync()

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/SqlSesrverSearchParameterValidatorTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/SqlSesrverSearchParameterValidatorTests.cs
@@ -1,0 +1,75 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.SqlServer.Features.Search;
+using Microsoft.Health.Fhir.SqlServer.Features.Storage;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
+{
+    public class SqlSesrverSearchParameterValidatorTests
+    {
+        private SearchParameterToSearchValueTypeMap _parameterToSearchValueTypeMap;
+        private SqlServerSearchParameterValidator _sqlServerSearchParameterValidator;
+
+        public SqlSesrverSearchParameterValidatorTests()
+        {
+            _parameterToSearchValueTypeMap = new SearchParameterToSearchValueTypeMap();
+            _sqlServerSearchParameterValidator = new SqlServerSearchParameterValidator(_parameterToSearchValueTypeMap);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetValidSearchParameters))]
+        public void GivenASupportedType_WhenSearchParameterisValidated_ThenReturnTrue(SearchParameterInfo searchParameter)
+        {
+            Assert.True(_sqlServerSearchParameterValidator.ValidateSearchParameter(searchParameter, out var _));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetInValidSearchParameters))]
+        public void GivenAnUnSupportedType_WhenSearchParameterisValidated_ThenReturnFalse(SearchParameterInfo searchParameter)
+        {
+            Assert.False(_sqlServerSearchParameterValidator.ValidateSearchParameter(searchParameter, out var _));
+        }
+
+        public static IEnumerable<object[]> GetValidSearchParameters()
+        {
+            yield return new object[] { new SearchParameterInfo("test", "test", ValueSets.SearchParamType.Date) };
+            yield return new object[] { new SearchParameterInfo("test", "test", ValueSets.SearchParamType.Token) };
+            yield return new object[] { new SearchParameterInfo("test", "test", ValueSets.SearchParamType.Number) };
+            yield return new object[] { new SearchParameterInfo("test", "test", ValueSets.SearchParamType.Quantity) };
+            yield return new object[] { new SearchParameterInfo("test", "test", ValueSets.SearchParamType.Reference) };
+            yield return new object[] { new SearchParameterInfo("test", "test", ValueSets.SearchParamType.String) };
+            yield return new object[] { new SearchParameterInfo("test", "test", ValueSets.SearchParamType.Uri) };
+
+            var components = new List<SearchParameterComponentInfo>();
+            var component = new SearchParameterComponentInfo();
+            component.ResolvedSearchParameter = new SearchParameterInfo("test", "test", ValueSets.SearchParamType.Token);
+            components.Add(component);
+            component = new SearchParameterComponentInfo();
+            component.ResolvedSearchParameter = new SearchParameterInfo("test", "test", ValueSets.SearchParamType.Quantity);
+            components.Add(component);
+            var compositeParam = new SearchParameterInfo("test", "test", ValueSets.SearchParamType.Composite, components: components);
+            yield return new object[] { compositeParam };
+        }
+
+        public static IEnumerable<object[]> GetInValidSearchParameters()
+        {
+            yield return new object[] { new SearchParameterInfo("test", "test", ValueSets.SearchParamType.Special) };
+
+            var components = new List<SearchParameterComponentInfo>();
+            var component = new SearchParameterComponentInfo();
+            component.ResolvedSearchParameter = new SearchParameterInfo("test", "test", ValueSets.SearchParamType.String);
+            components.Add(component);
+            component = new SearchParameterComponentInfo();
+            component.ResolvedSearchParameter = new SearchParameterInfo("test", "test", ValueSets.SearchParamType.Quantity);
+            components.Add(component);
+            var compositeParam = new SearchParameterInfo("test", "test", ValueSets.SearchParamType.Composite, components: components);
+            yield return new object[] { compositeParam };
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchParameterValidator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchParameterValidator.cs
@@ -1,0 +1,64 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using EnsureThat;
+using Microsoft.Health.Fhir.Core.Features.Search;
+using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
+using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.SqlServer.Features.Storage;
+using Microsoft.Health.Fhir.ValueSets;
+
+namespace Microsoft.Health.Fhir.SqlServer.Features.Search
+{
+    internal class SqlServerSearchParameterValidator : IDataStoreSearchParameterValidator
+    {
+        private readonly SearchParameterToSearchValueTypeMap _searchParameterToSearchValueTypeMap;
+
+        public SqlServerSearchParameterValidator(SearchParameterToSearchValueTypeMap searchParameterToSearchValueTypeMap)
+        {
+            EnsureArg.IsNotNull(searchParameterToSearchValueTypeMap, nameof(searchParameterToSearchValueTypeMap));
+
+            _searchParameterToSearchValueTypeMap = searchParameterToSearchValueTypeMap;
+        }
+
+        public bool ValidateSearchParameter(SearchParameterInfo searchParameter, out string errorMessage)
+        {
+            EnsureArg.IsNotNull(searchParameter, nameof(searchParameter));
+            errorMessage = null;
+
+            switch (searchParameter.Type)
+            {
+                case SearchParamType.Token:
+                case SearchParamType.Date:
+                case SearchParamType.Number:
+                case SearchParamType.Quantity:
+                case SearchParamType.Reference:
+                case SearchParamType.String:
+                case SearchParamType.Uri:
+                    return true;
+                case SearchParamType.Composite:
+                    Type searchValueType = _searchParameterToSearchValueTypeMap.GetSearchValueType(searchParameter);
+                    if (searchValueType == typeof(ValueTuple<TokenSearchValue, QuantitySearchValue>)
+                        || searchValueType == typeof(ValueTuple<ReferenceSearchValue, TokenSearchValue>)
+                        || searchValueType == typeof(ValueTuple<TokenSearchValue, DateTimeSearchValue>)
+                        || searchValueType == typeof(ValueTuple<TokenSearchValue, StringSearchValue>)
+                        || searchValueType == typeof(ValueTuple<TokenSearchValue, NumberSearchValue, NumberSearchValue>))
+                        {
+                            return true;
+                        }
+                        else
+                        {
+                            errorMessage = string.Format(Resources.SearchParameterTypeNotSupportedBySQLServer, searchParameter.Type);
+                            return false;
+                        }
+
+                default:
+                    errorMessage = string.Format(Resources.SearchParameterTypeNotSupportedBySQLServer, searchParameter.Type);
+                    return false;
+            }
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchParameterValidator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchParameterValidator.cs
@@ -3,13 +3,11 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
 using EnsureThat;
 using Microsoft.Health.Fhir.Core.Features.Search;
-using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
 using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors;
 using Microsoft.Health.Fhir.SqlServer.Features.Storage;
-using Microsoft.Health.Fhir.ValueSets;
 
 namespace Microsoft.Health.Fhir.SqlServer.Features.Search
 {
@@ -29,35 +27,17 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
             EnsureArg.IsNotNull(searchParameter, nameof(searchParameter));
             errorMessage = null;
 
-            switch (searchParameter.Type)
-            {
-                case SearchParamType.Token:
-                case SearchParamType.Date:
-                case SearchParamType.Number:
-                case SearchParamType.Quantity:
-                case SearchParamType.Reference:
-                case SearchParamType.String:
-                case SearchParamType.Uri:
-                    return true;
-                case SearchParamType.Composite:
-                    Type searchValueType = _searchParameterToSearchValueTypeMap.GetSearchValueType(searchParameter);
-                    if (searchValueType == typeof(ValueTuple<TokenSearchValue, QuantitySearchValue>)
-                        || searchValueType == typeof(ValueTuple<ReferenceSearchValue, TokenSearchValue>)
-                        || searchValueType == typeof(ValueTuple<TokenSearchValue, DateTimeSearchValue>)
-                        || searchValueType == typeof(ValueTuple<TokenSearchValue, StringSearchValue>)
-                        || searchValueType == typeof(ValueTuple<TokenSearchValue, NumberSearchValue, NumberSearchValue>))
-                        {
-                            return true;
-                        }
-                        else
-                        {
-                            errorMessage = string.Format(Resources.SearchParameterTypeNotSupportedBySQLServer, searchParameter.Type);
-                            return false;
-                        }
+            var factory = new SearchParamTableExpressionQueryGeneratorFactory(_searchParameterToSearchValueTypeMap);
 
-                default:
-                    errorMessage = string.Format(Resources.SearchParameterTypeNotSupportedBySQLServer, searchParameter.Type);
-                    return false;
+            try
+            {
+                factory.GetGenerator(searchParameter);
+                return true;
+            }
+            catch
+            {
+                errorMessage = string.Format(Resources.SearchParameterTypeNotSupportedBySQLServer, searchParameter.Type);
+                return false;
             }
         }
     }

--- a/src/Microsoft.Health.Fhir.SqlServer/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
@@ -97,6 +97,11 @@ namespace Microsoft.Extensions.DependencyInjection
                 .Transient()
                 .AsImplementedInterfaces();
 
+            services.Add<SqlServerSearchParameterValidator>()
+                .Singleton()
+                .AsSelf()
+                .AsImplementedInterfaces();
+
             return fhirServerBuilder;
         }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Health.Fhir.SqlServer {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -102,6 +102,15 @@ namespace Microsoft.Health.Fhir.SqlServer {
         internal static string SearchParameterStatusShouldNotBeNull {
             get {
                 return ResourceManager.GetString("SearchParameterStatusShouldNotBeNull", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The SearchParameter with type {0} is not supported by SQL server..
+        /// </summary>
+        internal static string SearchParameterTypeNotSupportedBySQLServer {
+            get {
+                return ResourceManager.GetString("SearchParameterTypeNotSupportedBySQLServer", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Health.Fhir.SqlServer/Resources.resx
+++ b/src/Microsoft.Health.Fhir.SqlServer/Resources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -134,5 +134,9 @@
   </data>
   <data name="SearchParameterStatusShouldNotBeNull" xml:space="preserve">
     <value>Search parameter status information should not be null.</value>
+  </data>
+  <data name="SearchParameterTypeNotSupportedBySQLServer" xml:space="preserve">
+    <value>The SearchParameter with type {0} is not supported by SQL server.</value>
+    <comment>{0} is the data type of the search parameter</comment>
   </data>
 </root>


### PR DESCRIPTION
## Description
Sql server data store implementation supports only certain types of search parameters.  This adds validation check to ensure we support the SearchParameter when it is added or modified.

## Related issues
Addresses [issue [AB#78059](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/78059)].

## Testing
Unit tests added

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
Skip, once CustomSearch is complete we will tag the last PR with Feature