### PR TITLE
Optimizes exact string search on SQL

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SearchParameterQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SearchParameterQueryGenerator.cs
@@ -222,6 +222,18 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                 column.IsAcentSensitive == expression.IgnoreCase ||
                 column.IsCaseSensitive == expression.IgnoreCase)
             {
+                if (!expression.IgnoreCase && expression.StringOperator == StringOperator.Equals && column.IsAcentSensitive != null && column.IsCaseSensitive != null)
+                {
+                    // We are doing a case/accent sensitive query over a column that is case/accent insensitive.
+                    // We can improve efficiency of the query by including an accent/case insensitive predicate
+                    // in addition to the sensitive one. This allows the optimizer choose an index seek.
+
+                    context.StringBuilder.Append(" AND ");
+                    AppendColumnName(context, column, expression);
+                    SqlParameter equalsParameter = context.Parameters.AddParameter(column, value);
+                    context.StringBuilder.Append(" = ").Append(equalsParameter.ParameterName);
+                }
+
                 context.StringBuilder.Append(" COLLATE ").Append(expression.IgnoreCase ? DefaultCaseInsensitiveCollation : DefaultCaseSensitiveCollation);
             }
 


### PR DESCRIPTION
## Description
We can achieve better query efficiency for exact string queries, such as `Patient?address-state:exact=Massachusetts`, by adding an additional predicate to the WHERE clause:

![image](https://user-images.githubusercontent.com/339432/115739645-19cb3a80-a35c-11eb-8f43-5948da9c0c00.png)

Adding in the case/accent-insensitive predicate allows the optimizer to choose an index seek (and that now has the results pre-sorted by ResourceSurrogateId).

In the example, above, the query plan goes from this:
![image](https://user-images.githubusercontent.com/339432/115739422-ebe5f600-a35b-11eb-8808-faa3ccb0a553.png)

To this:
![image](https://user-images.githubusercontent.com/339432/115739519-fe602f80-a35b-11eb-9f1b-0bf7b46bb823.png)


## Testing
Manual testing

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
