### PR TITLE
Catch generic exception to prevent server crash

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterResourceDataStore.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterResourceDataStore.cs
@@ -85,6 +85,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
                             {
                                 _logger.LogWarning(ex, $"Error loading search parameter {searchParam.GetStringScalar("url")} from data store.");
                             }
+                            catch (Exception ex)
+                            {
+                                _logger.LogError(ex, $"Error loading search parameter {searchParam.GetStringScalar("url")} from data store.");
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Description
Adding search parameter can cause different types of exception. Let's not crash server if one of them would happen.

## Related issues


## Testing
Manually.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
