### PR TITLE
Add artifact store in configuration

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Configs/FhirServerConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Api/Configs/FhirServerConfiguration.cs
@@ -29,5 +29,7 @@ namespace Microsoft.Health.Fhir.Api.Configs
         public BundleConfiguration Bundle { get; } = new BundleConfiguration();
 
         public ThrottlingConfiguration Throttling { get; } = new ThrottlingConfiguration();
+
+        public ArtifactStoreConfiguration ArtifactStore { get; } = new ArtifactStoreConfiguration();
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
@@ -115,15 +115,6 @@ namespace Microsoft.Health.Fhir.Api {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The container registry &apos;{0}&apos; is not configured..
-        /// </summary>
-        public static string ContainerRegistryNotConfigured {
-            get {
-                return ResourceManager.GetString("ContainerRegistryNotConfigured", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The &quot;content-type&quot; header must be &apos;application/x-www-form-urlencoded&apos;..
         /// </summary>
         public static string ContentTypeFormUrlEncodedExpected {
@@ -165,6 +156,15 @@ namespace Microsoft.Health.Fhir.Api {
         public static string ConvertDataParameterValueNotValid {
             get {
                 return ResourceManager.GetString("ConvertDataParameterValueNotValid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The template collection reference &apos;{0}&apos; is not configured..
+        /// </summary>
+        public static string ConvertDataTemplateNotConfigured {
+            get {
+                return ResourceManager.GetString("ConvertDataTemplateNotConfigured", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Health.Fhir.Api/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Api/Resources.resx
@@ -324,9 +324,9 @@
     <value>The _type parameter must be included when using the _typeFilter parameter. </value>
     <comment>Export job parameter exception messsage</comment>
   </data>
-  <data name="ContainerRegistryNotConfigured" xml:space="preserve">
-    <value>The container registry '{0}' is not configured.</value>
-    <comment>{0}: the container registry login server</comment>
+  <data name="ConvertDataTemplateNotConfigured" xml:space="preserve">
+    <value>The template collection reference '{0}' is not configured.</value>
+    <comment>{0}: the template collection reference</comment>
   </data>
   <data name="ConfigLocationRequiredForAnonymizedExport" xml:space="preserve">
     <value>Missing '_anonymizationConfig' for anonymized export</value>

--- a/src/Microsoft.Health.Fhir.Core/Configs/ArtifactStoreConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/ArtifactStoreConfiguration.cs
@@ -1,0 +1,15 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using Microsoft.Health.Fhir.Core.Features.ArtifactStore;
+
+namespace Microsoft.Health.Fhir.Core.Configs
+{
+    public class ArtifactStoreConfiguration
+    {
+        public ICollection<OciArtifactInfo> OciArtifacts { get; } = new List<OciArtifactInfo>();
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/ArtifactStore/OciArtifactInfo.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/ArtifactStore/OciArtifactInfo.cs
@@ -1,0 +1,40 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+using System;
+
+namespace Microsoft.Health.Fhir.Core.Features.ArtifactStore
+{
+    public class OciArtifactInfo
+    {
+        public string LoginServer { get; set; }
+
+        public string ImageName { get; set; }
+
+        public string Digest { get; set; }
+
+        public bool ContainsOciImage(string server, string name, string digest)
+        {
+            // If LoginServer is not provided, return false because this ArtifactInfo is invalid.
+            if (string.IsNullOrEmpty(LoginServer) || !string.Equals(LoginServer, server, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            // Compare imageName if ImageName is provided in ArtifactInfo.
+            if (!string.IsNullOrEmpty(ImageName) && !string.Equals(ImageName, name, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            // Compare digest if Digest is provided in ArtifactInfo.
+            if (!string.IsNullOrEmpty(Digest) && !string.Equals(Digest, digest, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/ArtifactStore/OciArtifactInfo.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/ArtifactStore/OciArtifactInfo.cs
@@ -6,6 +6,8 @@ using System;
 
 namespace Microsoft.Health.Fhir.Core.Features.ArtifactStore
 {
+    // Describes Open Container Initiative (OCI) artifacts managed in ACR
+    // https://docs.microsoft.com/en-us/azure/container-registry/container-registry-oci-artifacts
     public class OciArtifactInfo
     {
         public string LoginServer { get; set; }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
@@ -75,6 +75,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton(Options.Options.Create(fhirServerConfiguration.Audit));
             services.AddSingleton(Options.Options.Create(fhirServerConfiguration.Bundle));
             services.AddSingleton(Options.Options.Create(fhirServerConfiguration.Throttling));
+            services.AddSingleton(Options.Options.Create(fhirServerConfiguration.ArtifactStore));
             services.AddTransient<IStartupFilter, FhirServerStartupFilter>();
 
             services.RegisterAssemblyModules(Assembly.GetExecutingAssembly(), fhirServerConfiguration);

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -102,6 +102,15 @@
             "ConcurrentRequestLimit": 0,
             "MaxQueueSize": 0,
             "MaxMillisecondsInQueue": 0
+        },
+        "ArtifactStore": {
+            "OciArtifacts": [
+                {
+                    "LoginServer": "",
+                    "ImageName": "",
+                    "Digest": ""
+                }
+            ]
         }
     },
     "CosmosDb": {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConvertDataTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConvertDataTests.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
         [InlineData("test.azurecr.com/template@sha256:592535ef52d742f81e35f4d87b43d9b535ed56cf58c90a14fc5fd7ea0fbb8696")]
         [InlineData("*****####.com/template:default")]
         [InlineData("¶Š™œãý£¾.com/template:default")]
-        public async Task GivenAValidRequest_ButTemplateRegistryIsNotConfigured_WhenConvertData_ShouldReturnBadRequest(string templateReference)
+        public async Task GivenAValidRequest_ButTemplateReferenceIsNotConfigured_WhenConvertData_ShouldReturnBadRequest(string templateReference)
         {
             Skip.IfNot(_convertDataEnabled);
 
@@ -166,7 +166,7 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 
             var registryName = templateReference.Split('/')[0];
-            Assert.Contains($"The container registry '{registryName}' is not configured.", responseContent);
+            Assert.Contains($"The template collection reference '{templateReference}' is not configured.", responseContent);
         }
 
         [SkippableTheory]


### PR DESCRIPTION
## Description
Add artifact store support (currently [OCI artifacts](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-oci-artifacts)):

- User can config artifacts at image level with imageName and digest (previous only registry level)
- Artifact config can be shared by other features like de-id export (store config files in ACR)

## Related issues
Addresses [#AB80205](https://microsofthealth.visualstudio.com/Health/_workitems/edit/80205/).

## Testing
Unit tests.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip
