### PR TITLE
Cumulitive capability statement improvment

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Data/R4/BaseCapabilities.json
+++ b/src/Microsoft.Health.Fhir.Core/Data/R4/BaseCapabilities.json
@@ -18,7 +18,8 @@
     "kind": [ "capability" ],
     "fhirVersion": "4.0.0",
     "format": [
-        "application/fhir+json"
+        "application/fhir+json",
+        "json"
     ],
     "rest": [
         {

--- a/src/Microsoft.Health.Fhir.Core/Data/R5/BaseCapabilities.json
+++ b/src/Microsoft.Health.Fhir.Core/Data/R5/BaseCapabilities.json
@@ -18,7 +18,8 @@
     "kind": [ "capability" ],
     "fhirVersion": "4.2.0",
     "format": [
-        "application/fhir+json"
+        "application/fhir+json",
+        "json"
     ],
     "rest": [
         {

--- a/src/Microsoft.Health.Fhir.Core/Data/Stu3/BaseCapabilities.json
+++ b/src/Microsoft.Health.Fhir.Core/Data/Stu3/BaseCapabilities.json
@@ -18,6 +18,7 @@
     "kind": [ "capability" ],
     "fhirVersion": "3.0.1",
     "format": [
+        "application/fhir+json",
         "json"
     ],
     "acceptUnknown": "both",

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
@@ -220,10 +220,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
             foreach (string resource in _modelInfoProvider.GetResourceTypeNames())
             {
                 // Parameters is a non-persisted resource used to pass information into and back from an operation.
-                // Unfortunetly STU3 has cardinality of 1..* for interactions, so we need to put something inside.
-                if (string.Equals(resource, KnownResourceTypes.Parameters, StringComparison.Ordinal)
-                    && _modelInfoProvider.Version != FhirSpecification.Stu3)
+                if (string.Equals(resource, KnownResourceTypes.Parameters, StringComparison.Ordinal))
                 {
+                    // Unfortunetly STU3 has cardinality of 1..* for interactions, so we need to put something inside.
+                    if (_modelInfoProvider.Version == FhirSpecification.Stu3)
+                    {
+                        AddResourceInteraction(resource, TypeRestfulInteraction.Delete);
+                    }
+
                     continue;
                 }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
@@ -222,12 +222,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
                 // Parameters is a non-persisted resource used to pass information into and back from an operation.
                 if (string.Equals(resource, KnownResourceTypes.Parameters, StringComparison.Ordinal))
                 {
-                    // Unfortunetly STU3 has cardinality of 1..* for interactions, so we need to put something inside.
-                    if (_modelInfoProvider.Version == FhirSpecification.Stu3)
-                    {
-                        AddResourceInteraction(resource, TypeRestfulInteraction.Delete);
-                    }
-
                     continue;
                 }
 
@@ -290,6 +284,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
             _statement.Profile.Clear();
             foreach (string resource in _modelInfoProvider.GetResourceTypeNames())
             {
+                // Parameters is a non-persisted resource used to pass information into and back from an operation
+                if (string.Equals(resource, KnownResourceTypes.Parameters, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
                 SyncProfile(resource, disableCacheRefresh);
             }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using EnsureThat;
 using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Serialization;
@@ -55,6 +56,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
             using Stream resourceStream = modelInfoProvider.OpenVersionedFileStream("BaseCapabilities.json");
             using var reader = new StreamReader(resourceStream);
             var statement = JsonConvert.DeserializeObject<ListedCapabilityStatement>(reader.ReadToEnd());
+            statement.Date = File.GetCreationTime(Assembly.GetExecutingAssembly().Location).ToUniversalTime().ToString("O");
             return new CapabilityStatementBuilder(statement, modelInfoProvider, searchParameterDefinitionManager, supportedProfiles);
         }
 
@@ -135,6 +137,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
         public ICapabilityStatementBuilder AddGlobalSearchParameters()
         {
             _statement.Rest.Server().SearchParam.Add(new SearchParamComponent { Name = SearchParameterNames.ResourceType, Definition = SearchParameterNames.TypeUri, Type = SearchParamType.Token });
+            _statement.Rest.Server().SearchParam.Add(new SearchParamComponent { Name = KnownQueryParameterNames.Count, Type = SearchParamType.Number });
 
             return this;
         }
@@ -291,7 +294,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
         {
             // To build a CapabilityStatement we use a custom JsonConverter that serializes
             // the ListedCapabilityStatement into a CapabilityStatement poco
-
             var json = JsonConvert.SerializeObject(_statement, new JsonSerializerSettings
             {
                 ContractResolver = new CamelCasePropertyNamesContractResolver(),

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
@@ -220,7 +220,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
             foreach (string resource in _modelInfoProvider.GetResourceTypeNames())
             {
                 // Parameters is a non-persisted resource used to pass information into and back from an operation.
-                if (string.Equals(resource, KnownResourceTypes.Parameters, StringComparison.Ordinal))
+                // Unfortunetly STU3 has cardinality of 1..* for interactions, so we need to put something inside.
+                if (string.Equals(resource, KnownResourceTypes.Parameters, StringComparison.Ordinal)
+                    && _modelInfoProvider.Version != FhirSpecification.Stu3)
                 {
                     continue;
                 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/Models/ListedCapabilityStatement.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/Models/ListedCapabilityStatement.cs
@@ -45,6 +45,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance.Models
 
         public SoftwareComponent Software { get; set; }
 
+        public string Date { get; set; }
+
         public string FhirVersion { get; set; }
 
         public ICollection<string> Format { get; }

--- a/src/Microsoft.Health.Fhir.Core/Features/Security/Constants.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Security/Constants.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Security
 {
     public static class Constants
     {
-        private static readonly Coding RestfulSecurityServiceOAuthCodeableConcept = new Coding("http://hl7.org/fhir/ValueSet/restful-security-service", "OAuth");
+        private static readonly Coding RestfulSecurityServiceOAuthCodeableConcept = new Coding("http://terminology.hl7.org/CodeSystem/restful-security-service", "OAuth");
         public const string SmartOAuthUriExtension = "http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris";
         public const string SmartOAuthUriExtensionToken = "token";
         public const string SmartOAuthUriExtensionAuthorize = "authorize";

--- a/src/Microsoft.Health.Fhir.Core/Features/Security/Constants.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Security/Constants.cs
@@ -10,10 +10,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Security
     public static class Constants
     {
         private static readonly Coding RestfulSecurityServiceOAuthCodeableConcept = new Coding("http://terminology.hl7.org/CodeSystem/restful-security-service", "OAuth");
+        private static readonly Coding RestfulSecurityServiceStu3OAuthCodeableConcept = new Coding("http://hl7.org/fhir/restful-security-service", "OAuth");
         public const string SmartOAuthUriExtension = "http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris";
         public const string SmartOAuthUriExtensionToken = "token";
         public const string SmartOAuthUriExtensionAuthorize = "authorize";
 
         public static ref readonly Coding RestfulSecurityServiceOAuth => ref RestfulSecurityServiceOAuthCodeableConcept;
+
+        public static ref readonly Coding RestfulSecurityServiceStu3OAuth => ref RestfulSecurityServiceStu3OAuthCodeableConcept;
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Security/SecurityProvider.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Security/SecurityProvider.cs
@@ -53,7 +53,6 @@ namespace Microsoft.Health.Fhir.Api.Features.Security
             {
                 builder.Apply(statement =>
                 {
-                    bool stu3 = _modelInfoProvider.Version.Equals(FhirSpecification.Stu3);
                     if (_securityConfiguration.EnableAadSmartOnFhirProxy)
                     {
                         AddProxyOAuthSecurityService(statement, RouteNames.AadSmartOnFhirProxyAuthorize, RouteNames.AadSmartOnFhirProxyToken);

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/FeatureFlags/XmlFormatter/XmlFormatterConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/FeatureFlags/XmlFormatter/XmlFormatterConfiguration.cs
@@ -26,7 +26,11 @@ namespace Microsoft.Health.Fhir.Api.Modules.FeatureFlags.XmlFormatter
         {
             if (_featureConfiguration.SupportsXml)
             {
-                builder.Apply(x => x.Format.Add(KnownContentTypes.XmlContentType));
+                builder.Apply(x =>
+                {
+                    x.Format.Add(KnownContentTypes.XmlContentType);
+                    x.Format.Add("xml");
+                });
             }
         }
     }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Conformance/ConformanceBuilderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Conformance/ConformanceBuilderTests.cs
@@ -88,6 +88,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Conformance
             Assert.False(noDelete);
         }
 
+// STU3 doesn't allow empty interactions so we had have Parameters in capability statement.
+#if !Stu3
         [Fact]
         public void GivenAConformanceBuilder_WhenAddingDefaultInteractions_ThenParameterTypeIsNotAdded()
         {
@@ -99,6 +101,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Conformance
 
             Assert.False(noParameters);
         }
+#endif
 
         [Fact]
         public void GivenAConformanceBuilder_WhenAddingGlobalSearchParam_ThenTypeSearchParamIsAdded()

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Conformance/ConformanceBuilderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Conformance/ConformanceBuilderTests.cs
@@ -88,8 +88,6 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Conformance
             Assert.False(noDelete);
         }
 
-// STU3 doesn't allow empty interactions so we had have Parameters in capability statement.
-#if !Stu3
         [Fact]
         public void GivenAConformanceBuilder_WhenAddingDefaultInteractions_ThenParameterTypeIsNotAdded()
         {
@@ -101,7 +99,6 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Conformance
 
             Assert.False(noParameters);
         }
-#endif
 
         [Fact]
         public void GivenAConformanceBuilder_WhenAddingGlobalSearchParam_ThenTypeSearchParamIsAdded()


### PR DESCRIPTION
## Description
Add json and xml format
Add Date to capabilitystatement
Add _count search param
Change terminology for security.service.

## Related issues
Addresses [#1928], [#1926], [#338], [#1428].

## Testing
Manually.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch