### PR TITLE
Renames action ProfileDefinitionEditor to EditProfileDefinitions

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Security/DataActions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Security/DataActions.cs
@@ -23,9 +23,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Security
         ResourceValidate = 1 << 5,
         Reindex = 1 << 6,
         ConvertData = 1 << 7,
-        ProfileDefinitionsEditor = 1 << 8, // Allows to Create/Update/Delete resources related to profile's resources.
+        EditProfileDefinitions = 1 << 8, // Allows to Create/Update/Delete resources related to profile's resources.
 
         [EnumMember(Value = "*")]
-        All = (ProfileDefinitionsEditor << 1) - 1,
+        All = (EditProfileDefinitions << 1) - 1,
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Security/roles.schema.json
+++ b/src/Microsoft.Health.Fhir.Core/Features/Security/roles.schema.json
@@ -13,7 +13,7 @@
                 "resourceValidate",
                 "reindex",
                 "convertData",
-                "profileDefinitionsEditor"
+                "editProfileDefinitions"
             ]
         }
     },

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/ProfileResourcesBehaviour.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/ProfileResourcesBehaviour.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources
         private async Task<TResponse> GenericHandle<TResponse>(string resourceType, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
         {
             var resources = _profilesResolver.GetProfilesTypes();
-            if (resources.Contains(resourceType) && await _authorizationService.CheckAccess(DataActions.ProfileDefinitionsEditor, cancellationToken) != DataActions.ProfileDefinitionsEditor)
+            if (resources.Contains(resourceType) && await _authorizationService.CheckAccess(DataActions.EditProfileDefinitions, cancellationToken) != DataActions.EditProfileDefinitions)
             {
                 throw new UnauthorizedFhirActionException();
             }

--- a/src/Microsoft.Health.Fhir.Shared.Web/roles.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/roles.json
@@ -41,7 +41,7 @@
             ],
             "notDataActions": [
                 "hardDelete",
-                "profileDefinitionsEditor"
+                "editProfileDefinitions"
             ],
             "scopes": [
                 "/"


### PR DESCRIPTION
## Description
Renames action ProfileDefinitionEditor to EditProfileDefinitions based on feedback.

## Testing
Existing tests

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
