### PR TITLE
Limit max concurrency for CosmosDb queries

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -62,9 +62,11 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
 
         /// <summary>
         /// This is the maximum degree of parallelism for the SDK to use when querying physical partitions in parallel.
-        /// -1 means "System Decides", int.MaxValue sets the limit high enough that it shouldn't be limited.
+        /// -1 means "System Decides", any other value and the SDK will choose min(physical partitions, value).
+        /// During testing we noticed unexpected behavior when executing queries with max degree of parallelism values
+        /// higher than 1000 and hence we are setting a conservative value.for now.
         /// </summary>
-        internal const int MaxQueryConcurrency = int.MaxValue;
+        internal const int MaxQueryConcurrency = 500;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CosmosFhirDataStore"/> class.


### PR DESCRIPTION
## Description
During testing we noticed unexpected behavior when executing cosmos db queries with max degree of parallelism values higher than 1000. Hence updating the code to reduce it from `int.MaxValue` to something more conservative.

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
