### PR TITLE
Enable concurrent query execution if sequential execution timed out

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Configs/CosmosDataStoreParallelQueryOptions.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Configs/CosmosDataStoreParallelQueryOptions.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
+
 namespace Microsoft.Health.Fhir.CosmosDb.Configs
 {
     public class CosmosDataStoreParallelQueryOptions
@@ -10,7 +12,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Configs
         /// <summary>
         /// Gets the maximum degree of parallelism for the SDK to use when querying physical partitions in parallel.
         /// </summary>
-        public int MaxQueryConcurrency { get; set; }
+        public int MaxQueryConcurrency { get; set; } = Environment.ProcessorCount * 10;
 
         /// <summary>
         /// Enables the parallelism if sequential query execution takes more time

--- a/src/Microsoft.Health.Fhir.CosmosDb/Configs/CosmosDataStoreParallelQueryOptions.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Configs/CosmosDataStoreParallelQueryOptions.cs
@@ -11,5 +11,10 @@ namespace Microsoft.Health.Fhir.CosmosDb.Configs
         /// Gets the maximum degree of parallelism for the SDK to use when querying physical partitions in parallel.
         /// </summary>
         public int MaxQueryConcurrency { get; set; }
+
+        /// <summary>
+        /// Enables the parallelism if sequential query execution takes more time
+        /// </summary>
+        public bool EnableConcurrencyIfQueryExceedsTimeLimit { get; set; }
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
@@ -436,18 +436,19 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
                 if (feedOptions.MaxConcurrency == null &&
                     _cosmosConfig.ParallelQueryOptions.EnableConcurrencyIfQueryExceedsTimeLimit == true &&
                     string.IsNullOrEmpty(searchOptions.ContinuationToken) &&
+                    string.IsNullOrEmpty(continuationToken) &&
                     searchEnumerationTimeoutOverrideIfSequential == null)
                 {
                     searchEnumerationTimeoutOverrideIfSequential = TimeSpan.FromSeconds(5);
 
                     // Executing query sequentially until the timeout
-                    (results, nextContinuationToken) = await _fhirDataStore.ExecuteDocumentQueryAsync<T>(sqlQuerySpec, feedOptions, continuationToken, searchOptions.MaxItemCountSpecifiedByClient, searchEnumerationTimeoutOverrideIfSequential, cancellationToken);
+                    (results, nextContinuationToken) = await _fhirDataStore.ExecuteDocumentQueryAsync<T>(sqlQuerySpec, feedOptions, null, searchOptions.MaxItemCountSpecifiedByClient, searchEnumerationTimeoutOverrideIfSequential, cancellationToken);
 
                     // check if we need to restart the query in parallel
                     if (results.Count < desiredItemCount && !string.IsNullOrEmpty(nextContinuationToken))
                     {
                         feedOptions.MaxConcurrency = _cosmosConfig.ParallelQueryOptions.MaxQueryConcurrency;
-                        (results, nextContinuationToken) = await _fhirDataStore.ExecuteDocumentQueryAsync<T>(sqlQuerySpec, feedOptions, continuationToken, searchOptions.MaxItemCountSpecifiedByClient, null, cancellationToken);
+                        (results, nextContinuationToken) = await _fhirDataStore.ExecuteDocumentQueryAsync<T>(sqlQuerySpec, feedOptions, null, searchOptions.MaxItemCountSpecifiedByClient, null, cancellationToken);
                     }
                 }
                 else

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -130,7 +130,8 @@
             "http://hl7.org/fhir/SearchParameter/clinical-date"
         ],
         "ParallelQueryOptions": {
-            "MaxQueryConcurrency": 500
+            "MaxQueryConcurrency": 500,
+            "EnableConcurrencyIfQueryExceedsTimeLimit":  true
         }
     },
     "DataStore": "CosmosDb",


### PR DESCRIPTION
## Description
Since sequential query execution is taking longer for selective queries, we intend to enable parallel query execution as soon as the sequential query execution time exceeds the time limit(specified time limit as 5 secs).
And then we start querying concurrently across 500(or whatever value is set to MaxQueryConcurrency) physical partitions.

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
