### PR TITLE
Add cancellation token to CheckAccess

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Security/Authorization/DisabledFhirAuthorizationService.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Security/Authorization/DisabledFhirAuthorizationService.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Health.Fhir.Core.Features.Security.Authorization
@@ -14,7 +15,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Security.Authorization
     {
         public static readonly DisabledFhirAuthorizationService Instance = new DisabledFhirAuthorizationService();
 
-        public ValueTask<DataActions> CheckAccess(DataActions dataActions)
+        public ValueTask<DataActions> CheckAccess(DataActions dataActions, CancellationToken cancellationToken = default)
         {
             return new ValueTask<DataActions>(dataActions);
         }

--- a/src/Microsoft.Health.Fhir.Core/Features/Security/Authorization/IFhirAuthorizationService.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Security/Authorization/IFhirAuthorizationService.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Health.Fhir.Core.Features.Security.Authorization
@@ -18,6 +19,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Security.Authorization
         /// to more than one action by ORing values together.
         /// </summary>
         /// <param name="dataActions">The set of data actions to check</param>
+        /// <param name="cancellationToken">Cancellation token to cancel access check.</param>
         /// <returns>
         /// Either:
         /// (a) the same value as the input (return == input), which means that all actions are permitted
@@ -25,6 +27,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Security.Authorization
         /// (c) None, (0), meaning none of the requested actions are permitted.
         /// In all cases, no bits will set on the return value that were not set on input.
         /// </returns>
-        ValueTask<DataActions> CheckAccess(DataActions dataActions);
+        ValueTask<DataActions> CheckAccess(DataActions dataActions, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Security/Authorization/RoleBasedFhirAuthorizationService.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Security/Authorization/RoleBasedFhirAuthorizationService.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
+using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Health.Fhir.Core.Configs;
@@ -33,7 +34,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Security.Authorization
             _roles = authorizationConfiguration.Roles.ToDictionary(r => r.Name, StringComparer.OrdinalIgnoreCase);
         }
 
-        public ValueTask<DataActions> CheckAccess(DataActions dataActions)
+        public ValueTask<DataActions> CheckAccess(DataActions dataActions, CancellationToken cancellationToken = default)
         {
             ClaimsPrincipal principal = _requestContextAccessor.FhirRequestContext.Principal;
 


### PR DESCRIPTION
## Description
Adds cancellation token to interface method.

## Related issues
Addresses [#1758].

## Testing
Manually

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch 
