### PR TITLE
Adds Location header in Update requests

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
@@ -236,7 +236,8 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                 case SaveOutcomeType.Updated:
                     return FhirResult.Create(saveOutcome.RawResourceElement, HttpStatusCode.OK)
                         .SetETagHeader()
-                        .SetLastModifiedHeader();
+                        .SetLastModifiedHeader()
+                        .SetLocationHeader(_urlResolver);
             }
 
             return FhirResult.Create(saveOutcome.RawResourceElement, HttpStatusCode.BadRequest);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalUpdateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalUpdateTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Net;
+using System.Net.Http.Headers;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Client;
 using Microsoft.Health.Fhir.Core.Extensions;
@@ -137,6 +138,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
                 $"identifier={identifier}");
 
             Assert.Equal(HttpStatusCode.OK, updateResponse.StatusCode);
+            Assert.NotNull(updateResponse.Headers.Location);
 
             Observation updatedResource = updateResponse.Resource;
 


### PR DESCRIPTION
## Description
Adds `Location` header to be returned by update requests. This can assist conditional update where the id or resource was not previously known.

## Testing
Updates unit test

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
