### PR TITLE
Large db query perf optimizations

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Configs/CosmosDataStoreConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Configs/CosmosDataStoreConfiguration.cs
@@ -53,6 +53,11 @@ namespace Microsoft.Health.Fhir.CosmosDb.Configs
         public bool EnableChainedSearch { get; set; }
 
         /// <summary>
+        /// Uses query statistics to determine the optimal level of partition parallelism needed to return results
+        /// </summary>
+        public bool UseQueryStatistics { get; set; }
+
+        /// <summary>
         /// A list of Search Parameter URIs that will be enabled on first initialization
         /// </summary>
         public HashSet<string> InitialSortParameterUris { get; } = new();

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
@@ -419,7 +419,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
                     if (results.Count < feedOptions.MaxItemCount * CosmosFhirDataStore.ExecuteDocumentQueryAsyncMinimumFillFactor && string.IsNullOrEmpty(continuationToken))
                     {
                         // ExecuteDocumentQueryAsync gave up on filling the pages. This suggests that we would have been better off querying in parallel.
-                        queryPartitionStatistics.Update(_physicalPartitionInfo.PhysicalPartitionCount);
+                        queryPartitionStatistics.Update((queryPartitionStatistics.GetAveragePartitionCount() ?? 10) * 10); // should increment => 100, 1000, 10,000
                     }
                     else
                     {

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
@@ -449,7 +449,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
         {
             int? averagePartitionCount = queryPartitionStatistics.GetAveragePartitionCount();
 
-            if (averagePartitionCount.HasValue)
+            if (averagePartitionCount.HasValue && _cosmosConfig.UseQueryStatistics)
             {
                 // this is not a new query
 

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -123,6 +123,7 @@
             "MaxWaitTimeInSeconds": 90
         },
         "EnableChainedSearch": true,
+        "UseQueryStatistics": true,
         "InitialSortParameterUris": [
             "http://hl7.org/fhir/SearchParameter/individual-family",
             "http://hl7.org/fhir/SearchParameter/individual-given",

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
@@ -185,7 +185,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 fhirRequestContextAccessor,
                 _cosmosDataStoreConfiguration,
                 cosmosDbPhysicalPartitionInfo,
-                new QueryPartitionStatisticsCache());
+                new QueryPartitionStatisticsCache(),
+                NullLogger<FhirCosmosSearchService>.Instance);
 
             ISearchParameterSupportResolver searchParameterSupportResolver = Substitute.For<ISearchParameterSupportResolver>();
             searchParameterSupportResolver.IsSearchParameterSupported(Arg.Any<SearchParameterInfo>()).Returns((true, false));


### PR DESCRIPTION
## Description
Before if a query failed to find enough results it would switch to querying all results in parallel, which is increases the RU cost greatly with very large DBs. This scales that back to keep doubling the partitions queried in parallel until it finds the appropriate watermark.

Other changes:
- It looks like there is a bug where if the number of results found (in total) is less than the the MaxItemCount then it was switching to querying all results in parallel (I inverted the string.IsNullOrEmpty(continuationToken) logic
- Added a feature flag to turn off using query statistics
- Added the ability to use the average required number of partitions needed to get results as the degree of parallelism

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
