### PR TITLE
Logs when search parameter statuses change

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -641,18 +641,19 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             // here we check if all the resource types which are base types of the search parameter
             // were reindexed by this job.  If so, then we should mark the search parameters
             // as fully reindexed
-            var fullyIndexexParams = new List<string>();
+            var fullyIndexedParamUris = new List<string>();
             var reindexedResourcesSet = new HashSet<string>(_reindexJobRecord.Resources);
             foreach (var searchParam in _reindexJobRecord.SearchParams)
             {
                 var searchParamInfo = _supportedSearchParameterDefinitionManager.GetSearchParameter(new Uri(searchParam));
                 if (reindexedResourcesSet.IsSupersetOf(searchParamInfo.BaseResourceTypes))
                 {
-                    fullyIndexexParams.Add(searchParam);
+                    fullyIndexedParamUris.Add(searchParam);
                 }
             }
 
-            (bool success, string error) = await _reindexUtilities.UpdateSearchParameterStatus(fullyIndexexParams, _cancellationToken);
+            _logger.LogTrace("Completing reindex job. Updating the status of the fully indexed search parameters: '{paramUris}'", string.Join("', '", fullyIndexedParamUris));
+            (bool success, string error) = await _reindexUtilities.UpdateSearchParameterStatus(fullyIndexedParamUris, _cancellationToken);
 
             if (success)
             {

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
@@ -78,8 +78,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
                     throw new SearchParameterNotSupportedException(errorMessage);
                 }
 
+                _logger.LogTrace("Adding the search parameter '{url}'", searchParameterWrapper.Url);
                 _searchParameterDefinitionManager.AddNewSearchParameters(new List<ITypedElement> { searchParam });
-
                 await _searchParameterStatusManager.AddSearchParameterStatusAsync(new List<string> { searchParameterWrapper.Url });
             }
             catch (FhirException fex)
@@ -118,6 +118,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
                 // First we delete the status metadata from the data store as this fuction depends on the
                 // the in memory definition manager.  Once complete we remove the SearchParameter from
                 // the definition manager.
+                _logger.LogTrace("Deleting the search parameter '{url}'", searchParameterUrl);
                 await _searchParameterStatusManager.DeleteSearchParameterStatusAsync(searchParameterUrl);
                 _searchParameterDefinitionManager.DeleteSearchParameter(searchParam);
             }
@@ -172,8 +173,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
                 // As any part of the SearchParameter may have been changed, including the URL
                 // the most reliable method of updating the SearchParameter is to delete the previous
                 // data and insert the updated version
+                _logger.LogTrace("Deleting the search parameter '{url}' (update step 1/2)", prevSearchParamUrl);
                 await _searchParameterStatusManager.DeleteSearchParameterStatusAsync(prevSearchParamUrl);
                 _searchParameterDefinitionManager.DeleteSearchParameter(prevSearchParam);
+
+                _logger.LogTrace("Adding the search parameter '{url}' (update step 2/2)", searchParameterWrapper.Url);
                 _searchParameterDefinitionManager.AddNewSearchParameters(new List<ITypedElement>() { searchParam });
                 await _searchParameterStatusManager.AddSearchParameterStatusAsync(new List<string>() { searchParameterWrapper.Url });
             }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
@@ -109,6 +109,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
 
         public async Task UpdateSearchParameterStatusAsync(IReadOnlyCollection<string> searchParameterUris, SearchParameterStatus status)
         {
+            EnsureArg.IsNotNull(searchParameterUris);
+
+            if (searchParameterUris.Count == 0)
+            {
+                return;
+            }
+
             var searchParameterStatusList = new List<ResourceSearchParameterStatus>();
             var updated = new List<SearchParameterInfo>();
             var parameters = (await _searchParameterStatusDataStore.GetSearchParameterStatuses())
@@ -116,6 +123,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
 
             foreach (string uri in searchParameterUris)
             {
+                _logger.LogTrace("Setting the search parameter status of '{0}' to '{1}'", uri, status.ToString());
+
                 var searchParamUri = new Uri(uri);
 
                 SearchParameterInfo paramInfo = _searchParameterDefinitionManager.GetSearchParameter(searchParamUri);

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
 
             foreach (string uri in searchParameterUris)
             {
-                _logger.LogTrace("Setting the search parameter status of '{0}' to '{1}'", uri, status.ToString());
+                _logger.LogTrace("Setting the search parameter status of '{uri}' to '{newStatus}'", uri, status.ToString());
 
                 var searchParamUri = new Uri(uri);
 


### PR DESCRIPTION
## Description
Adds a trace message to track search parameter status changes. This was something raised during a recent investigation, and it will be helpful for any future custom search investigations.

## FHIR Team Checklist
- ✅ **Update the title** of the PR to be succinct and less than 50 characters
- ✅ **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- ✅ Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- ✅ Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
None (minor logging change)
