### PR TITLE
Retry 503 error from Cosmos DB

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/CosmosFhirDataStoreTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/CosmosFhirDataStoreTests.cs
@@ -6,9 +6,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
+using System.Threading;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -17,14 +21,20 @@ using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Core.Internal;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Configs;
+using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Definition;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.Core.UnitTests.Extensions;
 using Microsoft.Health.Fhir.CosmosDb.Configs;
 using Microsoft.Health.Fhir.CosmosDb.Features.Queries;
 using Microsoft.Health.Fhir.CosmosDb.Features.Storage;
+using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Test.Utilities;
 using NSubstitute;
 using Xunit;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Storage
 {
@@ -33,16 +43,22 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Storage
         private readonly ICosmosQueryFactory _cosmosQueryFactory;
         private readonly CosmosFhirDataStore _dataStore;
         private readonly CosmosDataStoreConfiguration _cosmosDataStoreConfiguration = new CosmosDataStoreConfiguration();
+        private readonly IScoped<Container> _container;
 
         public CosmosFhirDataStoreTests()
         {
+            _container = Substitute.For<Container>().CreateMockScope();
             _cosmosQueryFactory = Substitute.For<ICosmosQueryFactory>();
+            var fhirRequestContext = Substitute.For<IFhirRequestContext>();
+            fhirRequestContext.ExecutingBatchOrTransaction.Returns(true);
+            var requestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
+            requestContextAccessor.RequestContext.Returns(fhirRequestContext);
             _dataStore = new CosmosFhirDataStore(
-                Substitute.For<IScoped<Container>>(),
+                _container,
                 _cosmosDataStoreConfiguration,
                 Substitute.For<IOptionsMonitor<CosmosCollectionConfiguration>>(),
                 _cosmosQueryFactory,
-                new RetryExceptionPolicyFactory(_cosmosDataStoreConfiguration, Substitute.For<RequestContextAccessor<IFhirRequestContext>>()),
+                new RetryExceptionPolicyFactory(_cosmosDataStoreConfiguration, requestContextAccessor),
                 NullLogger<CosmosFhirDataStore>.Instance,
                 Options.Create(new CoreFeatureConfiguration()),
                 new Lazy<ISupportedSearchParameterDefinitionManager>(Substitute.For<ISupportedSearchParameterDefinitionManager>()));
@@ -183,6 +199,26 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Storage
             Assert.Equal("5", continuationToken);
         }
 
+        [Fact]
+        public async Task GivenAnUpsertDuringABatch_When503ExceptionOccurs_RetryWillHappen()
+        {
+            var observation = Samples.GetDefaultObservation().ToPoco<Observation>();
+            observation.Id = "id1";
+            observation.VersionId = "version1";
+            observation.Meta.Profile = new List<string> { "test" };
+            var rawResourceFactory = new RawResourceFactory(new FhirJsonSerializer());
+            ResourceElement typedElement = observation.ToResourceElement();
+
+            var wrapper = new ResourceWrapper(typedElement, rawResourceFactory.Create(typedElement, keepMeta: true), new ResourceRequest(HttpMethod.Post, "http://fhir"), false, null, null, null);
+
+            _container.Value.When(x => x.CreateItemAsync(Arg.Any<FhirCosmosResourceWrapper>(), Arg.Any<PartitionKey>(), Arg.Any<ItemRequestOptions>(), Arg.Any<CancellationToken>())).
+                Do(x => throw CreateCosmosException(null, HttpStatusCode.ServiceUnavailable));
+
+            await Assert.ThrowsAsync<CosmosException>(() => _dataStore.UpsertAsync(wrapper, null, true, true, CancellationToken.None));
+
+            await _container.Value.ReceivedWithAnyArgs(7).CreateItemAsync(Arg.Any<FhirCosmosResourceWrapper>(), Arg.Any<PartitionKey>(), Arg.Any<ItemRequestOptions>(), Arg.Any<CancellationToken>());
+        }
+
         private void CreateResponses(int pageSize, string continuationToken, params FeedResponse<int>[] responses)
         {
             ICosmosQuery<int> cosmosQuery = Substitute.For<ICosmosQuery<int>>();
@@ -206,9 +242,17 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Storage
             return feedResponse;
         }
 
-        private CosmosException CreateCosmosException(Exception innerException)
+        private CosmosException CreateCosmosException(Exception innerException, HttpStatusCode? statusCode = null)
         {
-            var cosmosException = (CosmosException)RuntimeHelpers.GetUninitializedObject(typeof(CosmosException));
+            CosmosException cosmosException = null;
+            if (statusCode.HasValue)
+            {
+                cosmosException = new CosmosException("message", statusCode.Value, 0, "id", 0.0);
+            }
+            else
+            {
+                cosmosException = (CosmosException)RuntimeHelpers.GetUninitializedObject(typeof(CosmosException));
+            }
 
             var sampleException = new Exception(null, innerException);
             foreach (FieldInfo fieldInfo in typeof(Exception).GetFields(BindingFlags.Instance | BindingFlags.NonPublic))

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Microsoft.Health.Fhir.CosmosDb.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Microsoft.Health.Fhir.CosmosDb.UnitTests.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Health.Extensions.Xunit\Microsoft.Health.Extensions.Xunit.csproj" />
+    <ProjectReference Include="..\Microsoft.Health.Fhir.Core.UnitTests\Microsoft.Health.Fhir.Core.UnitTests.csproj" />
     <ProjectReference Include="..\Microsoft.Health.Fhir.CosmosDb\Microsoft.Health.Fhir.CosmosDb.csproj" />
     <ProjectReference Include="..\Microsoft.Health.Fhir.R4.Core\Microsoft.Health.Fhir.R4.Core.csproj" />
     <ProjectReference Include="..\Microsoft.Health.Fhir.Tests.Common\Microsoft.Health.Fhir.Tests.Common.csproj" />

--- a/src/Microsoft.Health.Fhir.CosmosDb/AssemblyInfo.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/AssemblyInfo.cs
@@ -10,4 +10,5 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Microsoft.Health.Fhir.Stu3.Tests.Integration")]
 [assembly: InternalsVisibleTo("Microsoft.Health.Fhir.R4.Tests.Integration")]
 [assembly: InternalsVisibleTo("Microsoft.Health.Fhir.R5.Tests.Integration")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
 [assembly: NeutralResourcesLanguage("en-us")]

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosExceptionExtensions.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosExceptionExtensions.cs
@@ -69,5 +69,29 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
             return exception.StatusCode == HttpStatusCode.Forbidden
                 && (Enum.IsDefined(typeof(KnownCosmosDbCmkSubStatusValueClientIssue), exception.SubStatusCode) || exception.SubStatusCode == 3);
         }
+
+        /// <summary>
+        /// The Cosmos SDK will at times return a 503 error, whith additional info in the
+        /// body of the message indicating that the exception is due to a timeout
+        /// </summary>
+        /// <param name="exception">The exception object</param>
+        /// <returns>bool if request timeout found in the body of the message</returns>
+        public static bool IsServiceUnavailableDueToTimeout(this CosmosException exception)
+        {
+            if (exception.StatusCode == HttpStatusCode.ServiceUnavailable)
+            {
+                if (exception.Message.Contains("RequestTimeout", StringComparison.OrdinalIgnoreCase) ||
+                    exception.InnerException.Message.Contains("RequestTimeout", StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            return false;
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -138,17 +138,9 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
                 {
                     // this means there is already an existing version of this resource
                 }
-                catch (CosmosException e) when (e.StatusCode == HttpStatusCode.ServiceUnavailable)
+                catch (CosmosException e) when (e.IsServiceUnavailableDueToTimeout())
                 {
-                    if ((e.Message != null && e.Message.Contains("RequestTimeout", StringComparison.OrdinalIgnoreCase)) ||
-                        (e.InnerException != null && e.InnerException.Message != null && e.InnerException.Message.Contains("RequestTimeout", StringComparison.OrdinalIgnoreCase)))
-                    {
-                        throw new CosmosException(e.Message, HttpStatusCode.RequestTimeout, e.SubStatusCode, e.ActivityId, e.RequestCharge);
-                    }
-                    else
-                    {
-                        throw;
-                    }
+                    throw new CosmosException(e.Message, HttpStatusCode.RequestTimeout, e.SubStatusCode, e.ActivityId, e.RequestCharge);
                 }
             }
 

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -171,17 +171,9 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
 
                     throw;
                 }
-                catch (CosmosException e) when (e.StatusCode == HttpStatusCode.ServiceUnavailable)
+                catch (CosmosException e) when (e.IsServiceUnavailableDueToTimeout())
                 {
-                    if (e.Message.Contains("RequestTimeout", StringComparison.OrdinalIgnoreCase) ||
-                        e.InnerException.Message.Contains("RequestTimeout", StringComparison.OrdinalIgnoreCase))
-                    {
-                        throw new CosmosException(e.Message, HttpStatusCode.RequestTimeout, e.SubStatusCode, e.ActivityId, e.RequestCharge);
-                    }
-                    else
-                    {
-                        throw;
-                    }
+                    throw new CosmosException(e.Message, HttpStatusCode.RequestTimeout, e.SubStatusCode, e.ActivityId, e.RequestCharge);
                 }
 
                 if (weakETag != null && weakETag.VersionId != existingItemResource.Version)

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -171,6 +171,18 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
 
                     throw;
                 }
+                catch (CosmosException e) when (e.StatusCode == HttpStatusCode.ServiceUnavailable)
+                {
+                    if (e.Message.Contains("RequestTimeout", StringComparison.OrdinalIgnoreCase) ||
+                        e.InnerException.Message.Contains("RequestTimeout", StringComparison.OrdinalIgnoreCase))
+                    {
+                        throw new CosmosException(e.Message, HttpStatusCode.RequestTimeout, e.SubStatusCode, e.ActivityId, e.RequestCharge);
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
 
                 if (weakETag != null && weakETag.VersionId != existingItemResource.Version)
                 {

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/RetryExceptionPolicyFactory.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/RetryExceptionPolicyFactory.cs
@@ -58,6 +58,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
         {
             return Policy.Handle<RequestRateExceededException>()
                 .Or<CosmosException>(e => e.IsRequestRateExceeded())
+                .Or<CosmosException>(e => e.StatusCode == System.Net.HttpStatusCode.ServiceUnavailable)
                 .WaitAndRetryAsync(
                     retryCount: maxRetries,
                     sleepDurationProvider: (_, e, _) => e.AsRequestRateExceeded()?.RetryAfter ?? TimeSpan.FromSeconds(2),


### PR DESCRIPTION
## Description
The cosmos SDK will sometimes return a 503 Service Unavailable error after an underlying timeout occurs.  We should retry this error to see if we can get past this problem.

## Related issues
Addresses [issue [AB#83327](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/83327)].

## Testing
Unit test was added

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
Skip