### PR TITLE
Update IFhirRequestContextAccessor for RequestContextAccessor<IFhirRequestContext>

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/ApiNotifications/ApiNotificationMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/ApiNotifications/ApiNotificationMiddleware.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Health.Fhir.Api.Features.ApiNotifications
 
                     try
                     {
-                        IFhirRequestContext fhirRequestContext = _fhirRequestContextAccessor.FhirRequestContext;
+                        IFhirRequestContext fhirRequestContext = _fhirRequestContextAccessor.RequestContext;
 
                         // For now, we will only emit metrics for audited actions (e.g., metadata will not emit metrics).
                         if (fhirRequestContext?.AuditEventType != null)

--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditHelper.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditHelper.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
 
         private void Log(AuditAction auditAction, HttpStatusCode? statusCode, HttpContext httpContext, IClaimsExtractor claimsExtractor)
         {
-            IFhirRequestContext fhirRequestContext = _fhirRequestContextAccessor.FhirRequestContext;
+            IFhirRequestContext fhirRequestContext = _fhirRequestContextAccessor.RequestContext;
 
             string auditEventType = fhirRequestContext.AuditEventType;
 

--- a/src/Microsoft.Health.Fhir.Api/Features/Context/FhirRequestContextAfterAuthenticationMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Context/FhirRequestContextAfterAuthenticationMiddleware.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Context
             // Now the authentication is completed successfully, sets the user.
             if (context.User != null)
             {
-                fhirRequestContextAccessor.FhirRequestContext.Principal = context.User;
+                fhirRequestContextAccessor.RequestContext.Principal = context.User;
             }
 
             // Call the next delegate/middleware in the pipeline

--- a/src/Microsoft.Health.Fhir.Api/Features/Context/FhirRequestContextBeforeAuthenticationMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Context/FhirRequestContextBeforeAuthenticationMiddleware.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Context
                 // The authorization middleware runs before MVC middleware and therefore,
                 // information related to route and audit will not be populated if authentication fails.
                 // Handle such condition and populate them here if possible.
-                if (_fhirRequestContextAccessor.FhirRequestContext.RouteName == null &&
+                if (_fhirRequestContextAccessor.RequestContext.RouteName == null &&
                     (statusCode == HttpStatusCode.Unauthorized || statusCode == HttpStatusCode.Forbidden))
                 {
                     RouteData routeData = context.GetRouteData();
@@ -62,7 +62,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Context
                         routeData.Values.TryGetValue("action", out object actionName);
                         routeData.Values.TryGetValue(KnownActionParameterNames.ResourceType, out object resourceType);
 
-                        IFhirRequestContext fhirRequestContext = _fhirRequestContextAccessor.FhirRequestContext;
+                        IFhirRequestContext fhirRequestContext = _fhirRequestContextAccessor.RequestContext;
 
                         fhirRequestContext.AuditEventType = _auditEventTypeMapping.GetAuditEventType(
                             controllerName?.ToString(),

--- a/src/Microsoft.Health.Fhir.Api/Features/Context/FhirRequestContextMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Context/FhirRequestContextMiddleware.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Context
 
             context.Response.Headers[KnownHeaders.RequestId] = correlationId;
 
-            fhirRequestContextAccessor.FhirRequestContext = fhirRequestContext;
+            fhirRequestContextAccessor.RequestContext = fhirRequestContext;
 
             // Call the next delegate/middleware in the pipeline
             await _next(context);

--- a/src/Microsoft.Health.Fhir.Api/Features/ExceptionNotifications/ExceptionNotificationMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/ExceptionNotifications/ExceptionNotificationMiddleware.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Health.Fhir.Api.Features.ExceptionNotifications
 
                 try
                 {
-                    IFhirRequestContext fhirRequestContext = _fhirRequestContextAccessor.FhirRequestContext;
+                    IFhirRequestContext fhirRequestContext = _fhirRequestContextAccessor.RequestContext;
                     var innerMostException = exception.GetInnerMostException();
 
                     exceptionNotification.CorrelationId = fhirRequestContext?.CorrelationId;

--- a/src/Microsoft.Health.Fhir.Api/Features/Routing/UrlResolver.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Routing/UrlResolver.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
 
         public Uri ResolveRouteUrl(IEnumerable<Tuple<string, string>> unsupportedSearchParams = null, IReadOnlyList<(SearchParameterInfo searchParameterInfo, SortOrder sortOrder)> resultSortOrder = null, string continuationToken = null, bool removeTotalParameter = false)
         {
-            string routeName = _fhirRequestContextAccessor.FhirRequestContext.RouteName;
+            string routeName = _fhirRequestContextAccessor.RequestContext.RouteName;
 
             Debug.Assert(!string.IsNullOrWhiteSpace(routeName), "The routeName should not be null or empty.");
 

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Context/FhirRequestContextAccessorTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Context/FhirRequestContextAccessorTests.cs
@@ -23,9 +23,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Context
                 IFhirRequestContext fhirRequestContext = Substitute.For<IFhirRequestContext>();
                 fhirRequestContext.CorrelationId.Returns(Guid.NewGuid().ToString());
 
-                fhirRequestContextAccessor.FhirRequestContext = fhirRequestContext;
+                fhirRequestContextAccessor.RequestContext = fhirRequestContext;
                 await Task.Delay(50);
-                return fhirRequestContextAccessor.FhirRequestContext;
+                return fhirRequestContextAccessor.RequestContext;
             });
 
             var thread2 = Task.Run(async () =>
@@ -33,9 +33,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Context
                 IFhirRequestContext fhirRequestContext = Substitute.For<IFhirRequestContext>();
                 fhirRequestContext.CorrelationId.Returns(Guid.NewGuid().ToString());
 
-                fhirRequestContextAccessor.FhirRequestContext = fhirRequestContext;
+                fhirRequestContextAccessor.RequestContext = fhirRequestContext;
                 await Task.Delay(0);
-                return fhirRequestContextAccessor.FhirRequestContext;
+                return fhirRequestContextAccessor.RequestContext;
             });
 
             var correlationId1 = (await thread1).CorrelationId;

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportJobTaskTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportJobTaskTests.cs
@@ -402,7 +402,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
                 _cancellationToken)
                 .Returns(x =>
                 {
-                    _contextAccessor.FhirRequestContext.BundleIssues.Add(issue);
+                    _contextAccessor.RequestContext.BundleIssues.Add(issue);
 
                     return CreateSearchResult();
                 });

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Security/PrincipalClaimsExtractorTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Security/PrincipalClaimsExtractorTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Security
         public PrincipalClaimsExtractorTests()
         {
             _securityOptions.Value.Returns(_securityConfiguration);
-            _fhirRequestContextAccessor.FhirRequestContext.Principal.Returns(_claimsPrincipal);
+            _fhirRequestContextAccessor.RequestContext.Principal.Returns(_claimsPrincipal);
             _claimsIndexer = new PrincipalClaimsExtractor(_fhirRequestContextAccessor, _securityOptions);
         }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Context/FhirRequestContextAccessor.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Context/FhirRequestContextAccessor.cs
@@ -4,14 +4,15 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Threading;
+using Microsoft.Health.Core.Features.Context;
 
 namespace Microsoft.Health.Fhir.Core.Features.Context
 {
-    public class FhirRequestContextAccessor : IFhirRequestContextAccessor
+    public class FhirRequestContextAccessor : RequestContextAccessor<IFhirRequestContext>, IFhirRequestContextAccessor
     {
         private readonly AsyncLocal<IFhirRequestContext> _fhirRequestContextCurrent = new AsyncLocal<IFhirRequestContext>();
 
-        public IFhirRequestContext FhirRequestContext
+        public override IFhirRequestContext RequestContext
         {
             get => _fhirRequestContextCurrent.Value;
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Context/IFhirRequestContextAccessor.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Context/IFhirRequestContextAccessor.cs
@@ -7,6 +7,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Context
 {
     public interface IFhirRequestContextAccessor
     {
-        IFhirRequestContext FhirRequestContext { get; set; }
+        IFhirRequestContext RequestContext { get; set; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchableSearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchableSearchParameterDefinitionManager.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
 
         public IEnumerable<SearchParameterInfo> GetSearchParameters(string resourceType)
         {
-            if (_fhirReqeustContextAccessor.FhirRequestContext.IncludePartiallyIndexedSearchParams)
+            if (_fhirReqeustContextAccessor.RequestContext.IncludePartiallyIndexedSearchParams)
             {
                 return _inner.GetSearchParameters(resourceType)
                 .Where(x => x.IsSupported);
@@ -54,7 +54,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             searchParameter = null;
 
             if (_inner.TryGetSearchParameter(resourceType, name, out var parameter) &&
-                (parameter.IsSearchable || (_fhirReqeustContextAccessor.FhirRequestContext.IncludePartiallyIndexedSearchParams && parameter.IsSupported)))
+                (parameter.IsSearchable || (_fhirReqeustContextAccessor.RequestContext.IncludePartiallyIndexedSearchParams && parameter.IsSupported)))
             {
                 searchParameter = parameter;
 
@@ -69,7 +69,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             SearchParameterInfo parameter = _inner.GetSearchParameter(resourceType, name);
 
             if (parameter.IsSearchable ||
-                (_fhirReqeustContextAccessor.FhirRequestContext.IncludePartiallyIndexedSearchParams && parameter.IsSupported))
+                (_fhirReqeustContextAccessor.RequestContext.IncludePartiallyIndexedSearchParams && parameter.IsSupported))
             {
                 return parameter;
             }
@@ -82,7 +82,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             SearchParameterInfo parameter = _inner.GetSearchParameter(definitionUri);
 
             if (parameter.IsSearchable ||
-                (_fhirReqeustContextAccessor.FhirRequestContext.IncludePartiallyIndexedSearchParams && parameter.IsSupported))
+                (_fhirReqeustContextAccessor.RequestContext.IncludePartiallyIndexedSearchParams && parameter.IsSupported))
             {
                 return parameter;
             }
@@ -92,7 +92,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
 
         private IEnumerable<SearchParameterInfo> GetAllSearchParameters()
         {
-            if (_fhirReqeustContextAccessor.FhirRequestContext.IncludePartiallyIndexedSearchParams)
+            if (_fhirReqeustContextAccessor.RequestContext.IncludePartiallyIndexedSearchParams)
             {
                 return _inner.AllSearchParameters.Where(x => x.IsSupported);
             }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
             _weakETag = weakETag;
             _fileManager = new ExportFileManager(_exportJobRecord, _exportDestinationClient);
 
-            var existingFhirRequestContext = _contextAccessor.FhirRequestContext;
+            var existingFhirRequestContext = _contextAccessor.RequestContext;
 
             try
             {
@@ -112,7 +112,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                     IsBackgroundTask = true,
                 };
 
-                _contextAccessor.FhirRequestContext = fhirRequestContext;
+                _contextAccessor.RequestContext = fhirRequestContext;
 
                 string connectionHash = string.IsNullOrEmpty(_exportJobConfiguration.StorageAccountConnection) ?
                     string.Empty :
@@ -222,7 +222,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
             }
             finally
             {
-                _contextAccessor.FhirRequestContext = existingFhirRequestContext;
+                _contextAccessor.RequestContext = existingFhirRequestContext;
             }
         }
 
@@ -239,9 +239,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
         private async Task UpdateJobRecordAsync(CancellationToken cancellationToken)
         {
-            if (_contextAccessor?.FhirRequestContext?.BundleIssues != null)
+            if (_contextAccessor?.RequestContext?.BundleIssues != null)
             {
-                foreach (OperationOutcomeIssue issue in _contextAccessor.FhirRequestContext.BundleIssues)
+                foreach (OperationOutcomeIssue issue in _contextAccessor.RequestContext.BundleIssues)
                 {
                     _exportJobRecord.Issues.Add(issue);
                 }
@@ -254,7 +254,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                 _exportJobRecord = updatedExportJobOutcome.JobRecord;
                 _weakETag = updatedExportJobOutcome.ETag;
 
-                _contextAccessor.FhirRequestContext.BundleIssues.Clear();
+                _contextAccessor.RequestContext.BundleIssues.Clear();
             }
         }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             _weakETag = weakETag;
             var jobSemaphore = new SemaphoreSlim(1, 1);
 
-            var existingFhirRequestContext = _contextAccessor.FhirRequestContext;
+            var existingFhirRequestContext = _contextAccessor.RequestContext;
 
             try
             {
@@ -103,7 +103,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     AuditEventType = OperationsConstants.Reindex,
                 };
 
-                _contextAccessor.FhirRequestContext = fhirRequestContext;
+                _contextAccessor.RequestContext = fhirRequestContext;
 
                 using (IScoped<IFhirDataStore> store = _fhirDataStoreFactory())
                 {
@@ -345,7 +345,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             finally
             {
                 jobSemaphore.Dispose();
-                _contextAccessor.FhirRequestContext = existingFhirRequestContext;
+                _contextAccessor.RequestContext = existingFhirRequestContext;
             }
         }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Persistence/ResourceWrapperFactory.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Persistence/ResourceWrapperFactory.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
 
             ExtractMinAndMaxValues(searchIndices);
 
-            IFhirRequestContext fhirRequestContext = _fhirRequestContextAccessor.FhirRequestContext;
+            IFhirRequestContext fhirRequestContext = _fhirRequestContextAccessor.RequestContext;
 
             return new ResourceWrapper(
                 resource,

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/ReferenceSearchValueParser.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/ReferenceSearchValueParser.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.SearchValues
                 {
                     baseUri = new Uri(s.Substring(0, resourceTypeStartIndex), UriKind.RelativeOrAbsolute);
 
-                    if (baseUri == _fhirRequestContextAccessor.FhirRequestContext.BaseUri)
+                    if (baseUri == _fhirRequestContextAccessor.RequestContext.BaseUri)
                     {
                         // This is an absolute URL pointing to an internal resource.
                         return new ReferenceSearchValue(

--- a/src/Microsoft.Health.Fhir.Core/Features/Security/Authorization/RoleBasedFhirAuthorizationService.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Security/Authorization/RoleBasedFhirAuthorizationService.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Security.Authorization
 
         public ValueTask<DataActions> CheckAccess(DataActions dataActions, CancellationToken cancellationToken)
         {
-            ClaimsPrincipal principal = _requestContextAccessor.FhirRequestContext.Principal;
+            ClaimsPrincipal principal = _requestContextAccessor.RequestContext.Principal;
 
             DataActions permittedDataActions = 0;
             foreach (Claim claim in principal.FindAll(_rolesClaimName))

--- a/src/Microsoft.Health.Fhir.Core/Features/Security/PrincipalClaimsExtractor.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Security/PrincipalClaimsExtractor.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Security
 
         public IReadOnlyCollection<KeyValuePair<string, string>> Extract()
         {
-            return _fhirRequestContextAccessor.FhirRequestContext.Principal?.Claims?
+            return _fhirRequestContextAccessor.RequestContext.Principal?.Claims?
                 .Where(c => _securityConfiguration.PrincipalClaims?.Contains(c.Type) ?? false)
                 .Select(c => new KeyValuePair<string, string>(c.Type, c.Value))
                 .ToList();

--- a/src/Microsoft.Health.Fhir.Core/Features/Validation/ResourceProfileValidator.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Validation/ResourceProfileValidator.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
 
             if (context.PropertyValue is ResourceElement resourceElement)
             {
-                var fhirContext = _contextAccessor.FhirRequestContext;
+                var fhirContext = _contextAccessor.RequestContext;
                 var profileValidation = _runProfileValidation;
                 if (fhirContext.RequestHeaders.ContainsKey(KnownHeaders.ProfileValidation)
                     && fhirContext.RequestHeaders.TryGetValue(KnownHeaders.ProfileValidation, out var value))

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Operations/Reindex/ReindexJobCosmosThrottleControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Operations/Reindex/ReindexJobCosmosThrottleControllerTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Operations.Reindex
                 IsBackgroundTask = true,
                 AuditEventType = OperationsConstants.Reindex,
             };
-            _fhirRequestContextAccessor.FhirRequestContext = fhirRequestContext;
+            _fhirRequestContextAccessor.RequestContext = fhirRequestContext;
         }
 
         [Fact]
@@ -54,7 +54,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Operations.Reindex
             while (loopCount < 16)
             {
                 _output.WriteLine($"Current throttle based delay is: {throttleController.GetThrottleBasedDelay()}");
-                _fhirRequestContextAccessor.FhirRequestContext.ResponseHeaders.Add(CosmosDbHeaders.RequestCharge, "100.0");
+                _fhirRequestContextAccessor.RequestContext.ResponseHeaders.Add(CosmosDbHeaders.RequestCharge, "100.0");
                 throttleController.UpdateDatastoreUsage();
                 await Task.Delay(reindexJob.QueryDelayIntervalInMilliseconds + throttleController.GetThrottleBasedDelay());
                 loopCount++;
@@ -77,7 +77,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Operations.Reindex
             while (loopCount < 17)
             {
                 _output.WriteLine($"Current throttle based delay is: {throttleController.GetThrottleBasedDelay()}");
-                _fhirRequestContextAccessor.FhirRequestContext.ResponseHeaders.Add(CosmosDbHeaders.RequestCharge, "100.0");
+                _fhirRequestContextAccessor.RequestContext.ResponseHeaders.Add(CosmosDbHeaders.RequestCharge, "100.0");
                 throttleController.UpdateDatastoreUsage();
                 await Task.Delay(reindexJob.QueryDelayIntervalInMilliseconds + throttleController.GetThrottleBasedDelay());
                 loopCount++;
@@ -88,7 +88,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Operations.Reindex
             while (loopCount < 17)
             {
                 _output.WriteLine($"Current throttle based delay is: {throttleController.GetThrottleBasedDelay()}");
-                _fhirRequestContextAccessor.FhirRequestContext.ResponseHeaders.Add(CosmosDbHeaders.RequestCharge, "10.0");
+                _fhirRequestContextAccessor.RequestContext.ResponseHeaders.Add(CosmosDbHeaders.RequestCharge, "10.0");
                 throttleController.UpdateDatastoreUsage();
                 await Task.Delay(reindexJob.QueryDelayIntervalInMilliseconds + throttleController.GetThrottleBasedDelay());
                 loopCount++;
@@ -118,12 +118,12 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Operations.Reindex
             reindexJob.QueryDelayIntervalInMilliseconds = 50;
             throttleController.Initialize(reindexJob, 1000);
 
-            _fhirRequestContextAccessor.FhirRequestContext.ResponseHeaders.Add(CosmosDbHeaders.RequestCharge, "1000.0");
+            _fhirRequestContextAccessor.RequestContext.ResponseHeaders.Add(CosmosDbHeaders.RequestCharge, "1000.0");
             throttleController.UpdateDatastoreUsage();
 
             Assert.Equal<uint>(80, throttleController.GetThrottleBatchSize());
 
-            _fhirRequestContextAccessor.FhirRequestContext.ResponseHeaders.Add(CosmosDbHeaders.RequestCharge, "500.0");
+            _fhirRequestContextAccessor.RequestContext.ResponseHeaders.Add(CosmosDbHeaders.RequestCharge, "500.0");
             throttleController.UpdateDatastoreUsage();
 
             Assert.Equal<uint>(100, throttleController.GetThrottleBatchSize());

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/CosmosResponseProcessorTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/CosmosResponseProcessorTests.cs
@@ -34,10 +34,10 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Storage
         public CosmosResponseProcessorTests()
         {
             _fhirRequestContextAccessor = Substitute.For<IFhirRequestContextAccessor>();
-            _fhirRequestContextAccessor.FhirRequestContext.RequestHeaders.Returns(_requestHeaders);
-            _fhirRequestContextAccessor.FhirRequestContext.ResponseHeaders.Returns(_responseHeaders);
-            _fhirRequestContextAccessor.FhirRequestContext.ResourceType.Returns("resource");
-            _fhirRequestContextAccessor.FhirRequestContext.AuditEventType.Returns("operation");
+            _fhirRequestContextAccessor.RequestContext.RequestHeaders.Returns(_requestHeaders);
+            _fhirRequestContextAccessor.RequestContext.ResponseHeaders.Returns(_responseHeaders);
+            _fhirRequestContextAccessor.RequestContext.ResourceType.Returns("resource");
+            _fhirRequestContextAccessor.RequestContext.AuditEventType.Returns("operation");
 
             _mediator = Substitute.For<IMediator>();
             var nullLogger = NullLogger<CosmosResponseProcessor>.Instance;

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Operations/Reindex/ReindexJobCosmosThrottleController.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Operations/Reindex/ReindexJobCosmosThrottleController.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Operations.Reindex
 
             if (_initialized)
             {
-                var requestContext = _fhirRequestContextAccessor.FhirRequestContext;
+                var requestContext = _fhirRequestContextAccessor.RequestContext;
                 Debug.Assert(
                     requestContext.Method.Equals(OperationsConstants.Reindex, StringComparison.OrdinalIgnoreCase),
                     "We should not be here with FhirRequestContext that is not reindex!");

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/CosmosDbSortingValidator.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/CosmosDbSortingValidator.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
                     (SearchParameterInfo searchParameter, SortOrder sortOrder) parameter = sorting[0];
 
                     if (parameter.searchParameter.SortStatus == SortParameterStatus.Enabled ||
-                        (parameter.searchParameter.SortStatus == SortParameterStatus.Supported && _contextAccessor.FhirRequestContext?.RequestHeaders.TryGetValue(KnownHeaders.PartiallyIndexedParamsHeaderName, out StringValues _) == true))
+                        (parameter.searchParameter.SortStatus == SortParameterStatus.Supported && _contextAccessor.RequestContext?.RequestHeaders.TryGetValue(KnownHeaders.PartiallyIndexedParamsHeaderName, out StringValues _) == true))
                     {
                         errorMessages = Array.Empty<string>();
                         return true;

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
         private async Task<List<Expression>> PerformChainedSearch(SearchOptions searchOptions, IReadOnlyList<ChainedExpression> chainedExpressions, CancellationToken cancellationToken)
         {
             if (!_cosmosConfig.EnableChainedSearch &&
-                !(_requestContextAccessor.FhirRequestContext.RequestHeaders.TryGetValue(KnownHeaders.EnableChainSearch, out StringValues featureSetting) &&
+                !(_requestContextAccessor.RequestContext.RequestHeaders.TryGetValue(KnownHeaders.EnableChainSearch, out StringValues featureSetting) &&
                   string.Equals(featureSetting.FirstOrDefault(), "true", StringComparison.OrdinalIgnoreCase)))
             {
                 throw new SearchOperationNotSupportedException(Resources.ChainedExpressionNotSupported);
@@ -400,7 +400,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
                         // plant a ConcurrentBag int the request context's properties, so the CosmosResponseProcessor
                         // knows to add the individual ResponseMessages sent as part of this search.
 
-                        fhirRequestContext = _requestContextAccessor.FhirRequestContext;
+                        fhirRequestContext = _requestContextAccessor.RequestContext;
                         if (fhirRequestContext != null)
                         {
                             messagesList = new ConcurrentBag<ResponseMessage>();
@@ -480,7 +480,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
         {
             if (includesTruncated)
             {
-                _requestContextAccessor.FhirRequestContext.BundleIssues.Add(
+                _requestContextAccessor.RequestContext.BundleIssues.Add(
                     new OperationOutcomeIssue(
                         OperationOutcomeConstants.IssueSeverity.Warning,
                         OperationOutcomeConstants.IssueType.Incomplete,

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosResponseProcessor.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosResponseProcessor.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
                 double.TryParse(responseMessage.Headers["x-ms-request-duration-ms"], out var duration) ? duration : 0,
                 responseMessage.Headers["x-ms-documentdb-partitionkeyrangeid"]);
 
-            IFhirRequestContext fhirRequestContext = _fhirRequestContextAccessor.FhirRequestContext;
+            IFhirRequestContext fhirRequestContext = _fhirRequestContextAccessor.RequestContext;
             if (fhirRequestContext == null)
             {
                 return;
@@ -126,7 +126,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
 
         private async Task AddRequestChargeToFhirRequestContext(double responseRequestCharge, HttpStatusCode? statusCode)
         {
-            IFhirRequestContext requestContext = _fhirRequestContextAccessor.FhirRequestContext;
+            IFhirRequestContext requestContext = _fhirRequestContextAccessor.RequestContext;
 
             lock (requestContext.ResponseHeaders)
             {

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/FhirCosmosResponseHandler.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/FhirCosmosResponseHandler.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
 
         private (ConsistencyLevel? consistencyLevel, string sessionToken) GetConsistencyHeaders()
         {
-            IFhirRequestContext fhirRequestContext = _fhirRequestContextAccessor.FhirRequestContext;
+            IFhirRequestContext fhirRequestContext = _fhirRequestContextAccessor.RequestContext;
 
             if (fhirRequestContext == null)
             {

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/RetryExceptionPolicyFactory.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/RetryExceptionPolicyFactory.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
 
         public AsyncPolicy GetRetryPolicy()
         {
-            return _requestContextAccessor.FhirRequestContext switch
+            return _requestContextAccessor.RequestContext switch
             {
                 null or { IsBackgroundTask: true } => _backgroundJobRetryPolicy,
                 { ExecutingBatchOrTransaction: true } => _bundleActionRetryPolicy,

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/ApiNotifications/ApiNotificationMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/ApiNotifications/ApiNotificationMiddlewareTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Notifications
 
         public ApiNotificationMiddlewareTests()
         {
-            _fhirRequestContextAccessor.FhirRequestContext.Returns(_fhirRequestContext);
+            _fhirRequestContextAccessor.RequestContext.Returns(_fhirRequestContext);
 
             _apiNotificationMiddleware = new ApiNotificationMiddleware(
                     _fhirRequestContextAccessor,
@@ -61,7 +61,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Notifications
         [Fact]
         public async Task GivenRequestPath_AndNullFhirRequestContext_WhenInvoked_DoesNotFail_AndDoesNotEmitMediatREvents()
         {
-            _fhirRequestContextAccessor.FhirRequestContext.Returns((IFhirRequestContext)null);
+            _fhirRequestContextAccessor.RequestContext.Returns((IFhirRequestContext)null);
 
             _httpContext.Request.Path = "/Observation";
             await _apiNotificationMiddleware.InvokeAsync(_httpContext, _next);

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Audit/AuditHelperTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Audit/AuditHelperTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
             _fhirRequestContext.CorrelationId.Returns(CorrelationId);
             _fhirRequestContext.ResourceType.Returns("Patient");
 
-            _fhirRequestContextAccessor.FhirRequestContext = _fhirRequestContext;
+            _fhirRequestContextAccessor.RequestContext = _fhirRequestContext;
 
             _httpContext.Connection.RemoteIpAddress = CallerIpAddress;
 

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Context/FhirRequestContextAfterAuthenticationMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Context/FhirRequestContextAfterAuthenticationMiddlewareTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Context
 
             var fhirRequestContext = new DefaultFhirRequestContext();
 
-            fhirRequestContextAccessor.FhirRequestContext.Returns(fhirRequestContext);
+            fhirRequestContextAccessor.RequestContext.Returns(fhirRequestContext);
 
             HttpContext httpContext = new DefaultHttpContext();
 

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Context/FhirRequestContextBeforeAuthenticationMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Context/FhirRequestContextBeforeAuthenticationMiddlewareTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Context
 
         public FhirRequestContextBeforeAuthenticationMiddlewareTests()
         {
-            _fhirRequestContextAccessor.FhirRequestContext.Returns(_fhirRequestContext);
+            _fhirRequestContextAccessor.RequestContext.Returns(_fhirRequestContext);
 
             _fhirRequestContextBeforeAuthenticationMiddleware = new FhirRequestContextBeforeAuthenticationMiddleware(
                 httpContext => Task.CompletedTask,

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Context/FhirRequestContextMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Context/FhirRequestContextMiddlewareTests.cs
@@ -57,9 +57,9 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Context
 
             await fhirContextMiddlware.Invoke(httpContext, fhirRequestContextAccessor, Provider);
 
-            Assert.NotNull(fhirRequestContextAccessor.FhirRequestContext);
+            Assert.NotNull(fhirRequestContextAccessor.RequestContext);
 
-            return fhirRequestContextAccessor.FhirRequestContext;
+            return fhirRequestContextAccessor.RequestContext;
         }
 
         private HttpContext CreateHttpContext()

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Exceptions/BaseExceptionMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Exceptions/BaseExceptionMiddlewareTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Exceptions
             _correlationId = Guid.NewGuid().ToString();
 
             _fhirRequestContextAccessor = Substitute.For<IFhirRequestContextAccessor>();
-            _fhirRequestContextAccessor.FhirRequestContext.CorrelationId.Returns(_correlationId);
+            _fhirRequestContextAccessor.RequestContext.CorrelationId.Returns(_correlationId);
             _formatParametersValidator = Substitute.For<IFormatParametersValidator>();
 
             _context = new DefaultHttpContext();

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/FhirRequestContextRouteDataPopulatingFilterAttributeTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/FhirRequestContextRouteDataPopulatingFilterAttributeTests.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
                 FilterTestsHelper.CreateMockFhirController());
 
             _fhirRequestContext.CorrelationId = _correlationId;
-            _fhirRequestContextAccessor.FhirRequestContext.Returns(_fhirRequestContext);
+            _fhirRequestContextAccessor.RequestContext.Returns(_fhirRequestContext);
 
             _filterAttribute = new FhirRequestContextRouteDataPopulatingFilterAttribute(_fhirRequestContextAccessor, _auditEventTypeMapping);
         }
@@ -135,9 +135,9 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
 
             _filterAttribute.OnActionExecuting(_actionExecutingContext);
 
-            Assert.NotNull(_fhirRequestContextAccessor.FhirRequestContext.AuditEventType);
-            Assert.Equal(expectedAuditEventType, _fhirRequestContextAccessor.FhirRequestContext.AuditEventType);
-            Assert.Equal(RouteName, _fhirRequestContextAccessor.FhirRequestContext.RouteName);
+            Assert.NotNull(_fhirRequestContextAccessor.RequestContext.AuditEventType);
+            Assert.Equal(expectedAuditEventType, _fhirRequestContextAccessor.RequestContext.AuditEventType);
+            Assert.Equal(RouteName, _fhirRequestContextAccessor.RequestContext.RouteName);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/OperationOutcomeExceptionFilterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/OperationOutcomeExceptionFilterTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
                 FilterTestsHelper.CreateMockFhirController());
 
             _fhirRequestContext.CorrelationId = _correlationId;
-            _fhirRequestContextAccessor.FhirRequestContext.Returns(_fhirRequestContext);
+            _fhirRequestContextAccessor.RequestContext.Returns(_fhirRequestContext);
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
             };
 
             IFhirRequestContextAccessor fhirRequestContextAccessor = Substitute.For<IFhirRequestContextAccessor>();
-            fhirRequestContextAccessor.FhirRequestContext.Returns(_fhirRequestContext);
+            fhirRequestContextAccessor.RequestContext.Returns(_fhirRequestContext);
 
             IHttpContextAccessor httpContextAccessor = Substitute.For<IHttpContextAccessor>();
 

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleSerializerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleSerializerTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Health.Fhir.Shared.Api.UnitTests.Features.Resources.Bundle
         public BundleSerializerTests()
         {
             var requestContextAccessor = Substitute.For<IFhirRequestContextAccessor>();
-            requestContextAccessor.FhirRequestContext.Returns(x => new FhirRequestContext("get", "https://localhost/Patient", "https://localhost", "correlation", new Dictionary<string, StringValues>(), new Dictionary<string, StringValues>()));
+            requestContextAccessor.RequestContext.Returns(x => new FhirRequestContext("get", "https://localhost/Patient", "https://localhost", "correlation", new Dictionary<string, StringValues>(), new Dictionary<string, StringValues>()));
 
             _wrapperFactory = new ResourceWrapperFactory(
                                      new RawResourceFactory(new FhirJsonSerializer()),

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Routing/UrlResolverTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Routing/UrlResolverTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Routing
                 _actionContextAccessor,
                 _bundleHttpContextAccessor);
 
-            _fhirRequestContextAccessor.FhirRequestContext.RouteName = DefaultRouteName;
+            _fhirRequestContextAccessor.RequestContext.RouteName = DefaultRouteName;
 
             _httpContextAccessor.HttpContext.Returns(_httpContext);
 

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ExportController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ExportController.cs
@@ -180,7 +180,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         public async Task<IActionResult> GetExportStatusById(string idParameter)
         {
             var getExportResult = await _mediator.GetExportStatusAsync(
-                _fhirRequestContextAccessor.FhirRequestContext.Uri,
+                _fhirRequestContextAccessor.RequestContext.Uri,
                 idParameter,
                 HttpContext.RequestAborted);
 
@@ -222,7 +222,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             string anonymizationConfigFileETag = null)
         {
             CreateExportResponse response = await _mediator.ExportAsync(
-                _fhirRequestContextAccessor.FhirRequestContext.Uri,
+                _fhirRequestContextAccessor.RequestContext.Uri,
                 exportType,
                 resourceType,
                 since,

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             return FhirResult.Create(
                 new OperationOutcome
                 {
-                    Id = _fhirRequestContextAccessor.FhirRequestContext.CorrelationId,
+                    Id = _fhirRequestContextAccessor.RequestContext.CorrelationId,
                     Issue = new List<OperationOutcome.IssueComponent>
                     {
                         new OperationOutcome.IssueComponent

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Exceptions/BaseExceptionMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Exceptions/BaseExceptionMiddleware.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Exceptions
                     throw;
                 }
 
-                var localCorrelationId = _fhirRequestContextAccessor.FhirRequestContext?.CorrelationId;
+                var localCorrelationId = _fhirRequestContextAccessor.RequestContext?.CorrelationId;
 
                 Debug.Assert(!string.IsNullOrWhiteSpace(localCorrelationId), "The correlation id should have been generated.");
 

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/FhirRequestContextRouteDataPopulatingFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/FhirRequestContextRouteDataPopulatingFilterAttribute.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
 
         public override void OnActionExecuting(ActionExecutingContext context)
         {
-            IFhirRequestContext fhirRequestContext = _fhirRequestContextAccessor.FhirRequestContext;
+            IFhirRequestContext fhirRequestContext = _fhirRequestContextAccessor.RequestContext;
 
             fhirRequestContext.RouteName = context.ActionDescriptor?.AttributeRouteInfo?.Name;
 

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
                 var operationOutcomeResult = new OperationOutcomeResult(
                     new OperationOutcome
                     {
-                        Id = _fhirRequestContextAccessor.FhirRequestContext.CorrelationId,
+                        Id = _fhirRequestContextAccessor.RequestContext.CorrelationId,
                         Issue = fhirException.Issues.Select(x => x.ToPoco()).ToList(),
                     },
                     HttpStatusCode.BadRequest);
@@ -188,7 +188,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
                         healthExceptionResult = new OperationOutcomeResult(
                             new OperationOutcome
                             {
-                                Id = _fhirRequestContextAccessor.FhirRequestContext.CorrelationId,
+                                Id = _fhirRequestContextAccessor.RequestContext.CorrelationId,
                             },
                             HttpStatusCode.InternalServerError);
                         break;
@@ -221,7 +221,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
             return new OperationOutcomeResult(
                 new OperationOutcome
                 {
-                    Id = _fhirRequestContextAccessor.FhirRequestContext.CorrelationId,
+                    Id = _fhirRequestContextAccessor.RequestContext.CorrelationId,
                     Issue = new List<OperationOutcome.IssueComponent>
                     {
                         new OperationOutcome.IssueComponent

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                 throw new UnauthorizedFhirActionException();
             }
 
-            _originalFhirRequestContext = _fhirRequestContextAccessor.FhirRequestContext;
+            _originalFhirRequestContext = _fhirRequestContextAccessor.RequestContext;
             try
             {
                 var bundleResource = bundleRequest.Bundle.ToPoco<Hl7.Fhir.Model.Bundle>();
@@ -219,7 +219,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
             }
             finally
             {
-                _fhirRequestContextAccessor.FhirRequestContext = _originalFhirRequestContext;
+                _fhirRequestContextAccessor.RequestContext = _originalFhirRequestContext;
             }
         }
 
@@ -298,7 +298,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
             httpContext.Features[typeof(IHttpAuthenticationFeature)] = _httpAuthenticationFeature;
             httpContext.Response.Body = new MemoryStream();
 
-            var requestUri = new Uri(_fhirRequestContextAccessor.FhirRequestContext.BaseUri, requestUrl);
+            var requestUri = new Uri(_fhirRequestContextAccessor.RequestContext.BaseUri, requestUrl);
             httpContext.Request.Scheme = requestUri.Scheme;
             httpContext.Request.Host = new HostString(requestUri.Host, requestUri.Port);
             httpContext.Request.PathBase = _originalRequestBase;
@@ -489,7 +489,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                 ExecutingBatchOrTransaction = true,
             };
 
-            _fhirRequestContextAccessor.FhirRequestContext = newFhirRequestContext;
+            _fhirRequestContextAccessor.RequestContext = newFhirRequestContext;
 
             _bundleHttpContextAccessor.HttpContext = httpContext;
 

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Core.Features.Security;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Api.Configs;
@@ -127,6 +128,7 @@ namespace Microsoft.Health.Fhir.Api.Modules
             services.Add<FhirRequestContextAccessor>()
                 .Singleton()
                 .AsSelf()
+                .AsService<RequestContextAccessor<IFhirRequestContext>>()
                 .AsService<IFhirRequestContextAccessor>();
 
             services.AddSingleton<CorrelationIdProvider>(_ => () => Guid.NewGuid().ToString());

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Persistence/ResourceWrapperFactoryTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Persistence/ResourceWrapperFactoryTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Persistence
                 new Dictionary<string, StringValues>(),
                 new Dictionary<string, StringValues>());
             _fhirRequestContextAccessor = Substitute.For<IFhirRequestContextAccessor>();
-            _fhirRequestContextAccessor.FhirRequestContext.Returns(dummyRequestContext);
+            _fhirRequestContextAccessor.RequestContext.Returns(dummyRequestContext);
 
             _claimsExtractor = Substitute.For<IClaimsExtractor>();
             _compartmentIndexer = Substitute.For<ICompartmentIndexer>();

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/Create/CreateResourceValidatorTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/Create/CreateResourceValidatorTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Resources.Create
             var profileValidator = Substitute.For<IProfileValidator>();
             var config = Substitute.For<IOptions<CoreFeatureConfiguration>>();
             config.Value.Returns(new CoreFeatureConfiguration());
-            contextAccessor.FhirRequestContext.RequestHeaders.Returns(new Dictionary<string, StringValues>());
+            contextAccessor.RequestContext.RequestHeaders.Returns(new Dictionary<string, StringValues>());
             var validator = new CreateResourceValidator(
                 new ModelAttributeValidator(),
                 new NarrativeHtmlSanitizer(NullLogger<NarrativeHtmlSanitizer>.Instance),
@@ -69,7 +69,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Resources.Create
                 headers.Add(KnownHeaders.ProfileValidation, new StringValues(headerValue.Value.ToString()));
             }
 
-            contextAccessor.FhirRequestContext.RequestHeaders.Returns(headers);
+            contextAccessor.RequestContext.RequestHeaders.Returns(headers);
             var validator = new CreateResourceValidator(
                 new ModelAttributeValidator(),
                 new NarrativeHtmlSanitizer(NullLogger<NarrativeHtmlSanitizer>.Instance),

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/Upsert/UpsertResourceValidatorTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/Upsert/UpsertResourceValidatorTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Resources.Upsert
             var profileValidator = Substitute.For<IProfileValidator>();
             var config = Substitute.For<IOptions<CoreFeatureConfiguration>>();
             config.Value.Returns(new CoreFeatureConfiguration());
-            contextAccessor.FhirRequestContext.RequestHeaders.Returns(new Dictionary<string, StringValues>());
+            contextAccessor.RequestContext.RequestHeaders.Returns(new Dictionary<string, StringValues>());
             var validator = new UpsertResourceValidator(
                 new ModelAttributeValidator(),
                 new NarrativeHtmlSanitizer(NullLogger<NarrativeHtmlSanitizer>.Instance),
@@ -70,7 +70,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Resources.Upsert
                 headers.Add(KnownHeaders.ProfileValidation, new StringValues(headerValue.Value.ToString()));
             }
 
-            contextAccessor.FhirRequestContext.RequestHeaders.Returns(headers);
+            contextAccessor.RequestContext.RequestHeaders.Returns(headers);
             var validator = new UpsertResourceValidator(
                 new ModelAttributeValidator(),
                 new NarrativeHtmlSanitizer(NullLogger<NarrativeHtmlSanitizer>.Instance),

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/BundleFactoryTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/BundleFactoryTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
             fhirRequestContext.CorrelationId.Returns(_correlationId);
 
-            _fhirRequestContextAccessor.FhirRequestContext.Returns(fhirRequestContext);
+            _fhirRequestContextAccessor.RequestContext.Returns(fhirRequestContext);
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             _searchParameterStatusDataStore = Substitute.For<ISearchParameterStatusDataStore>();
             _searchParameterDefinitionManager = new SearchParameterDefinitionManager(ModelInfoProvider.Instance, _mediator);
             _fhirRequestContextAccessor = Substitute.For<IFhirRequestContextAccessor>();
-            _fhirRequestContextAccessor.FhirRequestContext.Returns(_fhirRequestContext);
+            _fhirRequestContextAccessor.RequestContext.Returns(_fhirRequestContext);
 
             _manager = new SearchParameterStatusManager(
                 _searchParameterStatusDataStore,

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchValues/ReferenceSearchValueParserTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchValues/ReferenceSearchValueParserTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.SearchValues
 
         public ReferenceSearchValueParserTests()
         {
-            _fhirRequestContextAccessor.FhirRequestContext.BaseUri.Returns(BaseUri);
+            _fhirRequestContextAccessor.RequestContext.BaseUri.Returns(BaseUri);
 
             _referenceSearchValueParser = new ReferenceSearchValueParser(_fhirRequestContextAccessor);
         }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/BundleFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/BundleFactory.cs
@@ -79,12 +79,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             // Create the bundle from the result.
             var bundle = new Bundle();
 
-            if (_fhirRequestContextAccessor.FhirRequestContext.BundleIssues.Any())
+            if (_fhirRequestContextAccessor.RequestContext.BundleIssues.Any())
             {
                 var operationOutcome = new OperationOutcome
                 {
-                    Id = _fhirRequestContextAccessor.FhirRequestContext.CorrelationId,
-                    Issue = new List<OperationOutcome.IssueComponent>(_fhirRequestContextAccessor.FhirRequestContext.BundleIssues.Select(x => x.ToPoco())),
+                    Id = _fhirRequestContextAccessor.RequestContext.CorrelationId,
+                    Issue = new List<OperationOutcome.IssueComponent>(_fhirRequestContextAccessor.RequestContext.BundleIssues.Select(x => x.ToPoco())),
                 };
 
                 bundle.Entry.Add(new Bundle.EntryComponent
@@ -113,7 +113,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             // Add the self link to indicate which search parameters were used.
             bundle.SelfLink = _urlResolver.ResolveRouteUrl(result.UnsupportedSearchParameters, result.SortOrder);
 
-            bundle.Id = _fhirRequestContextAccessor.FhirRequestContext.CorrelationId;
+            bundle.Id = _fhirRequestContextAccessor.RequestContext.CorrelationId;
             bundle.Type = type;
             bundle.Total = result?.TotalCount;
             bundle.Meta = new Meta

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
 
                     if (badTypes.Count != 0)
                     {
-                        _contextAccessor.FhirRequestContext?.BundleIssues.Add(
+                        _contextAccessor.RequestContext?.BundleIssues.Add(
                             new OperationOutcomeIssue(
                                 OperationOutcomeConstants.IssueSeverity.Warning,
                                 OperationOutcomeConstants.IssueType.NotSupported,
@@ -192,7 +192,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                 {
                     searchOptions.MaxItemCount = _featureConfiguration.MaxItemCountPerSearch;
 
-                    _contextAccessor.FhirRequestContext?.BundleIssues.Add(
+                    _contextAccessor.RequestContext?.BundleIssues.Add(
                         new OperationOutcomeIssue(
                             OperationOutcomeConstants.IssueSeverity.Information,
                             OperationOutcomeConstants.IssueType.Informational,
@@ -332,8 +332,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             if (unsupportedSearchParameters.Any())
             {
                 bool throwForUnsupported = false;
-                if (_contextAccessor.FhirRequestContext.RequestHeaders != null &&
-                    _contextAccessor.FhirRequestContext.RequestHeaders.TryGetValue(KnownHeaders.Prefer, out var values))
+                if (_contextAccessor.RequestContext.RequestHeaders != null &&
+                    _contextAccessor.RequestContext.RequestHeaders.TryGetValue(KnownHeaders.Prefer, out var values))
                 {
                     var handlingValue = values.FirstOrDefault(x => x.StartsWith("handling=", StringComparison.OrdinalIgnoreCase));
                     if (handlingValue != default)
@@ -366,7 +366,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                 {
                     foreach (var unsupported in unsupportedSearchParameters)
                     {
-                        _contextAccessor.FhirRequestContext?.BundleIssues.Add(new OperationOutcomeIssue(
+                        _contextAccessor.RequestContext?.BundleIssues.Add(new OperationOutcomeIssue(
                               OperationOutcomeConstants.IssueSeverity.Warning,
                               OperationOutcomeConstants.IssueType.NotSupported,
                               string.Format(CultureInfo.InvariantCulture, Core.Resources.SearchParameterNotSupported, unsupported.Item1, string.Join(",", resourceTypesString))));
@@ -391,7 +391,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                     catch (SearchParameterNotSupportedException)
                     {
                         sortingsValid = false;
-                        _contextAccessor.FhirRequestContext?.BundleIssues.Add(new OperationOutcomeIssue(
+                        _contextAccessor.RequestContext?.BundleIssues.Add(new OperationOutcomeIssue(
                             OperationOutcomeConstants.IssueSeverity.Warning,
                             OperationOutcomeConstants.IssueType.NotSupported,
                             string.Format(CultureInfo.InvariantCulture, Core.Resources.SearchParameterNotSupported, sorting.Item1, string.Join(", ", resourceTypesString))));
@@ -411,7 +411,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
 
                         foreach (var errorMessage in errorMessages)
                         {
-                            _contextAccessor.FhirRequestContext?.BundleIssues.Add(new OperationOutcomeIssue(
+                            _contextAccessor.RequestContext?.BundleIssues.Add(new OperationOutcomeIssue(
                                 OperationOutcomeConstants.IssueSeverity.Warning,
                                 OperationOutcomeConstants.IssueType.NotSupported,
                                 errorMessage));
@@ -457,7 +457,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                     // See https://www.hl7.org/fhir/search.html#revinclude.
                     if (expression.Iterate && expression.CircularReference)
                     {
-                        _contextAccessor.FhirRequestContext?.BundleIssues.Add(
+                        _contextAccessor.RequestContext?.BundleIssues.Add(
                         new OperationOutcomeIssue(
                             OperationOutcomeConstants.IssueSeverity.Information,
                             OperationOutcomeConstants.IssueType.Informational,

--- a/src/Microsoft.Health.Fhir.Shared.Tests/Context/FhirRequestContextExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Tests/Context/FhirRequestContextExtensions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Context
         public static IFhirRequestContextAccessor SetupAccessor(this IFhirRequestContext context)
         {
             IFhirRequestContextAccessor accessor = Substitute.For<IFhirRequestContextAccessor>();
-            accessor.FhirRequestContext.Returns(context);
+            accessor.RequestContext.Returns(context);
             return accessor;
         }
     }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -326,7 +326,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
 
                     if (isResultPartial)
                     {
-                        _requestContextAccessor.FhirRequestContext.BundleIssues.Add(
+                        _requestContextAccessor.RequestContext.BundleIssues.Add(
                             new OperationOutcomeIssue(
                                 OperationOutcomeConstants.IssueSeverity.Warning,
                                 OperationOutcomeConstants.IssueType.Incomplete,

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             optionsMonitor.Get(CosmosDb.Constants.CollectionConfigurationName).Returns(_cosmosCollectionConfiguration);
 
             var fhirRequestContextAccessor = Substitute.For<IFhirRequestContextAccessor>();
-            fhirRequestContextAccessor.FhirRequestContext.CorrelationId.Returns(Guid.NewGuid().ToString());
+            fhirRequestContextAccessor.RequestContext.CorrelationId.Returns(Guid.NewGuid().ToString());
 
             _searchParameterDefinitionManager = new SearchParameterDefinitionManager(ModelInfoProvider.Instance, _mediator);
             await _searchParameterDefinitionManager.StartAsync(CancellationToken.None);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             _fhirOperationDataStore = new SqlServerFhirOperationDataStore(SqlConnectionWrapperFactory, NullLogger<SqlServerFhirOperationDataStore>.Instance);
 
             var fhirRequestContextAccessor = Substitute.For<IFhirRequestContextAccessor>();
-            fhirRequestContextAccessor.FhirRequestContext.CorrelationId.Returns(Guid.NewGuid().ToString());
+            fhirRequestContextAccessor.RequestContext.CorrelationId.Returns(Guid.NewGuid().ToString());
 
             var searchableSearchParameterDefinitionManager = new SearchableSearchParameterDefinitionManager(_searchParameterDefinitionManager, fhirRequestContextAccessor);
             var searchParameterExpressionParser = new SearchParameterExpressionParser(new ReferenceSearchValueParser(fhirRequestContextAccessor));


### PR DESCRIPTION
## Description
This PR brings the `IFhirRequestContextAccessor` into line with the abstract `RequestContextAccessor<T>` from the shared components. Additionally, it registers the `FhirRequestContextAccessor` additionally as a `RequestContextAccessor<IFhirRequestContext>`.

## Related issues
Addresses [AB#80297](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/80297).

## Testing
Existing tests continue to pass.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
