### PR TITLE
Break cycle dependency between search service and search definition manager

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionBuilder.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionBuilder.cs
@@ -19,7 +19,6 @@ using Microsoft.Health.Fhir.Core.Data;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Features.Definition.BundleWrappers;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
-using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.ValueSets;
 
@@ -162,7 +161,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             var validatedSearchParameters = new List<(string ResourceType, SearchParameterInfo SearchParameter)>
             {
                 // _type is currently missing from the search params definition bundle, so we inject it in here.
-                (KnownResourceTypes.Resource, new SearchParameterInfo(SearchParameterNames.ResourceType, SearchParameterNames.ResourceType, SearchParamType.Token, SearchParameterNames.ResourceTypeUri, null, "Resource.type().name", null)),
+                (KnownResourceTypes.Resource, SearchParameterInfo.ResourceSearchParameter),
             };
 
             // Do the second pass to make sure the definition is valid.

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionBuilder.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionBuilder.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             var validatedSearchParameters = new List<(string ResourceType, SearchParameterInfo SearchParameter)>
             {
                 // _type is currently missing from the search params definition bundle, so we inject it in here.
-                (KnownResourceTypes.Resource, SearchParameterInfo.ResourceSearchParameter),
+                (KnownResourceTypes.Resource, SearchParameterInfo.ResourceTypeSearchParameter),
             };
 
             // Do the second pass to make sure the definition is valid.

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
@@ -20,6 +20,7 @@ using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Definition.BundleWrappers;
 using Microsoft.Health.Fhir.Core.Features.Search;
+using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
 using Microsoft.Health.Fhir.Core.Messages.CapabilityStatement;
 using Microsoft.Health.Fhir.Core.Messages.Search;
 using Microsoft.Health.Fhir.Core.Messages.Storage;
@@ -233,14 +234,17 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             string continuationToken = null;
             do
             {
-                var queryParams = new List<Tuple<string, string>>();
+                var searchOptions = new SearchOptions();
+                searchOptions.Sort = new List<(SearchParameterInfo, SortOrder)>();
+                searchOptions.UnsupportedSearchParams = new List<Tuple<string, string>>();
+                searchOptions.Expression = Expression.SearchParameter(SearchParameterInfo.ResourceSearchParameter, Expression.StringEquals(FieldName.TokenCode, null, KnownResourceTypes.SearchParameter, false));
                 if (continuationToken != null)
                 {
-                    queryParams.Add(new Tuple<string, string>(KnownQueryParameterNames.ContinuationToken, continuationToken));
+                    searchOptions.ContinuationToken = continuationToken;
                 }
 
-                var result = await search.Value.SearchAsync("SearchParameter", queryParams, cancellationToken);
-                continuationToken = string.IsNullOrEmpty(result?.ContinuationToken) ? null : ContinuationTokenConverter.Encode(result.ContinuationToken);
+                var result = await search.Value.SearchAsync(searchOptions, cancellationToken);
+                continuationToken = result?.ContinuationToken;
 
                 if (result?.Results != null && result.Results.Any())
                 {

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
@@ -237,7 +237,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
                 var searchOptions = new SearchOptions();
                 searchOptions.Sort = new List<(SearchParameterInfo, SortOrder)>();
                 searchOptions.UnsupportedSearchParams = new List<Tuple<string, string>>();
-                searchOptions.Expression = Expression.SearchParameter(SearchParameterInfo.ResourceSearchParameter, Expression.StringEquals(FieldName.TokenCode, null, KnownResourceTypes.SearchParameter, false));
+                searchOptions.Expression = Expression.SearchParameter(SearchParameterInfo.ResourceTypeSearchParameter, Expression.StringEquals(FieldName.TokenCode, null, KnownResourceTypes.SearchParameter, false));
                 if (continuationToken != null)
                 {
                     searchOptions.ContinuationToken = continuationToken;

--- a/src/Microsoft.Health.Fhir.Core/Models/SearchParameterInfo.cs
+++ b/src/Microsoft.Health.Fhir.Core/Models/SearchParameterInfo.cs
@@ -13,6 +13,7 @@ using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Utility;
 using Hl7.FhirPath;
 using Microsoft.Health.Fhir.Core.Features.Definition.BundleWrappers;
+using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.ValueSets;
 
 namespace Microsoft.Health.Fhir.Core.Models
@@ -20,6 +21,8 @@ namespace Microsoft.Health.Fhir.Core.Models
     [DebuggerDisplay("{Name}, Type: {Type}")]
     public class SearchParameterInfo : IEquatable<SearchParameterInfo>
     {
+        public static readonly SearchParameterInfo ResourceTypeSearchParameter = new SearchParameterInfo(SearchParameterNames.ResourceType, SearchParameterNames.ResourceType, SearchParamType.Token, SearchParameterNames.ResourceTypeUri, null, "Resource.type().name", null);
+
         public SearchParameterInfo(
             string name,
             string code,

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
             _physicalPartitionInfo = physicalPartitionInfo;
             _queryPartitionStatisticsCache = queryPartitionStatisticsCache;
             _logger = logger;
-            _resourceTypeSearchParameter = SearchParameterInfo.ResourceSearchParameter;
+            _resourceTypeSearchParameter = SearchParameterInfo.ResourceTypeSearchParameter;
             _resourceIdSearchParameter = new SearchParameterInfo(SearchParameterNames.Id, SearchParameterNames.Id);
         }
 

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
@@ -18,7 +18,6 @@ using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Context;
-using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
@@ -49,7 +48,6 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
             ISearchOptionsFactory searchOptionsFactory,
             CosmosFhirDataStore fhirDataStore,
             IQueryBuilder queryBuilder,
-            ISearchParameterDefinitionManager searchParameterDefinitionManager,
             RequestContextAccessor<IFhirRequestContext> requestContextAccessor,
             CosmosDataStoreConfiguration cosmosConfig,
             ICosmosDbCollectionPhysicalPartitionInfo physicalPartitionInfo,
@@ -59,7 +57,6 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
         {
             EnsureArg.IsNotNull(fhirDataStore, nameof(fhirDataStore));
             EnsureArg.IsNotNull(queryBuilder, nameof(queryBuilder));
-            EnsureArg.IsNotNull(searchParameterDefinitionManager, nameof(searchParameterDefinitionManager));
             EnsureArg.IsNotNull(requestContextAccessor, nameof(requestContextAccessor));
             EnsureArg.IsNotNull(cosmosConfig, nameof(cosmosConfig));
             EnsureArg.IsNotNull(physicalPartitionInfo, nameof(physicalPartitionInfo));
@@ -73,8 +70,8 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
             _physicalPartitionInfo = physicalPartitionInfo;
             _queryPartitionStatisticsCache = queryPartitionStatisticsCache;
             _logger = logger;
-            _resourceTypeSearchParameter = searchParameterDefinitionManager.GetSearchParameter(KnownResourceTypes.Resource, SearchParameterNames.ResourceType);
-            _resourceIdSearchParameter = searchParameterDefinitionManager.GetSearchParameter(KnownResourceTypes.Resource, SearchParameterNames.Id);
+            _resourceTypeSearchParameter = SearchParameterInfo.ResourceSearchParameter;
+            _resourceIdSearchParameter = new SearchParameterInfo(SearchParameterNames.Id, SearchParameterNames.Id);
         }
 
         public override async Task<SearchResult> SearchAsync(

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
@@ -423,26 +423,23 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
             var searchService = Substitute.For<ISearchService>();
 
-            searchService.SearchAsync("SearchParameter", Arg.Is<IReadOnlyList<Tuple<string, string>>>(l => !l.Any()), Arg.Any<CancellationToken>())
+            searchService.SearchAsync(Arg.Is<SearchOptions>(options => options.ContinuationToken == null), Arg.Any<CancellationToken>())
                 .Returns(result);
             searchService.SearchAsync(
-                "SearchParameter",
-                Arg.Is<IReadOnlyList<Tuple<string, string>>>(
-                    l => l.FirstOrDefault().Item2 == ContinuationTokenConverter.Encode("token")),
+                Arg.Is<SearchOptions>(
+                    options => options.ContinuationToken == "token"),
                 Arg.Any<CancellationToken>())
                 .Returns(result2);
             searchService.SearchAsync(
-                "SearchParameter",
-                Arg.Is<IReadOnlyList<Tuple<string, string>>>(
-                    l => l.FirstOrDefault().Item2 == ContinuationTokenConverter.Encode("token2")),
-                Arg.Any<CancellationToken>())
-                .Returns(result3);
+               Arg.Is<SearchOptions>(
+                   options => options.ContinuationToken == "token2"),
+               Arg.Any<CancellationToken>())
+               .Returns(result3);
             searchService.SearchAsync(
-                "SearchParameter",
-                Arg.Is<IReadOnlyList<Tuple<string, string>>>(
-                    l => l.FirstOrDefault().Item2 == ContinuationTokenConverter.Encode("token3")),
-                Arg.Any<CancellationToken>())
-                .Returns(result4);
+               Arg.Is<SearchOptions>(
+                   options => options.ContinuationToken == "token3"),
+               Arg.Any<CancellationToken>())
+               .Returns(result4);
 
             var dataStoreSearchParamValidator = Substitute.For<IDataStoreSearchParameterValidator>();
             dataStoreSearchParamValidator.ValidateSearchParameter(Arg.Any<SearchParameterInfo>(), out Arg.Any<string>()).Returns(true);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
@@ -183,7 +183,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 searchOptionsFactory,
                 _fhirDataStore,
                 new QueryBuilder(),
-                _searchParameterDefinitionManager,
                 fhirRequestContextAccessor,
                 _cosmosDataStoreConfiguration,
                 cosmosDbPhysicalPartitionInfo,

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -188,7 +188,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 SqlConnectionWrapperFactory,
                 schemaInformation,
                 fhirRequestContextAccessor,
-                () => searchableSearchParameterDefinitionManager,
                 NullLogger<SqlServerSearchService>.Instance);
 
             ISearchParameterSupportResolver searchParameterSupportResolver = Substitute.For<ISearchParameterSupportResolver>();


### PR DESCRIPTION
## Description
Move search definition manager from search service.

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
