### PR TITLE
Added status to bundle response

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleSerializerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleSerializerTests.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Health.Fhir.Shared.Api.UnitTests.Features.Resources.Bundle
                 wrapper.Version = "1";
 
                 var requestComponent = new RequestComponent { Method = HTTPVerb.POST, Url = "patient/" };
-                var responseComponent = new ResponseComponent { Etag = "W/\"1\"", LastModified = DateTimeOffset.UtcNow };
+                var responseComponent = new ResponseComponent { Etag = "W/\"1\"", LastModified = DateTimeOffset.UtcNow, Status = "201 Created" };
                 rawBundle.Entry.Add(new RawBundleEntryComponent(wrapper)
                 {
                     Request = requestComponent,

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleSerializer.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleSerializer.cs
@@ -147,6 +147,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
 
                             writer.WriteString("etag", rawBundleEntry.Response.Etag);
                             writer.WriteString("lastModified", rawBundleEntry.Response.LastModified?.ToInstantString());
+                            writer.WriteString("status", rawBundleEntry.Response.Status);
 
                             writer.WriteEndObject();
                         }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleSerializer.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleSerializer.cs
@@ -145,9 +145,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                         {
                             writer.WriteStartObject("response");
 
+                            writer.WriteString("status", rawBundleEntry.Response.Status);
                             writer.WriteString("etag", rawBundleEntry.Response.Etag);
                             writer.WriteString("lastModified", rawBundleEntry.Response.LastModified?.ToInstantString());
-                            writer.WriteString("status", rawBundleEntry.Response.Status);
 
                             writer.WriteEndObject();
                         }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/BundleFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/BundleFactory.cs
@@ -72,14 +72,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                         statusString = ((int)HttpStatusCode.Created).ToString() + " " + HttpStatusCode.Created;
                         break;
                     case Bundle.HTTPVerb.PUT:
+                    case Bundle.HTTPVerb.GET:
                         statusString = ((int)HttpStatusCode.OK).ToString() + " " + HttpStatusCode.OK;
                         break;
                     case Bundle.HTTPVerb.DELETE:
                         statusString = ((int)HttpStatusCode.NoContent).ToString() + " " + HttpStatusCode.NoContent;
                         break;
                     default:
-                        statusString = ((int)HttpStatusCode.OK).ToString() + " " + HttpStatusCode.OK;
-                        break;
+                        throw new NotImplementedException();
                 }
 
                 resource.Response = new Bundle.ResponseComponent

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/BundleFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/BundleFactory.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using EnsureThat;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Core;
@@ -65,6 +66,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                 };
                 resource.Response = new Bundle.ResponseComponent
                 {
+                    Status = ((int)HttpStatusCode.OK).ToString() + " " + HttpStatusCode.OK,
                     LastModified = r.Resource.LastModified,
                     Etag = WeakETag.FromVersionId(r.Resource.Version).ToString(),
                 };

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/BundleFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/BundleFactory.cs
@@ -64,9 +64,27 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                     Method = hasVerb ? httpVerb : null,
                     Url = hasVerb ? $"{r.Resource.ResourceTypeName}/{(httpVerb == Bundle.HTTPVerb.POST ? null : r.Resource.ResourceId)}" : null,
                 };
+
+                string statusString;
+                switch (httpVerb)
+                {
+                    case Bundle.HTTPVerb.POST:
+                        statusString = ((int)HttpStatusCode.Created).ToString() + " " + HttpStatusCode.Created;
+                        break;
+                    case Bundle.HTTPVerb.PUT:
+                        statusString = ((int)HttpStatusCode.OK).ToString() + " " + HttpStatusCode.OK;
+                        break;
+                    case Bundle.HTTPVerb.DELETE:
+                        statusString = ((int)HttpStatusCode.NoContent).ToString() + " " + HttpStatusCode.NoContent;
+                        break;
+                    default:
+                        statusString = ((int)HttpStatusCode.OK).ToString() + " " + HttpStatusCode.OK;
+                        break;
+                }
+
                 resource.Response = new Bundle.ResponseComponent
                 {
-                    Status = ((int)HttpStatusCode.OK).ToString() + " " + HttpStatusCode.OK,
+                    Status = statusString,
                     LastModified = r.Resource.LastModified,
                     Etag = WeakETag.FromVersionId(r.Resource.Version).ToString(),
                 };


### PR DESCRIPTION
## Description
Added status for bundle.Resource.Response while returning history bundle. This status depends on  bundle.Resource.Request method httpverb.

## Related issues
Addresses [issue #2026]. 

## Testing
Added Unit tests and also did some manually testing

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
