### PR TITLE
Don't run code quality on dependabot branches

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,9 @@
 name: "Code Scanning - Action"
 
 on:
+  push:
+    branches-ignore:
+     - 'dependabot/**'
   pull_request:
   schedule:
     - cron: '0 0 * * 0'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,7 +1,6 @@
 name: "Code Scanning - Action"
 
 on:
-  push:
   pull_request:
   schedule:
     - cron: '0 0 * * 0'


### PR DESCRIPTION
## Description
https://github.com/microsoft/fhir-server/pull/1872/checks?check_run_id=2444726685

>Workflows triggered by Dependabot on the "push" event run with read-only access. Uploading Code Scanning results requires write access. To use Code Scanning with Dependabot, please ensure you are using the "pull_request" event for this workflow and avoid triggering on the "push" event for Dependabot branches


## Related issues
Addresses [issue #].

## Testing
By running build.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip