### PR TITLE
UpdateReindexJobAsync retries on precondition failed

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 NullLogger<SqlServerFhirDataStore>.Instance,
                 schemaInformation);
 
-            _fhirOperationDataStore = new SqlServerFhirOperationDataStore(SqlConnectionWrapperFactory, NullLogger<SqlServerFhirOperationDataStore>.Instance);
+            _fhirOperationDataStore = new SqlServerFhirOperationDataStore(SqlConnectionWrapperFactory, config, Substitute.For<IPollyRetryLoggerFactory>(), NullLogger<SqlServerFhirOperationDataStore>.Instance);
 
             var fhirRequestContextAccessor = Substitute.For<IFhirRequestContextAccessor>();
             fhirRequestContextAccessor.FhirRequestContext.CorrelationId.Returns(Guid.NewGuid().ToString());


### PR DESCRIPTION
## Description
Note: this PR won't build until [this change](https://github.com/microsoft/healthcare-shared-components/commit/1e0dc8532113a5f7fdd0692c922e91b8273c240e) from the [healthcare-shared-components repo](https://github.com/microsoft/healthcare-shared-components) is pulled in.

When we attempt to reindex a large number of resources in SQL, we run into a `JobConflictException`.

There are two things that should be done to fix this:

1) The `ReindexJobTask` should prevent multiple threads from updating the same reindex job record at the same time (there is a bug for this: [AB#80853](https://microsofthealth.visualstudio.com/Health/_workitems/edit/80853))
2) We should add retry logic to `UpdateReindexJobAsync()` that will get the updated job and retry when a `PreconditionFailedException` is thrown by the stored procedure (what this PR addresses)

## Related issues
Addresses [AB#80852](https://microsofthealth.visualstudio.com/Health/_workitems/edit/80852).

## Testing
Manual load tests following the steps outlined in `docs/ReindexFlowResourceBase.http` with a large database.

## FHIR Team Checklist
- ✅ **Update the title** of the PR to be succinct and less than 50 characters
- ✅ **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- ✅ Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- ✅ Tag the PR with **Azure API for FHIR** if this will release to the managed service
- ✅ Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
None (bug fix)
