### PR TITLE
Fix dependency resolution in GroupMemberExtractor

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Export/GroupMemberExtractorTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Export/GroupMemberExtractorTests.cs
@@ -10,11 +10,11 @@ using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using Hl7.Fhir.Specification;
-using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.Core.UnitTests.Extensions;
 using Newtonsoft.Json.Linq;
 using NSubstitute;
 using Xunit;
@@ -55,11 +55,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
                     return _resourceElement;
                 })));
 
-            var fhirDataScope = Substitute.For<IScoped<IFhirDataStore>>();
-            fhirDataScope.Value.Returns(_fhirDataStore);
-
             _groupMemberExtractor = new GroupMemberExtractor(
-                fhirDataScope,
+                () => _fhirDataStore.CreateMockScope(),
                 _resourceDeserializer,
                 _referenceToElementResolver);
         }
@@ -171,11 +168,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
                     }
                 })));
 
-            var fhirDataScope = Substitute.For<IScoped<IFhirDataStore>>();
-            fhirDataScope.Value.Returns(_fhirDataStore);
-
             _groupMemberExtractor = new GroupMemberExtractor(
-                fhirDataScope,
+                () => _fhirDataStore.CreateMockScope(),
                 resourceDeserializer,
                 _referenceToElementResolver);
 

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Export/GroupMemberExtractor.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Export/GroupMemberExtractor.cs
@@ -24,20 +24,20 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
     /// </summary>
     public class GroupMemberExtractor : IGroupMemberExtractor
     {
-        private readonly IScoped<IFhirDataStore> _fhirDataStore;
+        private readonly Func<IScoped<IFhirDataStore>> _fhirDataStoreFactory;
         private readonly ResourceDeserializer _resourceDeserializer;
         private readonly IReferenceToElementResolver _referenceToElementResolver;
 
         public GroupMemberExtractor(
-            IScoped<IFhirDataStore> fhirDataStore,
+            Func<IScoped<IFhirDataStore>> fhirDataStoreFactory,
             ResourceDeserializer resourceDeserializer,
             IReferenceToElementResolver referenceToElementResolver)
         {
-            EnsureArg.IsNotNull(fhirDataStore, nameof(fhirDataStore));
+            EnsureArg.IsNotNull(fhirDataStoreFactory, nameof(fhirDataStoreFactory));
             EnsureArg.IsNotNull(resourceDeserializer, nameof(resourceDeserializer));
             EnsureArg.IsNotNull(referenceToElementResolver, nameof(referenceToElementResolver));
 
-            _fhirDataStore = fhirDataStore;
+            _fhirDataStoreFactory = fhirDataStoreFactory;
             _resourceDeserializer = resourceDeserializer;
             _referenceToElementResolver = referenceToElementResolver;
         }
@@ -88,7 +88,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
         public async Task<List<Tuple<string, string>>> GetGroupMembers(string groupId, DateTimeOffset groupMembershipTime, CancellationToken cancellationToken)
         {
-            var groupResource = await _fhirDataStore.Value.GetAsync(new ResourceKey(KnownResourceTypes.Group, groupId), cancellationToken);
+            ResourceWrapper groupResource;
+            using (IScoped<IFhirDataStore> dataStore = _fhirDataStoreFactory())
+            {
+                groupResource = await dataStore.Value.GetAsync(new ResourceKey(KnownResourceTypes.Group, groupId), cancellationToken);
+            }
 
             if (groupResource == null)
             {

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Export/GroupMemberExtractor.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Export/GroupMemberExtractor.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
         public async Task<List<Tuple<string, string>>> GetGroupMembers(string groupId, DateTimeOffset groupMembershipTime, CancellationToken cancellationToken)
         {
             ResourceWrapper groupResource;
-            using (IScoped<IFhirDataStore> dataStore = _fhirDataStoreFactory())
+            using (IScoped<IFhirDataStore> dataStore = _fhirDataStoreFactory.Invoke())
             {
                 groupResource = await dataStore.Value.GetAsync(new ResourceKey(KnownResourceTypes.Group, groupId), cancellationToken);
             }


### PR DESCRIPTION
## Description
Fix the way we resolve IFhirDataStore in GroupMemberExtractor

## Related issues
Addresses #1794 

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
