### PR TITLE
Add logging around recording reindex job progress.

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -393,6 +393,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     await jobSemaphore.WaitAsync();
                     try
                     {
+                        _logger.LogInformation($"Reindex job updating progress, current result count: {0}", results.Results.Count());
                         _reindexJobRecord.Progress += results.Results.Count();
                         query.Status = OperationStatus.Completed;
 
@@ -405,6 +406,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                         }
 
                         await UpdateJobAsync(cancellationToken);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, $"Reindex error occurred recording progress.");
+                        throw;
                     }
                     finally
                     {

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -393,7 +393,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     await jobSemaphore.WaitAsync();
                     try
                     {
-                        _logger.LogInformation($"Reindex job updating progress, current result count: {0}", results.Results.Count());
+                        _logger.LogInformation("Reindex job updating progress, current result count: {0}", results.Results.Count());
                         _reindexJobRecord.Progress += results.Results.Count();
                         query.Status = OperationStatus.Completed;
 
@@ -409,7 +409,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     }
                     catch (Exception ex)
                     {
-                        _logger.LogWarning(ex, $"Reindex error occurred recording progress.");
+                        _logger.LogWarning(ex, "Reindex error occurred recording progress.");
                         throw;
                     }
                     finally


### PR DESCRIPTION
## Description
Add some additional logging when updating progress of reindex job.  This is to help diagnos an issue where the reindex job reported progress past 100%

## Related issues
Addresses [issue [AB#81363](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/81363)].

## Testing
Loggin added, and manually tested.

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
Skip