### PR TITLE
Supports extension search parameter expressions

### DIFF
--- a/docs/rest/ReindexFlowTargettingResourceExtensions.http
+++ b/docs/rest/ReindexFlowTargettingResourceExtensions.http
@@ -1,0 +1,324 @@
+# This test flow confirms that reindexing operations can handle search parameters
+# that target extensions in resources. It checks that we can support simply putting
+# ".extension" in the search parameter's FHIR path expression.
+#
+# This test assumes the following local environment setup:
+# 1. appsettings.json has Reindex.Enabled = true
+# 2. The version is R4 or R5
+
+@baseUrl = https://localhost:44348
+@contentType = application/json
+
+### Testing 1, 2, 3...
+{{baseUrl}}/metadata
+
+### Get the bearer token to authenticate.
+# @name bearer
+POST {{baseUrl}}/connect/token
+content-type: application/x-www-form-urlencoded
+
+grant_type=client_credentials
+&client_id=globalAdminServicePrincipal
+&client_secret=globalAdminServicePrincipal
+&scope=fhir-api
+
+###
+# Create a PractitionerRole resource that
+# 1) has a network extension
+# 2) has a second extension that contains an array of extensions.
+POST {{baseUrl}}/PractitionerRole HTTP/1.1
+content-type: {{contentType}}
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+{
+  "resourceType" : "PractitionerRole",
+  "id" : "HansSoloRole1",
+  "meta" : {
+    "lastUpdated" : "2020-07-07T13:26:22.0314215+00:00",
+    "profile" : [
+      "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-PractitionerRole"
+    ]
+  },
+  "language" : "en-US",
+  "text" : {
+    "status" : "extensions",
+    "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en-US\" lang=\"en-US\"><p><b>Generated Narrative</b></p><p><b>Network Reference</b>: <a href=\"Organization-AcmeofCTStdNet.html\">Generated Summary: language: en-US; active; <span title=\"Codes: {http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/OrgTypeCS ntwk}\">Network</span>; name: ACME CT Preferred Provider Network</a></p><blockquote><p><b>Qualification</b></p><h3>Urls</h3><table class=\"grid\"><tr><td>-</td></tr><tr><td>*</td></tr></table><p><b>value</b>: <span title=\"Codes: {http://nucc.org/provider-taxonomy 207R00000X}\">Internal Medicine Physician</span></p><h3>Urls</h3><table class=\"grid\"><tr><td>-</td></tr><tr><td>*</td></tr></table><p><b>value</b>: active</p><h3>Urls</h3><table class=\"grid\"><tr><td>-</td></tr><tr><td>*</td></tr></table><p><b>value</b>: <span>American Board of Internal Medicine</span></p></blockquote><p><b>active</b>: true</p><p><b>practitioner</b>: <a href=\"Practitioner-HansSolo.html\">Generated Summary: language: en-US; id: NPI3233; active; Hans Solo, MD; <span title=\"Codes: {urn:ietf:bcp:47 ja}\">Japanese</span></a></p><p><b>code</b>: <span title=\"Codes: {http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/ProviderRoleCS ph}\">Physician</span></p><p><b>specialty</b>: <span title=\"Codes: {http://nucc.org/provider-taxonomy 207R00000X}\">Internal Medicine</span></p><p><b>location</b>: <a href=\"Location-HansSoloClinic.html\">Generated Summary: language: en-US; status: active; name: OrgA CT Location 1; <span title=\"Codes: {http://terminology.hl7.org/CodeSystem/v3-RoleCode OUTPHARM}\">outpatient pharmacy</span>; Phone: (111)-222-3333, https://www.hanssolo.com</a></p><p><b>healthcareService</b>: <a href=\"HealthcareService-HansSoloService.html\">Generated Summary: language: en-US; active; <span title=\"Codes: {http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/HealthcareServiceCategoryCS outpat}\">Clinic or Outpatient Facility</span>; <span title=\"Codes: {http://nucc.org/provider-taxonomy 207Q00000X}\">Family Medicine</span></a></p></div>"
+  },
+  "extension" : [
+    {
+      "url" : "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/network-reference",
+      "valueReference" : {
+        "reference" : "Organization/AcmeofCTStdNet"
+      }
+    },
+    {
+      "extension" : [
+        {
+          "url" : "code",
+          "valueCodeableConcept" : {
+            "coding" : [
+              {
+                "system" : "http://nucc.org/provider-taxonomy",
+                "code" : "207R00000X"
+              }
+            ]
+          }
+        },
+        {
+          "url" : "status",
+          "valueCode" : "active"
+        },
+        {
+          "url" : "issuer",
+          "valueReference" : {
+            "reference" : "Organization/3250",
+            "display" : "American Board of Internal Medicine"
+          }
+        }
+      ],
+      "url" : "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/qualification"
+    }
+  ],
+  "active" : true,
+  "practitioner" : {
+    "reference" : "Practitioner/HansSolo"
+  },
+  "code" : [
+    {
+      "coding" : [
+        {
+          "system" : "http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/ProviderRoleCS",
+          "code" : "ph"
+        }
+      ]
+    }
+  ],
+  "specialty" : [
+    {
+      "coding" : [
+        {
+          "system" : "http://nucc.org/provider-taxonomy",
+          "code" : "207R00000X",
+          "display" : "Internal Medicine"
+        }
+      ]
+    }
+  ],
+  "location" : [
+    {
+      "reference" : "Location/HansSoloClinic"
+    }
+  ],
+  "healthcareService" : [
+    {
+      "reference" : "HealthcareService/HansSoloService"
+    }
+  ]
+}
+
+###
+# Create a search parameter resource that targets the PractitionerRole network extension.
+POST {{baseUrl}}/SearchParameter HTTP/1.1
+content-type: {{contentType}}
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+{
+  "resourceType": "SearchParameter",
+  "id": "practitionerrole-network",
+  "url": "http://hl7.org/fhir/us/davinci-pdex-plan-net/SearchParameter/practitionerrole-network",
+  "version": "1.0.0",
+  "name": "Plannet_sp_practitionerrole_network",
+  "status": "active",
+  "date": "2018-05-23T00:00:00+00:00",
+  "publisher": "HL7 Financial Management Working Group",
+  "contact": [
+    {
+      "name": "HL7 Financial Management Working Group",
+      "telecom": [
+        {
+          "system": "url",
+          "value": "http://www.hl7.org/Special/committees/fm/index.cfm"
+        },
+        {
+          "system": "email",
+          "value": "fm@lists.HL7.org"
+        }
+      ]
+    }
+  ],
+  "description": "Select roles where the practitioner is a member of the specified health insurance provider network",
+  "jurisdiction": [
+    {
+      "coding": [
+        {
+          "system": "urn:iso:std:iso:3166",
+          "code": "US"
+        }
+      ]
+    }
+  ],
+  "code": "network",
+  "base": [
+    "PractitionerRole"
+  ],
+  "type": "reference",
+  "expression": "PractitionerRole.extension.where(url='http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/network-reference')",
+  "target": [
+    "Organization"
+  ],
+  "multipleOr": true,
+  "multipleAnd": true,
+  "chain": [
+    "name",
+    "address",
+    "partof",
+    "type"
+  ]
+}
+
+###
+# Create a search parameter resource that targets a token extension in the array of
+# extensions in the PractitionerRole resource.
+POST {{baseUrl}}/SearchParameter HTTP/1.1
+content-type: {{contentType}}
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+{
+  "resourceType" : "SearchParameter",
+  "id" : "practitionerrole-qualification-code",
+  "text" : {
+    "status" : "generated",
+    "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: practitionerrole-qualification-code</p><p><b>url</b>: <a href=\"http://hl7.org/fhir/us/davinci-pdex-plan-net/SearchParameter/practitionerrole-qualification-code\">http://hl7.org/fhir/us/davinci-pdex-plan-net/SearchParameter/practitionerrole-qualification-code</a></p><p><b>version</b>: 0.2.0</p><p><b>name</b>: Plannet_sp_practitionerrole_qualification_code</p><p><b>status</b>: active</p><p><b>date</b>: May 22, 2018 8:00:00 PM</p><p><b>publisher</b>: HL7 Patient Administration Committee</p><p><b>contact</b>: </p><p><b>description</b>: Select PractitionerRoles with a type of qualification matching the specified code</p><p><b>code</b>: qualification-code</p><p><b>base</b>: PractitionerRole</p><p><b>type</b>: token</p><p><b>expression</b>: PractitionerRole.extension.where(url='http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/qualification').extension.where(url='code')</p><p><b>multipleOr</b>: true</p><p><b>multipleAnd</b>: true</p><p><b>modifier</b>: text</p></div>"
+  },
+  "url" : "http://hl7.org/fhir/us/davinci-pdex-plan-net/SearchParameter/practitionerrole-qualification-code",
+  "version" : "0.2.0",
+  "name" : "Plannet_sp_practitionerrole_qualification_code",
+  "status" : "active",
+  "date" : "2018-05-23T00:00:00+00:00",
+  "publisher" : "HL7 Patient Administration Committee",
+  "contact" : [
+    {
+      "telecom" : [
+        {
+          "system" : "url",
+          "value" : "http://www.hl7.org/Special/committees/pafm/index.cfm"
+        }
+      ]
+    }
+  ],
+  "description" : "Select PractitionerRoles with a type of qualification matching the specified code",
+  "code" : "qualification-code",
+  "base" : [
+    "PractitionerRole"
+  ],
+  "type" : "token",
+  "expression" : "PractitionerRole.extension.where(url='http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/qualification').extension.where(url='code')",
+  "multipleOr" : true,
+  "multipleAnd" : true,
+  "modifier" : [
+    "text"
+  ]
+}
+
+###
+# Create a search parameter resource that targets a reference extension in the array
+# of extensions in the PractitionerRole resource.
+POST {{baseUrl}}/SearchParameter HTTP/1.1
+content-type: {{contentType}}
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+{
+  "resourceType" : "SearchParameter",
+  "id" : "practitionerrole-qualification-issuer",
+  "text" : {
+    "status" : "generated",
+    "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: practitionerrole-qualification-issuer</p><p><b>url</b>: <a href=\"http://hl7.org/fhir/us/davinci-pdex-plan-net/SearchParameter/practitionerrole-qualification-issuer\">http://hl7.org/fhir/us/davinci-pdex-plan-net/SearchParameter/practitionerrole-qualification-issuer</a></p><p><b>version</b>: 0.2.0</p><p><b>name</b>: Plannet_sp_practitionerrole_qualification_issuer</p><p><b>status</b>: active</p><p><b>date</b>: May 22, 2018 8:00:00 PM</p><p><b>publisher</b>: HL7 Patient Administration Committee</p><p><b>contact</b>: </p><p><b>description</b>: Select PractitionerRoles with a qualification issued by the specified organization</p><p><b>code</b>: qualification-issuer</p><p><b>base</b>: PractitionerRole</p><p><b>type</b>: reference</p><p><b>expression</b>: PractitionerRole.extension.where(url='http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/qualification').extension.where(url='issuer')</p><p><b>target</b>: Organization</p><p><b>multipleOr</b>: true</p><p><b>multipleAnd</b>: true</p><p><b>modifier</b>: below</p><p><b>chain</b>: identifier, name</p></div>"
+  },
+  "url" : "http://hl7.org/fhir/us/davinci-pdex-plan-net/SearchParameter/practitionerrole-qualification-issuer",
+  "version" : "0.2.0",
+  "name" : "Plannet_sp_practitionerrole_qualification_issuer",
+  "status" : "active",
+  "date" : "2018-05-23T00:00:00+00:00",
+  "publisher" : "HL7 Patient Administration Committee",
+  "contact" : [
+    {
+      "telecom" : [
+        {
+          "system" : "url",
+          "value" : "http://www.hl7.org/Special/committees/pafm/index.cfm"
+        }
+      ]
+    }
+  ],
+  "description" : "Select PractitionerRoles with a qualification issued by the specified organization",
+  "code" : "qualification-issuer",
+  "base" : [
+    "PractitionerRole"
+  ],
+  "type" : "reference",
+  "expression" : "PractitionerRole.extension.where(url='http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/qualification').extension.where(url='issuer')",
+  "target" : [
+    "Organization"
+  ],
+  "multipleOr" : true,
+  "multipleAnd" : true,
+  "modifier" : [
+    "below"
+  ],
+  "chain" : [
+    "identifier",
+    "name"
+  ]
+}
+
+###
+# Initiate a reindexing operation.
+# Copy the reindexing job ID into the variable below.
+# @name reindex
+POST {{baseUrl}}/$reindex HTTP/1.1
+content-type: application/json
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+{  "resourceType": "Parameters", "parameter": [] }
+
+###
+# Get the status of the reindex job.
+# This should complete quickly because we are only reindexing one resource.
+GET {{reindex.response.headers.Content-Location}}
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+###
+# Get the practitioner role with matching network reference info.
+# This should return one value.
+GET {{baseUrl}}/PractitionerRole?network=Organization/AcmeofCTStdNet&_total=accurate HTTP/1.1
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+###
+# Attempt to get a practitioner role with non-matching network reference info.
+# This shouldn't return any values.
+GET {{baseUrl}}/PractitionerRole?network=Organization/AcmeofDoesNotExist&_total=accurate HTTP/1.1
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+###
+# Get the practitioner role with matching qualification code info.
+# This should return one value.
+GET {{baseUrl}}/PractitionerRole?qualification-code=http://nucc.org/provider-taxonomy|207R00000X&_total=accurate HTTP/1.1
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+###
+# Attempt to get a practitioner role with non-matching qualification code info.
+# This shouldn't return any values.
+GET {{baseUrl}}/PractitionerRole?qualification-code=DoesNotExist&_total=accurate HTTP/1.1
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+###
+# Get the practitioner role with matching qualification issuer info.
+# This should return one value.
+GET {{baseUrl}}/PractitionerRole?qualification-issuer=Organization/3250&_total=accurate HTTP/1.1
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+###
+# Attempt to get a practitioner role with non-matching qualification issuer info.
+# This shouldn't return any values.
+GET {{baseUrl}}/PractitionerRole?qualification-issuer=DoesNotExist&_total=accurate HTTP/1.1
+Authorization: Bearer {{bearer.response.body.access_token}}

--- a/docs/rest/ReindexFlowTargettingResourceExtensions.http
+++ b/docs/rest/ReindexFlowTargettingResourceExtensions.http
@@ -273,7 +273,6 @@ Authorization: Bearer {{bearer.response.body.access_token}}
 
 ###
 # Initiate a reindexing operation.
-# Copy the reindexing job ID into the variable below.
 # @name reindex
 POST {{baseUrl}}/$reindex HTTP/1.1
 content-type: application/json

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Converters/FhirTypedElementToSearchValueConverterManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Converters/FhirTypedElementToSearchValueConverterManager.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Converters
             return _converterDictionary.TryGetValue((fhirType, searchValueType), out converter);
         }
 
-        private class ExtensionConverter<T> : ITypedElementToSearchValueConverter
+        internal class ExtensionConverter<T> : ITypedElementToSearchValueConverter
         {
             private readonly IEnumerable<ITypedElementToSearchValueConverter> _underlying;
             private readonly Type _type;

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Converters/FhirTypedElementToSearchValueConverterManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Converters/FhirTypedElementToSearchValueConverterManager.cs
@@ -64,11 +64,19 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Converters
             {
                 if (value == null)
                 {
-                    return new List<ISearchValue>();
+                    return Enumerable.Empty<ISearchValue>();
                 }
 
                 var typed = value.Select("value").FirstOrDefault();
-                var converter = _searchValueTypeConverters.First(x => x.FhirTypes.Contains(typed.InstanceType));
+                var converter = _searchValueTypeConverters.FirstOrDefault(x => x.FhirTypes.Contains(typed?.InstanceType));
+
+                // If the resource's extension type can't be converted to the user-specified search parameter type, we won't return any results.
+                // This means reindexing will succeed but the search parameter will not pick up resources with extensions that have an incompatible type.
+                if (converter == null)
+                {
+                    return Enumerable.Empty<ISearchValue>();
+                }
+
                 return converter.ConvertTo(typed);
             }
         }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Converters/FhirTypedElementToSearchValueConverterManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Converters/FhirTypedElementToSearchValueConverterManager.cs
@@ -59,6 +59,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Converters
 
             public IEnumerable<ISearchValue> ConvertTo(ITypedElement value)
             {
+                if (value == null)
+                {
+                    return new List<ISearchValue>();
+                }
+
                 var typed = value.Select("value").FirstOrDefault();
                 var converter = _underlying.Where(x => x.FhirTypes.Contains(typed.InstanceType)).First();
                 return converter.ConvertTo(typed);

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/SearchModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/SearchModule.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Linq;
 using EnsureThat;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
@@ -89,8 +90,10 @@ namespace Microsoft.Health.Fhir.Api.Modules
 
             // TypedElement based converters
             // These always need to be added as they are also used by the SearchParameterSupportResolver
+            // Exclude the extension converter, since it will be dynamically created by the converter manager
             services.TypesInSameAssemblyAs<ITypedElementToSearchValueConverter>()
                 .AssignableTo<ITypedElementToSearchValueConverter>()
+                .Where(t => t.Type != typeof(FhirTypedElementToSearchValueConverterManager.ExtensionConverter))
                 .Singleton()
                 .AsService<ITypedElementToSearchValueConverter>();
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/FhirInstanceToSearchValueConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/FhirInstanceToSearchValueConverterTests.cs
@@ -55,5 +55,17 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
             Assert.NotNull(values);
             Assert.Empty(values);
         }
+
+        protected async Task TestExtensionAsync<TValue>(Action<TElement> setup, Action<TValue, ISearchValue> validator, params TValue[] expected)
+        {
+            setup(Element);
+
+            IEnumerable<ISearchValue> values = (await GetTypeConverterAsync()).ConvertTo(TypedElement);
+
+            Assert.NotNull(values);
+            Assert.Collection(
+                values,
+                expected.Select(e => new Action<ISearchValue>(sv => validator(e, sv))).ToArray());
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/IntegerToNumberSearchValueConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/IntegerToNumberSearchValueConverterTests.cs
@@ -11,7 +11,7 @@ using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
 {
-    public class IntegerToIntegerSearchValueConverterTests : FhirTypedElementToSearchValueConverterTests<IntegerToNumberSearchValueConverter, Integer>
+    public class IntegerToNumberSearchValueConverterTests : FhirTypedElementToSearchValueConverterTests<IntegerToNumberSearchValueConverter, Integer>
     {
         [Fact]
         public async Task GivenAIntegerWithNoValue_WhenConverted_ThenNoSearchValueShouldBeCreated()

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/ExtensionToDateTimeSearchValueConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/ExtensionToDateTimeSearchValueConverterTests.cs
@@ -1,0 +1,52 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Hl7.Fhir.Model;
+using Microsoft.Health.Fhir.Core.Features.Search.Converters;
+using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
+using Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters;
+using Xunit;
+using static Microsoft.Health.Fhir.Tests.Common.Search.SearchValueValidationHelper;
+
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
+{
+    public sealed class ExtensionToDateTimeSearchValueConverterTests : FhirInstanceToSearchValueConverterTests<Extension>
+    {
+        protected override async Task<ITypedElementToSearchValueConverter> GetTypeConverterAsync()
+        {
+            FhirTypedElementToSearchValueConverterManager fhirTypedElementToSearchValueConverterManager = await SearchParameterFixtureData.GetFhirTypedElementToSearchValueConverterManagerAsync();
+            fhirTypedElementToSearchValueConverterManager.TryGetConverter("Extension", typeof(DateTimeSearchValue), out ITypedElementToSearchValueConverter extensionConverter);
+
+            return extensionConverter;
+        }
+
+        public static IEnumerable<object[]> GetDateTimeExtensionDataSource()
+        {
+            yield return new object[] { new Extension("test", new Period { Start = "2017" }), "2017", "9999-12-31T23:59:59" };
+            yield return new object[] { new Extension("test", new FhirDateTime { Value = "2018-03-30T05:12" }), "2018-03-30T05:12" };
+            yield return new object[] { new Extension("test", new Date { Value = "2018-03-30T05:12" }), "2018-03-30T05:12" };
+            yield return new object[] { new Extension("test", new Instant { Value = new DateTimeOffset(2018, 01, 20, 14, 34, 24, TimeSpan.FromMinutes(60)) }), "2018-01-20T13:34:24.0000000-00:00" };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetDateTimeExtensionDataSource))]
+        public async Task GivenADateTimeExtension_WhenConverted_ThenADateTimeSearchValueShouldBeCreated(Extension extension, string start, string end = null)
+        {
+            await TestExtensionAsync(
+                ext =>
+                {
+                    ext.Url = extension.Url;
+                    ext.Value = extension.Value;
+                },
+                ValidateDateTime,
+                (start, end ?? start));
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/ExtensionToNumberSearchValueConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/ExtensionToNumberSearchValueConverterTests.cs
@@ -1,0 +1,50 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Hl7.Fhir.Model;
+using Microsoft.Health.Fhir.Core.Features.Search.Converters;
+using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
+using Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters;
+using Xunit;
+using static Microsoft.Health.Fhir.Tests.Common.Search.SearchValueValidationHelper;
+
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
+{
+    public sealed class ExtensionToNumberSearchValueConverterTests : FhirInstanceToSearchValueConverterTests<Extension>
+    {
+        protected override async Task<ITypedElementToSearchValueConverter> GetTypeConverterAsync()
+        {
+            FhirTypedElementToSearchValueConverterManager fhirTypedElementToSearchValueConverterManager = await SearchParameterFixtureData.GetFhirTypedElementToSearchValueConverterManagerAsync();
+            fhirTypedElementToSearchValueConverterManager.TryGetConverter("Extension", typeof(NumberSearchValue), out ITypedElementToSearchValueConverter extensionConverter);
+
+            return extensionConverter;
+        }
+
+        public static IEnumerable<object[]> GetNumberExtensionDataSource()
+        {
+            yield return new object[] { new Extension("test", new UnsignedInt(1)), 1M };
+            yield return new object[] { new Extension("test", new PositiveInt(1)), 1M };
+            yield return new object[] { new Extension("test", new Integer(500)), 500 };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetNumberExtensionDataSource))]
+        public async Task GivenANumberExtension_WhenConverted_ThenANumberSearchValueShouldBeCreated(Extension extension, decimal expected)
+        {
+            await TestExtensionAsync(
+                ext =>
+                {
+                    ext.Url = extension.Url;
+                    ext.Value = extension.Value;
+                },
+                ValidateNumber,
+                expected);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/ExtensionToQuantitySearchValueConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/ExtensionToQuantitySearchValueConverterTests.cs
@@ -1,0 +1,48 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Hl7.Fhir.Model;
+using Microsoft.Health.Fhir.Core.Features.Search.Converters;
+using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
+using Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters;
+using Xunit;
+using static Microsoft.Health.Fhir.Tests.Common.Search.SearchValueValidationHelper;
+
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
+{
+    public sealed class ExtensionToQuantitySearchValueConverterTests : FhirInstanceToSearchValueConverterTests<Extension>
+    {
+        protected override async Task<ITypedElementToSearchValueConverter> GetTypeConverterAsync()
+        {
+            FhirTypedElementToSearchValueConverterManager fhirTypedElementToSearchValueConverterManager = await SearchParameterFixtureData.GetFhirTypedElementToSearchValueConverterManagerAsync();
+            fhirTypedElementToSearchValueConverterManager.TryGetConverter("Extension", typeof(QuantitySearchValue), out ITypedElementToSearchValueConverter extensionConverter);
+
+            return extensionConverter;
+        }
+
+        public static IEnumerable<object[]> GetQuantityExtensionDataSource()
+        {
+            yield return new object[] { new Extension("test", new Quantity(100.123456m, "unit", "system")), new Quantity(100.123456m, "unit", "system") };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetQuantityExtensionDataSource))]
+        public async Task GivenAQuantityExtension_WhenConverted_ThenAQuantitySearchValueShouldBeCreated(Extension extension, Quantity expected)
+        {
+            await TestExtensionAsync(
+                ext =>
+                {
+                    ext.Url = extension.Url;
+                    ext.Value = extension.Value;
+                },
+                ValidateQuantity,
+                expected);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/ExtensionToReferenceSearchValueConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/ExtensionToReferenceSearchValueConverterTests.cs
@@ -1,0 +1,62 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Model;
+using Microsoft.Health.Core.Features.Context;
+using Microsoft.Health.Fhir.Core.Features.Context;
+using Microsoft.Health.Fhir.Core.Features.Search.Converters;
+using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
+using NSubstitute;
+using Xunit;
+
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
+{
+    public sealed class ExtensionToReferenceSearchValueConverterTests
+    {
+        private readonly IReferenceSearchValueParser _referenceSearchValueParser;
+        private readonly RequestContextAccessor<IFhirRequestContext> _fhirRequestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
+
+        public ExtensionToReferenceSearchValueConverterTests()
+        {
+            _fhirRequestContextAccessor.RequestContext.BaseUri.Returns(new Uri("https://test:12345"));
+            _referenceSearchValueParser = new ReferenceSearchValueParser(_fhirRequestContextAccessor);
+        }
+
+        private async Task<ITypedElementToSearchValueConverter> GetTypeConverterAsync()
+        {
+            FhirTypedElementToSearchValueConverterManager fhirTypedElementToSearchValueConverterManager = await SearchParameterFixtureData.GetFhirTypedElementToSearchValueConverterManagerAsync();
+            fhirTypedElementToSearchValueConverterManager.TryGetConverter("Extension", typeof(ReferenceSearchValue), out ITypedElementToSearchValueConverter extensionConverter);
+
+            return extensionConverter;
+        }
+
+        [Fact]
+        public async Task GivenAReferenceExtension_WhenConverted_ThenAReferenceSearchValueShouldBeCreated()
+        {
+            var reference = new ResourceReference("Patient/123");
+            var extension = new Extension("test", reference);
+
+            ReferenceSearchValue expected = _referenceSearchValueParser.Parse(reference.Reference);
+
+            var values = (await GetTypeConverterAsync()).ConvertTo(extension.ToTypedElement()).ToList();
+
+            Assert.NotNull(values);
+            Assert.True(values.Count == 1);
+
+            var actual = (ReferenceSearchValue)values[0];
+
+            Assert.Equal(expected.Kind, actual.Kind);
+            Assert.Equal(expected.BaseUri, actual.BaseUri);
+            Assert.Equal(expected.ResourceType, actual.ResourceType);
+            Assert.Equal(expected.ResourceId, actual.ResourceId);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/ExtensionToStringSearchValueConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/ExtensionToStringSearchValueConverterTests.cs
@@ -1,0 +1,51 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Hl7.Fhir.Model;
+using Microsoft.Health.Fhir.Core.Features.Search.Converters;
+using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
+using Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters;
+using Xunit;
+using static Microsoft.Health.Fhir.Tests.Common.Search.SearchValueValidationHelper;
+
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
+{
+    public sealed class ExtensionToStringSearchValueConverterTests : FhirInstanceToSearchValueConverterTests<Extension>
+    {
+        protected override async Task<ITypedElementToSearchValueConverter> GetTypeConverterAsync()
+        {
+            FhirTypedElementToSearchValueConverterManager fhirTypedElementToSearchValueConverterManager = await SearchParameterFixtureData.GetFhirTypedElementToSearchValueConverterManagerAsync();
+            fhirTypedElementToSearchValueConverterManager.TryGetConverter("Extension", typeof(StringSearchValue), out ITypedElementToSearchValueConverter extensionConverter);
+
+            return extensionConverter;
+        }
+
+        public static IEnumerable<object[]> GetStringExtensionDataSource()
+        {
+            yield return new object[] { new Extension("test", new Address { City = "Seattle" }), "Seattle" };
+            yield return new object[] { new Extension("test", new HumanName { Given = new[] { "given" } }), "given" };
+            yield return new object[] { new Extension("test", new Markdown("value")), "value" };
+            yield return new object[] { new Extension("test", new FhirString("value")), "value" };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetStringExtensionDataSource))]
+        public async Task GivenAStringExtension_WhenConverted_ThenAStringSearchValueShouldBeCreated(Extension extension, string expected)
+        {
+            await TestExtensionAsync(
+                ext =>
+                {
+                    ext.Url = extension.Url;
+                    ext.Value = extension.Value;
+                },
+                ValidateString,
+                expected);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/ExtensionToTokenSearchValueConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/ExtensionToTokenSearchValueConverterTests.cs
@@ -1,0 +1,68 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Model;
+using Microsoft.Health.Fhir.Core.Features.Search.Converters;
+using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
+using Xunit;
+using static Microsoft.Health.Fhir.Tests.Common.Search.SearchValueValidationHelper;
+
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
+{
+    public sealed class ExtensionToTokenSearchValueConverterTests // : FhirInstanceToSearchValueConverterTests<Extension>
+    {
+        private Extension Element { get; } = new();
+
+        private ITypedElement TypedElement => Element.ToTypedElement();
+
+        public static IEnumerable<object[]> GetTokenExtensionDataSource()
+        {
+            yield return new object[] { new Extension("test", new Coding("system", "code")), new Token(system: "system", code: "code") };
+            yield return new object[] { new Extension("test", new Code("code")), new Token(code: "code") };
+            yield return new object[] { new Extension("test", new CodeableConcept("system", null, null)), new Token(system: "system", code: null, text: null) };
+            yield return new object[] { new Extension("test", new Id("id")), new Token(code: "id") };
+            yield return new object[] { new Extension("test", new Identifier("system", "value")), new Token(system: "system", code: "value") };
+            yield return new object[] { new Extension("test", new ContactPoint(ContactPoint.ContactPointSystem.Phone, ContactPoint.ContactPointUse.Home, "value")), new Token(system: "home", "value") };
+            yield return new object[] { new Extension("test", new FhirBoolean(true)), new Token(system: "http://hl7.org/fhir/special-values", code: "true") };
+            yield return new object[] { new Extension("test", new FhirString("value")), new Token(code: "value") };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTokenExtensionDataSource))]
+        public async Task GivenATokenExtension_WhenConverted_ThenOneTokenSearchValueShouldBeCreated(Extension extension, Token expected)
+        {
+            await TestExtensionAsync(
+                ext =>
+                {
+                    ext.Url = extension.Url;
+                    ext.Value = extension.Value;
+                },
+                ValidateToken,
+                expected);
+        }
+
+        // TODO: Make this non-token specific?
+        private async Task TestExtensionAsync(Action<Extension> setup, Action<Token, ISearchValue> validator, params Token[] expected)
+        {
+            setup(Element);
+
+            FhirTypedElementToSearchValueConverterManager fhirTypedElementToSearchValueConverterManager = await SearchParameterFixtureData.GetFhirTypedElementToSearchValueConverterManagerAsync();
+
+            fhirTypedElementToSearchValueConverterManager.TryGetConverter("Extension", typeof(TokenSearchValue), out ITypedElementToSearchValueConverter extensionConverter);
+            IEnumerable<ISearchValue> values = extensionConverter.ConvertTo(TypedElement);
+
+            Assert.NotNull(values);
+            Assert.Collection(
+                values,
+                expected.Select(e => new Action<ISearchValue>(sv => validator(e, sv))).ToArray());
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/ExtensionToUriSearchValueConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/ExtensionToUriSearchValueConverterTests.cs
@@ -1,0 +1,50 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Hl7.Fhir.Model;
+using Microsoft.Health.Fhir.Core.Features.Search.Converters;
+using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
+using Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters;
+using Xunit;
+using static Microsoft.Health.Fhir.Tests.Common.Search.SearchValueValidationHelper;
+
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
+{
+    public sealed class ExtensionToUriSearchValueConverterTests : FhirInstanceToSearchValueConverterTests<Extension>
+    {
+        protected override async Task<ITypedElementToSearchValueConverter> GetTypeConverterAsync()
+        {
+            FhirTypedElementToSearchValueConverterManager fhirTypedElementToSearchValueConverterManager = await SearchParameterFixtureData.GetFhirTypedElementToSearchValueConverterManagerAsync();
+            fhirTypedElementToSearchValueConverterManager.TryGetConverter("Extension", typeof(UriSearchValue), out ITypedElementToSearchValueConverter extensionConverter);
+
+            return extensionConverter;
+        }
+
+        public static IEnumerable<object[]> GetUriExtensionDataSource()
+        {
+            yield return new object[] { new Extension("test", new FhirUri { Value = "http://uri" }), "http://uri" };
+            yield return new object[] { new Extension("test", new Oid { Value = "1.3.6.1.4.1.343" }), "1.3.6.1.4.1.343" };
+            yield return new object[] { new Extension("test", new Canonical { Value = "http://uri" }), "http://uri" };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetUriExtensionDataSource))]
+        public async Task GivenAUriExtension_WhenConverted_ThenAUriSearchValueShouldBeCreated(Extension extension, string expected)
+        {
+            await TestExtensionAsync(
+                ext =>
+                {
+                    ext.Url = extension.Url;
+                    ext.Value = extension.Value;
+                },
+                ValidateUri,
+                expected);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterFixtureData.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterFixtureData.cs
@@ -72,8 +72,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
             foreach (Type type in types)
             {
-                // The extension converters will be added to the converter dictionary by the converter manager
-                if (!type.Name.Contains("ExtensionConverter"))
+                // Filter out the extension converter because it will be added to the converter dictionary in the converter manager's constructor
+                // We can use the fact that ExtensionsConverter is a generic type to filter it out
+                if (!type.ContainsGenericParameters)
                 {
                     var x = (ITypedElementToSearchValueConverter)Mock.TypeWithArguments(type, referenceSearchValueParser, codeSystemResolver);
                     fhirElementToSearchValueConverters.Add(x);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterFixtureData.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterFixtureData.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -66,8 +68,17 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             var codeSystemResolver = new CodeSystemResolver(ModelInfoProvider.Instance);
             await codeSystemResolver.StartAsync(CancellationToken.None);
 
-            var fhirElementToSearchValueConverters =
-                types.Select(x => (ITypedElementToSearchValueConverter)Mock.TypeWithArguments(x, referenceSearchValueParser, codeSystemResolver));
+            var fhirElementToSearchValueConverters = new List<ITypedElementToSearchValueConverter>();
+
+            foreach (Type type in types)
+            {
+                // The extension converters will be added to the converter dictionary by the converter manager
+                if (!type.Name.Contains("ExtensionConverter"))
+                {
+                    var x = (ITypedElementToSearchValueConverter)Mock.TypeWithArguments(type, referenceSearchValueParser, codeSystemResolver);
+                    fhirElementToSearchValueConverters.Add(x);
+                }
+            }
 
             return new FhirTypedElementToSearchValueConverterManager(fhirElementToSearchValueConverters);
         }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterFixtureData.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterFixtureData.cs
@@ -73,8 +73,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             foreach (Type type in types)
             {
                 // Filter out the extension converter because it will be added to the converter dictionary in the converter manager's constructor
-                // We can use the fact that ExtensionsConverter is a generic type to filter it out
-                if (!type.ContainsGenericParameters)
+                if (type.Name != nameof(FhirTypedElementToSearchValueConverterManager.ExtensionConverter))
                 {
                     var x = (ITypedElementToSearchValueConverter)Mock.TypeWithArguments(type, referenceSearchValueParser, codeSystemResolver);
                     fhirElementToSearchValueConverters.Add(x);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
@@ -21,6 +21,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\Export\GroupMemberExtractorTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Create\CreateResourceValidatorTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\ResourceHandlerTests_ConditionalDelete.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Search\ExtensionToStringSearchValueConverterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\ExtensionToTokenSearchValueConverterTests.cs" />
     <Compile Include="..\Microsoft.Health.Fhir.Shared.Core.UnitTests\Features\Persistence\ResourceWrapperFactoryTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\Converters\AddressToStringSearchValueConverterTests.cs" />

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
@@ -21,6 +21,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\Export\GroupMemberExtractorTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Create\CreateResourceValidatorTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\ResourceHandlerTests_ConditionalDelete.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Search\ExtensionToTokenSearchValueConverterTests.cs" />
     <Compile Include="..\Microsoft.Health.Fhir.Shared.Core.UnitTests\Features\Persistence\ResourceWrapperFactoryTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\Converters\AddressToStringSearchValueConverterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\Converters\BooleanToBooleanSearchValueConverterTests.cs" />

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
@@ -21,8 +21,13 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\Export\GroupMemberExtractorTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Create\CreateResourceValidatorTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\ResourceHandlerTests_ConditionalDelete.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Search\ExtensionToNumberSearchValueConverterTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Search\ExtensionToDateTimeSearchValueConverterTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Search\ExtensionToQuantitySearchValueConverterTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Search\ExtensionToReferenceSearchValueConverterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\ExtensionToStringSearchValueConverterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\ExtensionToTokenSearchValueConverterTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Search\ExtensionToUriSearchValueConverterTests.cs" />
     <Compile Include="..\Microsoft.Health.Fhir.Shared.Core.UnitTests\Features\Persistence\ResourceWrapperFactoryTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\Converters\AddressToStringSearchValueConverterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\Converters\BooleanToBooleanSearchValueConverterTests.cs" />
@@ -42,7 +47,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\Converters\IdentifierToTokenSearchValueConverterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\Converters\IdToTokenSearchValueConverterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\Converters\InstantToDateTimeSearchValueConverterTests.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Features\Search\Converters\IntegerToIntegerSearchValueConverterTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Search\Converters\IntegerToNumberSearchValueConverterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\Converters\MarkdownToStringSearchValueConverterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\Converters\OidToUriSearchValueConverterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\Converters\PeriodToDateTimeSearchValueConverterTests.cs" />


### PR DESCRIPTION
## Description
This PR adds support to resolve the FHIR type for custom search parameters that target choice type values in resource extensions. Previously, users would need to write more specific search parameter expressions:

`Organization.extension.where(url = 'https://mycompany.com/health-dictionary/DirectoryType').value.coding.code`

Now, they should be able to simply put:

`Organization.extension.where(url = 'https://mycompany.com/health-dictionary/DirectoryType')`

Note: this was a team effort! @Ivanidzo4ka gets creds for writing the extension converter.

## Related issues
Addresses [AB#82415](https://microsofthealth.visualstudio.com/Health/_workitems/edit/82415).

## Testing
Adds new unit tests and new HTTP file for manual test scenario.

## FHIR Team Checklist
- ✅ **Update the title** of the PR to be succinct and less than 50 characters
- ✅ **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- ✅ Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- ✅ Tag the PR with **Azure API for FHIR** if this will release to the managed service
- ✅ Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip (bug fix)
