### PR TITLE
Fixes schema version 12 compatibility

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaVersionConstants.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaVersionConstants.cs
@@ -13,5 +13,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema
         public const int SupportForReferencesWithMissingTypeVersion = (int)SchemaVersion.V7;
         public const int SearchParameterHashSchemaVersion = (int)SchemaVersion.V8;
         public const int PartitionedTables = (int)SchemaVersion.V9;
+        public const int SearchParameterSynchronizationVersion = (int)SchemaVersion.V12;
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerSearchParameterStatusDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerSearchParameterStatusDataStore.cs
@@ -79,30 +79,66 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry
                 {
                     while (await sqlDataReader.ReadAsync())
                     {
-                        (short id, string uri, string stringStatus, DateTimeOffset? lastUpdated, bool? isPartiallySupported) = sqlDataReader.ReadRow(
-                            VLatest.SearchParam.SearchParamId,
-                            VLatest.SearchParam.Uri,
-                            VLatest.SearchParam.Status,
-                            VLatest.SearchParam.LastUpdated,
-                            VLatest.SearchParam.IsPartiallySupported);
+                        short id;
+                        string uri;
+                        string stringStatus;
+                        DateTimeOffset? lastUpdated;
+                        bool? isPartiallySupported;
 
-                        if (string.IsNullOrEmpty(stringStatus) || lastUpdated == null || isPartiallySupported == null)
+                        ResourceSearchParameterStatus resourceSearchParameterStatus;
+
+                        if (_schemaInformation.Current >= SchemaVersionConstants.SearchParameterSynchronizationVersion)
                         {
-                            // These columns are nullable because they are added to dbo.SearchParam in a later schema version.
-                            // They should be populated as soon as they are added to the table and should never be null.
-                            throw new SearchParameterNotSupportedException(Resources.SearchParameterStatusShouldNotBeNull);
+                            (id, uri, stringStatus, lastUpdated, isPartiallySupported) = sqlDataReader.ReadRow(
+                                VLatest.SearchParam.SearchParamId,
+                                VLatest.SearchParam.Uri,
+                                VLatest.SearchParam.Status,
+                                VLatest.SearchParam.LastUpdated,
+                                VLatest.SearchParam.IsPartiallySupported);
+
+                            if (string.IsNullOrEmpty(stringStatus) || lastUpdated == null || isPartiallySupported == null)
+                            {
+                                // These columns are nullable because they are added to dbo.SearchParam in a later schema version.
+                                // They should be populated as soon as they are added to the table and should never be null.
+                                throw new SearchParameterNotSupportedException(Resources.SearchParameterStatusShouldNotBeNull);
+                            }
+
+                            var status = Enum.Parse<SearchParameterStatus>(stringStatus, true);
+
+                            resourceSearchParameterStatus = new SqlServerResourceSearchParameterStatus
+                            {
+                                Id = id,
+                                Uri = new Uri(uri),
+                                Status = status,
+                                IsPartiallySupported = (bool)isPartiallySupported,
+                                LastUpdated = (DateTimeOffset)lastUpdated,
+                            };
                         }
-
-                        var status = Enum.Parse<SearchParameterStatus>(stringStatus, true);
-
-                        var resourceSearchParameterStatus = new SqlServerResourceSearchParameterStatus
+                        else
                         {
-                            Id = id,
-                            Uri = new Uri(uri),
-                            Status = status,
-                            IsPartiallySupported = (bool)isPartiallySupported,
-                            LastUpdated = (DateTimeOffset)lastUpdated,
-                        };
+                            (uri, stringStatus, lastUpdated, isPartiallySupported) = sqlDataReader.ReadRow(
+                                VLatest.SearchParam.Uri,
+                                VLatest.SearchParam.Status,
+                                VLatest.SearchParam.LastUpdated,
+                                VLatest.SearchParam.IsPartiallySupported);
+
+                            if (string.IsNullOrEmpty(stringStatus) || lastUpdated == null || isPartiallySupported == null)
+                            {
+                                // These columns are nullable because they are added to dbo.SearchParam in a later schema version.
+                                // They should be populated as soon as they are added to the table and should never be null.
+                                throw new SearchParameterNotSupportedException(Resources.SearchParameterStatusShouldNotBeNull);
+                            }
+
+                            var status = Enum.Parse<SearchParameterStatus>(stringStatus, true);
+
+                            resourceSearchParameterStatus = new ResourceSearchParameterStatus
+                            {
+                                Uri = new Uri(uri),
+                                Status = status,
+                                IsPartiallySupported = (bool)isPartiallySupported,
+                                LastUpdated = (DateTimeOffset)lastUpdated,
+                            };
+                        }
 
                         if (_sortingValidator.SupportedParameterUris.Contains(resourceSearchParameterStatus.Uri))
                         {


### PR DESCRIPTION
## Description
PR #1976 introduces a change to the stored procedure `dbo.GetSearchParamStatuses`, adding a return value. This required a change in the data layer to expect the new value, and this change did not consider compatibility with older schema versions.

This PR adds some logic to check the schema version before calling the stored procedure.

## Related issues
Addresses [AB#82663](https://microsofthealth.visualstudio.com/Health/_workitems/edit/82663).

## Testing
Manual schema upgrade testing in a local environment.

## FHIR Team Checklist
- ✅ **Update the title** of the PR to be succinct and less than 50 characters
- ✅ **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- ✅ Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- ✅ Tag the PR with **Azure API for FHIR** if this will release to the managed service
- ✅ Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip (bug fix)
