### PR TITLE
Wider catch for exceptions during applying patch.

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Patch/JsonPatchService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Patch/JsonPatchService.cs
@@ -81,11 +81,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Patch
                 {
                     throw new BadRequestException($"{operation.op} is invalid.");
                 }
-
-                if (operation.path == null)
-                {
-                    throw new BadRequestException($"{operation.op} has empty path");
-                }
             }
         }
 
@@ -96,6 +91,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Patch
                 operations.ApplyTo(node.JsonObject);
             }
             catch (JsonPatchException e)
+            {
+                throw new RequestNotValidException(e.Message, OperationOutcomeConstants.IssueType.Processing);
+            }
+            catch (ArgumentNullException e)
             {
                 throw new RequestNotValidException(e.Message, OperationOutcomeConstants.IssueType.Processing);
             }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Patch/JsonPatchService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Patch/JsonPatchService.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Patch
             {
                 operations.ApplyTo(node.JsonObject);
             }
-            catch (JsonPatchException e)
+            catch (Exception e)
             {
                 throw new RequestNotValidException(e.Message, OperationOutcomeConstants.IssueType.Processing);
             }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Patch/JsonPatchService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Patch/JsonPatchService.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Patch
         {
             EnsureArg.IsNotNull(resourceToPatch, nameof(resourceToPatch));
 
-            Validate(resourceToPatch, weakETag);
+            Validate(resourceToPatch, weakETag, patchDocument);
 
             var node = (FhirJsonNode)FhirJsonNode.Parse(resourceToPatch.RawResource.Data);
 
@@ -63,7 +63,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Patch
             return patchedResource.ToResourceElement();
         }
 
-        private static void Validate(ResourceWrapper currentDoc, WeakETag eTag)
+        private static void Validate(ResourceWrapper currentDoc, WeakETag eTag, JsonPatchDocument patchDocument)
         {
             if (currentDoc.IsHistory)
             {
@@ -74,6 +74,19 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Patch
             {
                 throw new PreconditionFailedException(string.Format(Core.Resources.ResourceVersionConflict, eTag.VersionId));
             }
+
+            foreach (var operation in patchDocument.Operations)
+            {
+                if (operation.OperationType == AspNetCore.JsonPatch.Operations.OperationType.Invalid)
+                {
+                    throw new BadRequestException($"{operation.op} is invalid.");
+                }
+
+                if (operation.path == null)
+                {
+                    throw new BadRequestException($"{operation.op} has empty path");
+                }
+            }
         }
 
         private Resource GetPatchedJsonResource(FhirJsonNode node, JsonPatchDocument operations)
@@ -82,7 +95,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Patch
             {
                 operations.ApplyTo(node.JsonObject);
             }
-            catch (Exception e)
+            catch (JsonPatchException e)
             {
                 throw new RequestNotValidException(e.Message, OperationOutcomeConstants.IssueType.Processing);
             }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/PatchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/PatchTests.cs
@@ -61,6 +61,12 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             var exception = await Assert.ThrowsAsync<FhirException>(() => _client.PatchAsync(response.Resource, patchDocument));
             Assert.Equal(HttpStatusCode.BadRequest, exception.Response.StatusCode);
+
+            patchDocument =
+               "[{\"op\":\"coo\",\"path\":\"/gender\",\"value\":\"female\"}, {\"op\":\"remove\",\"path\":\"/address\"}]";
+
+            exception = await Assert.ThrowsAsync<FhirException>(() => _client.PatchAsync(response.Resource, patchDocument));
+            Assert.Equal(HttpStatusCode.BadRequest, exception.Response.StatusCode);
         }
 
         [SkippableFact]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/PatchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/PatchTests.cs
@@ -47,6 +47,22 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.Empty(patch.Resource.Address);
         }
 
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenAServerThatSupportsIt_WhenSubmittingIncorrectJsonPropertyPatch_ThenServerShouldBadRequest()
+        {
+            var poco = Samples.GetDefaultPatient().ToPoco<Patient>();
+            FhirResponse<Patient> response = await _client.CreateAsync(poco);
+            Assert.Equal(AdministrativeGender.Male, response.Resource.Gender);
+            Assert.NotNull(response.Resource.Address);
+
+            string patchDocument =
+                "[{\"op\":\"replace\",\"value\":\"female\"}, {\"op\":\"remove\",\"path\":\"/address\"}]";
+
+            var exception = await Assert.ThrowsAsync<FhirException>(() => _client.PatchAsync(response.Resource, patchDocument));
+            Assert.Equal(HttpStatusCode.BadRequest, exception.Response.StatusCode);
+        }
+
         [SkippableFact]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenAPatchDocument_WhenSubmittingABundleWithBinaryPatch_ThenServerShouldPatchCorrectly()

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/PatchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/PatchTests.cs
@@ -47,25 +47,19 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.Empty(patch.Resource.Address);
         }
 
-        [Fact]
+        [Theory]
+        [InlineData("[{\"op\":\"replace\",\"value\":\"female\"}, {\"op\":\"remove\",\"path\":\"/address\"}]")]
+        [InlineData("[{\"op\":\"coo\",\"path\":\"/gender\",\"value\":\"female\"}, {\"op\":\"remove\",\"path\":\"/address\"}]")]
+        [InlineData("[{\"op\":\"replace\",\"path\":\"\",\"value\":\"\"}]")]
+        [InlineData("[{\"op\":\"replace\",\"path\":\"/gender\"}]")]
         [Trait(Traits.Priority, Priority.One)]
-        public async Task GivenAServerThatSupportsIt_WhenSubmittingIncorrectJsonPropertyPatch_ThenServerShouldBadRequest()
+        public async Task GivenAServerThatSupportsIt_WhenSubmittingIncorrectJsonPropertyPatch_ThenServerShouldBadRequest(string patch)
         {
             var poco = Samples.GetDefaultPatient().ToPoco<Patient>();
             FhirResponse<Patient> response = await _client.CreateAsync(poco);
             Assert.Equal(AdministrativeGender.Male, response.Resource.Gender);
             Assert.NotNull(response.Resource.Address);
-
-            string patchDocument =
-                "[{\"op\":\"replace\",\"value\":\"female\"}, {\"op\":\"remove\",\"path\":\"/address\"}]";
-
-            var exception = await Assert.ThrowsAsync<FhirException>(() => _client.PatchAsync(response.Resource, patchDocument));
-            Assert.Equal(HttpStatusCode.BadRequest, exception.Response.StatusCode);
-
-            patchDocument =
-               "[{\"op\":\"coo\",\"path\":\"/gender\",\"value\":\"female\"}, {\"op\":\"remove\",\"path\":\"/address\"}]";
-
-            exception = await Assert.ThrowsAsync<FhirException>(() => _client.PatchAsync(response.Resource, patchDocument));
+            var exception = await Assert.ThrowsAsync<FhirException>(() => _client.PatchAsync(response.Resource, patch));
             Assert.Equal(HttpStatusCode.BadRequest, exception.Response.StatusCode);
         }
 


### PR DESCRIPTION
## Description
JsonPatchDocument can be formatted in a way it would be accepted by server, but during patch it would throw error.
One of the known cases: absence of `path` in operation.
I'm making wide catch statement to catch exceptions and return bad request rather than 500.

## Related issues
Addresses [#84831].

## Testing
Unit test added.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
