### PR TITLE
Update PercentComplete to display 1/10th of the Progress for reindexing

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobRecord.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobRecord.cs
@@ -115,13 +115,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
         public IReadOnlyCollection<string> TargetResourceTypes { get; private set; } = new List<string>();
 
         [JsonIgnore]
-        public int PercentComplete
+        public decimal PercentComplete
         {
             get
             {
                 if (Count > 0 && Progress > 0)
                 {
-                    return (int)((double)Progress / Count * 100);
+                    return (decimal)Math.Round((double)Progress / Count * 100, 1);
                 }
                 else
                 {

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobRecord.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobRecord.cs
@@ -115,22 +115,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
         public IReadOnlyCollection<string> TargetResourceTypes { get; private set; } = new List<string>();
 
         [JsonIgnore]
-        public decimal PercentComplete
-        {
-            get
-            {
-                if (Count > 0 && Progress > 0)
-                {
-                    return (decimal)Math.Round((double)Progress / Count * 100, 1);
-                }
-                else
-                {
-                    return 0;
-                }
-            }
-        }
-
-        [JsonIgnore]
         public string ResourceList
         {
             get { return string.Join(",", Resources); }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ReindexControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ReindexControllerTests.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using Hl7.Fhir.Model;
 using MediatR;
@@ -112,9 +113,12 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
 
             var parametersResource = (((FhirResult)result).Result as ResourceElement).ResourceInstance as Parameters;
             Assert.Equal("Queued", parametersResource.Parameter[5].Value.ToString());
-            Assert.Equal(string.Empty, parametersResource.Parameter[10].Value.ToString());
-            Assert.Equal("500", parametersResource.Parameter[11].Value.ToString());
-            Assert.Equal("100", parametersResource.Parameter[12].Value.ToString());
+            Assert.Empty(parametersResource.Parameter.Where(x => x.TypeName == "Resources"));
+            Assert.Empty(parametersResource.Parameter.Where(x => x.TypeName == "SearchParams"));
+            Assert.Empty(parametersResource.Parameter.Where(x => x.TypeName == "TargetResourceTypes"));
+            Assert.Empty(parametersResource.Parameter.Where(x => x.TypeName == "TargetDataStoreUsagePercentage"));
+            Assert.Equal("500", parametersResource.Parameter[7].Value.ToString());
+            Assert.Equal("100", parametersResource.Parameter[8].Value.ToString());
         }
 
         private ReindexController GetController(ReindexJobConfiguration reindexConfig)

--- a/src/Microsoft.Health.Fhir.Shared.Core/Extensions/ReindexJobRecordExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Extensions/ReindexJobRecordExtensions.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using EnsureThat;
 using Hl7.Fhir.Model;
@@ -47,10 +48,20 @@ namespace Microsoft.Health.Fhir.Core.Extensions
                 parametersResource.Add(JobRecordProperties.EndTime, new FhirDateTime(job.EndTime.Value));
             }
 
+            decimal progress;
+            if (job.Count > 0 && job.Progress > 0)
+            {
+                progress = (decimal)job.Progress / job.Count * 100;
+            }
+            else
+            {
+                progress = 0;
+            }
+
             parametersResource.Add(JobRecordProperties.QueuedTime, new FhirDateTime(job.QueuedTime));
             parametersResource.Add(JobRecordProperties.TotalResourcesToReindex, new FhirDecimal(job.Count));
             parametersResource.Add(JobRecordProperties.ResourcesSuccessfullyReindexed, new FhirDecimal(job.Progress));
-            parametersResource.Add(JobRecordProperties.Progress, new FhirDecimal(job.PercentComplete));
+            parametersResource.Add(JobRecordProperties.Progress, new FhirDecimal(Math.Round(progress, 1)));
             parametersResource.Add(JobRecordProperties.Status, new FhirString(job.Status.ToString()));
             parametersResource.Add(JobRecordProperties.MaximumConcurrency, new FhirDecimal(job.MaximumConcurrency));
             parametersResource.Add(JobRecordProperties.Resources, new FhirString(job.ResourceList));

--- a/src/Microsoft.Health.Fhir.Shared.Core/Extensions/ReindexJobRecordExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Extensions/ReindexJobRecordExtensions.cs
@@ -64,12 +64,29 @@ namespace Microsoft.Health.Fhir.Core.Extensions
             parametersResource.Add(JobRecordProperties.Progress, new FhirDecimal(Math.Round(progress, 1)));
             parametersResource.Add(JobRecordProperties.Status, new FhirString(job.Status.ToString()));
             parametersResource.Add(JobRecordProperties.MaximumConcurrency, new FhirDecimal(job.MaximumConcurrency));
-            parametersResource.Add(JobRecordProperties.Resources, new FhirString(job.ResourceList));
-            parametersResource.Add(JobRecordProperties.SearchParams, new FhirString(job.SearchParamList));
-            parametersResource.Add(JobRecordProperties.TargetResourceTypes, new FhirString(job.TargetResourceTypeList));
-            parametersResource.Add(JobRecordProperties.TargetDataStoreUsagePercentage, new FhirString(job.TargetDataStoreUsagePercentage.ToString()));
-            parametersResource.Add(JobRecordProperties.QueryDelayIntervalInMilliseconds, new FhirString(job.QueryDelayIntervalInMilliseconds.ToString()));
-            parametersResource.Add(JobRecordProperties.MaximumNumberOfResourcesPerQuery, new FhirString(job.MaximumNumberOfResourcesPerQuery.ToString()));
+
+            if (!string.IsNullOrEmpty(job.ResourceList))
+            {
+                parametersResource.Add(JobRecordProperties.Resources, new FhirString(job.ResourceList));
+            }
+
+            if (!string.IsNullOrEmpty(job.SearchParamList))
+            {
+                parametersResource.Add(JobRecordProperties.SearchParams, new FhirString(job.SearchParamList));
+            }
+
+            if (!string.IsNullOrEmpty(job.TargetResourceTypeList))
+            {
+                parametersResource.Add(JobRecordProperties.TargetResourceTypes, new FhirString(job.TargetResourceTypeList));
+            }
+
+            if (!string.IsNullOrEmpty(job.TargetDataStoreUsagePercentage.ToString()))
+            {
+                parametersResource.Add(JobRecordProperties.TargetDataStoreUsagePercentage, new FhirDecimal(job.TargetDataStoreUsagePercentage));
+            }
+
+            parametersResource.Add(JobRecordProperties.QueryDelayIntervalInMilliseconds, new FhirDecimal(job.QueryDelayIntervalInMilliseconds));
+            parametersResource.Add(JobRecordProperties.MaximumNumberOfResourcesPerQuery, new FhirDecimal(job.MaximumNumberOfResourcesPerQuery));
 
             return parametersResource.ToResourceElement();
         }


### PR DESCRIPTION
## Description
Updated PercentComplete  to display 1/10th of the progress when query for the reindexing status
Do not output fields with no values

## Related issues
Addresses [#AB81444](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Resolute/Stories/?workitem=81444)

## Testing
Unit test
Manual Testing

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
