### PR TITLE
Makes ConditionalDelete tests more durable

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TestFhirServer.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TestFhirServer.cs
@@ -8,6 +8,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
 using System.Threading;
@@ -235,7 +236,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
                         return false;
                     })
-                    .OrResult<HttpResponseMessage>(message => (int)message.StatusCode == 429)
+                    .OrResult<HttpResponseMessage>(message => message.StatusCode == HttpStatusCode.TooManyRequests ||
+                                                              message.StatusCode == HttpStatusCode.ServiceUnavailable)
                     .WaitAndRetryAsync(3, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)));
             }
 


### PR DESCRIPTION
## Description
Makes ConditionalDelete tests more durable

## Related issues
Addresses [issue #].

## Testing
[AB#83793](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/83793)

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
