### PR TITLE
Allow branches to be built in isolation

### DIFF
--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -19,7 +19,10 @@ stages:
     steps:
     - template: ./jobs/update-semver.yml  
     - powershell: |
-        $buildNumber = "$(semVer)" -replace "\.", "" 
+
+        $buildNumber = "$(semVer)".replace(".", "").replace("-", "")
+        $buildNumber = $buildNumber.subString(0, [System.Math]::Min(15, $buildNumber.Length))
+
         Write-Host "##vso[build.updatebuildnumber]$buildNumber" 
         Write-Host "Updated  build number to '$buildNumber"
       name: SetBuildVersion

--- a/build/pr-variables.yml
+++ b/build/pr-variables.yml
@@ -1,10 +1,10 @@
 variables:
     ResourceGroupRegion: 'westus2'
     resourceGroupRoot: 'msh-fhir-pr'
-    appServicePlanName: '$(resourceGroupRoot)-$(prNumber)-asp'
-    prNumber: $(system.pullRequest.pullRequestNumber)
-    ResourceGroupName: '$(resourceGroupRoot)-$(prNumber)'
+    appServicePlanName: '$(resourceGroupRoot)-$(prName)-asp'    
+    ResourceGroupName: '$(resourceGroupRoot)-$(prName)'
     DeploymentEnvironmentName: 'f$(build.BuildNumber)'
     CrucibleEnvironmentUrl: ''
-    TestEnvironmentName: 'OSS PR$(prNumber)'
+    TestEnvironmentName: 'OSS PR$(prName)'
     ImageTag: '$(build.BuildNumber)'
+    # prName: $(system.pullRequest.pullRequestNumber) # passed in as build variable

--- a/build/pr-variables.yml
+++ b/build/pr-variables.yml
@@ -7,4 +7,6 @@ variables:
     CrucibleEnvironmentUrl: ''
     TestEnvironmentName: 'OSS PR$(prName)'
     ImageTag: '$(build.BuildNumber)'
-    # prName: $(system.pullRequest.pullRequestNumber) # passed in as build variable
+
+    # The following is passed in from a Pipeline variable, this allows it to be overriden if required.
+    # prName: $(system.pullRequest.pullRequestNumber)


### PR DESCRIPTION
## Description
This PR adds a pipeline variable to allow a separate environment, which can be used to build branches in isolation.

By default the PR number is used:
![image](https://user-images.githubusercontent.com/197221/113244153-4ca47600-9269-11eb-9b11-922a39a9178b.png)

If a branch is picked, then a custom env can be specified:
![image](https://user-images.githubusercontent.com/197221/113244264-82495f00-9269-11eb-9c00-36cc65188eed.png)


## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
