### PR TITLE
Add support for client id and secret in basic auth header

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Controllers/AadSmartOnFhirProxyController.cs
+++ b/src/Microsoft.Health.Fhir.Api/Controllers/AadSmartOnFhirProxyController.cs
@@ -352,6 +352,8 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             {
                 EnsureArg.IsNotNull(compoundCode, nameof(compoundCode));
                 EnsureArg.IsNotNull(redirectUri, nameof(redirectUri));
+                EnsureArg.IsNotNull(clientId, nameof(clientId));
+                EnsureArg.IsNotNull(clientSecret, nameof(clientSecret));
             }
             catch (ArgumentNullException ex)
             {
@@ -372,16 +374,6 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             }
 
             Uri callbackUrl = _urlResolver.ResolveRouteNameUrl(RouteNames.AadSmartOnFhirProxyCallback, new RouteValueDictionary { { "encodedRedirect", Base64UrlEncoder.Encode(redirectUri.ToString()) } });
-
-            try
-            {
-                EnsureArg.IsNotNull(clientId, nameof(clientId));
-                EnsureArg.IsNotNull(clientSecret, nameof(clientSecret));
-            }
-            catch (ArgumentNullException ex)
-            {
-                throw new AadSmartOnFhirProxyBadRequestException(string.Format(Resources.ValueCannotBeNull, ex.ParamName), ex);
-            }
 
             using var content = new FormUrlEncodedContent(
                  new[]

--- a/src/Microsoft.Health.Fhir.Api/Controllers/AadSmartOnFhirProxyController.cs
+++ b/src/Microsoft.Health.Fhir.Api/Controllers/AadSmartOnFhirProxyController.cs
@@ -303,8 +303,9 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             var client = _httpClientFactory.CreateClient();
 #pragma warning restore CA2000
 
-            if (Request.Headers.TryGetValue("Authorization", out var authHeaderValues)
-                && string.IsNullOrEmpty(clientId))
+            if (Request != null &&
+                string.IsNullOrEmpty(clientId) &&
+                Request.Headers.TryGetValue("Authorization", out var authHeaderValues))
             {
                 var authHeader = authHeaderValues.ToString();
                 if (authHeader.Contains("Basic ", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
## Description
Inferno tests uses Basic authorization header with client id and client secret in the header value.  This update moves one step closer to being able to run Inferno tests.

## Related issues
Addresses [issue #].

## Testing
Ran Inferno tests against our endpoint.

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
