### PR TITLE
Catch cosmos exception when querying provisioned RUs

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -106,10 +106,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
 
                 _contextAccessor.RequestContext = fhirRequestContext;
 
-                using (IScoped<IFhirDataStore> store = _fhirDataStoreFactory())
+                if (reindexJobRecord.TargetDataStoreUsagePercentage != null &&
+                    reindexJobRecord.TargetDataStoreUsagePercentage > 0)
                 {
-                    var provisionedCapacity = await store.Value.GetProvisionedDataStoreCapacityAsync(cancellationToken);
-                    _throttleController.Initialize(_reindexJobRecord, provisionedCapacity);
+                    using (IScoped<IFhirDataStore> store = _fhirDataStoreFactory())
+                    {
+                        var provisionedCapacity = await store.Value.GetProvisionedDataStoreCapacityAsync(cancellationToken);
+                        _throttleController.Initialize(_reindexJobRecord, provisionedCapacity);
+                    }
                 }
 
                 if (_reindexJobRecord.Status != OperationStatus.Running ||

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                 if (reindexJobRecord.TargetDataStoreUsagePercentage != null &&
                     reindexJobRecord.TargetDataStoreUsagePercentage > 0)
                 {
-                    using (IScoped<IFhirDataStore> store = _fhirDataStoreFactory())
+                    using (IScoped<IFhirDataStore> store = _fhirDataStoreFactory.Invoke())
                     {
                         var provisionedCapacity = await store.Value.GetProvisionedDataStoreCapacityAsync(cancellationToken);
                         _throttleController.Initialize(_reindexJobRecord, provisionedCapacity);

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobWorker.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobWorker.cs
@@ -112,7 +112,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     }
                 }
 
-                await Task.Delay(_reindexJobConfiguration.JobPollingFrequency, cancellationToken);
+                try
+                {
+                    await Task.Delay(_reindexJobConfiguration.JobPollingFrequency, cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    // End the execution of the task
+                }
             }
         }
 

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Operations/Reindex/ReindexJobCosmosThrottleController.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Operations/Reindex/ReindexJobCosmosThrottleController.cs
@@ -64,6 +64,10 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Operations.Reindex
                 _initialized = true;
                 _targetBatchSize = reindexJobRecord.MaximumNumberOfResourcesPerQuery;
             }
+            else
+            {
+                _logger.LogInformation("Unable to initialize throttle controller.  Throttling unavailable. Provisioned RUs: {0}", _provisionedRUThroughput);
+            }
         }
 
         public int GetThrottleBasedDelay()

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -526,7 +526,15 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
 
         public async Task<int?> GetProvisionedDataStoreCapacityAsync(CancellationToken cancellationToken = default)
         {
-            return await _containerScope.Value.ReadThroughputAsync(cancellationToken);
+            try
+            {
+                return await _containerScope.Value.ReadThroughputAsync(cancellationToken);
+            }
+            catch (CosmosException ex)
+            {
+                _logger.LogWarning("Failed to obtain provisioned RU throughput. Error: {0}", ex.Message);
+                return null;
+            }
         }
     }
 }


### PR DESCRIPTION
## Description
In the case when the query to obtain the provisioned RUs fails, the reindex job will not run.  Catch and log the exception.

## Related issues
Addresses [issue [AB#81856](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/81856)].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
Skip