### PR TITLE
Update SchemaUpgradeTests

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using System.Threading;
@@ -72,8 +73,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         }
 
         [Theory]
-        [InlineData((int)SchemaVersion.V7)]
-        [InlineData(SchemaVersionConstants.Max)]
+        [MemberData(nameof(GetSchemaVersions))]
         public async Task GivenASchemaVersion_WhenApplyingDiffTwice_ShouldSucceed(int schemaVersion)
         {
             var snapshotDatabaseName = $"SNAPSHOT_{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}_{BigInteger.Abs(new BigInteger(Guid.NewGuid().ToByteArray()))}";
@@ -94,6 +94,17 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             finally
             {
                 await testHelper.DeleteDatabase(snapshotDatabaseName);
+            }
+        }
+
+        public static IEnumerable<object[]> GetSchemaVersions()
+        {
+            foreach (object item in Enum.GetValues(typeof(SchemaVersion)))
+            {
+                if ((int)item >= 7)
+                {
+                    yield return new object[] { item };
+                }
             }
         }
 


### PR DESCRIPTION
## Description
Updated the GivenASchemaVersion_WhenApplyingDiffTwice_ShouldSucceed test to run for all applicable schema versions so that we don't miss running the tests for older schema versions.

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
