### PR TITLE
Refine error logging level in convert data requests

### DIFF
--- a/src/Microsoft.Health.Fhir.Azure/ContainerRegistry/AzureContainerRegistryAccessTokenProvider.cs
+++ b/src/Microsoft.Health.Fhir.Azure/ContainerRegistry/AzureContainerRegistryAccessTokenProvider.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Health.Fhir.Azure.ContainerRegistry
             }
             catch (AccessTokenProviderException ex)
             {
-                _logger.LogError(ex, "Failed to get AAD access token from managed identity.");
+                _logger.LogWarning(ex, "Failed to get AAD access token from managed identity.");
                 throw new AzureContainerRegistryTokenException(Resources.CannotGetAcrAccessToken, HttpStatusCode.Unauthorized, ex);
             }
 
@@ -111,17 +111,17 @@ namespace Microsoft.Health.Fhir.Azure.ContainerRegistry
             var refreshTokenResponse = await SendRequestAsync(request, cancellationToken);
             if (refreshTokenResponse.StatusCode == HttpStatusCode.Unauthorized)
             {
-                _logger.LogError("Failed to exchange ACR refresh token: ACR server is unauthorized.");
+                _logger.LogInformation("Failed to exchange ACR refresh token: ACR server is unauthorized.");
                 throw new ContainerRegistryNotAuthorizedException(string.Format(Resources.ContainerRegistryNotAuthorized, registryServer));
             }
             else if (refreshTokenResponse.StatusCode == HttpStatusCode.NotFound)
             {
-                _logger.LogError("Failed to exchange ACR refresh token: ACR server is not found.");
+                _logger.LogInformation("Failed to exchange ACR refresh token: ACR server is not found.");
                 throw new ContainerRegistryNotFoundException(string.Format(Resources.ContainerRegistryNotFound, registryServer));
             }
             else if (!refreshTokenResponse.IsSuccessStatusCode)
             {
-                _logger.LogError("Failed to exchange ACR refresh token with AAD access token. Status code: {statusCode}.", refreshTokenResponse.StatusCode);
+                _logger.LogWarning("Failed to exchange ACR refresh token with AAD access token. Status code: {statusCode}.", refreshTokenResponse.StatusCode);
                 throw new AzureContainerRegistryTokenException(Resources.CannotGetAcrAccessToken, refreshTokenResponse.StatusCode);
             }
 
@@ -130,7 +130,7 @@ namespace Microsoft.Health.Fhir.Azure.ContainerRegistry
             string refreshToken = (string)refreshTokenJson.refresh_token;
             if (string.IsNullOrEmpty(refreshToken))
             {
-                _logger.LogError("ACR refresh token is empty.");
+                _logger.LogWarning("ACR refresh token is empty.");
                 throw new AzureContainerRegistryTokenException(Resources.CannotGetAcrAccessToken, refreshTokenResponse.StatusCode);
             }
 
@@ -158,17 +158,17 @@ namespace Microsoft.Health.Fhir.Azure.ContainerRegistry
             var accessTokenResponse = await SendRequestAsync(request, cancellationToken);
             if (accessTokenResponse.StatusCode == HttpStatusCode.Unauthorized)
             {
-                _logger.LogError("Failed to get ACR access token: ACR server is unauthorized.");
+                _logger.LogInformation("Failed to get ACR access token: ACR server is unauthorized.");
                 throw new ContainerRegistryNotAuthorizedException(string.Format(Resources.ContainerRegistryNotAuthorized, registryServer));
             }
             else if (accessTokenResponse.StatusCode == HttpStatusCode.NotFound)
             {
-                _logger.LogError("Failed to get ACR access token: ACR server is not found.");
+                _logger.LogInformation("Failed to get ACR access token: ACR server is not found.");
                 throw new ContainerRegistryNotFoundException(string.Format(Resources.ContainerRegistryNotFound, registryServer));
             }
             else if (!accessTokenResponse.IsSuccessStatusCode)
             {
-                _logger.LogError("Failed to get ACR access token with ACR refresh token. Status code: {statusCode}.", accessTokenResponse.StatusCode);
+                _logger.LogWarning("Failed to get ACR access token with ACR refresh token. Status code: {statusCode}.", accessTokenResponse.StatusCode);
                 throw new AzureContainerRegistryTokenException(Resources.CannotGetAcrAccessToken, accessTokenResponse.StatusCode);
             }
 
@@ -177,7 +177,7 @@ namespace Microsoft.Health.Fhir.Azure.ContainerRegistry
             string accessToken = accessTokenJson.access_token;
             if (string.IsNullOrEmpty(accessToken))
             {
-                _logger.LogError("ACR access token is empty.");
+                _logger.LogWarning("ACR access token is empty.");
                 throw new AzureContainerRegistryTokenException(Resources.CannotGetAcrAccessToken, accessTokenResponse.StatusCode);
             }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/ContainerRegistryTemplateProvider.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/ContainerRegistryTemplateProvider.cs
@@ -91,17 +91,17 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.ConvertData
                 // Remove token from cache when authentication failed.
                 _cache.Remove(GetCacheKey(request.RegistryServer));
 
-                _logger.LogError(authEx, "Failed to access container registry.");
+                _logger.LogWarning(authEx, "Failed to access container registry.");
                 throw new ContainerRegistryNotAuthorizedException(string.Format(Resources.ContainerRegistryNotAuthorized, request.RegistryServer), authEx);
             }
             catch (ImageFetchException fetchEx)
             {
-                _logger.LogError(fetchEx, "Failed to fetch template image.");
+                _logger.LogWarning(fetchEx, "Failed to fetch template image.");
                 throw new FetchTemplateCollectionFailedException(string.Format(Resources.FetchTemplateCollectionFailed, fetchEx.Message), fetchEx);
             }
             catch (TemplateManagementException templateEx)
             {
-                _logger.LogError(templateEx, "Template collection is invalid.");
+                _logger.LogWarning(templateEx, "Template collection is invalid.");
                 throw new TemplateCollectionErrorException(string.Format(Resources.FetchTemplateCollectionFailed, templateEx.Message), templateEx);
             }
             catch (Exception unhandledEx)

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/ConvertDataEngine.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/ConvertDataEngine.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.ConvertData
             if (templateProvider == null)
             {
                 // This case should never happen.
-                _logger.LogError("Invalid input data type for conversion.");
+                _logger.LogInformation("Invalid input data type for conversion.");
                 throw new RequestNotValidException("Invalid input data type for conversion.");
             }
 
@@ -77,7 +77,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.ConvertData
             if (converter == null)
             {
                 // This case should never happen.
-                _logger.LogError("Invalid input data type for conversion.");
+                _logger.LogInformation("Invalid input data type for conversion.");
                 throw new RequestNotValidException("Invalid input data type for conversion.");
             }
 
@@ -93,7 +93,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.ConvertData
                     throw new ConvertDataTimeoutException(Resources.ConvertDataOperationTimeout, convertException.InnerException);
                 }
 
-                _logger.LogError(convertException, "Convert data failed.");
+                _logger.LogInformation(convertException, "Convert data failed.");
                 throw new ConvertDataFailedException(string.Format(Resources.ConvertDataFailed, convertException.Message), convertException);
             }
             catch (Exception ex)


### PR DESCRIPTION
## Description
Refine error logging levels in convert data requests to reduce noise in logging stream.

- Log user errors to ```Information```
- Log unexpected but handled errors to ```Warning```
- Log unhandled error to ```Error``` 

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [*] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [*] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [*] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip
