### PR TITLE
Read existing SearchParameter resources

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/Registry/SearchParameterStatusManagerTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/Registry/SearchParameterStatusManagerTests.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Registry
         [Fact]
         public async Task GivenASPStatusManager_WhenInitializing_ThenSearchParameterIsUpdatedFromRegistry()
         {
-            await _manager.EnsureInitialized();
+            await _manager.StartAsync(CancellationToken.None);
 
             var list = _searchParameterDefinitionManager.GetSearchParameters("Account").ToList();
 
@@ -143,7 +143,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Registry
         [Fact]
         public async Task GivenASPStatusManager_WhenInitializing_ThenUpdatedSearchParametersInNotification()
         {
-            await _manager.EnsureInitialized();
+            await _manager.StartAsync(CancellationToken.None);
 
             // Id should not be modified in this test case
             var modifiedItems = _searchParameterInfos.Skip(1).ToArray();
@@ -158,7 +158,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Registry
         [Fact]
         public async Task GivenASPStatusManager_WhenInitializing_ThenRegistryShouldNotUpdateNewlyFoundParameters()
         {
-            await _manager.EnsureInitialized();
+            await _manager.StartAsync(CancellationToken.None);
 
             await _searchParameterStatusDataStore
                 .DidNotReceive()

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterResourceDataStore.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterResourceDataStore.cs
@@ -1,0 +1,78 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using EnsureThat;
+using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Core.Features.Definition;
+using Microsoft.Health.Fhir.Core.Models;
+
+namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
+{
+    public class SearchParameterResourceDataStore : IRequireInitializationOnFirstRequest
+    {
+        private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager;
+        private readonly SearchParameterStatusManager _searchParameterStatusManager;
+        private readonly Func<IScoped<ISearchService>> _searchServiceFactory;
+        private readonly IModelInfoProvider _modelInfoProvider;
+
+        public SearchParameterResourceDataStore(
+            ISearchParameterDefinitionManager searchParameterDefinitionManager,
+            SearchParameterStatusManager searchParameterStatusManager,
+            Func<IScoped<ISearchService>> searchServiceFactory,
+            IModelInfoProvider modelInfoProvider)
+        {
+            EnsureArg.IsNotNull(searchParameterDefinitionManager, nameof(searchParameterDefinitionManager));
+            EnsureArg.IsNotNull(searchParameterStatusManager, nameof(searchParameterStatusManager));
+            EnsureArg.IsNotNull(searchServiceFactory, nameof(searchServiceFactory));
+            EnsureArg.IsNotNull(modelInfoProvider, nameof(modelInfoProvider));
+
+            _searchParameterDefinitionManager = searchParameterDefinitionManager;
+            _searchParameterStatusManager = searchParameterStatusManager;
+            _searchServiceFactory = searchServiceFactory;
+            _modelInfoProvider = modelInfoProvider;
+        }
+
+        public async Task EnsureInitialized()
+        {
+            // now read in any previously POST'd SearchParameter resources
+            using (var search = _searchServiceFactory())
+            {
+                string continuationToken = null;
+                do
+                {
+                    var queryParams = new List<Tuple<string, string>>();
+                    if (continuationToken != null)
+                    {
+                        queryParams.Add(new Tuple<string, string>(KnownQueryParameterNames.ContinuationToken, continuationToken));
+                    }
+
+                    var result = await search.Value.SearchAsync("SearchParameter", queryParams, cancellationToken: default);
+                    if (!string.IsNullOrEmpty(result?.ContinuationToken))
+                    {
+                        continuationToken = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(result.ContinuationToken));
+                    }
+                    else
+                    {
+                        continuationToken = null;
+                    }
+
+                    if (result != null && result.Results != null && result.Results.Count() > 0)
+                    {
+                        var searchParams = result.Results.Select(r => r.Resource.RawResource.ToITypedElement(_modelInfoProvider)).ToList();
+
+                        _searchParameterDefinitionManager.AddNewSearchParameters(searchParams);
+                        await _searchParameterStatusManager.AddSearchParameterStatusAsync(searchParams.Select(s => s.GetStringScalar("url")).ToList());
+                    }
+                }
+                while (continuationToken != null);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
@@ -6,11 +6,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using MediatR;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Health.Core;
-using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Search.Parameters;
 using Microsoft.Health.Fhir.Core.Messages.Search;
@@ -18,7 +19,7 @@ using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
 {
-    public class SearchParameterStatusManager : IRequireInitializationOnFirstRequest
+    public class SearchParameterStatusManager : IHostedService
     {
         private readonly ISearchParameterStatusDataStore _searchParameterStatusDataStore;
         private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager;
@@ -42,7 +43,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
             _mediator = mediator;
         }
 
-        public async Task EnsureInitialized()
+        public async Task StartAsync(CancellationToken cancellationToken)
         {
             var updated = new List<SearchParameterInfo>();
 
@@ -93,6 +94,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
             }
 
             await _mediator.Publish(new SearchParametersUpdated(updated));
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
         }
 
         public async Task UpdateSearchParameterStatusAsync(IReadOnlyCollection<string> searchParameterUris, SearchParameterStatus status)

--- a/src/Microsoft.Health.Fhir.Shared.Api/Microsoft.Health.Fhir.Shared.Api.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Microsoft.Health.Fhir.Shared.Api.projitems
@@ -62,6 +62,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Modules\KnownAssemblies.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Modules\OperationsModule.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Modules\PersistenceModule.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Modules\SearchParametersModule.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Modules\SearchModule.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Modules\ValidationModule.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Registration\FhirServerServiceCollectionExtensions.cs" />

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/SearchModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/SearchModule.cs
@@ -145,6 +145,11 @@ namespace Microsoft.Health.Fhir.Api.Modules
             services.AddTransient(typeof(IPipelineBehavior<CreateResourceRequest, UpsertResourceResponse>), typeof(CreateOrUpdateSearchParameterBehavior<CreateResourceRequest, UpsertResourceResponse>));
             services.AddTransient(typeof(IPipelineBehavior<UpsertResourceRequest, UpsertResourceResponse>), typeof(CreateOrUpdateSearchParameterBehavior<UpsertResourceRequest, UpsertResourceResponse>));
             services.AddTransient(typeof(IPipelineBehavior<DeleteResourceRequest, DeleteResourceResponse>), typeof(DeleteSearchParameterBehavior<DeleteResourceRequest, DeleteResourceResponse>));
+
+            services.Add<SearchParameterResourceDataStore>()
+                .Singleton()
+                .AsSelf()
+                .AsImplementedInterfaces();
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/SearchModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/SearchModule.cs
@@ -69,11 +69,6 @@ namespace Microsoft.Health.Fhir.Api.Modules
                 .AsSelf()
                 .AsService<ISupportedSearchParameterDefinitionManager>();
 
-            services.Add<SearchParameterStatusManager>()
-                .Singleton()
-                .AsSelf()
-                .AsImplementedInterfaces();
-
             services.Add<FilebasedSearchParameterStatusDataStore>()
                 .Transient()
                 .AsSelf()
@@ -145,11 +140,6 @@ namespace Microsoft.Health.Fhir.Api.Modules
             services.AddTransient(typeof(IPipelineBehavior<CreateResourceRequest, UpsertResourceResponse>), typeof(CreateOrUpdateSearchParameterBehavior<CreateResourceRequest, UpsertResourceResponse>));
             services.AddTransient(typeof(IPipelineBehavior<UpsertResourceRequest, UpsertResourceResponse>), typeof(CreateOrUpdateSearchParameterBehavior<UpsertResourceRequest, UpsertResourceResponse>));
             services.AddTransient(typeof(IPipelineBehavior<DeleteResourceRequest, DeleteResourceResponse>), typeof(DeleteSearchParameterBehavior<DeleteResourceRequest, DeleteResourceResponse>));
-
-            services.Add<SearchParameterResourceDataStore>()
-                .Singleton()
-                .AsSelf()
-                .AsImplementedInterfaces();
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/SearchParametersModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/SearchParametersModule.cs
@@ -1,0 +1,33 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Extensions.Hosting;
+using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Health.Fhir.Core.Features.Search.Registry;
+using Microsoft.Health.Fhir.Core.Registration;
+
+namespace Microsoft.Health.Fhir.Api.Modules
+{
+    /// <summary>
+    /// Registration of search components.
+    /// </summary>
+    public static class SearchParametersModule
+    {
+        public static IFhirServerBuilder AddSearchParametersModules(this IFhirServerBuilder fhirServerBuilder)
+        {
+            fhirServerBuilder.Services.Add<SearchParameterStatusManager>()
+                .Singleton()
+                .AsSelf()
+                .AsService<IHostedService>();
+
+            fhirServerBuilder.Services.Add<SearchParameterResourceDataStore>()
+                .Singleton()
+                .AsSelf()
+                .AsService<IHostedService>();
+
+            return fhirServerBuilder;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         [Fact]
         public async Task GivenSupportedParams_WhenGettingSupported_ThenSupportedParamsReturned()
         {
-            await _manager.EnsureInitialized();
+            await _manager.StartAsync(CancellationToken.None);
             var supportedDefinitionManager = new SupportedSearchParameterDefinitionManager(_searchParameterDefinitionManager);
             var paramList = supportedDefinitionManager.GetSearchParametersRequiringReindexing();
 
@@ -148,7 +148,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         [Fact]
         public async Task GivenSearchableParams_WhenGettingSearchable_ThenCorrectParamsReturned()
         {
-            await _manager.EnsureInitialized();
+            await _manager.StartAsync(CancellationToken.None);
             var searchableDefinitionManager = new SearchableSearchParameterDefinitionManager(_searchParameterDefinitionManager, _fhirRequestContextAccessor);
             var paramList = searchableDefinitionManager.AllSearchParameters;
 
@@ -169,7 +169,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         [Fact]
         public async Task GivenContextToIncludePatialIndexedParams_WhenGettingSearchable_ThenCorrectParamsReturned()
         {
-            await _manager.EnsureInitialized();
+            await _manager.StartAsync(CancellationToken.None);
             _fhirRequestContext.IncludePartiallyIndexedSearchParams = true;
             var searchableDefinitionManager = new SearchableSearchParameterDefinitionManager(_searchParameterDefinitionManager, _fhirRequestContextAccessor);
             var paramList = searchableDefinitionManager.AllSearchParameters.OrderBy(p => p.Code);
@@ -203,7 +203,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         [Fact]
         public async Task GivenNoHeaderForPatiallyIndexedParams_WhenSearchingSupportedParameterByName_ThenExceptionThrown()
         {
-            await _manager.EnsureInitialized();
+            await _manager.StartAsync(CancellationToken.None);
             _fhirRequestContext.IncludePartiallyIndexedSearchParams = false;
             var searchableDefinitionManager = new SearchableSearchParameterDefinitionManager(_searchParameterDefinitionManager, _fhirRequestContextAccessor);
 
@@ -215,7 +215,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         [Fact]
         public async Task GivenHeaderToIncludePatialIndexedParams_WhenSearchingSupportedParameterByName_ThenSupportedParamsReturned()
         {
-            await _manager.EnsureInitialized();
+            await _manager.StartAsync(CancellationToken.None);
             _fhirRequestContext.IncludePartiallyIndexedSearchParams = true;
             var searchableDefinitionManager = new SearchableSearchParameterDefinitionManager(_searchParameterDefinitionManager, _fhirRequestContextAccessor);
 
@@ -441,7 +441,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
                 .IsSearchParameterSupported(Arg.Is<SearchParameterInfo>(s => s.Name.StartsWith("preexisting")))
                 .Returns((true, false));
 
-            await searchParameterResourceDataStore.EnsureInitialized();
+            await searchParameterResourceDataStore.StartAsync(CancellationToken.None);
 
             var patientParams = _searchParameterDefinitionManager.GetSearchParameters("Patient");
             Assert.False(patientParams.Where(p => p.Name == "preexisting").First().IsSearchable);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterFixtureData.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterFixtureData.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
                 definitionManager,
                 new SearchParameterSupportResolver(definitionManager, await GetFhirNodeToSearchValueTypeConverterManagerAsync()),
                 Substitute.For<IMediator>());
-            await statusManager.EnsureInitialized();
+            await statusManager.StartAsync(CancellationToken.None);
 
             return definitionManager;
         }

--- a/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Health.Fhir.Api.Modules;
 using Microsoft.Health.Fhir.Azure;
 
 namespace Microsoft.Health.Fhir.Web
@@ -43,6 +44,8 @@ namespace Microsoft.Health.Fhir.Web
             {
                 fhirServerBuilder.AddSqlServer(Configuration);
             }
+
+            fhirServerBuilder.AddSearchParametersModules();
 
             /*
             The execution of IHostedServices depends on the order they are added to the dependency injection container, so we

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
@@ -12,10 +12,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Abstractions.Exceptions;
-using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Search.Registry;
@@ -37,7 +37,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
     /// many many times in the database. For more compact storage, we use IDs instead of the strings when referencing these.
     /// Also, because the number of distinct values is small, we can maintain all values in memory and avoid joins when querying.
     /// </summary>
-    public sealed class SqlServerFhirModel : IRequireInitializationOnFirstRequest
+    public sealed class SqlServerFhirModel : IHostedService
     {
         private readonly SchemaInformation _schemaInformation;
         private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager;
@@ -141,12 +141,17 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             return _quantityCodeToId.TryGetValue(code, out quantityCodeId);
         }
 
-        public async Task EnsureInitialized()
+        public async Task StartAsync(CancellationToken cancellationToken)
         {
             ThrowIfCurrentSchemaVersionIsNull();
 
             // If the fhir-server is just starting up, synchronize the fhir-server dictionaries with the SQL database
             await Initialize((int)_schemaInformation.Current, true, CancellationToken.None);
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
         }
 
         public async Task Initialize(int version, bool runAllInitialization, CancellationToken cancellationToken)

--- a/src/Microsoft.Health.Fhir.SqlServer/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
@@ -7,6 +7,7 @@ using System;
 using System.Linq;
 using EnsureThat;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Features.Search.Registry;
 using Microsoft.Health.Fhir.Core.Registration;
@@ -44,11 +45,6 @@ namespace Microsoft.Extensions.DependencyInjection
                 .Singleton()
                 .AsSelf()
                 .ReplaceService<ISearchParameterStatusDataStore>();
-
-            services.Add<SqlServerFhirModel>()
-                .Singleton()
-                .AsSelf()
-                .AsImplementedInterfaces();
 
             services.Add<SearchParameterToSearchValueTypeMap>()
                 .Singleton()
@@ -93,6 +89,11 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AsImplementedInterfaces();
 
             services.AddFactory<IScoped<SqlConnectionWrapperFactory>>();
+
+            services.Add<SqlServerFhirModel>()
+                .Singleton()
+                .AsSelf()
+                .AsService<IHostedService>();
 
             services.Add<SchemaUpgradedHandler>()
                 .Transient()


### PR DESCRIPTION
## Description
Reads the SearchParameter resources that are present in the FHIR data store and loads them into the SearchParameterDefinitionManager with the proper status.

## Related issues
Addresses [issue [AB#77543](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/77543)].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
