### PR TITLE
Enable patient-everything in SQL Server

### DIFF
--- a/src/Microsoft.Health.Fhir.R4.Api/Features/Operations/OperationsCapabilityProvider.cs
+++ b/src/Microsoft.Health.Fhir.R4.Api/Features/Operations/OperationsCapabilityProvider.cs
@@ -4,11 +4,9 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Features.Conformance;
 using Microsoft.Health.Fhir.Core.Features.Conformance.Models;
 using Microsoft.Health.Fhir.Core.Features.Operations;
-using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Api.Features.Operations
@@ -31,16 +29,8 @@ namespace Microsoft.Health.Fhir.Api.Features.Operations
             GetAndAddOperationDefinitionUriToCapabilityStatement(capabilityStatement, OperationsConstants.Export);
         }
 
-        public void AddPatientEverythingDetails(ListedCapabilityStatement capabilityStatement)
+        public static void AddPatientEverythingDetails(ListedCapabilityStatement capabilityStatement)
         {
-            using IScoped<ISearchService> search = _searchServiceFactory();
-
-            // Will remove this when enabled in SQL Server
-            if (string.Equals(search.Value.GetType().Name, "SqlServerSearchService", StringComparison.Ordinal))
-            {
-                return;
-            }
-
             capabilityStatement.Rest.Server().Operation.Add(new OperationComponent
             {
                 Name = OperationsConstants.PatientEverything,

--- a/src/Microsoft.Health.Fhir.R5.Api/Features/Operations/OperationsCapabilityProvider.cs
+++ b/src/Microsoft.Health.Fhir.R5.Api/Features/Operations/OperationsCapabilityProvider.cs
@@ -4,11 +4,9 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Features.Conformance;
 using Microsoft.Health.Fhir.Core.Features.Conformance.Models;
 using Microsoft.Health.Fhir.Core.Features.Operations;
-using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Api.Features.Operations
@@ -31,16 +29,8 @@ namespace Microsoft.Health.Fhir.Api.Features.Operations
             GetAndAddOperationDefinitionUriToCapabilityStatement(capabilityStatement, OperationsConstants.Export);
         }
 
-        public void AddPatientEverythingDetails(ListedCapabilityStatement capabilityStatement)
+        public static void AddPatientEverythingDetails(ListedCapabilityStatement capabilityStatement)
         {
-            using IScoped<ISearchService> search = _searchServiceFactory();
-
-            // Will remove this when enabled in SQL Server
-            if (string.Equals(search.Value.GetType().Name, "SqlServerSearchService", StringComparison.Ordinal))
-            {
-                return;
-            }
-
             capabilityStatement.Rest.Server().Operation.Add(new OperationComponent
             {
                 Name = OperationsConstants.PatientEverything,

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Operations/OperationsCapabilityProvider.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Operations/OperationsCapabilityProvider.cs
@@ -3,22 +3,19 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
 using EnsureThat;
 using Microsoft.Extensions.Options;
-using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Api.Configs;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features.Conformance;
 using Microsoft.Health.Fhir.Core.Features.Conformance.Models;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Routing;
-using Microsoft.Health.Fhir.Core.Features.Search;
 
 namespace Microsoft.Health.Fhir.Api.Features.Operations
 {
     /// <summary>
-    /// Class that handles adding details of the supported operationsto the capability
+    /// Class that handles adding details of the supported operations to the capability
     /// statement of the fhir-server. This class is split across the different
     /// FHIR versions since the OperationDefinition has a different format
     /// for STU3 compared to R4 and R5.
@@ -28,23 +25,19 @@ namespace Microsoft.Health.Fhir.Api.Features.Operations
         private readonly OperationsConfiguration _operationConfiguration;
         private readonly FeatureConfiguration _featureConfiguration;
         private readonly IUrlResolver _urlResolver;
-        private readonly Func<IScoped<ISearchService>> _searchServiceFactory;
 
         public OperationsCapabilityProvider(
             IOptions<OperationsConfiguration> operationConfiguration,
             IOptions<FeatureConfiguration> featureConfiguration,
-            IUrlResolver urlResolver,
-            Func<IScoped<ISearchService>> searchServiceFactory)
+            IUrlResolver urlResolver)
         {
             EnsureArg.IsNotNull(operationConfiguration?.Value, nameof(operationConfiguration));
             EnsureArg.IsNotNull(featureConfiguration?.Value, nameof(featureConfiguration));
             EnsureArg.IsNotNull(urlResolver, nameof(urlResolver));
-            EnsureArg.IsNotNull(searchServiceFactory, nameof(searchServiceFactory));
 
             _operationConfiguration = operationConfiguration.Value;
             _featureConfiguration = featureConfiguration.Value;
             _urlResolver = urlResolver;
-            _searchServiceFactory = searchServiceFactory;
         }
 
         public void Build(ICapabilityStatementBuilder builder)

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
@@ -56,8 +56,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
             string continuationToken,
             CancellationToken cancellationToken)
         {
-            using IScoped<ISearchService> search = _searchServiceFactory();
-
             EverythingOperationContinuationToken token = string.IsNullOrEmpty(continuationToken)
                 ? new EverythingOperationContinuationToken(0, null)
                 : EverythingOperationContinuationToken.FromString(DecodeContinuationTokenFromBase64String(continuationToken));

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
@@ -58,12 +58,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
         {
             using IScoped<ISearchService> search = _searchServiceFactory();
 
-            // Will enable this after more tests
-            if (string.Equals(search.Value.GetType().Name, "SqlServerSearchService", StringComparison.Ordinal))
-            {
-                throw new OperationNotImplementedException("$everything operation is not yet implemented in SQL Server.");
-            }
-
             EverythingOperationContinuationToken token = string.IsNullOrEmpty(continuationToken)
                 ? new EverythingOperationContinuationToken(0, null)
                 : EverythingOperationContinuationToken.FromString(DecodeContinuationTokenFromBase64String(continuationToken));

--- a/src/Microsoft.Health.Fhir.Stu3.Api/Features/Operations/OperationsCapabilityProvider.cs
+++ b/src/Microsoft.Health.Fhir.Stu3.Api/Features/Operations/OperationsCapabilityProvider.cs
@@ -4,11 +4,9 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Features.Conformance;
 using Microsoft.Health.Fhir.Core.Features.Conformance.Models;
 using Microsoft.Health.Fhir.Core.Features.Operations;
-using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Api.Features.Operations
@@ -31,16 +29,8 @@ namespace Microsoft.Health.Fhir.Api.Features.Operations
             GetAndAddOperationDefinitionUriToCapabilityStatement(capabilityStatement, OperationsConstants.GroupExport);
         }
 
-        public void AddPatientEverythingDetails(ListedCapabilityStatement capabilityStatement)
+        public static void AddPatientEverythingDetails(ListedCapabilityStatement capabilityStatement)
         {
-            using IScoped<ISearchService> search = _searchServiceFactory();
-
-            // Will remove this when enabled in SQL Server
-            if (string.Equals(search.Value.GetType().Name, "SqlServerSearchService", StringComparison.Ordinal))
-            {
-                return;
-            }
-
             capabilityStatement.Rest.Server().Operation.Add(new OperationComponent
             {
                 Name = OperationsConstants.PatientEverything,

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTests.cs
@@ -26,7 +26,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
-        [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb)]
         public async Task GivenAPatientEverythingOperationWithId_WhenSearched_ThenResourcesInScopeShouldBeReturned()
         {
             string searchUrl = $"Patient/{Fixture.Patient.Id}/$everything";
@@ -45,7 +44,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
-        [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb)]
         public async Task GivenAPatientEverythingOperationWithNonExistentId_WhenSearched_ThenResourcesInScopeShouldBeReturned()
         {
             string searchUrl = $"Patient/{Fixture.NonExistentPatient.Id}/$everything";
@@ -55,7 +53,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
-        [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb)]
         public async Task GivenAEverythingOperationWithUnsupportedType_WhenSearched_ThenNotFoundShouldBeReturned()
         {
             string searchUrl = "Observation/bar/$everything";
@@ -67,7 +64,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
-        [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb)]
         public async Task GivenTypeSpecified_WhenAllValid_ThenResourcesOfValidTypesShouldBeReturned()
         {
             string searchUrl = $"Patient/{Fixture.Patient.Id}/$everything?_type=Patient,Observation";
@@ -77,7 +73,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
-        [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb)]
         public async Task GivenTypeSpecified_WhenAllInvalid_ThenAnEmptyBundleShouldBeReturned()
         {
             string searchUrl = $"Patient/{Fixture.Patient.Id}/$everything?_type=foo";
@@ -87,7 +82,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
-        [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb)]
         public async Task GivenTypeSpecified_WhenSomeInvalid_ThenResourcesOfValidTypesShouldBeReturned()
         {
             string searchUrl = $"Patient/{Fixture.Patient.Id}/$everything?_type=Patient,Device,foo";
@@ -97,7 +91,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
-        [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb)]
         public async Task GivenStartOrEndSpecified_WhenSearched_ThenResourcesOfSpecifiedRangeShouldBeReturned()
         {
             string searchUrl = $"Patient/{Fixture.Patient.Id}/$everything?end=2010";
@@ -107,7 +100,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
-        [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb)]
         public async Task GivenSinceSpecified_WhenSearched_ThenResourcesOfSpecifiedRangeShouldBeReturned()
         {
             string searchUrl = $"Patient/{Fixture.Patient.Id}/$everything?_since=3000";
@@ -120,7 +112,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [InlineData("Zm9v")]
         [InlineData("eyJQaGFzZSI6MSwgIkludGVybmFsQ29udGludWF0aW9uVG9rZW4iOiAiWm05diJ9")]
         [Trait(Traits.Priority, Priority.One)]
-        [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb)]
         public async Task GivenContinuationTokenSpecified_WhenInvalid_ThenBadRequestShouldBeReturned(string continuationToken)
         {
             string searchUrl = $"Patient/{Fixture.Patient.Id}/$everything?ct={continuationToken}";
@@ -132,7 +123,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
-        [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb)]
         public async Task GivenMultipleInputParametersSpecified_WhenAllValid_ThenResourcesOfSpecifiedRangeShouldBeReturned()
         {
             string searchUrl = $"Patient/{Fixture.Patient.Id}/$everything?_type=Patient,Observation,Encounter&start=2010&_since=2010";
@@ -142,7 +132,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
-        [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb)]
         public async Task GivenMultipleInputParametersSpecified_WhenAllInvalid_ThenInvalidInputParametersDoNotTakeEffect()
         {
             string searchUrl = $"Patient/{Fixture.Patient.Id}/$everything?_count=100&foo=bar";
@@ -166,7 +155,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
-        [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb)]
         public async Task GivenMultipleInputParametersSpecified_WhenSomeInvalid_ThenInvalidInputParametersDoNotTakeEffect()
         {
             string searchUrl = $"Patient/{Fixture.Patient.Id}/$everything?_type=Patient,Observation,Encounter&start=2010&_since=2010&foo=bar";
@@ -190,18 +178,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             var nextLink = firstBundle.Resource.NextLink.ToString();
             FhirResponse<Bundle> secondBundle = await Client.SearchAsync(nextLink);
             ValidateBundle(secondBundle, Fixture.Observation);
-        }
-
-        [Fact]
-        [Trait(Traits.Priority, Priority.One)]
-        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer)]
-        public async Task GivenAEverythingOperationWithSqlServer_WhenSearched_ThenMethodNotAllowedShouldBeReturned()
-        {
-            string searchUrl = "Patient/bar/$everything";
-
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.SearchAsync(searchUrl));
-
-            Assert.Equal(HttpStatusCode.MethodNotAllowed, ex.StatusCode);
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/MetadataTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/MetadataTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
-        public async Task GivenCosmosDb_WhenGettingMetadata_TheServerShouldReturnPatientEverythingSupported()
+        public async Task GivenBothDataStores_WhenGettingMetadata_TheServerShouldReturnPatientEverythingSupported()
         {
             FhirResponse<CapabilityStatement> capabilityStatement = await _client.ReadAsync<CapabilityStatement>("metadata");
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/MetadataTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/MetadataTests.cs
@@ -70,7 +70,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
-        [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb)]
         public async Task GivenCosmosDb_WhenGettingMetadata_TheServerShouldReturnPatientEverythingSupported()
         {
             FhirResponse<CapabilityStatement> capabilityStatement = await _client.ReadAsync<CapabilityStatement>("metadata");
@@ -80,20 +79,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
                 : capabilityStatement.Resource.ToTypedElement().Scalar($"CapabilityStatement.rest.operation.where(name = '{OperationsConstants.PatientEverything}').definition");
 
             Assert.Equal(OperationsConstants.PatientEverythingUri, operationDefinition.ToString());
-        }
-
-        [Fact]
-        [Trait(Traits.Priority, Priority.One)]
-        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer)]
-        public async Task GivenSqlServer_WhenGettingMetadata_TheServerShouldReturnPatientEverythingNotSupported()
-        {
-            FhirResponse<CapabilityStatement> capabilityStatement = await _client.ReadAsync<CapabilityStatement>("metadata");
-
-            object operationDefinition = ModelInfoProvider.Version == FhirSpecification.Stu3
-                ? capabilityStatement.Resource.ToTypedElement().Scalar($"CapabilityStatement.rest.operation.where(name = '{OperationsConstants.PatientEverything}').definition.reference")
-                : capabilityStatement.Resource.ToTypedElement().Scalar($"CapabilityStatement.rest.operation.where(name = '{OperationsConstants.PatientEverything}').definition");
-
-            Assert.Null(operationDefinition);
         }
     }
 }


### PR DESCRIPTION
## Description
Enable patient-everything in SQL Server.

## Related issues
[#81911](https://microsofthealth.visualstudio.com/Health/_workitems/edit/81911).

## Testing
E2E tests are updated. Performance test results could be found [here](https://microsofthealth.visualstudio.com/Health/_git/health-paas-docs/pullrequest/15114?_a=files&path=%2Fspecs%2FFHIR%2FOperation%2FPatientEverything.md&anchor=sql-server).

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
