### PR TITLE
Fix the schema manager tool documentation and turn app service setting 'Always On'

### DIFF
--- a/docs/SchemaMigrationTool.md
+++ b/docs/SchemaMigrationTool.md
@@ -23,14 +23,7 @@ Note - The tool can't downgrade a schema version.
 
 - #### How to install the tool
 
-    - ##### If available as .NET Core global tool (not available yet)
-
-        It can be installed using below steps:
-
-        - Open a terminal/command prompt 
-        - Type 'dotnet tool install -g Microsoft.Health.SchemaManager'
-
-     - ##### If not available as .NET core global tool, then install it from public feed
+     - ##### Install the tool from public feed
 
         It can be installed using below steps:
             

--- a/docs/SchemaMigrationTool.md
+++ b/docs/SchemaMigrationTool.md
@@ -23,30 +23,26 @@ Note - The tool can't downgrade a schema version.
 
 - #### How to install the tool
 
-    - ##### If available as .NET Core global tool 
+    - ##### If available as .NET Core global tool (not available yet)
 
-        It can be installed like this:
+        It can be installed using below steps:
 
         - Open a terminal/command prompt 
         - Type 'dotnet tool install -g Microsoft.Health.SchemaManager'
 
      - ##### If not available as .NET core global tool, then install it from public feed
 
-        It can be installed like this:
+        It can be installed using below steps:
             
-        - Visual Studio setup - Start Visual Studio as admin. On the Tools menu, select Options > NuGet Package Manager > Package Sources. Select the green plus in the upper-right corner and enter the name and source URL as below:
+        - Copy [nuget.config](https://github.com/microsoft/fhir-server/blob/main/nuget.config) in the current folder or any desired folder
+        -  Open a terminal/command prompt and hit command
 
-                Name: "Microsoft Health OSS"
-                Source: https://microsofthealthoss.pkgs.visualstudio.com/FhirServer/_packaging/Public/nuget/v3/index.json
-        
-        - In the Package Manager Console, type the below command
-        
-                PM> dotnet tool install -g Microsoft.Health.SchemaManager --version [latestversion]
+                dotnet tool install -g Microsoft.Health.SchemaManager
 
 - #### How to uninstall the tool
-    In any case, if the tool needs to be uninstalled, the command is as follows
+    Open a terminal/command prompt and hit command
 
-        PM> dotnet tool uninstall -g Microsoft.Health.SchemaManager          
+        dotnet tool uninstall -g Microsoft.Health.SchemaManager          
 
 - #### Commands
     The tool supports following commands:

--- a/samples/templates/default-azuredeploy.json
+++ b/samples/templates/default-azuredeploy.json
@@ -266,7 +266,10 @@
             },
             "properties": {
                 "clientAffinityEnabled": false,
-                "serverFarmId": "[resourceId(variables('appServicePlanResourceGroup'), 'Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                "serverFarmId": "[resourceId(variables('appServicePlanResourceGroup'), 'Microsoft.Web/serverfarms/', variables('appServicePlanName'))]",
+				"siteConfig": {
+                   "AlwaysOn": true
+               }
             },
             "dependsOn": [
                 "[if(empty(parameters('appServicePlanResourceGroup')), resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName')), resourceId('Microsoft.DocumentDB/databaseAccounts', variables('serviceName')))]"


### PR DESCRIPTION
## Description
This PR address two issues
- Update the schema manager tool documentation steps to install from public feed
- When fhir service deployed with the non docker template, the default setting for the app service was off, As a result, service didn't start and waits for the first request to initialize schema. This PR updates the app service setting to 'Always on' so that the service starts up and schema is initialized itself.

## Related issues
Addresses [bug](https://github.com/microsoft/fhir-server/issues/1789)

## Testing
The updated documentation steps were tested by copying the nuget.config in the current folder and install/uninstall tool with the dotnet command.
The fhir service was deployed using the updated template and setting is turned to 'Always On'
![image](https://user-images.githubusercontent.com/57157506/113072010-ce69a600-917a-11eb-8ef5-3366924f7712.png)

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
