### PR TITLE
Hotfix: Once again, improve `_revinclude` performance on Cosmos DB

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
@@ -478,10 +478,12 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
                             break;
                         }
 
+                        var remainingItemsToFind = maxIncludeCount - includes.Count;
+
                         var queryRequestOptions = new QueryRequestOptions
                         {
-                            MaxItemCount = 10, // to limit excess buffering in case this is not selective
-                            MaxConcurrency = int.MaxValue, // making a guess that this will be selective, so executing across all partitions in parallel
+                            MaxItemCount = includeResponse.continuationToken == null ? 10 : remainingItemsToFind, // to limit excess buffering in case this is not selective or if there is a continuation token, we know the query will not be done in parallel.
+                            MaxConcurrency = int.MaxValue, // This will only execute in parallel on the first iteration of this loop; the SDK ignores this value when there is a continuation token.
                         };
 
                         includeResponse = await _fhirDataStore.ExecuteDocumentQueryAsync<FhirCosmosResourceWrapper>(
@@ -489,7 +491,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
                             queryRequestOptions,
                             includeResponse.continuationToken,
                             false,
-                            minimumDesiredPercentage: (int)Math.Ceiling(maxIncludeCount * 100.0 / queryRequestOptions.MaxItemCount.Value), // ensure we fill up to maxIncludeCount in the initial query, as the SDK does not parallelize queries when there is a continuation token
+                            minimumDesiredPercentage: (int)Math.Ceiling(remainingItemsToFind * 100.0 / queryRequestOptions.MaxItemCount.Value), // ensure we fill up to maxIncludeCount in the initial query, as the SDK does not parallelize queries when there is a continuation token
                             cancellationToken);
 
                         includes.AddRange(includeResponse.results);


### PR DESCRIPTION
The initial fix for `_revinclude` suffered from a surprising behavior in the Cosmos DB SDK where the `MaxConcurrency` property is ignored when a query is provided with a continuation token. This resulted in sequential query execution after retrieving the first 10 out of the desired 100 include results.

This fix has two parts.
1. Ensures that we fill up 100 results (if available) from in the initial includes query without breaking and following a continuation.
2. Improves the efficiency of the include query.

For (2) the query goes from
```
SELECT r.id,r.isSystem,r.partitionKey,r.lastModified,r.rawResource,r.request,r.isDeleted,r.resourceId,r.resourceTypeName,r.isHistory,r.version,r._self,r._etag, r.searchParameterHash
FROM root r
WHERE r.isSystem = @param0
AND r.resourceTypeName = @param1
AND EXISTS (SELECT VALUE si FROM si IN r.searchIndices WHERE si.p = @param2 AND (si.rt = @param3 AND si.ri = @param4 OR si.rt = @param3 AND si.ri = @param5 OR si.rt = @param3 AND si.ri = @param6 OR si.rt = @param3 AND si.ri = @param7 OR si.rt = @param3 AND si.ri = @param8 OR si.rt = @param3 AND si.ri = @param9 OR si.rt = @param3 AND si.ri = @param10 OR si.rt = @param3 AND si.ri = @param11 OR si.rt = @param3 AND si.ri = @param12 OR si.rt = @param3 AND si.ri = @param13))
AND r.isHistory = @param0
AND r.isDeleted = @param0
```

to
 
```
SELECT r.id,r.isSystem,r.partitionKey,r.lastModified,r.rawResource,r.request,r.isDeleted,r.resourceId,r.resourceTypeName,r.isHistory,r.version,r._self,r._etag, r.searchParameterHash
FROM root r
WHERE r.isSystem = @param0
AND r.resourceTypeName = @param1
AND EXISTS (SELECT VALUE si FROM si IN r.searchIndices WHERE si.p = @param2 AND (si.rt = @param3 AND (si.ri = @param4 OR si.ri = @param5 OR si.ri = @param6 OR si.ri = @param7 OR si.ri = @param8 OR si.ri = @param9 OR si.ri = @param10 OR si.ri = @param11 OR si.ri = @param12 OR si.ri = @param13)))
AND r.isHistory = @param0
AND r.isDeleted = @param0
```

Here is a performance comparison on a database with 10 physical partitions:

|                  | includes query RU consumed | includes query sequential calls |
|:----------------:|:--------------------------:|:-------------------------------:|
| original         | 419                        | 9                               |
| with (1)         | 231                        | 1                               |
| with (1) and (2) | 62                         | 1                               |


Addresses [AB#81152](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/81152)