### PR TITLE
Prevent reindex job from been stuck

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobQueryStatus.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobQueryStatus.cs
@@ -44,5 +44,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
 
         [JsonProperty(JobRecordProperties.ResourceType)]
         public string ResourceType { get; private set; }
+
+        public bool HasOffspring { get; set; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -382,7 +382,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     {
                         var wrapper = await store.Value.GetReindexJobByIdAsync(_reindexJobRecord.Id, _cancellationToken);
                         _weakETag = wrapper.ETag;
-                        _reindexJobRecord = wrapper.JobRecord;
+                        _reindexJobRecord.Status = wrapper.JobRecord.Status;
                     }
                 }
                 finally

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -314,6 +314,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     CancellationTokenSource queryTokensSource = new CancellationTokenSource();
                     queryCancellationTokens.TryAdd(query, queryTokensSource);
 
+                    // We don't await ProcessQuery, so query status can or can not be changed inside immediately
+                    // In some cases we can go th6rough whole loop and pick same query from query list.
+                    // To prevent that we marking query as running here and not inside ProcessQuery code.
+                    query.Status = OperationStatus.Running;
+                    query.LastModified = DateTimeOffset.UtcNow;
 #pragma warning disable CS4014 // Suppressed as we want to continue execution and begin processing the next query while this continues to run
                     queryTasks.Add(ProcessQueryAsync(query, queryTokensSource.Token));
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
@@ -385,6 +390,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                         _reindexJobRecord.Status = wrapper.JobRecord.Status;
                     }
                 }
+                catch (Exception)
+                {
+                    // if something went wrong with fetching job status, we shouldn't fail process loop.
+                }
                 finally
                 {
                     _jobSemaphore.Release();
@@ -417,14 +426,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                 await _jobSemaphore.WaitAsync(cancellationToken);
                 try
                 {
-                    query.Status = OperationStatus.Running;
-                    query.LastModified = DateTimeOffset.UtcNow;
-
                     // Query first batch of resources
                     results = await ExecuteReindexQueryAsync(query, countOnly: false, cancellationToken);
 
-                    // if continuation token then update next query
-                    if (!string.IsNullOrEmpty(results?.ContinuationToken))
+                    // If continuation token then update next query but only if parent query haven't been in pipeline.
+                    // For cases like retry or stale query we don't want to start another chain.
+                    if (!string.IsNullOrEmpty(results?.ContinuationToken) && !query.HasOffspring)
                     {
                         var encodedContinuationToken = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(results.ContinuationToken));
                         var nextQuery = new ReindexJobQueryStatus(query.ResourceType, encodedContinuationToken)
@@ -433,6 +440,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                             Status = OperationStatus.Queued,
                         };
                         _reindexJobRecord.QueryList.TryAdd(nextQuery, 1);
+                        query.HasOffspring = true;
                     }
 
                     await UpdateJobAsync();


### PR DESCRIPTION
## Description
Reindex job task operates over reindex job object. We work with query list collection, we populate it, process it, make updates.
But that collection operates over ReindexJobQueryStatus which doesn't have GetHashCode and Equal override to compare elements. Which means we rely on memory addresses to add, update and remove items from collection.

What happens when we read instance of the job from database? Well, all memory addresses are different, because this is another instance of reindexjob, and if we replace current instance of the job with one read from db, we never complete query from query collection, because we would access original _reindexJob query list, while we constantly update actual reindexjob to be fetch from DB.



## Related issues
Addresses [issue #].

## Testing
Painfully.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
