### PR TITLE
Fix CI deploy pipeline

### DIFF
--- a/build/ci-deploy.yml
+++ b/build/ci-deploy.yml
@@ -21,7 +21,7 @@ stages:
   displayName: Provision Environment
   dependsOn: []
   jobs:
-  - template: ./jobs/cleanup.yml
+  - template: ./jobs/cleanup-resourcegroup-aad.yml
   - job: provision
     dependsOn: DeleteResourceGroup 
     steps:

--- a/build/ci-deploy.yml
+++ b/build/ci-deploy.yml
@@ -81,7 +81,7 @@ stages:
       resourceGroup: $(DeploymentEnvironmentName)
       testEnvironmentUrl: $(TestEnvironmentUrl)
       imageTag: $(ImageTag)
-      schemaAutomaticUpdatesEnabled: 'tool'
+      schemaAutomaticUpdatesEnabled: 'auto'
 
 - stage: deployR4
   displayName: 'Deploy R4 Site'
@@ -118,7 +118,7 @@ stages:
       resourceGroup: $(DeploymentEnvironmentName)
       testEnvironmentUrl: $(TestEnvironmentUrl)
       imageTag: $(ImageTag)
-      schemaAutomaticUpdatesEnabled: 'tool'
+      schemaAutomaticUpdatesEnabled: 'auto'
 
 - stage: deployR5
   displayName: 'Deploy R5 Site'
@@ -155,4 +155,4 @@ stages:
       resourceGroup: $(DeploymentEnvironmentName)
       testEnvironmentUrl: $(TestEnvironmentUrl)
       imageTag: $(ImageTag)
-      schemaAutomaticUpdatesEnabled: 'tool'
+      schemaAutomaticUpdatesEnabled: 'auto'

--- a/build/ci-deploy.yml
+++ b/build/ci-deploy.yml
@@ -40,7 +40,9 @@ stages:
   - provisionEnvironment
   - DockerBuild
   jobs:
-  - template: ./jobs/add-aad-test-environment.yml
+  - job: setup
+    steps:
+    - template: ./jobs/add-aad-test-environment.yml
 
 - stage: deployStu3
   displayName: 'Deploy STU3 Site'

--- a/build/ci-deploy.yml
+++ b/build/ci-deploy.yml
@@ -41,6 +41,8 @@ stages:
   - DockerBuild
   jobs:
   - job: setup
+    pool:
+      vmImage: '$(WindowsVmImage)'
     steps:
     - template: ./jobs/add-aad-test-environment.yml
 

--- a/build/jobs/cleanup-resourcegroup-aad.yml
+++ b/build/jobs/cleanup-resourcegroup-aad.yml
@@ -1,0 +1,16 @@
+jobs:
+- job: DeleteResourceGroup
+  displayName: 'Delete resource group'
+  pool:
+    name: '$(SharedLinuxPool)'
+    vmImage: '$(LinuxVmImage)'
+  steps:
+  - task: AzurePowerShell@4
+    displayName: 'Delete resource group'
+    inputs:
+      azureSubscription: $(ConnectedServiceName)
+      azurePowerShellVersion: latestVersion
+      ScriptType: InlineScript
+      Inline: 'Get-AzResourceGroup -Name $(ResourceGroupName) | Remove-AzResourceGroup -Verbose -Force'
+
+- template: ./cleanup-aad.yml

--- a/build/jobs/cleanup.yml
+++ b/build/jobs/cleanup.yml
@@ -14,3 +14,20 @@ jobs:
       Inline: 'Get-AzResourceGroup -Name $(ResourceGroupName) | Remove-AzResourceGroup -Verbose -Force'
 
 - template: ./cleanup-aad.yml
+
+- job: deleteImage
+  displayName: 'Delete Image'
+  pool:
+    name: '$(DefaultLinuxPool)'
+    vmImage: '$(LinuxVmImage)'
+  steps:
+  - task: AzureCLI@2
+    displayName: 'Delete Image'
+    inputs:
+      azureSubscription: $(ConnectedServiceName)
+      scriptType: pscore
+      scriptLocation: InlineScript
+      inlineScript: |
+        az acr repository delete --name $(azureContainerRegistryName) --image 'r4_fhir-server:$(ImageTag)' --yes
+        az acr repository delete --name $(azureContainerRegistryName) --image 'stu3_fhir-server:$(ImageTag)' --yes
+        az acr repository delete --name $(azureContainerRegistryName) --image 'r5_fhir-server:$(ImageTag)' --yes

--- a/build/jobs/cleanup.yml
+++ b/build/jobs/cleanup.yml
@@ -14,20 +14,3 @@ jobs:
       Inline: 'Get-AzResourceGroup -Name $(ResourceGroupName) | Remove-AzResourceGroup -Verbose -Force'
 
 - template: ./cleanup-aad.yml
-
-- job: deleteImage
-  displayName: 'Delete Image'
-  pool:
-    name: '$(DefaultLinuxPool)'
-    vmImage: '$(LinuxVmImage)'
-  steps:
-  - task: AzureCLI@2
-    displayName: 'Delete Image'
-    inputs:
-      azureSubscription: $(ConnectedServiceName)
-      scriptType: pscore
-      scriptLocation: InlineScript
-      inlineScript: |
-        az acr repository delete --name $(azureContainerRegistryName) --image 'r4_fhir-server:$(ImageTag)' --yes
-        az acr repository delete --name $(azureContainerRegistryName) --image 'stu3_fhir-server:$(ImageTag)' --yes
-        az acr repository delete --name $(azureContainerRegistryName) --image 'r5_fhir-server:$(ImageTag)' --yes


### PR DESCRIPTION
## Description
Fix [CI deploy pipeline](https://microsofthealthoss.visualstudio.com/FhirServer/_build?definitionId=29&_a=summary) which is broken due to several issues:
1. Syntax error in referencing add-aad-test-environment.yml job.
2. Wrong config in setting up aad which needs windows platform agent.
3. Wrong schemaAutomaticUpdatesEnabled value in sql deployment tasks.
 
## Related issues
Addresses [issue #].

## Testing
Manual test.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip