### PR TITLE
Fix how :above modifier works for URLs

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Expression.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Expression.cs
@@ -98,6 +98,19 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         }
 
         /// <summary>
+        /// Creates a <see cref="StringExpression"/> that represents left side starts with operation.
+        /// </summary>
+        /// <param name="fieldName">The field name.</param>
+        /// <param name="componentIndex">The component index.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="ignoreCase">A flag indicating whether it's case and accent sensitive or not.</param>
+        /// <returns>A <see cref="StringExpression"/> that represents contains operation.</returns>
+        public static StringExpression LeftSideStartsWtih(FieldName fieldName, int? componentIndex, string value, bool ignoreCase)
+        {
+            return new StringExpression(StringOperator.LeftSideStartsWith, fieldName, componentIndex, value, ignoreCase);
+        }
+
+        /// <summary>
         /// Creates a <see cref="StringExpression"/> that represents contains operation.
         /// </summary>
         /// <param name="fieldName">The field name.</param>

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Expression.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Expression.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// <param name="value">The value.</param>
         /// <param name="ignoreCase">A flag indicating whether it's case and accent sensitive or not.</param>
         /// <returns>A <see cref="StringExpression"/> that represents contains operation.</returns>
-        public static StringExpression LeftSideStartsWtih(FieldName fieldName, int? componentIndex, string value, bool ignoreCase)
+        public static StringExpression LeftSideStartsWith(FieldName fieldName, int? componentIndex, string value, bool ignoreCase)
         {
             return new StringExpression(StringOperator.LeftSideStartsWith, fieldName, componentIndex, value, ignoreCase);
         }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/SearchValueExpressionBuilderHelper.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/SearchValueExpressionBuilderHelper.cs
@@ -302,7 +302,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
                     break;
                 case SearchModifierCode.Above:
                     _outputExpression = Expression.And(
-                        Expression.EndsWith(FieldName.Uri, _componentIndex, uri.Uri, false),
+                        Expression.LeftSideStartsWtih(FieldName.Uri, _componentIndex, uri.Uri, false),
                         Expression.NotStartsWith(FieldName.Uri, _componentIndex, KnownUriSchemes.Urn, false));
                     break;
                 case SearchModifierCode.Below:

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/SearchValueExpressionBuilderHelper.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/SearchValueExpressionBuilderHelper.cs
@@ -302,7 +302,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
                     break;
                 case SearchModifierCode.Above:
                     _outputExpression = Expression.And(
-                        Expression.LeftSideStartsWtih(FieldName.Uri, _componentIndex, uri.Uri, false),
+                        Expression.LeftSideStartsWith(FieldName.Uri, _componentIndex, uri.Uri, false),
                         Expression.NotStartsWith(FieldName.Uri, _componentIndex, KnownUriSchemes.Urn, false));
                     break;
                 case SearchModifierCode.Below:

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/StringOperator.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/StringOperator.cs
@@ -17,5 +17,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         NotEndsWith,
         NotStartsWith,
         StartsWith,
+        LeftSideStartsWith,
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/ExpressionQueryBuilder.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/ExpressionQueryBuilder.cs
@@ -292,6 +292,16 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries
                     .Append(" = ")
                     .Append(AddParameterMapping(value));
             }
+            else if (expression.StringOperator == StringOperator.LeftSideStartsWith)
+            {
+                _queryBuilder
+                    .Append(GetMappedValue(StringOperatorMapping, StringOperator.StartsWith))
+                    .Append('(')
+                    .Append(AddParameterMapping(value))
+                    .Append(", ")
+                    .Append(context.InstanceVariableName).Append('.').Append(fieldName)
+                    .Append(')');
+            }
             else
             {
                 _queryBuilder

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CollectionInitializer.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CollectionInitializer.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
 using System.Net;
 using System.Threading.Tasks;
 using EnsureThat;

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/Parsers/SearchValueExpressionBuilderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/Parsers/SearchValueExpressionBuilderTests.cs
@@ -896,7 +896,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
                 e => ValidateMultiaryExpression(
                     e,
                     MultiaryOperator.And,
-                    e1 => ValidateStringExpression(e1, FieldName.Uri, StringOperator.EndsWith, input, false),
+                    e1 => ValidateStringExpression(e1, FieldName.Uri, StringOperator.LeftSideStartsWith, input, false),
                     e2 => ValidateStringExpression(e2, FieldName.Uri, StringOperator.NotStartsWith, "urn:", false)));
         }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/UriSearchTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/UriSearchTestFixture.cs
@@ -31,7 +31,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             ValueSets = await TestFhirClient.CreateResourcesAsync<ValueSet>(
                 vs => AddValueSet(vs, "http://somewhere.com/test/system"),
                 vs => AddValueSet(vs, "urn://localhost/test"),
-                vs => AddValueSet(vs, "http://example.org/rdf#54135-9"));
+                vs => AddValueSet(vs, "http://example.org/rdf#54135-9"),
+                vs => AddValueSet(vs, "http://example.org/rdf#54135-9-9"));
 
             void AddValueSet(ValueSet vs, string url)
             {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/UriSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/UriSearchTests.cs
@@ -25,10 +25,11 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [InlineData("", "http://somewhere.COM/test/system")]
         [InlineData("", "http://example.org/rdf#54135-9", 2)]
         [InlineData("", "urn://localhost/test", 1)]
-        [InlineData(":above", "system", 0)]
+        [InlineData(":above", "http://somewhere.com/test/system/123", 0)]
         [InlineData(":above", "test")]
         [InlineData(":above", "urn://localhost/test")]
-        [InlineData(":below", "http", 0, 2)]
+        [InlineData(":above", "http://example.org/rdf#54135-9-9-10", 2, 3)]
+        [InlineData(":below", "http", 0, 2, 3)]
         [InlineData(":below", "test")]
         [InlineData(":below", "urn")]
         public async Task GivenAUriSearchParam_WhenSearched_ThenCorrectBundleShouldBeReturned(string modifier, string queryValue, params int[] expectedIndices)


### PR DESCRIPTION
## Description
As it states in spec:
```
GET [base]/ValueSet?url:above=http://acme.org/fhir/ValueSet/123/_history/5

 search for any value set above a given specific URL. 

This will match on any value set with the specified URL, but also on http://acme.org/ValueSet/123. 
Note that there are not many use cases where :above is useful as compared to the :below search
```
Simply put if you looking for :above=ABC
and you have urls: A, AB, ABC they should be fetched, but everything else should be ignored.


## Related issues
Addresses [#158].

## Testing
Updated unit tests.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
