### PR TITLE
Fixes to prevent running against all partitions if not needed.

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Configs/CosmosDataStoreConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Configs/CosmosDataStoreConfiguration.cs
@@ -53,6 +53,11 @@ namespace Microsoft.Health.Fhir.CosmosDb.Configs
         public bool EnableChainedSearch { get; set; }
 
         /// <summary>
+        /// Uses query statistics to determine the optimal level of partition parallelism needed to return results
+        /// </summary>
+        public bool UseQueryStatistics { get; set; }
+
+        /// <summary>
         /// A list of Search Parameter URIs that will be enabled on first initialization
         /// </summary>
         public HashSet<string> InitialSortParameterUris { get; } = new();

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -123,6 +123,7 @@
             "MaxWaitTimeInSeconds": 90
         },
         "EnableChainedSearch": true,
+        "UseQueryStatistics": true,
         "InitialSortParameterUris": [
             "http://hl7.org/fhir/SearchParameter/individual-family",
             "http://hl7.org/fhir/SearchParameter/individual-given",

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
@@ -185,7 +185,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 fhirRequestContextAccessor,
                 _cosmosDataStoreConfiguration,
                 cosmosDbPhysicalPartitionInfo,
-                new QueryPartitionStatisticsCache());
+                new QueryPartitionStatisticsCache(),
+                NullLogger<FhirCosmosSearchService>.Instance);
 
             ISearchParameterSupportResolver searchParameterSupportResolver = Substitute.For<ISearchParameterSupportResolver>();
             searchParameterSupportResolver.IsSearchParameterSupported(Arg.Any<SearchParameterInfo>()).Returns((true, false));


### PR DESCRIPTION
## Description
Before if a query failed to find enough results it would switch to querying all results in parallel, which is increases the RU cost greatly with very large DBs. 

- It looks like there is a bug where if the number of results found (in total) is less than the the MaxItemCount then it was switching to querying all results in parallel (I inverted the string.IsNullOrEmpty(continuationToken) logic
- Added a feature flag to turn off using query statistics

## Testing
Manual testing 

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
