### PR TITLE
Custom search fixes for multi-instance scenario

### DIFF
--- a/build/ci-pipeline-mag.yml
+++ b/build/ci-pipeline-mag.yml
@@ -38,10 +38,10 @@ stages:
         azurePowerShellVersion: latestVersion
         ScriptType: inlineScript
         Inline: |
-          $cors = (ConvertFrom-Json (Get-Content -Raw "*/**/corstestconfiguration.json"))
-          $flattenedCors = $(System.DefaultWorkingDirectory)/release/scripts/PowerShell/ConvertTo-FlattenedConfigurationHashtable.ps1 -InputObject $cors
+          $testConfig = (ConvertFrom-Json (Get-Content -Raw "*/**/testconfiguration.json"))
+          $flattenedTestConfig = $(System.DefaultWorkingDirectory)/release/scripts/PowerShell/ConvertTo-FlattenedConfigurationHashtable.ps1 -InputObject $testConfig
       
-          $additionalProperties = $flattenedCors
+          $additionalProperties = $flattenedTestConfig
       
           $additionalProperties["SqlServer:DeleteAllDataOnStartup"] = "true"
 

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -63,6 +63,7 @@ jobs:
             fhirVersion = "${{ parameters.version }}"
             appServicePlanName = "${{ parameters.appServicePlanName }}"
             appServicePlanSku = "B3"
+            numberOfInstances = 2
             serviceName = $webAppName
             securityAuthenticationAuthority = "https://login.microsoftonline.com/$(tenant-id)"
             securityAuthenticationAudience = "${{ parameters.testEnvironmentUrl }}"

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -49,10 +49,10 @@ jobs:
      
         $deployPath = "$(System.DefaultWorkingDirectory)/test/Configuration"
      
-        $cors = (ConvertFrom-Json (Get-Content -Raw "$deployPath/corstestconfiguration.json"))
-        $flattenedCors = $(System.DefaultWorkingDirectory)/release/scripts/PowerShell/ConvertTo-FlattenedConfigurationHashtable.ps1 -InputObject $cors
+        $testConfig = (ConvertFrom-Json (Get-Content -Raw "$deployPath/testconfiguration.json"))
+        $flattenedTestConfig = $(System.DefaultWorkingDirectory)/release/scripts/PowerShell/ConvertTo-FlattenedConfigurationHashtable.ps1 -InputObject $testConfig
      
-        $additionalProperties = $flattenedCors
+        $additionalProperties = $flattenedTestConfig
      
         $additionalProperties["SqlServer__DeleteAllDataOnStartup"] = "false"
         $additionalProperties["SqlServer__AllowDatabaseCreation"] = "true"

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -42,6 +42,13 @@
             ],
             "defaultValue": "S1"
         },
+        "numberOfInstances" : {
+            "type": "int",
+            "defaultValue": 1,
+            "metadata": {
+                "description": "Sets the number of instances to deploy for the app service."
+            }
+        },
         "securityAuthenticationAuthority": {
             "type": "string",
             "defaultValue": "",
@@ -250,6 +257,7 @@
             },
             "properties": {
                 "name": "[variables('appServicePlanName')]",
+                "numberOfWorkers": "[parameters('numberOfInstances')]",
                 "reserved": true
             }
         },

--- a/samples/templates/default-azuredeploy.json
+++ b/samples/templates/default-azuredeploy.json
@@ -42,6 +42,13 @@
             ],
             "defaultValue": "S1"
         },
+        "numberOfInstances" : {
+            "type": "int",
+            "defaultValue": 1,
+            "metadata": {
+                "description": "Sets the number of instances to deploy for the app service."
+            }
+        },
         "securityAuthenticationAuthority": {
             "type": "string",
             "defaultValue": "",
@@ -250,7 +257,8 @@
                 "name": "[parameters('appServicePlanSku')]"
             },
             "properties": {
-                "name": "[variables('appServicePlanName')]"
+                "name": "[variables('appServicePlanName')]",
+                "numberOfWorkers": "[parameters('numberOfInstances')]"
             }
         },
         {
@@ -267,7 +275,7 @@
             "properties": {
                 "clientAffinityEnabled": false,
                 "serverFarmId": "[resourceId(variables('appServicePlanResourceGroup'), 'Microsoft.Web/serverfarms/', variables('appServicePlanName'))]",
-				"siteConfig": {
+                "siteConfig": {
                    "AlwaysOn": true
                }
             },

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
@@ -180,7 +180,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
 
             if (!UrlLookup.TryRemove(new Uri(url), out searchParameterInfo))
             {
-                throw new ResourceNotFoundException(string.Format(Resources.CustomSearchParameterNotfound, url));
+                // throw new ResourceNotFoundException(string.Format(Resources.CustomSearchParameterNotfound, url));
+                return;
             }
 
             var allResourceTypes = searchParameterInfo.TargetResourceTypes.Union(searchParameterInfo.BaseResourceTypes);

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
@@ -180,8 +180,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
 
             if (!UrlLookup.TryRemove(new Uri(url), out searchParameterInfo))
             {
-                // throw new ResourceNotFoundException(string.Format(Resources.CustomSearchParameterNotfound, url));
-                return;
+                throw new ResourceNotFoundException(string.Format(Resources.CustomSearchParameterNotfound, url));
             }
 
             var allResourceTypes = searchParameterInfo.TargetResourceTypes.Union(searchParameterInfo.BaseResourceTypes);

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/CreateReindexRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/CreateReindexRequestHandler.cs
@@ -62,6 +62,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                 throw new JobConflictException(string.Format(Resources.OnlyOneResourceJobAllowed, reindexJobId));
             }
 
+            // We need to pull in latest search parameter updates from the data store before creating a reindex job.
+            // There could be a potential delay of <see cref="ReindexJobConfiguration.JobPollingFrequency"/> before
+            // search parameter updates on one instance propagates to other instances. If we store the reindex
+            // job with the old hash value in _searchParameterDefinitionManager.SearchParameterHashMap, then we will
+            // not detect the resources that need to be reindexed.
             await _searchParameterOperations.GetAndApplySearchParameterUpdates(cancellationToken);
 
             var jobRecord = new ReindexJobRecord(

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/CreateReindexRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/CreateReindexRequestHandler.cs
@@ -13,6 +13,7 @@ using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models;
+using Microsoft.Health.Fhir.Core.Features.Search.Parameters;
 using Microsoft.Health.Fhir.Core.Features.Security;
 using Microsoft.Health.Fhir.Core.Messages.Reindex;
 
@@ -24,22 +25,26 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
         private readonly IAuthorizationService<DataActions> _authorizationService;
         private readonly ReindexJobConfiguration _reindexJobConfiguration;
         private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager;
+        private readonly ISearchParameterOperations _searchParameterOperations;
 
         public CreateReindexRequestHandler(
             IFhirOperationDataStore fhirOperationDataStore,
             IAuthorizationService<DataActions> authorizationService,
             IOptions<ReindexJobConfiguration> reindexJobConfiguration,
-            ISearchParameterDefinitionManager searchParameterDefinitionManager)
+            ISearchParameterDefinitionManager searchParameterDefinitionManager,
+            ISearchParameterOperations searchParameterOperations)
         {
             EnsureArg.IsNotNull(fhirOperationDataStore, nameof(fhirOperationDataStore));
             EnsureArg.IsNotNull(authorizationService, nameof(authorizationService));
             EnsureArg.IsNotNull(reindexJobConfiguration, nameof(reindexJobConfiguration));
             EnsureArg.IsNotNull(searchParameterDefinitionManager, nameof(searchParameterDefinitionManager));
+            EnsureArg.IsNotNull(searchParameterOperations, nameof(searchParameterOperations));
 
             _fhirOperationDataStore = fhirOperationDataStore;
             _authorizationService = authorizationService;
             _reindexJobConfiguration = reindexJobConfiguration.Value;
             _searchParameterDefinitionManager = searchParameterDefinitionManager;
+            _searchParameterOperations = searchParameterOperations;
         }
 
         public async Task<CreateReindexResponse> Handle(CreateReindexRequest request, CancellationToken cancellationToken)
@@ -56,6 +61,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             {
                 throw new JobConflictException(string.Format(Resources.OnlyOneResourceJobAllowed, reindexJobId));
             }
+
+            await _searchParameterOperations.GetAndApplySearchParameterUpdates(cancellationToken);
 
             var jobRecord = new ReindexJobRecord(
                 _searchParameterDefinitionManager.SearchParameterHashMap,

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
@@ -142,6 +142,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
         {
             try
             {
+                // We need to make sure we have the latest search parameters before trying to update
+                // existing search parameter. This is to avoid trying to update a search parameter that
+                // was recently added and that hasn't propogated to all fhir-server instances.
                 await GetAndApplySearchParameterUpdates(CancellationToken.None);
 
                 var searchParameterWrapper = new SearchParameterWrapper(searchParam);

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
@@ -142,6 +142,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
         {
             try
             {
+                await GetAndApplySearchParameterUpdates(CancellationToken.None);
+
                 var searchParameterWrapper = new SearchParameterWrapper(searchParam);
                 var searchParameterInfo = new SearchParameterInfo(searchParameterWrapper);
                 (bool Supported, bool IsPartiallySupported) supportedResult = _searchParameterSupportResolver.IsSearchParameterSupported(searchParameterInfo);

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
@@ -113,25 +113,17 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
             {
                 var searchParamUri = new Uri(uri);
 
-                SearchParameterInfo paramInfo = null;
-                try
-                {
-                    paramInfo = _searchParameterDefinitionManager.GetSearchParameter(searchParamUri);
-                    updated.Add(paramInfo);
-                    paramInfo.IsSearchable = status == SearchParameterStatus.Enabled;
-                    paramInfo.IsSupported = status == SearchParameterStatus.Supported || status == SearchParameterStatus.Enabled;
-                }
-                catch (SearchParameterNotSupportedException)
-                {
-                    // Don't do anything
-                }
+                SearchParameterInfo paramInfo = _searchParameterDefinitionManager.GetSearchParameter(searchParamUri);
+                updated.Add(paramInfo);
+                paramInfo.IsSearchable = status == SearchParameterStatus.Enabled;
+                paramInfo.IsSupported = status == SearchParameterStatus.Supported || status == SearchParameterStatus.Enabled;
 
                 if (parameters.TryGetValue(searchParamUri, out var existingStatus))
                 {
                     existingStatus.LastUpdated = Clock.UtcNow;
                     existingStatus.Status = status;
 
-                    if (paramInfo != null && paramInfo.IsSearchable && existingStatus.SortStatus == SortParameterStatus.Supported)
+                    if (paramInfo.IsSearchable && existingStatus.SortStatus == SortParameterStatus.Supported)
                     {
                         existingStatus.SortStatus = SortParameterStatus.Enabled;
                         paramInfo.SortStatus = SortParameterStatus.Enabled;

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -62,7 +62,7 @@
                 ]
             },
             "Reindex": {
-                "Enabled": false,
+                "Enabled": true,
                 "ConsecutiveFailuresThreshold": 5,
                 "DefaultMaximumThreadsPerReindexJob": 1,
                 "MaximumNumberOfResourcesPerQuery": 100,

--- a/test/Configuration/testconfiguration.json
+++ b/test/Configuration/testconfiguration.json
@@ -5,6 +5,11 @@
             "Methods": ["*"],
             "Headers": ["*"],
             "MaxAge": 1440 
+        },
+        "Operations": {
+            "Validate": {
+                "CacheDurationInSeconds": 0
+            }
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/InProcTestFhirServer.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/InProcTestFhirServer.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             : base(new Uri("http://localhost/"))
         {
             var projectDir = GetProjectPath("src", startupType);
-            var corsPath = Path.GetFullPath("corstestconfiguration.json");
+            var testConfigPath = Path.GetFullPath("testconfiguration.json");
 
             var launchSettings = JObject.Parse(File.ReadAllText(Path.Combine(projectDir, "Properties", "launchSettings.json")));
 
@@ -112,7 +112,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
                 .ConfigureAppConfiguration(configurationBuilder =>
                 {
                     configurationBuilder.AddDevelopmentAuthEnvironmentIfConfigured(new ConfigurationBuilder().AddInMemoryCollection(configuration).Build());
-                    configurationBuilder.AddJsonFile(corsPath);
+                    configurationBuilder.AddJsonFile(testConfigPath);
                     configurationBuilder.AddInMemoryCollection(configuration);
                 })
                 .UseStartup(startupType)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -96,8 +96,28 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 Assert.True(resourcesReindexed > 0.0);
 
                 // When job complete, search for resources using new parameter
-                await ExecuteAndValidateBundle(
-                    $"Appointment?{searchParam.Code}={Appointment.AppointmentStatus.Noshow.ToString().ToLower()}&_tag={tag.Code}", expectedAppointment.Resource);
+                int retryCount = 0;
+                bool success = true;
+                do
+                {
+                    success = true;
+                    retryCount++;
+                    try
+                    {
+                        await ExecuteAndValidateBundle(
+                            $"Appointment?{searchParam.Code}={Appointment.AppointmentStatus.Noshow.ToString().ToLower()}&_tag={tag.Code}",
+                            expectedAppointment.Resource);
+                    }
+                    catch (Exception ex)
+                    {
+                        _output.WriteLine($"Failed to validate bundle: {ex}");
+                        success = false;
+                        await Task.Delay(5000);
+                    }
+                }
+                while (!success && retryCount <= 3);
+
+                Assert.True(success);
             }
             catch (FhirException ex) when (ex.StatusCode == HttpStatusCode.BadRequest && ex.Message.Contains("not enabled"))
             {
@@ -160,7 +180,10 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 Assert.Equal(randomName, param.Value.ToString());
 
                 // When job complete, search for resources using new parameter
-                await ExecuteAndValidateBundle($"Patient?{searchParamPosted.Resource.Code}:exact={randomName}", Tuple.Create("x-ms-use-partial-indices", "true"), expectedPatient.Resource);
+                await ExecuteAndValidateBundle(
+                            $"Patient?{searchParamPosted.Resource.Code}:exact={randomName}",
+                            Tuple.Create("x-ms-use-partial-indices", "true"),
+                            expectedPatient.Resource);
             }
             catch (FhirException ex) when (ex.StatusCode == HttpStatusCode.BadRequest && ex.Message.Contains("not enabled"))
             {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -100,6 +100,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 bool success = true;
                 do
                 {
+                    await Task.Delay(10000);
                     success = true;
                     retryCount++;
                     try
@@ -112,7 +113,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                     {
                         _output.WriteLine($"Failed to validate bundle: {ex}");
                         success = false;
-                        await Task.Delay(5000);
                     }
                 }
                 while (!success && retryCount <= 3);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -96,11 +96,14 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 Assert.True(resourcesReindexed > 0.0);
 
                 // When job complete, search for resources using new parameter
+                // When there are multiple instances of the fhir-server running, it could take some time
+                // for the search parameter/reindex updates to propogate to all instances. Hence we are
+                // adding some retries below to account for that delay.
                 int retryCount = 0;
                 bool success = true;
                 do
                 {
-                    await Task.Delay(10000);
+                    await Task.Delay(7500);
                     success = true;
                     retryCount++;
                     try

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -103,7 +103,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 bool success = true;
                 do
                 {
-                    await Task.Delay(7500);
                     success = true;
                     retryCount++;
                     try
@@ -116,9 +115,10 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                     {
                         _output.WriteLine($"Failed to validate bundle: {ex}");
                         success = false;
+                        await Task.Delay(10000);
                     }
                 }
-                while (!success && retryCount <= 3);
+                while (!success && retryCount < 3);
 
                 Assert.True(success);
             }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -102,7 +102,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                                                 _fhirOperationDataStore,
                                                 DisabledFhirAuthorizationService.Instance,
                                                 optionsReindexConfig,
-                                                _searchParameterDefinitionManager);
+                                                _searchParameterDefinitionManager,
+                                                _searchParameterOperations);
 
             _reindexUtilities = new ReindexUtilities(
                 () => _scopedDataStore,


### PR DESCRIPTION
## Description
Updating our deployment pipeline to deploy 2 instances of the fhir-server by default. This will allow us to test scenarios where multiple instances of the fhir-server are running.

Update:
Updated code to handle different scenarios that might happen when we have multiple instances of the fhir-server.
1. Updating a newly created search parameter. Lets say the `POST SearchParameter` request goes to instance 1. If the subsequent `PUT SearchParameter` request goes to instance 2 we will fail the request since instance 2 does not know about the SearchParameter yet. 
2. Triggering a reindex job. Similar to the above except that we send a `POST $reindex` which lands on instance 2. Since instance 2 might not have the latest search parameters (there is a 10 second time window for the refresh cycle), it creates a reindex job with the "old" hash values. So when reindex runs it doesn't find the resources that need to be re-indexed since it is searching using the old hash. We end up marking the search parameter as enabled even though the resources have not been re-indexed. 

To address both scenarios, I have added code to get search parameter updates from the data store while processing the respective requests.

## Related issues
Addresses [AB#81878](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/81878)

## Testing
Locally deployed multiple-instances and tested the above scenarios.
Manually deployed the branch and verified that the app service plan had instance count set to 2:

![image](https://user-images.githubusercontent.com/41395116/117058417-70793280-acd3-11eb-85d9-4e8d1b6b59ef.png)

Also verified using application insights logs that requests were being sent to both instances:

![image](https://user-images.githubusercontent.com/41395116/117058575-a7e7df00-acd3-11eb-8435-40a45ac82cfa.png)



## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
