### PR TITLE
Change CI environment name

### DIFF
--- a/build/ci-variables.yml
+++ b/build/ci-variables.yml
@@ -1,6 +1,7 @@
 variables:
     ResourceGroupRegion: 'southcentralus'
-    resourceGroupRoot: 'msh-fhir-ci'
+    # Due to deleting a keyvault with purge protection we must use a name other than msh-fhir-ci for 90 days after 5/20/2021.
+    resourceGroupRoot: 'msh-fhir-ci2'
     appServicePlanName: '$(resourceGroupRoot)-linux'
     DeploymentEnvironmentName: '$(resourceGroupRoot)'
     ResourceGroupName: '$(resourceGroupRoot)'


### PR DESCRIPTION
## Description
CI is broken after deleting a keyvault with purge protection. This changes the name of the CI environment so that the keyvault can be remade. We can switch back in 90 days if we want when the old name becomes available. This is preferred to restoring the old keyvault because the new keyvault won't have purge protection so we won't run into this issue again.

## Related issues
CI not building

## Testing
Ran CI deployment

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip
