### PR TITLE
Synchronize search parameter changes between instances

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Reindex/ReindexJobWorkerTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Reindex/ReindexJobWorkerTests.cs
@@ -56,6 +56,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                 searchParameterOperations,
                 NullLogger<ReindexJobWorker>.Instance);
 
+            _reindexJobWorker.Handle(new Messages.Search.SearchParametersInitializedNotification(), CancellationToken.None);
+
             _cancellationToken = _cancellationTokenSource.Token;
         }
 

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Reindex/ReindexJobWorkerTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Reindex/ReindexJobWorkerTests.cs
@@ -15,6 +15,7 @@ using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Operations.Reindex;
 using Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Microsoft.Health.Fhir.Core.Features.Search.Parameters;
 using NSubstitute;
 using Xunit;
 
@@ -46,10 +47,13 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
             var scopedOperationDataStore = Substitute.For<IScoped<IFhirOperationDataStore>>();
             scopedOperationDataStore.Value.Returns(_fhirOperationDataStore);
 
+            var searchParameterOperations = Substitute.For<ISearchParameterOperations>();
+
             _reindexJobWorker = new ReindexJobWorker(
                 () => scopedOperationDataStore,
                 Options.Create(_reindexJobConfiguration),
                 _reindexJobTaskFactory,
+                searchParameterOperations,
                 NullLogger<ReindexJobWorker>.Instance);
 
             _cancellationToken = _cancellationTokenSource.Token;

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/ISearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/ISearchParameterDefinitionManager.cs
@@ -86,7 +86,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         /// Allows addition of a new search parameters at runtime.
         /// </summary>
         /// <param name="searchParameters">An collection containing SearchParameter resources.</param>
-        void AddNewSearchParameters(IReadOnlyCollection<ITypedElement> searchParameters);
+        /// <param name="calculateHash">Indicates whether the search parameter hash should be recalculated</param>
+        void AddNewSearchParameters(IReadOnlyCollection<ITypedElement> searchParameters, bool calculateHash = true);
 
         /// <summary>
         /// Allows removal of a custom search parameter.

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/ISearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/ISearchParameterDefinitionManager.cs
@@ -58,6 +58,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         /// Retrieves the search parameter with <paramref name="definitionUri"/>.
         /// </summary>
         /// <param name="definitionUri">The search parameter definition URL.</param>
+        /// <param name="value">The SearchParameterInfo pertaining to the specified <paramref name="definitionUri"/></param>
+        /// <returns>True if the search parameter is found <paramref name="definitionUri"/>.</returns>
+        public bool TryGetSearchParameter(Uri definitionUri, out SearchParameterInfo value);
+
+        /// <summary>
+        /// Retrieves the search parameter with <paramref name="definitionUri"/>.
+        /// </summary>
+        /// <param name="definitionUri">The search parameter definition URL.</param>
         /// <returns>The search parameter with the given <paramref name="definitionUri"/>.</returns>
         SearchParameterInfo GetSearchParameter(Uri definitionUri);
 
@@ -85,5 +93,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         /// </summary>
         /// <param name="searchParam">The custom search parameter to remove.</param>
         void DeleteSearchParameter(ITypedElement searchParam);
+
+        /// <summary>
+        /// Allows removal of a custom search parameter.
+        /// </summary>
+        /// <param name="url">The url identifying the custom search parameter to remove.</param>
+        /// <param name="calculateHash">Indicated whether the search parameter hash values should be recalulated after this delete.</param>
+        void DeleteSearchParameter(string url, bool calculateHash = true);
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             }
         }
 
-        public void AddNewSearchParameters(IReadOnlyCollection<ITypedElement> searchParameters)
+        public void AddNewSearchParameters(IReadOnlyCollection<ITypedElement> searchParameters, bool calculateHash = true)
         {
             SearchParameterDefinitionBuilder.Build(
                 searchParameters,
@@ -150,7 +150,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
                 TypeLookup,
                 _modelInfoProvider);
 
-            CalculateSearchParameterHash();
+            if (calculateHash)
+            {
+                CalculateSearchParameterHash();
+            }
         }
 
         private void CalculateSearchParameterHash()

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
@@ -180,7 +180,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
 
             if (!UrlLookup.TryRemove(new Uri(url), out searchParameterInfo))
             {
-                throw new ResourceNotFoundException(string.Format(Resources.CustomSearchParameterNotfound, searchParamWrapper.Url));
+                throw new ResourceNotFoundException(string.Format(Resources.CustomSearchParameterNotfound, url));
             }
 
             var allResourceTypes = searchParameterInfo.TargetResourceTypes.Union(searchParameterInfo.BaseResourceTypes);

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterResourceDataStore.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterResourceDataStore.cs
@@ -16,6 +16,7 @@ using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Features.Search.Parameters;
+using Microsoft.Health.Fhir.Core.Messages.Search;
 using Microsoft.Health.Fhir.Core.Messages.Storage;
 using Microsoft.Health.Fhir.Core.Models;
 
@@ -26,22 +27,26 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         private readonly ISearchParameterOperations _searchParameterOperations;
         private readonly Func<IScoped<ISearchService>> _searchServiceFactory;
         private readonly IModelInfoProvider _modelInfoProvider;
+        private readonly IMediator _mediator;
         private readonly ILogger _logger;
 
         public SearchParameterResourceDataStore(
             ISearchParameterOperations searchParameterOperations,
             Func<IScoped<ISearchService>> searchServiceFactory,
             IModelInfoProvider modelInfoProvider,
+            IMediator mediator,
             ILogger<SearchParameterResourceDataStore> logger)
         {
             EnsureArg.IsNotNull(searchParameterOperations, nameof(searchParameterOperations));
             EnsureArg.IsNotNull(searchServiceFactory, nameof(searchServiceFactory));
             EnsureArg.IsNotNull(modelInfoProvider, nameof(modelInfoProvider));
+            EnsureArg.IsNotNull(mediator, nameof(mediator));
             EnsureArg.IsNotNull(logger, nameof(logger));
 
             _searchParameterOperations = searchParameterOperations;
             _searchServiceFactory = searchServiceFactory;
             _modelInfoProvider = modelInfoProvider;
+            _mediator = mediator;
             _logger = logger;
         }
 
@@ -94,6 +99,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
                 }
             }
             while (continuationToken != null);
+
+            await _mediator.Publish(new SearchParametersInitializedNotification(), CancellationToken.None);
         }
 
         public async Task Handle(StorageInitializedNotification notification, CancellationToken cancellationToken)

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchableSearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchableSearchParameterDefinitionManager.cs
@@ -122,5 +122,25 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         {
             _inner.DeleteSearchParameter(searchParam);
         }
+
+        public bool TryGetSearchParameter(Uri definitionUri, out SearchParameterInfo value)
+        {
+            _inner.TryGetSearchParameter(definitionUri, out var parameter);
+
+            if (parameter.IsSearchable ||
+                (_fhirReqeustContextAccessor.FhirRequestContext.IncludePartiallyIndexedSearchParams && parameter.IsSupported))
+            {
+                value = parameter;
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+
+        public void DeleteSearchParameter(string url, bool calculateHash = true)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchableSearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchableSearchParameterDefinitionManager.cs
@@ -55,7 +55,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             searchParameter = null;
 
             if (_inner.TryGetSearchParameter(resourceType, code, out var parameter) &&
-                (parameter.IsSearchable || (_fhirReqeustContextAccessor.RequestContext.IncludePartiallyIndexedSearchParams && parameter.IsSupported)))
+                (parameter.IsSearchable ||
+                    (_fhirReqeustContextAccessor.RequestContext != null &&
+                    _fhirReqeustContextAccessor.RequestContext.IncludePartiallyIndexedSearchParams &&
+                    parameter.IsSupported)))
             {
                 searchParameter = parameter;
 
@@ -70,7 +73,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             SearchParameterInfo parameter = _inner.GetSearchParameter(resourceType, code);
 
             if (parameter.IsSearchable ||
-                (_fhirReqeustContextAccessor.RequestContext.IncludePartiallyIndexedSearchParams && parameter.IsSupported))
+                    (_fhirReqeustContextAccessor.RequestContext != null &&
+                    _fhirReqeustContextAccessor.RequestContext.IncludePartiallyIndexedSearchParams &&
+                    parameter.IsSupported))
             {
                 return parameter;
             }
@@ -83,7 +88,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             SearchParameterInfo parameter = _inner.GetSearchParameter(definitionUri);
 
             if (parameter.IsSearchable ||
-                (_fhirReqeustContextAccessor.RequestContext.IncludePartiallyIndexedSearchParams && parameter.IsSupported))
+                    (_fhirReqeustContextAccessor.RequestContext != null &&
+                    _fhirReqeustContextAccessor.RequestContext.IncludePartiallyIndexedSearchParams &&
+                    parameter.IsSupported))
             {
                 return parameter;
             }
@@ -93,7 +100,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
 
         private IEnumerable<SearchParameterInfo> GetAllSearchParameters()
         {
-            if (_fhirReqeustContextAccessor.RequestContext.IncludePartiallyIndexedSearchParams)
+            if (_fhirReqeustContextAccessor.RequestContext != null &&
+                _fhirReqeustContextAccessor.RequestContext.IncludePartiallyIndexedSearchParams)
             {
                 return _inner.AllSearchParameters.Where(x => x.IsSupported);
             }
@@ -108,9 +116,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             return _inner.GetSearchParameterHashForResourceType(resourceType);
         }
 
-        public void AddNewSearchParameters(IReadOnlyCollection<ITypedElement> searchParameters)
+        public void AddNewSearchParameters(IReadOnlyCollection<ITypedElement> searchParameters, bool calculateHash = true)
         {
-            _inner.AddNewSearchParameters(searchParameters);
+            _inner.AddNewSearchParameters(searchParameters, calculateHash);
         }
 
         public void UpdateSearchParameterHashMap(Dictionary<string, string> updatedSearchParamHashMap)
@@ -128,7 +136,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             _inner.TryGetSearchParameter(definitionUri, out var parameter);
 
             if (parameter.IsSearchable ||
-                (_fhirReqeustContextAccessor.RequestContext.IncludePartiallyIndexedSearchParams && parameter.IsSupported))
+                    (_fhirReqeustContextAccessor.RequestContext != null &&
+                    _fhirReqeustContextAccessor.RequestContext.IncludePartiallyIndexedSearchParams &&
+                    parameter.IsSupported))
             {
                 value = parameter;
                 return true;

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchableSearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchableSearchParameterDefinitionManager.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             _inner.TryGetSearchParameter(definitionUri, out var parameter);
 
             if (parameter.IsSearchable ||
-                (_fhirReqeustContextAccessor.FhirRequestContext.IncludePartiallyIndexedSearchParams && parameter.IsSupported))
+                (_fhirReqeustContextAccessor.RequestContext.IncludePartiallyIndexedSearchParams && parameter.IsSupported))
             {
                 value = parameter;
                 return true;

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchableSearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchableSearchParameterDefinitionManager.cs
@@ -38,7 +38,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
 
         public IEnumerable<SearchParameterInfo> GetSearchParameters(string resourceType)
         {
-            if (_fhirReqeustContextAccessor.RequestContext != null && _fhirReqeustContextAccessor.RequestContext.IncludePartiallyIndexedSearchParams)
+            if (_fhirReqeustContextAccessor.RequestContext != null
+                && _fhirReqeustContextAccessor.RequestContext.IncludePartiallyIndexedSearchParams)
             {
                 return _inner.GetSearchParameters(resourceType)
                 .Where(x => x.IsSupported);
@@ -55,10 +56,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             searchParameter = null;
 
             if (_inner.TryGetSearchParameter(resourceType, code, out var parameter) &&
-                (parameter.IsSearchable ||
-                    (_fhirReqeustContextAccessor.RequestContext != null &&
-                    _fhirReqeustContextAccessor.RequestContext.IncludePartiallyIndexedSearchParams &&
-                    parameter.IsSupported)))
+                (parameter.IsSearchable || UsePartialSearchParams(parameter)))
             {
                 searchParameter = parameter;
 
@@ -72,10 +70,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         {
             SearchParameterInfo parameter = _inner.GetSearchParameter(resourceType, code);
 
-            if (parameter.IsSearchable ||
-                    (_fhirReqeustContextAccessor.RequestContext != null &&
-                    _fhirReqeustContextAccessor.RequestContext.IncludePartiallyIndexedSearchParams &&
-                    parameter.IsSupported))
+            if (parameter.IsSearchable || UsePartialSearchParams(parameter))
             {
                 return parameter;
             }
@@ -87,10 +82,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         {
             SearchParameterInfo parameter = _inner.GetSearchParameter(definitionUri);
 
-            if (parameter.IsSearchable ||
-                    (_fhirReqeustContextAccessor.RequestContext != null &&
-                    _fhirReqeustContextAccessor.RequestContext.IncludePartiallyIndexedSearchParams &&
-                    parameter.IsSupported))
+            if (parameter.IsSearchable || UsePartialSearchParams(parameter))
             {
                 return parameter;
             }
@@ -135,10 +127,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         {
             _inner.TryGetSearchParameter(definitionUri, out var parameter);
 
-            if (parameter.IsSearchable ||
-                    (_fhirReqeustContextAccessor.RequestContext != null &&
-                    _fhirReqeustContextAccessor.RequestContext.IncludePartiallyIndexedSearchParams &&
-                    parameter.IsSupported))
+            if (parameter.IsSearchable || UsePartialSearchParams(parameter))
             {
                 value = parameter;
                 return true;
@@ -151,6 +140,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         public void DeleteSearchParameter(string url, bool calculateHash = true)
         {
             throw new NotImplementedException();
+        }
+
+        private bool UsePartialSearchParams(SearchParameterInfo parameter)
+        {
+            return _fhirReqeustContextAccessor.RequestContext != null &&
+                   _fhirReqeustContextAccessor.RequestContext.IncludePartiallyIndexedSearchParams &&
+                   parameter.IsSupported;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SupportedSearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SupportedSearchParameterDefinitionManager.cs
@@ -96,5 +96,23 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         {
             _inner.DeleteSearchParameter(searchParam);
         }
+
+        public bool TryGetSearchParameter(Uri definitionUri, out SearchParameterInfo value)
+        {
+            value = null;
+            if (_inner.TryGetSearchParameter(definitionUri, out var parameter) && parameter.IsSupported)
+            {
+                value = parameter;
+
+                return true;
+            }
+
+            return false;
+        }
+
+        public void DeleteSearchParameter(string url, bool calculateHash = true)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SupportedSearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SupportedSearchParameterDefinitionManager.cs
@@ -82,9 +82,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             return _inner.GetSearchParameterHashForResourceType(resourceType);
         }
 
-        public void AddNewSearchParameters(IReadOnlyCollection<ITypedElement> searchParameters)
+        public void AddNewSearchParameters(IReadOnlyCollection<ITypedElement> searchParameters, bool calculateHash = true)
         {
-            _inner.AddNewSearchParameters(searchParameters);
+            _inner.AddNewSearchParameters(searchParameters, calculateHash);
         }
 
         public void UpdateSearchParameterHashMap(Dictionary<string, string> updatedSearchParamHashMap)

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobWorker.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobWorker.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     }
                     catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                     {
-                        // End the execution of the task
+                        _logger.LogDebug("Reindex job worker canceled.");
                     }
                     catch (Exception ex)
                     {
@@ -84,7 +84,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                         // Get list of available jobs.
                         if (runningTasks.Count < _reindexJobConfiguration.MaximumNumberOfConcurrentJobsAllowed)
                         {
-                            using (IScoped<IFhirOperationDataStore> store = _fhirOperationDataStoreFactory())
+                            using (IScoped<IFhirOperationDataStore> store = _fhirOperationDataStoreFactory.Invoke())
                             {
                                 _logger.LogTrace("Querying datastore for reindex jobs.");
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobWorker.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobWorker.cs
@@ -72,7 +72,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     {
                         // The job failed.
                         _logger.LogError(ex, "Error querying latest SearchParameterStatus updates");
-                        await Task.Delay(_reindexJobConfiguration.JobPollingFrequency, cancellationToken);
                     }
 
                     // Check for any new Reindex Jobs
@@ -101,8 +100,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                                 }
                             }
                         }
-
-                        await Task.Delay(_reindexJobConfiguration.JobPollingFrequency, cancellationToken);
                     }
                     catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                     {
@@ -112,9 +109,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     {
                         // The job failed.
                         _logger.LogError(ex, "Error polling Reindex jobs.");
-                        await Task.Delay(_reindexJobConfiguration.JobPollingFrequency, cancellationToken);
                     }
                 }
+
+                await Task.Delay(_reindexJobConfiguration.JobPollingFrequency, cancellationToken);
             }
         }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/ISearchParameterOperations.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/ISearchParameterOperations.cs
@@ -26,7 +26,5 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>A task.</returns>
         Task GetAndApplySearchParameterUpdates(CancellationToken cancellationToken);
-
-        Task UpdateSearchParameterAsync(ITypedElement searchParam, RawResource previousSearchParamResource);
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/ISearchParameterOperations.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/ISearchParameterOperations.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Threading;
 using System.Threading.Tasks;
 using Hl7.Fhir.ElementModel;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
@@ -14,6 +15,17 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
         Task AddSearchParameterAsync(ITypedElement searchParam);
 
         Task DeleteSearchParameterAsync(RawResource searchParamResource);
+
+        Task UpdateSearchParameterAsync(ITypedElement searchParam, RawResource previousSearchParam);
+
+        /// <summary>
+        /// This method should be called periodically to get any updates to SearchParameters
+        /// added to the DB by other service instances.
+        /// It should also be called when a user starts a reindex job
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>A task.</returns>
+        Task GetAndApplySearchParameterUpdates(CancellationToken cancellationToken);
 
         Task UpdateSearchParameterAsync(ITypedElement searchParam, RawResource previousSearchParamResource);
     }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
             }
         }
 
-        public async Task UpdateSearchParameterAsync(ITypedElement searchParam, RawResource previousSearchParamResource)
+        public async Task UpdateSearchParameterAsync(ITypedElement searchParam, RawResource previousSearchParam)
         {
             try
             {
@@ -157,7 +157,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
                     throw new SearchParameterNotSupportedException(errorMessage);
                 }
 
-                var prevSearchParam = _modelInfoProvider.ToTypedElement(previousSearchParamResource);
+                var prevSearchParam = _modelInfoProvider.ToTypedElement(previousSearchParam);
                 var prevSearchParamUrl = prevSearchParam.GetStringScalar("url");
 
                 // As any part of the SearchParameter may have been changed, including the URL
@@ -233,11 +233,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
             // Now add the new or updated parameters to the SearchParameterDefinitionManager
             if (paramsToAdd.Any())
             {
-                _searchParameterDefinitionManager.AddNewSearchParameters(paramsToAdd, false);
+                _searchParameterDefinitionManager.AddNewSearchParameters(paramsToAdd);
 
                 // Once added to the definition manager we can update their status
-                await _searchParameterStatusManager.ApplySearchParameterStatus(
-                    updatedSearchParameterStatus.Where(p => p.Status != SearchParameterStatus.Deleted).ToList(), cancellationToken);
+                await _searchParameterStatusManager.ApplySearchParameterStatus(updatedSearchParameterStatus, cancellationToken);
             }
         }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
@@ -236,7 +236,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
                 _searchParameterDefinitionManager.AddNewSearchParameters(paramsToAdd, false);
 
                 // Once added to the definition manager we can update their status
-                await _searchParameterStatusManager.ApplySearchParameterStatus(updatedSearchParameterStatus, cancellationToken);
+                await _searchParameterStatusManager.ApplySearchParameterStatus(
+                    updatedSearchParameterStatus.Where(p => p.Status != SearchParameterStatus.Deleted).ToList(), cancellationToken);
             }
         }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
@@ -233,7 +233,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
             // Now add the new or updated parameters to the SearchParameterDefinitionManager
             if (paramsToAdd.Any())
             {
-                _searchParameterDefinitionManager.AddNewSearchParameters(paramsToAdd);
+                _searchParameterDefinitionManager.AddNewSearchParameters(paramsToAdd, false);
 
                 // Once added to the definition manager we can update their status
                 await _searchParameterStatusManager.ApplySearchParameterStatus(updatedSearchParameterStatus, cancellationToken);

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/UnableToUpdateSearchParameterException.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/UnableToUpdateSearchParameterException.cs
@@ -1,0 +1,37 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using EnsureThat;
+using Microsoft.Health.Fhir.Core.Exceptions;
+using Microsoft.Health.Fhir.Core.Models;
+
+namespace Microsoft.Health.Fhir.Core.Features.Search
+{
+    /// <summary>
+    /// The exception that is thrown when if unable to update search parameter information from the data store
+    /// </summary>
+    public class UnableToUpdateSearchParameterException : FhirException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnableToUpdateSearchParameterException"/> class.
+        /// </summary>
+        /// <param name="definitionUri">The search parameter definition URL.</param>
+        public UnableToUpdateSearchParameterException(Uri definitionUri)
+        {
+            EnsureArg.IsNotNull(definitionUri, nameof(definitionUri));
+
+            AddIssue(string.Format(Core.Resources.UnableToUpdateSearchParameter, definitionUri.ToString()));
+        }
+
+        private void AddIssue(string diagnostics)
+        {
+            Issues.Add(new OperationOutcomeIssue(
+                OperationOutcomeConstants.IssueSeverity.Error,
+                OperationOutcomeConstants.IssueType.NotSupported,
+                diagnostics));
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Messages/Search/SearchParametersInitializedNotification.cs
+++ b/src/Microsoft.Health.Fhir.Core/Messages/Search/SearchParametersInitializedNotification.cs
@@ -1,0 +1,16 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using MediatR;
+
+namespace Microsoft.Health.Fhir.Core.Messages.Search
+{
+    /// <summary>
+    /// A notification that is raised when the SearchParameters are initialized
+    /// </summary>
+    public class SearchParametersInitializedNotification : INotification
+    {
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -1160,6 +1160,15 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Attempt to update SearchParameter {0} failed..
+        /// </summary>
+        internal static string UnableToUpdateSearchParameter {
+            get {
+                return ResourceManager.GetString("UnableToUpdateSearchParameter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unknown Error..
         /// </summary>
         internal static string UnknownError {

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -544,6 +544,11 @@
   <data name="ReindexingResourceNotFound" xml:space="preserve">
     <value>One or more resources to be reindexed were not found, indicating that they have been deleted since the reindex job kicked off.</value>
   </data>
+  <data name="UnableToUpdateSearchParameter" xml:space="preserve">
+    <value>Attempt to update SearchParameter {0} failed.</value>
+    <comment>{0} the uri identifying the search parameter.</comment>
+  </data>
+</root>
   <data name="MemberMatchMultipleMatchesFound" xml:space="preserve">
     <value>Found multiple matches, narrow search criteria.</value>
   </data>

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -548,7 +548,6 @@
     <value>Attempt to update SearchParameter {0} failed.</value>
     <comment>{0} the uri identifying the search parameter.</comment>
   </data>
-</root>
   <data name="MemberMatchMultipleMatchesFound" xml:space="preserve">
     <value>Found multiple matches, narrow search criteria.</value>
   </data>

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/OperationsModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/OperationsModule.cs
@@ -4,12 +4,14 @@
 // -------------------------------------------------------------------------------------------------
 
 using EnsureThat;
+using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Api.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Conformance;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export;
 using Microsoft.Health.Fhir.Core.Features.Operations.Reindex;
+using Microsoft.Health.Fhir.Core.Messages.Search;
 
 namespace Microsoft.Health.Fhir.Api.Modules
 {
@@ -54,7 +56,8 @@ namespace Microsoft.Health.Fhir.Api.Modules
 
             services.Add<ReindexJobWorker>()
                 .Singleton()
-                .AsSelf();
+                .AsSelf()
+                .ReplaceService<INotificationHandler<SearchParametersInitializedNotification>>();
 
             services.AddSingleton<IReindexUtilities, ReindexUtilities>();
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexSingleResourceRequestHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexSingleResourceRequestHandlerTests.cs
@@ -15,6 +15,7 @@ using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Operations.Reindex;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Search;
+using Microsoft.Health.Fhir.Core.Features.Search.Parameters;
 using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
 using Microsoft.Health.Fhir.Core.Features.Security;
 using Microsoft.Health.Fhir.Core.Messages.Reindex;
@@ -48,11 +49,14 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
 
             _authorizationService.CheckAccess(Arg.Is(DataActions.Reindex), Arg.Any<CancellationToken>()).Returns(DataActions.Reindex);
 
+            var searchParameterOperations = Substitute.For<ISearchParameterOperations>();
+
             _reindexHandler = new ReindexSingleResourceRequestHandler(
                 _authorizationService,
                 _fhirDataStore,
                 _searchIndexer,
-                _resourceDeserializer);
+                _resourceDeserializer,
+                searchParameterOperations);
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
@@ -448,6 +448,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
                 searchParameterOperations,
                 () => searchService.CreateMockScope(),
                 ModelInfoProvider.Instance,
+                _mediator,
                 NullLogger<SearchParameterResourceDataStore>.Instance);
 
             _searchParameterSupportResolver

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
@@ -115,7 +115,16 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             var searchParameterDataStoreValidator = Substitute.For<IDataStoreSearchParameterValidator>();
             searchParameterDataStoreValidator.ValidateSearchParameter(Arg.Any<SearchParameterInfo>(), out Arg.Any<string>()).Returns(true, null);
 
-            _searchParameterOperations = new SearchParameterOperations(_manager, _searchParameterDefinitionManager, ModelInfoProvider.Instance, _searchParameterSupportResolver, searchParameterDataStoreValidator);
+            var searchService = Substitute.For<ISearchService>();
+
+            _searchParameterOperations = new SearchParameterOperations(
+                _manager,
+                _searchParameterDefinitionManager,
+                ModelInfoProvider.Instance,
+                _searchParameterSupportResolver,
+                searchParameterDataStoreValidator,
+                () => searchService.CreateMockScope(),
+                NullLogger<SearchParameterOperations>.Instance);
         }
 
         public async Task InitializeAsync()
@@ -431,7 +440,10 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
                 _searchParameterDefinitionManager,
                 ModelInfoProvider.Instance,
                 _searchParameterSupportResolver,
-                dataStoreSearchParamValidator);
+                dataStoreSearchParamValidator,
+                () => searchService.CreateMockScope(),
+                NullLogger<SearchParameterOperations>.Instance);
+
             var searchParameterResourceDataStore = new SearchParameterResourceDataStore(
                 searchParameterOperations,
                 () => searchService.CreateMockScope(),

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -333,8 +333,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             if (unsupportedSearchParameters.Any())
             {
                 bool throwForUnsupported = false;
-                if (_contextAccessor.RequestContext != null &&
-                    _contextAccessor.RequestContext.RequestHeaders != null &&
+                if (_contextAccessor.RequestContext?.RequestHeaders != null &&
                     _contextAccessor.RequestContext.RequestHeaders.TryGetValue(KnownHeaders.Prefer, out var values))
                 {
                     var handlingValue = values.FirstOrDefault(x => x.StartsWith("handling=", StringComparison.OrdinalIgnoreCase));

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -333,7 +333,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             if (unsupportedSearchParameters.Any())
             {
                 bool throwForUnsupported = false;
-                if (_contextAccessor.RequestContext.RequestHeaders != null &&
+                if (_contextAccessor.RequestContext != null &&
+                    _contextAccessor.RequestContext.RequestHeaders != null &&
                     _contextAccessor.RequestContext.RequestHeaders.TryGetValue(KnownHeaders.Prefer, out var values))
                 {
                     var handlingValue = values.FirstOrDefault(x => x.StartsWith("handling=", StringComparison.OrdinalIgnoreCase));

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -30,6 +30,7 @@ using Microsoft.Health.Fhir.Core.Features.Search.Registry;
 using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
 using Microsoft.Health.Fhir.Core.Features.Security.Authorization;
 using Microsoft.Health.Fhir.Core.Messages.Reindex;
+using Microsoft.Health.Fhir.Core.Messages.Search;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Core.UnitTests.Extensions;
 using Microsoft.Health.Fhir.Tests.Common;
@@ -165,6 +166,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                 _searchParameterOperations,
                 NullLogger<ReindexJobWorker>.Instance);
 
+            await _reindexJobWorker.Handle(new SearchParametersInitializedNotification(), CancellationToken.None);
+
             var cancellationTokenSource = new CancellationTokenSource();
 
             try
@@ -195,6 +198,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                 InitializeReindexJobTask,
                 _searchParameterOperations,
                 NullLogger<ReindexJobWorker>.Instance);
+
+            await _reindexJobWorker.Handle(new SearchParametersInitializedNotification(), CancellationToken.None);
 
             var cancellationTokenSource = new CancellationTokenSource();
 
@@ -446,6 +451,9 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                 InitializeReindexJobTask,
                 _searchParameterOperations,
                 NullLogger<ReindexJobWorker>.Instance);
+
+            await _reindexJobWorker.Handle(new SearchParametersInitializedNotification(), CancellationToken.None);
+
             return response;
         }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -65,7 +65,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
         private IScoped<ISearchService> _searchService;
 
         private readonly IReindexJobThrottleController _throttleController = Substitute.For<IReindexJobThrottleController>();
-        private readonly RequestContextAccessor<IFhirRequestContext> _contextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
+        private readonly IFhirRequestContextAccessor _contextAccessor = Substitute.For<IFhirRequestContextAccessor>();
+        private readonly ISearchParameterOperations _searchParameterOperations = Substitute.For<ISearchParameterOperations>();
 
         public ReindexJobTests(FhirStorageTestsFixture fixture)
         {
@@ -161,6 +162,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                 () => _scopedOperationDataStore,
                 Options.Create(_jobConfiguration),
                 InitializeReindexJobTask,
+                _searchParameterOperations,
                 NullLogger<ReindexJobWorker>.Instance);
 
             var cancellationTokenSource = new CancellationTokenSource();
@@ -191,6 +193,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                 () => _scopedOperationDataStore,
                 Options.Create(_jobConfiguration),
                 InitializeReindexJobTask,
+                _searchParameterOperations,
                 NullLogger<ReindexJobWorker>.Instance);
 
             var cancellationTokenSource = new CancellationTokenSource();
@@ -441,6 +444,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                 () => _scopedOperationDataStore,
                 Options.Create(_jobConfiguration),
                 InitializeReindexJobTask,
+                _searchParameterOperations,
                 NullLogger<ReindexJobWorker>.Instance);
             return response;
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
         private IScoped<ISearchService> _searchService;
 
         private readonly IReindexJobThrottleController _throttleController = Substitute.For<IReindexJobThrottleController>();
-        private readonly IFhirRequestContextAccessor _contextAccessor = Substitute.For<IFhirRequestContextAccessor>();
+        private readonly RequestContextAccessor<IFhirRequestContext> _contextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
         private readonly ISearchParameterOperations _searchParameterOperations = Substitute.For<ISearchParameterOperations>();
 
         public ReindexJobTests(FhirStorageTestsFixture fixture)


### PR DESCRIPTION
## Description
Use the ReindexJobWorker to poll for SearchParameter changes made by other instances

## Related issues
Addresses [issue [AB#81849](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/81849)].

## Testing
Manual testing by running multiple instances locally

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
Skip