### PR TITLE
Fix reindex on sql

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
@@ -123,6 +123,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations
 
         public const string TargetDataStoreUsagePercentage = "targetDataStoreUsagePercentage";
 
-        public const string HasOffstring = "hasOffstring";
+        public const string CreatedChild = "createdChild";
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
@@ -122,5 +122,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations
         public const string QueryDelayIntervalInMilliseconds = "queryDelayIntervalInMilliseconds";
 
         public const string TargetDataStoreUsagePercentage = "targetDataStoreUsagePercentage";
+
+        public const string HasOffstring = "hasOffstring";
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobQueryStatus.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobQueryStatus.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
         [JsonProperty(JobRecordProperties.ResourceType)]
         public string ResourceType { get; private set; }
 
+        [JsonProperty(JobRecordProperties.HasOffstring)]
         public bool HasOffspring { get; set; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobQueryStatus.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobQueryStatus.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
         [JsonProperty(JobRecordProperties.ResourceType)]
         public string ResourceType { get; private set; }
 
-        [JsonProperty(JobRecordProperties.HasOffstring)]
-        public bool HasOffspring { get; set; }
+        [JsonProperty(JobRecordProperties.CreatedChild)]
+        public bool CreatedChild { get; set; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -435,7 +435,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
 
                     // If continuation token then update next query but only if parent query haven't been in pipeline.
                     // For cases like retry or stale query we don't want to start another chain.
-                    if (!string.IsNullOrEmpty(results?.ContinuationToken) && !query.HasOffspring)
+                    if (!string.IsNullOrEmpty(results?.ContinuationToken) && !query.CreatedChild)
                     {
                         var encodedContinuationToken = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(results.ContinuationToken));
                         var nextQuery = new ReindexJobQueryStatus(query.ResourceType, encodedContinuationToken)
@@ -444,7 +444,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                             Status = OperationStatus.Queued,
                         };
                         _reindexJobRecord.QueryList.TryAdd(nextQuery, 1);
-                        query.HasOffspring = true;
+                        query.CreatedChild = true;
                     }
 
                     await UpdateJobAsync();

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -186,7 +186,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     OperationOutcomeConstants.IssueSeverity.Information,
                     OperationOutcomeConstants.IssueType.Informational,
                     Resources.NoSearchParametersNeededToBeIndexed));
-                _reindexJobRecord.CanceledTime = DateTimeOffset.UtcNow;
+                _reindexJobRecord.CanceledTime = Clock.UtcNow;
                 await MoveToFinalStatusAsync(OperationStatus.Canceled);
                 return false;
             }
@@ -322,7 +322,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     // In some cases we can go th6rough whole loop and pick same query from query list.
                     // To prevent that we marking query as running here and not inside ProcessQuery code.
                     query.Status = OperationStatus.Running;
-                    query.LastModified = DateTimeOffset.UtcNow;
+                    query.LastModified = Clock.UtcNow;
 #pragma warning disable CS4014 // Suppressed as we want to continue execution and begin processing the next query while this continues to run
                     queryTasks.Add(ProcessQueryAsync(query, queryTokensSource.Token));
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -122,6 +122,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                         _throttleController.Initialize(_reindexJobRecord, provisionedCapacity);
                     }
                 }
+                else
+                {
+                    _throttleController.Initialize(_reindexJobRecord, null);
+                }
 
                 // If we are resuming a job, we can detect that by checking the progress info from the job record.
                 // If no queries have been added to the progress then this is a new job

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 // Start a reindex job
                 (_, reindexJobUri) = await Client.PostReindexJobAsync(new Parameters());
 
-                await WaitForReindexStatus(reindexJobUri, "Running", "Completed");
+                await WaitForReindexStatus(reindexJobUri, "Completed");
 
                 FhirResponse<Parameters> reindexJobResult = await Client.CheckReindexAsync(reindexJobUri);
                 Parameters.ParameterComponent param = reindexJobResult.Resource.Parameter.FirstOrDefault(p => p.Name == "searchParams");

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
     [CollectionDefinition(Categories.CustomSearch, DisableParallelization = true)]
     [Collection(Categories.CustomSearch)]
     [Trait(Traits.Category, Categories.CustomSearch)]
-    [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb, Format.Json)]
+    [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.Json)]
     public class CustomSearchParamTests : SearchTestsBase<HttpIntegrationTestFixture>
     {
         private readonly HttpIntegrationTestFixture _fixture;


### PR DESCRIPTION
## Description
Reindex is not working in sql, see https://microsofthealth.visualstudio.com/Health/_workitems/edit/82175
This make sure we pass right parameter and enables tests in sql for reindex.

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
