### PR TITLE
Provide better exception in case of bad expression in search parameter.

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -79,6 +79,15 @@ namespace Microsoft.Health.Fhir.Core {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Can&apos;t find &apos;{0}&apos; in type &apos;{1}&apos;.
+        /// </summary>
+        internal static string CantResolveExpressionForAType {
+            get {
+                return ResourceManager.GetString("CantResolveExpressionForAType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The chained parameter must be a reference search parameter type..
         /// </summary>
         internal static string ChainedParameterMustBeReferenceSearchParamType {

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -593,4 +593,8 @@
   <data name="ReindexingResourceVersionConflict" xml:space="preserve">
     <value>One or more resources failed to reindex due to a non-matching version.</value>
   </data>
+  <data name="CantResolveExpressionForAType" xml:space="preserve">
+    <value>Can't find '{0}' in type '{1}'</value>
+    <comment>{0}: expression we trying to resolve, {1}: FHIR type</comment>
+  </data>
 </root>

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterToTypeResolverTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterToTypeResolverTests.cs
@@ -100,5 +100,16 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
             Assert.Equal("Reference", results.Single().FhirNodeType);
         }
+
+        [Fact]
+        public void GivenABadFhirPathExpression_WhenResolving_ThenResolveThrowException()
+        {
+            var expression = _compiler.Parse("Patient.cookie");
+            Assert.Throws<NotSupportedException>(() =>
+                SearchParameterToTypeResolver.Resolve(
+                    KnownResourceTypes.Patient,
+                    (SearchParamType.Token, expression, new Uri("http://hl7.org/fhir/SearchParameter/Patient-cookie")),
+                    null).ToArray());
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Parameters/SearchParameterToTypeResolver.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Parameters/SearchParameterToTypeResolver.cs
@@ -203,14 +203,15 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
             }
             else
             {
-                var pathBuilder = new StringBuilder(ctx.Path.First().propertyName);
+                var fhirType = ctx.Path.First().propertyName;
+                var pathBuilder = new StringBuilder(fhirType);
 
                 var skipResourceElement = true;
                 ClassMapping mapping = ctx.Path.First().knownMapping;
 
-                if (mapping == null && ModelInfoProvider.Instance.GetTypeForFhirType(ctx.Path.First().propertyName) != null)
+                if (mapping == null && ModelInfoProvider.Instance.GetTypeForFhirType(fhirType) != null)
                 {
-                    mapping = GetMapping(ctx.Path.First().propertyName);
+                    mapping = GetMapping(fhirType);
                 }
 
                 // Default to parent resource
@@ -250,9 +251,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
                             }
                             else
                             {
-                                foreach (Type fhirType in prop.FhirType)
+                                foreach (Type childFhirType in prop.FhirType)
                                 {
-                                    yield return new SearchParameterTypeResult(GetMapping(fhirType), ctx.SearchParamType, path, ctx.Definition);
+                                    yield return new SearchParameterTypeResult(GetMapping(childFhirType), ctx.SearchParamType, path, ctx.Definition);
                                 }
                             }
 
@@ -265,7 +266,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
                     }
                     else
                     {
-                        break;
+                        throw new NotSupportedException(string.Format(Core.Resources.CantResolveExpressionForAType, pathBuilder, fhirType));
                     }
                 }
 

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -1,7 +1,7 @@
 ﻿{
     "FhirServer": {
         "Security": {
-            "Enabled": false,
+            "Enabled": true,
             "EnableAadSmartOnFhirProxy": true,
             "Authentication": {
                 "Audience": null,

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -1,7 +1,7 @@
 ﻿{
     "FhirServer": {
         "Security": {
-            "Enabled": true,
+            "Enabled": false,
             "EnableAadSmartOnFhirProxy": true,
             "Authentication": {
                 "Audience": null,

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -212,7 +212,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
         [Theory]
         [InlineData("SearchParameterBadSyntax", "A search parameter with the same code value 'diagnosis' already exists for base type 'Encounter'")]
-        [InlineData("SearchParameterExpressionWrongProperty", "not supported")]
+        [InlineData("SearchParameterExpressionWrongProperty", "Can't find 'Encounter.diagnosis.conditions' in type 'Encounter'")]
         [InlineData("SearchParameterInvalidBase", "Literal 'foo' is not a valid value for enumeration 'ResourceType'")]
         [InlineData("SearchParameterInvalidType", "Literal 'foo' is not a valid value for enumeration 'SearchParamType'")]
         [InlineData("SearchParameterMissingBase", "cardinality is 1")]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -212,7 +212,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
         [Theory]
         [InlineData("SearchParameterBadSyntax", "A search parameter with the same code value 'diagnosis' already exists for base type 'Encounter'")]
-        [InlineData("SearchParameterExpressionWrongProperty", "Can't find 'Encounter.diagnosis.conditions' in type 'Encounter'")]
+        [InlineData("SearchParameterExpressionWrongProperty", "Can't find 'Encounter.diagnosis.foo' in type 'Encounter'")]
         [InlineData("SearchParameterInvalidBase", "Literal 'foo' is not a valid value for enumeration 'ResourceType'")]
         [InlineData("SearchParameterInvalidType", "Literal 'foo' is not a valid value for enumeration 'SearchParamType'")]
         [InlineData("SearchParameterMissingBase", "cardinality is 1")]


### PR DESCRIPTION
## Description
Update OperationOutcome during search parameter creation if expression in search parameter is invalid
```
"issue": [
        {
            "severity": "error",
            "code": "exception",
            "diagnostics": "An error occurred creating the custom search parameter.  The issue must be resolved and the parameter resubmitted to become functional."
        },
        {
            "severity": "error",
            "code": "exception",
            "diagnostics": "Can't find 'CarePlan.activity.detail.extension.values' in type 'CarePlan'"
        }
    ]
```
## Related issues
Addresses [#2146 ].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
