### PR TITLE
Group identity model nuget version under one variable.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
 
+  <!-- Nuget related properties.-->
   <PropertyGroup>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Product>Microsoft FHIR Server for Azure</Product>
@@ -20,6 +21,10 @@
     <Deterministic>true</Deterministic>
     <!--This will target the latest patch release of the runtime released with the current SDK.  -->
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
+  </PropertyGroup>
+  <!-- Shared dependencies versions.-->
+  <PropertyGroup>
+    <IdentityModel>6.10.2</IdentityModel>
     <RuntimePackageVersion>5.0.0</RuntimePackageVersion>
     <AspNetPackageVersion>5.0.5</AspNetPackageVersion>
     <HealthcareSharedPackageVersion>2.1.9</HealthcareSharedPackageVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,7 +24,7 @@
   </PropertyGroup>
   <!-- Shared dependencies versions.-->
   <PropertyGroup>
-    <IdentityModel>6.10.2</IdentityModel>
+    <IdentityModelVersion>6.10.2</IdentityModelVersion>
     <RuntimePackageVersion>5.0.0</RuntimePackageVersion>
     <AspNetPackageVersion>5.0.5</AspNetPackageVersion>
     <HealthcareSharedPackageVersion>2.1.9</HealthcareSharedPackageVersion>

--- a/src/Microsoft.Health.Fhir.R4.Client/Microsoft.Health.Fhir.R4.Client.csproj
+++ b/src/Microsoft.Health.Fhir.R4.Client/Microsoft.Health.Fhir.R4.Client.csproj
@@ -9,8 +9,8 @@
     <PackageReference Include="Hl7.Fhir.R4" Version="$(Hl7FhirVersion)" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.1" />
     <PackageReference Include="Microsoft.Health.Client" Version="$(HealthcareSharedPackageVersion)" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="$(IdentityModel)" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="$(IdentityModel)" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="$(IdentityModelVersion)" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="$(IdentityModelVersion)" />
   </ItemGroup>
   <Import Project="..\Microsoft.Health.Fhir.Shared.Client\Microsoft.Health.Fhir.Shared.Client.projitems" Label="Shared" />
 </Project>

--- a/src/Microsoft.Health.Fhir.R4.Client/Microsoft.Health.Fhir.R4.Client.csproj
+++ b/src/Microsoft.Health.Fhir.R4.Client/Microsoft.Health.Fhir.R4.Client.csproj
@@ -9,8 +9,8 @@
     <PackageReference Include="Hl7.Fhir.R4" Version="$(Hl7FhirVersion)" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.1" />
     <PackageReference Include="Microsoft.Health.Client" Version="$(HealthcareSharedPackageVersion)" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.10.1" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.10.1" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="$(IdentityModel)" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="$(IdentityModel)" />
   </ItemGroup>
   <Import Project="..\Microsoft.Health.Fhir.Shared.Client\Microsoft.Health.Fhir.Shared.Client.projitems" Label="Shared" />
 </Project>

--- a/src/Microsoft.Health.Fhir.R5.Client/Microsoft.Health.Fhir.R5.Client.csproj
+++ b/src/Microsoft.Health.Fhir.R5.Client/Microsoft.Health.Fhir.R5.Client.csproj
@@ -9,8 +9,8 @@
     <PackageReference Include="Hl7.Fhir.R5" Version="1.9.0-beta-june2020" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.1" />
     <PackageReference Include="Microsoft.Health.Client" Version="$(HealthcareSharedPackageVersion)" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.10.1" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.10.1" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="$(IdentityModel)" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="$(IdentityModel)" />
   </ItemGroup>
   <Import Project="..\Microsoft.Health.Fhir.Shared.Client\Microsoft.Health.Fhir.Shared.Client.projitems" Label="Shared" />
 </Project>

--- a/src/Microsoft.Health.Fhir.R5.Client/Microsoft.Health.Fhir.R5.Client.csproj
+++ b/src/Microsoft.Health.Fhir.R5.Client/Microsoft.Health.Fhir.R5.Client.csproj
@@ -9,8 +9,8 @@
     <PackageReference Include="Hl7.Fhir.R5" Version="1.9.0-beta-june2020" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.1" />
     <PackageReference Include="Microsoft.Health.Client" Version="$(HealthcareSharedPackageVersion)" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="$(IdentityModel)" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="$(IdentityModel)" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="$(IdentityModelVersion)" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="$(IdentityModelVersion)" />
   </ItemGroup>
   <Import Project="..\Microsoft.Health.Fhir.Shared.Client\Microsoft.Health.Fhir.Shared.Client.projitems" Label="Shared" />
 </Project>

--- a/src/Microsoft.Health.Fhir.Stu3.Client/Microsoft.Health.Fhir.Stu3.Client.csproj
+++ b/src/Microsoft.Health.Fhir.Stu3.Client/Microsoft.Health.Fhir.Stu3.Client.csproj
@@ -9,8 +9,8 @@
     <PackageReference Include="Hl7.Fhir.STU3" Version="$(Hl7FhirVersion)" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.1" />
     <PackageReference Include="Microsoft.Health.Client" Version="$(HealthcareSharedPackageVersion)" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="$(IdentityModel)" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="$(IdentityModel)" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="$(IdentityModelVersion)" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="$(IdentityModelVersion)" />
   </ItemGroup>
   <Import Project="..\Microsoft.Health.Fhir.Shared.Client\Microsoft.Health.Fhir.Shared.Client.projitems" Label="Shared" />
 </Project>

--- a/src/Microsoft.Health.Fhir.Stu3.Client/Microsoft.Health.Fhir.Stu3.Client.csproj
+++ b/src/Microsoft.Health.Fhir.Stu3.Client/Microsoft.Health.Fhir.Stu3.Client.csproj
@@ -9,8 +9,8 @@
     <PackageReference Include="Hl7.Fhir.STU3" Version="$(Hl7FhirVersion)" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.1" />
     <PackageReference Include="Microsoft.Health.Client" Version="$(HealthcareSharedPackageVersion)" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.10.1" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.10.1" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="$(IdentityModel)" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="$(IdentityModel)" />
   </ItemGroup>
   <Import Project="..\Microsoft.Health.Fhir.Shared.Client\Microsoft.Health.Fhir.Shared.Client.projitems" Label="Shared" />
 </Project>


### PR DESCRIPTION
## Description
Dependabot [struggling ](https://github.com/microsoft/fhir-server/pull/1861 )with identity model nuget updates since it treat it as two different packages but they release at same time. So I put them under one variable.

## Related issues


## Testing


## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
skip
