### PR TITLE
Update export pipeline to restart app

### DIFF
--- a/build/export-pipeline.yml
+++ b/build/export-pipeline.yml
@@ -41,45 +41,37 @@ stages:
   displayName: 'Redeploy STU3 Site'
   dependsOn: []
   jobs:
-  - template: ./jobs/redeploy-webapp.yml
+  - template: ./jobs/restart-webapp.yml
     parameters: 
-      version: Stu3
       webAppName: $(DeploymentEnvironmentName)
       subscription: $(ConnectedServiceName)
-      imageTag: $(ImageTag)
 
 - stage: redeployStu3Sql
   displayName: 'Redeploy STU3 SQL Site'
   dependsOn: []
   jobs:
-  - template: ./jobs/redeploy-webapp.yml
+  - template: ./jobs/restart-webapp.yml
     parameters: 
-      version: Stu3
       webAppName: $(DeploymentEnvironmentNameSql)
       subscription: $(ConnectedServiceName)
-      imageTag: $(ImageTag)
 
 - stage: redeployR4
   displayName: 'Redeploy R4 Site'
   dependsOn: []
   jobs:
-  - template: ./jobs/redeploy-webapp.yml
+  - template: ./jobs/restart-webapp.yml
     parameters: 
-      version: R4
       webAppName: $(DeploymentEnvironmentNameR4)
       subscription: $(ConnectedServiceName)
-      imageTag: $(ImageTag)
 
 - stage: redeployR4Sql
   displayName: 'Redeploy R4 SQL Site'
   dependsOn: []
   jobs:
-  - template: ./jobs/redeploy-webapp.yml
+  - template: ./jobs/restart-webapp.yml
     parameters: 
-      version: R4
       webAppName: $(DeploymentEnvironmentNameR4Sql)
       subscription: $(ConnectedServiceName)
-      imageTag: $(ImageTag)
 
 - stage: testStu3
   displayName: 'Run Stu3 Tests'

--- a/build/jobs/restart-webapp.yml
+++ b/build/jobs/restart-webapp.yml
@@ -1,0 +1,22 @@
+parameters:
+- name: webAppName
+  type: string
+- name: subscription
+  type: string
+
+jobs:
+- job: provisionEnvironment
+  pool:
+    name: '$(DefaultLinuxPool)'
+    vmImage: '$(LinuxVmImage)'
+  steps:  
+  - task: AzureAppServiceManage@0
+    displayName: 'Azure App Service Restart'
+    inputs:
+      azureSubscription: '${{ parameters.subscription }}'
+      action: 'Restart Azure App Service'
+      WebAppName: '${{ parameters.webAppName }}'
+
+  - template: ./provision-healthcheck.yml
+    parameters: 
+      webAppName: ${{ parameters.webAppName }}


### PR DESCRIPTION
## Description
Deploying a docker image with the same tag (that already exists) to App Service does not actually end up deploying the new image :(. Restarting the app service forces it to pull the latest image from the repository. Updating the export pipeline to restart the app instead of "re-deploy" latest image.

## Related issues
Addresses [issue #].

## Testing
Ran the pipeline with changes and validated that the newest image was pulled by the app service.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
