### PR TITLE
Bump HealthcareSharedPackageVersion to 2.1.9

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,7 +22,7 @@
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <RuntimePackageVersion>5.0.0</RuntimePackageVersion>
     <AspNetPackageVersion>5.0.5</AspNetPackageVersion>
-    <HealthcareSharedPackageVersion>2.1.0</HealthcareSharedPackageVersion>
+    <HealthcareSharedPackageVersion>2.1.9</HealthcareSharedPackageVersion>
     <Hl7FhirVersion>1.9.0</Hl7FhirVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
## Description
Updating Healthcare shared packages to version 2.1.9

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch