### PR TITLE
Fix cosmos iterating over pages of resources

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -393,6 +393,13 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
         {
             EnsureArg.IsNotNull(sqlQuerySpec, nameof(sqlQuerySpec));
 
+            int totalDesiredCount = 0;
+
+            if (feedOptions.MaxItemCount.HasValue)
+            {
+                totalDesiredCount = feedOptions.MaxItemCount.Value;
+            }
+
             var context = new CosmosQueryContext(sqlQuerySpec, feedOptions, continuationToken);
             ICosmosQuery<T> cosmosQuery = null;
             var startTime = Clock.UtcNow;
@@ -414,8 +421,6 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
                 singlePageResults.AddRange(page);
                 return (singlePageResults, page.ContinuationToken);
             }
-
-            int totalDesiredCount = feedOptions.MaxItemCount.Value;
 
             // try to obtain at least half of the requested results
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Net;
+using System.Text;
 using System.Threading.Tasks;
 using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.FhirPath;
@@ -828,6 +829,92 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             using FhirException ex = await Assert.ThrowsAsync<FhirException>(() =>
                 Client.SearchAsync("Patient?Cookie=Chip&Ramen=Spicy", Tuple.Create(KnownHeaders.Prefer, "handling=foo")));
             Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
+        }
+
+        [Fact]
+        public async Task GivenSetOfChunkyResources_WhenIteratingOverThem_ThenAllResourcesReturned()
+        {
+            int n = 30;
+            var tag = Guid.NewGuid().ToString();
+            var sb = new StringBuilder();
+            for (int i = 0; i < 500_000; i++)
+            {
+                sb.Append('A');
+            }
+
+            var text = "<div>" + sb.ToString() + "</div>";
+
+            for (int i = 0; i < n; i++)
+            {
+                var observation = await Client.CreateResourcesAsync<Observation>(() => new Observation()
+                {
+                    Meta = new Meta { Tag = new List<Coding> { new Coding(null, tag) } },
+                    Status = ObservationStatus.Final,
+                    Text = new Narrative() { Div = text },
+                    Code = new CodeableConcept("http://loinc.org", "11557-6"),
+                    Value = new Quantity(i, "kPa"),
+                });
+            }
+
+            List<int> values = new();
+            int count = 0;
+            string nextLink = $"Observation?_count=20&_tag={tag}";
+            do
+            {
+                Bundle firstBundle = await Client.SearchAsync(nextLink);
+                foreach (var entity in firstBundle.Entry)
+                {
+                    values.Add((int)((Quantity)((Observation)entity.Resource).Value).Value);
+                }
+
+                count += firstBundle.Entry.Count;
+                nextLink = firstBundle.NextLink?.ToString();
+            }
+            while (nextLink != null);
+            Assert.Equal(n, count);
+            Assert.Equal(Enumerable.Range(0, n), values.OrderBy(x => x));
+        }
+
+        [Fact]
+        public async Task GivenSetOfChunkyResources_WhenIteratingOverThemWithSort_ThenAllResourcesReturned()
+        {
+            int n = 30;
+            var tag = Guid.NewGuid().ToString();
+            var sb = new StringBuilder();
+            for (int i = 0; i < 500_000; i++)
+            {
+                sb.Append('A');
+            }
+
+            var text = "<div>" + sb.ToString() + "</div>";
+            var date = new DateTime(2000, 01, 01);
+            for (int i = 0; i < n; i++)
+            {
+                var observation = await Client.CreateResourcesAsync<Patient>(() => new Patient()
+                {
+                    Meta = new Meta { Tag = new List<Coding> { new Coding(null, tag) } },
+                    BirthDate = date.AddDays(i).ToString("yyyy-MM-dd"),
+                    Text = new Narrative() { Div = text },
+                });
+            }
+
+            List<int> values = new();
+            int count = 0;
+            string nextLink = $"Patient?_count=20&_tag={tag}&_sort=-_lastUpdated";
+            do
+            {
+                Bundle firstBundle = await Client.SearchAsync(nextLink);
+                foreach (var entity in firstBundle.Entry)
+                {
+                    values.Add(DateTime.Parse(((Patient)entity.Resource).BirthDate).Subtract(date).Days);
+                }
+
+                count += firstBundle.Entry.Count;
+                nextLink = firstBundle.NextLink?.ToString();
+            }
+            while (nextLink != null);
+            Assert.Equal(n, count);
+            Assert.Equal(Enumerable.Range(0, n), values.OrderBy(x => x));
         }
 
         private async Task<Patient[]> CreatePatientsWithSpecifiedElements(Coding tag, string[] elements)


### PR DESCRIPTION
## Description
Fix logic surrounding results which are larger than the desired total count.  This caused missing results when paging across results.

## Related issues
Addresses [issue #1898].

## Testing
New E2E tests were added and run.

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
Skip