### PR TITLE
Fixes processing 429s from SPs

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -307,7 +307,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
             }
             catch (CosmosException exception)
             {
-                if (exception.IsRequestEntityTooLarge())
+                if (exception.IsRequestRateExceeded())
                 {
                     throw;
                 }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosResponseProcessor.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosResponseProcessor.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
         public void ProcessErrorResponse(HttpStatusCode statusCode, Headers headers, string errorMessage)
         {
             // Stored procedure statuses will be in the substatuscode
-            if (statusCode == HttpStatusCode.TooManyRequests || string.Equals(headers["x-ms-substatus"], ((int)HttpStatusCode.TooManyRequests).ToString(), StringComparison.Ordinal))
+            if (statusCode == HttpStatusCode.TooManyRequests || headers.GetSubStatusValue() == (int)HttpStatusCode.TooManyRequests)
             {
                 string retryHeader = headers["x-ms-retry-after-ms"];
                 throw new RequestRateExceededException(int.TryParse(retryHeader, out int milliseconds) ? TimeSpan.FromMilliseconds(milliseconds) : null);

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosResponseProcessor.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosResponseProcessor.cs
@@ -59,7 +59,8 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
 
         public void ProcessErrorResponse(HttpStatusCode statusCode, Headers headers, string errorMessage)
         {
-            if (statusCode == HttpStatusCode.TooManyRequests)
+            // Stored procedure statuses will be in the substatuscode
+            if (statusCode == HttpStatusCode.TooManyRequests || string.Equals(headers["x-ms-substatus"], ((int)HttpStatusCode.TooManyRequests).ToString(), StringComparison.Ordinal))
             {
                 string retryHeader = headers["x-ms-retry-after-ms"];
                 throw new RequestRateExceededException(int.TryParse(retryHeader, out int milliseconds) ? TimeSpan.FromMilliseconds(milliseconds) : null);

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/StoredProcedures/AcquireExportJobs/acquireExportJobs.js
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/StoredProcedures/AcquireExportJobs/acquireExportJobs.js
@@ -1,6 +1,6 @@
 ﻿/**
-* This stored procedure acquires list of available export jobs. 
-* 
+* This stored procedure acquires list of available export jobs.
+*
 * @constructor
 * @param {string} maximumNumberOfConcurrentJobsAllowedInString - The maximum number of concurrent jobs allowed in string.
 * @param {string} jobHeartbeatTimeoutThresholdInSecondsInString - The number of seconds allowed before the job is considered to be stale in string.
@@ -145,6 +145,6 @@ function acquireExportJobs(maximumNumberOfConcurrentJobsAllowedInString, jobHear
     }
 
     function throwTooManyRequestsError() {
-        throw new Error(ErrorCodes.RequestEntityTooLarge, `The request could not be completed.`);
+        throw new Error(429, `The request could not be completed.`);
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/StoredProcedures/AcquireReindexJobs/acquireReindexJobs.js
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/StoredProcedures/AcquireReindexJobs/acquireReindexJobs.js
@@ -1,6 +1,6 @@
 ﻿/**
-* This stored procedure acquires list of available reindex jobs. 
-* 
+* This stored procedure acquires list of available reindex jobs.
+*
 * @constructor
 * @param {string} maximumNumberOfConcurrentJobsAllowedInString - The maximum number of concurrent jobs allowed in string.
 * @param {string} jobHeartbeatTimeoutThresholdInSecondsInString - The number of seconds allowed before the job is considered to be stale in string.
@@ -145,6 +145,6 @@ function acquireReindexJobs(maximumNumberOfConcurrentJobsAllowedInString, jobHea
     }
 
     function throwTooManyRequestsError() {
-        throw new Error(ErrorCodes.RequestEntityTooLarge, `The request could not be completed.`);
+        throw new Error(429, `The request could not be completed.`);
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/StoredProcedures/HardDelete/hardDelete.js
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/StoredProcedures/HardDelete/hardDelete.js
@@ -24,6 +24,7 @@ function hardDelete(resourceTypeName, resourceId, keepCurrentVersion) {
 
     let deletedResourceIdList = new Array();
 
+    throwTooManyRequestsError();
     tryQueryAndHardDelete();
 
     function tryQueryAndHardDelete() {
@@ -96,6 +97,6 @@ function hardDelete(resourceTypeName, resourceId, keepCurrentVersion) {
     }
 
     function throwTooManyRequestsError() {
-        throw new Error(ErrorCodes.RequestEntityTooLarge, `The request could not be completed.`);
+        throw new Error(429, `The request could not be completed.`);
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/StoredProcedures/HardDelete/hardDelete.js
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/StoredProcedures/HardDelete/hardDelete.js
@@ -24,7 +24,6 @@ function hardDelete(resourceTypeName, resourceId, keepCurrentVersion) {
 
     let deletedResourceIdList = new Array();
 
-    throwTooManyRequestsError();
     tryQueryAndHardDelete();
 
     function tryQueryAndHardDelete() {

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/StoredProcedures/Replace/replaceSingleResource.js
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/StoredProcedures/Replace/replaceSingleResource.js
@@ -1,6 +1,6 @@
 ﻿/**
 * This stored procedure can be used to replace an existing document
-* 
+*
 * @constructor
 * @param {any} doc - The CosmosResourceWrapper to save
 * @param {string} matchVersionId - required etag to match against when replacing an existing document
@@ -81,7 +81,7 @@ function replaceSingleResource(doc, matchVersionId) {
     }
 
     function throwRequestNotQueuedError() {
-        throw new Error(503, "Request could not be queued.");
+        throw new Error(429, "Request could not be queued.");
     }
 
     function throwPreconditionFailedError() {


### PR DESCRIPTION
## Description
Stored procedures return a statuscode 400 with a substatus when they fail. When this was a 429, we were not processing this correctly.
The errorcode in the SP was also not correct.

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the managed service
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
