### PR TITLE
Guard against double-dispose of CosmosDbCollectionPhysicalPartitionInfo

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosDbCollectionPhysicalPartitionInfo.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosDbCollectionPhysicalPartitionInfo.cs
@@ -151,10 +151,20 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
 
         public async ValueTask DisposeAsync()
         {
-            _backgroundLoopCancellationTokenSource.Cancel();
-            await _backgroundLoopTask;
-            _backgroundLoopCancellationTokenSource.Dispose();
-            _backgroundLoopTask.Dispose();
+            if (_backgroundLoopTask != null)
+            {
+                try
+                {
+                    _backgroundLoopCancellationTokenSource.Cancel();
+                    await _backgroundLoopTask;
+                    _backgroundLoopCancellationTokenSource.Dispose();
+                    _backgroundLoopTask.Dispose();
+                }
+                finally
+                {
+                    _backgroundLoopTask = null;
+                }
+            }
         }
 
         private static string GenerateAuthToken(string verb, string resourceType, string resourceId, string date, string key)


### PR DESCRIPTION
## Description
We get an ObjectDisposedException when shutting down the server because CosmosDbCollectionPhysicalPartitionInfo is registeres as an IRequireInitializationOnFirstRequest and an ICosmosDbCollectionPhysicalPartitionInfo, and so is disposed twice. The second time it throws.

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
