### PR TITLE
Update CustomSearchTests for stability

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Parameters/SearchParameterSupportResolver.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Parameters/SearchParameterSupportResolver.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using EnsureThat;
+using Hl7.Fhir.Introspection;
 using Hl7.FhirPath;
 using Hl7.FhirPath.Expressions;
 using Microsoft.Health.Fhir.Core.Features.Definition;
@@ -69,7 +70,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
                     .Select(result => (
                         result,
                         hasConverter: _searchValueTypeConverterManager.TryGetConverter(
-                            GetBaseType(result.ClassMapping.Name),
+                            GetBaseType(result.ClassMapping),
                             SearchIndexer.GetSearchValueTypeForSearchParamType(result.SearchParamType),
                             out IFhirNodeToSearchValueTypeConverter converter),
                         converter))
@@ -87,9 +88,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
                 }
             }
 
-            string GetBaseType(string classMapping)
+            string GetBaseType(ClassMapping classMapping)
             {
-                return classMapping.StartsWith(_codeOfTName, StringComparison.Ordinal) ? _codeOfTName : classMapping;
+                return classMapping.IsCodeOfT ? _codeOfTName : classMapping.Name;
             }
 
             return (true, false);

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Parameters/SearchParameterSupportResolver.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Parameters/SearchParameterSupportResolver.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
         private readonly ISearchParameterDefinitionManager _definitionManager;
         private readonly IFhirNodeToSearchValueTypeConverterManager _searchValueTypeConverterManager;
         private static readonly FhirPathCompiler _compiler = new FhirPathCompiler();
+        private const string _codeOfTName = "codeOfT";
 
         public SearchParameterSupportResolver(
             ISearchParameterDefinitionManager definitionManager,
@@ -68,7 +69,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
                     .Select(result => (
                         result,
                         hasConverter: _searchValueTypeConverterManager.TryGetConverter(
-                            result.ClassMapping.Name,
+                            GetBaseType(result.ClassMapping.Name),
                             SearchIndexer.GetSearchValueTypeForSearchParamType(result.SearchParamType),
                             out IFhirNodeToSearchValueTypeConverter converter),
                         converter))
@@ -84,6 +85,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
                     bool partialSupport = converters.Any(x => x.hasConverter);
                     return (partialSupport, partialSupport);
                 }
+            }
+
+            string GetBaseType(string classMapping)
+            {
+                return classMapping.StartsWith(_codeOfTName, StringComparison.Ordinal) ? _codeOfTName : classMapping;
             }
 
             return (true, false);

--- a/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
+++ b/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
@@ -36,6 +36,7 @@
     <None Remove="TestFiles\Device-d1.json" />
     <None Remove="TestFiles\DeviceComponent-For-Device-d1.json" />
     <None Remove="TestFiles\Encounter-For-Patient-f001.json" />
+    <None Remove="TestFiles\Normative\Appointment.json" />
     <None Remove="TestFiles\Normative\CarePlan.json" />
     <None Remove="TestFiles\Normative\CodeSystem-careplan-category.json" />
     <None Remove="TestFiles\Normative\MoneyWithWrongDecimal.json" />
@@ -44,6 +45,7 @@
     <None Remove="TestFiles\Normative\Profile-Organization-uscore.json" />
     <None Remove="TestFiles\Normative\Profile-Patient-uscore.json" />
     <None Remove="TestFiles\Normative\ProvenanceHeader.json" />
+    <None Remove="TestFiles\Normative\SearchParameter-AppointmentStatus.json" />
     <None Remove="TestFiles\Normative\SearchParameter.json" />
     <None Remove="TestFiles\Normative\SearchParameterBadSyntax.json" />
     <None Remove="TestFiles\Normative\SearchParameterExpressionWrongProperty.json" />
@@ -236,9 +238,11 @@
     <EmbeddedResource Include="DefinitionFiles\Stu3\SearchParametersWithInvalidBase.json" />
     <EmbeddedResource Include="DefinitionFiles\Stu3\SearchParametersWithNullEntry.json" />
     <EmbeddedResource Include="DefinitionFiles\Stu3\SearchParametersWithInvalidEntries.json" />
+    <EmbeddedResource Include="TestFiles\Normative\Appointment.json" />
     <EmbeddedResource Include="TestFiles\Normative\BloodGlucose.json" />
     <EmbeddedResource Include="TestFiles\Normative\BloodPressure.json" />
     <EmbeddedResource Include="TestFiles\Normative\Bundle-TypeMissing.json" />
+    <EmbeddedResource Include="TestFiles\Normative\SearchParameter-AppointmentStatus.json" />
     <EmbeddedResource Include="TestFiles\Normative\SearchParameterInvalidBase.json" />
     <EmbeddedResource Include="TestFiles\Normative\SearchParameterMissingType.json" />
     <EmbeddedResource Include="TestFiles\Normative\SearchParameterInvalidType.json" />

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/Appointment.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/Appointment.json
@@ -47,23 +47,12 @@
             }
         ]
     },
-    "reasonReference": [
-        {
-            "reference": "Condition/example",
-            "display": "Severe burn of left ear"
-        }
-    ],
     "priority": 5,
     "description": "Discussion on the results of your recent MRI",
     "start": "2013-12-10T09:00:00Z",
     "end": "2013-12-10T11:00:00Z",
     "created": "2013-10-10",
     "comment": "Further expand on the results of the MRI and determine the next actions that may be appropriate.",
-    "basedOn": [
-        {
-            "reference": "ServiceRequest/myringotomy"
-        }
-    ],
     "participant": [
         {
             "actor": {

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/Appointment.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/Appointment.json
@@ -1,0 +1,103 @@
+{
+    "resourceType": "Appointment",
+    "id": "example",
+    "text": {
+        "status": "generated",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Brian MRI results discussion</div>"
+    },
+    "status": "booked",
+    "serviceCategory": [
+        {
+            "coding": [
+                {
+                    "system": "http://example.org/service-category",
+                    "code": "gp",
+                    "display": "General Practice"
+                }
+            ]
+        }
+    ],
+    "serviceType": [
+        {
+            "coding": [
+                {
+                    "code": "52",
+                    "display": "General Discussion"
+                }
+            ]
+        }
+    ],
+    "specialty": [
+        {
+            "coding": [
+                {
+                    "system": "http://snomed.info/sct",
+                    "code": "394814009",
+                    "display": "General practice"
+                }
+            ]
+        }
+    ],
+    "appointmentType": {
+        "coding": [
+            {
+                "system": "http://terminology.hl7.org/CodeSystem/v2-0276",
+                "code": "FOLLOWUP",
+                "display": "A follow up visit from a previous appointment"
+            }
+        ]
+    },
+    "reasonReference": [
+        {
+            "reference": "Condition/example",
+            "display": "Severe burn of left ear"
+        }
+    ],
+    "priority": 5,
+    "description": "Discussion on the results of your recent MRI",
+    "start": "2013-12-10T09:00:00Z",
+    "end": "2013-12-10T11:00:00Z",
+    "created": "2013-10-10",
+    "comment": "Further expand on the results of the MRI and determine the next actions that may be appropriate.",
+    "basedOn": [
+        {
+            "reference": "ServiceRequest/myringotomy"
+        }
+    ],
+    "participant": [
+        {
+            "actor": {
+                "reference": "Patient/example",
+                "display": "Peter James Chalmers"
+            },
+            "required": "required",
+            "status": "accepted"
+        },
+        {
+            "type": [
+                {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
+                            "code": "ATND"
+                        }
+                    ]
+                }
+            ],
+            "actor": {
+                "reference": "Practitioner/example",
+                "display": "Dr Adam Careful"
+            },
+            "required": "required",
+            "status": "accepted"
+        },
+        {
+            "actor": {
+                "reference": "Location/1",
+                "display": "South Wing, second floor"
+            },
+            "required": "required",
+            "status": "accepted"
+        }
+    ]
+}

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/SearchParameter-AppointmentStatus.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/SearchParameter-AppointmentStatus.json
@@ -1,0 +1,42 @@
+{
+    "resourceType": "SearchParameter",
+    "id": "Appointment-foo",
+    "extension": [
+        {
+            "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+            "valueCode": "trial-use"
+        }
+    ],
+    "url": "http://hl7.org/fhir/SearchParameter/Appointment-foo",
+    "version": "4.0.1",
+    "name": "status",
+    "status": "draft",
+    "experimental": false,
+    "date": "2019-11-01T09:29:23+11:00",
+    "publisher": "Health Level Seven International (Patient Administration)",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://hl7.org/fhir"
+                }
+            ]
+        },
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/pafm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The overall status of the appointment",
+    "code": "foo",
+    "base": [ "Appointment" ],
+    "type": "token",
+    "expression": "Appointment.status",
+    "xpath": "f:Appointment/f:status",
+    "xpathUsage": "normal"
+}

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -44,7 +44,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             searchParam.Name = randomName;
             searchParam.Url = searchParam.Url.Replace("foo", randomName);
             searchParam.Code = randomName + "Code";
-            searchParam.Id = randomName;
 
             // POST a new appointment
             var appointment = Samples.GetJsonSample<Appointment>("Appointment");
@@ -56,6 +55,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
             // POST a second appointment to show it is filtered and not returned when using the new search parameter
             var appointment2 = Samples.GetJsonSample<Appointment>("Appointment");
+            appointment2.Status = Appointment.AppointmentStatus.Booked;
             appointment2.Meta = new Meta();
             appointment2.Meta.Tag.Add(tag);
             await Client.CreateAsync(appointment2);
@@ -91,7 +91,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 Assert.True(resourcesReindexed > 0.0);
 
                 // When job complete, search for resources using new parameter
-                await ExecuteAndValidateBundle($"Appointment?{searchParam.Code}=noshow&_tag={tag.Code}", expectedAppointment.Resource);
+                await ExecuteAndValidateBundle(
+                    $"Appointment?{searchParam.Code}={Appointment.AppointmentStatus.Noshow.ToString().ToLower()}& _tag={tag.Code}", expectedAppointment.Resource);
             }
             catch (FhirException ex) when (ex.StatusCode == HttpStatusCode.BadRequest && ex.Message.Contains("not enabled"))
             {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
                 // When job complete, search for resources using new parameter
                 await ExecuteAndValidateBundle(
-                    $"Appointment?{searchParam.Code}={Appointment.AppointmentStatus.Noshow.ToString().ToLower()}& _tag={tag.Code}", expectedAppointment.Resource);
+                    $"Appointment?{searchParam.Code}={Appointment.AppointmentStatus.Noshow.ToString().ToLower()}&_tag={tag.Code}", expectedAppointment.Resource);
             }
             catch (FhirException ex) when (ex.StatusCode == HttpStatusCode.BadRequest && ex.Message.Contains("not enabled"))
             {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -39,85 +39,82 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [SkippableFact]
         public async Task GivenANewSearchParam_WhenReindexingComplete_ThenResourcesSearchedWithNewParamReturned()
         {
-            var patientName = Guid.NewGuid().ToString().ComputeHash().Substring(28).ToLower();
-            var patient = new Patient { Name = new List<HumanName> { new HumanName { Family = patientName } } };
-            var searchParam = Samples.GetJsonSample<SearchParameter>("SearchParameter");
-            searchParam.Code = "fooCode";
+            var randomName = Guid.NewGuid().ToString().ComputeHash().Substring(0, 14).ToLower();
+            var appointment = Samples.GetJsonSample<Appointment>("Appointment");
+            appointment.Status = Appointment.AppointmentStatus.Noshow;
+            var searchParam = Samples.GetJsonSample<SearchParameter>("SearchParameter-AppointmentStatus");
+            searchParam.Name = randomName;
+            searchParam.Url = searchParam.Url.Replace("foo", randomName);
+            searchParam.Code = randomName + "Code";
+            searchParam.Id = randomName;
 
             // POST a new patient
-            FhirResponse<Patient> expectedPatient = await Client.CreateAsync(patient);
+            FhirResponse<Appointment> expectedAppointment = await Client.CreateAsync(appointment);
 
             // POST a second patient to show it is filtered and not returned when using the new search parameter
-            await Client.CreateAsync(Samples.GetJsonSample<Patient>("Patient"));
+            await Client.CreateAsync(Samples.GetJsonSample<Appointment>("Appointment"));
 
             // POST a new Search parameter
             FhirResponse<SearchParameter> searchParamPosted = null;
             try
             {
                 searchParamPosted = await Client.CreateAsync(searchParam);
-            }
-            catch (Exception ex)
-            {
-                _output.WriteLine("We encountered an error creating SearchParameter, the next step is to delete and re-add.");
-                _output.WriteLine(ex.Message);
 
-                // if the SearchParameter exists, we should delete it and recreate it
-                var searchParamBundle = await Client.SearchAsync(ResourceType.SearchParameter, $"url={searchParam.Url}");
-                if (searchParamBundle.Resource?.Entry[0] != null && searchParamBundle.Resource?.Entry[0].Resource.ResourceType == ResourceType.SearchParameter)
-                {
-                    await DeleteSearchParameterAndVerify(searchParamBundle.Resource?.Entry[0].Resource as SearchParameter);
-                    searchParamPosted = await Client.CreateAsync(searchParam);
-                }
-                else
-                {
-                    throw;
-                }
-            }
+                Uri reindexJobUri;
 
-            Uri reindexJobUri;
-            try
-            {
                 // Start a reindex job
                 (_, reindexJobUri) = await Client.PostReindexJobAsync(new Parameters());
+
+                await WaitForReindexStatus(reindexJobUri, "Running", "Completed");
+
+                FhirResponse<Parameters> reindexJobResult = await Client.CheckReindexAsync(reindexJobUri);
+                Parameters.ParameterComponent param = reindexJobResult.Resource.Parameter.FirstOrDefault(p => p.Name == "searchParams");
+
+                Assert.Contains(searchParamPosted.Resource.Url, param.Value.ToString());
+
+                reindexJobResult = await WaitForReindexStatus(reindexJobUri, "Completed");
+                _output.WriteLine($"Reindex job is completed, it should have reindexed the Patient resources with {randomName}");
+
+                var floatParse = float.TryParse(
+                    reindexJobResult.Resource.Parameter.FirstOrDefault(predicate => predicate.Name == "resourcesSuccessfullyReindexed").Value.ToString(),
+                    out float resourcesReindexed);
+
+                _output.WriteLine($"Reindex job is completed, {resourcesReindexed} Patient resources Reindexed");
+
+                Assert.True(floatParse);
+                Assert.True(resourcesReindexed > 0.0);
+
+                // When job complete, search for resources using new parameter
+                await ExecuteAndValidateBundle($"Appointment?{searchParam.Code}:exact={searchParamPosted.Resource.Status}", expectedAppointment.Resource);
             }
             catch (FhirException ex) when (ex.StatusCode == HttpStatusCode.BadRequest && ex.Message.Contains("not enabled"))
             {
                 Skip.If(!_fixture.IsUsingInProcTestServer, "Reindex is not enabled on this server.");
                 return;
             }
-
-            await WaitForReindexStatus(reindexJobUri, "Running", "Completed");
-
-            FhirResponse<Parameters> reindexJobResult = await Client.CheckReindexAsync(reindexJobUri);
-            Parameters.ParameterComponent param = reindexJobResult.Resource.Parameter.FirstOrDefault(p => p.Name == "searchParams");
-
-            Assert.Contains("http://hl7.org/fhir/SearchParameter/Patient-foo", param.Value.ToString());
-
-            reindexJobResult = await WaitForReindexStatus(reindexJobUri, "Completed");
-            _output.WriteLine("Reindex job is completed, it should have reindexed the Patient resources with foo");
-
-            var floatParse = float.TryParse(
-                reindexJobResult.Resource.Parameter.FirstOrDefault(predicate => predicate.Name == "resourcesSuccessfullyReindexed").Value.ToString(),
-                out float resourcesReindexed);
-
-            _output.WriteLine($"Reindex job is completed, {resourcesReindexed} Patient ressources Reindexed");
-
-            Assert.True(floatParse);
-            Assert.True(resourcesReindexed > 0.0);
-
-            // When job complete, search for resources using new parameter
-            await ExecuteAndValidateBundle($"Patient?{searchParam.Code}:exact={patientName}", expectedPatient.Resource);
-
-            // Clean up new SearchParameter
-            await DeleteSearchParameterAndVerify(searchParamPosted.Resource);
+            catch (Exception e)
+            {
+                _output.WriteLine($"Exception: {e.Message}");
+                _output.WriteLine($"Stack Trace: {e.StackTrace}");
+                throw;
+            }
+            finally
+            {
+                // Clean up new SearchParameter
+                await DeleteSearchParameterAndVerify(searchParamPosted?.Resource);
+            }
         }
 
         [SkippableFact]
         public async Task GivenASearchParam_WhenUpdatingParam_ThenResourcesIndexedWithUpdatedParam()
         {
-            var patientName = Guid.NewGuid().ToString().ComputeHash().Substring(28).ToLower();
-            var patient = new Patient { Name = new List<HumanName> { new HumanName { Family = patientName } } };
+            var randomName = Guid.NewGuid().ToString().ComputeHash().Substring(28).ToLower();
+            var patient = new Patient { Name = new List<HumanName> { new HumanName { Family = randomName } } };
             var searchParam = Samples.GetJsonSample<SearchParameter>("SearchParameter");
+            searchParam.Name = randomName;
+            searchParam.Url = searchParam.Url.Replace("foo", randomName);
+            searchParam.Code = randomName;
+            searchParam.Id = randomName;
 
             // POST a new patient
             FhirResponse<Patient> expectedPatient = await Client.CreateAsync(patient);
@@ -127,49 +124,42 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             try
             {
                 searchParamPosted = await Client.CreateAsync(searchParam);
-            }
-            catch (FhirException)
-            {
-                // if the SearchParameter exists, we should delete it and recreate it
-                var searchParamBundle = await Client.SearchAsync(ResourceType.SearchParameter, $"url={searchParam.Url}");
-                if (searchParamBundle.Resource?.Entry[0] != null && searchParamBundle.Resource?.Entry[0].Resource.ResourceType == ResourceType.SearchParameter)
-                {
-                    await DeleteSearchParameterAndVerify(searchParamBundle.Resource?.Entry[0].Resource as SearchParameter);
-                    searchParamPosted = await Client.CreateAsync(searchParam);
-                }
-                else
-                {
-                    throw;
-                }
-            }
 
-            // now update the new search parameter
-            searchParamPosted.Resource.Name = "foo2";
-            searchParamPosted.Resource.Url = "http://hl7.org/fhir/SearchParameter/Patient-foo2";
-            searchParamPosted.Resource.Code = "foo2";
-            searchParamPosted = await Client.UpdateAsync(searchParamPosted.Resource);
+                // now update the new search parameter
+                var randomNameUpdated = randomName + "U";
+                searchParamPosted.Resource.Name = randomNameUpdated;
+                searchParamPosted.Resource.Url = "http://hl7.org/fhir/SearchParameter/Patient-" + randomNameUpdated;
+                searchParamPosted.Resource.Code = randomNameUpdated;
+                searchParamPosted = await Client.UpdateAsync(searchParamPosted.Resource);
 
-            Uri reindexJobUri;
-            FhirResponse<Parameters> reindexJobResult;
-            try
-            {
+                Uri reindexJobUri;
+                FhirResponse<Parameters> reindexJobResult;
+
                 // Reindex just a single patient, so we can try searching with a partially indexed search param
                 (reindexJobResult, reindexJobUri) = await Client.PostReindexJobAsync(new Parameters(), $"Patient/{expectedPatient.Resource.Id}/");
-                Parameters.ParameterComponent param = reindexJobResult.Resource.Parameter.FirstOrDefault(p => p.Name == "foo2");
+                Parameters.ParameterComponent param = reindexJobResult.Resource.Parameter.FirstOrDefault(p => p.Name == randomNameUpdated);
 
-                Assert.Equal(patientName, param.Value.ToString());
+                Assert.Equal(randomName, param.Value.ToString());
+
+                // When job complete, search for resources using new parameter
+                await ExecuteAndValidateBundle($"Patient?{searchParamPosted.Resource.Code}:exact={randomName}", Tuple.Create("x-ms-use-partial-indices", "true"), expectedPatient.Resource);
             }
             catch (FhirException ex) when (ex.StatusCode == HttpStatusCode.BadRequest && ex.Message.Contains("not enabled"))
             {
                 Skip.If(!_fixture.IsUsingInProcTestServer, "Reindex is not enabled on this server.");
                 return;
             }
-
-            // When job complete, search for resources using new parameter
-            await ExecuteAndValidateBundle($"Patient?foo2:exact={patientName}", Tuple.Create("x-ms-use-partial-indices", "true"), expectedPatient.Resource);
-
-            // Clean up new SearchParameter
-            await DeleteSearchParameterAndVerify(searchParamPosted.Resource);
+            catch (Exception e)
+            {
+                _output.WriteLine($"Exception: {e.Message}");
+                _output.WriteLine($"Stack Trace: {e.StackTrace}");
+                throw;
+            }
+            finally
+            {
+                // Clean up new SearchParameter
+                await DeleteSearchParameterAndVerify(searchParamPosted?.Resource);
+            }
         }
 
         [Theory]
@@ -214,9 +204,12 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
         private async Task DeleteSearchParameterAndVerify(SearchParameter searchParam)
         {
-            await Client.DeleteAsync(searchParam);
-            var ex = await Assert.ThrowsAsync<FhirException>(() => Client.ReadAsync<SearchParameter>(ResourceType.SearchParameter, searchParam.Id));
-            Assert.Contains("Gone", ex.Message);
+            if (searchParam != null)
+            {
+                await Client.DeleteAsync(searchParam);
+                var ex = await Assert.ThrowsAsync<FhirException>(() => Client.ReadAsync<SearchParameter>(ResourceType.SearchParameter, searchParam.Id));
+                Assert.Contains("Gone", ex.Message);
+            }
         }
     }
 }


### PR DESCRIPTION
## Description
Changed from Patient to appointment.  Use a tag to better identify resources created in the test.
Stopped trying to delete and re-add SearchParam upon failure.

## Related issues
Addresses [issue [AB#80294](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/80294)].

## Testing
Ran the new E2E tests against OSS and PaaS

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
Skip