### PR TITLE
Improve parallelization of _revinclude queries

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
@@ -370,7 +370,8 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
                 }
                 else
                 {
-                    if (string.IsNullOrEmpty(searchOptions.ContinuationToken))
+                    if (searchOptions.Expression != null && // without a filter the query will not be selective
+                        string.IsNullOrEmpty(searchOptions.ContinuationToken))
                     {
                         // Telemetry currently shows that when there is a continuation token, the the query only hits one partition.
                         // This may not be true forever, in which case we would want to encode the max concurrency in the continuation token.


### PR DESCRIPTION
Filling the includes in `_revinclude` queries can be very expensive when lots of partitions are involved.

Changes:

- When filling the includes for `_revinclude` searches, we override the parallelization heuristics to timeout after 5 seconds instead of 30, after which we force parallelization.
- When issuing a query with parallelization, keep enumerating beyond 50% of desired page size because we probably already have the results buffered in the SDK.
- Ensure that when we give up attempting to fill a page after a timeout that we track the query as having high selectivity.

