### PR TITLE
Enable search parameters with %resource in expression

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/TypedElementSearchIndexer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/TypedElementSearchIndexer.cs
@@ -69,6 +69,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
 
             var context = _modelInfoProvider.GetEvaluationContext(_referenceToElementResolver.Resolve);
 
+            // This allow to resolve %resource FhirPath to provided value.
+            context.Container = resource.Instance;
+
             IEnumerable<SearchParameterInfo> searchParameters = _searchParameterDefinitionManager.GetSearchParameters(resource.InstanceType);
 
             foreach (SearchParameterInfo searchParameter in searchParameters)

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchIndexerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchIndexerTests.cs
@@ -92,5 +92,29 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
                 Assert.True(deepEquals);
             }
         }
+
+        [Fact]
+        public void GivenAResource_WhenExtractingValuesWithContainerInExpression_ThenTheCorrectValuesAreReturned()
+        {
+            var document = Samples.GetJsonSample<Resource>("Sequence").ToResourceElement();
+
+            var indices = _indexer.Extract(document)
+                .Select(x => new { x.SearchParameter.Code, x.SearchParameter.Type, x.Value })
+                .OrderBy(x => x.Code)
+                .ToArray();
+
+            // Molecular sequence has composite search parameters with expression looking like:
+            // %resource.referenceSeq.chromosome
+            // So we extract search values and make sure that search parameter got extracted
+
+            if (ModelInfoProvider.Version != FhirSpecification.Stu3)
+            {
+                Assert.NotEmpty(indices.Where(x => x.Code == "chromosome-variant-coordinate"));
+            }
+            else
+            {
+                Assert.NotEmpty(indices.Where(x => x.Code == "coordinate"));
+            }
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
+++ b/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
@@ -84,7 +84,6 @@
     <None Remove="TestFiles\R4\DocumentReference-example-relatesTo-code-transforms-replaces-target.json" />
     <None Remove="TestFiles\R4\DocumentReference-example-relatesTo-code-transforms.indexes.json" />
     <None Remove="TestFiles\R4\DocumentReference-example-relatesTo-code-transforms.json" />
-    <None Remove="TestFiles\R4\MolecularSequence.json" />
     <None Remove="TestFiles\R4\Parameter-Convert-Data.json" />
     <None Remove="TestFiles\R5\BasicExampleNarrative.json" />
     <None Remove="TestFiles\R5\BasicExampleNarrative.xml" />

--- a/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
+++ b/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
@@ -84,6 +84,7 @@
     <None Remove="TestFiles\R4\DocumentReference-example-relatesTo-code-transforms-replaces-target.json" />
     <None Remove="TestFiles\R4\DocumentReference-example-relatesTo-code-transforms.indexes.json" />
     <None Remove="TestFiles\R4\DocumentReference-example-relatesTo-code-transforms.json" />
+    <None Remove="TestFiles\R4\MolecularSequence.json" />
     <None Remove="TestFiles\R4\Parameter-Convert-Data.json" />
     <None Remove="TestFiles\R5\BasicExampleNarrative.json" />
     <None Remove="TestFiles\R5\BasicExampleNarrative.xml" />
@@ -196,6 +197,7 @@
     <None Remove="TestFiles\Stu3\Parameter-Convert-Data.json" />
     <None Remove="TestFiles\Stu3\PatientWithMinimalData.json" />
     <None Remove="TestFiles\Stu3\ProvenanceHeader.json" />
+    <None Remove="TestFiles\Stu3\Sequence.json" />
     <None Remove="TestFiles\Stu3\StructureDefinition-us-core-birthsex.json" />
     <None Remove="TestFiles\Stu3\StructureDefinition-us-core-careplan.json" />
     <None Remove="TestFiles\Stu3\StructureDefinition-us-core-ethnicity.json" />
@@ -299,6 +301,7 @@
     <EmbeddedResource Include="TestFiles\R4\DocumentReference-example-relatesTo-code-transforms-replaces-target.json" />
     <EmbeddedResource Include="TestFiles\R4\DocumentReference-example-relatesTo-code-transforms.indexes.json" />
     <EmbeddedResource Include="TestFiles\R4\DocumentReference-example-relatesTo-code-transforms.json" />
+    <EmbeddedResource Include="TestFiles\Normative\Sequence.json" />
     <EmbeddedResource Include="TestFiles\R4\Parameter-Convert-Data.json" />
     <EmbeddedResource Include="TestFiles\R5\BasicExampleNarrative.json" />
     <EmbeddedResource Include="TestFiles\R5\BasicExampleNarrative.xml" />
@@ -388,6 +391,7 @@
     <EmbeddedResource Include="TestFiles\Stu3\Patient.xml" />
     <EmbeddedResource Include="TestFiles\R4\ResourceWrapperNoVersion.json" />
     <EmbeddedResource Include="TestFiles\Stu3\ProvenanceHeader.json" />
+    <EmbeddedResource Include="TestFiles\Stu3\Sequence.json" />
     <EmbeddedResource Include="TestFiles\Stu3\StructureDefinition-us-core-birthsex.json" />
     <EmbeddedResource Include="TestFiles\Stu3\StructureDefinition-us-core-careplan.json" />
     <EmbeddedResource Include="TestFiles\Stu3\StructureDefinition-us-core-ethnicity.json" />

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/Sequence.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/Sequence.json
@@ -1,0 +1,82 @@
+﻿{
+    "resourceType": "MolecularSequence",
+    "id": "fda-example",
+    "text": {
+        "status": "generated",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: fda-example</p><p><b>type</b>: dna</p><p><b>coordinateSystem</b>: 1</p><p><b>patient</b>: <a>Patient/example</a></p><h3>ReferenceSeqs</h3><table><tr><td>-</td><td><b>ReferenceSeqId</b></td><td><b>Strand</b></td><td><b>WindowStart</b></td><td><b>WindowEnd</b></td></tr><tr><td>*</td><td>NC_000001.11 <span>(Details : {http://www.ncbi.nlm.nih.gov/nuccore code 'NC_000001.11' = 'NC_000001.11)</span></td><td>watson</td><td>10453</td><td>101770080</td></tr></table><h3>Variants</h3><table><tr><td>-</td><td><b>Start</b></td><td><b>End</b></td><td><b>ObservedAllele</b></td><td><b>ReferenceAllele</b></td></tr><tr><td>*</td><td>13116</td><td>13117</td><td>T</td><td>G</td></tr></table><h3>Qualities</h3><table><tr><td>-</td><td><b>Type</b></td><td><b>StandardSequence</b></td><td><b>Start</b></td><td><b>End</b></td><td><b>Method</b></td><td><b>TruthTP</b></td><td><b>QueryTP</b></td><td><b>TruthFN</b></td><td><b>QueryFP</b></td><td><b>GtFP</b></td><td><b>Precision</b></td><td><b>Recall</b></td><td><b>FScore</b></td></tr><tr><td>*</td><td>snp</td><td>file-Bk50V4Q0qVb65P0v2VPbfYPZ <span>(Details : {https://precision.fda.gov/files/ code 'file-Bk50V4Q0qVb65P0v2VPbfYPZ' = 'file-Bk50V4Q0qVb65P0v2VPbfYPZ)</span></td><td>10453</td><td>101770080</td><td>Vcfeval + Hap.py Comparison <span>(Details : {https://precision.fda.gov/jobs/ code 'job-ByxYPx809jFVy21KJG74Jg3Y' = 'job-ByxYPx809jFVy21KJG74Jg3Y)</span></td><td>7749</td><td>7984</td><td>2554</td><td>10670</td><td>2186</td><td>0.428005</td><td>0.752111</td><td>0.545551</td></tr></table><h3>Repositories</h3><table><tr><td>-</td><td><b>Type</b></td><td><b>Url</b></td><td><b>Name</b></td><td><b>VariantsetId</b></td></tr><tr><td>*</td><td>login</td><td><a>https://precision.fda.gov/files/file-Bx37ZK009P4bX5g3qjkFZV38</a></td><td>FDA</td><td>file-Bx37ZK009P4bX5g3qjkFZV38</td></tr></table></div>"
+    },
+    "type": "dna",
+    "coordinateSystem": 1,
+    "patient": {
+        "reference": "Patient/example"
+    },
+    "referenceSeq": {
+        "referenceSeqId": {
+            "coding": [
+                {
+                    "system": "http://www.ncbi.nlm.nih.gov/nuccore",
+                    "code": "NC_000001.11"
+                }
+            ]
+        },
+        "chromosome": {
+            "coding": [
+                {
+                    "system": "http://terminology.hl7.org/CodeSystem/chromosome-human",
+                    "code": "10"
+                }
+            ]
+        },
+        "strand": "watson",
+        "windowStart": 10453,
+        "windowEnd": 101770080
+    },
+    "variant": [
+        {
+            "start": 13116,
+            "end": 13117,
+            "observedAllele": "T",
+            "referenceAllele": "G"
+        }
+    ],
+    "quality": [
+        {
+            "type": "snp",
+            "standardSequence": {
+                "coding": [
+                    {
+                        "system": "https://precision.fda.gov/files/",
+                        "code": "file-Bk50V4Q0qVb65P0v2VPbfYPZ"
+                    }
+                ]
+            },
+            "start": 10453,
+            "end": 101770080,
+            "method": {
+                "coding": [
+                    {
+                        "system": "https://precision.fda.gov/jobs/",
+                        "code": "job-ByxYPx809jFVy21KJG74Jg3Y"
+                    }
+                ],
+                "text": "Vcfeval + Hap.py Comparison"
+            },
+            "truthTP": 7749,
+            "queryTP": 7984,
+            "truthFN": 2554,
+            "queryFP": 10670,
+            "gtFP": 2186,
+            "precision": 0.428005,
+            "recall": 0.752111,
+            "fScore": 0.545551
+        }
+    ],
+    "repository": [
+        {
+            "type": "login",
+            "url": "https://precision.fda.gov/files/file-Bx37ZK009P4bX5g3qjkFZV38",
+            "name": "FDA",
+            "variantsetId": "file-Bx37ZK009P4bX5g3qjkFZV38"
+        }
+    ]
+}

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Stu3/Sequence.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Stu3/Sequence.json
@@ -1,0 +1,82 @@
+﻿{
+    "resourceType": "Sequence",
+    "id": "fda-example",
+    "text": {
+        "status": "generated",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: fda-example</p><p><b>type</b>: dna</p><p><b>coordinateSystem</b>: 1</p><p><b>patient</b>: <a>Patient/example</a></p><h3>ReferenceSeqs</h3><table><tr><td>-</td><td><b>ReferenceSeqId</b></td><td><b>Strand</b></td><td><b>WindowStart</b></td><td><b>WindowEnd</b></td></tr><tr><td>*</td><td>NC_000001.11 <span>(Details : {http://www.ncbi.nlm.nih.gov/nuccore code 'NC_000001.11' = 'NC_000001.11)</span></td><td>watson</td><td>10453</td><td>101770080</td></tr></table><h3>Variants</h3><table><tr><td>-</td><td><b>Start</b></td><td><b>End</b></td><td><b>ObservedAllele</b></td><td><b>ReferenceAllele</b></td></tr><tr><td>*</td><td>13116</td><td>13117</td><td>T</td><td>G</td></tr></table><h3>Qualities</h3><table><tr><td>-</td><td><b>Type</b></td><td><b>StandardSequence</b></td><td><b>Start</b></td><td><b>End</b></td><td><b>Method</b></td><td><b>TruthTP</b></td><td><b>QueryTP</b></td><td><b>TruthFN</b></td><td><b>QueryFP</b></td><td><b>GtFP</b></td><td><b>Precision</b></td><td><b>Recall</b></td><td><b>FScore</b></td></tr><tr><td>*</td><td>snp</td><td>file-Bk50V4Q0qVb65P0v2VPbfYPZ <span>(Details : {https://precision.fda.gov/files/ code 'file-Bk50V4Q0qVb65P0v2VPbfYPZ' = 'file-Bk50V4Q0qVb65P0v2VPbfYPZ)</span></td><td>10453</td><td>101770080</td><td>Vcfeval + Hap.py Comparison <span>(Details : {https://precision.fda.gov/jobs/ code 'job-ByxYPx809jFVy21KJG74Jg3Y' = 'job-ByxYPx809jFVy21KJG74Jg3Y)</span></td><td>7749</td><td>7984</td><td>2554</td><td>10670</td><td>2186</td><td>0.428005</td><td>0.752111</td><td>0.545551</td></tr></table><h3>Repositories</h3><table><tr><td>-</td><td><b>Type</b></td><td><b>Url</b></td><td><b>Name</b></td><td><b>VariantsetId</b></td></tr><tr><td>*</td><td>login</td><td><a>https://precision.fda.gov/files/file-Bx37ZK009P4bX5g3qjkFZV38</a></td><td>FDA</td><td>file-Bx37ZK009P4bX5g3qjkFZV38</td></tr></table></div>"
+    },
+    "type": "dna",
+    "coordinateSystem": 1,
+    "patient": {
+        "reference": "Patient/example"
+    },
+    "referenceSeq": {
+        "referenceSeqId": {
+            "coding": [
+                {
+                    "system": "http://www.ncbi.nlm.nih.gov/nuccore",
+                    "code": "NC_000001.11"
+                }
+            ]
+        },
+        "chromosome": {
+            "coding": [
+                {
+                    "system": "http://terminology.hl7.org/CodeSystem/chromosome-human",
+                    "code": "10"
+                }
+            ]
+        },
+        "strand": 1,
+        "windowStart": 10453,
+        "windowEnd": 101770080
+    },
+    "variant": [
+        {
+            "start": 13116,
+            "end": 13117,
+            "observedAllele": "T",
+            "referenceAllele": "G"
+        }
+    ],
+    "quality": [
+        {
+            "type": "snp",
+            "standardSequence": {
+                "coding": [
+                    {
+                        "system": "https://precision.fda.gov/files/",
+                        "code": "file-Bk50V4Q0qVb65P0v2VPbfYPZ"
+                    }
+                ]
+            },
+            "start": 10453,
+            "end": 101770080,
+            "method": {
+                "coding": [
+                    {
+                        "system": "https://precision.fda.gov/jobs/",
+                        "code": "job-ByxYPx809jFVy21KJG74Jg3Y"
+                    }
+                ],
+                "text": "Vcfeval + Hap.py Comparison"
+            },
+            "truthTP": 7749,
+            "queryTP": 7984,
+            "truthFN": 2554,
+            "queryFP": 10670,
+            "gtFP": 2186,
+            "precision": 0.428005,
+            "recall": 0.752111,
+            "fScore": 0.545551
+        }
+    ],
+    "repository": [
+        {
+            "type": "login",
+            "url": "https://precision.fda.gov/files/file-Bx37ZK009P4bX5g3qjkFZV38",
+            "name": "FDA",
+            "variantsetId": "file-Bx37ZK009P4bX5g3qjkFZV38"
+        }
+    ]
+}


### PR DESCRIPTION
## Description
In order to work properly with "%resource" in FHIR path we need to properly specify what it means. So that's what I did.

Took me a while to figure out, and considering how solution works that remind me of this joke:

> There is an old story of a boilermaker who was hired to fix a huge steamship boiler system that was not working well.
> 
> After listening to the engineer’s description of the problems and asking a few questions, he went to the boiler room. He looked at the maze of twisting pipes, listened to the thump of the boiler and the hiss of the escaping steam for a few minutes, and felt some pipes with his hands. Then he hummed softly to himself, reached into his overalls and took out a small hammer, and tapped a bright red valve one time. Immediately, the entire system began working perfectly, and the boilermaker went home.
> 
> When the steamship owner received a bill for one thousand dollars, he became outraged and complained that the boilermaker had only been in the engine room for fifteen minutes and requested an itemized bill. So the boilermaker sent him a bill that reads as follows:
> For tapping the valve: $.50
> For knowing where to tap: $999.50
> TOTAL: $1,000.00


## Related issues
Addresses [#1642 ].

## Testing
Manual and unit test been added.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch (fixes bug)
