### PR TITLE
Improve error message for bad resource type in Reindex job

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobException.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobException.cs
@@ -1,0 +1,17 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
+{
+    public class ReindexJobException : Exception
+    {
+        public ReindexJobException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -493,8 +493,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Error running reindex query.");
-                    queryStatus.Error = ex.Message;
+                    var message = $"Error running reindex query for resource type {queryStatus.ResourceType}.";
+                    var reindexJobException = new ReindexJobException(message, ex);
+                    _logger.LogError(ex, message);
+                    queryStatus.Error = reindexJobException.Message + " : " + ex.Message;
 
                     throw;
                 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -498,7 +498,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     _logger.LogError(ex, message);
                     queryStatus.Error = reindexJobException.Message + " : " + ex.Message;
 
-                    throw;
+                    throw reindexJobException;
                 }
             }
         }


### PR DESCRIPTION
## Description
Include a better error message when trying to run a reindex job that has an incorrect resource type specified.

## Related issues
Addresses [issue [AB#78774](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/78774)].

## Testing
Manual testing

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
Skip