### PR TITLE
Fix continuation token passing in profiles

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Validation/ServerProvideProfileValidation.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Validation/ServerProvideProfileValidation.cs
@@ -73,7 +73,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
                             var queryParameters = new List<Tuple<string, string>>();
                             if (ct != null)
                             {
-                                queryParameters.Add(new Tuple<string, string>("ct", ct));
+                                ct = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(ct));
+                                queryParameters.Add(new Tuple<string, string>(KnownQueryParameterNames.ContinuationToken, ct));
                             }
 
                             var searchResult = await searchService.Value.SearchAsync(type, queryParameters, CancellationToken.None);

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -1,7 +1,7 @@
 ﻿{
     "FhirServer": {
         "Security": {
-            "Enabled": false,
+            "Enabled": true,
             "EnableAadSmartOnFhirProxy": true,
             "Authentication": {
                 "Audience": null,

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -1,7 +1,7 @@
 ﻿{
     "FhirServer": {
         "Security": {
-            "Enabled": true,
+            "Enabled": false,
             "EnableAadSmartOnFhirProxy": true,
             "Authentication": {
                 "Audience": null,
@@ -18,7 +18,9 @@
         "Features": {
             "SupportsUI": false,
             "SupportsXml": true,
-            "SupportsAnonymizedExport": false
+            "SupportsAnonymizedExport": false,
+            "ProfileValidationOnCreate": false,
+            "ProfileValidationOnUpdate":  false
         },
         "CoreFeatures": {
             "SupportsBatch": true,

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -18,14 +18,15 @@
         "Features": {
             "SupportsUI": false,
             "SupportsXml": true,
-            "SupportsAnonymizedExport": false,
-            "ProfileValidationOnCreate": false,
-            "ProfileValidationOnUpdate":  false
+            "SupportsAnonymizedExport": false
+           
         },
         "CoreFeatures": {
             "SupportsBatch": true,
             "SupportsTransaction": true,
-            "IncludeTotalInBundle": "None"
+            "IncludeTotalInBundle": "None",
+            "ProfileValidationOnCreate": false,
+            "ProfileValidationOnUpdate": false
         },
         "CosmosDb": {
             "CollectionId": null,


### PR DESCRIPTION
## Description
Make it work with more that default _count value of resources.

## Related issues
Addresses [issue #].

## Testing
Manually

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
