### PR TITLE
Add throttling for reindex operations

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Configs/ReindexJobConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/ReindexJobConfiguration.cs
@@ -46,5 +46,11 @@ namespace Microsoft.Health.Fhir.Core.Configs
         /// currently fixed at 1
         /// </summary>
         public ushort MaximumNumberOfConcurrentJobsAllowed { get; internal set; } = 1;
+
+        /// <summary>
+        /// Controls the target percentage of how much of the allocated
+        /// data store resources to use
+        /// </summary>
+        public ushort? TargetDataStoreResourcePercentage { get; set; } = null;
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
@@ -121,6 +121,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations
 
         public const string QueryDelayIntervalInMilliseconds = "queryDelayIntervalInMilliseconds";
 
-        public const string TargetDataStoreResourcePercentage = "targetDataStoreResourcePercentage";
+        public const string TargetDataStoreUsagePercentage = "targetDataStoreUsagePercentage";
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
@@ -118,5 +118,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations
         public const string TotalResourcesToReindex = "totalResourcesToReindex";
 
         public const string ResourcesSuccessfullyReindexed = "resourcesSuccessfullyReindexed";
+
+        public const string QueryDelayIntervalInMilliseconds = "queryDelayIntervalInMilliseconds";
+
+        public const string TargetDataStoreResourcePercentage = "targetDataStoreResourcePercentage";
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/CreateReindexRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/CreateReindexRequestHandler.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                 request.MaximumConcurrency ?? _reindexJobConfiguration.DefaultMaximumThreadsPerReindexJob,
                 request.MaximumResourcesPerQuery ?? _reindexJobConfiguration.MaximumNumberOfResourcesPerQuery,
                 request.QueryDelayIntervalInMilliseconds ?? _reindexJobConfiguration.QueryDelayIntervalInMilliseconds,
-                request.TargetDataStoreResourcePercentage);
+                request.TargetDataStoreUsagePercentage);
             var outcome = await _fhirOperationDataStore.CreateReindexJobAsync(jobRecord, cancellationToken);
 
             return new CreateReindexResponse(outcome);

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/CreateReindexRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/CreateReindexRequestHandler.cs
@@ -60,7 +60,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             var jobRecord = new ReindexJobRecord(
                 _searchParameterDefinitionManager.SearchParameterHashMap,
                 request.MaximumConcurrency ?? _reindexJobConfiguration.DefaultMaximumThreadsPerReindexJob,
-                _reindexJobConfiguration.MaximumNumberOfResourcesPerQuery);
+                request.MaximumResourcesPerQuery ?? _reindexJobConfiguration.MaximumNumberOfResourcesPerQuery,
+                request.QueryDelayIntervalInMilliseconds ?? _reindexJobConfiguration.QueryDelayIntervalInMilliseconds,
+                request.TargetDataStoreResourcePercentage);
             var outcome = await _fhirOperationDataStore.CreateReindexJobAsync(jobRecord, cancellationToken);
 
             return new CreateReindexResponse(outcome);

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/IReindexJobThrottleController.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/IReindexJobThrottleController.cs
@@ -18,8 +18,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
         int GetThrottleBasedDelay();
 
         /// <summary>
-        /// Updates the current usage of the datastore.  Call after a query to the datastore.
+        /// Captures the currently recorded database consumption
         /// </summary>
-        void UpdateDatastoreUsage();
+        /// <returns>Returns an average database resource consumtion per second</returns>
+        double UpdateDatastoreUsage();
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/IReindexJobThrottleController.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/IReindexJobThrottleController.cs
@@ -22,5 +22,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
         /// </summary>
         /// <returns>Returns an average database resource consumtion per second</returns>
         double UpdateDatastoreUsage();
+
+        /// <summary>
+        /// If one single query consumes more than the target datastore resources
+        /// reduce the batch size to help acheive the desired level of usage
+        /// If one query is not too expensive, this will return the same number as is configured
+        /// for the Reindex job.
+        /// </summary>
+        /// <returns>The query batch size</returns>
+        public uint GetThrottleBatchSize();
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/IReindexJobThrottleController.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/IReindexJobThrottleController.cs
@@ -9,8 +9,17 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
 {
     public interface IReindexJobThrottleController
     {
-        void Initialize(ReindexJobRecord reindexJobRecord);
+        void Initialize(ReindexJobRecord reindexJobRecord, int? provisionedDataStoreCapacity);
 
+        /// <summary>
+        /// Gets the current delay to achieve a target resource utilization
+        /// </summary>
+        /// <returns>delay in milliseconds</returns>
         int GetThrottleBasedDelay();
+
+        /// <summary>
+        /// Updates the current usage of the datastore.  Call after a query to the datastore.
+        /// </summary>
+        void UpdateDatastoreUsage();
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/IReindexJobThrottleController.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/IReindexJobThrottleController.cs
@@ -1,0 +1,16 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models;
+
+namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
+{
+    public interface IReindexJobThrottleController
+    {
+        void Initialize(ReindexJobRecord reindexJobRecord);
+
+        int GetThrottleBasedDelay();
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobRecord.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobRecord.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
             ushort maxiumumConcurrency = 1,
             uint maxResourcesPerQuery = 100,
             int queryDelayIntervalInMilliseconds = 500,
-            ushort? targetDataStoreResourcePercentage = null)
+            ushort? targetDataStoreUsagePercentage = null)
         {
             EnsureArg.IsNotNull(searchParametersHash, nameof(searchParametersHash));
 
@@ -39,7 +39,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
             MaximumConcurrency = maxiumumConcurrency;
             MaximumNumberOfResourcesPerQuery = maxResourcesPerQuery;
             QueryDelayIntervalInMilliseconds = queryDelayIntervalInMilliseconds;
-            TargetDataStoreResourcePercentage = targetDataStoreResourcePercentage;
+            TargetDataStoreUsagePercentage = targetDataStoreUsagePercentage;
         }
 
         [JsonConstructor]
@@ -98,9 +98,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
         /// <summary>
         /// Controls the target percentage of how much of the allocated
         /// data store resources to use
+        /// Ex: 1 - 100 percent of provisioned datastore resources
+        /// 0 means the value is not set, no throttling will occur
         /// </summary>
-        [JsonProperty(JobRecordProperties.TargetDataStoreResourcePercentage)]
-        public ushort? TargetDataStoreResourcePercentage { get; set; }
+        [JsonProperty(JobRecordProperties.TargetDataStoreUsagePercentage)]
+        public ushort? TargetDataStoreUsagePercentage { get; set; }
 
         [JsonIgnore]
         public int PercentComplete

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobRecord.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobRecord.cs
@@ -21,7 +21,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
         public ReindexJobRecord(
             IReadOnlyDictionary<string, string> searchParametersHash,
             ushort maxiumumConcurrency = 1,
-            uint maxResourcesPerQuery = 100)
+            uint maxResourcesPerQuery = 100,
+            int queryDelayIntervalInMilliseconds = 500,
+            ushort? targetDataStoreResourcePercentage = null)
         {
             EnsureArg.IsNotNull(searchParametersHash, nameof(searchParametersHash));
 
@@ -36,6 +38,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
             ResourceTypeSearchParameterHashMap = searchParametersHash;
             MaximumConcurrency = maxiumumConcurrency;
             MaximumNumberOfResourcesPerQuery = maxResourcesPerQuery;
+            QueryDelayIntervalInMilliseconds = queryDelayIntervalInMilliseconds;
+            TargetDataStoreResourcePercentage = targetDataStoreResourcePercentage;
         }
 
         [JsonConstructor]
@@ -84,6 +88,18 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
 
         [JsonProperty(JobRecordProperties.MaximumNumberOfResourcesPerQuery)]
         public uint MaximumNumberOfResourcesPerQuery { get; private set; }
+
+        /// <summary>
+        /// Controls the time between queries of resources to be reindexed
+        /// </summary>
+        [JsonProperty(JobRecordProperties.QueryDelayIntervalInMilliseconds)]
+        public int QueryDelayIntervalInMilliseconds { get; set; }
+
+        /// <summary>
+        /// Controls the target percentage of how much of the allocated
+        /// data store resources to use
+        /// </summary>
+        public ushort? TargetDataStoreResourcePercentage { get; set; }
 
         [JsonIgnore]
         public int PercentComplete

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobRecord.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobRecord.cs
@@ -99,6 +99,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
         /// Controls the target percentage of how much of the allocated
         /// data store resources to use
         /// </summary>
+        [JsonProperty(JobRecordProperties.TargetDataStoreResourcePercentage)]
         public ushort? TargetDataStoreResourcePercentage { get; set; }
 
         [JsonIgnore]

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -259,7 +259,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                         }
                     }
 
-                    await Task.Delay(_reindexJobRecord.QueryDelayIntervalInMilliseconds + _throttleController.GetThrottleBasedDelay());
+                    var throttleDelayTime = _throttleController.GetThrottleBasedDelay();
+                    _logger.LogTrace($"Reindex throttle delay: {throttleDelayTime}");
+                    await Task.Delay(_reindexJobRecord.QueryDelayIntervalInMilliseconds + throttleDelayTime);
 
                     // Remove all finished tasks from the collections of tasks
                     // and cancellationTokens

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             ISupportedSearchParameterDefinitionManager supportedSearchParameterDefinitionManager,
             IReindexUtilities reindexUtilities,
             IFhirRequestContextAccessor fhirRequestContextAccessor,
-            IReindexJobThrottleController throttleControllerFactory,
+            IReindexJobThrottleController throttleController,
+            IModelInfoProvider modelInfoProvider,
             ILogger<ReindexJobTask> logger)
         {
             EnsureArg.IsNotNull(fhirOperationDataStoreFactory, nameof(fhirOperationDataStoreFactory));
@@ -59,7 +60,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             EnsureArg.IsNotNull(searchServiceFactory, nameof(searchServiceFactory));
             EnsureArg.IsNotNull(supportedSearchParameterDefinitionManager, nameof(supportedSearchParameterDefinitionManager));
             EnsureArg.IsNotNull(reindexUtilities, nameof(reindexUtilities));
-            EnsureArg.IsNotNull(throttleControllerFactory, nameof(throttleControllerFactory));
+            EnsureArg.IsNotNull(throttleController, nameof(throttleController));
+            EnsureArg.IsNotNull(modelInfoProvider, nameof(modelInfoProvider));
             EnsureArg.IsNotNull(logger, nameof(logger));
 
             _fhirOperationDataStoreFactory = fhirOperationDataStoreFactory;
@@ -69,7 +71,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             _supportedSearchParameterDefinitionManager = supportedSearchParameterDefinitionManager;
             _reindexUtilities = reindexUtilities;
             _contextAccessor = fhirRequestContextAccessor;
-            _throttleControllerFactory = throttleControllerFactory;
+            _throttleController = throttleController;
+            _modelInfoProvider = modelInfoProvider;
             _logger = logger;
         }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -259,8 +259,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                         }
                     }
 
+                    var averageDbConsumption = _throttleController.UpdateDatastoreUsage();
+                    _logger.LogInformation($"Reindex avaerage DB consumption: {averageDbConsumption}");
                     var throttleDelayTime = _throttleController.GetThrottleBasedDelay();
-                    _logger.LogTrace($"Reindex throttle delay: {throttleDelayTime}");
+                    _logger.LogInformation($"Reindex throttle delay: {throttleDelayTime}");
                     await Task.Delay(_reindexJobRecord.QueryDelayIntervalInMilliseconds + throttleDelayTime);
 
                     // Remove all finished tasks from the collections of tasks

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -468,7 +468,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
         {
             var queryParametersList = new List<Tuple<string, string>>()
             {
-                Tuple.Create(KnownQueryParameterNames.Count, _reindexJobRecord.MaximumNumberOfResourcesPerQuery.ToString(CultureInfo.InvariantCulture)),
+                Tuple.Create(KnownQueryParameterNames.Count, _throttleController.GetThrottleBatchSize().ToString(CultureInfo.InvariantCulture)),
                 Tuple.Create(KnownQueryParameterNames.Type, queryStatus.ResourceType),
             };
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Persistence/IFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Persistence/IFhirDataStore.cs
@@ -27,5 +27,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
         Task UpdateSearchParameterIndicesBatchAsync(IReadOnlyCollection<ResourceWrapper> resources, CancellationToken cancellationToken);
 
         Task<ResourceWrapper> UpdateSearchIndexForResourceAsync(ResourceWrapper resourceWrapper, WeakETag weakETag, CancellationToken cancellationToken);
+
+        Task<int?> GetProvisionedDataStoreCapacityAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Messages/Reindex/CreateReindexRequest.cs
+++ b/src/Microsoft.Health.Fhir.Core/Messages/Reindex/CreateReindexRequest.cs
@@ -13,12 +13,12 @@ namespace Microsoft.Health.Fhir.Core.Messages.Reindex
             ushort? maximumConcurrency = null,
             uint? maximumResourcesPerQuery = null,
             int? queryDelayIntervalInMilliseconds = null,
-            ushort? targetDataStoreResourcePercentage = null)
+            ushort? targetDataStoreUsagePercentage = null)
         {
             MaximumConcurrency = maximumConcurrency;
             MaximumResourcesPerQuery = maximumResourcesPerQuery;
             QueryDelayIntervalInMilliseconds = queryDelayIntervalInMilliseconds;
-            TargetDataStoreResourcePercentage = targetDataStoreResourcePercentage;
+            TargetDataStoreUsagePercentage = targetDataStoreUsagePercentage;
         }
 
         public ushort? MaximumConcurrency { get; }
@@ -27,6 +27,6 @@ namespace Microsoft.Health.Fhir.Core.Messages.Reindex
 
         public int? QueryDelayIntervalInMilliseconds { get; }
 
-        public ushort? TargetDataStoreResourcePercentage { get; }
+        public ushort? TargetDataStoreUsagePercentage { get; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Messages/Reindex/CreateReindexRequest.cs
+++ b/src/Microsoft.Health.Fhir.Core/Messages/Reindex/CreateReindexRequest.cs
@@ -9,11 +9,24 @@ namespace Microsoft.Health.Fhir.Core.Messages.Reindex
 {
     public class CreateReindexRequest : IRequest<CreateReindexResponse>
     {
-        public CreateReindexRequest(ushort? maximumConcurrency = null)
+        public CreateReindexRequest(
+            ushort? maximumConcurrency = null,
+            uint? maximumResourcesPerQuery = null,
+            int? queryDelayIntervalInMilliseconds = null,
+            ushort? targetDataStoreResourcePercentage = null)
         {
             MaximumConcurrency = maximumConcurrency;
+            MaximumResourcesPerQuery = maximumResourcesPerQuery;
+            QueryDelayIntervalInMilliseconds = queryDelayIntervalInMilliseconds;
+            TargetDataStoreResourcePercentage = targetDataStoreResourcePercentage;
         }
 
         public ushort? MaximumConcurrency { get; }
+
+        public uint? MaximumResourcesPerQuery { get; }
+
+        public int? QueryDelayIntervalInMilliseconds { get; }
+
+        public ushort? TargetDataStoreResourcePercentage { get; }
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Operations/Reindex/ReindexJobCosmosThrottleControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Operations/Reindex/ReindexJobCosmosThrottleControllerTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Operations.Reindex
 
             int loopCount = 0;
 
-            while (loopCount < 17)
+            while (loopCount < 16)
             {
                 _output.WriteLine($"Current throttle based delay is: {throttleController.GetThrottleBasedDelay()}");
                 _fhirRequestContextAccessor.FhirRequestContext.ResponseHeaders.Add(CosmosDbHeaders.RequestCharge, "100.0");

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Operations/Reindex/ReindexJobCosmosThrottleControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Operations/Reindex/ReindexJobCosmosThrottleControllerTests.cs
@@ -1,0 +1,101 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Health.Fhir.Core.Features.Operations;
+using Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models;
+using Microsoft.Health.Fhir.CosmosDb.Features.Metrics;
+using Microsoft.Health.Fhir.CosmosDb.Features.Operations.Reindex;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Operations.Reindex
+{
+    public class ReindexJobCosmosThrottleControllerTests
+    {
+        private ITestOutputHelper _output;
+
+        public ReindexJobCosmosThrottleControllerTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public async Task GivenATargetRUConsumption_WhenConsumedRUsIsTooHigh_QueryDelayIsIncreased()
+        {
+            var throttleController = new ReindexJobCosmosThrottleController(1000);
+            var reindexJob = new ReindexJobRecord(new Dictionary<string, string>(), targetDataStoreResourcePercentage: 80);
+            reindexJob.QueryDelayIntervalInMilliseconds = 50;
+            throttleController.Initialize(reindexJob);
+
+            var cosmosMetrics = new CosmosStorageRequestMetricsNotification(OperationsConstants.Reindex, "Resource");
+            cosmosMetrics.TotalRequestCharge = 100;
+            int loopCount = 0;
+
+            while (loopCount < 17)
+            {
+                _output.WriteLine($"Current throttle based delay is: {throttleController.GetThrottleBasedDelay()}");
+                await throttleController.Handle(cosmosMetrics, CancellationToken.None);
+                await Task.Delay(reindexJob.QueryDelayIntervalInMilliseconds + throttleController.GetThrottleBasedDelay());
+                loopCount++;
+            }
+
+            _output.WriteLine($"Final throttle based delay is: {throttleController.GetThrottleBasedDelay()}");
+            Assert.Equal(100, throttleController.GetThrottleBasedDelay());
+        }
+
+        [Fact]
+        public async Task GivenATargetRUConsumption_WhenConsumedRUsDecreases_QueryDelayIsDecreased()
+        {
+            var throttleController = new ReindexJobCosmosThrottleController(1000);
+            var reindexJob = new ReindexJobRecord(new Dictionary<string, string>(), targetDataStoreResourcePercentage: 80);
+            reindexJob.QueryDelayIntervalInMilliseconds = 50;
+            throttleController.Initialize(reindexJob);
+
+            var cosmosMetrics = new CosmosStorageRequestMetricsNotification(OperationsConstants.Reindex, "Resource");
+            cosmosMetrics.TotalRequestCharge = 100;
+            int loopCount = 0;
+
+            while (loopCount < 17)
+            {
+                _output.WriteLine($"Current throttle based delay is: {throttleController.GetThrottleBasedDelay()}");
+                await throttleController.Handle(cosmosMetrics, CancellationToken.None);
+                await Task.Delay(reindexJob.QueryDelayIntervalInMilliseconds + throttleController.GetThrottleBasedDelay());
+                loopCount++;
+            }
+
+            cosmosMetrics.TotalRequestCharge = 10;
+            loopCount = 0;
+
+            while (loopCount < 17)
+            {
+                _output.WriteLine($"Current throttle based delay is: {throttleController.GetThrottleBasedDelay()}");
+                await throttleController.Handle(cosmosMetrics, CancellationToken.None);
+                await Task.Delay(reindexJob.QueryDelayIntervalInMilliseconds + throttleController.GetThrottleBasedDelay());
+                loopCount++;
+            }
+
+            _output.WriteLine($"Final throttle based delay is: {throttleController.GetThrottleBasedDelay()}");
+            Assert.Equal(0, throttleController.GetThrottleBasedDelay());
+        }
+
+        [Fact]
+        public void GivenThrottleControllerNotInitialized_WhenGetThrottleDelayCalled_ZeroReturned()
+        {
+            var throttleController = new ReindexJobCosmosThrottleController(null);
+            Assert.Equal(0, throttleController.GetThrottleBasedDelay());
+
+            throttleController = new ReindexJobCosmosThrottleController(1000);
+            Assert.Equal(0, throttleController.GetThrottleBasedDelay());
+
+            var reindexJob = new ReindexJobRecord(new Dictionary<string, string>(), targetDataStoreResourcePercentage: null);
+            reindexJob.QueryDelayIntervalInMilliseconds = 50;
+            throttleController.Initialize(reindexJob);
+            Assert.Equal(0, throttleController.GetThrottleBasedDelay());
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Operations/Reindex/ReindexJobCosmosThrottleControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Operations/Reindex/ReindexJobCosmosThrottleControllerTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Operations.Reindex
         public async Task GivenATargetRUConsumption_WhenConsumedRUsIsTooHigh_QueryDelayIsIncreased()
         {
             var throttleController = new ReindexJobCosmosThrottleController(_fhirRequestContextAccessor);
-            var reindexJob = new ReindexJobRecord(new Dictionary<string, string>(), targetDataStoreResourcePercentage: 80);
+            var reindexJob = new ReindexJobRecord(new Dictionary<string, string>(), targetDataStoreUsagePercentage: 80);
             reindexJob.QueryDelayIntervalInMilliseconds = 50;
             throttleController.Initialize(reindexJob, 1000);
 
@@ -66,7 +66,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Operations.Reindex
         public async Task GivenATargetRUConsumption_WhenConsumedRUsDecreases_QueryDelayIsDecreased()
         {
             var throttleController = new ReindexJobCosmosThrottleController(_fhirRequestContextAccessor);
-            var reindexJob = new ReindexJobRecord(new Dictionary<string, string>(), targetDataStoreResourcePercentage: 80);
+            var reindexJob = new ReindexJobRecord(new Dictionary<string, string>(), targetDataStoreUsagePercentage: 80);
             reindexJob.QueryDelayIntervalInMilliseconds = 50;
             throttleController.Initialize(reindexJob, 1000);
 
@@ -102,7 +102,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Operations.Reindex
             var throttleController = new ReindexJobCosmosThrottleController(_fhirRequestContextAccessor);
             Assert.Equal(0, throttleController.GetThrottleBasedDelay());
 
-            var reindexJob = new ReindexJobRecord(new Dictionary<string, string>(), targetDataStoreResourcePercentage: null);
+            var reindexJob = new ReindexJobRecord(new Dictionary<string, string>(), targetDataStoreUsagePercentage: null);
             reindexJob.QueryDelayIntervalInMilliseconds = 50;
             throttleController.Initialize(reindexJob, null);
             Assert.Equal(0, throttleController.GetThrottleBasedDelay());

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Operations/Reindex/ReindexJobCosmosThrottleControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Operations/Reindex/ReindexJobCosmosThrottleControllerTests.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Operations;
@@ -42,7 +43,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Operations.Reindex
         [Fact]
         public async Task GivenATargetRUConsumption_WhenConsumedRUsIsTooHigh_QueryDelayIsIncreased()
         {
-            var throttleController = new ReindexJobCosmosThrottleController(_fhirRequestContextAccessor);
+            var throttleController = new ReindexJobCosmosThrottleController(_fhirRequestContextAccessor, new NullLogger<ReindexJobCosmosThrottleController>());
             var reindexJob = new ReindexJobRecord(new Dictionary<string, string>(), targetDataStoreUsagePercentage: 80);
             reindexJob.QueryDelayIntervalInMilliseconds = 50;
             throttleController.Initialize(reindexJob, 1000);
@@ -65,7 +66,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Operations.Reindex
         [Fact]
         public async Task GivenATargetRUConsumption_WhenConsumedRUsDecreases_QueryDelayIsDecreased()
         {
-            var throttleController = new ReindexJobCosmosThrottleController(_fhirRequestContextAccessor);
+            var throttleController = new ReindexJobCosmosThrottleController(_fhirRequestContextAccessor, new NullLogger<ReindexJobCosmosThrottleController>());
             var reindexJob = new ReindexJobRecord(new Dictionary<string, string>(), targetDataStoreUsagePercentage: 80);
             reindexJob.QueryDelayIntervalInMilliseconds = 50;
             throttleController.Initialize(reindexJob, 1000);
@@ -99,7 +100,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Operations.Reindex
         [Fact]
         public void GivenThrottleControllerNotInitialized_WhenGetThrottleDelayCalled_ZeroReturned()
         {
-            var throttleController = new ReindexJobCosmosThrottleController(_fhirRequestContextAccessor);
+            var throttleController = new ReindexJobCosmosThrottleController(_fhirRequestContextAccessor, new NullLogger<ReindexJobCosmosThrottleController>());
             Assert.Equal(0, throttleController.GetThrottleBasedDelay());
 
             var reindexJob = new ReindexJobRecord(new Dictionary<string, string>(), targetDataStoreUsagePercentage: null);

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Operations/Reindex/ReindexJobCosmosThrottleController.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Operations/Reindex/ReindexJobCosmosThrottleController.cs
@@ -42,12 +42,12 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Operations.Reindex
             ReindexJobRecord = reindexJobRecord;
             _provisionedRUThroughput = provisionedDatastoreCapacity;
 
-            if (ReindexJobRecord.TargetDataStoreResourcePercentage.HasValue
-                && ReindexJobRecord.TargetDataStoreResourcePercentage.Value > 0
+            if (ReindexJobRecord.TargetDataStoreUsagePercentage.HasValue
+                && ReindexJobRecord.TargetDataStoreUsagePercentage.Value > 0
                 && _provisionedRUThroughput.HasValue
                 && _provisionedRUThroughput > 0)
             {
-                _targetRUs = _provisionedRUThroughput.Value * (ReindexJobRecord.TargetDataStoreResourcePercentage.Value / 100.0);
+                _targetRUs = _provisionedRUThroughput.Value * (ReindexJobRecord.TargetDataStoreUsagePercentage.Value / 100.0);
                 _delayFactor = 0;
                 _rUsConsumedDuringInterval = 0.0;
                 _initialized = true;

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Operations/Reindex/ReindexJobCosmosThrottleController.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Operations/Reindex/ReindexJobCosmosThrottleController.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Operations.Reindex
             {
                 var requestContext = _fhirRequestContextAccessor.FhirRequestContext;
                 Debug.Assert(
-                    !requestContext.Method.Equals(OperationsConstants.Reindex, StringComparison.OrdinalIgnoreCase),
+                    requestContext.Method.Equals(OperationsConstants.Reindex, StringComparison.OrdinalIgnoreCase),
                     "We should not be here with FhirRequestContext that is not reindex!");
 
                 if (!_intervalStart.HasValue)

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Operations/Reindex/ReindexJobCosmosThrottleController.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Operations/Reindex/ReindexJobCosmosThrottleController.cs
@@ -26,11 +26,11 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Operations.Reindex
         private double? _targetRUs = null;
         private bool _initialized = false;
         private readonly IFhirRequestContextAccessor _fhirRequestContextAccessor;
-        private readonly ILogger _logger;
+        private readonly ILogger<ReindexJobCosmosThrottleController> _logger;
 
         public ReindexJobCosmosThrottleController(
             IFhirRequestContextAccessor fhirRequestContextAccessor,
-            ILogger logger)
+            ILogger<ReindexJobCosmosThrottleController> logger)
         {
             EnsureArg.IsNotNull(fhirRequestContextAccessor, nameof(fhirRequestContextAccessor));
             EnsureArg.IsNotNull(logger, nameof(logger));

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Operations/Reindex/ReindexJobCosmosThrottleController.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Operations/Reindex/ReindexJobCosmosThrottleController.cs
@@ -1,0 +1,113 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EnsureThat;
+using MediatR;
+using Microsoft.Health.Core;
+using Microsoft.Health.Fhir.Core.Features.Operations;
+using Microsoft.Health.Fhir.Core.Features.Operations.Reindex;
+using Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models;
+using Microsoft.Health.Fhir.CosmosDb.Features.Metrics;
+
+namespace Microsoft.Health.Fhir.CosmosDb.Features.Operations.Reindex
+{
+    public class ReindexJobCosmosThrottleController : IReindexJobThrottleController, INotificationHandler<CosmosStorageRequestMetricsNotification>
+    {
+        private int? _configuredRUThroughput;
+        private DateTimeOffset? _intervalStart = null;
+        private double _rUsConsumedDuringInterval = 0.0;
+        private ushort _delayFactor = 0;
+        private double? _targetRUs = null;
+        private bool _initialized = false;
+
+        public ReindexJobCosmosThrottleController(int? configuredRUThroughput)
+        {
+            _configuredRUThroughput = configuredRUThroughput;
+        }
+
+        public ReindexJobRecord ReindexJobRecord { get; set; } = null;
+
+        public void Initialize(ReindexJobRecord reindexJobRecord)
+        {
+            EnsureArg.IsNotNull(reindexJobRecord, nameof(reindexJobRecord));
+
+            ReindexJobRecord = reindexJobRecord;
+
+            if (ReindexJobRecord.TargetDataStoreResourcePercentage.HasValue
+                && ReindexJobRecord.TargetDataStoreResourcePercentage.Value > 0
+                && _configuredRUThroughput.HasValue
+                && _configuredRUThroughput > 0)
+            {
+                _targetRUs = _configuredRUThroughput.Value * (ReindexJobRecord.TargetDataStoreResourcePercentage.Value / 100.0);
+                _delayFactor = 0;
+                _rUsConsumedDuringInterval = 0.0;
+                _initialized = true;
+            }
+        }
+
+        public int GetThrottleBasedDelay()
+        {
+            if (!_initialized)
+            {
+                // not initialized
+                return 0;
+            }
+
+            return ReindexJobRecord.QueryDelayIntervalInMilliseconds * _delayFactor;
+        }
+
+        public Task Handle(CosmosStorageRequestMetricsNotification notification, CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested || notification == null || notification.FhirOperation == null)
+            {
+                return Task.CompletedTask;
+            }
+
+            if (notification.FhirOperation.Equals(OperationsConstants.Reindex, StringComparison.OrdinalIgnoreCase)
+                && _initialized)
+            {
+                if (!_intervalStart.HasValue)
+                {
+                    _intervalStart = Clock.UtcNow;
+                }
+
+                // we want to sum all the consumed RUs over a period of time
+                // that is about 5x the current delay between queries
+                // then we average that RU consumption per second
+                // and compare it against the target
+                if ((Clock.UtcNow - _intervalStart).Value.TotalMilliseconds <
+                    (5 * (ReindexJobRecord.QueryDelayIntervalInMilliseconds + GetThrottleBasedDelay())))
+                {
+                    _rUsConsumedDuringInterval += notification.TotalRequestCharge;
+                }
+                else
+                {
+                    // calculate average RU consumption per second
+                    _rUsConsumedDuringInterval += notification.TotalRequestCharge;
+
+                    double averageRUsConsumed = _rUsConsumedDuringInterval / (Clock.UtcNow - _intervalStart).Value.TotalSeconds;
+
+                    if (averageRUsConsumed > _targetRUs)
+                    {
+                        _delayFactor += 1;
+                    }
+                    else if (averageRUsConsumed < (_targetRUs * 0.75)
+                        && _delayFactor > 0)
+                    {
+                        _delayFactor -= 1;
+                    }
+
+                    _intervalStart = Clock.UtcNow;
+                    _rUsConsumedDuringInterval = 0.0;
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -502,5 +502,10 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
                 builder.AddRestInteraction(SystemRestfulInteraction.Batch);
             }
         }
+
+        public async Task<int?> GetProvisionedDataStoreCapacityAsync(CancellationToken cancellationToken = default)
+        {
+            return await _containerScope.Value.ReadThroughputAsync(cancellationToken);
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
@@ -13,7 +13,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Extensions.DependencyInjection;
-using Microsoft.Health.Fhir.Core.Features.Operations.Reindex;
 using Microsoft.Health.Fhir.Core.Features.Search.Registry;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Core.Registration;
@@ -204,12 +203,8 @@ namespace Microsoft.Extensions.DependencyInjection
             // FhirCosmosClientInitializer is Singleton, so provide a factory that can resolve new RequestHandlers
             services.AddFactory<IEnumerable<RequestHandler>>();
 
-            services.Add<ReindexJobCosmosThrottleController>(sp =>
-                {
-                    var config = sp.GetService<CosmosDataStoreConfiguration>();
-                    return new ReindexJobCosmosThrottleController(config.InitialDatabaseThroughput);
-                })
-                .Singleton()
+            services.Add<ReindexJobCosmosThrottleController>()
+                .Transient()
                 .AsImplementedInterfaces();
 
             services.Add<CosmosDbCollectionPhysicalPartitionInfo>()

--- a/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
@@ -13,12 +13,14 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Health.Fhir.Core.Features.Operations.Reindex;
 using Microsoft.Health.Fhir.Core.Features.Search.Registry;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Core.Registration;
 using Microsoft.Health.Fhir.CosmosDb;
 using Microsoft.Health.Fhir.CosmosDb.Configs;
 using Microsoft.Health.Fhir.CosmosDb.Features.Health;
+using Microsoft.Health.Fhir.CosmosDb.Features.Operations.Reindex;
 using Microsoft.Health.Fhir.CosmosDb.Features.Queries;
 using Microsoft.Health.Fhir.CosmosDb.Features.Search;
 using Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries;
@@ -201,6 +203,14 @@ namespace Microsoft.Extensions.DependencyInjection
 
             // FhirCosmosClientInitializer is Singleton, so provide a factory that can resolve new RequestHandlers
             services.AddFactory<IEnumerable<RequestHandler>>();
+
+            services.Add<ReindexJobCosmosThrottleController>(sp =>
+                {
+                    var config = sp.GetService<CosmosDataStoreConfiguration>();
+                    return new ReindexJobCosmosThrottleController(config.InitialDatabaseThroughput);
+                })
+                .Singleton()
+                .AsImplementedInterfaces();
 
             services.Add<CosmosDbCollectionPhysicalPartitionInfo>()
                 .Singleton()

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ReindexController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ReindexController.cs
@@ -72,9 +72,17 @@ namespace Microsoft.Health.Fhir.Api.Controllers
 
             ValidateParams(inputParams);
 
-            ushort? maximumConcurrency = ReadNumericParameter(inputParams, JobRecordProperties.MaximumConcurrency);
+            ushort? maximumConcurrency = (ushort?)ReadNumericParameter(inputParams, JobRecordProperties.MaximumConcurrency);
+            uint? maxResourcesPerQuery = (uint?)ReadNumericParameter(inputParams, JobRecordProperties.MaximumNumberOfResourcesPerQuery);
+            int? queryDelay = ReadNumericParameter(inputParams, JobRecordProperties.QueryDelayIntervalInMilliseconds);
+            ushort? targetDataStoreResourcePercentage = (ushort?)ReadNumericParameter(inputParams, JobRecordProperties.TargetDataStoreResourcePercentage);
 
-            ResourceElement response = await _mediator.CreateReindexJobAsync(maximumConcurrency, HttpContext.RequestAborted);
+            ResourceElement response = await _mediator.CreateReindexJobAsync(
+                maximumConcurrency,
+                maxResourcesPerQuery,
+                queryDelay,
+                targetDataStoreResourcePercentage,
+                HttpContext.RequestAborted);
 
             var result = FhirResult.Create(response, HttpStatusCode.Created)
                 .SetETagHeader()
@@ -174,7 +182,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             }
         }
 
-        private ushort? ReadNumericParameter(Parameters parameters, string paramName)
+        private int? ReadNumericParameter(Parameters parameters, string paramName)
         {
             var param = parameters?.Parameter.Find(p =>
                 string.Equals(p.Name, paramName, StringComparison.OrdinalIgnoreCase));
@@ -184,7 +192,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                 return null;
             }
 
-            if (ushort.TryParse(param.Value.ToString(), out var intValue))
+            if (int.TryParse(param.Value.ToString(), out var intValue))
             {
                 return intValue;
             }
@@ -212,11 +220,17 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             var postParams = new HashSet<string>()
             {
                 JobRecordProperties.MaximumConcurrency,
+                JobRecordProperties.QueryDelayIntervalInMilliseconds,
+                JobRecordProperties.MaximumNumberOfResourcesPerQuery,
+                JobRecordProperties.TargetDataStoreResourcePercentage,
             };
 
             var patchParams = new HashSet<string>()
             {
                 JobRecordProperties.MaximumConcurrency,
+                JobRecordProperties.QueryDelayIntervalInMilliseconds,
+                JobRecordProperties.MaximumNumberOfResourcesPerQuery,
+                JobRecordProperties.TargetDataStoreResourcePercentage,
                 JobRecordProperties.Status,
             };
 

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ReindexController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ReindexController.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             ushort? maximumConcurrency = (ushort?)ReadNumericParameter(inputParams, JobRecordProperties.MaximumConcurrency);
             uint? maxResourcesPerQuery = (uint?)ReadNumericParameter(inputParams, JobRecordProperties.MaximumNumberOfResourcesPerQuery);
             int? queryDelay = ReadNumericParameter(inputParams, JobRecordProperties.QueryDelayIntervalInMilliseconds);
-            ushort? targetDataStoreResourcePercentage = (ushort?)ReadNumericParameter(inputParams, JobRecordProperties.TargetDataStoreResourcePercentage);
+            ushort? targetDataStoreResourcePercentage = (ushort?)ReadNumericParameter(inputParams, JobRecordProperties.TargetDataStoreUsagePercentage);
 
             ResourceElement response = await _mediator.CreateReindexJobAsync(
                 maximumConcurrency,
@@ -222,7 +222,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                 JobRecordProperties.MaximumConcurrency,
                 JobRecordProperties.QueryDelayIntervalInMilliseconds,
                 JobRecordProperties.MaximumNumberOfResourcesPerQuery,
-                JobRecordProperties.TargetDataStoreResourcePercentage,
+                JobRecordProperties.TargetDataStoreUsagePercentage,
             };
 
             var patchParams = new HashSet<string>()
@@ -230,7 +230,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                 JobRecordProperties.MaximumConcurrency,
                 JobRecordProperties.QueryDelayIntervalInMilliseconds,
                 JobRecordProperties.MaximumNumberOfResourcesPerQuery,
-                JobRecordProperties.TargetDataStoreResourcePercentage,
+                JobRecordProperties.TargetDataStoreUsagePercentage,
                 JobRecordProperties.Status,
             };
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexJobTaskTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexJobTaskTests.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
 
         private readonly SearchParameterFixtureData _fixture;
         private readonly IFhirOperationDataStore _fhirOperationDataStore = Substitute.For<IFhirOperationDataStore>();
+        private readonly IFhirDataStore _fhirDataStore = Substitute.For<IFhirDataStore>();
         private readonly ReindexJobConfiguration _reindexJobConfiguration = new ReindexJobConfiguration();
         private readonly ISearchService _searchService = Substitute.For<ISearchService>();
         private readonly IReindexUtilities _reindexUtilities = Substitute.For<IReindexUtilities>();
@@ -68,6 +69,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
 
             _reindexJobTask = new ReindexJobTask(
                 () => _fhirOperationDataStore.CreateMockScope(),
+                () => _fhirDataStore.CreateMockScope(),
                 Options.Create(_reindexJobConfiguration),
                 () => _searchService.CreateMockScope(),
                 await _fixture.GetSupportedSearchDefinitionManagerAsync(),

--- a/src/Microsoft.Health.Fhir.Shared.Core/Extensions/ReindexMediatorExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Extensions/ReindexMediatorExtensions.cs
@@ -18,11 +18,14 @@ namespace Microsoft.Health.Fhir.Core.Extensions
         public static async Task<ResourceElement> CreateReindexJobAsync(
             this IMediator mediator,
             ushort? maximumConcurrency,
+            uint? maxResourcesPerQuery,
+            int? queryDelay,
+            ushort? targetDataStoreResourcePercentage,
             CancellationToken cancellationToken)
         {
             EnsureArg.IsNotNull(mediator, nameof(mediator));
 
-            var request = new CreateReindexRequest(maximumConcurrency);
+            var request = new CreateReindexRequest(maximumConcurrency, maxResourcesPerQuery, queryDelay, targetDataStoreResourcePercentage);
 
             CreateReindexResponse response = await mediator.Send(request, cancellationToken);
             return response.Job.ToParametersResourceElement();

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Reindex/ReindexJobSqlThrottlingController.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Reindex/ReindexJobSqlThrottlingController.cs
@@ -1,0 +1,28 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Fhir.Core.Features.Operations.Reindex;
+using Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models;
+
+namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Reindex
+{
+    public class ReindexJobSqlThrottlingController : IReindexJobThrottleController
+    {
+        public int GetThrottleBasedDelay()
+        {
+            return 0;
+        }
+
+        public void Initialize(ReindexJobRecord reindexJobRecord, int? provisionedDatastoreCapacity)
+        {
+            return;
+        }
+
+        public void UpdateDatastoreUsage()
+        {
+            return;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Reindex/ReindexJobSqlThrottlingController.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Reindex/ReindexJobSqlThrottlingController.cs
@@ -20,9 +20,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Reindex
             return;
         }
 
-        public void UpdateDatastoreUsage()
+        public double UpdateDatastoreUsage()
         {
-            return;
+            return 0.0;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Reindex/ReindexJobSqlThrottlingController.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Reindex/ReindexJobSqlThrottlingController.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Reindex
 {
     public class ReindexJobSqlThrottlingController : IReindexJobThrottleController
     {
+        private uint _targetBatchSize;
+
         public int GetThrottleBasedDelay()
         {
             return 0;
@@ -17,12 +19,18 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Reindex
 
         public void Initialize(ReindexJobRecord reindexJobRecord, int? provisionedDatastoreCapacity)
         {
+            _targetBatchSize = reindexJobRecord.MaximumNumberOfResourcesPerQuery;
             return;
         }
 
         public double UpdateDatastoreUsage()
         {
             return 0.0;
+        }
+
+        public uint GetThrottleBatchSize()
+        {
+            return _targetBatchSize;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -315,5 +315,10 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
         {
             throw new NotImplementedException();
         }
+
+        public async Task<int?> GetProvisionedDataStoreCapacityAsync(CancellationToken cancellationToken = default)
+        {
+            return await Task.FromResult((int?)null);
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Features.Search.Registry;
 using Microsoft.Health.Fhir.Core.Registration;
+using Microsoft.Health.Fhir.SqlServer.Features.Operations.Reindex;
 using Microsoft.Health.Fhir.SqlServer.Features.Schema;
 using Microsoft.Health.Fhir.SqlServer.Features.Search;
 using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors;
@@ -100,6 +101,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Add<SqlServerSearchParameterValidator>()
                 .Singleton()
                 .AsSelf()
+                .AsImplementedInterfaces();
+
+            services.Add<ReindexJobSqlThrottlingController>()
+                .Singleton()
                 .AsImplementedInterfaces();
 
             return fhirServerBuilder;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -481,6 +481,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
         {
             return new ReindexJobTask(
                 () => _scopedOperationDataStore,
+                () => _scopedDataStore,
                 Options.Create(_jobConfiguration),
                 () => _searchService,
                 _supportedSearchParameterDefinitionManager,

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -122,6 +122,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
             await _fhirStorageTestHelper.DeleteAllReindexJobRecordsAsync(CancellationToken.None);
 
             _throttleController.GetThrottleBasedDelay().Returns(0);
+            _throttleController.GetThrottleBatchSize().Returns(100U);
         }
 
         public Task DisposeAsync()


### PR DESCRIPTION
## Description
This adds functionality to automatically throttle the reindex job to a percentage of the allocated RUs in Cosmos DB.  Also some additional parameters are available to manually adjust the resources consumed by a reindex job

## Related issues
Addresses [issue [AB#79863](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/79863)].
Addresses [issue [AB#80428](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/80428)].

## Testing
Added unit tests, and performed manual test

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
