### PR TITLE
Improve _include performance

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/ExpressionQueryBuilder.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/ExpressionQueryBuilder.cs
@@ -102,20 +102,6 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries
                     // we will override the mapping for that
                     expression.Expression.AcceptVisitor(this, context.WithFieldNameOverride((n, i) => SearchValueConstants.LastModified));
                     break;
-                case SearchValueConstants.TypeIdCompositeSearchParameterName:
-                    // This is an internal composite search parameter with components _type and _id, used when performing a query for includes.
-                    // We use the SearchValueConstants.RootResourceTypeName and SearchValueConstants.ResourceId fields respectively.
-                    expression.Expression.AcceptVisitor(
-                        this,
-                        context.WithFieldNameOverride(
-                            (fieldName, componentIndex) =>
-                                componentIndex switch
-                                {
-                                    0 => SearchValueConstants.RootResourceTypeName,
-                                    1 => KnownResourceWrapperProperties.ResourceId,
-                                    _ => throw new InvalidOperationException("unexpected component index"),
-                                }));
-                    break;
                 case SearchValueConstants.WildcardReferenceSearchParameterName:
                     // This is an internal search parameter that that matches any reference search parameter.
                     // It is used for wildcard revinclude queries

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/SearchValueConstants.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/SearchValueConstants.cs
@@ -57,8 +57,6 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
 
         public const string SelectedFields = "r.id,r.isSystem,r.partitionKey,r.lastModified,r.rawResource,r.request,r.isDeleted,r.resourceId,r.resourceTypeName,r.isHistory,r.version,r._self,r._etag, r.searchParameterHash";
 
-        public const string TypeIdCompositeSearchParameterName = "_typeAndId";
-
         public const string WildcardReferenceSearchParameterName = "_wildcardReference";
 
         public const string SortLowValueFieldName = "l";

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosResponseProcessor.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosResponseProcessor.cs
@@ -128,20 +128,23 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
         {
             IFhirRequestContext requestContext = _fhirRequestContextAccessor.FhirRequestContext;
 
-            // If there has already been a request to the database for this request, then we want to add to it.
-            if (requestContext.ResponseHeaders.TryGetValue(CosmosDbHeaders.RequestCharge, out StringValues existingHeaderValue))
+            lock (requestContext.ResponseHeaders)
             {
-                if (double.TryParse(existingHeaderValue.ToString(), out double existing))
+                // If there has already been a request to the database for this request, then we want to add to it.
+                if (requestContext.ResponseHeaders.TryGetValue(CosmosDbHeaders.RequestCharge, out StringValues existingHeaderValue))
                 {
-                    responseRequestCharge += existing;
+                    if (double.TryParse(existingHeaderValue.ToString(), out double existing))
+                    {
+                        responseRequestCharge += existing;
+                    }
+                    else
+                    {
+                        _logger.LogWarning("Unable to parse request charge header: {request change}", existingHeaderValue);
+                    }
                 }
-                else
-                {
-                    _logger.LogWarning("Unable to parse request charge header: {request change}", existingHeaderValue);
-                }
-            }
 
-            requestContext.ResponseHeaders[CosmosDbHeaders.RequestCharge] = responseRequestCharge.ToString(CultureInfo.InvariantCulture);
+                requestContext.ResponseHeaders[CosmosDbHeaders.RequestCharge] = responseRequestCharge.ToString(CultureInfo.InvariantCulture);
+            }
 
             var cosmosMetrics = new CosmosStorageRequestMetricsNotification(requestContext.AuditEventType, requestContext.ResourceType)
             {


### PR DESCRIPTION
## Description
Updates the approach for retrieving included resources for `_include` searches. Instead of a query that needs to execute on all partitions, we perform point reads for each resource. 

## Testing
Manual and automated tests

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
