### PR TITLE
Convert validators to AbstractValidator

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Validation/NarrativeValidator.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Validation/NarrativeValidator.cs
@@ -29,10 +29,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation.Narratives
 
         public override Task<ValidationResult> ValidateAsync(ValidationContext<ResourceElement> context, CancellationToken cancellation = default)
         {
+            return Task.FromResult(Validate(context));
+        }
+
+        public override ValidationResult Validate(ValidationContext<ResourceElement> context)
+        {
             EnsureArg.IsNotNull(context, nameof(context));
-
             var failures = new List<ValidationFailure>();
-
             if (context.InstanceToValidate is ResourceElement resourceElement)
             {
                 if (resourceElement.IsDomainResource)
@@ -50,7 +53,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation.Narratives
             }
 
             failures.ForEach(x => context.AddFailure(x));
-            return Task.FromResult(new ValidationResult(failures));
+            return new ValidationResult(failures);
         }
 
         private IEnumerable<ValidationFailure> ValidateResource(ITypedElement typedElement)

--- a/src/Microsoft.Health.Fhir.Core/Features/Validation/ResourceContentValidator.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Validation/ResourceContentValidator.cs
@@ -35,6 +35,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
 
         public override Task<FluentValidation.Results.ValidationResult> ValidateAsync(ValidationContext<ResourceElement> context, CancellationToken cancellation = default)
         {
+            return Task.FromResult(Validate(context));
+        }
+
+        public override FluentValidation.Results.ValidationResult Validate(ValidationContext<ResourceElement> context)
+        {
             EnsureArg.IsNotNull(context, nameof(context));
             var failures = new List<ValidationFailure>();
             if (context.InstanceToValidate is ResourceElement resourceElement)
@@ -53,7 +58,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
             }
 
             failures.ForEach(x => context.AddFailure(x));
-            return Task.FromResult(new FluentValidation.Results.ValidationResult(failures));
+            return new FluentValidation.Results.ValidationResult(failures);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Validation/ResourceContentValidator.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Validation/ResourceContentValidator.cs
@@ -4,10 +4,11 @@
 // -------------------------------------------------------------------------------------------------
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using EnsureThat;
 using FluentValidation;
 using FluentValidation.Results;
-using FluentValidation.Validators;
 using Microsoft.Health.Fhir.Core.Models;
 using ValidationResult = System.ComponentModel.DataAnnotations.ValidationResult;
 
@@ -21,7 +22,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
     /// Even if we correctly parsed resource into object it doesn't mean resource is valid.
     /// We need to check that properties have right cardinality, correct types, proper format, etc.
     /// </remarks>
-    public class ResourceContentValidator : NoopPropertyValidator<ResourceElement, ResourceElement>
+    public class ResourceContentValidator : AbstractValidator<ResourceElement>
     {
         private readonly IModelAttributeValidator _modelAttributeValidator;
 
@@ -32,12 +33,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
             _modelAttributeValidator = modelAttributeValidator;
         }
 
-        public override string Name => nameof(ResourceContentValidator);
-
-        public override bool IsValid(ValidationContext<ResourceElement> context, ResourceElement value)
+        public override Task<FluentValidation.Results.ValidationResult> ValidateAsync(ValidationContext<ResourceElement> context, CancellationToken cancellation = default)
         {
             EnsureArg.IsNotNull(context, nameof(context));
-            bool isValid = true;
+            var failures = new List<ValidationFailure>();
             if (context.InstanceToValidate is ResourceElement resourceElement)
             {
                 var results = new List<ValidationResult>();
@@ -48,14 +47,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
                         var fullFhirPath = resourceElement.InstanceType;
                         fullFhirPath += string.IsNullOrEmpty(error.MemberNames?.FirstOrDefault()) ? string.Empty : "." + error.MemberNames?.FirstOrDefault();
                         var validationFailure = new ValidationFailure(fullFhirPath, error.ErrorMessage);
-                        validationFailure.ErrorCode = "Custom";
-                        context.AddFailure(validationFailure);
-                        isValid = false;
+                        failures.Add(validationFailure);
                     }
                 }
             }
 
-            return isValid;
+            failures.ForEach(x => context.AddFailure(x));
+            return Task.FromResult(new FluentValidation.Results.ValidationResult(failures));
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Validation/ResourceElementValidator.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Validation/ResourceElementValidator.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 using FluentValidation;
-using FluentValidation.Validators;
 using Microsoft.Health.Fhir.Core.Features.Validation.FhirPrimitiveTypes;
 using Microsoft.Health.Fhir.Core.Features.Validation.Narratives;
 using Microsoft.Health.Fhir.Core.Models;
@@ -12,10 +11,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
 {
     public class ResourceElementValidator : AbstractValidator<ResourceElement>
     {
-        public ResourceElementValidator(IPropertyValidator<ResourceElement, ResourceElement> contentValidator, INarrativeHtmlSanitizer narrativeHtmlSanitizer)
+        public ResourceElementValidator(AbstractValidator<ResourceElement> contentValidator, INarrativeHtmlSanitizer narrativeHtmlSanitizer)
         {
             RuleFor(x => x.Id)
-              .SetValidator(new IdValidator<ResourceElement>()).WithMessage(Core.Resources.IdRequirements);
+              .SetValidator(new IdValidator<ResourceElement>()).WithMessage(Resources.IdRequirements);
             RuleFor(x => x)
                   .SetValidator(contentValidator);
             RuleFor(x => x)

--- a/src/Microsoft.Health.Fhir.Core/Features/Validation/ResourceProfileValidator.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Validation/ResourceProfileValidator.cs
@@ -39,7 +39,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
             _runProfileValidation = runProfileValidation;
         }
 
-        public override async Task<ValidationResult> ValidateAsync(ValidationContext<ResourceElement> context, CancellationToken cancellation = default)
+        public override Task<ValidationResult> ValidateAsync(ValidationContext<ResourceElement> context, CancellationToken cancellation = default)
+        {
+            return Task.FromResult(Validate(context));
+        }
+
+        public override ValidationResult Validate(ValidationContext<ResourceElement> context)
         {
             EnsureArg.IsNotNull(context, nameof(context));
             var failures = new List<ValidationFailure>();
@@ -69,7 +74,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
                     }
                 }
 
-                var baseValidation = await base.ValidateAsync(context, cancellation);
+                var baseValidation = base.Validate(context);
                 failures.AddRange(baseValidation.Errors);
             }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Validation/ValidateRequestPreProcessor.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Validation/ValidateRequestPreProcessor.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
 
             if (!allResults.All(x => x.IsValid))
             {
-                throw new ResourceNotValidException(allResults.SelectMany(x => x.Errors).Where(e => e.ErrorCode == "Custom").ToList());
+                throw new ResourceNotValidException(allResults.SelectMany(x => x.Errors).ToList());
             }
         }
     }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Validation/Narratives/NarrativeValidatorTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Validation/Narratives/NarrativeValidatorTests.cs
@@ -3,13 +3,11 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using FluentValidation;
 using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Validation.Narratives;
-using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Tests.Common;
 using Xunit;
 
@@ -32,10 +30,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Validation.Narratives
             defaultObservation.Text.Div = maliciousNarrative;
 
             var instanceToValidate = defaultObservation.ToResourceElement();
-            var result = _validator.IsValid(
-                    new ValidationContext<ResourceElement>(instanceToValidate), instanceToValidate);
+            var result = _validator.Validate(instanceToValidate);
 
-            Assert.False(result);
+            Assert.False(result.IsValid);
         }
 
         [Theory]
@@ -53,10 +50,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Validation.Narratives
             bundle.Entry.Add(new Bundle.EntryComponent { Resource = defaultPatient });
 
             var instanceToValidate = bundle.ToResourceElement();
-            var result = _validator.IsValid(
-                    new ValidationContext<ResourceElement>(instanceToValidate), instanceToValidate);
+            var result = _validator.Validate(instanceToValidate);
 
-            Assert.False(result);
+            Assert.False(result.IsValid);
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalCreateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalCreateTests.cs
@@ -136,6 +136,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
                 "&"));
 
             Assert.Equal(HttpStatusCode.BadRequest, exception.Response.StatusCode);
+            Assert.Single(exception.OperationOutcome.Issue);
+            Assert.Equal(Core.Resources.ConditionalOperationNotSelectiveEnough, exception.OperationOutcome.Issue[0].Diagnostics);
         }
     }
 }


### PR DESCRIPTION
## Description
Describe the changes in this PR.

## Related issues
Addresses [#2168].

## Testing

In the past there was filter by errorCode == "Custom" which lead to not showing certain non custom errors. I remove it.
I also convert validators from NoopProperty to Abstract one.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
