### PR TITLE
Prevent 500 for too big post request

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -620,7 +620,7 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Links can&apos;t be created for bundle.
+        ///   Looks up a localized string similar to Bundle.link values omitted because they exceeded the maximum Uri length..
         /// </summary>
         internal static string LinksCantBeCreated {
             get {

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -611,6 +611,15 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Links can&apos;t be created for bundle.
+        /// </summary>
+        internal static string LinksCantBeCreated {
+            get {
+                return ResourceManager.GetString("LinksCantBeCreated", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Malformed search value &apos;{0}&apos;..
         /// </summary>
         internal static string MalformedSearchValue {

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -570,6 +570,6 @@
     <value>The operation was stopped due to the underlying request being too resource intensive. If possible, try narrowing or changing the criteria.</value>
   </data>
   <data name="LinksCantBeCreated" xml:space="preserve">
-    <value>Links can't be created for bundle</value>
+    <value>Bundle.link values omitted because they exceeded the maximum Uri length.</value>
   </data>
 </root>

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -566,4 +566,7 @@
   <data name="InvalidEverythingOperationPhase" xml:space="preserve">
     <value>The phase '{0}' in $everything operation is invalid.</value>
   </data>
+  <data name="LinksCantBeCreated" xml:space="preserve">
+    <value>Links can't be created for bundle</value>
+  </data>
 </root>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -104,6 +104,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
+        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer)]
         public async Task GivenResourcesWithReference_WhenSearchedWithReferenceAndIdParameter_ThenOnlyResourcesMatchingAllSearchParamsShouldBeReturned()
         {
             Patient patientWithMatchingReference = (await Client.CreateResourcesAsync<Patient>(p =>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -104,7 +104,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
-        [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb)]
         public async Task GivenResourcesWithReference_WhenSearchedWithReferenceAndIdParameter_ThenOnlyResourcesMatchingAllSearchParamsShouldBeReturned()
         {
             Patient patientWithMatchingReference = (await Client.CreateResourcesAsync<Patient>(p =>
@@ -140,6 +139,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
+        [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb)]
         public async Task GivenTooBigPostRequest_WhenSearching_ThenDontCrashServer()
         {
             var sb = new StringBuilder();

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -194,6 +194,20 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenTooBigPostRequest_WhenSearching_ThenDontCrashServer()
+        {
+            var sb = new StringBuilder();
+
+            for (int i = 0; i < 100_000; i++)
+            {
+                sb.Append('a');
+            }
+
+            await Client.SearchPostAsync("Patient", default, ("name", sb.ToString()));
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
         public async Task GivenAllInvalidTypeOfResources_WhenSearching_ThenEmptyBundleAndOperationOutcomeIssue()
         {
             string[] expectedDiagnosticsOneWrongType = { string.Format(Core.Resources.InvalidTypeParameter, "'Patient1'") };

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
-        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer)]
+        [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb)]
         public async Task GivenResourcesWithReference_WhenSearchedWithReferenceAndIdParameter_ThenOnlyResourcesMatchingAllSearchParamsShouldBeReturned()
         {
             Patient patientWithMatchingReference = (await Client.CreateResourcesAsync<Patient>(p =>


### PR DESCRIPTION
## Description
Make sure what we don't explode if user does search with big post form.

## Related issues
Addresses [AB82090](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Resolute/Stories/?workitem=82090).

## Testing
Unit tests

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
