### PR TITLE
Add health check for web sites

### DIFF
--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -324,7 +324,8 @@
                     "properties": {
                         "linuxFxVersion": "[concat('DOCKER|', variables('registryName'), '/', toLower(parameters('fhirVersion')), '_fhir-server',':', parameters('imageTag'))]",
                         "appCommandLine": "azure-fhir-api",
-                        "alwaysOn": true
+                        "alwaysOn": true,
+                        "healthCheckPath": "/health/check"
                     }
                 }
             ]

--- a/samples/templates/default-azuredeploy.json
+++ b/samples/templates/default-azuredeploy.json
@@ -276,7 +276,8 @@
                 "clientAffinityEnabled": false,
                 "serverFarmId": "[resourceId(variables('appServicePlanResourceGroup'), 'Microsoft.Web/serverfarms/', variables('appServicePlanName'))]",
                 "siteConfig": {
-                   "AlwaysOn": true
+                    "AlwaysOn": true,
+                    "healthCheckPath": "/health/check"
                }
             },
             "dependsOn": [


### PR DESCRIPTION
## Description
Our tests for Sql are failing down.
I've track issue to the root cause of two containers attempt to initialize schema for sql, but on of them fails, and basically put web site into permanent 500.

So with two web site I have 50% chance of getting 500 during request and that fails sql e2e tests.

I assume we don't encounter this issue in PaaS because we have configured health checks and dead container get restarted. So I'm adding health check monitoring to app service.

## Related issues


## Testing
E2E tests.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
