### PR TITLE
Make sure we don't return deleted resources in _include.

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
@@ -545,7 +545,9 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
                     foreach (Task<ResourceWrapper> task in tasks)
                     {
                         var resourceWrapper = (FhirCosmosResourceWrapper)await task;
-                        if (resourceWrapper != null)
+
+                        // Get Async always return latest resource, so no need to check for history flag.
+                        if (resourceWrapper != null && !resourceWrapper.IsDeleted)
                         {
                             includes.Add(resourceWrapper);
                             if (includes.Count > maxIncludeCount)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -640,6 +640,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                 AppendHistoryClause(delimited, referenceTargetResourceTableAlias);
                 AppendHistoryClause(delimited, referenceSourceTableAlias);
 
+                AppendDeletedClause(delimited, referenceTargetResourceTableAlias);
+
                 table = !includeExpression.Reversed ? referenceSourceTableAlias : referenceTargetResourceTableAlias;
 
                 // For RevIncludeIterate we expect to have a TargetType specified if the target reference can be of multiple types

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
@@ -309,6 +309,37 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             ValidateSearchEntryMode(bundle, ResourceType.Observation);
         }
 
+        [Fact]
+        public async Task GivenAnIncludeSearchExpression_WhenSearched_DoesnotIncludeDeletedOrUpdatedResources()
+        {
+            Bundle bundle = await Client.SearchAsync(ResourceType.Patient, $"_tag={Fixture.Tag}&_include=Patient:organization");
+
+            ValidateSearchEntryMode(bundle, ResourceType.Patient);
+            ValidateBundle(
+                bundle,
+                Fixture.PatiPatient,
+                Fixture.SmithPatient,
+                Fixture.TrumanPatient,
+                Fixture.AdamsPatient,
+                Fixture.PatientWithDeletedOrganization,
+                Fixture.Organization);
+        }
+
+        [Fact]
+        public async Task GivenAnRevIncludeSearchExpression_WhenSearched_DoesnotIncludeDeletedResources()
+        {
+            Bundle bundle = await Client.SearchAsync(ResourceType.Patient, $"_tag={Fixture.Tag}&_revinclude=Device:patient");
+
+            ValidateSearchEntryMode(bundle, ResourceType.Patient);
+            ValidateBundle(
+                bundle,
+                Fixture.PatiPatient,
+                Fixture.SmithPatient,
+                Fixture.TrumanPatient,
+                Fixture.AdamsPatient,
+                Fixture.PatientWithDeletedOrganization);
+        }
+
         // RevInclude
         [Fact]
         public async Task GivenARevIncludeSearchExpression_WhenSearched_ThenCorrectBundleShouldBeReturned()
@@ -506,7 +537,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 Fixture.PatiPatient,
                 Fixture.SmithPatient,
                 Fixture.TrumanPatient,
-                Fixture.AdamsPatient);
+                Fixture.AdamsPatient,
+                Fixture.PatientWithDeletedOrganization);
 
             ValidateSearchEntryMode(bundle, ResourceType.Patient);
         }
@@ -868,6 +900,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 Fixture.AdamsPatient,
                 Fixture.SmithPatient,
                 Fixture.TrumanPatient,
+                Fixture.PatientWithDeletedOrganization,
                 Fixture.AdamsMedicationRequest,
                 Fixture.SmithMedicationRequest,
                 Fixture.AdamsMedicationDispense,
@@ -879,11 +912,11 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
             // ensure that the included resources are not counted
             bundle = await Client.SearchAsync(ResourceType.Patient, $"{query}&_summary=count");
-            Assert.Equal(4, bundle.Total);
+            Assert.Equal(5, bundle.Total);
 
             // ensure that the included resources are not counted when _total is specified and the results fit in a single bundle.
             bundle = await Client.SearchAsync(ResourceType.Patient, $"{query}&_total=accurate");
-            Assert.Equal(4, bundle.Total);
+            Assert.Equal(5, bundle.Total);
         }
 
         [Fact]
@@ -901,6 +934,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 Fixture.AdamsPatient,
                 Fixture.SmithPatient,
                 Fixture.TrumanPatient,
+                Fixture.PatientWithDeletedOrganization,
                 Fixture.AdamsMedicationRequest,
                 Fixture.SmithMedicationRequest,
                 Fixture.AdamsMedicationDispense,
@@ -912,11 +946,11 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
             // ensure that the included resources are not counted
             bundle = await Client.SearchAsync(ResourceType.Patient, $"{query}&_summary=count");
-            Assert.Equal(4, bundle.Total);
+            Assert.Equal(5, bundle.Total);
 
             // ensure that the included resources are not counted when _total is specified and the results fit in a single bundle.
             bundle = await Client.SearchAsync(ResourceType.Patient, $"{query}&_total=accurate");
-            Assert.Equal(4, bundle.Total);
+            Assert.Equal(5, bundle.Total);
         }
 
         [Fact]
@@ -934,6 +968,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 Fixture.AdamsPatient,
                 Fixture.SmithPatient,
                 Fixture.TrumanPatient,
+                Fixture.PatientWithDeletedOrganization,
                 Fixture.AdamsMedicationRequest,
                 Fixture.SmithMedicationRequest,
                 Fixture.AdamsMedicationDispense,
@@ -1050,6 +1085,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 Fixture.AdamsPatient,
                 Fixture.SmithPatient,
                 Fixture.TrumanPatient,
+                Fixture.PatientWithDeletedOrganization,
                 Fixture.AndersonPractitioner,
                 Fixture.SanchezPractitioner,
                 Fixture.TaylorPractitioner,
@@ -1078,6 +1114,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 Fixture.AdamsPatient,
                 Fixture.SmithPatient,
                 Fixture.TrumanPatient,
+                Fixture.PatientWithDeletedOrganization,
                 Fixture.CareTeam);
 
             ValidateSearchEntryMode(bundle, ResourceType.Practitioner);
@@ -1104,6 +1141,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 Fixture.SanchezPractitioner,
                 Fixture.AdamsPatient,
                 Fixture.SmithPatient,
+                Fixture.PatientWithDeletedOrganization,
                 Fixture.PatiPatient);
 
             ValidateSearchEntryMode(bundle, ResourceType.MedicationDispense);
@@ -1189,6 +1227,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 Fixture.TaylorPractitioner,
                 Fixture.Practitioner,
                 Fixture.PatiPatient,
+                Fixture.PatientWithDeletedOrganization,
                 Fixture.AdamsPatient,
                 Fixture.SmithPatient,
                 Fixture.TrumanPatient);
@@ -1211,7 +1250,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 Fixture.PatiPatient,
                 Fixture.AdamsPatient,
                 Fixture.SmithPatient,
-                Fixture.TrumanPatient);
+                Fixture.TrumanPatient,
+                Fixture.PatientWithDeletedOrganization);
 
             ValidateSearchEntryMode(bundle, ResourceType.Patient);
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
@@ -1205,6 +1205,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 Fixture.AdamsPatient,
                 Fixture.SmithPatient,
                 Fixture.TrumanPatient,
+                Fixture.PatientWithDeletedOrganization,
                 Fixture.AdamsMedicationRequest,
                 Fixture.SmithMedicationRequest);
 


### PR DESCRIPTION
## Description
_include in cosmos and sql returns deleted resource, which doesn't make sense for me.
So I added guards against that and unit tests to test it.

## Related issues
Addresses [#1955].

## Testing
By adding e2e tests.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
