### PR TITLE
Use DatetimeOffset in search manager

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
             _searchParameterSupportResolver = searchParameterSupportResolver;
             _mediator = mediator;
 
-            _latestSearchParams = DateTime.MinValue;
+            _latestSearchParams = DateTimeOffset.MinValue;
         }
 
         internal async Task EnsureInitializedAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
## Description
As described in the below issue. Updated code to use `DateTimeOffset.MinValue` instead of `DateTime.MinValue`

## Related issues
Addresses #1916 

## Testing
Tested manually by setting system timezone to UTC+2 and running the code. Server starts up as expected (whereas it previously failed). 

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
