### PR TITLE
Disable parallel execution of tests for reindex.

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexJobTaskTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexJobTaskTests.cs
@@ -25,6 +25,7 @@ using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
 {
+    [CollectionDefinition("ReindexTaskTests", DisableParallelization = true)]
     public class ReindexJobTaskTests : IClassFixture<SearchParameterFixtureData>, IAsyncLifetime
     {
         private readonly SearchParameterFixtureData _fixture;


### PR DESCRIPTION
## Description
If you look into each test in Reindex they all starts with taking search parameter and making it non searchable, then trigger reindex, then return back search parameter to previous state.

Reindex job determines what to process and which resources to scan based on searchability of search parameter.
All tests design with idea what only one search parameter in whole collection is affected. Guess what would happen if we run tests in parallel...

## Related issues
Addresses [#1619].

## Testing
mostly mentally.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
skip  (only tests are affected)
