### PR TITLE
Update e2e test category for long running anonymizer tests

### DIFF
--- a/build/export-pipeline.yml
+++ b/build/export-pipeline.yml
@@ -83,6 +83,7 @@ stages:
   - template: ./jobs/run-export-tests.yml
     parameters:
       version: Stu3
+      webAppName: $(DeploymentEnvironmentName)
       keyVaultName: $(DeploymentEnvironmentName)
 
 - stage: testR4
@@ -95,6 +96,7 @@ stages:
   - template: ./jobs/run-export-tests.yml
     parameters:
       version: R4
+      webAppName: $(DeploymentEnvironmentNameR4)
       keyVaultName: $(DeploymentEnvironmentNameR4)
 
 - stage: cleanStorageAccounts

--- a/build/jobs/run-export-tests.yml
+++ b/build/jobs/run-export-tests.yml
@@ -51,7 +51,7 @@ jobs:
         Write-Host "##vso[task.setvariable variable=AllStorageAccounts]$($allStorageAccounts)"
 
         # Get export store for uploading anonymizer configuration file
-        $appServiceName = "${{ parameters.appServiceName }}"
+        $appServiceName = "${{ parameters.webAppName }}"
         $appSettings = (Get-AzWebApp -ResourceGroupName $(ResourceGroupName) -Name $appServiceName).SiteConfig.AppSettings
 
         $exportStoreSettings = $appSettings | where {$_.Name -eq "FhirServer__Operations__Export__StorageAccountUri"}
@@ -164,7 +164,7 @@ jobs:
         Write-Host "##vso[task.setvariable variable=AllStorageAccounts]$($allStorageAccounts)"
 
         # Get export store for uploading anonymizer configuration file
-        $appServiceName = "${{ parameters.appServiceName }}-sql"
+        $appServiceName = "${{ parameters.webAppName }}-sql"
         $appSettings = (Get-AzWebApp -ResourceGroupName $(ResourceGroupName) -Name $appServiceName).SiteConfig.AppSettings
 
         $exportStoreSettings = $appSettings | where {$_.Name -eq "FhirServer__Operations__Export__StorageAccountUri"}

--- a/build/jobs/run-export-tests.yml
+++ b/build/jobs/run-export-tests.yml
@@ -1,6 +1,8 @@
 parameters:
 - name: version
   type: string
+- name: webAppName
+  type: string
 - name: keyVaultName
   type: string
 
@@ -48,6 +50,19 @@ jobs:
         }
         Write-Host "##vso[task.setvariable variable=AllStorageAccounts]$($allStorageAccounts)"
 
+        # Get export store for uploading anonymizer configuration file
+        $appServiceName = "${{ parameters.appServiceName }}"
+        $appSettings = (Get-AzWebApp -ResourceGroupName $(ResourceGroupName) -Name $appServiceName).SiteConfig.AppSettings
+
+        $exportStoreSettings = $appSettings | where {$_.Name -eq "FhirServer__Operations__Export__StorageAccountUri"}
+        $exportStoreUri = $exportStoreSettings[0].Value
+        Write-Host "$exportStoreUri"
+        $exportStoreAccountName = [System.Uri]::new("$exportStoreUri").Host.Split('.')[0]
+        $exportStoreKey = Get-AzStorageAccountKey -ResourceGroupName $(ResourceGroupName) -Name "$exportStoreAccountName" | Where-Object {$_.KeyName -eq "key1"}
+        
+        Write-Host "##vso[task.setvariable variable=TestExportStoreUri]$($exportStoreUri)"
+        Write-Host "##vso[task.setvariable variable=TestExportStoreKey]$($exportStoreKey.Value)"
+
         Write-Host "##vso[task.setvariable variable=Resource]$(TestEnvironmentUrl)"
         
         $secrets = Get-AzKeyVaultSecret -VaultName resolute-oss-tenant-info
@@ -79,6 +94,8 @@ jobs:
     env:
       'TestEnvironmentUrl': $(TestEnvironmentUrl)
       'TestEnvironmentUrl_${{ parameters.version }}': $(TestEnvironmentUrl_${{ parameters.version }})
+      'TestExportStoreUri': $(TestExportStoreUri)
+      'TestExportStoreKey': $(TestExportStoreKey)
       'Resource': $(Resource)
       'AllStorageAccounts': $(AllStorageAccounts)
       'tenant-admin-service-principal-name': $(tenant-admin-service-principal-name)
@@ -146,6 +163,18 @@ jobs:
         }
         Write-Host "##vso[task.setvariable variable=AllStorageAccounts]$($allStorageAccounts)"
 
+        # Get export store for uploading anonymizer configuration file
+        $appServiceName = "${{ parameters.appServiceName }}-sql"
+        $appSettings = (Get-AzWebApp -ResourceGroupName $(ResourceGroupName) -Name $appServiceName).SiteConfig.AppSettings
+
+        $exportStoreSettings = $appSettings | where {$_.Name -eq "FhirServer__Operations__Export__StorageAccountUri"}
+        $exportStoreUri = $exportStoreSettings[0].Value
+        Write-Host "$exportStoreUri"
+        $exportStoreAccountName = [System.Uri]::new("$exportStoreUri").Host.Split('.')[0]
+        $exportStoreKey = Get-AzStorageAccountKey -ResourceGroupName $(ResourceGroupName) -Name "$exportStoreAccountName" | Where-Object {$_.KeyName -eq "key1"}
+        
+        Write-Host "##vso[task.setvariable variable=TestExportStoreUri]$($exportStoreUri)"
+        Write-Host "##vso[task.setvariable variable=TestExportStoreKey]$($exportStoreKey.Value)"
         Write-Host "##vso[task.setvariable variable=Resource]$(TestEnvironmentUrl)"
         
         $secrets = Get-AzKeyVaultSecret -VaultName resolute-oss-tenant-info
@@ -177,6 +206,8 @@ jobs:
     env:
       'TestEnvironmentUrl_Sql': $(TestEnvironmentUrl_Sql)
       'TestEnvironmentUrl_${{ parameters.version }}_Sql': $(TestEnvironmentUrl_${{ parameters.version }}_Sql)
+      'TestExportStoreUri': $(TestExportStoreUri)
+      'TestExportStoreKey': $(TestExportStoreKey)
       'Resource': $(Resource)
       'AllStorageAccounts': $(AllStorageAccounts)
       'tenant-admin-service-principal-name': $(tenant-admin-service-principal-name)

--- a/test/Microsoft.Health.Fhir.R4.Tests.E2E/Microsoft.Health.Fhir.R4.Tests.E2E.csproj
+++ b/test/Microsoft.Health.Fhir.R4.Tests.E2E/Microsoft.Health.Fhir.R4.Tests.E2E.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <Compile Include="..\Microsoft.Health.Fhir.Shared.Tests.E2E\Rest\AnonymizedExportTests.cs" Link="Rest\AnonymizedExportTests.cs" />
+    <Compile Include="..\Microsoft.Health.Fhir.Shared.Tests.E2E\Rest\AnonymizedExportLongRunningTests.cs" Link="Rest\AnonymizedExportLongRunningTests.cs" />
     <Compile Include="..\Microsoft.Health.Fhir.Shared.Tests.E2E\Rest\ConvertDataTests.cs" Link="Rest\ConvertDataTests.cs" />
     <Compile Include="..\Microsoft.Health.Fhir.Shared.Tests.E2E\Rest\CustomConvertDataTests.cs" Link="Rest\CustomConvertDataTests.cs" />
   </ItemGroup>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Microsoft.Health.Fhir.Shared.Tests.E2E.shproj
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Microsoft.Health.Fhir.Shared.Tests.E2E.shproj
@@ -10,6 +10,7 @@
   <PropertyGroup />
   <ItemGroup>
     <None Include="Rest\AnonymizedExportTests.cs" />
+    <None Include="Rest\AnonymizedExportLongRunningTests.cs" />
     <None Include="Rest\CustomConvertDataTests.cs" />
     <None Include="Rest\ConvertDataTests.cs" />
   </ItemGroup>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/AnonymizedExportLongRunningTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/AnonymizedExportLongRunningTests.cs
@@ -1,0 +1,187 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
+using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Core.Features.Operations.Export;
+using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Microsoft.Health.Fhir.Tests.E2E.Rest;
+using Microsoft.Health.Test.Utilities;
+using Xunit;
+using FhirGroup = Hl7.Fhir.Model.Group;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Fhir.Core.Rest
+{
+    [Trait(Traits.Category, Categories.ExportLongRunning)]
+    [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.Json)]
+    public class AnonymizedExportLongRunningTests : AnonymizedExportTests
+    {
+        public AnonymizedExportLongRunningTests(ExportTestFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("Patient/")]
+        public async Task GivenAValidConfigurationWithETag_WhenExportingAnonymizedData_ResourceShouldBeAnonymized(string path)
+        {
+            MetricHandler?.ResetCount();
+            var dateTime = DateTimeOffset.UtcNow;
+            var resourceToCreate = Samples.GetDefaultPatient().ToPoco<Patient>();
+            resourceToCreate.Id = Guid.NewGuid().ToString();
+            await TestFhirClient.UpdateAsync(resourceToCreate);
+
+            (string fileName, string etag) = await UploadConfigurationAsync(RedactResourceIdAnonymizationConfiguration);
+            string containerName = Guid.NewGuid().ToString("N");
+            Uri contentLocation = await TestFhirClient.AnonymizedExportAsync(fileName, dateTime, containerName, etag, path);
+            HttpResponseMessage response = await WaitForCompleteAsync(contentLocation);
+            IList<Uri> blobUris = await CheckExportStatus(response);
+
+            IEnumerable<string> dataFromExport = await DownloadBlobAndParse(blobUris);
+            FhirJsonParser parser = new FhirJsonParser();
+
+            foreach (string content in dataFromExport)
+            {
+                Resource result = parser.Parse<Resource>(content);
+
+                Assert.Contains(result.Meta.Security, c => "REDACTED".Equals(c.Code));
+            }
+
+            // Only check metric for local tests
+            if (IsUsingInProcTestServer)
+            {
+                Assert.Single(MetricHandler.NotificationMapping[typeof(ExportTaskMetricsNotification)]);
+            }
+        }
+
+        [Fact]
+        public async Task GivenAValidConfigurationWithETag_WhenExportingGroupAnonymizedData_ResourceShouldBeAnonymized()
+        {
+            MetricHandler?.ResetCount();
+
+            var patientToCreate = Samples.GetDefaultPatient().ToPoco<Patient>();
+            var dateTime = DateTimeOffset.UtcNow;
+            patientToCreate.Id = Guid.NewGuid().ToString();
+            var patientReponse = await TestFhirClient.UpdateAsync(patientToCreate);
+            var patientId = patientReponse.Resource.Id;
+
+            var group = new FhirGroup()
+            {
+                Type = FhirGroup.GroupType.Person,
+                Actual = true,
+                Id = Guid.NewGuid().ToString(),
+                Member = new List<FhirGroup.MemberComponent>()
+                {
+                    new FhirGroup.MemberComponent()
+                    {
+                        Entity = new ResourceReference($"{KnownResourceTypes.Patient}/{patientId}"),
+                    },
+                },
+            };
+            var groupReponse = await TestFhirClient.UpdateAsync(group);
+            var groupId = groupReponse.Resource.Id;
+
+            (string fileName, string etag) = await UploadConfigurationAsync(RedactResourceIdAnonymizationConfiguration);
+            string containerName = Guid.NewGuid().ToString("N");
+            Uri contentLocation = await TestFhirClient.AnonymizedExportAsync(fileName, dateTime, containerName, etag, $"Group/{groupId}/");
+            HttpResponseMessage response = await WaitForCompleteAsync(contentLocation);
+            IList<Uri> blobUris = await CheckExportStatus(response);
+
+            IEnumerable<string> dataFromExport = await DownloadBlobAndParse(blobUris);
+            FhirJsonParser parser = new FhirJsonParser();
+
+            foreach (string content in dataFromExport)
+            {
+                Resource result = parser.Parse<Resource>(content);
+
+                Assert.Contains(result.Meta.Security, c => "REDACTED".Equals(c.Code));
+            }
+
+            Assert.Equal(2, dataFromExport.Count());
+
+            // Only check metric for local tests
+            if (IsUsingInProcTestServer)
+            {
+                Assert.Single(MetricHandler.NotificationMapping[typeof(ExportTaskMetricsNotification)]);
+            }
+        }
+
+        [SkippableFact]
+        public async Task GivenAValidConfigurationWithETagNoQuotes_WhenExportingAnonymizedData_ResourceShouldBeAnonymized()
+        {
+            MetricHandler?.ResetCount();
+            var dateTime = DateTimeOffset.UtcNow;
+            var resourceToCreate = Samples.GetDefaultPatient().ToPoco<Patient>();
+            resourceToCreate.Id = Guid.NewGuid().ToString();
+            await TestFhirClient.UpdateAsync(resourceToCreate);
+
+            (string fileName, string etag) = await UploadConfigurationAsync(RedactResourceIdAnonymizationConfiguration);
+            etag = etag.Substring(1, 17);
+            string containerName = Guid.NewGuid().ToString("N");
+            Uri contentLocation = await TestFhirClient.AnonymizedExportAsync(fileName, dateTime, containerName, etag);
+            HttpResponseMessage response = await WaitForCompleteAsync(contentLocation);
+            IList<Uri> blobUris = await CheckExportStatus(response);
+
+            IEnumerable<string> dataFromExport = await DownloadBlobAndParse(blobUris);
+            FhirJsonParser parser = new FhirJsonParser();
+
+            foreach (string content in dataFromExport)
+            {
+                Resource result = parser.Parse<Resource>(content);
+
+                Assert.Contains(result.Meta.Security, c => "REDACTED".Equals(c.Code));
+            }
+
+            // Only check metric for local tests
+            if (IsUsingInProcTestServer)
+            {
+                Assert.Single(MetricHandler.NotificationMapping[typeof(ExportTaskMetricsNotification)]);
+            }
+        }
+
+        [SkippableFact]
+        public async Task GivenAValidConfigurationWithoutETag_WhenExportingAnonymizedData_ResourceShouldBeAnonymized()
+        {
+            MetricHandler?.ResetCount();
+
+            var resourceToCreate = Samples.GetDefaultPatient().ToPoco<Patient>();
+            resourceToCreate.Id = Guid.NewGuid().ToString();
+            var dateTime = DateTimeOffset.UtcNow;
+            await TestFhirClient.UpdateAsync(resourceToCreate);
+
+            (string fileName, string _) = await UploadConfigurationAsync(RedactResourceIdAnonymizationConfiguration);
+
+            string containerName = Guid.NewGuid().ToString("N");
+            Uri contentLocation = await TestFhirClient.AnonymizedExportAsync(fileName, dateTime, containerName);
+            HttpResponseMessage response = await WaitForCompleteAsync(contentLocation);
+            IList<Uri> blobUris = await CheckExportStatus(response);
+
+            IEnumerable<string> dataFromExport = await DownloadBlobAndParse(blobUris);
+            FhirJsonParser parser = new FhirJsonParser();
+
+            foreach (string content in dataFromExport)
+            {
+                Resource result = parser.Parse<Resource>(content);
+
+                Assert.Contains(result.Meta.Security, c => "REDACTED".Equals(c.Code));
+            }
+
+            // Only check metric for local tests
+            if (IsUsingInProcTestServer)
+            {
+                Assert.Single(MetricHandler.NotificationMapping[typeof(ExportTaskMetricsNotification)]);
+            }
+        }
+    }
+}

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/AnonymizedExportTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/AnonymizedExportTests.cs
@@ -210,7 +210,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             return (blobName, blob.Properties.ETag);
         }
 
-        protected async Task<CloudBlobContainer> InitializeAnonymizationContainer()
+        private async Task<CloudBlobContainer> InitializeAnonymizationContainer()
         {
             CloudStorageAccount cloudAccount = GetCloudStorageAccountHelper();
             CloudBlobClient blobClient = cloudAccount.CreateCloudBlobClient();
@@ -276,7 +276,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             return result;
         }
 
-        protected CloudStorageAccount GetCloudStorageAccountHelper()
+        private CloudStorageAccount GetCloudStorageAccountHelper()
         {
             CloudStorageAccount storageAccount = null;
 

--- a/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/Microsoft.Health.Fhir.Stu3.Tests.E2E.csproj
+++ b/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/Microsoft.Health.Fhir.Stu3.Tests.E2E.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Microsoft.Health.Fhir.Shared.Tests.E2E\Rest\AnonymizedExportTests.cs" Link="Rest\AnonymizedExportTests.cs" />
+    <Compile Include="..\Microsoft.Health.Fhir.Shared.Tests.E2E\Rest\AnonymizedExportLongRunningTests.cs" Link="Rest\AnonymizedExportLongRunningTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(AspNetPackageVersion)" />


### PR DESCRIPTION
## Description
Update e2e test category for long running anonymizer tests

## Related issues
Addresses [issue #2102](https://github.com/microsoft/fhir-server/issues/2102).

## Testing
E2E tests

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip
