### PR TITLE
Turns querystatics off

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -123,7 +123,7 @@
             "MaxWaitTimeInSeconds": 90
         },
         "EnableChainedSearch": true,
-        "UseQueryStatistics": true,
+        "UseQueryStatistics": false,
         "InitialSortParameterUris": [
             "http://hl7.org/fhir/SearchParameter/individual-family",
             "http://hl7.org/fhir/SearchParameter/individual-given",


### PR DESCRIPTION
## Description
Querystatics must be turned off as this feature needs more work

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
