### PR TITLE
Add test to check reference for anonymizer

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Export/ExportAnonymizerFactoryTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Export/ExportAnonymizerFactoryTests.cs
@@ -4,12 +4,17 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.IO;
+using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Hl7.Fhir.Serialization;
 using Microsoft.Extensions.Logging;
+using Microsoft.Health.Fhir.Anonymizer.Core;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export;
+using Newtonsoft.Json;
 using NSubstitute;
 using Xunit;
 
@@ -38,6 +43,14 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Export
 		}
 	]
 }";
+
+        [Fact]
+        public void GivenAnonymizer_WhenUpdatingReferenceLibraryVersion_ThenAnonymizerShouldBeUpdatedToSameVersion()
+        {
+            AssemblyName[] referencesFromAnonymizationEngion = typeof(AnonymizerEngine).Assembly.GetReferencedAssemblies();
+            Assert.Contains(typeof(FhirJsonParser).Assembly.FullName, referencesFromAnonymizationEngion.Select(r => r.FullName));
+            Assert.Contains(typeof(JsonConvert).Assembly.FullName, referencesFromAnonymizationEngion.Select(r => r.FullName));
+        }
 
         [Fact]
         public async Task GivenAValidAnonymizationConfiguration_WhenCreatingAnonymizer_AnonymizerShouldBeCreated()


### PR DESCRIPTION
## Description
Add tests to check reference library between anonymizer and fhir server.

## Related issues
FHIR lib upgrade might introduce breaking change for anonymizer, we need to make sure anonymizer also get upgraded.

## Testing
Add unit tests

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
