### PR TITLE
Fix pagination for SQL _sort queries

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -745,7 +745,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
                                 delimited.BeginDelimitedElement();
                                 StringBuilder.Append("((").Append(sortColumnName, null).Append($" = ").Append(Parameters.AddParameter(sortColumnName, sortValue));
-                                StringBuilder.Append(" AND ").Append(VLatest.Resource.ResourceSurrogateId, null).Append($" >= ").Append(Parameters.AddParameter(VLatest.Resource.ResourceSurrogateId, continuationToken.ResourceSurrogateId)).Append(")");
+                                StringBuilder.Append(" AND ").Append(VLatest.Resource.ResourceSurrogateId, null).Append($" > ").Append(Parameters.AddParameter(VLatest.Resource.ResourceSurrogateId, continuationToken.ResourceSurrogateId)).Append(")");
                                 StringBuilder.Append(" OR ").Append(sortColumnName, null).Append($" {sortOperand} ").Append(Parameters.AddParameter(sortColumnName, sortValue)).AppendLine(")");
                             }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                             : Expression.LessThan(SqlFieldName.ResourceSurrogateId, null, continuationToken.ResourceSurrogateId);
 
                         var tokenExpression = Expression.SearchParameter(SqlSearchParameters.ResourceSurrogateIdParameter, lastUpdatedExpression);
-                        searchExpression = searchExpression == null ? tokenExpression : (Expression)Expression.And(tokenExpression, searchExpression);
+                        searchExpression = searchExpression == null ? tokenExpression : Expression.And(tokenExpression, searchExpression);
                     }
                 }
                 else
@@ -228,7 +228,17 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
 
                     while (await reader.ReadAsync(cancellationToken))
                     {
-                        (short resourceTypeId, string resourceId, int version, bool isDeleted, long resourceSurrogateId, string requestMethod, bool isMatch, bool isPartialEntry, bool isRawResourceMetaSet, Stream rawResourceStream) = reader.ReadRow(
+                        (short resourceTypeId,
+                        string resourceId,
+                        int version,
+                        bool isDeleted,
+                        long resourceSurrogateId,
+                        string requestMethod,
+                        bool isMatch,
+                        bool isPartialEntry,
+                        bool isRawResourceMetaSet,
+                        Stream rawResourceStream) =
+                            reader.ReadRow(
                             VLatest.Resource.ResourceTypeId,
                             VLatest.Resource.ResourceId,
                             VLatest.Resource.Version,
@@ -246,27 +256,28 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                         {
                             moreResults = true;
 
-                            // At this point we are at the last row.
-                            // if we have more columns, it means sort expressions were added.
-                            if (reader.FieldCount > 10)
-                            {
-                                sortValue = reader.GetValue(SortValueColumnName) as DateTime?;
-                            }
-
                             continue;
-                        }
-
-                        // See if this resource is a continuation token candidate and increase the count
-                        if (isMatch)
-                        {
-                            newContinuationId = resourceSurrogateId;
-                            matchCount++;
                         }
 
                         string rawResource;
                         using (rawResourceStream)
                         {
                             rawResource = await CompressedRawResourceConverter.ReadCompressedRawResource(rawResourceStream);
+                        }
+
+                        // See if this resource is a continuation token candidate and increase the count
+                        if (isMatch)
+                        {
+                            newContinuationId = resourceSurrogateId;
+
+                            // Keep track of sort value if this is the last row.
+                            // if we have more than 10 columns, it means sort expressions were added.
+                            if (matchCount == searchOptions.MaxItemCount - 1 && reader.FieldCount > 10)
+                            {
+                                sortValue = reader.GetValue(SortValueColumnName) as DateTime?;
+                            }
+
+                            matchCount++;
                         }
 
                         // as long as at least one entry was marked as partial, this resultset

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SearchTestsBase.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SearchTestsBase.cs
@@ -33,18 +33,24 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
         protected async Task<Bundle> ExecuteAndValidateBundle(string searchUrl, Tuple<string, string> customHeader, params Resource[] expectedResources)
         {
-            return await ExecuteAndValidateBundle(searchUrl, searchUrl, true, customHeader, expectedResources);
+            return await ExecuteAndValidateBundle(searchUrl, searchUrl, true, customHeader, pageSize: 10, expectedResources);
         }
 
         protected async Task<Bundle> ExecuteAndValidateBundle(string searchUrl, params Resource[] expectedResources)
         {
-            return await ExecuteAndValidateBundle(searchUrl, searchUrl, true, null, expectedResources);
+            return await ExecuteAndValidateBundle(searchUrl, searchUrl, true, null, pageSize: 10, expectedResources);
         }
 
         protected async Task<Bundle> ExecuteAndValidateBundle(string searchUrl, bool sort, params Resource[] expectedResources)
         {
             var actualDecodedUrl = WebUtility.UrlDecode(searchUrl);
-            return await ExecuteAndValidateBundle(searchUrl, actualDecodedUrl, sort, null, expectedResources);
+            return await ExecuteAndValidateBundle(searchUrl, actualDecodedUrl, sort, null, pageSize: 10, expectedResources);
+        }
+
+        protected async Task<Bundle> ExecuteAndValidateBundle(string searchUrl, bool sort, int pageSize, params Resource[] expectedResources)
+        {
+            var actualDecodedUrl = WebUtility.UrlDecode(searchUrl);
+            return await ExecuteAndValidateBundle(searchUrl, actualDecodedUrl, sort, null, pageSize, expectedResources);
         }
 
         protected async Task<Bundle> ExecuteAndValidateBundle(string searchUrl, string selfLink, Tuple<string, string> customHeader, params Resource[] expectedResources)
@@ -56,11 +62,16 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             return bundle;
         }
 
-        protected async Task<Bundle> ExecuteAndValidateBundle(string searchUrl, string selfLink, bool sort, Tuple<string, string> customHeader = null, params Resource[] expectedResources)
+        protected async Task<Bundle> ExecuteAndValidateBundle(
+            string searchUrl,
+            string selfLink,
+            bool sort,
+            Tuple<string, string> customHeader = null,
+            int pageSize = 10,
+            params Resource[] expectedResources)
         {
             Bundle firstBundle = await Client.SearchAsync(searchUrl, customHeader);
 
-            var pageSize = 10;
             var expectedFirstBundle = expectedResources.Length > pageSize ? expectedResources.ToList().GetRange(0, pageSize).ToArray() : expectedResources;
 
             ValidateBundle(firstBundle, selfLink, sort, expectedFirstBundle);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SortTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SortTests.cs
@@ -45,22 +45,26 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             await ExecuteAndValidateBundle($"Patient?_tag={tag}&_sort=-_lastUpdated", false, patients.Reverse().Cast<Resource>().ToArray());
         }
 
-        [Fact]
-        public async Task GivenMoreThanTenPatients_WhenSearchedWithSortParam_ThenPatientsAreReturnedInAscendingOrder()
+        [Theory]
+        [InlineData("birthdate")]
+        [InlineData("_lastUpdated")]
+        public async Task GivenMoreThanTenPatients_WhenSearchedWithSortParam_ThenPatientsAreReturnedInAscendingOrder(string sortParameterName)
         {
             var tag = Guid.NewGuid().ToString();
             var patients = await CreatePaginatedPatients(tag);
 
-            await ExecuteAndValidateBundle($"Patient?_tag={tag}&_sort=_lastUpdated", false, patients.Cast<Resource>().ToArray());
+            await ExecuteAndValidateBundle($"Patient?_tag={tag}&_sort={sortParameterName}", false, patients.Cast<Resource>().ToArray());
         }
 
-        [Fact]
-        public async Task GivenMoreThanTenPatients_WhenSearchedWithSortParamWithHyphen_ThenPatientsAreReturnedInDescendingOrder()
+        [Theory]
+        [InlineData("birthdate")]
+        [InlineData("_lastUpdated")]
+        public async Task GivenMoreThanTenPatients_WhenSearchedWithSortParamWithHyphen_ThenPatientsAreReturnedInDescendingOrder(string sortParameterName)
         {
             var tag = Guid.NewGuid().ToString();
             var patients = await CreatePaginatedPatients(tag);
 
-            await ExecuteAndValidateBundle($"Patient?_tag={tag}&_sort=-_lastUpdated", false, patients.Reverse().Cast<Resource>().ToArray());
+            await ExecuteAndValidateBundle($"Patient?_tag={tag}&_sort=-{sortParameterName}", false, patients.Reverse().Cast<Resource>().ToArray());
         }
 
         // uncomment only when db cleanup happens on each run, otherwise the paging might cause expected resources to not arrive
@@ -460,18 +464,18 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         {
             // Create various resources.
             Patient[] patients = await Client.CreateResourcesAsync<Patient>(
-                p => SetPatientInfo(p, "Seattle", "Robinson", tag),
-                p => SetPatientInfo(p, "Portland", "Williamas", tag),
-                p => SetPatientInfo(p, "Portland", "James", tag),
-                p => SetPatientInfo(p, "Seatt;e", "Alex", tag),
-                p => SetPatientInfo(p, "Portland", "Rock", tag),
-                p => SetPatientInfo(p, "Seattle", "Mike", tag),
-                p => SetPatientInfo(p, "Portland", "Christie", tag),
-                p => SetPatientInfo(p, "Portland", "Lone", tag),
-                p => SetPatientInfo(p, "Seattle", "Sophie", tag),
-                p => SetPatientInfo(p, "Portland", "Peter", tag),
-                p => SetPatientInfo(p, "Portland", "Cathy", tag),
-                p => SetPatientInfo(p, "Seattle", "Jones", tag));
+                p => SetPatientInfo(p, "Seattle", "Robinson", tag, new DateTime(1940, 01, 15)),
+                p => SetPatientInfo(p, "Portland", "Williamas", tag, new DateTime(1942, 01, 15)),
+                p => SetPatientInfo(p, "Portland", "James", tag, new DateTime(1943, 10, 23)),
+                p => SetPatientInfo(p, "Seatt;e", "Alex", tag, new DateTime(1943, 11, 23)),
+                p => SetPatientInfo(p, "Portland", "Rock", tag, new DateTime(1944, 06, 24)),
+                p => SetPatientInfo(p, "Seattle", "Mike", tag, new DateTime(1946, 02, 24)),
+                p => SetPatientInfo(p, "Portland", "Christie", tag, new DateTime(1947, 02, 24)),
+                p => SetPatientInfo(p, "Portland", "Lone", tag, new DateTime(1950, 05, 12)),
+                p => SetPatientInfo(p, "Seattle", "Sophie", tag, new DateTime(1953, 05, 12)),
+                p => SetPatientInfo(p, "Portland", "Peter", tag, new DateTime(1956, 06, 12)),
+                p => SetPatientInfo(p, "Portland", "Cathy", tag, new DateTime(1960, 09, 22)),
+                p => SetPatientInfo(p, "Seattle", "Jones", tag, new DateTime(1970, 05, 13)));
 
             return patients;
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SortTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SortTests.cs
@@ -70,12 +70,33 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [Theory]
         [InlineData("birthdate")]
         [InlineData("-birthdate")]
+        [HttpIntegrationFixtureArgumentSets(dataStores: DataStore.SqlServer)]
         public async Task GivenPatientsWithSameBirthdateAndMultiplePages_WhenSortedByBirthdate_ThenPatientsAreReturnedInCorrectOrder(string sortParameterName)
         {
             var tag = Guid.NewGuid().ToString();
             var patients = await CreatePatientsWithSameBirthdate(tag);
 
             await ExecuteAndValidateBundle($"Patient?_tag={tag}&_sort={sortParameterName}&_count=3", false, pageSize: 3, patients.Cast<Resource>().ToArray());
+        }
+
+        [Fact]
+        [HttpIntegrationFixtureArgumentSets(dataStores: DataStore.CosmosDb)]
+        public async Task GivenPatientsWithSameBirthdateAndMultiplePages_WhenSortedByBirthdate_ThenPatientsAreReturnedInAscendingOrder()
+        {
+            var tag = Guid.NewGuid().ToString();
+            var patients = await CreatePatientsWithSameBirthdate(tag);
+
+            await ExecuteAndValidateBundle($"Patient?_tag={tag}&_sort=birthdate&_count=3", false, pageSize: 3, patients.Cast<Resource>().ToArray());
+        }
+
+        [Fact]
+        [HttpIntegrationFixtureArgumentSets(dataStores: DataStore.CosmosDb)]
+        public async Task GivenPatientsWithSameBirthdateAndMultiplePages_WhenSortedByBirthdateWithHyphen_ThenPatientsAreReturnedInDescendingOrder()
+        {
+            var tag = Guid.NewGuid().ToString();
+            var patients = await CreatePatientsWithSameBirthdate(tag);
+
+            await ExecuteAndValidateBundle($"Patient?_tag={tag}&_sort=-birthdate&_count=3", false, pageSize: 3, patients.Reverse().Cast<Resource>().ToArray());
         }
 
         // uncomment only when db cleanup happens on each run, otherwise the paging might cause expected resources to not arrive


### PR DESCRIPTION
## Description
This PR handles two related issues with respect to paging through sorted results (when using SQL provider).

1. Let's assume we have multiple pages of patiens with the same birthdate. Let's execute the below query:
`GET <fhir-server>/Patient?_sort=birthdate`

When following then next links, we always return the last patient on the previous page as the first patient on the new page of results (duplicate results). This is because we execute the below query:
```
SELECT ResourceSurrogateId AS Sid1, StartDateTime as SortValue
FROM dbo.DateTimeSearchParam
WHERE IsHistory = 0
	AND SearchParamId = @p3
	AND ResourceTypeId = @p2
	AND ((StartDateTime = @p4 AND ResourceSurrogateId >= @p5) OR StartDateTime > @p4)
	AND ResourceSurrogateId IN (SELECT Sid1 FROM cte0)
```

Updated the code so that the ResourceSurrogateId filter is correct:
`AND ((StartDateTime = @p4 AND ResourceSurrogateId > @p5) OR StartDateTime > @p4)`

2. When we calculate the continuation token for queries containing _sort, we use the `ResourceSurrogateId` from the 10th row and the `SortValue` from the 11th row (assuming the requests asks for the default 10 rows). This can cause us to return incorrect results in certain situations (eg: when sort values for 10th and 11th rows are distinct and the `ResourceSurrogateId` for 11th row is less than the 10th row). Updated code to use both `SortValue` and `ResourceSurrogateId` from the 10th row to maintain consistency.

## Related issues
Addresses #1792 .

## Testing
Added more E2E tests to cover the above scenarios

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
