### PR TITLE
Add capability statement for patient-everything

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/OperationsConstants.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/OperationsConstants.cs
@@ -28,5 +28,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations
         public const string ConvertData = "convert-data";
 
         public const string MemberMatch = "member-match";
+
+        public const string PatientEverything = "patient-everything";
+
+        public const string PatientEverythingUri = "https://www.hl7.org/fhir/patient-operation-everything.html";
     }
 }

--- a/src/Microsoft.Health.Fhir.R4.Api/Features/Operations/OperationsCapabilityProvider.cs
+++ b/src/Microsoft.Health.Fhir.R4.Api/Features/Operations/OperationsCapabilityProvider.cs
@@ -4,9 +4,11 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Features.Conformance;
 using Microsoft.Health.Fhir.Core.Features.Conformance.Models;
 using Microsoft.Health.Fhir.Core.Features.Operations;
+using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Api.Features.Operations
@@ -27,6 +29,23 @@ namespace Microsoft.Health.Fhir.Api.Features.Operations
         public void AddExportDetails(ListedCapabilityStatement capabilityStatement)
         {
             GetAndAddOperationDefinitionUriToCapabilityStatement(capabilityStatement, OperationsConstants.Export);
+        }
+
+        public void AddPatientEverythingDetails(ListedCapabilityStatement capabilityStatement)
+        {
+            using IScoped<ISearchService> search = _searchServiceFactory();
+
+            // Will remove this when enabled in SQL Server
+            if (string.Equals(search.Value.GetType().Name, "SqlServerSearchService", StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            capabilityStatement.Rest.Server().Operation.Add(new OperationComponent
+            {
+                Name = OperationsConstants.PatientEverything,
+                Definition = OperationsConstants.PatientEverythingUri,
+            });
         }
 
         private void GetAndAddOperationDefinitionUriToCapabilityStatement(ListedCapabilityStatement capabilityStatement, string operationType)

--- a/src/Microsoft.Health.Fhir.R5.Api/Features/Operations/OperationsCapabilityProvider.cs
+++ b/src/Microsoft.Health.Fhir.R5.Api/Features/Operations/OperationsCapabilityProvider.cs
@@ -4,9 +4,11 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Features.Conformance;
 using Microsoft.Health.Fhir.Core.Features.Conformance.Models;
 using Microsoft.Health.Fhir.Core.Features.Operations;
+using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Api.Features.Operations
@@ -27,6 +29,23 @@ namespace Microsoft.Health.Fhir.Api.Features.Operations
         public void AddExportDetails(ListedCapabilityStatement capabilityStatement)
         {
             GetAndAddOperationDefinitionUriToCapabilityStatement(capabilityStatement, OperationsConstants.Export);
+        }
+
+        public void AddPatientEverythingDetails(ListedCapabilityStatement capabilityStatement)
+        {
+            using IScoped<ISearchService> search = _searchServiceFactory();
+
+            // Will remove this when enabled in SQL Server
+            if (string.Equals(search.Value.GetType().Name, "SqlServerSearchService", StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            capabilityStatement.Rest.Server().Operation.Add(new OperationComponent
+            {
+                Name = OperationsConstants.PatientEverything,
+                Definition = OperationsConstants.PatientEverythingUri,
+            });
         }
 
         private void GetAndAddOperationDefinitionUriToCapabilityStatement(ListedCapabilityStatement capabilityStatement, string operationType)

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Operations/OperationsCapabilityProvider.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Operations/OperationsCapabilityProvider.cs
@@ -15,7 +15,6 @@ using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Routing;
 using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Models;
-using Microsoft.Health.Fhir.ValueSets;
 
 namespace Microsoft.Health.Fhir.Api.Features.Operations
 {
@@ -100,10 +99,10 @@ namespace Microsoft.Health.Fhir.Api.Features.Operations
             {
                 capabilityStatement.Rest.Server().Operation.Add(new OperationComponent
                 {
-                    Name = OperationTypes.PatientEverything,
+                    Name = OperationsConstants.PatientEverything,
                     Definition = new ReferenceComponent
                     {
-                        Reference = OperationTypes.PatientEverythingUri,
+                        Reference = OperationsConstants.PatientEverythingUri,
                     },
                 });
             }
@@ -111,8 +110,8 @@ namespace Microsoft.Health.Fhir.Api.Features.Operations
             {
                 capabilityStatement.Rest.Server().Operation.Add(new OperationComponent
                 {
-                    Name = OperationTypes.PatientEverything,
-                    Definition = OperationTypes.PatientEverythingUri,
+                    Name = OperationsConstants.PatientEverything,
+                    Definition = OperationsConstants.PatientEverythingUri,
                 });
             }
         }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Operations/OperationsCapabilityProvider.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Operations/OperationsCapabilityProvider.cs
@@ -14,7 +14,6 @@ using Microsoft.Health.Fhir.Core.Features.Conformance.Models;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Routing;
 using Microsoft.Health.Fhir.Core.Features.Search;
-using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Api.Features.Operations
 {
@@ -83,37 +82,6 @@ namespace Microsoft.Health.Fhir.Api.Features.Operations
         public void AddMemberMatchDetails(ListedCapabilityStatement capabilityStatement)
         {
             GetAndAddOperationDefinitionUriToCapabilityStatement(capabilityStatement, OperationsConstants.MemberMatch);
-        }
-
-        public void AddPatientEverythingDetails(ListedCapabilityStatement capabilityStatement)
-        {
-            using IScoped<ISearchService> search = _searchServiceFactory();
-
-            // Will remove this when enabled in SQL Server
-            if (string.Equals(search.Value.GetType().Name, "SqlServerSearchService", StringComparison.Ordinal))
-            {
-                return;
-            }
-
-            if (ModelInfoProvider.Version.Equals(FhirSpecification.Stu3))
-            {
-                capabilityStatement.Rest.Server().Operation.Add(new OperationComponent
-                {
-                    Name = OperationsConstants.PatientEverything,
-                    Definition = new ReferenceComponent
-                    {
-                        Reference = OperationsConstants.PatientEverythingUri,
-                    },
-                });
-            }
-            else
-            {
-                capabilityStatement.Rest.Server().Operation.Add(new OperationComponent
-                {
-                    Name = OperationsConstants.PatientEverything,
-                    Definition = OperationsConstants.PatientEverythingUri,
-                });
-            }
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Operations/OperationsCapabilityProvider.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Operations/OperationsCapabilityProvider.cs
@@ -3,14 +3,19 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using EnsureThat;
 using Microsoft.Extensions.Options;
+using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Api.Configs;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features.Conformance;
 using Microsoft.Health.Fhir.Core.Features.Conformance.Models;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Routing;
+using Microsoft.Health.Fhir.Core.Features.Search;
+using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.ValueSets;
 
 namespace Microsoft.Health.Fhir.Api.Features.Operations
 {
@@ -25,19 +30,23 @@ namespace Microsoft.Health.Fhir.Api.Features.Operations
         private readonly OperationsConfiguration _operationConfiguration;
         private readonly FeatureConfiguration _featureConfiguration;
         private readonly IUrlResolver _urlResolver;
+        private readonly Func<IScoped<ISearchService>> _searchServiceFactory;
 
         public OperationsCapabilityProvider(
             IOptions<OperationsConfiguration> operationConfiguration,
             IOptions<FeatureConfiguration> featureConfiguration,
-            IUrlResolver urlResolver)
+            IUrlResolver urlResolver,
+            Func<IScoped<ISearchService>> searchServiceFactory)
         {
             EnsureArg.IsNotNull(operationConfiguration?.Value, nameof(operationConfiguration));
             EnsureArg.IsNotNull(featureConfiguration?.Value, nameof(featureConfiguration));
             EnsureArg.IsNotNull(urlResolver, nameof(urlResolver));
+            EnsureArg.IsNotNull(searchServiceFactory, nameof(searchServiceFactory));
 
             _operationConfiguration = operationConfiguration.Value;
             _featureConfiguration = featureConfiguration.Value;
             _urlResolver = urlResolver;
+            _searchServiceFactory = searchServiceFactory;
         }
 
         public void Build(ICapabilityStatementBuilder builder)
@@ -58,6 +67,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Operations
             }
 
             builder.Apply(AddMemberMatchDetails);
+            builder.Apply(AddPatientEverythingDetails);
         }
 
         public void AddAnonymizedExportDetails(ListedCapabilityStatement capabilityStatement)
@@ -74,6 +84,37 @@ namespace Microsoft.Health.Fhir.Api.Features.Operations
         public void AddMemberMatchDetails(ListedCapabilityStatement capabilityStatement)
         {
             GetAndAddOperationDefinitionUriToCapabilityStatement(capabilityStatement, OperationsConstants.MemberMatch);
+        }
+
+        public void AddPatientEverythingDetails(ListedCapabilityStatement capabilityStatement)
+        {
+            using IScoped<ISearchService> search = _searchServiceFactory();
+
+            // Will remove this when enabled in SQL Server
+            if (string.Equals(search.Value.GetType().Name, "SqlServerSearchService", StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            if (ModelInfoProvider.Version.Equals(FhirSpecification.Stu3))
+            {
+                capabilityStatement.Rest.Server().Operation.Add(new OperationComponent
+                {
+                    Name = OperationTypes.PatientEverything,
+                    Definition = new ReferenceComponent
+                    {
+                        Reference = OperationTypes.PatientEverythingUri,
+                    },
+                });
+            }
+            else
+            {
+                capabilityStatement.Rest.Server().Operation.Add(new OperationComponent
+                {
+                    Name = OperationTypes.PatientEverything,
+                    Definition = OperationTypes.PatientEverythingUri,
+                });
+            }
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Stu3.Api/Features/Operations/OperationsCapabilityProvider.cs
+++ b/src/Microsoft.Health.Fhir.Stu3.Api/Features/Operations/OperationsCapabilityProvider.cs
@@ -4,9 +4,11 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Features.Conformance;
 using Microsoft.Health.Fhir.Core.Features.Conformance.Models;
 using Microsoft.Health.Fhir.Core.Features.Operations;
+using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Api.Features.Operations
@@ -27,6 +29,26 @@ namespace Microsoft.Health.Fhir.Api.Features.Operations
             GetAndAddOperationDefinitionUriToCapabilityStatement(capabilityStatement, OperationsConstants.Export);
             GetAndAddOperationDefinitionUriToCapabilityStatement(capabilityStatement, OperationsConstants.PatientExport);
             GetAndAddOperationDefinitionUriToCapabilityStatement(capabilityStatement, OperationsConstants.GroupExport);
+        }
+
+        public void AddPatientEverythingDetails(ListedCapabilityStatement capabilityStatement)
+        {
+            using IScoped<ISearchService> search = _searchServiceFactory();
+
+            // Will remove this when enabled in SQL Server
+            if (string.Equals(search.Value.GetType().Name, "SqlServerSearchService", StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            capabilityStatement.Rest.Server().Operation.Add(new OperationComponent
+            {
+                Name = OperationsConstants.PatientEverything,
+                Definition = new ReferenceComponent
+                {
+                    Reference = OperationsConstants.PatientEverythingUri,
+                },
+            });
         }
 
         private void GetAndAddOperationDefinitionUriToCapabilityStatement(ListedCapabilityStatement capabilityStatement, string operationType)

--- a/src/Microsoft.Health.Fhir.ValueSets/OperationTypes.cs
+++ b/src/Microsoft.Health.Fhir.ValueSets/OperationTypes.cs
@@ -9,6 +9,6 @@ namespace Microsoft.Health.Fhir.ValueSets
     {
         public const string Validate = "validate";
 
-        public const string ValidateUri = "http://hl7.org/fhir/OperationDefinition/Resource-validate";
+        public const string ValidateUri = "https://www.hl7.org/fhir/operation-resource-validate.html";
     }
 }

--- a/src/Microsoft.Health.Fhir.ValueSets/OperationTypes.cs
+++ b/src/Microsoft.Health.Fhir.ValueSets/OperationTypes.cs
@@ -10,5 +10,9 @@ namespace Microsoft.Health.Fhir.ValueSets
         public const string Validate = "validate";
 
         public const string ValidateUri = "http://hl7.org/fhir/OperationDefinition/Resource-validate";
+
+        public const string PatientEverything = "patient-everything";
+
+        public const string PatientEverythingUri = "https://www.hl7.org/fhir/patient-operation-everything.html";
     }
 }

--- a/src/Microsoft.Health.Fhir.ValueSets/OperationTypes.cs
+++ b/src/Microsoft.Health.Fhir.ValueSets/OperationTypes.cs
@@ -10,9 +10,5 @@ namespace Microsoft.Health.Fhir.ValueSets
         public const string Validate = "validate";
 
         public const string ValidateUri = "http://hl7.org/fhir/OperationDefinition/Resource-validate";
-
-        public const string PatientEverything = "patient-everything";
-
-        public const string PatientEverythingUri = "https://www.hl7.org/fhir/patient-operation-everything.html";
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/MetadataTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/MetadataTests.cs
@@ -76,8 +76,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             FhirResponse<CapabilityStatement> capabilityStatement = await _client.ReadAsync<CapabilityStatement>("metadata");
 
             object operationDefinition = ModelInfoProvider.Version == FhirSpecification.Stu3
-                ? capabilityStatement.Resource.ToTypedElement().Scalar("CapabilityStatement.rest.operation.where(name = 'everything').definition.reference")
-                : capabilityStatement.Resource.ToTypedElement().Scalar("CapabilityStatement.rest.operation.where(name = 'everything').definition");
+                ? capabilityStatement.Resource.ToTypedElement().Scalar($"CapabilityStatement.rest.operation.where(name = '{OperationTypes.PatientEverything}').definition.reference")
+                : capabilityStatement.Resource.ToTypedElement().Scalar($"CapabilityStatement.rest.operation.where(name = '{OperationTypes.PatientEverything}').definition");
 
             Assert.Equal(OperationTypes.PatientEverythingUri, operationDefinition.ToString());
         }
@@ -90,8 +90,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             FhirResponse<CapabilityStatement> capabilityStatement = await _client.ReadAsync<CapabilityStatement>("metadata");
 
             object operationDefinition = ModelInfoProvider.Version == FhirSpecification.Stu3
-                ? capabilityStatement.Resource.ToTypedElement().Scalar("CapabilityStatement.rest.operation.where(name = 'everything').definition.reference")
-                : capabilityStatement.Resource.ToTypedElement().Scalar("CapabilityStatement.rest.operation.where(name = 'everything').definition");
+                ? capabilityStatement.Resource.ToTypedElement().Scalar($"CapabilityStatement.rest.operation.where(name = '{OperationTypes.PatientEverything}').definition.reference")
+                : capabilityStatement.Resource.ToTypedElement().Scalar($"CapabilityStatement.rest.operation.where(name = '{OperationTypes.PatientEverything}').definition");
 
             Assert.Null(operationDefinition);
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/MetadataTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/MetadataTests.cs
@@ -4,10 +4,14 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Net;
+using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
+using Hl7.FhirPath;
 using Microsoft.Health.Fhir.Client;
+using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.E2E.Common;
+using Microsoft.Health.Fhir.ValueSets;
 using Microsoft.Health.Test.Utilities;
 using Xunit;
 using Task = System.Threading.Tasks.Task;
@@ -62,6 +66,34 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         {
             using FhirException ex = await Assert.ThrowsAsync<FhirException>(async () => await _client.ReadAsync<CapabilityStatement>($"metadata?_elements={value}"));
             Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb)]
+        public async Task GivenCosmosDb_WhenGettingMetadata_TheServerShouldReturnPatientEverythingSupported()
+        {
+            FhirResponse<CapabilityStatement> capabilityStatement = await _client.ReadAsync<CapabilityStatement>("metadata");
+
+            object operationDefinition = ModelInfoProvider.Version == FhirSpecification.Stu3
+                ? capabilityStatement.Resource.ToTypedElement().Scalar("CapabilityStatement.rest.operation.where(name = 'everything').definition.reference")
+                : capabilityStatement.Resource.ToTypedElement().Scalar("CapabilityStatement.rest.operation.where(name = 'everything').definition");
+
+            Assert.Equal(OperationTypes.PatientEverythingUri, operationDefinition.ToString());
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer)]
+        public async Task GivenSqlServer_WhenGettingMetadata_TheServerShouldReturnPatientEverythingNotSupported()
+        {
+            FhirResponse<CapabilityStatement> capabilityStatement = await _client.ReadAsync<CapabilityStatement>("metadata");
+
+            object operationDefinition = ModelInfoProvider.Version == FhirSpecification.Stu3
+                ? capabilityStatement.Resource.ToTypedElement().Scalar("CapabilityStatement.rest.operation.where(name = 'everything').definition.reference")
+                : capabilityStatement.Resource.ToTypedElement().Scalar("CapabilityStatement.rest.operation.where(name = 'everything').definition");
+
+            Assert.Null(operationDefinition);
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/MetadataTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/MetadataTests.cs
@@ -8,10 +8,10 @@ using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
 using Hl7.FhirPath;
 using Microsoft.Health.Fhir.Client;
+using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.E2E.Common;
-using Microsoft.Health.Fhir.ValueSets;
 using Microsoft.Health.Test.Utilities;
 using Xunit;
 using Task = System.Threading.Tasks.Task;
@@ -76,10 +76,10 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             FhirResponse<CapabilityStatement> capabilityStatement = await _client.ReadAsync<CapabilityStatement>("metadata");
 
             object operationDefinition = ModelInfoProvider.Version == FhirSpecification.Stu3
-                ? capabilityStatement.Resource.ToTypedElement().Scalar($"CapabilityStatement.rest.operation.where(name = '{OperationTypes.PatientEverything}').definition.reference")
-                : capabilityStatement.Resource.ToTypedElement().Scalar($"CapabilityStatement.rest.operation.where(name = '{OperationTypes.PatientEverything}').definition");
+                ? capabilityStatement.Resource.ToTypedElement().Scalar($"CapabilityStatement.rest.operation.where(name = '{OperationsConstants.PatientEverything}').definition.reference")
+                : capabilityStatement.Resource.ToTypedElement().Scalar($"CapabilityStatement.rest.operation.where(name = '{OperationsConstants.PatientEverything}').definition");
 
-            Assert.Equal(OperationTypes.PatientEverythingUri, operationDefinition.ToString());
+            Assert.Equal(OperationsConstants.PatientEverythingUri, operationDefinition.ToString());
         }
 
         [Fact]
@@ -90,8 +90,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             FhirResponse<CapabilityStatement> capabilityStatement = await _client.ReadAsync<CapabilityStatement>("metadata");
 
             object operationDefinition = ModelInfoProvider.Version == FhirSpecification.Stu3
-                ? capabilityStatement.Resource.ToTypedElement().Scalar($"CapabilityStatement.rest.operation.where(name = '{OperationTypes.PatientEverything}').definition.reference")
-                : capabilityStatement.Resource.ToTypedElement().Scalar($"CapabilityStatement.rest.operation.where(name = '{OperationTypes.PatientEverything}').definition");
+                ? capabilityStatement.Resource.ToTypedElement().Scalar($"CapabilityStatement.rest.operation.where(name = '{OperationsConstants.PatientEverything}').definition.reference")
+                : capabilityStatement.Resource.ToTypedElement().Scalar($"CapabilityStatement.rest.operation.where(name = '{OperationsConstants.PatientEverything}').definition");
 
             Assert.Null(operationDefinition);
         }


### PR DESCRIPTION
## Description
List `patient-everything` in `CapabilityStatement.rest.operation` when the data store is Cosmos DB.

## Related issues
Addresses #1989.

## Testing
E2E tests are added to cover changes.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
