### PR TITLE
Used SqlErrorCodes.TimeoutExpired constant

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/ChangeFeed/SqlServerFhirResourceChangeDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/ChangeFeed/SqlServerFhirResourceChangeDataStore.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Health.Abstractions.Data;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.SqlServer;
+using Microsoft.Health.SqlServer.Features.Storage;
 
 namespace Microsoft.Health.Fhir.SqlServer.Features.ChangeFeed
 {
@@ -26,9 +27,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.ChangeFeed
         private readonly ISqlConnectionFactory _sqlConnectionFactory;
         private readonly ILogger<SqlServerFhirResourceChangeDataStore> _logger;
         private static readonly ConcurrentDictionary<short, string> ResourceTypeIdToTypeNameMap = new ConcurrentDictionary<short, string>();
-
-        // dbnetlib error value for timeout expired
-        private const short TIMEOUTEXPIRED = -2;
 
         /// <summary>
         /// Creates a new instance of the <see cref="SqlServerFhirResourceChangeDataStore"/> class.
@@ -109,7 +107,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.ChangeFeed
             {
                 switch (ex.Number)
                 {
-                    case TIMEOUTEXPIRED:
+                    case SqlErrorCodes.TimeoutExpired:
                         throw new TimeoutException(ex.Message, ex);
                     default:
                         _logger.LogError(ex, string.Format(Resources.SqlExceptionOccurredWhenFetchingResourceChanges, ex.Number));


### PR DESCRIPTION
## Description
Replaced a private constant with a TimeoutExpired constant from SqlErrorCodes class.

## Related issues
Addresses [#83513](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Aegean/Stories/?workitem=83513).

## Testing
Deployed and validated locally. Run unit and integration tests.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
