### PR TITLE
Improves efficiency of normal string searches

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/DateTimeEqualityRewriter.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/DateTimeEqualityRewriter.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         public override Expression VisitSearchParameter(SearchParameterExpression expression, object context)
         {
             if (expression.Parameter.Type == SearchParamType.Date ||
-                (expression.Parameter.Type == SearchParamType.Composite && expression.Parameter.ResolvedComponents.Any(c => c.Type == SearchParamType.Date)))
+                (expression.Parameter.Type == SearchParamType.Composite && expression.Parameter.Component.Any(c => c.ResolvedSearchParameter.Type == SearchParamType.Date)))
             {
                 return base.VisitSearchParameter(expression, context);
             }

--- a/src/Microsoft.Health.Fhir.Core/Models/SearchParameterInfo.cs
+++ b/src/Microsoft.Health.Fhir.Core/Models/SearchParameterInfo.cs
@@ -121,11 +121,6 @@ namespace Microsoft.Health.Fhir.Core.Models
         /// </summary>
         public IReadOnlyList<SearchParameterComponentInfo> Component { get; }
 
-        /// <summary>
-        /// The resolved <see cref="SearchParameterInfo"/>s for each component if this is a composite search parameter (<see cref="Type"/> is <see cref="SearchParamType.Composite"/>)
-        /// </summary>
-        public IReadOnlyList<SearchParameterInfo> ResolvedComponents { get; set; } = Array.Empty<SearchParameterInfo>();
-
         public bool Equals([AllowNull] SearchParameterInfo other)
         {
             if (other == null)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/9.diff.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/9.diff.sql
@@ -1236,9 +1236,9 @@ ON dbo.StringSearchParam
 )
 INCLUDE
 (
-    TextOverflow -- workaround for https://support.microsoft.com/en-gb/help/3051225/a-filtered-index-that-you-create-together-with-the-is-null-predicate-i
+    TextOverflow -- will not be needed when all servers are targeting at least this version.
 )
-WHERE IsHistory = 0 AND TextOverflow IS NULL
+WHERE IsHistory = 0
 WITH (DATA_COMPRESSION = PAGE, ONLINE=ON, DROP_EXISTING=ON) 
 ON PartitionScheme_ResourceTypeId(ResourceTypeId)
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/9.diff.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/9.diff.sql
@@ -1787,9 +1787,9 @@ ON dbo.TokenStringCompositeSearchParam
 INCLUDE
 (
     SystemId1,
-    TextOverflow2 -- workaround for https://support.microsoft.com/en-gb/help/3051225/a-filtered-index-that-you-create-together-with-the-is-null-predicate-i
+    TextOverflow2 -- will not be needed when all servers are targeting at least this version.
 )
-WHERE IsHistory = 0 AND TextOverflow2 IS NULL
+WHERE IsHistory = 0
 WITH (DATA_COMPRESSION = PAGE, ONLINE=ON, DROP_EXISTING=ON) 
 ON PartitionScheme_ResourceTypeId(ResourceTypeId)
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/9.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/9.sql
@@ -1134,9 +1134,9 @@ ON dbo.TokenStringCompositeSearchParam
 INCLUDE
 (
     SystemId1,
-    TextOverflow2 -- workaround for https://support.microsoft.com/en-gb/help/3051225/a-filtered-index-that-you-create-together-with-the-is-null-predicate-i
+    TextOverflow2 -- will not be needed when all servers are targeting at least this version.
 )
-WHERE IsHistory = 0 AND TextOverflow2 IS NULL
+WHERE IsHistory = 0
 WITH (DATA_COMPRESSION = PAGE) 
 ON PartitionScheme_ResourceTypeId(ResourceTypeId)
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/9.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/9.sql
@@ -429,9 +429,9 @@ ON dbo.StringSearchParam
 )
 INCLUDE
 (
-    TextOverflow -- workaround for https://support.microsoft.com/en-gb/help/3051225/a-filtered-index-that-you-create-together-with-the-is-null-predicate-i
+    TextOverflow -- will not be needed when all servers are targeting at least this version.
 )
-WHERE IsHistory = 0 AND TextOverflow IS NULL
+WHERE IsHistory = 0
 WITH (DATA_COMPRESSION = PAGE) 
 ON PartitionScheme_ResourceTypeId(ResourceTypeId)
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/LegacyStringOverflowRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/LegacyStringOverflowRewriter.cs
@@ -1,0 +1,87 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
+using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.SqlServer.Features.Schema;
+using Microsoft.Health.Fhir.SqlServer.Features.Schema.Model;
+using Microsoft.Health.Fhir.ValueSets;
+
+namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
+{
+    /// <summary>
+    /// To be used with schema versions less than <see cref="SchemaVersionConstants.PartitionedTables"/>.
+    /// Rewrites expressions over string search parameters to account for entries where the TextOverflow
+    /// column is not null.
+    /// </summary>
+    internal class LegacyStringOverflowRewriter : ConcatenationRewriter
+    {
+        public static readonly LegacyStringOverflowRewriter Instance = new LegacyStringOverflowRewriter();
+
+        public LegacyStringOverflowRewriter()
+            : base(new Scout())
+        {
+        }
+
+        public override Expression VisitSearchParameter(SearchParameterExpression expression, object context)
+        {
+            if (expression.Parameter.Type == SearchParamType.String ||
+                expression.Parameter.Type == SearchParamType.Composite)
+            {
+                return base.VisitSearchParameter(expression, expression.Parameter);
+            }
+
+            return expression;
+        }
+
+        public override Expression VisitString(StringExpression expression, object context)
+        {
+            var searchParameterInfo = (SearchParameterInfo)context;
+            if ((expression.ComponentIndex == null ? searchParameterInfo.Type : searchParameterInfo.Component[expression.ComponentIndex.Value].ResolvedSearchParameter.Type) != SearchParamType.String)
+            {
+                return expression;
+            }
+
+            return new StringExpression(expression.StringOperator, SqlFieldName.TextOverflow, expression.ComponentIndex, expression.Value, expression.IgnoreCase);
+        }
+
+        private class Scout : DefaultSqlExpressionVisitor<object, bool>
+        {
+            internal Scout()
+                : base((accumulated, current) => accumulated || current)
+            {
+            }
+
+            public override bool VisitSearchParameter(SearchParameterExpression expression, object context)
+            {
+                if (expression.Parameter.Type == SearchParamType.String ||
+                    expression.Parameter.Type == SearchParamType.Composite)
+                {
+                    return expression.Expression.AcceptVisitor(this, expression.Parameter);
+                }
+
+                return false;
+            }
+
+            public override bool VisitString(StringExpression expression, object context)
+            {
+                var searchParameterInfo = (SearchParameterInfo)context;
+
+                if ((expression.ComponentIndex == null ? searchParameterInfo.Type : searchParameterInfo.Component[expression.ComponentIndex.Value].ResolvedSearchParameter.Type) != SearchParamType.String)
+                {
+                    return false;
+                }
+
+                if (expression.StringOperator == StringOperator.Equals && expression.Value.Length <= VLatest.StringSearchParam.Text.Metadata.MaxLength)
+                {
+                    // in these cases, we will know for sure that we do not need to consider the overflow column
+                    return false;
+                }
+
+                return true;
+            }
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SearchParameterQueryGeneratorContext.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SearchParameterQueryGeneratorContext.cs
@@ -6,21 +6,24 @@
 using EnsureThat;
 using Microsoft.Health.Fhir.SqlServer.Features.Storage;
 using Microsoft.Health.SqlServer;
+using Microsoft.Health.SqlServer.Features.Schema;
 using Microsoft.Health.SqlServer.Features.Storage;
 
 namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.QueryGenerators
 {
     internal readonly struct SearchParameterQueryGeneratorContext
     {
-        internal SearchParameterQueryGeneratorContext(IndentedStringBuilder stringBuilder, SqlQueryParameterManager parameters, ISqlServerFhirModel model, string tableAlias = null)
+        internal SearchParameterQueryGeneratorContext(IndentedStringBuilder stringBuilder, SqlQueryParameterManager parameters, ISqlServerFhirModel model, SchemaInformation schemaInformation, string tableAlias = null)
         {
             EnsureArg.IsNotNull(stringBuilder, nameof(stringBuilder));
             EnsureArg.IsNotNull(parameters, nameof(parameters));
             EnsureArg.IsNotNull(model, nameof(model));
+            EnsureArg.IsNotNull(schemaInformation, nameof(schemaInformation));
 
             StringBuilder = stringBuilder;
             Parameters = parameters;
             Model = model;
+            SchemaInformation = schemaInformation;
             TableAlias = tableAlias;
         }
 
@@ -29,6 +32,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
         public SqlQueryParameterManager Parameters { get; }
 
         public ISqlServerFhirModel Model { get; }
+
+        public SchemaInformation SchemaInformation { get; }
 
         public string TableAlias { get; }
     }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -920,7 +920,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
         private SearchParameterQueryGeneratorContext GetContext(string tableAlias = null)
         {
-            return new SearchParameterQueryGeneratorContext(StringBuilder, Parameters, Model, tableAlias);
+            return new SearchParameterQueryGeneratorContext(StringBuilder, Parameters, Model, _schemaInfo, tableAlias);
         }
 
         private void AppendIntersectionWithPredecessor(IndentedStringBuilder.DelimitedScope delimited, SearchParamTableExpression searchParamTableExpression, string tableAlias = null)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/StringQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/StringQueryGenerator.cs
@@ -5,6 +5,7 @@
 
 using System;
 using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
+using Microsoft.Health.Fhir.SqlServer.Features.Schema;
 using Microsoft.Health.Fhir.SqlServer.Features.Schema.Model;
 using Microsoft.Health.SqlServer.Features.Schema.Model;
 
@@ -18,37 +19,59 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
         public override SearchParameterQueryGeneratorContext VisitString(StringExpression expression, SearchParameterQueryGeneratorContext context)
         {
-            AppendColumnName(context, VLatest.StringSearchParam.TextOverflow, expression);
-
-            StringColumn column;
-            switch (expression.FieldName)
+            if (context.SchemaInformation.Current >= SchemaVersionConstants.PartitionedTables)
             {
-                case FieldName.String:
-                    column = VLatest.StringSearchParam.Text;
-                    context.StringBuilder.Append(" IS NULL AND ");
-                    break;
-                case SqlFieldName.TextOverflow:
-                    column = VLatest.StringSearchParam.TextOverflow;
-                    switch (expression.StringOperator)
-                    {
-                        case StringOperator.StartsWith:
-                        case StringOperator.NotStartsWith:
-                        case StringOperator.Equals:
-                            if (expression.Value.Length <= VLatest.StringSearchParam.Text.Metadata.MaxLength)
-                            {
-                                column = VLatest.StringSearchParam.Text;
-                            }
+                StringColumn column;
+                switch (expression.FieldName)
+                {
+                    case FieldName.String:
+                        column = VLatest.StringSearchParam.Text;
+                        break;
+                    case SqlFieldName.TextOverflow:
+                        column = VLatest.StringSearchParam.TextOverflow;
+                        AppendColumnName(context, column, expression);
+                        context.StringBuilder.Append(" IS NOT NULL AND ");
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException(expression.FieldName.ToString());
+                }
 
-                            break;
-                    }
-
-                    context.StringBuilder.Append(" IS NOT NULL AND ");
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException(expression.FieldName.ToString());
+                return VisitSimpleString(expression, context, column, expression.Value);
             }
+            else
+            {
+                AppendColumnName(context, VLatest.StringSearchParam.TextOverflow, expression);
 
-            return VisitSimpleString(expression, context, column, expression.Value);
+                StringColumn column;
+                switch (expression.FieldName)
+                {
+                    case FieldName.String:
+                        column = VLatest.StringSearchParam.Text;
+                        context.StringBuilder.Append(" IS NULL AND ");
+                        break;
+                    case SqlFieldName.TextOverflow:
+                        column = VLatest.StringSearchParam.TextOverflow;
+                        switch (expression.StringOperator)
+                        {
+                            case StringOperator.StartsWith:
+                            case StringOperator.NotStartsWith:
+                            case StringOperator.Equals:
+                                if (expression.Value.Length <= VLatest.StringSearchParam.Text.Metadata.MaxLength)
+                                {
+                                    column = VLatest.StringSearchParam.Text;
+                                }
+
+                                break;
+                        }
+
+                        context.StringBuilder.Append(" IS NOT NULL AND ");
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException(expression.FieldName.ToString());
+                }
+
+                return VisitSimpleString(expression, context, column, expression.Value);
+            }
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/StringOverflowRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/StringOverflowRewriter.cs
@@ -3,30 +3,41 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
-using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.SqlServer.Features.Schema;
 using Microsoft.Health.Fhir.SqlServer.Features.Schema.Model;
 using Microsoft.Health.Fhir.ValueSets;
 
 namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
 {
     /// <summary>
-    /// Rewrites expressions over string search parameters to account for entries where the TextOverflow
-    /// column is not null.
+    /// To be used with schema versions greater than or equal to <see cref="SchemaVersionConstants.PartitionedTables"/>.
+    /// Rewrites expressions over string search parameters to account for long entries that require use of the TextOverflow column.
     /// </summary>
-    internal class StringOverflowRewriter : ConcatenationRewriter
+    internal class StringOverflowRewriter : SqlExpressionRewriterWithInitialContext<object>
     {
-        public static readonly StringOverflowRewriter Instance = new StringOverflowRewriter();
+        public static readonly StringOverflowRewriter Instance = new();
 
-        public StringOverflowRewriter()
-            : base(new Scout())
+        public override Expression VisitSqlRoot(SqlRootExpression expression, object context)
         {
+            IReadOnlyList<SearchParamTableExpression> visitedTableExpressions = VisitArray(expression.SearchParamTableExpressions, context);
+
+            if (ReferenceEquals(visitedTableExpressions, expression.SearchParamTableExpressions))
+            {
+                return expression;
+            }
+
+            return new SqlRootExpression(visitedTableExpressions, expression.ResourceTableExpressions);
         }
 
         public override Expression VisitSearchParameter(SearchParameterExpression expression, object context)
         {
             if (expression.Parameter.Type == SearchParamType.String ||
-                expression.Parameter.Type == SearchParamType.Composite)
+                (expression.Parameter.Type == SearchParamType.Composite &&
+                 expression.Parameter.ResolvedComponents.Any(c => c.Type == SearchParamType.String)))
             {
                 return base.VisitSearchParameter(expression, expression.Parameter);
             }
@@ -36,49 +47,30 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
 
         public override Expression VisitString(StringExpression expression, object context)
         {
-            var searchParameterInfo = (SearchParameterInfo)context;
-            if ((expression.ComponentIndex == null ? searchParameterInfo.Type : searchParameterInfo.Component[expression.ComponentIndex.Value].ResolvedSearchParameter.Type) != SearchParamType.String)
+            switch (expression.StringOperator)
             {
-                return expression;
-            }
+                case StringOperator.Equals:
+                case StringOperator.StartsWith:
+                    if (expression.Value.Length <= VLatest.StringSearchParam.Text.Metadata.MaxLength)
+                    {
+                        // checking the Text column will be sufficient
+                        return expression;
+                    }
 
-            return new StringExpression(expression.StringOperator, SqlFieldName.TextOverflow, expression.ComponentIndex, expression.Value, expression.IgnoreCase);
-        }
+                    // We need to check the TextOverflow column. But we also check the Text column to allow an index seek
+                    string prefix = expression.Value.Substring(0, (int)VLatest.StringSearchParam.Text.Metadata.MaxLength);
 
-        private class Scout : DefaultSqlExpressionVisitor<object, bool>
-        {
-            internal Scout()
-                : base((accumulated, current) => accumulated || current)
-            {
-            }
+                    return Expression.And(
+                        new StringExpression(expression.StringOperator, expression.FieldName, expression.ComponentIndex, prefix, expression.IgnoreCase),
+                        new StringExpression(expression.StringOperator, SqlFieldName.TextOverflow, expression.ComponentIndex, expression.Value, expression.IgnoreCase));
 
-            public override bool VisitSearchParameter(SearchParameterExpression expression, object context)
-            {
-                if (expression.Parameter.Type == SearchParamType.String ||
-                    expression.Parameter.Type == SearchParamType.Composite)
-                {
-                    return expression.Expression.AcceptVisitor(this, expression.Parameter);
-                }
-
-                return false;
-            }
-
-            public override bool VisitString(StringExpression expression, object context)
-            {
-                var searchParameterInfo = (SearchParameterInfo)context;
-
-                if ((expression.ComponentIndex == null ? searchParameterInfo.Type : searchParameterInfo.Component[expression.ComponentIndex.Value].ResolvedSearchParameter.Type) != SearchParamType.String)
-                {
-                    return false;
-                }
-
-                if (expression.StringOperator == StringOperator.Equals && expression.Value.Length <= VLatest.StringSearchParam.Text.Metadata.MaxLength)
-                {
-                    // in these cases, we will know for sure that we do not need to consider the overflow column
-                    return false;
-                }
-
-                return true;
+                case StringOperator.Contains:
+                    // We need to consider the entire string, so we need to check TextOverflow if it is populated.
+                    return Expression.Or(
+                        expression,
+                        new StringExpression(expression.StringOperator, SqlFieldName.TextOverflow, expression.ComponentIndex, expression.Value, expression.IgnoreCase));
+                default:
+                    throw new InvalidOperationException($"Unexpected operator '{expression.StringOperator}' for string search parameter.");
             }
         }
     }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/StringOverflowRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/StringOverflowRewriter.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
         {
             if (expression.Parameter.Type == SearchParamType.String ||
                 (expression.Parameter.Type == SearchParamType.Composite &&
-                 expression.Parameter.ResolvedComponents.Any(c => c.Type == SearchParamType.String)))
+                 expression.Parameter.Component.Any(c => c.ResolvedSearchParameter.Type == SearchParamType.String)))
             {
                 return base.VisitSearchParameter(expression, expression.Parameter);
             }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -210,7 +210,10 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                                                .AcceptVisitor(_chainFlatteningRewriter)
                                                .AcceptVisitor(ResourceColumnPredicatePushdownRewriter.Instance)
                                                .AcceptVisitor(DateTimeBoundedRangeRewriter.Instance)
-                                               .AcceptVisitor(StringOverflowRewriter.Instance)
+                                               .AcceptVisitor(
+                                                   (SqlExpressionRewriterWithInitialContext<object>)(_schemaInformation.Current >= SchemaVersionConstants.PartitionedTables
+                                                       ? StringOverflowRewriter.Instance
+                                                       : LegacyStringOverflowRewriter.Instance))
                                                .AcceptVisitor(NumericRangeRewriter.Instance)
                                                .AcceptVisitor(IncludeMatchSeedRewriter.Instance)
                                                .AcceptVisitor(TopRewriter.Instance, searchOptions)


### PR DESCRIPTION
## Description

SQL Server does not support arbitrarily large index widths. For that reason, we have a truncated `Text` column on the `StringSearchParam` table, and a `TextOverflow` column in cases where the text does not fit in the `Text` column.

With this change, we are tweaking a nonclustered index to not be filtered on `WHERE TextOverflow IS NULL` which allows for simpler and more efficient queries. Example (for `/Patient?family=Breitenberg`):

![image](https://user-images.githubusercontent.com/339432/115876138-f4016c80-a413-11eb-9ba4-3fd4b30d76a1.png)


For the query  `/Patient?family=Breitenberg`, logical reads are reduced from 10 to 5 on the `StringSearchParam` table.

The difference becomes more important for a query like `/Patient?family=Breitenberg&gender=male` when the optimizer chooses a bad plan (it does an inner loop join with `males` on in the outer loop in my database). There logical reads are reduced from 32,821 to 16,429.


