### PR TITLE
Fix case where all detected changes are from another instance starting

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
@@ -224,7 +224,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
 
                 if (searchParamResource == null)
                 {
-                    _logger.LogWarning(
+                    _logger.LogInformation(
                         "Updated SearchParameter status found for SearchParameter: {0}, but did not find any SearchParameter resources when querying for this url.",
                         searchParam.Uri);
                     continue;
@@ -243,12 +243,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
             if (paramsToAdd.Any())
             {
                 _searchParameterDefinitionManager.AddNewSearchParameters(paramsToAdd);
-
-                // Once added to the definition manager we can update their status
-                await _searchParameterStatusManager.ApplySearchParameterStatus(
-                    updatedSearchParameterStatus.Where(p => p.Status != SearchParameterStatus.Deleted).ToList(),
-                    cancellationToken);
             }
+
+            // Once added to the definition manager we can update their status
+            await _searchParameterStatusManager.ApplySearchParameterStatus(
+                updatedSearchParameterStatus.Where(p => p.Status != SearchParameterStatus.Deleted).ToList(),
+                cancellationToken);
         }
 
         private void DeleteSearchParameter(string url)

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
@@ -173,30 +173,32 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
 
         internal async Task ApplySearchParameterStatus(IReadOnlyCollection<ResourceSearchParameterStatus> updatedSearchParameterStatus, CancellationToken cancellationToken)
         {
-            if (updatedSearchParameterStatus.Any())
+            if (!updatedSearchParameterStatus.Any())
             {
-                var updated = new List<SearchParameterInfo>();
-
-                foreach (var paramStatus in updatedSearchParameterStatus)
-                {
-                    var param = _searchParameterDefinitionManager.GetSearchParameter(paramStatus.Uri);
-
-                    var tempStatus = EvaluateSearchParamStatus(paramStatus);
-
-                    param.IsSearchable = tempStatus.IsSearchable;
-                    param.IsSupported = tempStatus.IsSupported;
-                    param.IsPartiallySupported = tempStatus.IsPartiallySupported;
-                    param.SortStatus = paramStatus.SortStatus;
-
-                    updated.Add(param);
-                }
-
-                _latestSearchParams = updatedSearchParameterStatus.Select(p => p.LastUpdated).Max();
-
-                _searchParameterStatusDataStore.SyncStatuses(updatedSearchParameterStatus);
-
-                await _mediator.Publish(new SearchParametersUpdatedNotification(updated), cancellationToken);
+                return;
             }
+
+            var updated = new List<SearchParameterInfo>();
+
+            foreach (var paramStatus in updatedSearchParameterStatus)
+            {
+                var param = _searchParameterDefinitionManager.GetSearchParameter(paramStatus.Uri);
+
+                var tempStatus = EvaluateSearchParamStatus(paramStatus);
+
+                param.IsSearchable = tempStatus.IsSearchable;
+                param.IsSupported = tempStatus.IsSupported;
+                param.IsPartiallySupported = tempStatus.IsPartiallySupported;
+                param.SortStatus = paramStatus.SortStatus;
+
+                updated.Add(param);
+            }
+
+            _latestSearchParams = updatedSearchParameterStatus.Select(p => p.LastUpdated).Max();
+
+            _searchParameterStatusDataStore.SyncStatuses(updatedSearchParameterStatus);
+
+            await _mediator.Publish(new SearchParametersUpdatedNotification(updated), cancellationToken);
         }
 
         private (bool Supported, bool IsPartiallySupported) CheckSearchParameterSupport(SearchParameterInfo parameterInfo)

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
@@ -173,30 +173,30 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
 
         internal async Task ApplySearchParameterStatus(IReadOnlyCollection<ResourceSearchParameterStatus> updatedSearchParameterStatus, CancellationToken cancellationToken)
         {
-            var updated = new List<SearchParameterInfo>();
-
-            foreach (var paramStatus in updatedSearchParameterStatus)
-            {
-                var param = _searchParameterDefinitionManager.GetSearchParameter(paramStatus.Uri);
-
-                var tempStatus = EvaluateSearchParamStatus(paramStatus);
-
-                param.IsSearchable = tempStatus.IsSearchable;
-                param.IsSupported = tempStatus.IsSupported;
-                param.IsPartiallySupported = tempStatus.IsPartiallySupported;
-                param.SortStatus = paramStatus.SortStatus;
-
-                updated.Add(param);
-            }
-
             if (updatedSearchParameterStatus.Any())
             {
+                var updated = new List<SearchParameterInfo>();
+
+                foreach (var paramStatus in updatedSearchParameterStatus)
+                {
+                    var param = _searchParameterDefinitionManager.GetSearchParameter(paramStatus.Uri);
+
+                    var tempStatus = EvaluateSearchParamStatus(paramStatus);
+
+                    param.IsSearchable = tempStatus.IsSearchable;
+                    param.IsSupported = tempStatus.IsSupported;
+                    param.IsPartiallySupported = tempStatus.IsPartiallySupported;
+                    param.SortStatus = paramStatus.SortStatus;
+
+                    updated.Add(param);
+                }
+
                 _latestSearchParams = updatedSearchParameterStatus.Select(p => p.LastUpdated).Max();
+
+                _searchParameterStatusDataStore.SyncStatuses(updatedSearchParameterStatus);
+
+                await _mediator.Publish(new SearchParametersUpdatedNotification(updated), cancellationToken);
             }
-
-            _searchParameterStatusDataStore.SyncStatuses(updatedSearchParameterStatus);
-
-            await _mediator.Publish(new SearchParametersUpdatedNotification(updated), cancellationToken);
         }
 
         private (bool Supported, bool IsPartiallySupported) CheckSearchParameterSupport(SearchParameterInfo parameterInfo)

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
@@ -189,7 +189,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
                 updated.Add(param);
             }
 
-            _latestSearchParams = updatedSearchParameterStatus.Select(p => p.LastUpdated).Max();
+            if (updatedSearchParameterStatus.Any())
+            {
+                _latestSearchParams = updatedSearchParameterStatus.Select(p => p.LastUpdated).Max();
+            }
 
             _searchParameterStatusDataStore.SyncStatuses(updatedSearchParameterStatus);
 


### PR DESCRIPTION
## Description
Fixes a bug where all the SearchParameters status updates from another instance starting up would be detected but not correctly processed.

## Related issues
Addresses [issue [AB#82428](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/82428)].

## Testing
Ran all E2E tests, manually tested multiple instances.

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
