### PR TITLE
Adds /doc/rest to GeoPol exclude list

### DIFF
--- a/GeoPol.xml
+++ b/GeoPol.xml
@@ -19,5 +19,6 @@
     <ExcludeFolder>THIRDPARTYNOTICES.md</ExcludeFolder>
     <ExcludeFolder>src\Microsoft.Health.Fhir.Core\Data\*.json</ExcludeFolder>
     <ExcludeFolder>src\Microsoft.Health.Fhir.Tests.Common\TestFiles\*.json</ExcludeFolder>
+    <ExcludeFolder>docs\rest\</ExcludeFolder>
   </Component>
 </GeoPol_Folders>


### PR DESCRIPTION
## Description
Adds /doc/rest to GeoPol exclude list

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip
