### PR TITLE
Fix link to fhir-proxy project in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To see what is releasing in the FHIR Server, please refer to the [releases](http
 ## Additional Capabilities
 - [Bulk Export](docs/BulkExport.md): Describes using Bulk Export within the FHIR Server.
 - [Convert Data](docs/ConvertDataOperation.md): Describes how to use $convert to convert data into FHIR.
-- [FHIR Proxy](https://github.com/microsoft/health-architectures/tree/master/FHIR/FHIRProxy): Secure FHIR Gateway and Proxy to FHIR Servers.
+- [FHIR Proxy](https://github.com/microsoft/fhir-proxy): Secure FHIR Gateway and Proxy to FHIR Servers.
 
 ## Tutorials & How-to Guides
 - [Health Architectures](https://aka.ms/healtharchitectures): A collection of reference architectures illustrating end-to-end best practices for using the Azure API for FHIR and related technologies.


### PR DESCRIPTION
## Description
Fixes the link to fhir-proxy project in README.md

## Related issues
No related issue

## Testing
Checked the link now works.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch - no code changes.
