### PR TITLE
Remove case insensitivity in data types mapping 

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Data/R4/search-parameters.json
+++ b/src/Microsoft.Health.Fhir.Core/Data/R4/search-parameters.json
@@ -45840,7 +45840,7 @@
       },
       {
         "definition" : "http://hl7.org/fhir/SearchParameter/Observation-value-date",
-        "expression" : "value.as(DateTime) | value.as(Period)"
+        "expression" : "value.as(dateTime) | value.as(Period)"
       }]
     }
   },

--- a/src/Microsoft.Health.Fhir.Core/Data/R5/search-parameters.json
+++ b/src/Microsoft.Health.Fhir.Core/Data/R5/search-parameters.json
@@ -58554,7 +58554,7 @@
                     },
                     {
                         "definition": "http://hl7.org/fhir/SearchParameter/Observation-value-date",
-                        "expression": "value.as(DateTime) | value.as(Period)"
+                        "expression": "value.as(dateTime) | value.as(Period)"
                     }
                 ]
             }

--- a/src/Microsoft.Health.Fhir.Core/Data/Stu3/search-parameters.json
+++ b/src/Microsoft.Health.Fhir.Core/Data/Stu3/search-parameters.json
@@ -2656,7 +2656,7 @@
         ],
         "type": "date",
         "description": "Multiple Resources: \r\n\r\n* [Consent](consent.html): When this Consent was created or indexed\r\n* [SupplyRequest](supplyrequest.html): When the request was made\r\n* [RiskAssessment](riskassessment.html): When was assessment made?\r\n* [CareTeam](careteam.html): Time period team covers\r\n* [FamilyMemberHistory](familymemberhistory.html): When history was captured/updated\r\n* [Encounter](encounter.html): A date within the period the Encounter lasted\r\n* [AllergyIntolerance](allergyintolerance.html): Date record was believed accurate\r\n* [CarePlan](careplan.html): Time period plan covers\r\n* [EpisodeOfCare](episodeofcare.html): The provided date search value falls within the episode of care's period\r\n* [Procedure](procedure.html): Date/Period the procedure was performed\r\n* [List](list.html): When the list was prepared\r\n* [Immunization](immunization.html): Vaccination  (non)-Administration Date\r\n* [Flag](flag.html): Time period when flag is active\r\n* [Observation](observation.html): Obtained date/time. If the obtained element is a period, a date that falls in the period\r\n* [DiagnosticReport](diagnosticreport.html): The clinically relevant time of the report\r\n* [Composition](composition.html): Composition editing time\r\n* [DetectedIssue](detectedissue.html): When identified\r\n* [ClinicalImpression](clinicalimpression.html): When the assessment was documented\r\n",
-        "expression": "Consent.dateTime | SupplyRequest.authoredOn | RiskAssessment.occurrence.as(DateTime) | CareTeam.period | FamilyMemberHistory.date | Encounter.period | AllergyIntolerance.assertedDate | CarePlan.period | EpisodeOfCare.period | Procedure.performed | List.date | Immunization.date | Flag.period | Observation.effective | DiagnosticReport.effective | Composition.date | DetectedIssue.date | ClinicalImpression.date",
+        "expression": "Consent.dateTime | SupplyRequest.authoredOn | RiskAssessment.occurrence.as(dateTime) | CareTeam.period | FamilyMemberHistory.date | Encounter.period | AllergyIntolerance.assertedDate | CarePlan.period | EpisodeOfCare.period | Procedure.performed | List.date | Immunization.date | Flag.period | Observation.effective | DiagnosticReport.effective | Composition.date | DetectedIssue.date | ClinicalImpression.date",
         "xpath": "f:Consent/f:dateTime | f:SupplyRequest/f:authoredOn | f:RiskAssessment/f:occurrenceDateTime | f:CareTeam/f:period | f:FamilyMemberHistory/f:date | f:Encounter/f:period | f:AllergyIntolerance/f:assertedDate | f:CarePlan/f:period | f:EpisodeOfCare/f:period | f:Procedure/f:performedDateTime | f:Procedure/f:performedPeriod | f:List/f:date | f:Immunization/f:date | f:Flag/f:period | f:Observation/f:effectiveDateTime | f:Observation/f:effectivePeriod | f:DiagnosticReport/f:effectiveDateTime | f:DiagnosticReport/f:effectivePeriod | f:Composition/f:date | f:DetectedIssue/f:date | f:ClinicalImpression/f:date",
         "xpathUsage": "normal"
       }
@@ -11301,7 +11301,7 @@
         ],
         "type": "date",
         "description": "When scheduled",
-        "expression": "CommunicationRequest.occurrence.as(DateTime)",
+        "expression": "CommunicationRequest.occurrence.as(dateTime)",
         "xpath": "f:CommunicationRequest/f:occurrenceDateTime",
         "xpathUsage": "normal"
       }
@@ -13402,7 +13402,7 @@
         ],
         "type": "reference",
         "description": "Identifies the source of the concepts which are being mapped",
-        "expression": "ConceptMap.source.as(Uri)",
+        "expression": "ConceptMap.source.as(uri)",
         "xpath": "f:ConceptMap/f:sourceUri",
         "xpathUsage": "normal",
         "target": [
@@ -13608,7 +13608,7 @@
         ],
         "type": "reference",
         "description": "Provides context to the mappings",
-        "expression": "ConceptMap.target.as(Uri)",
+        "expression": "ConceptMap.target.as(uri)",
         "xpath": "f:ConceptMap/f:targetUri",
         "xpathUsage": "normal",
         "target": [
@@ -18354,7 +18354,7 @@
         ],
         "type": "date",
         "description": "When service should occur",
-        "expression": "DeviceRequest.occurrence.as(DateTime) | DeviceRequest.occurrence.as(Period)",
+        "expression": "DeviceRequest.occurrence.as(dateTime) | DeviceRequest.occurrence.as(Period)",
         "xpath": "f:DeviceRequest/f:occurrenceDateTime | f:DeviceRequest/f:occurrencePeriod",
         "xpathUsage": "normal"
       }
@@ -24442,7 +24442,7 @@
         ],
         "type": "date",
         "description": "When goal pursuit begins",
-        "expression": "Goal.start.as(Date)",
+        "expression": "Goal.start.as(date)",
         "xpath": "f:Goal/f:startDate",
         "xpathUsage": "normal"
       }
@@ -24567,7 +24567,7 @@
         ],
         "type": "date",
         "description": "Reach goal on or before",
-        "expression": "Goal.target.due.as(Date)",
+        "expression": "Goal.target.due.as(date)",
         "xpath": "f:Goal/f:target/f:dueDate",
         "xpathUsage": "normal"
       }
@@ -36857,7 +36857,7 @@
             "definition": {
               "reference": "http://hl7.org/fhir/SearchParameter/Observation-value-date"
             },
-            "expression": "value.as(DateTime) | value.as(Period)"
+            "expression": "value.as(dateTime) | value.as(Period)"
           }
         ]
       }
@@ -38056,7 +38056,7 @@
         ],
         "type": "date",
         "description": "The value of the observation, if the value is a date or period of time",
-        "expression": "Observation.value.as(DateTime) | Observation.value.as(Period)",
+        "expression": "Observation.value.as(dateTime) | Observation.value.as(Period)",
         "xpath": "f:Observation/f:valueDateTime | f:Observation/f:valuePeriod",
         "xpathUsage": "normal"
       }
@@ -38136,7 +38136,7 @@
         ],
         "type": "string",
         "description": "The value of the observation, if the value is a string, and also searches in CodeableConcept.text",
-        "expression": "Observation.value.as(String)",
+        "expression": "Observation.value.as(string)",
         "xpath": "f:Observation/f:valueString",
         "xpathUsage": "normal"
       }
@@ -39728,7 +39728,7 @@
         ],
         "type": "date",
         "description": "The date of death has been provided and satisfies this search value",
-        "expression": "Patient.deceased.as(DateTime)",
+        "expression": "Patient.deceased.as(dateTime)",
         "xpath": "f:Patient/f:deceasedDateTime",
         "xpathUsage": "normal"
       }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchIndexEntry.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchIndexEntry.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Diagnostics;
 using EnsureThat;
 using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
 using Microsoft.Health.Fhir.Core.Models;
@@ -13,6 +14,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
     /// <summary>
     /// Represents a search index entry.
     /// </summary>
+    [DebuggerDisplay("Parameter: {SearchParameter.Code} {Value}")]
     public class SearchIndexEntry : IEquatable<SearchIndexEntry>
     {
         /// <summary>

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Parameters/SearchParameterToTypeResolver.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Parameters/SearchParameterToTypeResolver.cs
@@ -305,20 +305,20 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
         {
             switch (type.ToUpperInvariant())
             {
-                case "AGE":
+                case "Age":
                     return GetMapping(typeof(Age));
-                case "DATETIME":
-                case "DATE":
+                case "dateTime":
+                case "date":
                     return GetMapping(typeof(FhirDateTime));
-                case "URI":
+                case "uri":
                     return GetMapping(typeof(FhirUri));
-                case "BOOLEAN":
+                case "boolean":
                     return GetMapping(typeof(FhirBoolean));
-                case "STRING":
+                case "string":
                     return GetMapping(typeof(FhirString));
-                case "PERIOD":
+                case "Period":
                     return GetMapping(typeof(Period));
-                case "RANGE":
+                case "Range":
                     return GetMapping(typeof(Range));
                 default:
                     return GetMapping(ModelInfoProvider.Instance.GetTypeForFhirType(type));

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Parameters/SearchParameterToTypeResolver.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Parameters/SearchParameterToTypeResolver.cs
@@ -303,7 +303,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
 
         private static ClassMapping GetMapping(string type)
         {
-            switch (type.ToUpperInvariant())
+            switch (type)
             {
                 case "Age":
                     return GetMapping(typeof(Age));


### PR DESCRIPTION
## Description
https://github.com/microsoft/fhir-server/blob/2790a877ec4397f9c61c129a99dbf9e6145ad84a/src/Microsoft.Health.Fhir.Core/Features/Search/TypedElementSearchIndexer.cs#L190

`.Select(fhirPathExpression)` is case sensitive so there is different results in doing `value.as(DateTime)` and `value.as(dateTime)`. First yield nothing, and second produce dateTime node.

This change normalizes case in search-parameter json files and put restriction in place in order to avoid this situation in future.

On a side note: all these search parameters currently produce nothing and can't be searched, but they are in `searchable` state and I'm not sure what we can do to reindex them, or put them in `supported` state.

## Related issues
Addresses [#2020].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
