### PR TITLE
Improve Chained Queries with Group by Type

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Exceptions/RequestTooCostlyException.cs
+++ b/src/Microsoft.Health.Fhir.Core/Exceptions/RequestTooCostlyException.cs
@@ -1,0 +1,24 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using EnsureThat;
+using Microsoft.Health.Fhir.Core.Models;
+
+namespace Microsoft.Health.Fhir.Core.Exceptions
+{
+    public class RequestTooCostlyException : FhirException
+    {
+        public RequestTooCostlyException(string message)
+        : base(message)
+        {
+            EnsureArg.IsNotNull(message, nameof(message));
+
+            Issues.Add(new OperationOutcomeIssue(
+                OperationOutcomeConstants.IssueSeverity.Error,
+                OperationOutcomeConstants.IssueType.TooCostly,
+                message));
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Models/OperationOutcomeConstants.cs
+++ b/src/Microsoft.Health.Fhir.Core/Models/OperationOutcomeConstants.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Health.Fhir.Core.Models
             public const string Incomplete = "Incomplete";
             public const string Informational = "Informational";
             public const string Throttled = "Throttled";
+            public const string TooCostly = "TooCostly";
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -232,6 +232,15 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The operation was stopped due to the underlying request being too resource intensive. If possible, try narrowing or changing the criteria..
+        /// </summary>
+        internal static string ConditionalRequestTooCostly {
+            get {
+                return ResourceManager.GetString("ConditionalRequestTooCostly", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Found result with Id &apos;{0}&apos;, which did not match the provided Id &apos;{1}&apos;..
         /// </summary>
         internal static string ConditionalUpdateMismatchedIds {

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -565,6 +565,7 @@
   </data>
   <data name="InvalidEverythingOperationPhase" xml:space="preserve">
     <value>The phase '{0}' in $everything operation is invalid.</value>
+  </data>
   <data name="ConditionalRequestTooCostly" xml:space="preserve">
     <value>The operation was stopped due to the underlying request being too resource intensive. If possible, try narrowing or changing the criteria.</value>
   </data>

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -565,5 +565,7 @@
   </data>
   <data name="InvalidEverythingOperationPhase" xml:space="preserve">
     <value>The phase '{0}' in $everything operation is invalid.</value>
+  <data name="ConditionalRequestTooCostly" xml:space="preserve">
+    <value>The operation was stopped due to the underlying request being too resource intensive. If possible, try narrowing or changing the criteria.</value>
   </data>
 </root>

--- a/src/Microsoft.Health.Fhir.CosmosDb/Configs/CosmosDataStoreConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Configs/CosmosDataStoreConfiguration.cs
@@ -48,11 +48,6 @@ namespace Microsoft.Health.Fhir.CosmosDb.Configs
         public int SearchEnumerationTimeoutInSeconds { get; set; } = 30;
 
         /// <summary>
-        /// Enables chained searches in CosmosDB
-        /// </summary>
-        public bool EnableChainedSearch { get; set; }
-
-        /// <summary>
         /// Uses query statistics to determine the optimal level of partition parallelism needed to return results
         /// </summary>
         public bool UseQueryStatistics { get; set; }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -181,13 +182,6 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
 
         private async Task<List<Expression>> PerformChainedSearch(SearchOptions searchOptions, IReadOnlyList<ChainedExpression> chainedExpressions, CancellationToken cancellationToken)
         {
-            if (!_cosmosConfig.EnableChainedSearch &&
-                !(_requestContextAccessor.RequestContext.RequestHeaders.TryGetValue(KnownHeaders.EnableChainSearch, out StringValues featureSetting) &&
-                  string.Equals(featureSetting.FirstOrDefault(), "true", StringComparison.OrdinalIgnoreCase)))
-            {
-                throw new SearchOperationNotSupportedException(Resources.ChainedExpressionNotSupported);
-            }
-
             var chainedReferences = new List<Expression>();
             SearchOptions chainedOptions = searchOptions.Clone();
             chainedOptions.CountOnly = false;
@@ -258,50 +252,53 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
 
             chainedOptions.Expression = filterExpression;
 
-            var chainedResults = await ExecuteSearchAsync<FhirCosmosResourceWrapper>(
-                _queryBuilder.BuildSqlQuerySpec(chainedOptions, new QueryBuilderOptions(includeExpressions, projection: includeExpressions.Any() ? QueryProjection.ReferencesOnly : QueryProjection.Id)),
+            var chainedResults = new List<FhirCosmosResourceWrapper>();
+
+            if (!await ExecuteSubQuery(
+                chainedResults,
+                _queryBuilder.BuildSqlQuerySpec(chainedOptions, new QueryBuilderOptions(includeExpressions, projection: includeExpressions.Any() ? QueryProjection.ReferencesOnly : QueryProjection.IdAndType)),
+                _chainedSearchMaxSubqueryItemLimit,
                 chainedOptions,
-                null,
-                null,
-                null,
-                cancellationToken);
-
-            if (!string.IsNullOrEmpty(chainedResults.continuationToken))
+                cancellationToken))
             {
-                throw new InvalidSearchOperationException(string.Format(Resources.ChainedExpressionSubqueryLimit, _chainedSearchMaxSubqueryItemLimit));
+                throw new InvalidSearchOperationException(string.Format(CultureInfo.InvariantCulture, Resources.ChainedExpressionSubqueryLimit, _chainedSearchMaxSubqueryItemLimit));
             }
 
-            Expression[] chainedExpressionReferences;
-
-            if (!expression.Reversed)
+            if (!chainedResults.Any())
             {
-                // When normal chained expression we can filter using references in the parent object. e.g. Observation.subject
-                // The following expression constrains "subject" references on "Observation" with the ids that have matched the sub-query
-                chainedExpressionReferences = chainedResults.results.Select(x =>
-                        Expression.SearchParameter(
-                            expression.ReferenceSearchParameter,
-                            Expression.And(
-                                Expression.Equals(FieldName.ReferenceResourceId, null, x.Id),
-                                Expression.Equals(FieldName.ReferenceResourceType, null, filteredType))))
-                    .ToArray<Expression>();
+                return null;
             }
-            else
+
+            if (expression.Reversed)
             {
                 // When reverse chained, we take the ids and types from the child object and use it to filter the parent objects.
                 // e.g. Patient?_has:Group:member:_id=group1. In this case we would have run the query there Group.id = group1
                 // and returned the indexed entries for Group.member. The following query will use these items to filter the parent Patient query.
-                chainedExpressionReferences = chainedResults.results.SelectMany(x => x.ReferencesToInclude.Select(y => y)).Distinct()
-                           .Select(include => Expression.And(
-                                  Expression.SearchParameter(
-                                      _resourceIdSearchParameter,
-                                      Expression.Equals(FieldName.TokenCode, null, include.ResourceId)),
-                                  Expression.SearchParameter(
-                                      _resourceTypeSearchParameter,
-                                      Expression.Equals(FieldName.TokenCode, null, include.ResourceTypeName))))
-                .ToArray<Expression>();
+
+                IEnumerable<ResourceTypeAndId> resourceTypeAndIds = chainedResults.SelectMany(x => x.ReferencesToInclude.Select(y => y)).Distinct();
+
+                IEnumerable<MultiaryExpression> typeAndResourceExpressions = resourceTypeAndIds
+                    .GroupBy(x => x.ResourceTypeName)
+                    .Select(g =>
+                        Expression.And(
+                            Expression.SearchParameter(_resourceTypeSearchParameter, Expression.Equals(FieldName.TokenCode, null, g.Key)),
+                            Expression.Or(g.Select(m => Expression.SearchParameter(_resourceIdSearchParameter, Expression.Equals(FieldName.TokenCode, null, m.ResourceId))).ToList())));
+
+                return typeAndResourceExpressions.Count() == 1 ? typeAndResourceExpressions.First() : Expression.Or(typeAndResourceExpressions.ToArray());
             }
 
-            return chainedExpressionReferences.Length > 1 ? Expression.Or(chainedExpressionReferences) : chainedExpressionReferences.FirstOrDefault();
+            // When normal chained expression we can filter using references in the parent object. e.g. Observation.subject
+            // The following expression constrains "subject" references on "Observation" with the ids that have matched the sub-query
+
+            return Expression.SearchParameter(
+                expression.ReferenceSearchParameter,
+                Expression.Or(
+                    chainedResults
+                        .GroupBy(m => m.ResourceTypeName)
+                        .Select(g =>
+                            Expression.And(
+                                Expression.Equals(FieldName.ReferenceResourceType, null, g.Key),
+                                Expression.Or(g.Select(m => Expression.Equals(FieldName.ReferenceResourceId, null, m.ResourceId)).ToList()))).ToList()));
         }
 
         protected override async Task<SearchResult> SearchHistoryInternalAsync(
@@ -590,84 +587,94 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
 
                     QueryDefinition revIncludeQuery = _queryBuilder.BuildSqlQuerySpec(revIncludeSearchOptions);
 
-                    (IReadOnlyList<FhirCosmosResourceWrapper> results, string continuationToken, int? maxConcurrency) includeResponse = default;
-
-                    for (int i = 0; i == 0 || !string.IsNullOrEmpty(includeResponse.continuationToken); i++)
-                    {
-                        // inflate the item count so that we we get at least maxIncludeCount - includes.Count results back
-                        revIncludeSearchOptions.MaxItemCount = (int)((maxIncludeCount - includes.Count) / CosmosFhirDataStore.ExecuteDocumentQueryAsyncMinimumFillFactor);
-
-                        switch (i)
-                        {
-                            case 0:
-
-                                // First time around. The query may or may not execute in parallel depending on past performance. If it is not going to execute in parallel, we give it 5 seconds before cancelling. After that, we will force parallelism.
-
-                                includeResponse = await ExecuteSearchAsync<FhirCosmosResourceWrapper>(
-                                    revIncludeQuery,
-                                    revIncludeSearchOptions,
-                                    null,
-                                    TimeSpan.FromSeconds(5),
-                                    queryRequestOptionsOverride: null,
-                                    cancellationToken);
-
-                                // check if we will restart the query in the next iteration (see next case below)
-                                // if not, take the results now
-                                if (includeResponse.continuationToken == null || includeResponse.maxConcurrency != null || includeResponse.results.Count >= maxIncludeCount)
-                                {
-                                    includes.AddRange(includeResponse.results);
-                                }
-
-                                break;
-
-                            case 1 when includeResponse.maxConcurrency == null:
-
-                                // The previous iteration executed sequentially and did not retrieve the desired number of results. We will switch to parallel execution.
-                                // Note that we are not passing in the continuation token, because if we do, the SDK does not execute in parallel.
-
-                                var queryRequestOptionsOverride = new QueryRequestOptions { MaxItemCount = revIncludeSearchOptions.MaxItemCount, MaxConcurrency = CosmosFhirDataStore.MaxQueryConcurrency };
-
-                                includeResponse = await ExecuteSearchAsync<FhirCosmosResourceWrapper>(
-                                    revIncludeQuery,
-                                    revIncludeSearchOptions,
-                                    null,
-                                    null,
-                                    queryRequestOptionsOverride,
-                                    cancellationToken);
-
-                                includes.AddRange(includeResponse.results);
-                                break;
-
-                            default:
-
-                                // follow the continuation
-
-                                includeResponse = await ExecuteSearchAsync<FhirCosmosResourceWrapper>(
-                                    revIncludeQuery,
-                                    revIncludeSearchOptions,
-                                    includeResponse.continuationToken,
-                                    null,
-                                    null,
-                                    cancellationToken);
-
-                                includes.AddRange(includeResponse.results);
-                                break;
-                        }
-
-                        if (includes.Count >= maxIncludeCount)
-                        {
-                            int toRemove = includes.Count - maxIncludeCount;
-                            includes.RemoveRange(includes.Count - toRemove, toRemove);
-                            includesTruncated = true;
-
-                            // break from the for loop because enough results have been found
-                            break;
-                        }
-                    }
+                    includesTruncated = !await ExecuteSubQuery(includes, revIncludeQuery, maxIncludeCount, revIncludeSearchOptions, cancellationToken);
                 }
             }
 
             return (includes, includesTruncated);
+        }
+
+        /// <summary>
+        /// Aggressively searches for results as part of server-side sub-queries
+        /// </summary>
+        /// <returns>True if results were within MaxCount. False if results were truncated</returns>
+        private async Task<bool> ExecuteSubQuery(List<FhirCosmosResourceWrapper> includes, QueryDefinition query, int maxCount, SearchOptions searchOptions, CancellationToken cancellationToken)
+        {
+            (IReadOnlyList<FhirCosmosResourceWrapper> results, string continuationToken, int? maxConcurrency) includeResponse = default;
+
+            for (int i = 0; i == 0 || !string.IsNullOrEmpty(includeResponse.continuationToken); i++)
+            {
+                // inflate the item count so that we we get at least maxIncludeCount - includes.Count results back
+                searchOptions.MaxItemCount = (int)((maxCount - includes.Count) / CosmosFhirDataStore.ExecuteDocumentQueryAsyncMinimumFillFactor);
+
+                switch (i)
+                {
+                    case 0:
+
+                        // First time around. The query may or may not execute in parallel depending on past performance. If it is not going to execute in parallel, we give it 5 seconds before cancelling. After that, we will force parallelism.
+
+                        includeResponse = await ExecuteSearchAsync<FhirCosmosResourceWrapper>(
+                            query,
+                            searchOptions,
+                            null,
+                            TimeSpan.FromSeconds(5),
+                            queryRequestOptionsOverride: null,
+                            cancellationToken);
+
+                        // check if we will restart the query in the next iteration (see next case below)
+                        // if not, take the results now
+                        if (includeResponse.continuationToken == null || includeResponse.maxConcurrency != null || includeResponse.results.Count >= maxCount)
+                        {
+                            includes.AddRange(includeResponse.results);
+                        }
+
+                        break;
+
+                    case 1 when includeResponse.maxConcurrency == null:
+
+                        // The previous iteration executed sequentially and did not retrieve the desired number of results. We will switch to parallel execution.
+                        // Note that we are not passing in the continuation token, because if we do, the SDK does not execute in parallel.
+
+                        var queryRequestOptionsOverride = new QueryRequestOptions { MaxItemCount = searchOptions.MaxItemCount, MaxConcurrency = CosmosFhirDataStore.MaxQueryConcurrency };
+
+                        includeResponse = await ExecuteSearchAsync<FhirCosmosResourceWrapper>(
+                            query,
+                            searchOptions,
+                            null,
+                            null,
+                            queryRequestOptionsOverride,
+                            cancellationToken);
+
+                        includes.AddRange(includeResponse.results);
+                        break;
+
+                    default:
+
+                        // follow the continuation
+
+                        includeResponse = await ExecuteSearchAsync<FhirCosmosResourceWrapper>(
+                            query,
+                            searchOptions,
+                            includeResponse.continuationToken,
+                            null,
+                            null,
+                            cancellationToken);
+
+                        includes.AddRange(includeResponse.results);
+                        break;
+                }
+
+                if (includes.Count >= maxCount)
+                {
+                    int toRemove = includes.Count - maxCount;
+                    includes.RemoveRange(includes.Count - toRemove, toRemove);
+
+                    // break from the for loop because enough results have been found
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         private static bool ExtractIncludeAndChainedExpressions(

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/ExpressionQueryBuilder.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/ExpressionQueryBuilder.cs
@@ -187,10 +187,13 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries
             return null;
         }
 
+        /// <summary>
+        /// Implemented in <see cref="FhirCosmosSearchService"/>
+        /// </summary>
         public object VisitChained(ChainedExpression expression, Context context)
         {
             // Chained expressions require additional queries and are handled in the FhirCosmosSearchService.
-            throw new SearchOperationNotSupportedException(Resources.ChainedExpressionNotSupported);
+            return null;
         }
 
         public object VisitSortParameter(SortExpression expression, Context context)

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/QueryBuilder.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/QueryBuilder.cs
@@ -57,9 +57,9 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries
                 {
                     AppendSelectFromRoot("VALUE COUNT(1)");
                 }
-                else if (queryOptions.Projection == QueryProjection.Id)
+                else if (queryOptions.Projection == QueryProjection.IdAndType)
                 {
-                    AppendSelectFromRoot($"r.{KnownResourceWrapperProperties.ResourceId}", queryOptions.Includes);
+                    AppendSelectFromRoot($"r.{KnownResourceWrapperProperties.ResourceId}, r.{KnownResourceWrapperProperties.ResourceTypeName}", queryOptions.Includes);
                 }
                 else if (queryOptions.Projection == QueryProjection.ReferencesOnly)
                 {

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/QueryProjection.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/QueryProjection.cs
@@ -13,9 +13,9 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries
         Default,
 
         /// <summary>
-        /// Only the ID columns a selected (can be ID + Reference IDs)
+        /// Only the ID and Type columns are selected (can be ID + Reference IDs)
         /// </summary>
-        Id,
+        IdAndType,
 
         /// <summary>
         /// Only reference IDs are selected

--- a/src/Microsoft.Health.Fhir.CosmosDb/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Resources.Designer.cs
@@ -79,15 +79,6 @@ namespace Microsoft.Health.Fhir.CosmosDb {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Chained expression is not supported..
-        /// </summary>
-        internal static string ChainedExpressionNotSupported {
-            get {
-                return ResourceManager.GetString("ChainedExpressionNotSupported", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Sub-queries in a chained expression cannot return more than {0} results, please use a more selective criteria..
         /// </summary>
         internal static string ChainedExpressionSubqueryLimit {

--- a/src/Microsoft.Health.Fhir.CosmosDb/Resources.resx
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Resources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -117,9 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ChainedExpressionNotSupported" xml:space="preserve">
-    <value>Chained expression is not supported.</value>
-  </data>
   <data name="InvalidConsistencyLevel" xml:space="preserve">
     <value>Consistency level '{0}' specified in the request is invalid when service is configured with consistency level '{1}'. Ensure the request consistency level is not stronger than the service consistency level.</value>
   </data>

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
@@ -106,6 +106,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
                     case RequestNotValidException _:
                     case BundleEntryLimitExceededException _:
                     case ProvenanceHeaderException _:
+                    case RequestTooCostlyException _:
                         operationOutcomeResult.StatusCode = HttpStatusCode.BadRequest;
                         break;
                     case ResourceConflictException _:

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/MemberMatch/MemberMatchService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/MemberMatch/MemberMatchService.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.MemberMatch
             var patientValues = _searchIndexer.Extract(patient);
             var expressions = new List<Expression>();
             var reverseChainExpressions = new List<Expression>();
-            expressions.Add(Expression.SearchParameter(_resourceTypeSearchParameter, Expression.StringEquals(FieldName.TokenCode, null, "Patient", false)));
+            expressions.Add(Expression.SearchParameter(_resourceTypeSearchParameter, Expression.StringEquals(FieldName.TokenCode, null, KnownResourceTypes.Patient, false)));
             foreach (var patientValue in patientValues)
             {
                 if (IgnoreInSearch(patientValue))
@@ -134,7 +134,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.MemberMatch
                     modifier = ":exact";
                 }
 
-                expressions.Add(_expressionParser.Parse(new[] { "Patient" }, patientValue.SearchParameter.Code + modifier, patientValue.Value.ToString()));
+                expressions.Add(_expressionParser.Parse(new[] { KnownResourceTypes.Patient }, patientValue.SearchParameter.Code + modifier, patientValue.Value.ToString()));
             }
 
             foreach (var coverageValue in coverageValues)
@@ -150,7 +150,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.MemberMatch
                     modifier = ":exact";
                 }
 
-                reverseChainExpressions.Add(_expressionParser.Parse(new[] { "Coverage" }, coverageValue.SearchParameter.Code + modifier, coverageValue.Value.ToString()));
+                reverseChainExpressions.Add(_expressionParser.Parse(new[] { KnownResourceTypes.Coverage }, coverageValue.SearchParameter.Code + modifier, coverageValue.Value.ToString()));
             }
 
             if (reverseChainExpressions.Count != 0)
@@ -165,7 +165,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.MemberMatch
                     reverseChainedExpression = Expression.And(reverseChainExpressions);
                 }
 
-                var expression = Expression.Chained(new string[] { "Coverage" }, _coverageBeneficiaryParameter, new string[] { "Patient" }, true, reverseChainedExpression);
+                var expression = Expression.Chained(new[] { KnownResourceTypes.Coverage }, _coverageBeneficiaryParameter, new[] { KnownResourceTypes.Patient }, true, reverseChainedExpression);
                 expressions.Add(expression);
             }
 

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -122,7 +122,6 @@
             "MaxNumberOfRetries": 18,
             "MaxWaitTimeInSeconds": 90
         },
-        "EnableChainedSearch": true,
         "UseQueryStatistics": false,
         "InitialSortParameterUris": [
             "http://hl7.org/fhir/SearchParameter/individual-family",

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
@@ -268,10 +268,10 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
             Patient resource = Samples.GetJsonSample("Patient-f001").ToPoco<Patient>();
 
-            // Create 101 patients that exceed the sub-query limit
-            for (var i = 0; i < 101; i++)
+            // Create 1001 patients that exceed the sub-query limit
+            foreach (IEnumerable<int> batch in Enumerable.Range(1, 1001).TakeBatch(100))
             {
-                await Client.CreateAsync(resource);
+                await Task.WhenAll(batch.Select(_ => Client.CreateAsync(resource)));
             }
 
             await Assert.ThrowsAsync<FhirException>(async () => await Client.SearchAsync(ResourceType.Observation, query));


### PR DESCRIPTION
## Description
Updating Chained searches to use some of the recent optimizations for _include.
Removes feature flag.
More efficient query allows for more results (updated to 1000).

Previous query (Avg. duration in testing: 4971ms):
```
SELECT r.id,r.isSystem,r.partitionKey,r.lastModified,r.rawResource,r.request,r.isDeleted,r.resourceId,r.resourceTypeName,r.isHistory,r.version,r._self,r._etag, r.searchParameterHash
      FROM root r
      WHERE r.isSystem = @param0
      AND r.resourceTypeName = @param1
      AND (EXISTS (SELECT VALUE si FROM si IN r.searchIndices WHERE si.p = @param2 AND si.ri = @param3 AND si.rt = @param4)
      OR EXISTS (SELECT VALUE si FROM si IN r.searchIndices WHERE si.p = @param2 AND si.ri = @param5 AND si.rt = @param4)
      /* snip */
      OR EXISTS (SELECT VALUE si FROM si IN r.searchIndices WHERE si.p = @param2 AND si.ri = @param391 AND si.rt = @param4)
      )AND r.isHistory = @param0
      AND r.isDeleted = @param0
```

Now (Avg. duration in testing: 876ms):
```
SELECT r.id,r.isSystem,r.partitionKey,r.lastModified,r.rawResource,r.request,r.isDeleted,r.resourceId,r.resourceTypeName,r.isHistory,r.version,r._self,r._etag, r.searchParameterHash
      FROM root r
      WHERE r.isSystem = @param0
      AND r.resourceTypeName = @param1
      AND EXISTS (SELECT VALUE si FROM si IN r.searchIndices WHERE si.p = @param2 AND (si.rt = @param3 AND (si.ri = @param4 OR si.ri = @param5 OR /*snip*/ OR si.ri = @param391)))
      AND r.isHistory = @param0
      AND r.isDeleted = @param0
```

 Types of errors now returned:
```json
{
  "resourceType": "OperationOutcome",
  "issue": [
    {
      "severity": "error",
      "code": "invalid",
      "diagnostics": "Sub-queries in a chained expression cannot return more than 1000 results, please use a more selective criteria."
    }
  ]
}

{
  "resourceType": "OperationOutcome",
  "issue": [
    {
      "severity": "error",
      "code": "too-costly",
      "diagnostics": "The operation was stopped due to the underlying request being too resource intensive. If possible, try narrowing or changing the criteria."
    }
  ]
}
```

## Work items
[AB#82235](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/82235)

## Testing
Existing tests should pass, manual testing and inspection of queries

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
