### PR TITLE
Sync SearchParameters and catch Cosmos DB authorization error

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Reindex/ReindexJobWorkerTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Reindex/ReindexJobWorkerTests.cs
@@ -15,6 +15,7 @@ using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Operations.Reindex;
 using Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Microsoft.Health.Fhir.Core.Features.Search.Parameters;
 using NSubstitute;
 using Xunit;
 
@@ -46,11 +47,16 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
             var scopedOperationDataStore = Substitute.For<IScoped<IFhirOperationDataStore>>();
             scopedOperationDataStore.Value.Returns(_fhirOperationDataStore);
 
+            var searchParameterOperations = Substitute.For<ISearchParameterOperations>();
+
             _reindexJobWorker = new ReindexJobWorker(
                 () => scopedOperationDataStore,
                 Options.Create(_reindexJobConfiguration),
                 _reindexJobTaskFactory,
+                searchParameterOperations,
                 NullLogger<ReindexJobWorker>.Instance);
+
+            _reindexJobWorker.Handle(new Messages.Search.SearchParametersInitializedNotification(), CancellationToken.None);
 
             _cancellationToken = _cancellationTokenSource.Token;
         }

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/ISearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/ISearchParameterDefinitionManager.cs
@@ -58,6 +58,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         /// Retrieves the search parameter with <paramref name="definitionUri"/>.
         /// </summary>
         /// <param name="definitionUri">The search parameter definition URL.</param>
+        /// <param name="value">The SearchParameterInfo pertaining to the specified <paramref name="definitionUri"/></param>
+        /// <returns>True if the search parameter is found <paramref name="definitionUri"/>.</returns>
+        public bool TryGetSearchParameter(Uri definitionUri, out SearchParameterInfo value);
+
+        /// <summary>
+        /// Retrieves the search parameter with <paramref name="definitionUri"/>.
+        /// </summary>
+        /// <param name="definitionUri">The search parameter definition URL.</param>
         /// <returns>The search parameter with the given <paramref name="definitionUri"/>.</returns>
         SearchParameterInfo GetSearchParameter(Uri definitionUri);
 
@@ -78,12 +86,20 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         /// Allows addition of a new search parameters at runtime.
         /// </summary>
         /// <param name="searchParameters">An collection containing SearchParameter resources.</param>
-        void AddNewSearchParameters(IReadOnlyCollection<ITypedElement> searchParameters);
+        /// <param name="calculateHash">Indicates whether the search parameter hash should be recalculated</param>
+        void AddNewSearchParameters(IReadOnlyCollection<ITypedElement> searchParameters, bool calculateHash = true);
 
         /// <summary>
         /// Allows removal of a custom search parameter.
         /// </summary>
         /// <param name="searchParam">The custom search parameter to remove.</param>
         void DeleteSearchParameter(ITypedElement searchParam);
+
+        /// <summary>
+        /// Allows removal of a custom search parameter.
+        /// </summary>
+        /// <param name="url">The url identifying the custom search parameter to remove.</param>
+        /// <param name="calculateHash">Indicated whether the search parameter hash values should be recalulated after this delete.</param>
+        void DeleteSearchParameter(string url, bool calculateHash = true);
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
@@ -14,6 +14,7 @@ using EnsureThat;
 using Hl7.Fhir.ElementModel;
 using MediatR;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Features.Definition.BundleWrappers;
 using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Messages.CapabilityStatement;
@@ -111,6 +112,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             throw new SearchParameterNotSupportedException(definitionUri);
         }
 
+        public bool TryGetSearchParameter(Uri definitionUri, out SearchParameterInfo value)
+        {
+            return UrlLookup.TryGetValue(definitionUri, out value);
+        }
+
         public string GetSearchParameterHashForResourceType(string resourceType)
         {
             EnsureArg.IsNotNullOrWhiteSpace(resourceType, nameof(resourceType));
@@ -136,7 +142,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             }
         }
 
-        public void AddNewSearchParameters(IReadOnlyCollection<ITypedElement> searchParameters)
+        public void AddNewSearchParameters(IReadOnlyCollection<ITypedElement> searchParameters, bool calculateHash = true)
         {
             SearchParameterDefinitionBuilder.Build(
                 searchParameters,
@@ -144,7 +150,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
                 TypeLookup,
                 _modelInfoProvider);
 
-            CalculateSearchParameterHash();
+            if (calculateHash)
+            {
+                CalculateSearchParameterHash();
+            }
         }
 
         private void CalculateSearchParameterHash()
@@ -162,11 +171,16 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         public void DeleteSearchParameter(ITypedElement searchParam)
         {
             var searchParamWrapper = new SearchParameterWrapper(searchParam);
+            DeleteSearchParameter(searchParamWrapper.Url);
+        }
+
+        public void DeleteSearchParameter(string url, bool calculateHash = true)
+        {
             SearchParameterInfo searchParameterInfo = null;
 
-            if (!UrlLookup.TryRemove(new Uri(searchParamWrapper.Url), out searchParameterInfo))
+            if (!UrlLookup.TryRemove(new Uri(url), out searchParameterInfo))
             {
-                throw new Exception(string.Format(Resources.CustomSearchParameterNotfound, searchParamWrapper.Url));
+                throw new ResourceNotFoundException(string.Format(Resources.CustomSearchParameterNotfound, url));
             }
 
             var allResourceTypes = searchParameterInfo.TargetResourceTypes.Union(searchParameterInfo.BaseResourceTypes);
@@ -175,13 +189,16 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
                 TypeLookup[resourceType].TryRemove(searchParameterInfo.Code, out var removedParam);
             }
 
-            CalculateSearchParameterHash();
+            if (calculateHash)
+            {
+                CalculateSearchParameterHash();
+            }
         }
 
         public async Task Handle(SearchParametersUpdated notification, CancellationToken cancellationToken)
         {
             CalculateSearchParameterHash();
-            await _mediator.Publish(new RebuildCapabilityStatement(RebuildPart.SearchParameter));
+            await _mediator.Publish(new RebuildCapabilityStatement(RebuildPart.SearchParameter), cancellationToken);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterResourceDataStore.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterResourceDataStore.cs
@@ -16,6 +16,7 @@ using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Features.Search.Parameters;
+using Microsoft.Health.Fhir.Core.Messages.Search;
 using Microsoft.Health.Fhir.Core.Messages.Storage;
 using Microsoft.Health.Fhir.Core.Models;
 
@@ -26,22 +27,26 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         private readonly ISearchParameterOperations _searchParameterOperations;
         private readonly Func<IScoped<ISearchService>> _searchServiceFactory;
         private readonly IModelInfoProvider _modelInfoProvider;
+        private readonly IMediator _mediator;
         private readonly ILogger _logger;
 
         public SearchParameterResourceDataStore(
             ISearchParameterOperations searchParameterOperations,
             Func<IScoped<ISearchService>> searchServiceFactory,
             IModelInfoProvider modelInfoProvider,
+            IMediator mediator,
             ILogger<SearchParameterResourceDataStore> logger)
         {
             EnsureArg.IsNotNull(searchParameterOperations, nameof(searchParameterOperations));
             EnsureArg.IsNotNull(searchServiceFactory, nameof(searchServiceFactory));
             EnsureArg.IsNotNull(modelInfoProvider, nameof(modelInfoProvider));
+            EnsureArg.IsNotNull(mediator, nameof(mediator));
             EnsureArg.IsNotNull(logger, nameof(logger));
 
             _searchParameterOperations = searchParameterOperations;
             _searchServiceFactory = searchServiceFactory;
             _modelInfoProvider = modelInfoProvider;
+            _mediator = mediator;
             _logger = logger;
         }
 
@@ -94,6 +99,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
                 }
             }
             while (continuationToken != null);
+
+            await _mediator.Publish(new SearchParametersInitializedNotification(), CancellationToken.None);
         }
 
         public async Task Handle(StorageInitializedNotification notification, CancellationToken cancellationToken)

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchableSearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchableSearchParameterDefinitionManager.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
 
         public IEnumerable<SearchParameterInfo> GetSearchParameters(string resourceType)
         {
-            if (_fhirReqeustContextAccessor.FhirRequestContext != null
+            if (_fhirReqeustContextAccessor.FhirRequestContext != null &&
                 _fhirReqeustContextAccessor.FhirRequestContext.IncludePartiallyIndexedSearchParams)
             {
                 return _inner.GetSearchParameters(resourceType)

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SupportedSearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SupportedSearchParameterDefinitionManager.cs
@@ -82,9 +82,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             return _inner.GetSearchParameterHashForResourceType(resourceType);
         }
 
-        public void AddNewSearchParameters(IReadOnlyCollection<ITypedElement> searchParameters)
+        public void AddNewSearchParameters(IReadOnlyCollection<ITypedElement> searchParameters, bool calculateHash = true)
         {
-            _inner.AddNewSearchParameters(searchParameters);
+            _inner.AddNewSearchParameters(searchParameters, calculateHash);
         }
 
         public void UpdateSearchParameterHashMap(Dictionary<string, string> updatedSearchParamHashMap)
@@ -95,6 +95,24 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         public void DeleteSearchParameter(ITypedElement searchParam)
         {
             _inner.DeleteSearchParameter(searchParam);
+        }
+
+        public bool TryGetSearchParameter(Uri definitionUri, out SearchParameterInfo value)
+        {
+            value = null;
+            if (_inner.TryGetSearchParameter(definitionUri, out var parameter) && parameter.IsSupported)
+            {
+                value = parameter;
+
+                return true;
+            }
+
+            return false;
+        }
+
+        public void DeleteSearchParameter(string url, bool calculateHash = true)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -105,10 +105,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
 
                 _contextAccessor.FhirRequestContext = fhirRequestContext;
 
-                using (IScoped<IFhirDataStore> store = _fhirDataStoreFactory())
+                if (reindexJobRecord.TargetDataStoreUsagePercentage != null &&
+                    reindexJobRecord.TargetDataStoreUsagePercentage > 0)
                 {
-                    var provisionedCapacity = await store.Value.GetProvisionedDataStoreCapacityAsync(cancellationToken);
-                    _throttleController.Initialize(_reindexJobRecord, provisionedCapacity);
+                    using (IScoped<IFhirDataStore> store = _fhirDataStoreFactory.Invoke())
+                    {
+                        var provisionedCapacity = await store.Value.GetProvisionedDataStoreCapacityAsync(cancellationToken);
+                        _throttleController.Initialize(_reindexJobRecord, provisionedCapacity);
+                    }
                 }
 
                 if (_reindexJobRecord.Status != OperationStatus.Running ||

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobWorker.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobWorker.cs
@@ -112,7 +112,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     }
                 }
 
-                await Task.Delay(_reindexJobConfiguration.JobPollingFrequency, cancellationToken);
+                try
+                {
+                    await Task.Delay(_reindexJobConfiguration.JobPollingFrequency, cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    // End the execution of the task
+                }
             }
         }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobWorker.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobWorker.cs
@@ -8,34 +8,46 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
+using MediatR;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models;
+using Microsoft.Health.Fhir.Core.Features.Search.Parameters;
+using Microsoft.Health.Fhir.Core.Messages.Search;
 
 namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
 {
     /// <summary>
     /// The worker responsible for running the reindex job tasks.
     /// </summary>
-    public class ReindexJobWorker
+    public class ReindexJobWorker : INotificationHandler<SearchParametersInitializedNotification>
     {
         private readonly Func<IScoped<IFhirOperationDataStore>> _fhirOperationDataStoreFactory;
         private readonly ReindexJobConfiguration _reindexJobConfiguration;
         private readonly Func<IReindexJobTask> _reindexJobTaskFactory;
+        private readonly ISearchParameterOperations _searchParameterOperations;
         private readonly ILogger _logger;
+        private bool _searchParametersInitialized = false;
 
-        public ReindexJobWorker(Func<IScoped<IFhirOperationDataStore>> fhirOperationDataStoreFactory, IOptions<ReindexJobConfiguration> reindexJobConfiguration, Func<IReindexJobTask> reindexJobTaskFactory, ILogger<ReindexJobWorker> logger)
+        public ReindexJobWorker(
+            Func<IScoped<IFhirOperationDataStore>> fhirOperationDataStoreFactory,
+            IOptions<ReindexJobConfiguration> reindexJobConfiguration,
+            Func<IReindexJobTask> reindexJobTaskFactory,
+            ISearchParameterOperations searchParameterOperations,
+            ILogger<ReindexJobWorker> logger)
         {
             EnsureArg.IsNotNull(fhirOperationDataStoreFactory, nameof(fhirOperationDataStoreFactory));
             EnsureArg.IsNotNull(reindexJobConfiguration?.Value, nameof(reindexJobConfiguration));
             EnsureArg.IsNotNull(reindexJobTaskFactory, nameof(reindexJobTaskFactory));
+            EnsureArg.IsNotNull(searchParameterOperations, nameof(searchParameterOperations));
             EnsureArg.IsNotNull(logger, nameof(logger));
 
             _fhirOperationDataStoreFactory = fhirOperationDataStoreFactory;
             _reindexJobConfiguration = reindexJobConfiguration.Value;
             _reindexJobTaskFactory = reindexJobTaskFactory;
+            _searchParameterOperations = searchParameterOperations;
             _logger = logger;
         }
 
@@ -45,45 +57,69 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
 
             while (!cancellationToken.IsCancellationRequested)
             {
-                try
+                if (_searchParametersInitialized)
                 {
-                    // Remove all completed tasks.
-                    runningTasks.RemoveAll(task => task.IsCompleted);
-
-                    // Get list of available jobs.
-                    if (runningTasks.Count < _reindexJobConfiguration.MaximumNumberOfConcurrentJobsAllowed)
+                    // Check for any changes to Search Parameters
+                    try
                     {
-                        using (IScoped<IFhirOperationDataStore> store = _fhirOperationDataStoreFactory())
+                        await _searchParameterOperations.GetAndApplySearchParameterUpdates(cancellationToken);
+                    }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        _logger.LogDebug("Reindex job worker canceled.");
+                    }
+                    catch (Exception ex)
+                    {
+                        // The job failed.
+                        _logger.LogError(ex, "Error querying latest SearchParameterStatus updates");
+                    }
+
+                    // Check for any new Reindex Jobs
+                    try
+                    {
+                        // Remove all completed tasks.
+                        runningTasks.RemoveAll(task => task.IsCompleted);
+
+                        // Get list of available jobs.
+                        if (runningTasks.Count < _reindexJobConfiguration.MaximumNumberOfConcurrentJobsAllowed)
                         {
-                            _logger.LogTrace("Querying datastore for reindex jobs.");
-
-                            IReadOnlyCollection<ReindexJobWrapper> jobs = await store.Value.AcquireReindexJobsAsync(
-                                _reindexJobConfiguration.MaximumNumberOfConcurrentJobsAllowed,
-                                _reindexJobConfiguration.JobHeartbeatTimeoutThreshold,
-                                cancellationToken);
-
-                            foreach (ReindexJobWrapper job in jobs)
+                            using (IScoped<IFhirOperationDataStore> store = _fhirOperationDataStoreFactory.Invoke())
                             {
-                                _logger.LogTrace("Picked up reindex job: {jobId}.", job.JobRecord.Id);
+                                _logger.LogTrace("Querying datastore for reindex jobs.");
 
-                                runningTasks.Add(_reindexJobTaskFactory().ExecuteAsync(job.JobRecord, job.ETag, cancellationToken));
+                                IReadOnlyCollection<ReindexJobWrapper> jobs = await store.Value.AcquireReindexJobsAsync(
+                                    _reindexJobConfiguration.MaximumNumberOfConcurrentJobsAllowed,
+                                    _reindexJobConfiguration.JobHeartbeatTimeoutThreshold,
+                                    cancellationToken);
+
+                                foreach (ReindexJobWrapper job in jobs)
+                                {
+                                    _logger.LogTrace("Picked up reindex job: {jobId}.", job.JobRecord.Id);
+
+                                    runningTasks.Add(_reindexJobTaskFactory().ExecuteAsync(job.JobRecord, job.ETag, cancellationToken));
+                                }
                             }
                         }
                     }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        // End the execution of the task
+                    }
+                    catch (Exception ex)
+                    {
+                        // The job failed.
+                        _logger.LogError(ex, "Error polling Reindex jobs.");
+                    }
+                }
 
-                    await Task.Delay(_reindexJobConfiguration.JobPollingFrequency, cancellationToken);
-                }
-                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-                {
-                    // End the execution of the task
-                }
-                catch (Exception ex)
-                {
-                    // The job failed.
-                    _logger.LogError(ex, "Unhandled exception in the worker.");
-                    await Task.Delay(_reindexJobConfiguration.JobPollingFrequency, cancellationToken);
-                }
+                await Task.Delay(_reindexJobConfiguration.JobPollingFrequency, cancellationToken);
             }
+        }
+
+        public Task Handle(SearchParametersInitializedNotification notification, CancellationToken cancellationToken)
+        {
+            _searchParametersInitialized = true;
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/ISearchParameterOperations.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/ISearchParameterOperations.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Threading;
 using System.Threading.Tasks;
 using Hl7.Fhir.ElementModel;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
@@ -16,5 +17,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
         Task DeleteSearchParameterAsync(RawResource searchParam);
 
         Task UpdateSearchParameterAsync(ITypedElement searchParam, RawResource previousSearchParam);
+
+        /// <summary>
+        /// This method should be called periodically to get any updates to SearchParameters
+        /// added to the DB by other service instances.
+        /// It should also be called when a user starts a reindex job
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>A task.</returns>
+        Task GetAndApplySearchParameterUpdates(CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
@@ -5,9 +5,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using Hl7.Fhir.ElementModel;
+using Microsoft.Extensions.Logging;
+using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Definition;
@@ -25,25 +29,33 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
         private readonly IModelInfoProvider _modelInfoProvider;
         private readonly ISearchParameterSupportResolver _searchParameterSupportResolver;
         private readonly IDataStoreSearchParameterValidator _dataStoreSearchParameterValidator;
+        private readonly Func<IScoped<ISearchService>> _searchServiceFactory;
+        private readonly ILogger _logger;
 
         public SearchParameterOperations(
             SearchParameterStatusManager searchParameterStatusManager,
             ISearchParameterDefinitionManager searchParameterDefinitionManager,
             IModelInfoProvider modelInfoProvider,
             ISearchParameterSupportResolver searchParameterSupportResolver,
-            IDataStoreSearchParameterValidator dataStoreSearchParameterValidator)
+            IDataStoreSearchParameterValidator dataStoreSearchParameterValidator,
+            Func<IScoped<ISearchService>> searchServiceFactory,
+            ILogger<SearchParameterOperations> logger)
         {
             EnsureArg.IsNotNull(searchParameterStatusManager, nameof(searchParameterStatusManager));
             EnsureArg.IsNotNull(searchParameterDefinitionManager, nameof(searchParameterDefinitionManager));
             EnsureArg.IsNotNull(modelInfoProvider, nameof(modelInfoProvider));
             EnsureArg.IsNotNull(searchParameterSupportResolver, nameof(searchParameterSupportResolver));
             EnsureArg.IsNotNull(dataStoreSearchParameterValidator, nameof(dataStoreSearchParameterValidator));
+            EnsureArg.IsNotNull(searchServiceFactory, nameof(searchServiceFactory));
+            EnsureArg.IsNotNull(logger, nameof(logger));
 
             _searchParameterStatusManager = searchParameterStatusManager;
             _searchParameterDefinitionManager = searchParameterDefinitionManager;
             _modelInfoProvider = modelInfoProvider;
             _searchParameterSupportResolver = searchParameterSupportResolver;
             _dataStoreSearchParameterValidator = dataStoreSearchParameterValidator;
+            _searchServiceFactory = searchServiceFactory;
+            _logger = logger;
         }
 
         public async Task AddSearchParameterAsync(ITypedElement searchParam)
@@ -126,7 +138,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
             }
         }
 
-        public async Task UpdateSearchParameterAsync(ITypedElement searchParam, RawResource prevSearchParamRaw)
+        public async Task UpdateSearchParameterAsync(ITypedElement searchParam, RawResource previousSearchParam)
         {
             try
             {
@@ -145,7 +157,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
                     throw new SearchParameterNotSupportedException(errorMessage);
                 }
 
-                var prevSearchParam = _modelInfoProvider.ToTypedElement(prevSearchParamRaw);
+                var prevSearchParam = _modelInfoProvider.ToTypedElement(previousSearchParam);
                 var prevSearchParamUrl = prevSearchParam.GetStringScalar("url");
 
                 // As any part of the SearchParameter may have been changed, including the URL
@@ -175,6 +187,93 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
 
                 throw customSearchException;
             }
+        }
+
+        /// <summary>
+        /// This method should be called periodically to get any updates to SearchParameters
+        /// added to the DB by other service instances.
+        /// It should also be called when a user starts a reindex job
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>A task.</returns>
+        public async Task GetAndApplySearchParameterUpdates(CancellationToken cancellationToken)
+        {
+            var updatedSearchParameterStatus = await _searchParameterStatusManager.GetSearchParameterStatusUpdates();
+
+            // first process any deletes, then we will do any adds or updates
+            // this way any deleted params which might have the same code or name as a new
+            // parameter will not cause conflicts
+            foreach (var searchParam in updatedSearchParameterStatus.Where(p => p.Status == SearchParameterStatus.Deleted))
+            {
+                DeleteSearchParameter(searchParam.Uri.ToString());
+            }
+
+            var paramsToAdd = new List<ITypedElement>();
+            foreach (var searchParam in updatedSearchParameterStatus.Where(p => p.Status != SearchParameterStatus.Deleted))
+            {
+                var searchParamResource = await GetSearchParameterByUrl(searchParam.Uri.ToString(), cancellationToken);
+
+                if (searchParamResource == null)
+                {
+                    _logger.LogWarning(
+                        "Updated SearchParameter status found for SearchParameter: {0}, but did not find any SearchParameter resources when querying for this url.",
+                        searchParam.Uri);
+                    continue;
+                }
+
+                if (_searchParameterDefinitionManager.TryGetSearchParameter(searchParam.Uri, out var existingSearchParam))
+                {
+                    // if the search parameter exists we should delete the old information currently stored
+                    DeleteSearchParameter(searchParam.Uri.ToString());
+                }
+
+                paramsToAdd.Add(searchParamResource);
+            }
+
+            // Now add the new or updated parameters to the SearchParameterDefinitionManager
+            if (paramsToAdd.Any())
+            {
+                _searchParameterDefinitionManager.AddNewSearchParameters(paramsToAdd);
+
+                // Once added to the definition manager we can update their status
+                await _searchParameterStatusManager.ApplySearchParameterStatus(
+                    updatedSearchParameterStatus.Where(p => p.Status != SearchParameterStatus.Deleted).ToList(),
+                    cancellationToken);
+            }
+        }
+
+        private void DeleteSearchParameter(string url)
+        {
+            try
+            {
+                _searchParameterDefinitionManager.DeleteSearchParameter(url, false);
+            }
+            catch (ResourceNotFoundException)
+            {
+                // do nothing, there may not be a search parameter to remove
+            }
+        }
+
+        private async Task<ITypedElement> GetSearchParameterByUrl(string url, CancellationToken cancellationToken)
+        {
+            using IScoped<ISearchService> search = _searchServiceFactory.Invoke();
+            var queryParams = new List<Tuple<string, string>>();
+
+            queryParams.Add(new Tuple<string, string>("url", url));
+            var result = await search.Value.SearchAsync(KnownResourceTypes.SearchParameter, queryParams, cancellationToken);
+
+            if (result.Results.Any())
+            {
+                if (result.Results.Count() > 1)
+                {
+                    _logger.LogWarning("More than one SearchParameter found with url {0}. This may cause unpredictable behavior.", url);
+                }
+
+                // There should be only one SearchParameter per url
+                return result.Results.First().Resource.RawResource.ToITypedElement(_modelInfoProvider);
+            }
+
+            return null;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
         private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager;
         private readonly ISearchParameterSupportResolver _searchParameterSupportResolver;
         private readonly IMediator _mediator;
+        private DateTimeOffset _latestSearchParams;
 
         public SearchParameterStatusManager(
             ISearchParameterStatusDataStore searchParameterStatusDataStore,
@@ -41,40 +42,40 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
             _searchParameterDefinitionManager = searchParameterDefinitionManager;
             _searchParameterSupportResolver = searchParameterSupportResolver;
             _mediator = mediator;
+
+            _latestSearchParams = DateTime.MinValue;
         }
 
         internal async Task EnsureInitializedAsync(CancellationToken cancellationToken)
         {
             var updated = new List<SearchParameterInfo>();
-
-            var parameters = (await _searchParameterStatusDataStore.GetSearchParameterStatuses())
-                .ToDictionary(x => x.Uri);
+            var searchParamResourceStatus = await _searchParameterStatusDataStore.GetSearchParameterStatuses();
+            var parameters = searchParamResourceStatus.ToDictionary(x => x.Uri);
+            _latestSearchParams = parameters.Values.Select(p => p.LastUpdated).Max();
 
             // Set states of known parameters
             foreach (SearchParameterInfo p in _searchParameterDefinitionManager.AllSearchParameters)
             {
                 if (parameters.TryGetValue(p.Url, out ResourceSearchParameterStatus result))
                 {
-                    bool isSearchable = result.Status == SearchParameterStatus.Enabled;
-                    bool isSupported = result.Status == SearchParameterStatus.Supported || result.Status == SearchParameterStatus.Enabled;
-                    bool isPartiallySupported = result.IsPartiallySupported;
+                    var tempStatus = EvaluateSearchParamStatus(result);
 
                     if (result.Status == SearchParameterStatus.Disabled)
                     {
                         // Re-check if this parameter is now supported.
                         (bool Supported, bool IsPartiallySupported) supportedResult = _searchParameterSupportResolver.IsSearchParameterSupported(p);
-                        isSupported = supportedResult.Supported;
-                        isPartiallySupported = supportedResult.IsPartiallySupported;
+                        tempStatus.IsSupported = supportedResult.Supported;
+                        tempStatus.IsPartiallySupported = supportedResult.IsPartiallySupported;
                     }
 
-                    if (p.IsSearchable != isSearchable ||
-                        p.IsSupported != isSupported ||
-                        p.IsPartiallySupported != isPartiallySupported ||
+                    if (p.IsSearchable != tempStatus.IsSearchable ||
+                        p.IsSupported != tempStatus.IsSupported ||
+                        p.IsPartiallySupported != tempStatus.IsPartiallySupported ||
                         p.SortStatus != result.SortStatus)
                     {
-                        p.IsSearchable = isSearchable;
-                        p.IsSupported = isSupported;
-                        p.IsPartiallySupported = isPartiallySupported;
+                        p.IsSearchable = tempStatus.IsSearchable;
+                        p.IsSupported = tempStatus.IsSupported;
+                        p.IsPartiallySupported = tempStatus.IsPartiallySupported;
                         p.SortStatus = result.SortStatus;
 
                         updated.Add(p);
@@ -157,6 +158,52 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
         {
             var searchParamUris = new List<string>() { url };
             await UpdateSearchParameterStatusAsync(searchParamUris, SearchParameterStatus.Deleted);
+        }
+
+        internal async Task<IReadOnlyCollection<ResourceSearchParameterStatus>> GetSearchParameterStatusUpdates()
+        {
+            var searchParamStatus = await _searchParameterStatusDataStore.GetSearchParameterStatuses();
+            return searchParamStatus.Where(p => p.LastUpdated > _latestSearchParams).ToList();
+        }
+
+        internal async Task ApplySearchParameterStatus(IReadOnlyCollection<ResourceSearchParameterStatus> updatedSearchParameterStatus, CancellationToken cancellationToken)
+        {
+            var updated = new List<SearchParameterInfo>();
+
+            foreach (var paramStatus in updatedSearchParameterStatus)
+            {
+                var param = _searchParameterDefinitionManager.GetSearchParameter(paramStatus.Uri);
+
+                var tempStatus = EvaluateSearchParamStatus(paramStatus);
+
+                param.IsSearchable = tempStatus.IsSearchable;
+                param.IsSupported = tempStatus.IsSupported;
+                param.IsPartiallySupported = tempStatus.IsPartiallySupported;
+                param.SortStatus = paramStatus.SortStatus;
+
+                updated.Add(param);
+            }
+
+            _latestSearchParams = updatedSearchParameterStatus.Select(p => p.LastUpdated).Max();
+
+            await _mediator.Publish(new SearchParametersUpdated(updated), cancellationToken);
+        }
+
+        private static TempStatus EvaluateSearchParamStatus(ResourceSearchParameterStatus paramStatus)
+        {
+            TempStatus tempStatus;
+            tempStatus.IsSearchable = paramStatus.Status == SearchParameterStatus.Enabled;
+            tempStatus.IsSupported = paramStatus.Status == SearchParameterStatus.Supported || paramStatus.Status == SearchParameterStatus.Enabled;
+            tempStatus.IsPartiallySupported = paramStatus.IsPartiallySupported;
+
+            return tempStatus;
+        }
+
+        private struct TempStatus
+        {
+            public bool IsSearchable;
+            public bool IsSupported;
+            public bool IsPartiallySupported;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/UnableToUpdateSearchParameterException.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/UnableToUpdateSearchParameterException.cs
@@ -1,0 +1,37 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using EnsureThat;
+using Microsoft.Health.Fhir.Core.Exceptions;
+using Microsoft.Health.Fhir.Core.Models;
+
+namespace Microsoft.Health.Fhir.Core.Features.Search
+{
+    /// <summary>
+    /// The exception that is thrown when if unable to update search parameter information from the data store
+    /// </summary>
+    public class UnableToUpdateSearchParameterException : FhirException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnableToUpdateSearchParameterException"/> class.
+        /// </summary>
+        /// <param name="definitionUri">The search parameter definition URL.</param>
+        public UnableToUpdateSearchParameterException(Uri definitionUri)
+        {
+            EnsureArg.IsNotNull(definitionUri, nameof(definitionUri));
+
+            AddIssue(string.Format(Core.Resources.UnableToUpdateSearchParameter, definitionUri.ToString()));
+        }
+
+        private void AddIssue(string diagnostics)
+        {
+            Issues.Add(new OperationOutcomeIssue(
+                OperationOutcomeConstants.IssueSeverity.Error,
+                OperationOutcomeConstants.IssueType.NotSupported,
+                diagnostics));
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Messages/Search/SearchParametersInitializedNotification.cs
+++ b/src/Microsoft.Health.Fhir.Core/Messages/Search/SearchParametersInitializedNotification.cs
@@ -1,0 +1,16 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using MediatR;
+
+namespace Microsoft.Health.Fhir.Core.Messages.Search
+{
+    /// <summary>
+    /// A notification that is raised when the SearchParameters are initialized
+    /// </summary>
+    public class SearchParametersInitializedNotification : INotification
+    {
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -1142,6 +1142,15 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Attempt to update SearchParameter {0} failed..
+        /// </summary>
+        internal static string UnableToUpdateSearchParameter {
+            get {
+                return ResourceManager.GetString("UnableToUpdateSearchParameter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unknown Error..
         /// </summary>
         internal static string UnknownError {

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -543,5 +543,9 @@
   </data>
   <data name="ReindexingResourceNotFound" xml:space="preserve">
     <value>One or more resources to be reindexed were not found, indicating that they have been deleted since the reindex job kicked off.</value>
+  </data>
+  <data name="UnableToUpdateSearchParameter" xml:space="preserve">
+    <value>Attempt to update SearchParameter {0} failed.</value>
+    <comment>{0} the uri identifying the search parameter.</comment>
   </data>
 </root>

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Operations/Reindex/ReindexJobCosmosThrottleController.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Operations/Reindex/ReindexJobCosmosThrottleController.cs
@@ -63,6 +63,10 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Operations.Reindex
                 _initialized = true;
                 _targetBatchSize = reindexJobRecord.MaximumNumberOfResourcesPerQuery;
             }
+            else
+            {
+                _logger.LogInformation("Unable to initialize throttle controller.  Throttling unavailable. Provisioned RUs: {0}", _provisionedRUThroughput);
+            }
         }
 
         public int GetThrottleBasedDelay()

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -526,7 +526,15 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
 
         public async Task<int?> GetProvisionedDataStoreCapacityAsync(CancellationToken cancellationToken = default)
         {
-            return await _containerScope.Value.ReadThroughputAsync(cancellationToken);
+            try
+            {
+                return await _containerScope.Value.ReadThroughputAsync(cancellationToken);
+            }
+            catch (CosmosException ex)
+            {
+                _logger.LogWarning("Failed to obtain provisioned RU throughput. Error: {0}", ex.Message);
+                return null;
+            }
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/OperationsModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/OperationsModule.cs
@@ -4,12 +4,14 @@
 // -------------------------------------------------------------------------------------------------
 
 using EnsureThat;
+using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Api.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Conformance;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export;
 using Microsoft.Health.Fhir.Core.Features.Operations.Reindex;
+using Microsoft.Health.Fhir.Core.Messages.Search;
 
 namespace Microsoft.Health.Fhir.Api.Modules
 {
@@ -54,7 +56,8 @@ namespace Microsoft.Health.Fhir.Api.Modules
 
             services.Add<ReindexJobWorker>()
                 .Singleton()
-                .AsSelf();
+                .AsSelf()
+                .ReplaceService<INotificationHandler<SearchParametersInitializedNotification>>();
 
             services.AddSingleton<IReindexUtilities, ReindexUtilities>();
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexSingleResourceRequestHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexSingleResourceRequestHandlerTests.cs
@@ -15,6 +15,7 @@ using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Operations.Reindex;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Search;
+using Microsoft.Health.Fhir.Core.Features.Search.Parameters;
 using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
 using Microsoft.Health.Fhir.Core.Features.Security;
 using Microsoft.Health.Fhir.Core.Messages.Reindex;
@@ -48,11 +49,14 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
 
             _authorizationService.CheckAccess(Arg.Is(DataActions.Reindex), Arg.Any<CancellationToken>()).Returns(DataActions.Reindex);
 
+            var searchParameterOperations = Substitute.For<ISearchParameterOperations>();
+
             _reindexHandler = new ReindexSingleResourceRequestHandler(
                 _authorizationService,
                 _fhirDataStore,
                 _searchIndexer,
-                _resourceDeserializer);
+                _resourceDeserializer,
+                searchParameterOperations);
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
@@ -114,7 +114,16 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             var searchParameterDataStoreValidator = Substitute.For<IDataStoreSearchParameterValidator>();
             searchParameterDataStoreValidator.ValidateSearchParameter(Arg.Any<SearchParameterInfo>(), out Arg.Any<string>()).Returns(true, null);
 
-            _searchParameterOperations = new SearchParameterOperations(_manager, _searchParameterDefinitionManager, ModelInfoProvider.Instance, _searchParameterSupportResolver, searchParameterDataStoreValidator);
+            var searchService = Substitute.For<ISearchService>();
+
+            _searchParameterOperations = new SearchParameterOperations(
+                _manager,
+                _searchParameterDefinitionManager,
+                ModelInfoProvider.Instance,
+                _searchParameterSupportResolver,
+                searchParameterDataStoreValidator,
+                () => searchService.CreateMockScope(),
+                NullLogger<SearchParameterOperations>.Instance);
         }
 
         public async Task InitializeAsync()
@@ -430,11 +439,15 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
                 _searchParameterDefinitionManager,
                 ModelInfoProvider.Instance,
                 _searchParameterSupportResolver,
-                dataStoreSearchParamValidator);
+                dataStoreSearchParamValidator,
+                () => searchService.CreateMockScope(),
+                NullLogger<SearchParameterOperations>.Instance);
+
             var searchParameterResourceDataStore = new SearchParameterResourceDataStore(
                 searchParameterOperations,
                 () => searchService.CreateMockScope(),
                 ModelInfoProvider.Instance,
+                _mediator,
                 NullLogger<SearchParameterResourceDataStore>.Instance);
 
             _searchParameterSupportResolver

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -332,7 +332,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             if (unsupportedSearchParameters.Any())
             {
                 bool throwForUnsupported = false;
-                if (_contextAccessor.FhirRequestContext.RequestHeaders != null &&
+                if (_contextAccessor.FhirRequestContext?.RequestHeaders != null &&
                     _contextAccessor.FhirRequestContext.RequestHeaders.TryGetValue(KnownHeaders.Prefer, out var values))
                 {
                     var handlingValue = values.FirstOrDefault(x => x.StartsWith("handling=", StringComparison.OrdinalIgnoreCase));

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -30,6 +30,7 @@ using Microsoft.Health.Fhir.Core.Features.Search.Registry;
 using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
 using Microsoft.Health.Fhir.Core.Features.Security.Authorization;
 using Microsoft.Health.Fhir.Core.Messages.Reindex;
+using Microsoft.Health.Fhir.Core.Messages.Search;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Core.UnitTests.Extensions;
 using Microsoft.Health.Fhir.Tests.Common;
@@ -66,6 +67,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
 
         private readonly IReindexJobThrottleController _throttleController = Substitute.For<IReindexJobThrottleController>();
         private readonly IFhirRequestContextAccessor _contextAccessor = Substitute.For<IFhirRequestContextAccessor>();
+        private readonly ISearchParameterOperations _searchParameterOperations = Substitute.For<ISearchParameterOperations>();
 
         public ReindexJobTests(FhirStorageTestsFixture fixture)
         {
@@ -160,7 +162,10 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                 () => _scopedOperationDataStore,
                 Options.Create(_jobConfiguration),
                 InitializeReindexJobTask,
+                _searchParameterOperations,
                 NullLogger<ReindexJobWorker>.Instance);
+
+            await _reindexJobWorker.Handle(new SearchParametersInitializedNotification(), CancellationToken.None);
 
             var cancellationTokenSource = new CancellationTokenSource();
 
@@ -190,7 +195,10 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                 () => _scopedOperationDataStore,
                 Options.Create(_jobConfiguration),
                 InitializeReindexJobTask,
+                _searchParameterOperations,
                 NullLogger<ReindexJobWorker>.Instance);
+
+            await _reindexJobWorker.Handle(new SearchParametersInitializedNotification(), CancellationToken.None);
 
             var cancellationTokenSource = new CancellationTokenSource();
 
@@ -440,7 +448,11 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                 () => _scopedOperationDataStore,
                 Options.Create(_jobConfiguration),
                 InitializeReindexJobTask,
+                _searchParameterOperations,
                 NullLogger<ReindexJobWorker>.Instance);
+
+            await _reindexJobWorker.Handle(new SearchParametersInitializedNotification(), CancellationToken.None);
+
             return response;
         }
 


### PR DESCRIPTION
## Description
Two fixes are included here:
Synchronizing SearchParameters between FHIR instances, and catching authentication error for Cosmos DB when starting a reindex job

## Related issues
Addresses [issue [AB#81856](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/81856)].
Addresses [issue [AB#81849](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/81849)].

## Testing
Manual and automated tests

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
