### PR TITLE
upgrade fhir converter package from 3.5.1 to 4.0

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Microsoft.Health.Fhir.Core.csproj
+++ b/src/Microsoft.Health.Fhir.Core/Microsoft.Health.Fhir.Core.csproj
@@ -47,7 +47,7 @@
     <PackageReference Include="Hl7.Fhir.Support.Poco" Version="$(Hl7FhirVersion)" />
     <PackageReference Include="Hl7.Fhir.Serialization" Version="$(Hl7FhirVersion)" />
     <PackageReference Include="Hl7.FhirPath" Version="$(Hl7FhirVersion)" />
-    <PackageReference Include="Microsoft.Health.Fhir.Liquid.Converter" Version="3.5.113.4" />
+    <PackageReference Include="Microsoft.Health.Fhir.Liquid.Converter" Version="4.0.102.2" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.14" />
     <PackageReference Include="Polly" Version="7.2.2" />


### PR DESCRIPTION
## Description
Upgrade fhir converter package to [4.0 release](https://github.com/microsoft/FHIR-Converter/releases/tag/v4.0) which adds C-CDA templates.

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip
