### PR TITLE
Addresses issue with delete CustomSearch parameter, adds back one ValidateTest

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
@@ -202,12 +202,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
 
                     updated.Add(param);
                 }
-                else if (paramStatus.Status != SearchParameterStatus.Deleted)
+                else if (!updatedSearchParameterStatus.Where(p => p.Uri.Equals(paramStatus) && p.Status == SearchParameterStatus.Deleted).Any())
                 {
                     // if we cannot find the search parameter in the search parameter definition manager
-                    // and the status is set to deleted, then it simply means a parameter was marked
-                    // deleted before it was added to this instance, and there is no issue
-                    // however if the status is not deleted, then we have an issue
+                    // and there is an entry in the list of updates with a delete status then it indicates
+                    // the search parameter was deleted before it was added to this instance, and there is no issue
+                    // however if there is no indication that the search parameter was deleted, then there is a problem
                     throw new UnableToUpdateSearchParameterException(paramStatus.Uri);
                 }
             }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
@@ -202,7 +202,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
 
                     updated.Add(param);
                 }
-                else if (!updatedSearchParameterStatus.Where(p => p.Uri.Equals(paramStatus) && p.Status == SearchParameterStatus.Deleted).Any())
+                else if (!updatedSearchParameterStatus.Any(p => p.Uri.Equals(paramStatus.Uri) && p.Status == SearchParameterStatus.Deleted))
                 {
                     // if we cannot find the search parameter in the search parameter definition manager
                     // and there is an entry in the list of updates with a delete status then it indicates

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                         await Task.Delay(10000);
                     }
                 }
-                while (!success && retryCount < 3);
+                while (!success && retryCount < 10);
 
                 Assert.True(success);
             }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -450,6 +450,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             }
             catch (FhirException ex) when (ex.StatusCode == HttpStatusCode.BadRequest && ex.Message.Contains("not enabled"))
             {
+                _output.WriteLine($"Skipping because reindex is disabled.");
                 Skip.If(!_fixture.IsUsingInProcTestServer, "Reindex is not enabled on this server.");
                 return;
             }
@@ -503,12 +504,25 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                     }
                     catch (Exception exp)
                     {
-                        _output.WriteLine($"Failed to delete searchParameter: {exp}");
+                        var fhirException = exp as FhirException;
+                        if (fhirException != null && fhirException.OperationOutcome?.Issue != null)
+                        {
+                            foreach (var issue in fhirException.OperationOutcome.Issue)
+                            {
+                                _output.WriteLine("Issue: {message}", issue.Diagnostics);
+                            }
+                        }
+                        else
+                        {
+                            _output.WriteLine($"Failed to delete searchParameter: {exp}");
+                        }
+
                         success = false;
                         await Task.Delay(10000);
                     }
                 }
                 while (!success && retryCount < 5);
+
                 Assert.True(success);
                 var ex = await Assert.ThrowsAsync<FhirException>(() => Client.ReadAsync<SearchParameter>(ResourceType.SearchParameter, searchParam.Id));
                 Assert.Contains("Gone", ex.Message);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ValidateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ValidateTests.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [InlineData("Patient/$validate", "Profile-Patient-uscore", "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient")]
         [InlineData("Organization/$validate", "Profile-Organization-uscore", "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization")]
         [InlineData("Organization/$validate", "Profile-Organization-uscore-endpoint", "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization")]
+        [InlineData("CarePlan/$validate", "Profile-CarePlan-uscore", "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan")]
         [InlineData("Patient/$validate", "Profile-Patient-uscore", null)]
         [InlineData("Organization/$validate", "Profile-Organization-uscore", null)]
         [InlineData("Organization/$validate", "Profile-Organization-uscore-endpoint", null)]


### PR DESCRIPTION
## Description
Addresses the delete failure with CustomSearch parameters.  Adds back one missing test case on Validate tests

## Related issues
Addresses [issue [AB#82428](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/82428)].

## Testing
Reran the branch against CI environment

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
Skip