### PR TITLE
Allows for search history bundles with PATCH requests

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/BundleFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/BundleFactory.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using EnsureThat;
@@ -71,7 +72,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
 
                 string statusString = null;
 
-                string ConvertStatusString(HttpStatusCode statusCode)
+                string ToStatusString(HttpStatusCode statusCode)
                 {
                     return $"{(int)statusCode} {statusCode}";
                 }
@@ -79,31 +80,31 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                 switch (httpVerb)
                 {
                     case Bundle.HTTPVerb.POST:
-                        statusString = ConvertStatusString(HttpStatusCode.Created);
+                        statusString = ToStatusString(HttpStatusCode.Created);
                         break;
                     case Bundle.HTTPVerb.PUT:
 
                         if (string.Equals(r.Resource.Version, "1", StringComparison.Ordinal))
                         {
-                            statusString = ConvertStatusString(HttpStatusCode.Created);
+                            statusString = ToStatusString(HttpStatusCode.Created);
                             break;
                         }
 
-                        statusString = ConvertStatusString(HttpStatusCode.OK);
+                        statusString = ToStatusString(HttpStatusCode.OK);
                         break;
 
                     case Bundle.HTTPVerb.GET:
 #if !Stu3
                     case Bundle.HTTPVerb.PATCH:
+                    case Bundle.HTTPVerb.HEAD:
 #endif
-                        statusString = ConvertStatusString(HttpStatusCode.OK);
+                        statusString = ToStatusString(HttpStatusCode.OK);
                         break;
                     case Bundle.HTTPVerb.DELETE:
-                        statusString = ConvertStatusString(HttpStatusCode.NoContent);
+                        statusString = ToStatusString(HttpStatusCode.NoContent);
                         break;
                     default:
-                        _logger.LogWarning(nameof(CreateHistoryBundle) + " tried to resolve a status string for {httpVerb} but a mapping wasn't defined.", httpVerb);
-                        break;
+                        throw new NotImplementedException($"{httpVerb} was not defined.");
                 }
 
                 resource.Response = new Bundle.ResponseComponent


### PR DESCRIPTION
## Description
Allows for search history bundles with PATCH requests

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
