### PR TITLE
Updated the SMART on FHIR Launcher sample

### DIFF
--- a/samples/apps/SmartLauncher/wwwroot/sampleapp/index.html
+++ b/samples/apps/SmartLauncher/wwwroot/sampleapp/index.html
@@ -5,7 +5,7 @@
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
         <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-        <script src="https://cdn.jsdelivr.net/npm/fhir-js-client@1.0.0/dist/fhir-client.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/fhirclient/build/fhir-client.js"></script>
     </head>
     <body>
     
@@ -29,10 +29,10 @@
         }
 
         FHIR.oauth2.ready(function(client) {
-            $.when(client.patient.read()).then(
+            client.patient.read().then(
                 function(patient){
                     $('#patientfield').val(JSON.stringify(patient, null, 4));
-                    $('#tokenresponsefield').val(JSON.stringify(client.tokenResponse, null, 4));
+                    $('#tokenresponsefield').val(JSON.stringify(client.state.tokenResponse, null, 4));
                 },
                 function(error){
                     console.log("Error:\n" + error);

--- a/samples/apps/SmartLauncher/wwwroot/sampleapp/launch.html
+++ b/samples/apps/SmartLauncher/wwwroot/sampleapp/launch.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/fhir-js-client@1.0.0/dist/fhir-client.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/fhirclient/build/fhir-client.js"></script>
     <script>
 
     var launchUri = window.location.protocol + "//" + window.location.host + window.location.pathname;


### PR DESCRIPTION
## Description
The SMART of FHIR Launcher sample had an outdated `fhir-client.js` reference, and was not working anymore with current AAD.
I upgraded the lib to use the recent release, and changed the API call to make it work.

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
