### PR TITLE
Fixed _lastUpdated sort with :not or :missing expression

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -313,7 +313,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
                 case SearchParamTableExpressionKind.NotExists:
                     StringBuilder.Append("SELECT Sid1");
-                    StringBuilder.AppendLine(context.Sort?.Count > 0 ? ", SortValue" : string.Empty);
+                    StringBuilder.AppendLine(IsInSortMode(context) ? ", SortValue" : string.Empty);
                     StringBuilder.Append("FROM ").AppendLine(TableExpressionName(_tableExpressionCounter - 1));
                     StringBuilder.AppendLine("WHERE Sid1 NOT IN").AppendLine("(");
 


### PR DESCRIPTION
## Description
Fixes SQL Query generator when `NotExists` table expression is used in conjunction with `_lastUpdated` sort.
Which fixes the following example queries:
```http
GET /Task?_sort=-_lastUpdated&priority:not=stat
GET /Observtion?_sort=_lastUpdated&subject:missing=true
```

## Related issues
Addresses [issue #].

## Testing
Added new E2E test.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
