### PR TITLE
Fix cosmos iterating over big resources.

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -445,7 +445,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
                 // The advantage is that we don't need to construct a new query with a new page size.
 
                 int currentDesiredCount = totalDesiredCount - results.Count;
-                if (mustNotExceedMaxItemCount && currentDesiredCount != feedOptions.MaxItemCount && !executingWithMaxParallelism)
+                if (mustNotExceedMaxItemCount && currentDesiredCount != feedOptions.MaxItemCount)
                 {
                     // Construct a new query with a smaller page size.
                     // We do this to ensure that we will not exceed the original max page size and that
@@ -461,14 +461,6 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
                     if (page.Count > 0)
                     {
                         results.AddRange(page);
-                        if (mustNotExceedMaxItemCount && page.Count > feedOptions.MaxItemCount)
-                        {
-                            // we might get here if executingWithParallelism == true
-
-                            int toRemove = page.Count - feedOptions.MaxItemCount.Value;
-                            results.RemoveRange(results.Count - toRemove, toRemove);
-                            break;
-                        }
                     }
                 }
                 catch (CosmosException e) when (e.IsRequestRateExceeded())

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -461,11 +461,11 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
                     if (page.Count > 0)
                     {
                         results.AddRange(page);
-                        if (mustNotExceedMaxItemCount && results.Count > feedOptions.MaxItemCount)
+                        if (mustNotExceedMaxItemCount && page.Count > feedOptions.MaxItemCount)
                         {
                             // we might get here if executingWithParallelism == true
 
-                            int toRemove = results.Count - feedOptions.MaxItemCount.Value;
+                            int toRemove = page.Count - feedOptions.MaxItemCount.Value;
                             results.RemoveRange(results.Count - toRemove, toRemove);
                             break;
                         }


### PR DESCRIPTION
## Description
Cosmos db has limit in 4mb of data be returned per request. If we didn't get enough data from cosmos we need to issue more requests to fetch more resources (up to half of requested). There is logic which discards results, and it's flawed, so I fixed it.

## Related issues
https://github.com/microsoft/fhir-server/issues/1898

## Testing
Added E2E tests

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
