### PR TITLE
Validates code value on search parameter creation

### DIFF
--- a/docs/rest/InvalidCustomSearchParameterHandling.http
+++ b/docs/rest/InvalidCustomSearchParameterHandling.http
@@ -1,0 +1,152 @@
+# This test flow confirms that we handle search parameters with invalid code
+# values appropriately. New search parameters can't have the same code value
+# as an existing search parameter with a matching base type.
+#
+# This test assumes the following local environment setup:
+# 1. appsettings.json has Security.Enabled = false
+
+@baseUrl = https://localhost:44348
+@contentType = application/json
+
+###
+# Create a search parameter resource with a code value that already exists.
+# This should fail and indicate that "identifier" already used by an
+# existing search parameter that also has Patient as a base resource type.
+POST {{baseUrl}}/SearchParameter HTTP/1.1
+content-type: {{contentType}}
+
+{
+  "resourceType" : "SearchParameter",
+  "id" : "us-core-patient-identifier",
+  "text" : {
+    "status" : "generated",
+    "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCorePatientIdentifier</h2><p><b> description</b> : A patient identifier<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-patient-identifier</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-identifier</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCorePatientIdentifier</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Patient-identifier\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>identifier</code>\n\t\t\t</p><p><b> base</b> :Patient</p><p><b> type</b> : token</p><p><b> expression</b> : <code>Patient.identifier</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Patient/f:identifier</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
+  },
+  "url" : "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-identifier",
+  "version" : "3.1.1",
+  "name" : "USCorePatientIdentifier",
+  "derivedFrom" : "http://hl7.org/fhir/SearchParameter/Patient-identifier",
+  "status" : "active",
+  "experimental" : false,
+  "date" : "2020-07-01T21:51:57.604969Z",
+  "publisher" : "HL7 International - US Realm Steering Committee",
+  "contact" : [
+    {
+      "telecom" : [
+        {
+          "system" : "url",
+          "value" : "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+        }
+      ]
+    }
+  ],
+  "description" : "A patient identifier<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+  "jurisdiction" : [
+    {
+      "coding" : [
+        {
+          "system" : "urn:iso:std:iso:3166",
+          "code" : "US",
+          "display" : "United States of America"
+        }
+      ]
+    }
+  ],
+  "code" : "identifier",
+  "base" : [
+    "Patient"
+  ],
+  "type" : "token",
+  "expression" : "Patient.identifier",
+  "xpath" : "f:Patient/f:identifier",
+  "xpathUsage" : "normal",
+  "multipleOr" : true,
+  "_multipleOr" : {
+    "extension" : [
+      {
+        "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+        "valueCode" : "MAY"
+      }
+    ]
+  },
+  "multipleAnd" : true,
+  "_multipleAnd" : {
+    "extension" : [
+      {
+        "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+        "valueCode" : "MAY"
+      }
+    ]
+  }
+}
+
+###
+# Now, create the search parameter resource with a code value that is unique.
+# This should succeed.
+POST {{baseUrl}}/SearchParameter HTTP/1.1
+content-type: {{contentType}}
+
+{
+  "resourceType" : "SearchParameter",
+  "id" : "us-core-patient-identifier",
+  "text" : {
+    "status" : "generated",
+    "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCorePatientIdentifier</h2><p><b> description</b> : A patient identifier<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-patient-identifier</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-identifier</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCorePatientIdentifier</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Patient-identifier\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>identifier</code>\n\t\t\t</p><p><b> base</b> :Patient</p><p><b> type</b> : token</p><p><b> expression</b> : <code>Patient.identifier</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Patient/f:identifier</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
+  },
+  "url" : "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-identifier",
+  "version" : "3.1.1",
+  "name" : "USCorePatientIdentifier",
+  "derivedFrom" : "http://hl7.org/fhir/SearchParameter/Patient-identifier",
+  "status" : "active",
+  "experimental" : false,
+  "date" : "2020-07-01T21:51:57.604969Z",
+  "publisher" : "HL7 International - US Realm Steering Committee",
+  "contact" : [
+    {
+      "telecom" : [
+        {
+          "system" : "url",
+          "value" : "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+        }
+      ]
+    }
+  ],
+  "description" : "A patient identifier<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+  "jurisdiction" : [
+    {
+      "coding" : [
+        {
+          "system" : "urn:iso:std:iso:3166",
+          "code" : "US",
+          "display" : "United States of America"
+        }
+      ]
+    }
+  ],
+  "code" : "uniqueidentifier",
+  "base" : [
+    "Patient"
+  ],
+  "type" : "token",
+  "expression" : "Patient.identifier",
+  "xpath" : "f:Patient/f:identifier",
+  "xpathUsage" : "normal",
+  "multipleOr" : true,
+  "_multipleOr" : {
+    "extension" : [
+      {
+        "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+        "valueCode" : "MAY"
+      }
+    ]
+  },
+  "multipleAnd" : true,
+  "_multipleAnd" : {
+    "extension" : [
+      {
+        "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+        "valueCode" : "MAY"
+      }
+    ]
+  }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
@@ -78,10 +78,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
                     throw new SearchParameterNotSupportedException(errorMessage);
                 }
 
-                _searchParameterDefinitionManager.AddNewSearchParameters(new List<ITypedElement>() { searchParam });
+                _searchParameterDefinitionManager.AddNewSearchParameters(new List<ITypedElement> { searchParam });
 
-                var searchParameterUrl = searchParam.GetStringScalar("url");
-                await _searchParameterStatusManager.AddSearchParameterStatusAsync(new List<string>() { searchParameterWrapper.Url });
+                await _searchParameterStatusManager.AddSearchParameterStatusAsync(new List<string> { searchParameterWrapper.Url });
             }
             catch (FhirException fex)
             {

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Health.Fhir.Core {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -940,6 +940,15 @@ namespace Microsoft.Health.Fhir.Core {
         internal static string SearchParameterDefinitionComponentReferenceCannotBeComposite {
             get {
                 return ResourceManager.GetString("SearchParameterDefinitionComponentReferenceCannotBeComposite", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A search parameter with the same code value &apos;{0}&apos; already exists for base type &apos;{1}&apos;..
+        /// </summary>
+        internal static string SearchParameterDefinitionConflictingCodeValue {
+            get {
+                return ResourceManager.GetString("SearchParameterDefinitionConflictingCodeValue", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -10,8 +10,8 @@
 
 namespace Microsoft.Health.Fhir.Core {
     using System;
-    
-    
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -19,19 +19,19 @@ namespace Microsoft.Health.Fhir.Core {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
-        
+
         private static global::System.Resources.ResourceManager resourceMan;
-        
+
         private static global::System.Globalization.CultureInfo resourceCulture;
-        
+
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         internal Resources() {
         }
-        
+
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
@@ -45,7 +45,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return resourceMan;
             }
         }
-        
+
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
@@ -59,7 +59,7 @@ namespace Microsoft.Health.Fhir.Core {
                 resourceCulture = value;
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to {0} and {1} cannot both be specified..
         /// </summary>
@@ -68,7 +68,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("AtCannotBeSpecifiedWithBeforeOrSince", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Only a bundle can be submitted for batch or transaction processing..
         /// </summary>
@@ -77,7 +77,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("BundleRequiredForBatchOrTransaction", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The chained parameter must be a reference search parameter type..
         /// </summary>
@@ -86,7 +86,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ChainedParameterMustBeReferenceSearchParamType", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The chained parameter is not supported..
         /// </summary>
@@ -95,7 +95,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ChainedParameterNotSupported", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The reference search parameter &apos;{0}&apos; refers to multiple possible resource types. Please specify a type in the search expression: {1}.
         /// </summary>
@@ -104,7 +104,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ChainedParameterSpecifyType", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Changes to seach parameters is not allowed while a reindex job is ongoing.  Wait for the reindex job with Id: {0} to finish, or cancel it..
         /// </summary>
@@ -113,7 +113,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ChangesToSearchParametersNotAllowedWhileReindexing", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Comparator &apos;{0}&apos; is not supported for search parameter &apos;{1}&apos;..
         /// </summary>
@@ -122,7 +122,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ComparatorNotSupported", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The compartment definition contains one or more invalid entries..
         /// </summary>
@@ -131,7 +131,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CompartmentDefinitionContainsInvalidEntry", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to bundle.entry[{0}].resource has duplicate resources..
         /// </summary>
@@ -140,7 +140,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CompartmentDefinitionDupeResource", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to bundle.entry[{0}] is null..
         /// </summary>
@@ -149,7 +149,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CompartmentDefinitionInvalidBundle", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to bundle.entry[{0}].resource.code is null. Not a valid compartment type..
         /// </summary>
@@ -158,7 +158,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CompartmentDefinitionInvalidCompartmentType", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to bundle.entry[{0}].resource is null or is not a CompartmentDefinition resource..
         /// </summary>
@@ -167,7 +167,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CompartmentDefinitionInvalidResource", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to bundle.entry[{0}].resource.url is invalid..
         /// </summary>
@@ -176,7 +176,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CompartmentDefinitionInvalidUrl", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to bundle.entry[{0}].resource has duplicate compartment definitions..
         /// </summary>
@@ -185,7 +185,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CompartmentDefinitionIsDupe", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Compartment id is null or empty..
         /// </summary>
@@ -194,7 +194,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CompartmentIdIsInvalid", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Compartment type {0} is invalid..
         /// </summary>
@@ -203,7 +203,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CompartmentTypeIsInvalid", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The composite separator cannot be found..
         /// </summary>
@@ -212,7 +212,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CompositeSeparatorNotFound", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Operation was not attempted because search criteria was not selective enough..
         /// </summary>
@@ -221,7 +221,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ConditionalOperationNotSelectiveEnough", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Found result with Id &apos;{0}&apos;, which did not match the provided Id &apos;{1}&apos;..
         /// </summary>
@@ -230,7 +230,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ConditionalUpdateMismatchedIds", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Fail to access the container registry &apos;{0}&apos;, please check the registry configuration..
         /// </summary>
@@ -239,7 +239,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ContainerRegistryNotAuthorized", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Failed to convert the input data. Reason: {0}.
         /// </summary>
@@ -248,7 +248,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ConvertDataFailed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Convert data operation has timed out..
         /// </summary>
@@ -257,7 +257,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ConvertDataOperationTimeout", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The prefix used to identify custom audit headers cannot be empty..
         /// </summary>
@@ -266,7 +266,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CustomHeaderPrefixCannotBeEmpty", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to An error occurred creating the custom search parameter.  The issue must be resolved and the parameter resubmitted to become functional..
         /// </summary>
@@ -275,7 +275,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CustomSearchCreateError", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to An error occurred deleting the custom search parameter.  The issue must be resolved and the delete request resubmitted to remove the parameter..
         /// </summary>
@@ -284,7 +284,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CustomSearchDeleteError", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Custom Search parameter with Uri: {0} was not found..
         /// </summary>
@@ -293,7 +293,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CustomSearchParameterNotfound", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to An error occurred updating the custom search parameter.  The issue must be resolved and the update resubmitted to be applied..
         /// </summary>
@@ -302,7 +302,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CustomSearchUpdateError", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The date time string &apos;{0}&apos; is not in a correct format..
         /// </summary>
@@ -311,7 +311,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("DateTimeStringIsIncorrectlyFormatted", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to At least one portion of the date time string &apos;{0}&apos; is out of range..
         /// </summary>
@@ -320,7 +320,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("DateTimeStringIsOutOfRange", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Deleting a specific record version is not supported..
         /// </summary>
@@ -329,7 +329,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("DeleteVersionNotAllowed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to There are {0} roles with the name &apos;{1}&apos;.
         /// </summary>
@@ -338,7 +338,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("DuplicateRoleNames", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The &apos;_elements&apos; parameter is supported only when &apos;_summary&apos; is SummaryType.False or &apos;_summary&apos; is not specified at all..
         /// </summary>
@@ -347,7 +347,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ElementsAndSummaryParametersAreIncompatible", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Error validating roles:
         ///{0}.
@@ -357,7 +357,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ErrorValidatingRoles", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The format &apos;{0}&apos; could not be found..
         /// </summary>
@@ -366,7 +366,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ExportFormatNotFound", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Failed to fetch the template collection. Reason: {0}.
         /// </summary>
@@ -375,7 +375,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("FetchTemplateCollectionFailed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Authorization failed..
         /// </summary>
@@ -384,7 +384,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("Forbidden", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Parameter {0} cannot a be a value in the future..
         /// </summary>
@@ -393,7 +393,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("HistoryParameterBeforeCannotBeFuture", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Id must be any combination of upper or lower case ASCII letters (&apos;A&apos;..&apos;Z&apos;, and &apos;a&apos;..&apos;z&apos;), numerals (&apos;0&apos;..&apos;9&apos;), &apos;-&apos; and &apos;.&apos;, with a length limit of 64 characters. (This might be an integer, an un-prefixed OID, UUID, or any other identifier pattern that meets these constraints.).
         /// </summary>
@@ -402,7 +402,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("IdRequirements", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to A valid if-match header is required for resource type &apos;{0}&apos;..
         /// </summary>
@@ -411,7 +411,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("IfMatchHeaderRequiredForResource", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Illegal attribute name &apos;{0}&apos; on element &apos;{1}&apos;..
         /// </summary>
@@ -420,7 +420,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("IllegalHtmlAttribute", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Illegal element name &apos;{0}&apos;..
         /// </summary>
@@ -429,7 +429,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("IllegalHtmlElement", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The div element must not be empty or only whitespace..
         /// </summary>
@@ -438,7 +438,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("IllegalHtmlEmpty", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to XHTML content should be contained within a single &lt;div&gt; element..
         /// </summary>
@@ -447,7 +447,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("IllegalHtmlOuterDiv", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Error while parsing XHTML: {0} Line: {1} Col: {2}..
         /// </summary>
@@ -456,7 +456,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("IllegalHtmlParsingError", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The _include search cannot be used against the base route..
         /// </summary>
@@ -465,7 +465,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("IncludeCannotBeAgainstBase", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The parameter {0}={1} with circular reference is executed once (a single iteration)..
         /// </summary>
@@ -474,7 +474,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("IncludeIterateCircularReferenceExecutedOnce", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The _include search is missing the type to search..
         /// </summary>
@@ -483,7 +483,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("IncludeMissingType", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Field &apos;{0}&apos; with value &apos;{1}&apos; is not supported..
         /// </summary>
@@ -492,7 +492,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("InvalidBooleanConfigSetting", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Given conditional reference &apos;{0}&apos; does not resolve to a resource..
         /// </summary>
@@ -501,7 +501,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("InvalidConditionalReference", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Resource type and query parameter must be present in a given request &apos;{0}&apos;..
         /// </summary>
@@ -510,7 +510,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("InvalidConditionalReferenceParameters", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Value &apos;{0}&apos; is not supported. Please select from the following list of supported capabilities: [{1}]..
         /// </summary>
@@ -519,7 +519,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("InvalidConfigSetting", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The continuation token is invalid..
         /// </summary>
@@ -528,7 +528,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("InvalidContinuationToken", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The &apos;handling&apos; value &apos;{0}&apos; is invalid. The supported values are: {1}..
         /// </summary>
@@ -537,7 +537,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("InvalidHandlingValue", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The count must be greater than zero..
         /// </summary>
@@ -546,7 +546,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("InvalidSearchCountSpecified", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The &apos;_total&apos; parameter value &apos;{0}&apos; is invalid. The supported values are: {1}..
         /// </summary>
@@ -555,7 +555,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("InvalidTotalParameter", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The &apos;_type&apos; parameter contains unknown resource(s): {0}.
         /// </summary>
@@ -564,7 +564,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("InvalidTypeParameter", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Invalid value for :missing modifier. Valid values are: true, false..
         /// </summary>
@@ -573,7 +573,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("InvalidValueTypeForMissingModifier", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The requested job &quot;{0}&quot; was not found..
         /// </summary>
@@ -582,7 +582,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("JobNotFound", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Malformed search value &apos;{0}&apos;..
         /// </summary>
@@ -591,7 +591,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("MalformedSearchValue", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Found multiple matches, narrow search criteria..
         /// </summary>
@@ -600,7 +600,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("MemberMatchMultipleMatchesFound", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to No match found..
         /// </summary>
@@ -609,7 +609,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("MemberMatchNoMatchFound", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Modifier &apos;{0}&apos; is not supported for search parameter &apos;{1}&apos;..
         /// </summary>
@@ -618,7 +618,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ModifierNotSupported", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Only one token separator can be specified..
         /// </summary>
@@ -627,7 +627,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("MoreThanOneTokenSeparatorSpecified", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to No more than two token separators can be specified..
         /// </summary>
@@ -636,7 +636,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("MoreThanTwoTokenSeparatorSpecified", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Query parameter &apos;{0}&apos; cannot be specified more than once..
         /// </summary>
@@ -645,7 +645,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("MultipleQueryParametersNotAllowed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Multiple sort parameters are currently not supported. Only a single sort parameter is supported..
         /// </summary>
@@ -654,7 +654,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("MultiSortParameterNotSupported", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to No resources were found matching the type of the updated search parameters needing to be reindexed.  ReindexJob marked completed..
         /// </summary>
@@ -663,7 +663,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("NoResourcesNeedToBeReindexed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to No search parameters found needing to be indexed.  Job cancelled..
         /// </summary>
@@ -672,7 +672,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("NoSearchParametersNeededToBeIndexed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The number of composite components specified for search parameter &apos;{0}&apos; exceeded the number of components defined..
         /// </summary>
@@ -681,7 +681,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("NumberOfCompositeComponentsExceeded", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Only equal comparator is supported for this search type..
         /// </summary>
@@ -690,7 +690,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("OnlyEqualComparatorIsSupported", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Only one modifier separator can be specified..
         /// </summary>
@@ -699,7 +699,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("OnlyOneModifierSeparatorSupported", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Only one active or paused reindex job allowed.  Cancel job with id: {0} before submitting a new job..
         /// </summary>
@@ -708,7 +708,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("OnlyOneResourceJobAllowed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Failed to retrieve the OpenId configuration from the authentication provider..
         /// </summary>
@@ -717,7 +717,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("OpenIdConfiguration", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to {0} operation failed for reason: {1}.
         /// </summary>
@@ -726,7 +726,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("OperationFailed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to  or .
         /// </summary>
@@ -735,7 +735,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("OrDelimiter", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to X-Provenance header is malformed and can&apos;t be parsed.
         /// </summary>
@@ -744,7 +744,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ProvenanceHeaderMalformed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to X-Provenance header shall not have a specified `Provenance.target`.
         /// </summary>
@@ -753,7 +753,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ProvenanceHeaderShouldntHaveTarget", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to ReadHistory is disabled for resources of type &apos;{0}&apos;..
         /// </summary>
@@ -762,7 +762,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ReadHistoryDisabled", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Resource type &apos;{0}&apos; in the reference &apos;{1}&apos; is not supported..
         /// </summary>
@@ -771,7 +771,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ReferenceResourceTypeNotSupported", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to One or more resources to be reindexed were not found, indicating that they have been deleted since the reindex job kicked off..
         /// </summary>
@@ -780,7 +780,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ReindexingResourceNotFound", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The version of one or more resources did not match, indicating that they have been updated since the reindex job kicked off..
         /// </summary>
@@ -789,7 +789,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ReindexingResourceVersionConflict", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Reindex job id {0} is in state {1} and cannot be cancelled..
         /// </summary>
@@ -798,7 +798,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ReindexJobInCompletedState", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The requested action is not allowed..
         /// </summary>
@@ -807,7 +807,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("RequestedActionNotAllowed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Resource creation is not allowed..
         /// </summary>
@@ -816,7 +816,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ResourceCreationNotAllowed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Resource type &apos;{0}&apos; with id &apos;{1}&apos; couldn&apos;t be found..
         /// </summary>
@@ -825,7 +825,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ResourceNotFoundById", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Resource type &apos;{0}&apos; with id &apos;{1}&apos; and version &apos;{2}&apos; couldn&apos;t be found..
         /// </summary>
@@ -834,7 +834,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ResourceNotFoundByIdAndVersion", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Resource type &apos;{0}&apos; is not supported..
         /// </summary>
@@ -843,7 +843,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ResourceNotSupported", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The requested resource exceeded the backing database&apos;s size limit..
         /// </summary>
@@ -852,7 +852,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ResourceTooLarge", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The supplied version &apos;{0}&apos; did not match..
         /// </summary>
@@ -861,7 +861,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ResourceVersionConflict", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The reverse chain search is missing the reference to search..
         /// </summary>
@@ -870,7 +870,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ReverseChainMissingReference", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The reverse chain search is missing the type to search..
         /// </summary>
@@ -879,7 +879,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ReverseChainMissingType", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The &apos;_revinclude:iterate={0}&apos; search parameter has multiple target types. Please specify a target type..
         /// </summary>
@@ -888,7 +888,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("RevIncludeIterateTargetTypeNotSpecified", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The _revinclude search is missing the type to search..
         /// </summary>
@@ -897,7 +897,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("RevIncludeMissingType", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Comparator is not supported when multiple values are specified using OR search parameter..
         /// </summary>
@@ -906,7 +906,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchComparatorNotSupported", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The &apos;_count&apos; parameter exceeds limit configured for server. Current limit is {0} while `_count` parameter set to {1}..
         /// </summary>
@@ -915,7 +915,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParamaterCountExceedLimit", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The search parameter with definition URL &apos;{0}&apos; is not supported..
         /// </summary>
@@ -924,7 +924,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterByDefinitionUriNotSupported", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to SearchParameter[{0}].resource.base is not defined..
         /// </summary>
@@ -933,7 +933,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionBaseNotDefined", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to SearchParameter[{0}].component[{1}] cannot refer to a composite SearchParameter..
         /// </summary>
@@ -942,7 +942,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionComponentReferenceCannotBeComposite", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to A search parameter with the same code value &apos;{0}&apos; already exists for base type &apos;{1}&apos;..
         /// </summary>
@@ -951,7 +951,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionConflictingCodeValue", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The search parameter definition contains one or more invalid entries..
         /// </summary>
@@ -960,7 +960,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionContainsInvalidEntry", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to A search parameter with the same definition URL &apos;{0}&apos; already exists..
         /// </summary>
@@ -969,7 +969,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionDuplicatedEntry", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to SearchParameter[{0}].component is null or empty..
         /// </summary>
@@ -978,7 +978,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionInvalidComponent", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to SearchParameter[{0}].component[{1}].expression is null or empty..
         /// </summary>
@@ -987,7 +987,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionInvalidComponentExpression", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to SearchParameter[{0}].component[{1}].definition.reference is null or empty or does not refer to a valid SearchParameter resource..
         /// </summary>
@@ -996,7 +996,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionInvalidComponentReference", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to SearchParameter[{0}].url is invalid..
         /// </summary>
@@ -1005,7 +1005,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionInvalidDefinitionUri", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to SearchParameter[{0}].resource.expression is null or empty..
         /// </summary>
@@ -1014,7 +1014,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionInvalidExpression", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The search parameter defintion is missing the Uri..
         /// </summary>
@@ -1023,7 +1023,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionInvalidMissingUri", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Entry {0} is not a SearchParameter resource..
         /// </summary>
@@ -1032,7 +1032,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionInvalidResource", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to A search parameter with Uri &apos;{0}&apos; was not found..
         /// </summary>
@@ -1041,7 +1041,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionNotFound", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Search parameter &apos;{0}&apos; is not common for &apos;{1}&apos; and &apos;{2}&apos;..
         /// </summary>
@@ -1050,7 +1050,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterMustBeCommon", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to {0} So it cannot be marked enabled..
         /// </summary>
@@ -1059,7 +1059,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterNoLongerSupported", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The search parameter &apos;{0}&apos; is not supported for resource type &apos;{1}&apos;..
         /// </summary>
@@ -1068,7 +1068,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterNotSupported", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to A search parameter is no longer supported..
         /// </summary>
@@ -1077,7 +1077,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterUnknownNotSupported", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Sorting by the &apos;{0}&apos; parameter is not supported..
         /// </summary>
@@ -1086,7 +1086,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchSortParameterNotSupported", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Microsoft FHIR Server.
         /// </summary>
@@ -1095,7 +1095,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ServerName", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The _sort parameter is not supported..
         /// </summary>
@@ -1104,7 +1104,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SortNotSupported", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Include result was truncated.
         /// </summary>
@@ -1113,7 +1113,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("TruncatedIncludeMessage", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The _typeFilter segment &apos;{0}&apos; could not be parsed..
         /// </summary>
@@ -1122,7 +1122,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("TypeFilterUnparseable", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The _type parameter must be included when using the _typeFilter parameter..
         /// </summary>
@@ -1131,7 +1131,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("TypeFilterWithoutTypeIsUnsupported", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Bundle type is not present. Possible values are: transaction or batch.
         /// </summary>
@@ -1140,7 +1140,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("TypeNotPresent", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Unable to delete secret from SecretStore.
         /// </summary>
@@ -1149,7 +1149,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("UnableToDeleteSecret", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Unable to get secret from SecretStore.
         /// </summary>
@@ -1158,7 +1158,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("UnableToGetSecret", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Unable to set secret in SecretStore.
         /// </summary>
@@ -1167,7 +1167,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("UnableToSetSecret", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Attempt to update SearchParameter {0} failed..
         /// </summary>
@@ -1176,7 +1176,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("UnableToUpdateSearchParameter", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Unknown Error..
         /// </summary>
@@ -1185,7 +1185,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("UnknownError", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Unsupported configuration found..
         /// </summary>
@@ -1194,7 +1194,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("UnsupportedConfigurationMessage", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The &apos;_total&apos; parameter value &apos;{0}&apos; is not supported. The supported values are: {1}..
         /// </summary>
@@ -1203,7 +1203,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("UnsupportedTotalParameter", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Resource id is required for updates..
         /// </summary>
@@ -1212,7 +1212,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("UpdateRequestsRequireId", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to User requested cancellation of operation..
         /// </summary>
@@ -1221,7 +1221,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("UserRequestedCancellation", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to All OK.
         /// </summary>
@@ -1230,7 +1230,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ValidationPassed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to VersionId should not be in the weak ETag format..
         /// </summary>
@@ -1239,7 +1239,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("VersionIdFormatNotETag", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to WeakETag must be in the weak ETag format..
         /// </summary>

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -553,5 +553,8 @@
   </data>
   <data name="MemberMatchNoMatchFound" xml:space="preserve">
     <value>No match found.</value>
+  </data>
+  <data name="SearchParameterDefinitionConflictingCodeValue" xml:space="preserve">
+    <value>A search parameter with the same code value '{0}' already exists for base type '{1}'.</value>
   </data>
 </root>

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/SearchParameterFilterAttributeTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/SearchParameterFilterAttributeTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
 
             await filter.OnActionExecutionAsync(context, actionExecutionDelegate);
 
-            await _searchParameterValidator.DidNotReceive().ValidateSearchParamterInput(Arg.Any<SearchParameter>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+            await _searchParameterValidator.DidNotReceive().ValidateSearchParameterInput(Arg.Any<SearchParameter>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
         }
 
         [Fact]
@@ -49,7 +49,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
 
             await filter.OnActionExecutionAsync(context, actionExecutionDelegate);
 
-            await _searchParameterValidator.Received().ValidateSearchParamterInput(Arg.Any<SearchParameter>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+            await _searchParameterValidator.Received().ValidateSearchParameterInput(Arg.Any<SearchParameter>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
         }
 
         private static ActionExecutingContext CreateContext(Base type)

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/SearchParameterFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/SearchParameterFilterAttribute.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
                 if (parsedModel is SearchParameter searchParameter)
                 {
                     // wait for the validation checks to pass before allowing the FHIRController action to continue
-                    await _searchParameterValidator.ValidateSearchParamterInput(
+                    await _searchParameterValidator.ValidateSearchParameterInput(
                         searchParameter,
                         context.HttpContext.Request.Method,
                         context.HttpContext.RequestAborted);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterValidatorTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterValidatorTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         public async Task GivenInvalidSearchParam_WhenValidatingSearchParam_ThenResourceNotValidExceptionThrown(SearchParameter searchParam, string method)
         {
             var validator = new SearchParameterValidator(() => _fhirOperationDataStore.CreateMockScope(), _authorizationService, _searchParameterDefinitionManager);
-            await Assert.ThrowsAsync<ResourceNotValidException>(() => validator.ValidateSearchParamterInput(searchParam, method, CancellationToken.None));
+            await Assert.ThrowsAsync<ResourceNotValidException>(() => validator.ValidateSearchParameterInput(searchParam, method, CancellationToken.None));
         }
 
         [Theory]
@@ -52,7 +52,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         public async Task GivenValidSearchParam_WhenValidatingSearchParam_ThenNoExceptionThrown(SearchParameter searchParam, string method)
         {
             var validator = new SearchParameterValidator(() => _fhirOperationDataStore.CreateMockScope(), _authorizationService, _searchParameterDefinitionManager);
-            await validator.ValidateSearchParamterInput(searchParam, method, CancellationToken.None);
+            await validator.ValidateSearchParameterInput(searchParam, method, CancellationToken.None);
         }
 
         [Fact]
@@ -62,7 +62,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             authorizationService.CheckAccess(DataActions.Reindex, Arg.Any<CancellationToken>()).Returns(DataActions.Write);
             var validator = new SearchParameterValidator(() => _fhirOperationDataStore.CreateMockScope(), authorizationService, _searchParameterDefinitionManager);
 
-            await Assert.ThrowsAsync<UnauthorizedFhirActionException>(() => validator.ValidateSearchParamterInput(new SearchParameter(), "POST", CancellationToken.None));
+            await Assert.ThrowsAsync<UnauthorizedFhirActionException>(() => validator.ValidateSearchParameterInput(new SearchParameter(), "POST", CancellationToken.None));
         }
 
         [Fact]
@@ -73,7 +73,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
             var validator = new SearchParameterValidator(() => fhirOperationDataStore.CreateMockScope(), _authorizationService, _searchParameterDefinitionManager);
 
-            await Assert.ThrowsAsync<JobConflictException>(() => validator.ValidateSearchParamterInput(new SearchParameter(), "POST", CancellationToken.None));
+            await Assert.ThrowsAsync<JobConflictException>(() => validator.ValidateSearchParameterInput(new SearchParameter(), "POST", CancellationToken.None));
         }
 
         public static IEnumerable<object[]> InvalidSearchParamData()

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterValidatorTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterValidatorTests.cs
@@ -89,6 +89,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             data.Add(new object[] { uniqueUrl, "PUT" });
             data.Add(new object[] { uniqueUrl, "DELETE" });
             data.Add(new object[] { duplicateCode, "POST" });
+            data.Add(new object[] { duplicateCode, "PUT" });
 
             return data;
         }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Parameters/ISearchParameterValidator.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Parameters/ISearchParameterValidator.cs
@@ -10,6 +10,6 @@ namespace Microsoft.Health.Fhir.Shared.Core.Features.Search.Parameters
 {
     public interface ISearchParameterValidator
     {
-        System.Threading.Tasks.Task ValidateSearchParamterInput(SearchParameter searchParam, string method, CancellationToken cancellationToken);
+        System.Threading.Tasks.Task ValidateSearchParameterInput(SearchParameter searchParam, string method, CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Parameters/SearchParameterValidator.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Parameters/SearchParameterValidator.cs
@@ -16,7 +16,6 @@ using Microsoft.Health.Fhir.Core;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Operations;
-using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Features.Security;
 using Microsoft.Health.Fhir.Core.Features.Validation;
 using Task = System.Threading.Tasks.Task;

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Parameters/SearchParameterValidator.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Parameters/SearchParameterValidator.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Health.Fhir.Shared.Core.Features.Search.Parameters
             _searchParameterDefinitionManager = searchParameterDefinitionManager;
         }
 
-        public async Task ValidateSearchParamterInput(SearchParameter searchParam, string method, CancellationToken cancellationToken)
+        public async Task ValidateSearchParameterInput(SearchParameter searchParam, string method, CancellationToken cancellationToken)
         {
             if (await _authorizationService.CheckAccess(DataActions.Reindex, cancellationToken) != DataActions.Reindex)
             {
@@ -75,18 +75,44 @@ namespace Microsoft.Health.Fhir.Shared.Core.Features.Search.Parameters
             {
                 try
                 {
-                    _searchParameterDefinitionManager.GetSearchParameter(new Uri(searchParam.Url));
-
-                    // If a post, then it is a creation of a new search parameter
-                    // only allow this if no other parameters exist with the same Uri
-                    if (method.Equals(HttpPostName, StringComparison.OrdinalIgnoreCase))
+                    // If a search parameter with the same uri exists already
+                    if (_searchParameterDefinitionManager.TryGetSearchParameter(new Uri(searchParam.Url), out _))
                     {
-                        // if no exception is thrown, then the search parameter with the same Uri was found
-                        // and this is a conflict
-                        validationFailures.Add(
-                            new ValidationFailure(
-                                nameof(searchParam.Url),
-                                string.Format(Resources.SearchParameterDefinitionDuplicatedEntry, searchParam.Url)));
+                        // And if this is a request to create a new search parameter
+                        if (method.Equals(HttpPostName, StringComparison.OrdinalIgnoreCase))
+                        {
+                            // We have a conflict
+                            validationFailures.Add(
+                                new ValidationFailure(
+                                    nameof(searchParam.Url),
+                                    string.Format(Resources.SearchParameterDefinitionDuplicatedEntry, searchParam.Url)));
+                        }
+                    }
+                    else
+                    {
+                        // Otherwise, no search parameters with a matching uri exist
+                        // Ensure this isn't a request to modify an existing parameter
+                        if (method.Equals(HttpPutName, StringComparison.OrdinalIgnoreCase) ||
+                            method.Equals(HttpDeleteName, StringComparison.OrdinalIgnoreCase))
+                        {
+                            validationFailures.Add(
+                                new ValidationFailure(
+                                    nameof(searchParam.Url),
+                                    string.Format(Resources.SearchParameterDefinitionNotFound, searchParam.Url)));
+                        }
+
+                        // Ensure the new search parameter's code value does not already exist for its base type(s)
+                        foreach (ResourceType? baseType in searchParam.Base)
+                        {
+                            if (_searchParameterDefinitionManager.TryGetSearchParameter(baseType.ToString(), searchParam.Code, out _))
+                            {
+                                // The new search parameter's code value conflicts with an existing one
+                                validationFailures.Add(
+                                    new ValidationFailure(
+                                        nameof(searchParam.Code),
+                                        string.Format(Resources.SearchParameterDefinitionConflictingCodeValue, searchParam.Code, baseType.ToString())));
+                            }
+                        }
                     }
                 }
                 catch (FormatException)
@@ -95,21 +121,6 @@ namespace Microsoft.Health.Fhir.Shared.Core.Features.Search.Parameters
                           new ValidationFailure(
                               nameof(searchParam.Url),
                               string.Format(Resources.SearchParameterDefinitionInvalidDefinitionUri, searchParam.Url)));
-                }
-                catch (SearchParameterNotSupportedException)
-                {
-                    // if thrown, then the search parameter is not found
-                    // if a PUT, then we should be updating an exsting paramter, but it was not found
-                    if (method.Equals(HttpPutName, StringComparison.OrdinalIgnoreCase) ||
-                        method.Equals(HttpDeleteName, StringComparison.OrdinalIgnoreCase))
-                    {
-                        // if an exception above was thrown, then the search parameter with the same Uri was not found
-                        // and DELETE or PUT can only run on existing parameter
-                        validationFailures.Add(
-                            new ValidationFailure(
-                                nameof(searchParam.Url),
-                                string.Format(Resources.SearchParameterDefinitionNotFound, searchParam.Url)));
-                    }
                 }
             }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -207,7 +207,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         }
 
         [Theory]
-        [InlineData("SearchParameterBadSyntax", "Parsing failure")]
+        [InlineData("SearchParameterBadSyntax", "A search parameter with the same code value 'diagnosis' already exists for base type 'Encounter'")]
         [InlineData("SearchParameterExpressionWrongProperty", "not supported")]
         [InlineData("SearchParameterInvalidBase", "Literal 'foo' is not a valid value for enumeration 'ResourceType'")]
         [InlineData("SearchParameterInvalidType", "Literal 'foo' is not a valid value for enumeration 'SearchParamType'")]
@@ -225,7 +225,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             }
             catch (FhirException ex)
             {
-                Assert.True(ex.OperationOutcome.Issue.Where(i => i.Diagnostics.Contains(errorMessage)).Any());
+                Assert.Contains(ex.OperationOutcome.Issue, i => i.Diagnostics.Contains(errorMessage));
             }
         }
 


### PR DESCRIPTION
## Description
New search parameters can't have the same code value as other search parameters with the same base resource types. 

Before this PR, when a user would post a new search parameter with a duplicate code value, we would throw an exception in the `SearchParameterDefinitionBuilder`, after the search parameter information was added to the `SearchParameterDefinitionManager`'s `UrlLookup` dictionary. If the user posted the search parameter again after fixing the code value, they would see the error message: "A search parameter with the same definition URL already exists." 

This PR adds a check during search parameter validation to ensure the code value of a search parameter does not match the code value of any existing search parameters that have the same resource type. 

## Related issues
Addresses [AB#81596](https://microsofthealth.visualstudio.com/Health/_workitems/edit/81596).

## Testing
Adds new unit test cases and added an http file for manual testing.

## FHIR Team Checklist
- ✅ **Update the title** of the PR to be succinct and less than 50 characters
- ✅ **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- ✅ Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- ✅ Tag the PR with **Azure API for FHIR** if this will release to the managed service
- ✅ Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
None (bug fix)
