### PR TITLE
Avoid recompiling every SQL query

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/HashingSqlQueryParameterManagerTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/HashingSqlQueryParameterManagerTests.cs
@@ -1,0 +1,136 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Text;
+using Microsoft.Data.SqlClient;
+using Microsoft.Health.Fhir.SqlServer.Features.Schema.Model;
+using Microsoft.Health.Fhir.SqlServer.Features.Search;
+using Microsoft.Health.SqlServer;
+using Microsoft.Health.SqlServer.Features.Storage;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
+{
+    public class HashingSqlQueryParameterManagerTests
+    {
+        public static readonly TheoryData<object> Data = new()
+        {
+            true, 1, 1L, DateTime.UtcNow, DateTimeOffset.UtcNow, 9M, 99.9, (short)6, (byte)9, Guid.Parse("0fd465f0-095b-425c-a3e8-acc879d20835"), "Hello",
+        };
+
+        [Fact]
+        public void GivenParametersThatShouldNotBeHashed_WhenAdded_ResultsInNoChangeToHash()
+        {
+            using var command = new SqlCommand();
+            var parameters = new HashingSqlQueryParameterManager(new SqlQueryParameterManager(command.Parameters));
+
+            AssertDoesNotChangeHash(parameters, () =>
+            {
+                parameters.AddParameter(1, includeInHash: false);
+                parameters.AddParameter(VLatest.Resource.ResourceId, "abc", false);
+                parameters.AddParameter(VLatest.Resource.ResourceId, (object)"123", false);
+            });
+
+            Assert.False(parameters.HasParametersToHash);
+        }
+
+        [Theory]
+        [MemberData(nameof(Data))]
+        public void GivenAParameterThatShouldBeHashed_WhenAdded_ChangesHash(object value)
+        {
+            using var command = new SqlCommand();
+            var parameters = new HashingSqlQueryParameterManager(new SqlQueryParameterManager(command.Parameters));
+
+            AssertChangesHash(parameters, () => parameters.AddParameter(value));
+        }
+
+        [Fact]
+        public void GivenAParameterThatShouldAndThenShouldNotBeHashed_WhenAdded_ChangesHash()
+        {
+            using var command = new SqlCommand();
+            var parameters = new HashingSqlQueryParameterManager(new SqlQueryParameterManager(command.Parameters));
+
+            AssertChangesHash(parameters, () =>
+            {
+                parameters.AddParameter(1, includeInHash: false);
+                parameters.AddParameter(1, includeInHash: true);
+            });
+
+            Assert.True(parameters.HasParametersToHash);
+        }
+
+        [Fact]
+        public void GivenAParameterThatShouldNotAndThenShouldBeHashed_WhenAdded_ChangesHash()
+        {
+            using var command = new SqlCommand();
+            var parameters = new HashingSqlQueryParameterManager(new SqlQueryParameterManager(command.Parameters));
+
+            AssertChangesHash(parameters, () =>
+            {
+                parameters.AddParameter(1, includeInHash: true);
+                parameters.AddParameter(1, includeInHash: false);
+            });
+
+            Assert.True(parameters.HasParametersToHash);
+        }
+
+        [Fact]
+        public void GivenALargeNumberOfParameters_WhenAdded_ChangesHash()
+        {
+            using var command = new SqlCommand();
+            var parameters = new HashingSqlQueryParameterManager(new SqlQueryParameterManager(command.Parameters));
+
+            for (int i = 0; i < 100; i++)
+            {
+                AssertChangesHash(parameters, () =>
+                {
+                    parameters.AddParameter(Guid.NewGuid());
+                });
+
+                Assert.True(parameters.HasParametersToHash);
+            }
+
+            // ensure hash is repeatable with IncrementalHash
+            Assert.Equal(GetHash(parameters), GetHash(parameters));
+        }
+
+        [Fact]
+        public void GivenALargeStringParameter_WhenAdded_ChangesHash()
+        {
+            using var command = new SqlCommand();
+            var parameters = new HashingSqlQueryParameterManager(new SqlQueryParameterManager(command.Parameters));
+
+            parameters.AddParameter(1);
+
+            AssertChangesHash(parameters, () => parameters.AddParameter(new string('a', 500)));
+        }
+
+        private static string GetHash(HashingSqlQueryParameterManager parameterManager)
+        {
+            var sb = new IndentedStringBuilder(new StringBuilder());
+            parameterManager.AppendHash(sb);
+            return sb.ToString();
+        }
+
+        private static void AssertChangesHash(HashingSqlQueryParameterManager parameters, Action action)
+        {
+            var originalHash = GetHash(parameters);
+
+            action();
+
+            Assert.NotEqual(originalHash, GetHash(parameters));
+        }
+
+        private static void AssertDoesNotChangeHash(HashingSqlQueryParameterManager parameters, Action action)
+        {
+            var originalHash = GetHash(parameters);
+
+            action();
+
+            Assert.Equal(originalHash, GetHash(parameters));
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/HashingSqlQueryParameterManagerTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/HashingSqlQueryParameterManagerTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             using var command = new SqlCommand();
             var parameters = new HashingSqlQueryParameterManager(new SqlQueryParameterManager(command.Parameters));
 
-            AssertChangesHash(parameters, () => parameters.AddParameter(value));
+            AssertChangesHash(parameters, () => parameters.AddParameter(value, true));
         }
 
         [Fact]
@@ -87,7 +87,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             {
                 AssertChangesHash(parameters, () =>
                 {
-                    parameters.AddParameter(Guid.NewGuid());
+                    parameters.AddParameter(Guid.NewGuid(), true);
                 });
 
                 Assert.True(parameters.HasParametersToHash);
@@ -103,9 +103,9 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             using var command = new SqlCommand();
             var parameters = new HashingSqlQueryParameterManager(new SqlQueryParameterManager(command.Parameters));
 
-            parameters.AddParameter(1);
+            parameters.AddParameter(1, true);
 
-            AssertChangesHash(parameters, () => parameters.AddParameter(new string('a', 500)));
+            AssertChangesHash(parameters, () => parameters.AddParameter(new string('a', 500), true));
         }
 
         private static string GetHash(HashingSqlQueryParameterManager parameterManager)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/CompartmentQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/CompartmentQueryGenerator.cs
@@ -22,12 +22,12 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             context.StringBuilder
                 .Append(VLatest.CompartmentAssignment.CompartmentTypeId, context.TableAlias)
                 .Append(" = ")
-                .Append(context.Parameters.AddParameter(VLatest.CompartmentAssignment.CompartmentTypeId, compartmentTypeId))
+                .Append(context.Parameters.AddParameter(VLatest.CompartmentAssignment.CompartmentTypeId, compartmentTypeId, true))
                 .AppendLine()
                 .Append("AND ")
                 .Append(VLatest.CompartmentAssignment.ReferenceResourceId, context.TableAlias)
                 .Append(" = ")
-                .Append(context.Parameters.AddParameter(VLatest.CompartmentAssignment.ReferenceResourceId, expression.CompartmentId));
+                .Append(context.Parameters.AddParameter(VLatest.CompartmentAssignment.ReferenceResourceId, expression.CompartmentId, true));
 
             return context;
         }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/PrimaryKeyRangeParameterQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/PrimaryKeyRangeParameterQueryGenerator.cs
@@ -24,9 +24,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             context.StringBuilder.AppendLine("(");
             using (context.StringBuilder.Indent())
             {
-                VisitSimpleBinary(BinaryOperator.Equal, context, VLatest.Resource.ResourceTypeId, null, primaryKeyRange.CurrentValue.ResourceTypeId);
+                VisitSimpleBinary(BinaryOperator.Equal, context, VLatest.Resource.ResourceTypeId, null, primaryKeyRange.CurrentValue.ResourceTypeId, includeInParameterHash: false);
                 context.StringBuilder.Append(" AND ");
-                VisitSimpleBinary(expression.BinaryOperator, context, VLatest.Resource.ResourceSurrogateId, null, primaryKeyRange.CurrentValue.ResourceSurrogateId);
+                VisitSimpleBinary(expression.BinaryOperator, context, VLatest.Resource.ResourceSurrogateId, null, primaryKeyRange.CurrentValue.ResourceSurrogateId, includeInParameterHash: false);
                 context.StringBuilder.AppendLine();
                 context.StringBuilder.Append("OR ");
                 AppendColumnName(context, VLatest.Resource.ResourceTypeId, (int?)null).Append(" IN (");
@@ -45,7 +45,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                             context.StringBuilder.Append(", ");
                         }
 
-                        context.StringBuilder.Append(context.Parameters.AddParameter(VLatest.Resource.ResourceTypeId, i));
+                        context.StringBuilder.Append(context.Parameters.AddParameter(VLatest.Resource.ResourceTypeId, i, includeInHash: false));
                     }
                 }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/QuantityQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/QuantityQueryGenerator.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                         .Append(" WHERE ")
                         .Append(VLatest.QuantityCode.Value, null)
                         .Append(" = ")
-                        .Append(context.Parameters.AddParameter(VLatest.QuantityCode.Value, expression.Value))
+                        .Append(context.Parameters.AddParameter(VLatest.QuantityCode.Value, expression.Value, true))
                         .Append(")");
 
                     return context;
@@ -75,7 +75,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                         .Append(" WHERE ")
                         .Append(VLatest.System.Value, null)
                         .Append(" = ")
-                        .Append(context.Parameters.AddParameter(VLatest.System.Value, expression.Value))
+                        .Append(context.Parameters.AddParameter(VLatest.System.Value, expression.Value, true))
                         .Append(")");
 
                     return context;

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/ResourceSurrogateIdParameterQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/ResourceSurrogateIdParameterQueryGenerator.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
         public override SearchParameterQueryGeneratorContext VisitBinary(BinaryExpression expression, SearchParameterQueryGeneratorContext context)
         {
-            VisitSimpleBinary(expression.BinaryOperator, context, VLatest.Resource.ResourceSurrogateId, expression.ComponentIndex, expression.Value);
+            VisitSimpleBinary(expression.BinaryOperator, context, VLatest.Resource.ResourceSurrogateId, expression.ComponentIndex, expression.Value, includeInParameterHash: false);
             return context;
         }
     }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SearchParameterQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SearchParameterQueryGenerator.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             return false;
         }
 
-        protected SearchParameterQueryGeneratorContext VisitSimpleBinary(BinaryOperator binaryOperator, SearchParameterQueryGeneratorContext context, Column column, int? componentIndex, object value)
+        protected SearchParameterQueryGeneratorContext VisitSimpleBinary(BinaryOperator binaryOperator, SearchParameterQueryGeneratorContext context, Column column, int? componentIndex, object value, bool includeInParameterHash = true)
         {
             AppendColumnName(context, column, componentIndex);
 
@@ -169,7 +169,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     throw new ArgumentOutOfRangeException(binaryOperator.ToString());
             }
 
-            context.StringBuilder.Append(context.Parameters.AddParameter(column, value).ParameterName);
+            context.StringBuilder.Append(context.Parameters.AddParameter(column, value, includeInParameterHash).ParameterName);
 
             return context;
         }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SearchParameterQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SearchParameterQueryGenerator.cs
@@ -230,7 +230,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
                     context.StringBuilder.Append(" AND ");
                     AppendColumnName(context, column, expression);
-                    SqlParameter equalsParameter = context.Parameters.AddParameter(column, value);
+                    SqlParameter equalsParameter = context.Parameters.AddParameter(column, value, true);
                     context.StringBuilder.Append(" = ").Append(equalsParameter.ParameterName);
                 }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SearchParameterQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SearchParameterQueryGenerator.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             context.StringBuilder
                 .Append(searchParamIdColumn, context.TableAlias)
                 .Append(" = ")
-                .AppendLine(context.Parameters.AddParameter(searchParamIdColumn, searchParamId).ParameterName)
+                .AppendLine(context.Parameters.AddParameter(searchParamIdColumn, searchParamId, true).ParameterName)
                 .Append("AND ");
 
             return expression.Expression.AcceptVisitor(this, context);
@@ -52,7 +52,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             context.StringBuilder
                 .Append(searchParamIdColumn, context.TableAlias)
                 .Append(" = ")
-                .AppendLine(context.Parameters.AddParameter(searchParamIdColumn, searchParamId).ParameterName);
+                .AppendLine(context.Parameters.AddParameter(searchParamIdColumn, searchParamId, true).ParameterName);
 
             return context;
         }
@@ -75,7 +75,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             context.StringBuilder
                 .Append(searchParamIdColumn, context.TableAlias)
                 .Append(" = ")
-                .AppendLine(context.Parameters.AddParameter(searchParamIdColumn, searchParamId).ParameterName);
+                .AppendLine(context.Parameters.AddParameter(searchParamIdColumn, searchParamId, true).ParameterName);
 
             return context;
         }
@@ -183,16 +183,16 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             {
                 case StringOperator.Contains:
                     needsEscaping = TryEscapeValueForLike(ref value);
-                    SqlParameter containsParameter = context.Parameters.AddParameter(column, $"%{value}%");
+                    SqlParameter containsParameter = context.Parameters.AddParameter(column, $"%{value}%", true);
                     context.StringBuilder.Append(" LIKE ").Append(containsParameter.ParameterName);
                     break;
                 case StringOperator.EndsWith:
                     needsEscaping = TryEscapeValueForLike(ref value);
-                    SqlParameter endWithParameter = context.Parameters.AddParameter(column, $"%{value}");
+                    SqlParameter endWithParameter = context.Parameters.AddParameter(column, $"%{value}", true);
                     context.StringBuilder.Append(" LIKE ").Append(endWithParameter.ParameterName);
                     break;
                 case StringOperator.Equals:
-                    SqlParameter equalsParameter = context.Parameters.AddParameter(column, value);
+                    SqlParameter equalsParameter = context.Parameters.AddParameter(column, value, true);
                     context.StringBuilder.Append(" = ").Append(equalsParameter.ParameterName);
                     break;
                 case StringOperator.NotContains:
@@ -206,7 +206,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     goto case StringOperator.StartsWith;
                 case StringOperator.StartsWith:
                     needsEscaping = TryEscapeValueForLike(ref value);
-                    SqlParameter startsWithParameter = context.Parameters.AddParameter(column, $"{value}%");
+                    SqlParameter startsWithParameter = context.Parameters.AddParameter(column, $"{value}%", true);
                     context.StringBuilder.Append(" LIKE ").Append(startsWithParameter.ParameterName);
                     break;
                 default:

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SearchParameterQueryGeneratorContext.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SearchParameterQueryGeneratorContext.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 {
     internal readonly struct SearchParameterQueryGeneratorContext
     {
-        internal SearchParameterQueryGeneratorContext(IndentedStringBuilder stringBuilder, SqlQueryParameterManager parameters, ISqlServerFhirModel model, SchemaInformation schemaInformation, string tableAlias = null)
+        internal SearchParameterQueryGeneratorContext(IndentedStringBuilder stringBuilder, HashingSqlQueryParameterManager parameters, ISqlServerFhirModel model, SchemaInformation schemaInformation, string tableAlias = null)
         {
             EnsureArg.IsNotNull(stringBuilder, nameof(stringBuilder));
             EnsureArg.IsNotNull(parameters, nameof(parameters));
@@ -29,7 +29,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
         public IndentedStringBuilder StringBuilder { get; }
 
-        public SqlQueryParameterManager Parameters { get; }
+        public HashingSqlQueryParameterManager Parameters { get; }
 
         public ISqlServerFhirModel Model { get; }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -549,19 +549,19 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             using (var delimited = StringBuilder.BeginDelimitedWhereClause())
             {
                 delimited.BeginDelimitedElement().Append(VLatest.ReferenceSearchParam.SearchParamId, referenceSourceTableAlias)
-                    .Append(" = ").Append(Parameters.AddParameter(VLatest.ReferenceSearchParam.SearchParamId, Model.GetSearchParamId(chainedExpression.ReferenceSearchParameter.Url)));
+                    .Append(" = ").Append(Parameters.AddParameter(VLatest.ReferenceSearchParam.SearchParamId, Model.GetSearchParamId(chainedExpression.ReferenceSearchParameter.Url), true));
 
                 AppendHistoryClause(delimited, referenceTargetResourceTableAlias);
                 AppendHistoryClause(delimited, referenceSourceTableAlias);
 
                 delimited.BeginDelimitedElement().Append(VLatest.ReferenceSearchParam.ResourceTypeId, referenceSourceTableAlias)
                     .Append(" IN (")
-                    .Append(string.Join(", ", chainedExpression.ResourceTypes.Select(x => Parameters.AddParameter(VLatest.ReferenceSearchParam.ResourceTypeId, Model.GetResourceTypeId(x)))))
+                    .Append(string.Join(", ", chainedExpression.ResourceTypes.Select(x => Parameters.AddParameter(VLatest.ReferenceSearchParam.ResourceTypeId, Model.GetResourceTypeId(x), true))))
                     .Append(")");
 
                 delimited.BeginDelimitedElement().Append(VLatest.ReferenceSearchParam.ReferenceResourceTypeId, referenceSourceTableAlias)
                     .Append(" IN (")
-                    .Append(string.Join(", ", chainedExpression.TargetResourceTypes.Select(x => Parameters.AddParameter(VLatest.ReferenceSearchParam.ReferenceResourceTypeId, Model.GetResourceTypeId(x)))))
+                    .Append(string.Join(", ", chainedExpression.TargetResourceTypes.Select(x => Parameters.AddParameter(VLatest.ReferenceSearchParam.ReferenceResourceTypeId, Model.GetResourceTypeId(x), true))))
                     .Append(")");
 
                 if (searchParamTableExpression.ChainLevel == 1)
@@ -628,12 +628,12 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                 if (!includeExpression.WildCard)
                 {
                     delimited.BeginDelimitedElement().Append(VLatest.ReferenceSearchParam.SearchParamId, referenceSourceTableAlias)
-                        .Append(" = ").Append(Parameters.AddParameter(VLatest.ReferenceSearchParam.SearchParamId, Model.GetSearchParamId(includeExpression.ReferenceSearchParameter.Url)));
+                        .Append(" = ").Append(Parameters.AddParameter(VLatest.ReferenceSearchParam.SearchParamId, Model.GetSearchParamId(includeExpression.ReferenceSearchParameter.Url), true));
 
                     if (includeExpression.TargetResourceType != null)
                     {
                         delimited.BeginDelimitedElement().Append(VLatest.ReferenceSearchParam.ReferenceResourceTypeId, referenceSourceTableAlias)
-                            .Append(" = ").Append(Parameters.AddParameter(VLatest.ReferenceSearchParam.ReferenceResourceTypeId, Model.GetResourceTypeId(includeExpression.TargetResourceType)));
+                            .Append(" = ").Append(Parameters.AddParameter(VLatest.ReferenceSearchParam.ReferenceResourceTypeId, Model.GetResourceTypeId(includeExpression.TargetResourceType), true));
                     }
                 }
 
@@ -706,7 +706,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                 if (includeExpression.Reversed)
                 {
                     delimited.BeginDelimitedElement().Append(VLatest.ReferenceSearchParam.ResourceTypeId, referenceSourceTableAlias)
-                        .Append(" = ").Append(Parameters.AddParameter(VLatest.ReferenceSearchParam.ResourceTypeId, Model.GetResourceTypeId(includeExpression.SourceResourceType)));
+                        .Append(" = ").Append(Parameters.AddParameter(VLatest.ReferenceSearchParam.ResourceTypeId, Model.GetResourceTypeId(includeExpression.SourceResourceType), true));
                 }
 
                 delimited.BeginDelimitedElement().Append("EXISTS( SELECT * FROM ").Append(fromCte)
@@ -718,7 +718,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     // Limit the join to the main select CTE.
                     // The main select will have max+1 items in the result set to account for paging, so we only want to join using the max amount.
 
-                    StringBuilder.Append(" AND Row < ").Append(Parameters.AddParameter(context.MaxItemCount + 1));
+                    StringBuilder.Append(" AND Row < ").Append(Parameters.AddParameter(context.MaxItemCount + 1, true));
                 }
 
                 StringBuilder.Append(")");
@@ -797,7 +797,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             if (isRev)
             {
                 StringBuilder.Append("CASE WHEN count(*) over() > ")
-                    .Append(Parameters.AddParameter(context.IncludeCount))
+                    .Append(Parameters.AddParameter(context.IncludeCount, true))
                     .AppendLine(" THEN 1 ELSE 0 END AS IsPartial ");
             }
             else
@@ -914,11 +914,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             // the related cte is a reverse include, limit the number of returned items and count to
             // see if we are over the threshold (to produce a warning to the client)
             StringBuilder.Append("SELECT DISTINCT ");
-            StringBuilder.Append("TOP (").Append(Parameters.AddParameter(context.IncludeCount)).Append(") ");
+            StringBuilder.Append("TOP (").Append(Parameters.AddParameter(context.IncludeCount, true)).Append(") ");
 
             StringBuilder.Append("T1, Sid1, IsMatch, ");
             StringBuilder.Append("CASE WHEN count(*) over() > ")
-                .Append(Parameters.AddParameter(context.IncludeCount))
+                .Append(Parameters.AddParameter(context.IncludeCount, true))
                 .AppendLine(" THEN 1 ELSE 0 END AS IsPartial ");
 
             StringBuilder.Append("FROM ").AppendLine(cteToLimit);
@@ -998,7 +998,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             {
                 delimited.BeginDelimitedElement();
 
-                StringBuilder.Append("(").Append(VLatest.Resource.SearchParamHash, tableAlias).Append(" != ").Append(Parameters.AddParameter(_searchParameterHash)).Append(" OR ").Append(VLatest.Resource.SearchParamHash, tableAlias).Append(" IS NULL)");
+                StringBuilder.Append("(").Append(VLatest.Resource.SearchParamHash, tableAlias).Append(" != ").Append(Parameters.AddParameter(_searchParameterHash, true)).Append(" OR ").Append(VLatest.Resource.SearchParamHash, tableAlias).Append(" IS NULL)");
             }
         }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/TokenQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/TokenQueryGenerator.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                         .Append(" WHERE ")
                         .Append(VLatest.System.Value, null)
                         .Append(" = ")
-                        .Append(context.Parameters.AddParameter(VLatest.System.Value, expression.Value))
+                        .Append(context.Parameters.AddParameter(VLatest.System.Value, expression.Value, true))
                         .Append(")");
 
                     return context;

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/HashingSqlQueryParameterManager.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/HashingSqlQueryParameterManager.cs
@@ -1,0 +1,201 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using EnsureThat;
+using Microsoft.Data.SqlClient;
+using Microsoft.Health.SqlServer;
+using Microsoft.Health.SqlServer.Features.Schema.Model;
+using Microsoft.Health.SqlServer.Features.Storage;
+
+namespace Microsoft.Health.Fhir.SqlServer.Features.Search
+{
+    /// <summary>
+    /// Wraps a <see cref="SqlQueryParameterManager"/>, adding the ability to compute a hash of a subset of the parameters.
+    /// </summary>
+    public class HashingSqlQueryParameterManager
+    {
+        private readonly SqlQueryParameterManager _inner;
+        private readonly HashSet<SqlParameter> _setToHash = new();
+
+        public HashingSqlQueryParameterManager(SqlQueryParameterManager inner)
+        {
+            EnsureArg.IsNotNull(inner, nameof(inner));
+            _inner = inner;
+        }
+
+        public bool HasParametersToHash => _setToHash.Count > 0;
+
+        public SqlParameter AddParameter<T>(Column<T> column, T value, bool includeInHash = true)
+        {
+            return AddParameter((Column)column, value, includeInHash);
+        }
+
+        public SqlParameter AddParameter(Column column, object value, bool includeInHash = true)
+        {
+            SqlParameter parameter = _inner.AddParameter(column, value);
+            if (includeInHash)
+            {
+                _setToHash.Add(parameter);
+            }
+
+            return parameter;
+        }
+
+        public SqlParameter AddParameter(object value, bool includeInHash = true)
+        {
+            SqlParameter parameter = _inner.AddParameter(value);
+            if (includeInHash)
+            {
+                _setToHash.Add(parameter);
+            }
+
+            return parameter;
+        }
+
+        /// <summary>
+        /// Appends a Base64-encoded SHA-256 hash of the parameters currently added to this instance with includeInHash = true
+        /// </summary>
+        /// <param name="stringBuilder">A string builder to append the hash to.</param>
+        public void AppendHash(IndentedStringBuilder stringBuilder)
+        {
+            IncrementalHash incrementalHash = null;
+            Span<byte> buf = stackalloc byte[256];
+            int currentBufferIndex = 0;
+
+            foreach (SqlParameter sqlParameter in _setToHash)
+            {
+                if (!_setToHash.Contains(sqlParameter))
+                {
+                    continue;
+                }
+
+                switch (sqlParameter.SqlDbType)
+                {
+                    case SqlDbType.BigInt:
+                        WriteAndAdvance(buf, ref currentBufferIndex, ref incrementalHash, (long)sqlParameter.Value);
+                        break;
+                    case SqlDbType.Bit:
+                        WriteAndAdvance(buf, ref currentBufferIndex, ref incrementalHash, (bool)sqlParameter.Value);
+                        break;
+                    case SqlDbType.Date:
+                    case SqlDbType.DateTime:
+                    case SqlDbType.DateTime2:
+                    case SqlDbType.SmallDateTime:
+                    case SqlDbType.Time:
+                        WriteAndAdvance(buf, ref currentBufferIndex, ref incrementalHash, (DateTime)sqlParameter.Value);
+                        break;
+                    case SqlDbType.DateTimeOffset:
+                        WriteAndAdvance(buf, ref currentBufferIndex, ref incrementalHash, (DateTimeOffset)sqlParameter.Value);
+                        break;
+                    case SqlDbType.Decimal:
+                        WriteAndAdvance(buf, ref currentBufferIndex, ref incrementalHash, (decimal)sqlParameter.Value);
+                        break;
+                    case SqlDbType.Float:
+                    case SqlDbType.Real:
+                        WriteAndAdvance(buf, ref currentBufferIndex, ref incrementalHash, (double)sqlParameter.Value);
+                        break;
+                    case SqlDbType.Int:
+                        WriteAndAdvance(buf, ref currentBufferIndex, ref incrementalHash, (int)sqlParameter.Value);
+                        break;
+                    case SqlDbType.SmallInt:
+                        WriteAndAdvance(buf, ref currentBufferIndex, ref incrementalHash, (short)sqlParameter.Value);
+                        break;
+                    case SqlDbType.TinyInt:
+                        WriteAndAdvance(buf, ref currentBufferIndex, ref incrementalHash, (byte)sqlParameter.Value);
+                        break;
+                    case SqlDbType.UniqueIdentifier:
+                        WriteAndAdvance(buf, ref currentBufferIndex, ref incrementalHash, (Guid)sqlParameter.Value);
+                        break;
+                    case SqlDbType.NChar:
+                    case SqlDbType.NText:
+                    case SqlDbType.VarChar:
+                    case SqlDbType.NVarChar:
+                    case SqlDbType.Text:
+                        WriteAndAdvanceString(buf, ref currentBufferIndex, ref incrementalHash, (string)sqlParameter.Value);
+                        break;
+                    default:
+                        throw new InvalidOperationException($"Unexpected parameter type {sqlParameter.SqlDbType}");
+                }
+            }
+
+            Span<byte> hashBytes = stackalloc byte[32];
+
+            if (incrementalHash != null)
+            {
+                if (currentBufferIndex > 0)
+                {
+                    incrementalHash.AppendData(buf[..currentBufferIndex]);
+                }
+
+                incrementalHash.GetCurrentHash(hashBytes);
+                incrementalHash.Dispose();
+            }
+            else
+            {
+                if (!SHA256.TryHashData(buf[..currentBufferIndex], hashBytes, out _))
+                {
+                    throw new InvalidOperationException("Failed to hash data");
+                }
+            }
+
+            Span<char> hashChars = stackalloc char[44]; // 44 since inputLength = 32 and inputLength => (inputLength / 3 * 4) + (((inputLength % 3) != 0) ? 4 : 0) = 44
+
+            if (!Convert.TryToBase64Chars(hashBytes, hashChars, out int hashCharsLength))
+            {
+                throw new InvalidOperationException("Failed to convert to Base64 chars.");
+            }
+
+            stringBuilder.Append(hashChars[..hashCharsLength]);
+        }
+
+        private static void WriteAndAdvance<T>(Span<byte> buffer, ref int currentIndex, ref IncrementalHash incrementalHash, T element)
+            where T : struct
+        {
+            int elementLength = Unsafe.SizeOf<T>();
+            if (currentIndex + elementLength > buffer.Length)
+            {
+                incrementalHash ??= IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+
+                incrementalHash.AppendData(buffer[..currentIndex]);
+                currentIndex = 0;
+                Debug.Assert(buffer.Length >= elementLength, "Initial buffer size is not large enough for the datatypes we are trying to write to it");
+            }
+
+            MemoryMarshal.Write(buffer[currentIndex..], ref element);
+            currentIndex += elementLength;
+        }
+
+        private static void WriteAndAdvanceString(Span<byte> buffer, ref int currentIndex, ref IncrementalHash incrementalHash, string element)
+        {
+            ReadOnlySpan<byte> elementSpan = MemoryMarshal.AsBytes(element.AsSpan());
+
+            if (currentIndex + elementSpan.Length > buffer.Length)
+            {
+                incrementalHash ??= IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+
+                incrementalHash.AppendData(buffer[..currentIndex]);
+                currentIndex = 0;
+            }
+
+            if (currentIndex + elementSpan.Length > buffer.Length)
+            {
+                // still too big to fit.
+                incrementalHash.AppendData(elementSpan);
+            }
+            else
+            {
+                elementSpan.CopyTo(buffer);
+                currentIndex += elementSpan.Length;
+            }
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/HashingSqlQueryParameterManager.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/HashingSqlQueryParameterManager.cs
@@ -34,12 +34,32 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
 
         public bool HasParametersToHash => _setToHash.Count > 0;
 
-        public SqlParameter AddParameter<T>(Column<T> column, T value, bool includeInHash = true)
+        /// <summary>
+        /// Add a parameter to the SQL command.
+        /// </summary>
+        /// <param name="column">The table column the parameter is bound to.</param>
+        /// <param name="value">The parameter value.</param>
+        /// <param name="includeInHash">
+        /// Whether this parameter should be included in the hash of the overall parameters.
+        /// If true, this parameter will prevent other identical queries with a different value for this parameter from re-using the query plan.
+        /// </param>
+        /// <returns>The SQL parameter.</returns>
+        public SqlParameter AddParameter<T>(Column<T> column, T value, bool includeInHash)
         {
             return AddParameter((Column)column, value, includeInHash);
         }
 
-        public SqlParameter AddParameter(Column column, object value, bool includeInHash = true)
+        /// <summary>
+        /// Add a parameter to the SQL command.
+        /// </summary>
+        /// <param name="column">The table column the parameter is bound to.</param>
+        /// <param name="value">The parameter value</param>
+        /// <param name="includeInHash">
+        /// Whether this parameter should be included in the hash of the overall parameters.
+        /// If true, this parameter will prevent other identical queries with a different value for this parameter from re-using the query plan.
+        /// </param>
+        /// <returns>The SQL parameter.</returns>
+        public SqlParameter AddParameter(Column column, object value, bool includeInHash)
         {
             SqlParameter parameter = _inner.AddParameter(column, value);
             if (includeInHash)
@@ -50,7 +70,16 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
             return parameter;
         }
 
-        public SqlParameter AddParameter(object value, bool includeInHash = true)
+        /// <summary>
+        /// Add a parameter to the SQL command.
+        /// </summary>
+        /// <param name="value">The parameter value</param>
+        /// <param name="includeInHash">
+        /// Whether this parameter should be included in the hash of the overall parameters.
+        /// If true, this parameter will prevent other identical queries with a different value for this parameter from re-using the query plan.
+        /// </param>
+        /// <returns>The SQL parameter.</returns>
+        public SqlParameter AddParameter(object value, bool includeInHash)
         {
             SqlParameter parameter = _inner.AddParameter(value);
             if (includeInHash)
@@ -73,11 +102,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
 
             foreach (SqlParameter sqlParameter in _setToHash)
             {
-                if (!_setToHash.Contains(sqlParameter))
-                {
-                    continue;
-                }
-
                 switch (sqlParameter.SqlDbType)
                 {
                     case SqlDbType.BigInt:

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -228,9 +228,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
 
                 EnableTimeAndIoMessageLogging(stringBuilder, sqlConnectionWrapper);
 
+                var parameters = new HashingSqlQueryParameterManager(new SqlQueryParameterManager(sqlCommandWrapper.Parameters));
+
                 var queryGenerator = new SqlQueryGenerator(
                     stringBuilder,
-                    new SqlQueryParameterManager(sqlCommandWrapper.Parameters),
+                    parameters,
                     _model,
                     searchType,
                     _schemaInformation,

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -228,11 +228,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
 
                 EnableTimeAndIoMessageLogging(stringBuilder, sqlConnectionWrapper);
 
-                var parameters = new HashingSqlQueryParameterManager(new SqlQueryParameterManager(sqlCommandWrapper.Parameters));
-
                 var queryGenerator = new SqlQueryGenerator(
                     stringBuilder,
-                    parameters,
+                    new HashingSqlQueryParameterManager(new SqlQueryParameterManager(sqlCommandWrapper.Parameters)),
                     _model,
                     searchType,
                     _schemaInformation,


### PR DESCRIPTION
## Description

We currently add `OPTION(RECOMPILE)` to every query we generate for searches. The reason for this is that the optimizer chooses different query plans based on parameter values and sometimes there can be an enormous differences in performance between plans.

But there is a cost to recompiling queries:

|                      | Logical reads WITHOUT caching | Duration WITHOUT caching (ms) | Logical reads WITH cache hit| Duration WITH cache hit (ms) |
|----------------------|-------------------------------|-------------------------------|----------------------------|---------------------------|
| /Patient?gender=male | 191                           | 15                            | 39                         | 2                         |
| /Patient?family=Smith&birthdate=1982-11-05| 631                           | 57                            | 21                         | 3                         |
| /MedicationRequest?subject:Patient.identifier=999-60-8644 | 382                           | 32                            | 3                          | 4                         |

This PR makes a first change in avoiding recompilations for every query. We remove the `OPTION(RECOMPILE)` hint, and instead add a hash of a subset of the parameter values in a comment. This means that two identical searches will have the same query text and can use the same query plan. 

Excluded from the hashes are `TOP` values and parameters related to continuation tokens (so we don't require recompiling for every page of a query).

We'll want to to more here; this is just a first step. A promising option is 
[`OPTIMIZE FOR ( @variable_name { UNKNOWN | = <literal_constant> } [ , ...n ] ) ` ](https://docs.microsoft.com/en-us/sql/t-sql/queries/hints-transact-sql-query?view=sql-server-ver15).

## Testing
Manual and unit tests

