### PR TITLE
Configurable max query concurrency

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Configs/CosmosDataStoreConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Configs/CosmosDataStoreConfiguration.cs
@@ -60,6 +60,6 @@ namespace Microsoft.Health.Fhir.CosmosDb.Configs
         /// <summary>
         /// Options to determine if the parallel query execution is needed across physical partitions to speed up the selective queries
         /// </summary>
-        public CosmosDataStoreParallelQueryOptions ParallelQueryOptions { get; } = new CosmosDataStoreParallelQueryOptions { MaxQueryConcurrency = 1000 };
+        public CosmosDataStoreParallelQueryOptions ParallelQueryOptions { get; } = new CosmosDataStoreParallelQueryOptions { MaxQueryConcurrency = 500 };
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Configs/CosmosDataStoreConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Configs/CosmosDataStoreConfiguration.cs
@@ -60,6 +60,6 @@ namespace Microsoft.Health.Fhir.CosmosDb.Configs
         /// <summary>
         /// Options to determine if the parallel query execution is needed across physical partitions to speed up the selective queries
         /// </summary>
-        public CosmosDataStoreParallelQueryOptions ParallelQueryOptions { get; } = new CosmosDataStoreParallelQueryOptions { Enabled = true, MaxQueryConcurrency = 1000 };
+        public CosmosDataStoreParallelQueryOptions ParallelQueryOptions { get; } = new CosmosDataStoreParallelQueryOptions { MaxQueryConcurrency = 1000 };
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Configs/CosmosDataStoreConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Configs/CosmosDataStoreConfiguration.cs
@@ -56,5 +56,10 @@ namespace Microsoft.Health.Fhir.CosmosDb.Configs
         /// A list of Search Parameter URIs that will be enabled on first initialization
         /// </summary>
         public HashSet<string> InitialSortParameterUris { get; } = new();
+
+        /// <summary>
+        /// Options to determine if the parallel query execution is needed across physical partitions to speed up the selective queries
+        /// </summary>
+        public CosmosDataStoreParallelQueryOptions ParallelQueryOptions { get; } = new CosmosDataStoreParallelQueryOptions { Enabled = true, MaxQueryConcurrency = 1000 };
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Configs/CosmosDataStoreParallelQueryOptions.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Configs/CosmosDataStoreParallelQueryOptions.cs
@@ -1,0 +1,15 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Fhir.CosmosDb.Configs
+{
+    public class CosmosDataStoreParallelQueryOptions
+    {
+        /// <summary>
+        /// Gets the maximum degree of parallelism for the SDK to use when querying physical partitions in parallel.
+        /// </summary>
+        public int MaxQueryConcurrency { get; set; }
+    }
+}

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
@@ -398,7 +398,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
             {
                 if (searchOptions.Sort?.Count > 0)
                 {
-                    feedOptions.MaxConcurrency = CosmosFhirDataStore.MaxQueryConcurrency;
+                    feedOptions.MaxConcurrency = _cosmosConfig.ParallelQueryOptions.MaxQueryConcurrency;
                 }
                 else
                 {
@@ -411,7 +411,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
                         queryPartitionStatistics = _queryPartitionStatisticsCache.GetQueryPartitionStatistics(searchOptions.Expression);
                         if (IsQuerySelective(queryPartitionStatistics))
                         {
-                            feedOptions.MaxConcurrency = CosmosFhirDataStore.MaxQueryConcurrency;
+                            feedOptions.MaxConcurrency = _cosmosConfig.ParallelQueryOptions.MaxQueryConcurrency;
                         }
 
                         // plant a ConcurrentBag int the request context's properties, so the CosmosResponseProcessor
@@ -501,7 +501,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
         {
             var feedOptions = new QueryRequestOptions
             {
-                MaxConcurrency = CosmosFhirDataStore.MaxQueryConcurrency, // execute counts across all partitions
+                MaxConcurrency = _cosmosConfig.ParallelQueryOptions.MaxQueryConcurrency, // execute counts across all partitions
             };
 
             return (await _fhirDataStore.ExecuteDocumentQueryAsync<int>(sqlQuerySpec, feedOptions, continuationToken: null, cancellationToken: cancellationToken)).results.Single();
@@ -652,7 +652,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
                         // The previous iteration executed sequentially and did not retrieve the desired number of results. We will switch to parallel execution.
                         // Note that we are not passing in the continuation token, because if we do, the SDK does not execute in parallel.
 
-                        var queryRequestOptionsOverride = new QueryRequestOptions { MaxItemCount = searchOptions.MaxItemCount, MaxConcurrency = CosmosFhirDataStore.MaxQueryConcurrency };
+                        var queryRequestOptionsOverride = new QueryRequestOptions { MaxItemCount = searchOptions.MaxItemCount, MaxConcurrency = _cosmosConfig.ParallelQueryOptions.MaxQueryConcurrency };
 
                         includeResponse = await ExecuteSearchAsync<FhirCosmosResourceWrapper>(
                             query,

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -432,6 +432,11 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
 
             bool executingWithMaxParallelism = feedOptions.MaxConcurrency == _cosmosDataStoreConfiguration.ParallelQueryOptions.MaxQueryConcurrency && continuationToken == null;
 
+            if (executingWithMaxParallelism)
+            {
+                _logger.LogInformation("Executing {maxConcurrency} parallel queries across physical partitions", feedOptions.MaxConcurrency);
+            }
+
             var maxCount = executingWithMaxParallelism
                 ? totalDesiredCount * (mustNotExceedMaxItemCount ? 1 : ExecuteDocumentQueryAsyncMaximumFillFactor) // in this mode, the SDK likely has already fetched pages, so we might as well consume them
                 : totalDesiredCount * ExecuteDocumentQueryAsyncMinimumFillFactor;

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -61,12 +61,6 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
         private readonly CoreFeatureConfiguration _coreFeatures;
 
         /// <summary>
-        /// This is the maximum degree of parallelism for the SDK to use when querying physical partitions in parallel.
-        /// -1 means "System Decides", int.MaxValue sets the limit high enough that it shouldn't be limited.
-        /// </summary>
-        internal const int MaxQueryConcurrency = int.MaxValue;
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="CosmosFhirDataStore"/> class.
         /// </summary>
         /// <param name="containerScope">
@@ -436,7 +430,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
             using var timeoutTokenSource = new CancellationTokenSource(timeout);
             using var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutTokenSource.Token);
 
-            bool executingWithMaxParallelism = feedOptions.MaxConcurrency == MaxQueryConcurrency && continuationToken == null;
+            bool executingWithMaxParallelism = feedOptions.MaxConcurrency == _cosmosDataStoreConfiguration.ParallelQueryOptions.MaxQueryConcurrency && continuationToken == null;
 
             var maxCount = executingWithMaxParallelism
                 ? totalDesiredCount * (mustNotExceedMaxItemCount ? 1 : ExecuteDocumentQueryAsyncMaximumFillFactor) // in this mode, the SDK likely has already fetched pages, so we might as well consume them

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -130,7 +130,7 @@
             "http://hl7.org/fhir/SearchParameter/clinical-date"
         ],
         "ParallelQueryOptions": {
-            "MaxQueryConcurrency": 1000
+            "MaxQueryConcurrency": 500
         }
     },
     "DataStore": "CosmosDb",

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -128,7 +128,10 @@
             "http://hl7.org/fhir/SearchParameter/individual-given",
             "http://hl7.org/fhir/SearchParameter/individual-birthdate",
             "http://hl7.org/fhir/SearchParameter/clinical-date"
-        ]
+        ],
+        "ParallelQueryOptions": {
+            "MaxQueryConcurrency": 1000
+        }
     },
     "DataStore": "CosmosDb",
     "KeyVault": {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -232,7 +232,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             }
         }
 
-        [SkippableFact]
+        [Fact(Skip = "To re-enable when the bug(82891) is fixed")]
         public async Task GivenASearchParameterWithMultipleBaseResourceTypes_WhenTargetingReindexJobToResourceType_ThenOnlyTargetedTypesAreReindexed()
         {
             var randomName = Guid.NewGuid().ToString().ComputeHash().Substring(0, 14).ToLower();
@@ -351,7 +351,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             }
         }
 
-        [SkippableFact]
+        [Fact(Skip = "To re-enable when the bug(82891) is fixed")]
         public async Task GivenASearchParameterWithMultipleBaseResourceTypes_WhenTargetingReindexJobToSameListOfResourceTypes_ThenSearchParametersMarkedFullyIndexed()
         {
             var randomName = Guid.NewGuid().ToString().ComputeHash().Substring(0, 14).ToLower();


### PR DESCRIPTION
## Description
Adds configurable max number of parallel queries to execute selective queries across physical partitions

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
