### PR TITLE
Handle cancel reindex job request in ReindexJobWorker

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -371,11 +371,15 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     }
                 }
 
-                // Get the latest version of the reindex job in case another thread has updated it
+
+                // for most cases if another process updates the job (such as a DELETE request)
+                // the _etag change will cause a JobConflict exception and this task will be aborted
+                // but here we add one more check before attempting to mark the job as complete,
+                // or starting another iteration of the loop
                 await _jobSemaphore.WaitAsync();
                 try
                 {
-                    using (IScoped<IFhirOperationDataStore> store = _fhirOperationDataStoreFactory())
+                    using (IScoped<IFhirOperationDataStore> store = _fhirOperationDataStoreFactory.Invoke())
                     {
                         var wrapper = await store.Value.GetReindexJobByIdAsync(_reindexJobRecord.Id, _cancellationToken);
                         _weakETag = wrapper.ETag;

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -371,7 +371,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     }
                 }
 
-
                 // for most cases if another process updates the job (such as a DELETE request)
                 // the _etag change will cause a JobConflict exception and this task will be aborted
                 // but here we add one more check before attempting to mark the job as complete,

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -371,21 +371,25 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     }
                 }
 
-                // Get the latest version of the reindex job in case another thread has updated it
-                await jobSemaphore.WaitAsync();
-                try
-                {
-                    using (IScoped<IFhirOperationDataStore> store = _fhirOperationDataStoreFactory())
+                    // Get the latest version of the reindex job in case another thread has updated it
+                    // for most cases if another process updates the job (such as a DELETE request)
+                    // the _etag change will cause a JobConflict exception and this task will be aborted
+                    // but here we add one more check before attempting to mark the job as complete,
+                    // or starting another iteration of the loop
+                    await jobSemaphore.WaitAsync();
+                    try
                     {
-                        var wrapper = await store.Value.GetReindexJobByIdAsync(_reindexJobRecord.Id, cancellationToken);
-                        _weakETag = wrapper.ETag;
-                        _reindexJobRecord = wrapper.JobRecord;
+                    using (IScoped<IFhirOperationDataStore> store = _fhirOperationDataStoreFactory.Invoke())
+                        {
+                            var wrapper = await store.Value.GetReindexJobByIdAsync(_reindexJobRecord.Id, cancellationToken);
+                            _weakETag = wrapper.ETag;
+                            _reindexJobRecord = wrapper.JobRecord;
+                        }
                     }
-                }
-                finally
-                {
-                    jobSemaphore.Release();
-                }
+                    finally
+                    {
+                        jobSemaphore.Release();
+                    }
 
                 // if our received CancellationToken is cancelled, or the job has been marked canceled we should
                 // pass that cancellation request onto all the cancellationTokens

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexJobTaskTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexJobTaskTests.cs
@@ -96,6 +96,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
             var expectedResourceType = param.BaseResourceTypes.FirstOrDefault();
 
             ReindexJobRecord job = CreateReindexJobRecord();
+            _fhirOperationDataStore.GetReindexJobByIdAsync(job.Id, _cancellationToken).ReturnsForAnyArgs(new ReindexJobWrapper(job, _weakETag));
 
             // setup search result
             _searchService.SearchForReindexAsync(
@@ -137,6 +138,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
             var expectedResourceType = param.BaseResourceTypes.FirstOrDefault();
 
             ReindexJobRecord job = CreateReindexJobRecord();
+            _fhirOperationDataStore.GetReindexJobByIdAsync(job.Id, _cancellationToken).ReturnsForAnyArgs(new ReindexJobWrapper(job, _weakETag));
 
             // setup search result
             _searchService.SearchForReindexAsync(
@@ -190,6 +192,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
             resourceTypeSearchParamHashMap.Add("AppointmentResponse", "appointmentResponseHash");
 
             ReindexJobRecord job = CreateReindexJobRecord(paramHashMap: resourceTypeSearchParamHashMap);
+            _fhirOperationDataStore.GetReindexJobByIdAsync(job.Id, _cancellationToken).ReturnsForAnyArgs(new ReindexJobWrapper(job, _weakETag));
 
             // setup search result
             _searchService.SearchForReindexAsync(
@@ -266,6 +269,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         public async Task GivenNoSupportedParams_WhenExecuted_ThenJobCanceled()
         {
             var job = CreateReindexJobRecord();
+            _fhirOperationDataStore.GetReindexJobByIdAsync(job.Id, _cancellationToken).ReturnsForAnyArgs(new ReindexJobWrapper(job, _weakETag));
 
             await _reindexJobTaskFactory().ExecuteAsync(job, _weakETag, _cancellationToken);
 
@@ -283,6 +287,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
             _reindexJobConfiguration.JobHeartbeatTimeoutThreshold = new TimeSpan(0, 0, 0, 1, 0);
 
             ReindexJobRecord job = CreateReindexJobRecord(maxResourcePerQuery: 3);
+            _fhirOperationDataStore.GetReindexJobByIdAsync(job.Id, _cancellationToken).ReturnsForAnyArgs(new ReindexJobWrapper(job, _weakETag));
 
             job.QueryList.TryAdd(new ReindexJobQueryStatus("patient", "token") { Status = OperationStatus.Running }, 1);
 
@@ -315,6 +320,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
             param.IsSearchable = false;
 
             var job = CreateReindexJobRecord(maxResourcePerQuery: 3);
+            _fhirOperationDataStore.GetReindexJobByIdAsync(job.Id, _cancellationToken).ReturnsForAnyArgs(new ReindexJobWrapper(job, _weakETag));
 
             job.QueryList.TryAdd(new ReindexJobQueryStatus("patient", "token") { Status = OperationStatus.Running }, 1);
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -14,6 +14,7 @@ using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Microsoft.Health.Core.Extensions;
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Configs;
@@ -219,12 +220,13 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
         [Fact]
         public async Task GivenNewSearchParamCreatedBeforeResourcesToBeIndexed_WhenReindexJobCompleted_ThenResourcesAreIndexedAndParamIsSearchable()
         {
-            const string searchParamName = "foo";
-            const string searchParamCode = "fooCode";
+            var randomName = Guid.NewGuid().ToString().ComputeHash().Substring(0, 14).ToLower();
+            string searchParamName = randomName;
+            string searchParamCode = randomName + "Code";
             SearchParameter searchParam = await CreateSearchParam(searchParamName, SearchParamType.String, ResourceType.Patient, "Patient.name", searchParamCode);
 
-            const string sampleName1 = "searchIndicesPatient1";
-            const string sampleName2 = "searchIndicesPatient2";
+            string sampleName1 = randomName + "searchIndicesPatient1";
+            string sampleName2 = randomName + "searchIndicesPatient2";
 
             string sampleId1 = Guid.NewGuid().ToString();
             string sampleId2 = Guid.NewGuid().ToString();
@@ -283,8 +285,9 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
         [Fact]
         public async Task GivenReindexJobRunning_WhenReindexJobCancelRequest_ThenReindexJobStopsAndMarkedCanceled()
         {
-            const string searchParamName = "foo";
-            const string searchParamCode = "fooCode";
+            var randomName = Guid.NewGuid().ToString().ComputeHash().Substring(0, 14).ToLower();
+            string searchParamName = randomName;
+            string searchParamCode = randomName + "Code";
             SearchParameter searchParam = await CreateSearchParam(searchParamName, SearchParamType.String, ResourceType.Patient, "Patient.name", searchParamCode);
 
             const string sampleName1 = "searchIndicesPatient1";
@@ -332,9 +335,9 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
             try
             {
                 var cancelReindexHandler = new CancelReindexRequestHandler(_fhirOperationDataStore, DisabledFhirAuthorizationService.Instance);
-                var reindexWrapper = await PerformReindexingOperation(response, OperationStatus.Running, cancellationTokenSource, 50);
-                await cancelReindexHandler.Handle(new CancelReindexRequest(reindexWrapper.JobRecord.Id), CancellationToken.None);
-                reindexWrapper = await _fhirOperationDataStore.GetReindexJobByIdAsync(reindexWrapper.JobRecord.Id, cancellationTokenSource.Token);
+                Task reindexWorkerTask = _reindexJobWorker.ExecuteAsync(cancellationTokenSource.Token);
+                await cancelReindexHandler.Handle(new CancelReindexRequest(response.Job.JobRecord.Id), CancellationToken.None);
+                var reindexWrapper = await _fhirOperationDataStore.GetReindexJobByIdAsync(response.Job.JobRecord.Id, cancellationTokenSource.Token);
 
                 Assert.Equal(OperationStatus.Canceled, reindexWrapper.JobRecord.Status);
             }
@@ -347,14 +350,20 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
 
                 await _fixture.DataStore.HardDeleteAsync(sample1.Wrapper.ToResourceKey(), CancellationToken.None);
                 await _fixture.DataStore.HardDeleteAsync(sample2.Wrapper.ToResourceKey(), CancellationToken.None);
+                await _fixture.DataStore.HardDeleteAsync(sample3.Wrapper.ToResourceKey(), CancellationToken.None);
+                await _fixture.DataStore.HardDeleteAsync(sample4.Wrapper.ToResourceKey(), CancellationToken.None);
             }
         }
 
         [Fact]
         public async Task GivenNewSearchParamCreatedAfterResourcesToBeIndexed_WhenReindexJobCompleted_ThenResourcesAreIndexedAndParamIsSearchable()
         {
-            const string sampleName1 = "searchIndicesPatient1";
-            const string sampleName2 = "searchIndicesPatient2";
+            var randomName = Guid.NewGuid().ToString().ComputeHash().Substring(0, 14).ToLower();
+            string searchParamName = randomName;
+            string searchParamCode = randomName + "Code";
+
+            string sampleName1 = randomName + "searchIndicesPatient1";
+            string sampleName2 = randomName + "searchIndicesPatient2";
 
             string sampleId1 = Guid.NewGuid().ToString();
             string sampleId2 = Guid.NewGuid().ToString();
@@ -362,8 +371,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
             UpsertOutcome sample1 = await CreatePatientResource(sampleName1, sampleId1);
             UpsertOutcome sample2 = await CreatePatientResource(sampleName2, sampleId2);
 
-            const string searchParamName = "foo";
-            const string searchParamCode = "fooCode";
             SearchParameter searchParam = await CreateSearchParam(searchParamName, SearchParamType.String, ResourceType.Patient, "Patient.name", searchParamCode);
 
             // Create the query <fhirserver>/Patient?foo=searchIndicesPatient1

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -289,16 +289,29 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
 
             const string sampleName1 = "searchIndicesPatient1";
             const string sampleName2 = "searchIndicesPatient2";
+            const string sampleName3 = "searchIndicesPatient3";
+            const string sampleName4 = "searchIndicesPatient4";
 
             string sampleId1 = Guid.NewGuid().ToString();
             string sampleId2 = Guid.NewGuid().ToString();
+            string sampleId3 = Guid.NewGuid().ToString();
+            string sampleId4 = Guid.NewGuid().ToString();
 
             // Set up the values that the search index extraction should return during reindexing
-            var searchValues = new List<(string, ISearchValue)> { (sampleId1, new StringSearchValue(sampleName1)), (sampleId2, new StringSearchValue(sampleName2)) };
+            var searchValues = new List<(string, ISearchValue)>
+            {
+                (sampleId1, new StringSearchValue(sampleName1)),
+                (sampleId2, new StringSearchValue(sampleName2)),
+                (sampleId3, new StringSearchValue(sampleName3)),
+                (sampleId4, new StringSearchValue(sampleName4)),
+            };
+
             MockSearchIndexExtraction(searchValues, searchParam);
 
             UpsertOutcome sample1 = await CreatePatientResource(sampleName1, sampleId1);
             UpsertOutcome sample2 = await CreatePatientResource(sampleName2, sampleId2);
+            UpsertOutcome sample3 = await CreatePatientResource(sampleName3, sampleId3);
+            UpsertOutcome sample4 = await CreatePatientResource(sampleName4, sampleId4);
 
             // Create the query <fhirserver>/Patient?foo=searchIndicesPatient1
             var queryParams = new List<Tuple<string, string>> { new(searchParamCode, sampleName1) };
@@ -309,7 +322,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
 
             // When search parameters aren't recognized, they are ignored
             // Confirm that "foo" is dropped from the query string and all patients are returned
-            Assert.Equal(2, searchResults.Results.Count());
+            Assert.Equal(4, searchResults.Results.Count());
 
             var createReindexRequest = new CreateReindexRequest(1, 1, 500);
             CreateReindexResponse response = await SetUpForReindexing(createReindexRequest);


### PR DESCRIPTION
## Description
Check for job cancellation inside ReindexJobTask

## Related issues
Addresses [issue [AB#81248](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/81248)].

## Testing
Integration tests updated, and manual testing performed.

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
Skip