### PR TITLE
Fix SQL query gen for multiple _type params

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/PrimaryKeyRangeParameterQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/PrimaryKeyRangeParameterQueryGenerator.cs
@@ -27,9 +27,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                 VisitSimpleBinary(BinaryOperator.Equal, context, VLatest.Resource.ResourceTypeId, null, primaryKeyRange.CurrentValue.ResourceTypeId, includeInParameterHash: false);
                 context.StringBuilder.Append(" AND ");
                 VisitSimpleBinary(expression.BinaryOperator, context, VLatest.Resource.ResourceSurrogateId, null, primaryKeyRange.CurrentValue.ResourceSurrogateId, includeInParameterHash: false);
-                context.StringBuilder.AppendLine();
-                context.StringBuilder.Append("OR ");
-                AppendColumnName(context, VLatest.Resource.ResourceTypeId, (int?)null).Append(" IN (");
 
                 bool first = true;
                 for (short i = 0; i < primaryKeyRange.NextResourceTypeIds.Count; i++)
@@ -38,6 +35,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     {
                         if (first)
                         {
+                            context.StringBuilder.AppendLine();
+                            context.StringBuilder.Append("OR ");
+                            AppendColumnName(context, VLatest.Resource.ResourceTypeId, (int?)null).Append(" IN (");
                             first = false;
                         }
                         else
@@ -49,7 +49,10 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     }
                 }
 
-                context.StringBuilder.AppendLine(")");
+                if (!first)
+                {
+                    context.StringBuilder.AppendLine(")");
+                }
             }
 
             context.StringBuilder.AppendLine(")");

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -49,24 +49,11 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         {
             // Create various resources.
             Patient[] patients = await Client.CreateResourcesAsync<Patient>(
-                p => SetPatientInfo(p, "Seattle", "Robinson"),
-                p => SetPatientInfo(p, "Portland", "Williamas"),
-                p => SetPatientInfo(p, "Seattle", "Jones"));
+                p => SetPatientInfo(p, "Seattle", "Robinson", tag: null),
+                p => SetPatientInfo(p, "Portland", "Williamas", tag: null),
+                p => SetPatientInfo(p, "Seattle", "Jones", tag: null));
 
             await ExecuteAndValidateBundle("Patient?address-city=seattle&family=Jones", patients[2]);
-
-            void SetPatientInfo(Patient patient, string city, string family)
-            {
-                patient.Address = new List<Address>()
-                {
-                    new Address() { City = city },
-                };
-
-                patient.Name = new List<HumanName>()
-                {
-                    new HumanName() { Family = family },
-                };
-            }
         }
 
         [Fact]
@@ -77,30 +64,15 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
             // Create various resources.
             Patient[] patients = await Client.CreateResourcesAsync<Patient>(
-                p => SetPatientInfo(p, "seattle", "Robinson"), // match
-                p => SetPatientInfo(p, "Portland", "Williamas"),
-                p => SetPatientInfo(p, "SEATTLE", "Skouras"), // match
-                p => SetPatientInfo(p, "Sea", "Luecke"),
-                p => SetPatientInfo(p, "Seattle", "Jones"), // match
-                p => SetPatientInfo(p, "New York", "Cook"),
-                p => SetPatientInfo(p, "Amsterdam", "Hill"));
+                p => SetPatientInfo(p, "seattle", "Robinson", tag), // match
+                p => SetPatientInfo(p, "Portland", "Williamas", tag),
+                p => SetPatientInfo(p, "SEATTLE", "Skouras", tag), // match
+                p => SetPatientInfo(p, "Sea", "Luecke", tag),
+                p => SetPatientInfo(p, "Seattle", "Jones", tag), // match
+                p => SetPatientInfo(p, "New York", "Cook", tag),
+                p => SetPatientInfo(p, "Amsterdam", "Hill", tag));
 
             await ExecuteAndValidateBundle("Patient?address-city=Seattle", patients[0], patients[2], patients[4]);
-
-            void SetPatientInfo(Patient patient, string city, string family)
-            {
-                patient.Meta = new Meta();
-                patient.Meta.Tag.Add(new Coding(null, tag));
-                patient.Address = new List<Address>()
-                {
-                    new Address() { City = city },
-                };
-
-                patient.Name = new List<HumanName>()
-                {
-                    new HumanName() { Family = family },
-                };
-            }
         }
 
         [Fact]
@@ -190,6 +162,68 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             await ExecuteAndValidateBundle($"?_type=Observation,Patient&_id={organization.Id}");
             bundle = await Client.SearchPostAsync(null, default, ("_type", "Patient,Observation"), ("_id", organization.Id));
             ValidateBundle(bundle, $"?_type=Patient,Observation&_id={organization.Id}");
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        [HttpIntegrationFixtureArgumentSets(dataStores: DataStore.SqlServer)]
+        public async Task GivenMultiplePagesOfVariousTypesOfResourcesInSql_WhenUsingTypeParameterToSearchForMultipleResourceTypes_ThenCorrectResourcesAreReturned()
+        {
+            // Create various resources.
+            string tag = Guid.NewGuid().ToString();
+            Patient[] patients = await Client.CreateResourcesAsync<Patient>(
+                p => SetPatientInfo(p, "city1", "name1", tag),
+                p => SetPatientInfo(p, "city2", "name2", tag),
+                p => SetPatientInfo(p, "city3", "name3", tag),
+                p => SetPatientInfo(p, "city4", "name4", tag));
+
+            Observation[] observations = await Client.CreateResourcesAsync<Observation>(
+                o => SetObservationInfo(o, tag),
+                o => SetObservationInfo(o, tag));
+
+            List<Resource> expectedResources = new List<Resource>();
+            foreach (Observation observation in observations)
+            {
+                expectedResources.Add(observation);
+            }
+
+            foreach (Patient patient in patients)
+            {
+                expectedResources.Add(patient);
+            }
+
+            await ExecuteAndValidateBundle($"?_type=Patient,Observation&_tag={tag}&_count=3", sort: false, pageSize: 3, expectedResources.ToArray());
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        [HttpIntegrationFixtureArgumentSets(dataStores: DataStore.CosmosDb)]
+        public async Task GivenMultiplePagesOfVariousTypesOfResourcesInCosmos_WhenUsingTypeParameterToSearchForMultipleResourceTypes_ThenCorrectResourcesAreReturned()
+        {
+            // Create various resources.
+            string tag = Guid.NewGuid().ToString();
+            Patient[] patients = await Client.CreateResourcesAsync<Patient>(
+                p => SetPatientInfo(p, "city1", "name1", tag),
+                p => SetPatientInfo(p, "city2", "name2", tag),
+                p => SetPatientInfo(p, "city3", "name3", tag),
+                p => SetPatientInfo(p, "city4", "name4", tag));
+
+            Observation[] observations = await Client.CreateResourcesAsync<Observation>(
+                o => SetObservationInfo(o, tag),
+                o => SetObservationInfo(o, tag));
+
+            List<Resource> expectedResources = new List<Resource>();
+            foreach (Patient patient in patients)
+            {
+                expectedResources.Add(patient);
+            }
+
+            foreach (Observation observation in observations)
+            {
+                expectedResources.Add(observation);
+            }
+
+            await ExecuteAndValidateBundle($"?_type=Patient,Observation&_tag={tag}&_count=3", sort: false, pageSize: 3, expectedResources.ToArray());
         }
 
         [Fact]
@@ -943,6 +977,35 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             }
 
             return patients;
+        }
+
+        private void SetPatientInfo(Patient patient, string city, string family, string tag)
+        {
+            if (tag != null)
+            {
+                patient.Meta = new Meta();
+                patient.Meta.Tag.Add(new Coding(null, tag));
+            }
+
+            patient.Address = new List<Address>()
+                {
+                    new Address() { City = city },
+                };
+
+            patient.Name = new List<HumanName>()
+                {
+                    new HumanName() { Family = family },
+                };
+        }
+
+        private void SetObservationInfo(Observation observation, string tag)
+        {
+            observation.Status = ObservationStatus.Final;
+            observation.Code = new CodeableConcept
+            {
+                Coding = new List<Coding> { new Coding(null, tag) },
+            };
+            observation.Meta = new Meta { Tag = new List<Coding> { new Coding(null, tag) }, };
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -48,12 +48,13 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         public async Task GivenResourceWithVariousValues_WhenSearchedWithMultipleParams_ThenOnlyResourcesMatchingAllSearchParamsShouldBeReturned()
         {
             // Create various resources.
+            string tag = Guid.NewGuid().ToString();
             Patient[] patients = await Client.CreateResourcesAsync<Patient>(
-                p => SetPatientInfo(p, "Seattle", "Robinson", tag: null),
-                p => SetPatientInfo(p, "Portland", "Williamas", tag: null),
-                p => SetPatientInfo(p, "Seattle", "Jones", tag: null));
+                p => SetPatientInfo(p, "Seattle", "Robinson", tag),
+                p => SetPatientInfo(p, "Portland", "Williamas", tag),
+                p => SetPatientInfo(p, "Seattle", "Jones", tag));
 
-            await ExecuteAndValidateBundle("Patient?address-city=seattle&family=Jones", patients[2]);
+            await ExecuteAndValidateBundle($"Patient?address-city=seattle&family=Jones&_tag={tag}", patients[2]);
         }
 
         [Fact]
@@ -72,7 +73,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 p => SetPatientInfo(p, "New York", "Cook", tag),
                 p => SetPatientInfo(p, "Amsterdam", "Hill", tag));
 
-            await ExecuteAndValidateBundle("Patient?address-city=Seattle", patients[0], patients[2], patients[4]);
+            await ExecuteAndValidateBundle($"Patient?address-city=Seattle&_tag={tag}", patients[0], patients[2], patients[4]);
         }
 
         [Fact]


### PR DESCRIPTION
## Description
As mentioned in the issue, in some situations we generate an incorrect query when paging through results for queries that contain multiple `_type` parameters. This happens when we are returning the results for the "last" resource type. An example of the query we generate:

```
SELECT DISTINCT TOP (@p0) r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(1 AS bit) AS IsMatch, CAST(0 AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource
      FROM dbo.Resource r
      WHERE (
              ResourceTypeId = @p1 AND ResourceSurrogateId > @p2
              OR ResourceTypeId IN ()
          )
          AND IsHistory = 0
          AND IsDeleted = 0
      ORDER BY r.ResourceTypeId ASC, r.ResourceSurrogateId ASC
```

The extra `()` throws an exception since that is not a valid query. The `OR` clause is only required when there are other resource types to search for. Since we are only returning the resources of the "last" resource type (represented by p2) we don't need the `OR` clause. 

Updated the query generator logic to add the `OR` clause only when there are other resource types to search for.

## Related issues
Addresses #1985 

## Testing
Added new tests. Manual tests on local deployment.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
