### PR TITLE
Refactoring related to continuation token.

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportJobTaskTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportJobTaskTests.cs
@@ -237,7 +237,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
             // Third search returns a search result without continuation token.
             _searchService.SearchAsync(
                 null,
-                Arg.Is(CreateQueryParametersExpressionWithContinuationToken(ContinuationTokenConverter.Encode(continuationToken), KnownResourceTypes.Patient)),
+                Arg.Is(CreateQueryParametersExpressionWithContinuationToken(ContinuationTokenConverter.Encode(newContinuationToken), KnownResourceTypes.Patient)),
                 _cancellationToken)
                 .Returns(x =>
                 {
@@ -276,7 +276,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
             // Second search returns a search result with continuation token.
             _searchService.SearchAsync(
                 null,
-                Arg.Is(CreateQueryParametersExpressionWithContinuationToken(Convert.ToBase64String(Encoding.UTF8.GetBytes(continuationToken)), _exportJobRecord.Since, KnownResourceTypes.Patient)),
+                Arg.Is(CreateQueryParametersExpressionWithContinuationToken(ContinuationTokenConverter.Encode(continuationToken), _exportJobRecord.Since, KnownResourceTypes.Patient)),
                 _cancellationToken)
                 .Returns(x =>
                 {
@@ -290,7 +290,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
             // Third search returns a search result without continuation token.
             _searchService.SearchAsync(
                 null,
-                Arg.Is(CreateQueryParametersExpressionWithContinuationToken(ContinuationTokenConverter.Encode(continuationToken), _exportJobRecord.Since, KnownResourceTypes.Patient)),
+                Arg.Is(CreateQueryParametersExpressionWithContinuationToken(ContinuationTokenConverter.Encode(newContinuationToken), _exportJobRecord.Since, KnownResourceTypes.Patient)),
                 _cancellationToken)
                 .Returns(x =>
                 {

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportJobTaskTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportJobTaskTests.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
             // Second search returns a search result without continuation token.
             _searchService.SearchAsync(
                 null,
-                Arg.Is(CreateQueryParametersExpressionWithContinuationToken(Convert.ToBase64String(Encoding.UTF8.GetBytes(continuationToken)), KnownResourceTypes.Patient)),
+                Arg.Is(CreateQueryParametersExpressionWithContinuationToken(ContinuationTokenConverter.Encode(continuationToken), KnownResourceTypes.Patient)),
                 _cancellationToken)
                 .Returns(x =>
                 {
@@ -185,7 +185,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
             // Second search returns a search result without continuation token.
             _searchService.SearchAsync(
                 null,
-                Arg.Is(CreateQueryParametersExpressionWithContinuationToken(Convert.ToBase64String(Encoding.UTF8.GetBytes(continuationToken)), _exportJobRecord.Since, KnownResourceTypes.Patient)),
+                Arg.Is(CreateQueryParametersExpressionWithContinuationToken(ContinuationTokenConverter.Encode(continuationToken), _exportJobRecord.Since, KnownResourceTypes.Patient)),
                 _cancellationToken)
                 .Returns(x =>
                 {
@@ -223,7 +223,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
             // Second search returns a search result with continuation token.
             _searchService.SearchAsync(
                 null,
-                Arg.Is(CreateQueryParametersExpressionWithContinuationToken(Convert.ToBase64String(Encoding.UTF8.GetBytes(continuationToken)), KnownResourceTypes.Patient)),
+                Arg.Is(CreateQueryParametersExpressionWithContinuationToken(ContinuationTokenConverter.Encode(continuationToken), KnownResourceTypes.Patient)),
                 _cancellationToken)
                 .Returns(x =>
                 {
@@ -237,7 +237,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
             // Third search returns a search result without continuation token.
             _searchService.SearchAsync(
                 null,
-                Arg.Is(CreateQueryParametersExpressionWithContinuationToken(Convert.ToBase64String(Encoding.UTF8.GetBytes(newContinuationToken)), KnownResourceTypes.Patient)),
+                Arg.Is(CreateQueryParametersExpressionWithContinuationToken(ContinuationTokenConverter.Encode(continuationToken), KnownResourceTypes.Patient)),
                 _cancellationToken)
                 .Returns(x =>
                 {
@@ -290,7 +290,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
             // Third search returns a search result without continuation token.
             _searchService.SearchAsync(
                 null,
-                Arg.Is(CreateQueryParametersExpressionWithContinuationToken(Convert.ToBase64String(Encoding.UTF8.GetBytes(newContinuationToken)), _exportJobRecord.Since, KnownResourceTypes.Patient)),
+                Arg.Is(CreateQueryParametersExpressionWithContinuationToken(ContinuationTokenConverter.Encode(continuationToken), _exportJobRecord.Since, KnownResourceTypes.Patient)),
                 _cancellationToken)
                 .Returns(x =>
                 {

--- a/src/Microsoft.Health.Fhir.Core/Extensions/SearchServiceExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Extensions/SearchServiceExtensions.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Health.Fhir.Core.Extensions
 
             if (!string.IsNullOrEmpty(continuationToken))
             {
-                filteredParameters.Add(Tuple.Create(KnownQueryParameterNames.ContinuationToken, Convert.ToBase64String(Encoding.UTF8.GetBytes(continuationToken))));
+                filteredParameters.Add(Tuple.Create(KnownQueryParameterNames.ContinuationToken, ContinuationTokenConverter.Encode(continuationToken)));
             }
 
             SearchResult results = await searchService.SearchAsync(instanceType, filteredParameters.ToImmutableList(), cancellationToken);

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
@@ -239,21 +239,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
                     queryParams.Add(new Tuple<string, string>(KnownQueryParameterNames.ContinuationToken, continuationToken));
                 }
 
-                var searchOptions = new SearchOptions();
-                searchOptions.MaxItemCount = 2;
-                searchOptions.Sort = new List<(SearchParameterInfo, SortOrder)>();
-                searchOptions.UnsupportedSearchParams = new List<Tuple<string, string>>();
-
-                // searchOptions.Expression = Expression.SearchParameter(_resourceTypeSearchParameter, Expression.StringEquals(FieldName.TokenCode, null, KnownResourceTypes.Patient, false));
                 var result = await search.Value.SearchAsync("SearchParameter", queryParams, cancellationToken);
-                if (!string.IsNullOrEmpty(result?.ContinuationToken))
-                {
-                    continuationToken = ContinuationTokenConverter.Encode(result.ContinuationToken);
-                }
-                else
-                {
-                    continuationToken = null;
-                }
+                continuationToken = string.IsNullOrEmpty(result?.ContinuationToken) ? null : ContinuationTokenConverter.Encode(result.ContinuationToken);
 
                 if (result?.Results != null && result.Results.Any())
                 {

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
@@ -239,10 +239,16 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
                     queryParams.Add(new Tuple<string, string>(KnownQueryParameterNames.ContinuationToken, continuationToken));
                 }
 
+                var searchOptions = new SearchOptions();
+                searchOptions.MaxItemCount = 2;
+                searchOptions.Sort = new List<(SearchParameterInfo, SortOrder)>();
+                searchOptions.UnsupportedSearchParams = new List<Tuple<string, string>>();
+
+                // searchOptions.Expression = Expression.SearchParameter(_resourceTypeSearchParameter, Expression.StringEquals(FieldName.TokenCode, null, KnownResourceTypes.Patient, false));
                 var result = await search.Value.SearchAsync("SearchParameter", queryParams, cancellationToken);
                 if (!string.IsNullOrEmpty(result?.ContinuationToken))
                 {
-                    continuationToken = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(result.ContinuationToken));
+                    continuationToken = ContinuationTokenConverter.Encode(result.ContinuationToken);
                 }
                 else
                 {

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -658,7 +658,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
         {
             // Update the continuation token in local cache and queryParams.
             // We will add or udpate the continuation token in the query parameters list.
-            progress.UpdateContinuationToken(Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(continuationToken)));
+            progress.UpdateContinuationToken(ContinuationTokenConverter.Encode(continuationToken));
 
             bool replacedContinuationToken = false;
             for (int index = 0; index < queryParametersList.Count; index++)

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -446,7 +446,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     // For cases like retry or stale query we don't want to start another chain.
                     if (!string.IsNullOrEmpty(results?.ContinuationToken) && !query.CreatedChild)
                     {
-                        var encodedContinuationToken = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(results.ContinuationToken));
+                        var encodedContinuationToken = ContinuationTokenConverter.Encode(results.ContinuationToken));
                         var nextQuery = new ReindexJobQueryStatus(query.ResourceType, encodedContinuationToken)
                         {
                             LastModified = Clock.UtcNow,

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -446,7 +446,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     // For cases like retry or stale query we don't want to start another chain.
                     if (!string.IsNullOrEmpty(results?.ContinuationToken) && !query.CreatedChild)
                     {
-                        var encodedContinuationToken = ContinuationTokenConverter.Encode(results.ContinuationToken));
+                        var encodedContinuationToken = ContinuationTokenConverter.Encode(results.ContinuationToken);
                         var nextQuery = new ReindexJobQueryStatus(query.ResourceType, encodedContinuationToken)
                         {
                             LastModified = Clock.UtcNow,

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/ContinuationTokenConverter.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/ContinuationTokenConverter.cs
@@ -1,0 +1,32 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using EnsureThat;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
+
+namespace Microsoft.Health.Fhir.Core.Features.Search
+{
+    public sealed class ContinuationTokenConverter
+    {
+        public static string Decode(string encodedContinuationToken)
+        {
+            try
+            {
+                return System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(encodedContinuationToken));
+            }
+            catch (FormatException)
+            {
+                throw new BadRequestException(Resources.InvalidContinuationToken);
+            }
+        }
+
+        public static string Encode(string continuationToken)
+        {
+            EnsureArg.IsNotEmptyOrWhiteSpace(continuationToken);
+            return Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(continuationToken));
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/BundleFactoryTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/BundleFactoryTests.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         [Fact]
         public void GivenASearchResultWithContinuationToken_WhenCreateSearchBundle_ThenCorrectBundleShouldBeReturned()
         {
-            string encodedContinuationToken = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(_continuationToken));
+            string encodedContinuationToken = ContinuationTokenConverter.Encode(_continuationToken);
             _urlResolver.ResolveRouteUrl(_unsupportedSearchParameters, null, encodedContinuationToken, true).Returns(_nextUrl);
             _urlResolver.ResolveRouteUrl(_unsupportedSearchParameters).Returns(_selfUrl);
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
@@ -428,19 +428,19 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             searchService.SearchAsync(
                 "SearchParameter",
                 Arg.Is<IReadOnlyList<Tuple<string, string>>>(
-                    l => l.FirstOrDefault().Item2 == Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes("token"))),
+                    l => l.FirstOrDefault().Item2 == ContinuationTokenConverter.Encode("token")),
                 Arg.Any<CancellationToken>())
                 .Returns(result2);
             searchService.SearchAsync(
                 "SearchParameter",
                 Arg.Is<IReadOnlyList<Tuple<string, string>>>(
-                    l => l.FirstOrDefault().Item2 == Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes("token2"))),
+                    l => l.FirstOrDefault().Item2 == ContinuationTokenConverter.Encode("token2")),
                 Arg.Any<CancellationToken>())
                 .Returns(result3);
             searchService.SearchAsync(
                 "SearchParameter",
                 Arg.Is<IReadOnlyList<Tuple<string, string>>>(
-                    l => l.FirstOrDefault().Item2 == Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes("token3"))),
+                    l => l.FirstOrDefault().Item2 == ContinuationTokenConverter.Encode("token3")),
                 Arg.Any<CancellationToken>())
                 .Returns(result4);
 

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
@@ -66,9 +66,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
             }
 
             SearchResult searchResult;
-            string encodedInternalContinuationToken = string.IsNullOrEmpty(continuationToken)
+            string encodedInternalContinuationToken = string.IsNullOrEmpty(token.InternalContinuationToken)
                 ? null
-                : ContinuationTokenConverter.Encode(continuationToken);
+                : ContinuationTokenConverter.Encode(token.InternalContinuationToken);
             IReadOnlyList<string> types = string.IsNullOrEmpty(type) ? new List<string>() : type.SplitByOrSeparator();
 
             var phase = token.Phase;

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
         {
             EverythingOperationContinuationToken token = string.IsNullOrEmpty(continuationToken)
                 ? new EverythingOperationContinuationToken(0, null)
-                : EverythingOperationContinuationToken.FromString(DecodeContinuationTokenFromBase64String(continuationToken));
+                : EverythingOperationContinuationToken.FromString(ContinuationTokenConverter.Decode(continuationToken));
 
             if (token == null || token.Phase < 0 || token.Phase > 3)
             {
@@ -66,7 +66,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
             }
 
             SearchResult searchResult;
-            string encodedInternalContinuationToken = EncodeContinuationToken(token.InternalContinuationToken);
+            string encodedInternalContinuationToken = string.IsNullOrEmpty(continuationToken)
+                ? null
+                : ContinuationTokenConverter.Encode(continuationToken);
             IReadOnlyList<string> types = string.IsNullOrEmpty(type) ? new List<string>() : type.SplitByOrSeparator();
 
             var phase = token.Phase;
@@ -335,25 +337,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
             using IScoped<ISearchService> search = _searchServiceFactory();
             SearchOptions searchOptions = _searchOptionsFactory.Create(ResourceType.Patient.ToString(), resourceId, null, searchParameters);
             return await search.Value.SearchAsync(searchOptions, cancellationToken);
-        }
-
-        private static string DecodeContinuationTokenFromBase64String(string encodedString)
-        {
-            try
-            {
-                return System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(encodedString));
-            }
-            catch (FormatException)
-            {
-                throw new BadRequestException(Core.Resources.InvalidContinuationToken);
-            }
-        }
-
-        private static string EncodeContinuationToken(string continuationToken)
-        {
-            return string.IsNullOrEmpty(continuationToken)
-                ? null
-                : Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(continuationToken));
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/BundleFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/BundleFactory.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                     bundle.NextLink = _urlResolver.ResolveRouteUrl(
                         result.UnsupportedSearchParameters,
                         result.SortOrder,
-                        Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(result.ContinuationToken)),
+                        ContinuationTokenConverter.Encode(result.ContinuationToken),
                         true);
                 }
                 catch (UriFormatException)

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -4,12 +4,10 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
-using DotLiquid.Tags;
 using EnsureThat;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
@@ -92,15 +90,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                             string.Format(Core.Resources.MultipleQueryParametersNotAllowed, KnownQueryParameterNames.ContinuationToken));
                     }
 
-                    try
-                    {
-                        continuationToken = System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(query.Item2));
-                    }
-                    catch (FormatException)
-                    {
-                        throw new BadRequestException(Core.Resources.InvalidContinuationToken);
-                    }
-
+                    continuationToken = ContinuationTokenConverter.Decode(query.Item2);
                     setDefaultBundleTotal = false;
                 }
                 else if (query.Item1 == KnownQueryParameterNames.Format || query.Item1 == KnownQueryParameterNames.Pretty)

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Validation/ServerProvideProfileValidation.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Validation/ServerProvideProfileValidation.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
                             var queryParameters = new List<Tuple<string, string>>();
                             if (ct != null)
                             {
-                                ct = Convert.ToBase64String(Encoding.UTF8.GetBytes(ct));
+                                ct = ContinuationTokenConverter.Encode(ct);
                                 queryParameters.Add(new Tuple<string, string>(KnownQueryParameterNames.ContinuationToken, ct));
                             }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/ContinuationToken.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/ContinuationToken.cs
@@ -7,7 +7,7 @@ using System;
 using System.Globalization;
 using System.Text.Json;
 
-namespace Microsoft.Health.Fhir.Core.Features.Search
+namespace Microsoft.Health.Fhir.SqlServer.Features.Search
 {
     /// <summary>
     /// Represents the search continuation token.


### PR DESCRIPTION
## Description
- Adds ContinuationTokenConverter class as single place to keep logic related to encoding/decoding continuation token.
- Move ContinuationToken from Core project to SqlServer since it's SqlServer specific.


## Related issues

## Testing
Through existing unit tests.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip
