### PR TITLE
Ignore non searchable parameters in member match

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/MemberMatch/MemberMatchService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/MemberMatch/MemberMatchService.cs
@@ -173,6 +173,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.MemberMatch
         }
 
         private static bool IgnoreInSearch(SearchIndexEntry searchEntry) =>
-         searchEntry.SearchParameter.Code == SearchParameterNames.Id || searchEntry.SearchParameter.Type == ValueSets.SearchParamType.Reference;
+         searchEntry.SearchParameter.Code == SearchParameterNames.Id
+            || searchEntry.SearchParameter.Type == ValueSets.SearchParamType.Reference
+            || !searchEntry.SearchParameter.IsSearchable;
     }
 }


### PR DESCRIPTION
## Description
It's possible what someone post new search parameter on server, and we would extract values for patient and coverage, but that search parameter could be non searchable yet (Reindex job hasn't been run) so as soon as we hit search service it would throw exception.

This change make sure we using only searchable extracted values from Patient and Coverage.

## Related issues
Addresses [issue #].

## Testing
Manually, there is tests in PaaS which is failing right now, so confirmation of this one is working would be green tests on top of main branch in PaaS.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
