### PR TITLE
Set max item count in search options in SearchParameterDefinitionManager

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
@@ -238,6 +238,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
                 searchOptions.Sort = new List<(SearchParameterInfo, SortOrder)>();
                 searchOptions.UnsupportedSearchParams = new List<Tuple<string, string>>();
                 searchOptions.Expression = Expression.SearchParameter(SearchParameterInfo.ResourceTypeSearchParameter, Expression.StringEquals(FieldName.TokenCode, null, KnownResourceTypes.SearchParameter, false));
+                searchOptions.MaxItemCount = 10;
                 if (continuationToken != null)
                 {
                     searchOptions.ContinuationToken = continuationToken;
@@ -275,7 +276,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
                     }
                 }
             }
-            while (continuationToken != null);
+            while (continuationToken != null && !continuationToken.Contains("null", StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
@@ -276,7 +276,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
                     }
                 }
             }
-            while (continuationToken != null && !continuationToken.Contains("null", StringComparison.OrdinalIgnoreCase));
+            while (continuationToken != null);
         }
     }
 }


### PR DESCRIPTION
## Description
Sets a value for MaxItemCount in searchOptions when searching for SearchParameter resources in SearchParameterDefinitionManager.

Downstream users of the searchOptions object expect a non-zero value to be populated in this field.  When it was left at zero, a bug would be encountered which generated an invalid continuationToken causing searches to fail.

This manifested in the Stu3-CI-SQL environment, where the SearchParameterDefinitionManager would fail to initialize, then the searchParameterHash value would not be initialized, and then subsequent requests would fail with an error that the searchParameterHash was not specified for a stored procedure.

## Related issues
Addresses [issue [AB#84143](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/84143)].

## Testing
Pointed my local environment at CI sql server, was able to repro the issue, made the fix and then the issue did not repro.

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
Skip