### PR TITLE
Upgrade anonymizer nuget

### DIFF
--- a/build/jobs/run-pr-tests.yml
+++ b/build/jobs/run-pr-tests.yml
@@ -98,6 +98,15 @@ jobs:
         Write-Host "##vso[task.setvariable variable=TestContainerRegistryServer]$($acrLoginServer)"
         Write-Host "##vso[task.setvariable variable=TestContainerRegistryPassword]$($acrPassword)"
 
+        $exportStoreSettings = $appSettings | where {$_.Name -eq "FhirServer__Operations__Export__StorageAccountUri"}
+        $exportStoreUri = $exportStoreSettings[0].Value
+        Write-Host "$exportStoreUri"
+        $exportStoreAccountName = [System.Uri]::new("$exportStoreUri").Host.Split('.')[0]
+        $exportStoreKey = Get-AzStorageAccountKey -ResourceGroupName $(ResourceGroupName) -Name "$exportStoreAccountName" | Where-Object {$_.KeyName -eq "key1"}
+        
+        Write-Host "##vso[task.setvariable variable=TestExportStoreUri]$($exportStoreUri)"
+        Write-Host "##vso[task.setvariable variable=TestExportStoreKey]$($exportStoreKey.Value)"
+
         Write-Host "##vso[task.setvariable variable=Resource]$(TestEnvironmentUrl)"
         
         $secrets = Get-AzKeyVaultSecret -VaultName resolute-oss-tenant-info
@@ -133,6 +142,8 @@ jobs:
       'AllStorageAccounts': $(AllStorageAccounts)
       'TestContainerRegistryServer': $(TestContainerRegistryServer)
       'TestContainerRegistryPassword': $(TestContainerRegistryPassword)
+      'TestExportStoreUri': $(TestExportStoreUri)
+      'TestExportStoreKey': $(TestExportStoreKey)
       'tenant-admin-service-principal-name': $(tenant-admin-service-principal-name)
       'tenant-admin-service-principal-password': $(tenant-admin-service-principal-password)
       'tenant-admin-user-name': $(tenant-admin-user-name)
@@ -207,6 +218,15 @@ jobs:
         Write-Host "##vso[task.setvariable variable=TestContainerRegistryServer]$($acrLoginServer)"
         Write-Host "##vso[task.setvariable variable=TestContainerRegistryPassword]$($acrPassword)"
 
+        $exportStoreSettings = $appSettings | where {$_.Name -eq "FhirServer__Operations__Export__StorageAccountUri"}
+        $exportStoreUri = $exportStoreSettings[0].Value
+        Write-Host "$exportStoreUri"
+        $exportStoreAccountName = [System.Uri]::new("$exportStoreUri").Host.Split('.')[0]
+        $exportStoreKey = Get-AzStorageAccountKey -ResourceGroupName $(ResourceGroupName) -Name "$exportStoreAccountName" | Where-Object {$_.KeyName -eq "key1"}
+        
+        Write-Host "##vso[task.setvariable variable=TestExportStoreUri]$($exportStoreUri)"
+        Write-Host "##vso[task.setvariable variable=TestExportStoreKey]$($exportStoreKey.Value)"
+        
         Write-Host "##vso[task.setvariable variable=Resource]$(TestEnvironmentUrl)"
         
         $secrets = Get-AzKeyVaultSecret -VaultName resolute-oss-tenant-info
@@ -242,6 +262,8 @@ jobs:
       'AllStorageAccounts': $(AllStorageAccounts)
       'TestContainerRegistryServer': $(TestContainerRegistryServer)
       'TestContainerRegistryPassword': $(TestContainerRegistryPassword)
+      'TestExportStoreUri': $(TestExportStoreUri)
+      'TestExportStoreKey': $(TestExportStoreKey)
       'tenant-admin-service-principal-name': $(tenant-admin-service-principal-name)
       'tenant-admin-service-principal-password': $(tenant-admin-service-principal-password)
       'tenant-admin-user-name': $(tenant-admin-user-name)

--- a/src/Microsoft.Health.Fhir.R4.Core/Microsoft.Health.Fhir.R4.Core.csproj
+++ b/src/Microsoft.Health.Fhir.R4.Core/Microsoft.Health.Fhir.R4.Core.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="$(RuntimePackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(RuntimePackageVersion)" />
     <PackageReference Include="Hl7.Fhir.R4" Version="$(Hl7FhirVersion)" />
-    <PackageReference Include="Microsoft.Health.Fhir.Anonymizer.R4.Core" Version="2.2.0-20210322.3" />
+    <PackageReference Include="Microsoft.Health.Fhir.Anonymizer.R4.Core" Version="2.2.0.50" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -18,8 +18,7 @@
         "Features": {
             "SupportsUI": false,
             "SupportsXml": true,
-            "SupportsAnonymizedExport": false
-
+            "SupportsAnonymizedExport": true
         },
         "CoreFeatures": {
             "SupportsBatch": true,

--- a/src/Microsoft.Health.Fhir.Stu3.Core/Microsoft.Health.Fhir.Stu3.Core.csproj
+++ b/src/Microsoft.Health.Fhir.Stu3.Core/Microsoft.Health.Fhir.Stu3.Core.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(RuntimePackageVersion)" />
     <PackageReference Include="Hl7.Fhir.STU3" Version="$(Hl7FhirVersion)" />
     <PackageReference Include="Hl7.Fhir.Specification.STU3" Version="$(Hl7FhirVersion)" PrivateAssets="build;analyzers" />
-    <PackageReference Include="Microsoft.Health.Fhir.Anonymizer.Stu3.Core" Version="2.2.0-20210322.3" />
+    <PackageReference Include="Microsoft.Health.Fhir.Anonymizer.Stu3.Core" Version="2.2.0.50" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/AnonymizedExportTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/AnonymizedExportTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
         [InlineData("Patient/")]
         public async Task GivenAValidConfigurationWithETag_WhenExportingAnonymizedData_ResourceShouldBeAnonymized(string path)
         {
-            _metricHandler.ResetCount();
+            _metricHandler?.ResetCount();
 
             var resourceToCreate = Samples.GetDefaultPatient().ToPoco<Patient>();
             resourceToCreate.Id = Guid.NewGuid().ToString();
@@ -93,7 +93,7 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
         [Fact]
         public async Task GivenAValidConfigurationWithETag_WhenExportingGroupAnonymizedData_ResourceShouldBeAnonymized()
         {
-            _metricHandler.ResetCount();
+            _metricHandler?.ResetCount();
 
             var patientToCreate = Samples.GetDefaultPatient().ToPoco<Patient>();
             patientToCreate.Id = Guid.NewGuid().ToString();
@@ -144,7 +144,7 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
         [SkippableFact]
         public async Task GivenAValidConfigurationWithETagNoQuotes_WhenExportingAnonymizedData_ResourceShouldBeAnonymized()
         {
-            _metricHandler.ResetCount();
+            _metricHandler?.ResetCount();
 
             var resourceToCreate = Samples.GetDefaultPatient().ToPoco<Patient>();
             resourceToCreate.Id = Guid.NewGuid().ToString();
@@ -177,7 +177,7 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
         [SkippableFact]
         public async Task GivenAValidConfigurationWithoutETag_WhenExportingAnonymizedData_ResourceShouldBeAnonymized()
         {
-            _metricHandler.ResetCount();
+            _metricHandler?.ResetCount();
 
             var resourceToCreate = Samples.GetDefaultPatient().ToPoco<Patient>();
             resourceToCreate.Id = Guid.NewGuid().ToString();
@@ -210,7 +210,7 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
         [SkippableFact]
         public async Task GivenInvalidConfiguration_WhenExportingAnonymizedData_ThenBadRequestShouldBeReturned()
         {
-            _metricHandler.ResetCount();
+            _metricHandler?.ResetCount();
 
             (string fileName, string etag) = await UploadConfigurationAsync("Invalid Json.");
 
@@ -232,7 +232,7 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
         [SkippableFact]
         public async Task GivenAGroupIdNotExisted_WhenExportingGroupAnonymizedData_ThenBadRequestShouldBeReturned()
         {
-            _metricHandler.ResetCount();
+            _metricHandler?.ResetCount();
 
             (string fileName, string etag) = await UploadConfigurationAsync(RedactResourceIdAnonymizationConfiguration);
 
@@ -255,7 +255,7 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
         [SkippableFact]
         public async Task GivenInvalidEtagProvided_WhenExportingAnonymizedData_ThenBadRequestShouldBeReturned()
         {
-            _metricHandler.ResetCount();
+            _metricHandler?.ResetCount();
 
             (string fileName, string _) = await UploadConfigurationAsync(RedactResourceIdAnonymizationConfiguration);
 
@@ -277,7 +277,7 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
         [SkippableFact]
         public async Task GivenEtagInWrongFormatProvided_WhenExportingAnonymizedData_ThenBadRequestShouldBeReturned()
         {
-            _metricHandler.ResetCount();
+            _metricHandler?.ResetCount();
 
             (string fileName, string _) = await UploadConfigurationAsync(RedactResourceIdAnonymizationConfiguration);
 
@@ -299,7 +299,7 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
         [SkippableFact]
         public async Task GivenAContainerNotExisted_WhenExportingAnonymizedData_ThenBadRequestShouldBeReturned()
         {
-            _metricHandler.ResetCount();
+            _metricHandler?.ResetCount();
 
             string containerName = Guid.NewGuid().ToString("N");
             Uri contentLocation = await _testFhirClient.AnonymizedExportAsync("not-exist.json", containerName);
@@ -319,7 +319,7 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest
         [SkippableFact]
         public async Task GivenALargeConfigurationProvided_WhenExportingAnonymizedData_ThenBadRequestShouldBeReturned()
         {
-            _metricHandler.ResetCount();
+            _metricHandler?.ResetCount();
 
             string largeConfig = new string('*', (1024 * 1024) + 1); // Large config > 1MB
             (string fileName, string etag) = await UploadConfigurationAsync(largeConfig);


### PR DESCRIPTION
Upgrade anonymizer nuget to use FHIR lib 3.4


## Testing
Enable anonymized export tests in CI pipeline.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
