### PR TITLE
Adds Binary encoded JSON Patch in Bundles.

### DIFF
--- a/docs/rest/PatchRequests.http
+++ b/docs/rest/PatchRequests.http
@@ -152,3 +152,30 @@ Authorization: Bearer {{bearer.response.body.access_token}}
         "value": true
     }
 ]
+
+### Patch in a bundle
+## See: https://chat.fhir.org/#narrow/stream/179166-implementers/topic/Transaction.20with.20PATCH.20request
+
+POST https://{{hostname}}/
+content-type: application/json
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+{
+    "resourceType": "Bundle",
+    "id": "bundle-batch",
+    "type": "batch",
+    "entry": [
+        {
+            "fullUrl": "Patient/{{patient.response.body.id}}",
+            "resource": {
+                "resourceType": "Binary",
+                "contentType": "application/json-patch+json",
+                "data": "W3sib3AiOiJyZXBsYWNlIiwicGF0aCI6Ii9nZW5kZXIiLCJ2YWx1ZSI6ImZlbWFsZSJ9XQ=="
+            },
+            "request": {
+                "method": "PATCH",
+                "url": "Patient/{{patient.response.body.id}}"
+            }
+        }
+    ]
+}

--- a/src/Microsoft.Health.Fhir.Stu3.Api/Microsoft.Health.Fhir.Stu3.Api.csproj
+++ b/src/Microsoft.Health.Fhir.Stu3.Api/Microsoft.Health.Fhir.Stu3.Api.csproj
@@ -5,6 +5,10 @@
     <RootNamespace>Microsoft.Health.Fhir.Api</RootNamespace>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <DefineConstants>STU3</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="..\Microsoft.Health.Fhir.Shared.Api\Modules\AnonymizationModule.cs" Link="Modules\AnonymizationModule.cs" />
   </ItemGroup>

--- a/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
+++ b/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
@@ -247,6 +247,7 @@
     <EmbeddedResource Include="TestFiles\Normative\Appointment.json" />
     <EmbeddedResource Include="TestFiles\Normative\BloodGlucose.json" />
     <EmbeddedResource Include="TestFiles\Normative\BloodPressure.json" />
+    <EmbeddedResource Include="TestFiles\Normative\Bundle-BinaryPatch.json" />
     <EmbeddedResource Include="TestFiles\Normative\Bundle-TypeMissing.json" />
     <EmbeddedResource Include="TestFiles\Normative\Coverage.json" />
     <EmbeddedResource Include="TestFiles\Normative\SearchParameter-AppointmentStatus.json" />

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/Bundle-BinaryPatch.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/Bundle-BinaryPatch.json
@@ -1,0 +1,56 @@
+﻿{
+    "resourceType": "Bundle",
+    "id": "bundle-patch",
+    "meta": {
+        "lastUpdated": "2014-08-18T01:43:30Z"
+    },
+    "type": "batch",
+    "entry": [
+        {
+            "fullUrl": "Patient/9F746C86-48B4-424D-9F92-1E46215E35D5",
+            "resource": {
+                "id": "9F746C86-48B4-424D-9F92-1E46215E35D5",
+                "resourceType": "Patient",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"
+                },
+                "identifier": [
+                    {
+                        "system": "http:/example.org/fhir/ids",
+                        "value": "9F746C86-48B4-424D-9F92-1E46215E35D5"
+                    }
+                ],
+                "active": true,
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "Chalmers",
+                        "given": [
+                            "Peter",
+                            "James"
+                        ]
+                    }
+                ],
+                "gender": "male",
+                "birthDate": "1974-12-25"
+            },
+            "request": {
+                "method": "PUT",
+                "url": "Patient/9F746C86-48B4-424D-9F92-1E46215E35D5"
+            }
+        },
+        {
+            "fullUrl": "Patient/9F746C86-48B4-424D-9F92-1E46215E35D5",
+            "resource": {
+                "resourceType": "Binary",
+                "contentType": "application/json-patch+json",
+                "data": "W3sib3AiOiJyZXBsYWNlIiwicGF0aCI6Ii9nZW5kZXIiLCJ2YWx1ZSI6ImZlbWFsZSJ9XQ=="
+            },
+            "request": {
+                "method": "PATCH",
+                "url": "Patient/9F746C86-48B4-424D-9F92-1E46215E35D5"
+            }
+        }
+    ]
+}

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/PatchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/PatchTests.cs
@@ -8,6 +8,7 @@ using System.Net;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Client;
 using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.E2E.Common;
@@ -44,6 +45,20 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.Equal(HttpStatusCode.OK, patch.Response.StatusCode);
             Assert.Equal(AdministrativeGender.Female, patch.Resource.Gender);
             Assert.Empty(patch.Resource.Address);
+        }
+
+        [SkippableFact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenAPatchDocument_WhenSubmittingABundleWithBinaryPatch_ThenServerShouldPatchCorrectly()
+        {
+            Skip.If(ModelInfoProvider.Version == FhirSpecification.Stu3, "Patch isn't supported in Bundles by STU3");
+
+            var bundleWithPatch = Samples.GetJsonSample("Bundle-BinaryPatch").ToPoco<Bundle>();
+
+            using FhirResponse<Bundle> patched = await _client.PostBundleAsync(bundleWithPatch);
+
+            Assert.Equal(HttpStatusCode.OK, patched.Response.StatusCode);
+            Assert.Equal(AdministrativeGender.Female, ((Patient)patched.Resource.Entry[1].Resource).Gender);
         }
 
         [Fact]


### PR DESCRIPTION
## Description
In current moment when you submit Bundle there is no good way to pass PATCH operation.
Main reason is Bundle can work only with FHIR resources, and our PATCH implementation is based on JsonPatch  (where we pass json string of operations to be applied to resource) and not FhirPathPatch (where you pass Parameters object with operations to be applied, which is FHIR resource)

This is workaround, where instead of implementing FhirPatchPatch we treat Binary resource as base64 encoding of json string and pass it to the server.

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
