### PR TITLE
Unique search parameter collection in tests.

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexJobTaskTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexJobTaskTests.cs
@@ -13,6 +13,7 @@ using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features;
 using Microsoft.Health.Fhir.Core.Features.Context;
+using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Operations.Reindex;
 using Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models;
@@ -47,6 +48,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
         private Func<IReindexJobTask> _reindexJobTaskFactory;
 
+        private SearchParameterDefinitionManager _searchDefinitionManager;
         private CancellationToken _cancellationToken;
 
         public ReindexJobTaskTests(SearchParameterFixtureData fixture) => _fixture = fixture;
@@ -55,6 +57,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         {
             _cancellationToken = _cancellationTokenSource.Token;
 
+            _searchDefinitionManager = await _fixture.GetSearchDefinitionManagerAsync();
+            var supportedSearchDefinitionManager = new SupportedSearchParameterDefinitionManager(_searchDefinitionManager);
             var job = CreateReindexJobRecord();
 
             _fhirOperationDataStore.UpdateReindexJobAsync(job, _weakETag, _cancellationToken).ReturnsForAnyArgs(new ReindexJobWrapper(job, _weakETag));
@@ -67,14 +71,13 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                 Returns(new SearchResult(_mockedSearchCount, new List<Tuple<string, string>>()));
 
             _throttleController.GetThrottleBasedDelay().Returns(0);
-            var supportedSearchParameterDefinitionManager = await _fixture.GetSupportedSearchDefinitionManagerAsync();
             _reindexJobTaskFactory = () =>
                  new ReindexJobTask(
                      () => _fhirOperationDataStore.CreateMockScope(),
                      () => _fhirDataStore.CreateMockScope(),
                      Options.Create(_reindexJobConfiguration),
                      () => _searchService.CreateMockScope(),
-                     supportedSearchParameterDefinitionManager,
+                     supportedSearchDefinitionManager,
                      _reindexUtilities,
                      _contextAccessor,
                      _throttleController,
@@ -90,8 +93,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         public async Task GivenSupportedParams_WhenExecuted_ThenCorrectSearchIsPerformed()
         {
             // Get one search parameter and configure it such that it needs to be reindexed
-            var param = (await _fixture.GetSearchDefinitionManagerAsync()).
-                AllSearchParameters.FirstOrDefault(p => p.Url == new Uri("http://hl7.org/fhir/SearchParameter/Account-status"));
+            var param = _searchDefinitionManager.AllSearchParameters.FirstOrDefault(p => p.Url == new Uri("http://hl7.org/fhir/SearchParameter/Account-status"));
             param.IsSearchable = false;
             var expectedResourceType = param.BaseResourceTypes.FirstOrDefault();
 
@@ -133,7 +135,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         public async Task GivenContinuationToken_WhenExecuted_ThenAdditionalQueryAdded()
         {
             // Get one search parameter and configure it such that it needs to be reindexed
-            var param = (await _fixture.GetSearchDefinitionManagerAsync()).AllSearchParameters.FirstOrDefault(p => p.Code == "identifier");
+            var param = _searchDefinitionManager.AllSearchParameters.FirstOrDefault(p => p.Code == "identifier");
             param.IsSearchable = false;
             var expectedResourceType = param.BaseResourceTypes.FirstOrDefault();
 
@@ -178,8 +180,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         public async Task GivenRunningJob_WhenExecuted_ThenQueuedQueryCompleted()
         {
             // Get two search parameters with different base resource types and configure them such that they need to be reindexed
-            var paramWithAppointmentResponseBaseType = (await _fixture.GetSearchDefinitionManagerAsync()).AllSearchParameters.FirstOrDefault(p => p.Url == new Uri("http://hl7.org/fhir/SearchParameter/AppointmentResponse-appointment"));
-            var paramWithAppointmentBaseType = (await _fixture.GetSearchDefinitionManagerAsync()).AllSearchParameters.FirstOrDefault(p => p.Url == new Uri("http://hl7.org/fhir/SearchParameter/Appointment-date"));
+            var paramWithAppointmentResponseBaseType = _searchDefinitionManager.AllSearchParameters.FirstOrDefault(p => p.Url == new Uri("http://hl7.org/fhir/SearchParameter/AppointmentResponse-appointment"));
+            var paramWithAppointmentBaseType = _searchDefinitionManager.AllSearchParameters.FirstOrDefault(p => p.Url == new Uri("http://hl7.org/fhir/SearchParameter/Appointment-date"));
 
             Assert.NotNull(paramWithAppointmentResponseBaseType);
             Assert.NotNull(paramWithAppointmentBaseType);
@@ -281,7 +283,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         public async Task GivenQueryInRunningState_WhenExecuted_ThenQueryResetToQueuedOnceStale()
         {
             // Add one parameter that needs to be indexed
-            var param = (await _fixture.GetSearchDefinitionManagerAsync()).AllSearchParameters.FirstOrDefault(p => p.Code == "appointment");
+            var param = _searchDefinitionManager.AllSearchParameters.FirstOrDefault(p => p.Code == "appointment");
             param.IsSearchable = false;
 
             _reindexJobConfiguration.JobHeartbeatTimeoutThreshold = new TimeSpan(0, 0, 0, 1, 0);
@@ -316,7 +318,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         public async Task GivenQueryWhichContinuallyFails_WhenExecuted_ThenJobWillBeMarkedFailed()
         {
             // Add one parameter that needs to be indexed
-            var param = (await _fixture.GetSearchDefinitionManagerAsync()).AllSearchParameters.FirstOrDefault(p => p.Code == "appointment");
+            var param = _searchDefinitionManager.AllSearchParameters.FirstOrDefault(p => p.Code == "appointment");
             param.IsSearchable = false;
 
             var job = CreateReindexJobRecord(maxResourcePerQuery: 3);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterFixtureData.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterFixtureData.cs
@@ -30,7 +30,6 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         private static FhirTypedElementToSearchValueConverterManager _fhirTypedElementToSearchValueConverterManager;
 
         private SearchParameterDefinitionManager _searchDefinitionManager;
-        private SupportedSearchParameterDefinitionManager _supportedSearchDefinitionManager;
         private readonly IMediator _mediator = Substitute.For<IMediator>();
 
         static SearchParameterFixtureData()
@@ -43,11 +42,6 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         public async Task<SearchParameterDefinitionManager> GetSearchDefinitionManagerAsync()
         {
             return _searchDefinitionManager ??= await CreateSearchParameterDefinitionManagerAsync(new VersionSpecificModelInfoProvider(), _mediator);
-        }
-
-        public async Task<SupportedSearchParameterDefinitionManager> GetSupportedSearchDefinitionManagerAsync()
-        {
-            return _supportedSearchDefinitionManager ??= new SupportedSearchParameterDefinitionManager(await GetSearchDefinitionManagerAsync());
         }
 
         public static async Task<FhirTypedElementToSearchValueConverterManager> GetFhirTypedElementToSearchValueConverterManagerAsync()

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterSupportResolverTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterSupportResolverTests.cs
@@ -12,12 +12,9 @@ using Xunit;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 {
-    public class SearchParameterSupportResolverTests : IClassFixture<SearchParameterFixtureData>, IAsyncLifetime
+    public class SearchParameterSupportResolverTests : IAsyncLifetime
     {
-        private readonly SearchParameterFixtureData _fixture;
         private SearchParameterSupportResolver _resolver;
-
-        public SearchParameterSupportResolverTests(SearchParameterFixtureData fixture) => _fixture = fixture;
 
         public async Task InitializeAsync()
         {


### PR DESCRIPTION
## Description
Make sure each test operates on ITS OWN search parameter collection.
If it's not gonna stop reindex tests crash with too many calls to mocked object, I'm gonna eat my hat.

## Related issues
Addresses [#1619].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip
