### PR TITLE
Updates search parameter error handling

### DIFF
--- a/docs/rest/ReindexFlowReferenceExtension.http
+++ b/docs/rest/ReindexFlowReferenceExtension.http
@@ -1,0 +1,219 @@
+# This test flow confirms that reindexing operations can handle search parameters
+# that target the network extension of PractitionerRole resources.
+# It also checks that the appropriate error message is returned when the
+# search parameter's expression is not specific enough.
+#
+# This test assumes the following local environment setup:
+# 1. appsettings.json has Security.Enabled = false
+# 2. The version is R4 or R5
+
+@baseUrl = https://localhost:44348
+@contentType = application/json
+
+###
+# Create a PractitionerRole resource with a network extension.
+POST {{baseUrl}}/PractitionerRole HTTP/1.1
+content-type: {{contentType}}
+
+{
+  "resourceType" : "PractitionerRole",
+  "id" : "CounselorRole1",
+  "meta" : {
+    "lastUpdated" : "2020-07-07T13:26:22.0314215+00:00",
+    "profile" : [
+      "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-PractitionerRole"
+    ]
+  },
+  "language" : "en-US",
+  "text" : {
+    "status" : "extensions",
+    "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en-US\" lang=\"en-US\"><p><b>Generated Narrative</b></p><p><b>Network Reference</b>: <a href=\"Organization-AcmeofCTStdNet.html\">Generated Summary: language: en-US; active; <span title=\"Codes: {http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/OrgTypeCS ntwk}\">Network</span>; name: ACME CT Preferred Provider Network</a></p><p><b>active</b>: true</p><p><b>practitioner</b>: <a href=\"Practitioner-Counselor.html\">Generated Summary: language: en-US; id: NPI3238; active; Susie Smith, LPC; <span title=\"Codes: {urn:ietf:bcp:47 ru}\">Russian</span></a></p><p><b>code</b>: <span title=\"Codes: {http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/ProviderRoleCS co}\">Counselor</span></p><p><b>specialty</b>: <span title=\"Codes: {http://nucc.org/provider-taxonomy 101YP2500X}\">Professional Counselor</span></p><p><b>healthcareService</b>: <a href=\"HealthcareService-VirtualCounselService.html\">Generated Summary: language: en-US; active; <span title=\"Codes: {http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/HealthcareServiceCategoryCS prov}\">Medical Provider</span>; <span title=\"Codes: {http://nucc.org/provider-taxonomy 101YP2500X}\">Professional</span></a></p></div>"
+  },
+  "extension" : [
+    {
+      "url" : "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/network-reference",
+      "valueReference" : {
+        "reference" : "Organization/AcmeofCTStdNet"
+      }
+    }
+  ],
+  "active" : true,
+  "practitioner" : {
+    "reference" : "Practitioner/Counselor"
+  },
+  "code" : [
+    {
+      "coding" : [
+        {
+          "system" : "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/ProviderRoleCS",
+          "code" : "co",
+          "display" : "Counselor"
+        }
+      ]
+    }
+  ],
+  "specialty" : [
+    {
+      "coding" : [
+        {
+          "system" : "http://nucc.org/provider-taxonomy",
+          "code" : "101YP2500X",
+          "display" : "Professional Counselor"
+        }
+      ]
+    }
+  ],
+  "healthcareService" : [
+    {
+      "reference" : "HealthcareService/VirtualCounselService"
+    }
+  ]
+}
+
+###
+# Create a search parameter resource that targets the PractitionerRole network extension.
+POST {{baseUrl}}/SearchParameter HTTP/1.1
+content-type: {{contentType}}
+
+{
+  "resourceType": "SearchParameter",
+  "id": "practitionerrole-network",
+  "url": "http://hl7.org/fhir/us/davinci-pdex-plan-net/SearchParameter/practitionerrole-network",
+  "version": "1.0.0",
+  "name": "Plannet_sp_practitionerrole_network",
+  "status": "active",
+  "date": "2018-05-23T00:00:00+00:00",
+  "publisher": "HL7 Financial Management Working Group",
+  "contact": [
+    {
+      "name": "HL7 Financial Management Working Group",
+      "telecom": [
+        {
+          "system": "url",
+          "value": "http://www.hl7.org/Special/committees/fm/index.cfm"
+        },
+        {
+          "system": "email",
+          "value": "fm@lists.HL7.org"
+        }
+      ]
+    }
+  ],
+  "description": "Select roles where the practitioner is a member of the specified health insurance provider network",
+  "jurisdiction": [
+    {
+      "coding": [
+        {
+          "system": "urn:iso:std:iso:3166",
+          "code": "US"
+        }
+      ]
+    }
+  ],
+  "code": "network",
+  "base": [
+    "PractitionerRole"
+  ],
+  "type": "reference",
+  "expression": "PractitionerRole.extension.where(url='http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/network-reference').value.as(Reference)",
+  "target": [
+    "Organization"
+  ],
+  "multipleOr": true,
+  "multipleAnd": true,
+  "chain": [
+    "name",
+    "address",
+    "partof",
+    "type"
+  ]
+}
+
+###
+# Initiate a reindexing operation.
+# Copy the reindexing job ID into the variable below.
+POST {{baseUrl}}/$reindex HTTP/1.1
+content-type: application/json
+
+{  "resourceType": "Parameters", "parameter": [] }
+
+@reindexId = 438002bc-1995-44d7-aaa5-1f291b7d4a78
+
+
+###
+
+@reindexId = 028575cb-b7bd-4a70-9dea-0787143109da
+
+# Get the status of the reindex job.
+# This should complete quickly because we are only reindexing one resource.
+GET {{baseUrl}}/_operations/reindex/{{reindexId}} HTTP/1.1
+
+###
+# Get the practitioner role with matching network reference info.
+# This should return one value.
+GET {{baseUrl}}/PractitionerRole?network=Organization/AcmeofCTStdNet&_total=accurate HTTP/1.1
+
+###
+# Attempt to get a practitioner role with non-matching network reference info.
+# This shouldn't return any values.
+GET {{baseUrl}}/PractitionerRole?network=Organization/AcmeofDoesNotExist&_total=accurate HTTP/1.1
+
+###
+# Attempt to create a search parameter resource with an expression that is not specific enough.
+# This should fail with the message that the search parameter is unable to be indexed.
+POST {{baseUrl}}/SearchParameter HTTP/1.1
+content-type: {{contentType}}
+
+{
+  "resourceType": "SearchParameter",
+  "id": "practitionerrole-network",
+  "url": "http://hl7.org/fhir/us/davinci-pdex-plan-net/SearchParameter/practitionerrole-network-incomplete-expression",
+  "version": "1.0.0",
+  "name": "Plannet_sp_practitionerrole_network_incomplete_expression",
+  "status": "active",
+  "date": "2018-05-23T00:00:00+00:00",
+  "publisher": "HL7 Financial Management Working Group",
+  "contact": [
+    {
+      "name": "HL7 Financial Management Working Group",
+      "telecom": [
+        {
+          "system": "url",
+          "value": "http://www.hl7.org/Special/committees/fm/index.cfm"
+        },
+        {
+          "system": "email",
+          "value": "fm@lists.HL7.org"
+        }
+      ]
+    }
+  ],
+  "description": "Select roles where the practitioner is a member of the specified health insurance provider network",
+  "jurisdiction": [
+    {
+      "coding": [
+        {
+          "system": "urn:iso:std:iso:3166",
+          "code": "US"
+        }
+      ]
+    }
+  ],
+  "code": "network-incomplete-expression",
+  "base": [
+    "PractitionerRole"
+  ],
+  "type": "reference",
+  "expression": "PractitionerRole.extension.where(url='http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/network-reference')",
+  "target": [
+    "Organization"
+  ],
+  "multipleOr": true,
+  "multipleAnd": true,
+  "chain": [
+    "name",
+    "address",
+    "partof",
+    "type"
+  ]
+}

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/Registry/SearchParameterStatusManagerTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/Registry/SearchParameterStatusManagerTests.cs
@@ -105,11 +105,11 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Registry
 
             _searchParameterSupportResolver
                 .IsSearchParameterSupported(Arg.Any<SearchParameterInfo>())
-                .Returns((false, false));
+                .Returns((false, false, Resources.SearchParameterCannotBeIndexed));
 
             _searchParameterSupportResolver
                 .IsSearchParameterSupported(Arg.Is(_searchParameterInfos[4]))
-                .Returns((true, false));
+                .Returns((true, false, null));
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/ISearchParameterSupportResolver.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/ISearchParameterSupportResolver.cs
@@ -12,7 +12,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
         /// <summary>
         /// Determines if the given search parameter is able to be indexed
         /// </summary>
-        /// <param name="parameterInfo">Search Parameter info</param>
-        (bool Supported, bool IsPartiallySupported) IsSearchParameterSupported(SearchParameterInfo parameterInfo);
+        /// <param name="parameterInfo">The search parameter to check.</param>
+        /// <returns name="Supported">True if one or more matching converters is found.</returns>
+        /// <returns name="IsPartiallySupported">False if all matching converters are found or no matching converters are found, true otherwise.</returns>
+        /// <returns name="ErrorMessage">Provides more detail if a search parameter is not supported.</returns>
+        (bool Supported, bool IsPartiallySupported, string ErrorMessage) IsSearchParameterSupported(SearchParameterInfo parameterInfo);
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
@@ -65,15 +65,15 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
                 // verify the parameter is supported before continuing
                 var searchParameterWrapper = new SearchParameterWrapper(searchParam);
                 var searchParameterInfo = new SearchParameterInfo(searchParameterWrapper);
-                (bool Supported, bool IsPartiallySupported) supportedResult = _searchParameterSupportResolver.IsSearchParameterSupported(searchParameterInfo);
+                (bool supported, bool _, string errorMessage) = _searchParameterSupportResolver.IsSearchParameterSupported(searchParameterInfo);
 
-                if (!supportedResult.Supported)
+                if (!supported)
                 {
-                    throw new SearchParameterNotSupportedException(searchParameterInfo.Url);
+                    throw new SearchParameterNotSupportedException(errorMessage);
                 }
 
                 // check data store specific support for SearchParameter
-                if (!_dataStoreSearchParameterValidator.ValidateSearchParameter(searchParameterInfo, out var errorMessage))
+                if (!_dataStoreSearchParameterValidator.ValidateSearchParameter(searchParameterInfo, out errorMessage))
                 {
                     throw new SearchParameterNotSupportedException(errorMessage);
                 }
@@ -148,15 +148,15 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
 
                 var searchParameterWrapper = new SearchParameterWrapper(searchParam);
                 var searchParameterInfo = new SearchParameterInfo(searchParameterWrapper);
-                (bool Supported, bool IsPartiallySupported) supportedResult = _searchParameterSupportResolver.IsSearchParameterSupported(searchParameterInfo);
+                (bool supported, bool _, string errorMessage) = _searchParameterSupportResolver.IsSearchParameterSupported(searchParameterInfo);
 
-                if (!supportedResult.Supported)
+                if (!supported)
                 {
-                    throw new SearchParameterNotSupportedException(searchParameterInfo.Url);
+                    throw new SearchParameterNotSupportedException(errorMessage);
                 }
 
                 // check data store specific support for SearchParameter
-                if (!_dataStoreSearchParameterValidator.ValidateSearchParameter(searchParameterInfo, out var errorMessage))
+                if (!_dataStoreSearchParameterValidator.ValidateSearchParameter(searchParameterInfo, out errorMessage))
                 {
                     throw new SearchParameterNotSupportedException(errorMessage);
                 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
                     if (result.Status == SearchParameterStatus.Disabled)
                     {
                         // Re-check if this parameter is now supported.
-                        (bool Supported, bool IsPartiallySupported) supportedResult = _searchParameterSupportResolver.IsSearchParameterSupported(p);
+                        (bool Supported, bool IsPartiallySupported, string _) supportedResult = _searchParameterSupportResolver.IsSearchParameterSupported(p);
                         tempStatus.IsSupported = supportedResult.Supported;
                         tempStatus.IsPartiallySupported = supportedResult.IsPartiallySupported;
                     }
@@ -86,7 +86,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
                     p.IsSearchable = false;
 
                     // Check if this parameter is now supported.
-                    (bool Supported, bool IsPartiallySupported) supportedResult = _searchParameterSupportResolver.IsSearchParameterSupported(p);
+                    (bool Supported, bool IsPartiallySupported, string _) supportedResult = _searchParameterSupportResolver.IsSearchParameterSupported(p);
                     p.IsSupported = supportedResult.Supported;
                     p.IsPartiallySupported = supportedResult.IsPartiallySupported;
 

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Health.Fhir.Core {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -926,6 +926,15 @@ namespace Microsoft.Health.Fhir.Core {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Unable to index search parameter. Check the search parameter expression and base type(s)..
+        /// </summary>
+        internal static string SearchParameterCannotBeIndexed {
+            get {
+                return ResourceManager.GetString("SearchParameterCannotBeIndexed", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to SearchParameter[{0}].resource.base is not defined..
         /// </summary>
         internal static string SearchParameterDefinitionBaseNotDefined {
@@ -1039,6 +1048,15 @@ namespace Microsoft.Health.Fhir.Core {
         internal static string SearchParameterDefinitionNotFound {
             get {
                 return ResourceManager.GetString("SearchParameterDefinitionNotFound", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Search parameter expression cannot be empty..
+        /// </summary>
+        internal static string SearchParameterExpressionEmpty {
+            get {
+                return ResourceManager.GetString("SearchParameterExpressionEmpty", resourceCulture);
             }
         }
 

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -557,4 +557,10 @@
   <data name="SearchParameterDefinitionConflictingCodeValue" xml:space="preserve">
     <value>A search parameter with the same code value '{0}' already exists for base type '{1}'.</value>
   </data>
+  <data name="SearchParameterExpressionEmpty" xml:space="preserve">
+    <value>Search parameter expression cannot be empty.</value>
+  </data>
+  <data name="SearchParameterCannotBeIndexed" xml:space="preserve">
+    <value>Unable to index search parameter. Check the search parameter expression and base type(s).</value>
+  </data>
 </root>

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
@@ -106,11 +106,11 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
             _searchParameterSupportResolver
                 .IsSearchParameterSupported(Arg.Any<SearchParameterInfo>())
-                .Returns((false, false));
+                .Returns((false, false, Core.Resources.SearchParameterCannotBeIndexed));
 
             _searchParameterSupportResolver
                 .IsSearchParameterSupported(Arg.Is(_searchParameterInfos[4]))
-                .Returns((true, false));
+                .Returns((true, false, null));
 
             var searchParameterDataStoreValidator = Substitute.For<IDataStoreSearchParameterValidator>();
             searchParameterDataStoreValidator.ValidateSearchParameter(Arg.Any<SearchParameterInfo>(), out Arg.Any<string>()).Returns(true, null);
@@ -307,7 +307,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
             _searchParameterSupportResolver
                 .IsSearchParameterSupported(Arg.Is<SearchParameterInfo>(p => p.Name == "test"))
-                .Returns((true, false));
+                .Returns((true, false, null));
 
             await _searchParameterOperations.AddSearchParameterAsync(searchParam.ToTypedElement());
 
@@ -350,7 +350,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
             _searchParameterSupportResolver
                 .IsSearchParameterSupported(Arg.Is<SearchParameterInfo>(p => p.Name == "test"))
-                .Returns((true, false));
+                .Returns((true, false, null));
 
             await _searchParameterOperations.AddSearchParameterAsync(searchParam.ToTypedElement());
 
@@ -453,7 +453,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
             _searchParameterSupportResolver
                 .IsSearchParameterSupported(Arg.Is<SearchParameterInfo>(s => s.Name.StartsWith("preexisting")))
-                .Returns((true, false));
+                .Returns((true, false, null));
 
             await searchParameterResourceDataStore.EnsureInitializedAsync(CancellationToken.None);
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterSupportResolverTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterSupportResolverTests.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
             Assert.True(supported.Supported);
             Assert.False(supported.IsPartiallySupported);
+            Assert.Null(supported.ErrorMessage);
         }
 
         [Fact]
@@ -60,6 +61,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
             Assert.False(supported.Supported);
             Assert.False(supported.IsPartiallySupported);
+            Assert.Equal(Core.Resources.SearchParameterCannotBeIndexed, supported.ErrorMessage);
         }
 
         [Fact]
@@ -79,6 +81,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
             Assert.True(supported.Supported);
             Assert.True(supported.IsPartiallySupported);
+            Assert.Null(supported.ErrorMessage);
         }
 
         [Fact]
@@ -96,6 +99,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
             Assert.False(supported.Supported);
             Assert.False(supported.IsPartiallySupported);
+            Assert.Equal(Core.Resources.SearchParameterCannotBeIndexed, supported.ErrorMessage);
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Parameters/SearchParameterSupportResolver.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Parameters/SearchParameterSupportResolver.cs
@@ -29,13 +29,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
             _searchValueConverterManager = searchValueConverterManager;
         }
 
-        public (bool Supported, bool IsPartiallySupported) IsSearchParameterSupported(SearchParameterInfo parameterInfo)
+        public (bool Supported, bool IsPartiallySupported, string ErrorMessage) IsSearchParameterSupported(SearchParameterInfo parameterInfo)
         {
             EnsureArg.IsNotNull(parameterInfo, nameof(parameterInfo));
 
             if (string.IsNullOrWhiteSpace(parameterInfo.Expression))
             {
-                return (false, false);
+                return (false, false, Core.Resources.SearchParameterExpressionEmpty);
             }
 
             Expression parsed = _compiler.Parse(parameterInfo.Expression);
@@ -72,13 +72,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
 
                 if (!converters.Any())
                 {
-                    return (false, false);
+                    return (false, false, Core.Resources.SearchParameterCannotBeIndexed);
                 }
 
                 if (!converters.All(x => x.hasConverter))
                 {
                     bool partialSupport = converters.Any(x => x.hasConverter);
-                    return (partialSupport, partialSupport);
+                    return (partialSupport, partialSupport, partialSupport ? null : Core.Resources.SearchParameterCannotBeIndexed);
                 }
             }
 
@@ -87,7 +87,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
                 return classMapping.IsCodeOfT ? _codeOfTName : classMapping.Name;
             }
 
-            return (true, false);
+            return (true, false, null);
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
@@ -190,7 +190,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 NullLogger<FhirCosmosSearchService>.Instance);
 
             ISearchParameterSupportResolver searchParameterSupportResolver = Substitute.For<ISearchParameterSupportResolver>();
-            searchParameterSupportResolver.IsSearchParameterSupported(Arg.Any<SearchParameterInfo>()).Returns((true, false));
+            searchParameterSupportResolver.IsSearchParameterSupported(Arg.Any<SearchParameterInfo>()).Returns((true, false, null));
 
             _searchParameterStatusManager = new SearchParameterStatusManager(
                 _searchParameterStatusDataStore,

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -190,7 +190,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 NullLogger<SqlServerSearchService>.Instance);
 
             ISearchParameterSupportResolver searchParameterSupportResolver = Substitute.For<ISearchParameterSupportResolver>();
-            searchParameterSupportResolver.IsSearchParameterSupported(Arg.Any<SearchParameterInfo>()).Returns((true, false));
+            searchParameterSupportResolver.IsSearchParameterSupported(Arg.Any<SearchParameterInfo>()).Returns((true, false, null));
 
             _searchParameterStatusManager = new SearchParameterStatusManager(
                 SqlServerSearchParameterStatusDataStore,


### PR DESCRIPTION
## Description
Before, if we posted a search parameter that didn't have a complete expression in the search parameter definition, we returned an error that simply stated that the search parameter was not supported.

This PR updates the error message that is returned to be more specific. 

## Related issues
Addresses [AB#82165](https://microsofthealth.visualstudio.com/Health/_workitems/edit/82165) and #1941.

## Testing
Adds error message check to existing unit tests and adds new .http test file for manual testing.

## FHIR Team Checklist
- ✅ **Update the title** of the PR to be succinct and less than 50 characters
- ✅ **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- ✅ Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- ✅ Tag the PR with **Azure API for FHIR** if this will release to the managed service
- ✅ Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip (minor error message tweaking)
