### PR TITLE
Run Patient $everything on "seealso" Links

### DIFF
--- a/docs/rest/PatientEverythingLinks.http
+++ b/docs/rest/PatientEverythingLinks.http
@@ -109,7 +109,7 @@ Authorization: Bearer {{bearer.response.body.access_token}}
       "other": {
         "reference": "RelatedPerson/newborn-mom-2"
       },
-      "type": "refers"
+      "type": "refer"
     }
   ]
 }

--- a/docs/rest/PatientEverythingLinks.http
+++ b/docs/rest/PatientEverythingLinks.http
@@ -588,7 +588,6 @@ Authorization: Bearer {{bearer.response.body.access_token}}
 # - The device-mum device
 # Then, it should run Patient $everything on the Patient "mother", which should return:
 # - The Patient "mother" resource
-# - The patient's compartment resource: the Patient "mum"
 # - The device-mother device
 GET https://{{hostname}}/Patient/{{mum.response.body.id}}/$everything
 Authorization: Bearer {{bearer.response.body.access_token}}

--- a/docs/rest/PatientEverythingLinks.http
+++ b/docs/rest/PatientEverythingLinks.http
@@ -642,7 +642,7 @@ Authorization: Bearer {{bearer.response.body.access_token}}
   "link": [
     {
       "other": {
-        "reference": "RelatedPerson/newborn-mom"
+        "reference": "Patient/mother"
       },
       "type": "replaced-by"
     }
@@ -651,5 +651,10 @@ Authorization: Bearer {{bearer.response.body.access_token}}
 
 ###
 # An operation outcome should be returned.
+# The url to the correct request should be in the content location header.
 GET https://{{hostname}}/Patient/{{replacedby.response.body.id}}/$everything
 Authorization: Bearer {{bearer.response.body.access_token}}
+
+###
+# Paste the response's content location header below
+GET <paste content location header here>

--- a/docs/rest/PatientEverythingLinks.http
+++ b/docs/rest/PatientEverythingLinks.http
@@ -3,7 +3,7 @@
 # behaviour depending on the type of the link:
 # - "seealso": Patient $everything is run on this patient as well
 # - "replaced-by": An operation outcome is returned
-# - "replaces"/"refers": These links are ignored
+# - "replaces"/"refer": These links are ignored
 #
 # This test assumes you are running the FHIR server locally with R4
 
@@ -25,7 +25,7 @@ grant_type=client_credentials
 # This patient directly references HL7 as its managing organization.
 # It also has two "seealso" links: one to a RelatedPerson and one
 # to another Patient resource.
-# Finally, it has a "replaces" link and a "refers" link. These 
+# Finally, it has a "replaces" link and a "refer" link. These 
 # should be ignored by the Patient $everything operation.
 # @name mum
 PUT https://{{hostname}}/Patient/mum

--- a/docs/rest/PatientEverythingLinks.http
+++ b/docs/rest/PatientEverythingLinks.http
@@ -1,0 +1,656 @@
+# This test flow confirms the Patient $everything operation's behaviour
+# when a patient's links are populated. We can expect different 
+# behaviour depending on the type of the link:
+# - "seealso": Patient $everything is run on this patient as well
+# - "replaced-by": An operation outcome is returned
+# - "replaces"/"refers": These links are ignored
+#
+# This test assumes you are running the FHIR server locally with R4
+
+@hostname = localhost:44348
+
+###
+# Get the bearer token if authentication is enabled
+# @name bearer
+POST https://{{hostname}}/connect/token
+content-type: application/x-www-form-urlencoded
+
+grant_type=client_credentials
+&client_id=globalAdminServicePrincipal
+&client_secret=globalAdminServicePrincipal
+&scope=fhir-api
+
+###
+# Create a patient to run the Patient $everything operation on.
+# This patient directly references HL7 as its managing organization.
+# It also has two "seealso" links: one to a RelatedPerson and one
+# to another Patient resource.
+# Finally, it has a "replaces" link and a "refers" link. These 
+# should be ignored by the Patient $everything operation.
+# @name mum
+PUT https://{{hostname}}/Patient/mum
+Content-Type: application/json
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+{
+  "resourceType": "Patient",
+  "id": "mum",
+  "meta": {
+    "lastUpdated": "2012-05-29T23:45:32Z"
+  },
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: mom</p><p><b>meta</b>: </p><p><b>identifier</b>: Social Security number = 444222222</p><p><b>active</b>: true</p><p><b>name</b>: Eve Everywoman (OFFICIAL)</p><p><b>telecom</b>: ph: 555-555-2003(WORK)</p><p><b>gender</b>: female</p><p><b>birthDate</b>: 31/05/1973</p><p><b>address</b>: 2222 Home Street (HOME)</p><p><b>managingOrganization</b>: <a>Organization/hl7</a></p><h3>Links</h3><table><tr><td>-</td><td><b>Other</b></td><td><b>Type</b></td></tr><tr><td>*</td><td><a>RelatedPerson/newborn-mom</a></td><td>seealso</td></tr></table></div>"
+  },
+  "identifier": [
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "SS"
+          }
+        ]
+      },
+      "system": "http://hl7.org/fhir/sid/us-ssn",
+      "value": "444222222"
+    }
+  ],
+  "active": true,
+  "name": [
+    {
+      "use": "official",
+      "family": "Everywoman",
+      "given": [
+        "Eve"
+      ]
+    }
+  ],
+  "telecom": [
+    {
+      "system": "phone",
+      "value": "555-555-2003",
+      "use": "work"
+    }
+  ],
+  "gender": "female",
+  "birthDate": "1973-05-31",
+  "address": [
+    {
+      "use": "home",
+      "line": [
+        "2222 Home Street"
+      ]
+    }
+  ],
+  "managingOrganization": {
+    "reference": "Organization/hl7"
+  },
+  "link": [
+    {
+      "other": {
+        "reference": "RelatedPerson/newborn-mom"
+      },
+      "type": "seealso"
+    },
+    {
+      "other": {
+        "reference": "Patient/mother"
+      },
+      "type": "seealso"
+    },
+    {
+      "other": {
+        "reference": "RelatedPerson/newborn-mom-1"
+      },
+      "type": "replaces"
+    },
+    {
+      "other": {
+        "reference": "RelatedPerson/newborn-mom-2"
+      },
+      "type": "refers"
+    }
+  ]
+}
+
+###
+# Create the Organization resource directly referenced by Patient "mum".
+# This will be picked up by the Patient $everything operation.
+PUT https://{{hostname}}/Organization/hl7
+Content-Type: application/json
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+{
+  "resourceType": "Organization",
+  "id": "hl7",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n      Health Level Seven International\n      <br/>\n\t\t\t\t3300 Washtenaw Avenue, Suite 227\n      <br/>\n\t\t\t\tAnn Arbor, MI 48104\n      <br/>\n\t\t\t\tUSA\n      <br/>\n\t\t\t\t(+1) 734-677-7777 (phone)\n      <br/>\n\t\t\t\t(+1) 734-677-6622 (fax)\n      <br/>\n\t\t\t\tE-mail:  \n      <a href=\"mailto:hq@HL7.org\">hq@HL7.org</a>\n    \n    </div>"
+  },
+  "name": "Health Level Seven International",
+  "alias": [
+    "HL7 International"
+  ],
+  "telecom": [
+    {
+      "system": "phone",
+      "value": "(+1) 734-677-7777"
+    },
+    {
+      "system": "fax",
+      "value": "(+1) 734-677-6622"
+    },
+    {
+      "system": "email",
+      "value": "hq@HL7.org"
+    }
+  ],
+  "address": [
+    {
+      "line": [
+        "3300 Washtenaw Avenue, Suite 227"
+      ],
+      "city": "Ann Arbor",
+      "state": "MI",
+      "postalCode": "48104",
+      "country": "USA"
+    }
+  ],
+  "endpoint": [
+    {
+      "reference": "Endpoint/example"
+    }
+  ]
+}
+
+###
+# Create the Patient resource referenced by Patient "mum".
+# Since this is linked as "seealso" in "mum", this will be picked up by
+# the Patient $everything operation.
+# The Patient $everything operation will be run on this Patient as well.
+PUT https://{{hostname}}/Patient/mother
+Content-Type: application/json
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+{
+  "resourceType": "Patient",
+  "id": "mother",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: mother</p><p><b>gender</b>: female</p><p><b>birthDate</b>: 1973/05/31</p></div>"
+  },
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/patient-mothersMaidenName",
+      "valueString": "Everywoman"
+    }
+  ],
+  "gender": "female",
+  "birthDate": "1973-05-31",
+  "_birthDate": {
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/StructureDefinition/patient-birthTime",
+        "valueDateTime": "1973-05-31T17:11:00+01:00"
+      }
+    ]
+  }
+}
+
+
+###
+# Create the RelatedPerson resource referenced by Patient "mum".
+# Even though this is linked as "seealso" in "mum", this will not be picked
+# up by the Patient $everything operation because it is not a Patient resource.
+PUT https://{{hostname}}/RelatedPerson/newborn-mom
+Content-Type: application/json
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+{
+  "resourceType": "RelatedPerson",
+  "id": "newborn-mom",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: newborn-mom</p><p><b>identifier</b>: Social Security number = 444222222</p><p><b>active</b>: true</p><p><b>patient</b>: <a>Patient/newborn</a></p><p><b>relationship</b>: Natural Mother <span>(Details : {http://terminology.hl7.org/CodeSystem/v3-RoleCode code 'NMTH' = 'natural mother', given as 'natural mother'})</span></p><p><b>name</b>: Eve Everywoman (OFFICIAL)</p><p><b>telecom</b>: ph: 555-555-2003(WORK)</p><p><b>gender</b>: female</p><p><b>birthDate</b>: 31/05/1973</p><p><b>address</b>: 2222 Home Street (HOME)</p></div>"
+  },
+  "identifier": [
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "SS"
+          }
+        ]
+      },
+      "system": "http://hl7.org/fhir/sid/us-ssn",
+      "value": "444222222"
+    }
+  ],
+  "active": true,
+  "patient": {
+    "reference": "Patient/newborn"
+  },
+  "relationship": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+          "code": "NMTH",
+          "display": "natural mother"
+        }
+      ],
+      "text": "Natural Mother"
+    }
+  ],
+  "name": [
+    {
+      "use": "official",
+      "family": "Everywoman",
+      "given": [
+        "Eve"
+      ]
+    }
+  ],
+  "telecom": [
+    {
+      "system": "phone",
+      "value": "555-555-2003",
+      "use": "work"
+    }
+  ],
+  "gender": "female",
+  "birthDate": "1973-05-31",
+  "address": [
+    {
+      "use": "home",
+      "line": [
+        "2222 Home Street"
+      ]
+    }
+  ]
+}
+
+###
+# Create a procedure that references Patient "mum".
+# This will be apart of Patient "mum"'s patient compartment and will be picked
+# up by the Patient $everything operation.
+PUT https://{{hostname}}/Procedure/appendectomy
+Content-Type: application/json
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+{
+  "resourceType": "Procedure",
+  "id": "appendectomy",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Routine Appendectomy</div>"
+  },
+  "status": "completed",
+  "code": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "80146002",
+        "display": "Appendectomy (Procedure)"
+      }
+    ],
+    "text": "Appendectomy"
+  },
+  "subject": {
+    "reference": "Patient/mum"
+  },
+  "recorder": {
+    "reference": "Practitioner/dude",
+    "display": "Dr Adam Careful"
+  },
+  "performer": [
+    {
+      "actor": {
+        "reference": "Practitioner/dude",
+        "display": "Dr Adam Careful"
+      }
+    }
+  ],
+  "followUp": [
+    {
+      "text": "ROS 5 days  - 2013-04-10"
+    }
+  ],
+  "note": [
+    {
+      "text": "Routine Appendectomy. Appendix was inflamed and in retro-caecal position"
+    }
+  ]
+}
+
+###
+# Create an allergy intolerance that references Patient "mum".
+# This will be apart of Patient "mum"'s patient compartment and will be picked
+# up by the Patient $everything operation.
+PUT https://{{hostname}}/AllergyIntolerance/cashews
+Content-Type: application/json
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+{
+  "resourceType": "AllergyIntolerance",
+  "id": "cashews",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: cashews</p><p><b>identifier</b>: 49476534</p><p><b>clinicalStatus</b>: Active <span>(Details : {http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical code 'active' = 'Active', given as 'Active'})</span></p><p><b>verificationStatus</b>: Confirmed <span>(Details : {http://terminology.hl7.org/CodeSystem/allergyintolerance-verification code 'confirmed' = 'Confirmed', given as 'Confirmed'})</span></p><p><b>type</b>: allergy</p><p><b>category</b>: food</p><p><b>criticality</b>: high</p><p><b>code</b>: Cashew nuts <span>(Details : {SNOMED CT code '227493005' = 'Cashew nuts', given as 'Cashew nuts'})</span></p><p><b>patient</b>: <a>Patient/example</a></p><p><b>onset</b>: 01/01/2004</p><p><b>recordedDate</b>: 09/10/2014 2:58:00 PM</p><p><b>recorder</b>: <a>Practitioner/example</a></p><p><b>asserter</b>: <a>Patient/example</a></p><p><b>lastOccurrence</b>: 01/06/2012</p><p><b>note</b>: The criticality is high becasue of the observed anaphylactic reaction when challenged with cashew extract.</p><blockquote><p><b>reaction</b></p><p><b>substance</b>: cashew nut allergenic extract Injectable Product <span>(Details : {RxNorm code '1160593' = 'cashew nut allergenic extract Injectable Product', given as 'cashew nut allergenic extract Injectable Product'})</span></p><p><b>manifestation</b>: Anaphylactic reaction <span>(Details : {SNOMED CT code '39579001' = 'Anaphylaxis', given as 'Anaphylactic reaction'})</span></p><p><b>description</b>: Challenge Protocol. Severe reaction to subcutaneous cashew extract. Epinephrine administered</p><p><b>onset</b>: 12/06/2012</p><p><b>severity</b>: severe</p><p><b>exposureRoute</b>: Subcutaneous route <span>(Details : {SNOMED CT code '34206005' = 'Subcutaneous route', given as 'Subcutaneous route'})</span></p></blockquote><blockquote><p><b>reaction</b></p><p><b>manifestation</b>: Urticaria <span>(Details : {SNOMED CT code '64305001' = 'Urticaria', given as 'Urticaria'})</span></p><p><b>onset</b>: 01/01/2004</p><p><b>severity</b>: moderate</p><p><b>note</b>: The patient reports that the onset of urticaria was within 15 minutes of eating cashews.</p></blockquote></div>"
+  },
+  "identifier": [
+    {
+      "system": "http://acme.com/ids/patients/risks",
+      "value": "49476534"
+    }
+  ],
+  "clinicalStatus": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+        "code": "active",
+        "display": "Active"
+      }
+    ]
+  },
+  "verificationStatus": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+        "code": "confirmed",
+        "display": "Confirmed"
+      }
+    ]
+  },
+  "type": "allergy",
+  "category": [
+    "food"
+  ],
+  "criticality": "high",
+  "code": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "227493005",
+        "display": "Cashew nuts"
+      }
+    ]
+  },
+  "patient": {
+    "reference": "Patient/mum"
+  },
+  "onsetDateTime": "2004",
+  "recordedDate": "2014-10-09T14:58:00+11:00",
+  "recorder": {
+    "reference": "Practitioner/dude"
+  },
+  "asserter": {
+    "reference": "Patient/mum"
+  },
+  "lastOccurrence": "2012-06",
+  "note": [
+    {
+      "text": "The criticality is high becasue of the observed anaphylactic reaction when challenged with cashew extract."
+    }
+  ],
+  "reaction": [
+    {
+      "substance": {
+        "coding": [
+          {
+            "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+            "code": "1160593",
+            "display": "cashew nut allergenic extract Injectable Product"
+          }
+        ]
+      },
+      "manifestation": [
+        {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "39579001",
+              "display": "Anaphylactic reaction"
+            }
+          ]
+        }
+      ],
+      "description": "Challenge Protocol. Severe reaction to subcutaneous cashew extract. Epinephrine administered",
+      "onset": "2012-06-12",
+      "severity": "severe",
+      "exposureRoute": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "34206005",
+            "display": "Subcutaneous route"
+          }
+        ]
+      }
+    },
+    {
+      "manifestation": [
+        {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "64305001",
+              "display": "Urticaria"
+            }
+          ]
+        }
+      ],
+      "onset": "2004",
+      "severity": "moderate",
+      "note": [
+        {
+          "text": "The patient reports that the onset of urticaria was within 15 minutes of eating cashews."
+        }
+      ]
+    }
+  ]
+}
+
+###
+# Create the practitioner that will be referenced by the two other resources
+# above: the Procedure "appendectomy" and the AllergyIntollerance "cashews"
+# This will not be picked up by the Patient $everything operation because
+# it does not live in the patient compartment and it is not referenced by
+# the patient directly.
+PUT https://{{hostname}}/Practitioner/dude
+Content-Type: application/json
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+{
+  "resourceType": "Practitioner",
+  "id": "dude",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n      <p>Dr Adam Careful is a Referring Practitioner for Acme Hospital from 1-Jan 2012 to 31-Mar\n        2012</p>\n    </div>"
+  },
+  "identifier": [
+    {
+      "system": "http://www.acme.org/practitioners",
+      "value": "23"
+    }
+  ],
+  "active": true,
+  "name": [
+    {
+      "family": "Careful",
+      "given": [
+        "Adam"
+      ],
+      "prefix": [
+        "Dr"
+      ]
+    }
+  ],
+  "address": [
+    {
+      "use": "home",
+      "line": [
+        "534 Erewhon St"
+      ],
+      "city": "PleasantVille",
+      "state": "Vic",
+      "postalCode": "3999"
+    }
+  ],
+  "qualification": [
+    {
+      "identifier": [
+        {
+          "system": "http://example.org/UniversityIdentifier",
+          "value": "12345"
+        }
+      ],
+      "code": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0360/2.7",
+            "code": "BS",
+            "display": "Bachelor of Science"
+          }
+        ],
+        "text": "Bachelor of Science"
+      },
+      "period": {
+        "start": "1995"
+      },
+      "issuer": {
+        "display": "Example University"
+      }
+    }
+  ]
+}
+
+###
+# Create a device that references Patient "mum".
+# This will be picked up by the Patient $everything operation.
+PUT https://{{hostname}}/Device/device-mum
+Content-Type: application/json
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+{
+  "resourceType": "Device",
+  "id": "device-mum",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: device-mum</p><p><b>identifier</b>: 345675</p></div>"
+  },
+  "identifier": [
+    {
+      "system": "http://goodcare.org/devices/id",
+      "value": "345675"
+    }
+  ],
+  "patient" : {
+    "reference": "Patient/mum"
+  }
+}
+
+
+###
+# Create a device that references Patient "mother".
+# This will be picked up when the Patient $everything operation considers
+# the "seealso" link to Patient "mother"
+PUT https://{{hostname}}/Device/device-mother
+Content-Type: application/json
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+{
+  "resourceType": "Device",
+  "id": "device-mother",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: device-mother</p><p><b>identifier</b>: 345675</p></div>"
+  },
+  "identifier": [
+    {
+      "system": "http://goodcare.org/devices/id",
+      "value": "345675"
+    }
+  ],
+  "patient" : {
+    "reference": "Patient/mother"
+  }
+}
+
+###
+# Run Patient $everything on the Patient "mum" and continue to follow the "next" link
+# in the returned bundles to retrieve all the results.
+# This should return:
+# - The Patient "mum" resource and the HL7 organization that it references directly
+# - The patient's compartment resources: the cashew allergy intolerance and the appendectomy procedure
+# - The device-mum device
+# Then, it should run Patient $everything on the Patient "mother", which should return:
+# - The Patient "mother" resource
+# - The patient's compartment resource: the Patient "mum"
+# - The device-mother device
+GET https://{{hostname}}/Patient/{{mum.response.body.id}}/$everything
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+
+###
+# Paste the "next" link below
+GET <paste next link here>
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+###
+# Run Patient $everything, but only request Device resources.
+# This should return:
+# - The device-mum device
+# - The device-mother device
+GET https://{{hostname}}/Patient/{{mum.response.body.id}}/$everything?_type=Device
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+###
+# Paste the "next" link below
+GET <paste next link here>
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+###
+# Create a patient to run the Patient $everything operation on that
+# has a "replaced-by" link.
+# An error should be returned when the operation is run.
+# @name replacedby
+PUT https://{{hostname}}/Patient/replaced-by-link
+Content-Type: application/json
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+{
+  "resourceType": "Patient",
+  "id": "replaced-by-link",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: test</p><p><b>meta</b>: </p><p><b>identifier</b>: Social Security number = 444222222</p><p><b>active</b>: true</p><p><b>name</b>: Eve Everywoman (OFFICIAL)</p><p><b>telecom</b>: ph: 555-555-2003(WORK)</p><p><b>gender</b>: female</p><p><b>birthDate</b>: 31/05/1973</p><p><b>address</b>: 2222 Home Street (HOME)</p><p><b>managingOrganization</b>: <a>Organization/hl7</a></p><h3>Links</h3><table><tr><td>-</td><td><b>Other</b></td><td><b>Type</b></td></tr><tr><td>*</td><td><a>RelatedPerson/newborn-mom</a></td><td>seealso</td></tr></table></div>"
+  },
+  "active": true,
+  "name": [
+    {
+      "use": "official",
+      "family": "Test",
+      "given": [
+        "Test"
+      ]
+    }
+  ],
+  "gender": "female",
+  "birthDate": "1973-05-31",
+  "link": [
+    {
+      "other": {
+        "reference": "RelatedPerson/newborn-mom"
+      },
+      "type": "replaced-by"
+    }
+  ]
+}
+
+###
+# An operation outcome should be returned.
+GET https://{{hostname}}/Patient/{{replacedby.response.body.id}}/$everything
+Authorization: Bearer {{bearer.response.body.access_token}}

--- a/docs/rest/PatientEverythingLinks.http
+++ b/docs/rest/PatientEverythingLinks.http
@@ -658,3 +658,109 @@ Authorization: Bearer {{bearer.response.body.access_token}}
 ###
 # Paste the response's content location header below
 GET <paste content location header here>
+
+###
+# @name toomanylinks
+PUT https://{{hostname}}/Patient/toomanylinks
+Content-Type: application/json
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+{
+  "resourceType": "Patient",
+  "id": "toomanylinks",
+  "active": true,
+  "name": [
+    {
+      "use": "official",
+      "family": "Test",
+      "given": [
+        "Test"
+      ]
+    }
+  ],
+  "gender": "other",
+  "birthDate": "2006-06-06",
+  "address": [
+    {
+      "use": "home",
+      "line": [
+        "1 Microsoft Way"
+      ]
+    }
+  ],
+  "link": [
+    {
+      "other": {
+        "reference": "Patient/test0"
+      },
+      "type": "seealso"
+    },
+    {
+      "other": {
+        "reference": "Patient/test1"
+      },
+      "type": "seealso"
+    },
+    {
+      "other": {
+        "reference": "Patient/test2"
+      },
+      "type": "seealso"
+    },
+    {
+      "other": {
+        "reference": "Patient/test3"
+      },
+      "type": "seealso"
+    },
+    {
+      "other": {
+        "reference": "Patient/test4"
+      },
+      "type": "seealso"
+    },
+    {
+      "other": {
+        "reference": "Patient/test5"
+      },
+      "type": "seealso"
+    },
+    {
+      "other": {
+        "reference": "Patient/test6"
+      },
+      "type": "seealso"
+    },
+    {
+      "other": {
+        "reference": "Patient/test7"
+      },
+      "type": "seealso"
+    },
+    {
+      "other": {
+        "reference": "Patient/test8"
+      },
+      "type": "seealso"
+    },
+    {
+      "other": {
+        "reference": "Patient/test9"
+      },
+      "type": "seealso"
+    },
+    {
+      "other": {
+        "reference": "Patient/test10"
+      },
+      "type": "seealso"
+    }
+  ]
+}
+
+###
+# An operation outcome should be returned indicating that the patient has more than
+# the maximum number of links.
+GET https://{{hostname}}/Patient/{{toomanylinks.response.body.id}}/$everything
+Authorization: Bearer {{bearer.response.body.access_token}}
+

--- a/docs/rest/PatientEverythingLinks.http
+++ b/docs/rest/PatientEverythingLinks.http
@@ -1,5 +1,5 @@
 # This test flow confirms the Patient $everything operation's behaviour
-# when a patient's links are populated. We can expect different 
+# when a patient's links are populated. We can expect different
 # behaviour depending on the type of the link:
 # - "seealso": Patient $everything is run on this patient as well
 # - "replaced-by": An operation outcome is returned
@@ -25,7 +25,7 @@ grant_type=client_credentials
 # This patient directly references HL7 as its managing organization.
 # It also has two "seealso" links: one to a RelatedPerson and one
 # to another Patient resource.
-# Finally, it has a "replaces" link and a "refer" link. These 
+# Finally, it has a "replaces" link and a "refer" link. These
 # should be ignored by the Patient $everything operation.
 # @name mum
 PUT https://{{hostname}}/Patient/mum
@@ -658,109 +658,3 @@ Authorization: Bearer {{bearer.response.body.access_token}}
 ###
 # Paste the response's content location header below
 GET <paste content location header here>
-
-###
-# @name toomanylinks
-PUT https://{{hostname}}/Patient/toomanylinks
-Content-Type: application/json
-Authorization: Bearer {{bearer.response.body.access_token}}
-
-{
-  "resourceType": "Patient",
-  "id": "toomanylinks",
-  "active": true,
-  "name": [
-    {
-      "use": "official",
-      "family": "Test",
-      "given": [
-        "Test"
-      ]
-    }
-  ],
-  "gender": "other",
-  "birthDate": "2006-06-06",
-  "address": [
-    {
-      "use": "home",
-      "line": [
-        "1 Microsoft Way"
-      ]
-    }
-  ],
-  "link": [
-    {
-      "other": {
-        "reference": "Patient/test0"
-      },
-      "type": "seealso"
-    },
-    {
-      "other": {
-        "reference": "Patient/test1"
-      },
-      "type": "seealso"
-    },
-    {
-      "other": {
-        "reference": "Patient/test2"
-      },
-      "type": "seealso"
-    },
-    {
-      "other": {
-        "reference": "Patient/test3"
-      },
-      "type": "seealso"
-    },
-    {
-      "other": {
-        "reference": "Patient/test4"
-      },
-      "type": "seealso"
-    },
-    {
-      "other": {
-        "reference": "Patient/test5"
-      },
-      "type": "seealso"
-    },
-    {
-      "other": {
-        "reference": "Patient/test6"
-      },
-      "type": "seealso"
-    },
-    {
-      "other": {
-        "reference": "Patient/test7"
-      },
-      "type": "seealso"
-    },
-    {
-      "other": {
-        "reference": "Patient/test8"
-      },
-      "type": "seealso"
-    },
-    {
-      "other": {
-        "reference": "Patient/test9"
-      },
-      "type": "seealso"
-    },
-    {
-      "other": {
-        "reference": "Patient/test10"
-      },
-      "type": "seealso"
-    }
-  ]
-}
-
-###
-# An operation outcome should be returned indicating that the patient has more than
-# the maximum number of links.
-GET https://{{hostname}}/Patient/{{toomanylinks.response.body.id}}/$everything
-Authorization: Bearer {{bearer.response.body.access_token}}
-

--- a/src/Microsoft.Health.Fhir.Api/Features/Routing/UrlResolver.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Routing/UrlResolver.cs
@@ -253,6 +253,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
                 case OperationsConstants.Import:
                     routeName = RouteNames.GetImportStatusById;
                     break;
+                case OperationsConstants.PatientEverything:
+                    routeName = RouteNames.PatientEverythingById;
+                    break;
                 default:
                     throw new OperationNotImplementedException(string.Format(Resources.OperationNotImplemented, operationName));
             }

--- a/src/Microsoft.Health.Fhir.Core/Exceptions/EverythingOperationException.cs
+++ b/src/Microsoft.Health.Fhir.Core/Exceptions/EverythingOperationException.cs
@@ -11,12 +11,13 @@ namespace Microsoft.Health.Fhir.Core.Exceptions
 {
     public class EverythingOperationException : FhirException
     {
-        public EverythingOperationException(string message, HttpStatusCode httpStatusCode)
+        public EverythingOperationException(string message, HttpStatusCode httpStatusCode, string contentLocationHeaderValue = null)
             : base(message)
         {
             Debug.Assert(!string.IsNullOrEmpty(message), "Exception message should not be empty.");
 
             ResponseStatusCode = httpStatusCode;
+            ContentLocationHeaderValue = contentLocationHeaderValue;
 
             Issues.Add(new OperationOutcomeIssue(
                 OperationOutcomeConstants.IssueSeverity.Error,
@@ -25,5 +26,7 @@ namespace Microsoft.Health.Fhir.Core.Exceptions
         }
 
         public HttpStatusCode ResponseStatusCode { get; }
+
+        public string ContentLocationHeaderValue { get; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Exceptions/EverythingOperationException.cs
+++ b/src/Microsoft.Health.Fhir.Core/Exceptions/EverythingOperationException.cs
@@ -4,21 +4,26 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Diagnostics;
+using System.Net;
 using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Core.Exceptions
 {
     public class EverythingOperationException : FhirException
     {
-        public EverythingOperationException(string message)
+        public EverythingOperationException(string message, HttpStatusCode httpStatusCode)
             : base(message)
         {
             Debug.Assert(!string.IsNullOrEmpty(message), "Exception message should not be empty.");
+
+            ResponseStatusCode = httpStatusCode;
 
             Issues.Add(new OperationOutcomeIssue(
                 OperationOutcomeConstants.IssueSeverity.Error,
                 OperationOutcomeConstants.IssueType.Invalid,
                 message));
         }
+
+        public HttpStatusCode ResponseStatusCode { get; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -10,8 +10,8 @@
 
 namespace Microsoft.Health.Fhir.Core {
     using System;
-
-
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -19,19 +19,19 @@ namespace Microsoft.Health.Fhir.Core {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
-
+        
         private static global::System.Resources.ResourceManager resourceMan;
-
+        
         private static global::System.Globalization.CultureInfo resourceCulture;
-
+        
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         internal Resources() {
         }
-
+        
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
@@ -45,7 +45,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return resourceMan;
             }
         }
-
+        
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
@@ -59,7 +59,7 @@ namespace Microsoft.Health.Fhir.Core {
                 resourceCulture = value;
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {0} and {1} cannot both be specified..
         /// </summary>
@@ -68,7 +68,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("AtCannotBeSpecifiedWithBeforeOrSince", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Only a bundle can be submitted for batch or transaction processing..
         /// </summary>
@@ -77,7 +77,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("BundleRequiredForBatchOrTransaction", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Can&apos;t find &apos;{0}&apos; in type &apos;{1}&apos;.
         /// </summary>
@@ -95,7 +95,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ChainedParameterMustBeReferenceSearchParamType", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The chained parameter is not supported..
         /// </summary>
@@ -104,7 +104,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ChainedParameterNotSupported", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The reference search parameter &apos;{0}&apos; refers to multiple possible resource types. Please specify a type in the search expression: {1}.
         /// </summary>
@@ -113,7 +113,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ChainedParameterSpecifyType", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Changes to seach parameters is not allowed while a reindex job is ongoing.  Wait for the reindex job with Id: {0} to finish, or cancel it..
         /// </summary>
@@ -122,7 +122,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ChangesToSearchParametersNotAllowedWhileReindexing", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Comparator &apos;{0}&apos; is not supported for search parameter &apos;{1}&apos;..
         /// </summary>
@@ -131,7 +131,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ComparatorNotSupported", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The compartment definition contains one or more invalid entries..
         /// </summary>
@@ -140,7 +140,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CompartmentDefinitionContainsInvalidEntry", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to bundle.entry[{0}].resource has duplicate resources..
         /// </summary>
@@ -149,7 +149,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CompartmentDefinitionDupeResource", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to bundle.entry[{0}] is null..
         /// </summary>
@@ -158,7 +158,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CompartmentDefinitionInvalidBundle", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to bundle.entry[{0}].resource.code is null. Not a valid compartment type..
         /// </summary>
@@ -167,7 +167,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CompartmentDefinitionInvalidCompartmentType", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to bundle.entry[{0}].resource is null or is not a CompartmentDefinition resource..
         /// </summary>
@@ -176,7 +176,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CompartmentDefinitionInvalidResource", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to bundle.entry[{0}].resource.url is invalid..
         /// </summary>
@@ -185,7 +185,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CompartmentDefinitionInvalidUrl", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to bundle.entry[{0}].resource has duplicate compartment definitions..
         /// </summary>
@@ -194,7 +194,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CompartmentDefinitionIsDupe", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Compartment id is null or empty..
         /// </summary>
@@ -203,7 +203,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CompartmentIdIsInvalid", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Compartment type {0} is invalid..
         /// </summary>
@@ -212,7 +212,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CompartmentTypeIsInvalid", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The composite separator cannot be found..
         /// </summary>
@@ -221,7 +221,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CompositeSeparatorNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The _count parameter must be between {0} and {1}..
         /// </summary>
@@ -230,7 +230,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ConditionalDeleteCountOutOfRange", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Operation was not attempted because search criteria was not selective enough..
         /// </summary>
@@ -239,7 +239,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ConditionalOperationNotSelectiveEnough", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The operation was stopped due to the underlying request being too resource intensive. If possible, try narrowing or changing the criteria..
         /// </summary>
@@ -248,7 +248,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ConditionalRequestTooCostly", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Found result with Id &apos;{0}&apos;, which did not match the provided Id &apos;{1}&apos;..
         /// </summary>
@@ -257,7 +257,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ConditionalUpdateMismatchedIds", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Fail to access the container registry &apos;{0}&apos;, please check the registry configuration..
         /// </summary>
@@ -266,7 +266,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ContainerRegistryNotAuthorized", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Failed to convert the input data. Reason: {0}.
         /// </summary>
@@ -275,7 +275,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ConvertDataFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Convert data operation has timed out..
         /// </summary>
@@ -284,7 +284,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ConvertDataOperationTimeout", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The prefix used to identify custom audit headers cannot be empty..
         /// </summary>
@@ -293,7 +293,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CustomHeaderPrefixCannotBeEmpty", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to An error occurred creating the custom search parameter.  The issue must be resolved and the parameter resubmitted to become functional..
         /// </summary>
@@ -302,7 +302,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CustomSearchCreateError", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to An error occurred deleting the custom search parameter.  The issue must be resolved and the delete request resubmitted to remove the parameter..
         /// </summary>
@@ -311,7 +311,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CustomSearchDeleteError", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Custom Search parameter with Uri: {0} was not found..
         /// </summary>
@@ -320,7 +320,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CustomSearchParameterNotfound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to An error occurred updating the custom search parameter.  The issue must be resolved and the update resubmitted to be applied..
         /// </summary>
@@ -329,7 +329,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("CustomSearchUpdateError", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The date time string &apos;{0}&apos; is not in a correct format..
         /// </summary>
@@ -338,7 +338,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("DateTimeStringIsIncorrectlyFormatted", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to At least one portion of the date time string &apos;{0}&apos; is out of range..
         /// </summary>
@@ -347,7 +347,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("DateTimeStringIsOutOfRange", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Deleting a specific record version is not supported..
         /// </summary>
@@ -356,7 +356,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("DeleteVersionNotAllowed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to There are {0} roles with the name &apos;{1}&apos;.
         /// </summary>
@@ -365,7 +365,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("DuplicateRoleNames", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The &apos;_elements&apos; parameter is supported only when &apos;_summary&apos; is SummaryType.False or &apos;_summary&apos; is not specified at all..
         /// </summary>
@@ -374,7 +374,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ElementsAndSummaryParametersAreIncompatible", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Error validating roles:
         ///{0}.
@@ -384,7 +384,16 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ErrorValidatingRoles", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The patient with id `{0}` is no longer relevant. Use patient with id `{1}` instead..
+        /// </summary>
+        internal static string EverythingOperationResourceIrrelevant {
+            get {
+                return ResourceManager.GetString("EverythingOperationResourceIrrelevant", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to The format &apos;{0}&apos; could not be found..
         /// </summary>
@@ -393,7 +402,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ExportFormatNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Failed to anonymize resource. The job will be marked as failed. {0}.
         /// </summary>
@@ -402,7 +411,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("FailedToAnonymizeResource", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Failed to fetch the template collection. Reason: {0}.
         /// </summary>
@@ -411,7 +420,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("FetchTemplateCollectionFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Authorization failed..
         /// </summary>
@@ -420,7 +429,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("Forbidden", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Parameter {0} cannot a be a value in the future..
         /// </summary>
@@ -429,7 +438,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("HistoryParameterBeforeCannotBeFuture", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Id must be any combination of upper or lower case ASCII letters (&apos;A&apos;..&apos;Z&apos;, and &apos;a&apos;..&apos;z&apos;), numerals (&apos;0&apos;..&apos;9&apos;), &apos;-&apos; and &apos;.&apos;, with a length limit of 64 characters. (This might be an integer, an un-prefixed OID, UUID, or any other identifier pattern that meets these constraints.).
         /// </summary>
@@ -438,7 +447,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("IdRequirements", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to A valid if-match header is required for resource type &apos;{0}&apos;..
         /// </summary>
@@ -447,7 +456,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("IfMatchHeaderRequiredForResource", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Illegal attribute name &apos;{0}&apos; on element &apos;{1}&apos;..
         /// </summary>
@@ -456,7 +465,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("IllegalHtmlAttribute", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Illegal element name &apos;{0}&apos;..
         /// </summary>
@@ -465,7 +474,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("IllegalHtmlElement", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The div element must not be empty or only whitespace..
         /// </summary>
@@ -474,7 +483,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("IllegalHtmlEmpty", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to XHTML content should be contained within a single &lt;div&gt; element..
         /// </summary>
@@ -483,7 +492,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("IllegalHtmlOuterDiv", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Error while parsing XHTML: {0} Line: {1} Col: {2}..
         /// </summary>
@@ -492,7 +501,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("IllegalHtmlParsingError", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Import operation has already completed.
         /// </summary>
@@ -528,7 +537,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("IncludeCannotBeAgainstBase", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The parameter {0}={1} with circular reference is executed once (a single iteration)..
         /// </summary>
@@ -537,7 +546,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("IncludeIterateCircularReferenceExecutedOnce", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The _include search is missing the type to search..
         /// </summary>
@@ -546,7 +555,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("IncludeMissingType", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Field &apos;{0}&apos; with value &apos;{1}&apos; is not supported..
         /// </summary>
@@ -555,7 +564,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("InvalidBooleanConfigSetting", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Given conditional reference &apos;{0}&apos; does not resolve to a resource..
         /// </summary>
@@ -564,7 +573,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("InvalidConditionalReference", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Resource type and query parameter must be present in a given request &apos;{0}&apos;..
         /// </summary>
@@ -573,7 +582,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("InvalidConditionalReferenceParameters", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Value &apos;{0}&apos; is not supported. Please select from the following list of supported capabilities: [{1}]..
         /// </summary>
@@ -582,7 +591,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("InvalidConfigSetting", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The continuation token is invalid..
         /// </summary>
@@ -591,7 +600,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("InvalidContinuationToken", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The phase &apos;{0}&apos; in $everything operation is invalid..
         /// </summary>
@@ -600,7 +609,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("InvalidEverythingOperationPhase", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The &apos;handling&apos; value &apos;{0}&apos; is invalid. The supported values are: {1}..
         /// </summary>
@@ -609,7 +618,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("InvalidHandlingValue", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Reindex operation parameter &apos;{0}&apos; was out of the range of valid values. Please specify different value within a range &apos;{1}&apos; - &apos;{2}&apos;..
         /// </summary>
@@ -627,7 +636,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("InvalidSearchCountSpecified", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The &apos;_total&apos; parameter value &apos;{0}&apos; is invalid. The supported values are: {1}..
         /// </summary>
@@ -636,7 +645,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("InvalidTotalParameter", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The &apos;_type&apos; parameter contains unknown resource(s): {0}.
         /// </summary>
@@ -645,7 +654,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("InvalidTypeParameter", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Invalid value for :missing modifier. Valid values are: true, false..
         /// </summary>
@@ -654,7 +663,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("InvalidValueTypeForMissingModifier", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The requested job &quot;{0}&quot; was not found..
         /// </summary>
@@ -663,7 +672,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("JobNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Bundle.link values omitted because they exceeded the maximum Uri length..
         /// </summary>
@@ -672,7 +681,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("LinksCantBeCreated", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Malformed search value &apos;{0}&apos;..
         /// </summary>
@@ -681,7 +690,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("MalformedSearchValue", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Found multiple matches, narrow search criteria..
         /// </summary>
@@ -690,7 +699,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("MemberMatchMultipleMatchesFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to No match found..
         /// </summary>
@@ -699,7 +708,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("MemberMatchNoMatchFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Modifier &apos;{0}&apos; is not supported for search parameter &apos;{1}&apos;..
         /// </summary>
@@ -708,7 +717,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ModifierNotSupported", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Only one token separator can be specified..
         /// </summary>
@@ -717,7 +726,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("MoreThanOneTokenSeparatorSpecified", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to No more than two token separators can be specified..
         /// </summary>
@@ -726,7 +735,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("MoreThanTwoTokenSeparatorSpecified", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Query parameter &apos;{0}&apos; cannot be specified more than once..
         /// </summary>
@@ -735,7 +744,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("MultipleQueryParametersNotAllowed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Multiple sort parameters are currently not supported. Only a single sort parameter is supported..
         /// </summary>
@@ -744,7 +753,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("MultiSortParameterNotSupported", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to No resources were found matching the type of the updated search parameters needing to be reindexed.  ReindexJob marked completed..
         /// </summary>
@@ -753,7 +762,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("NoResourcesNeedToBeReindexed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to No search parameters found needing to be indexed.  Job cancelled..
         /// </summary>
@@ -762,7 +771,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("NoSearchParametersNeededToBeIndexed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The number of composite components specified for search parameter &apos;{0}&apos; exceeded the number of components defined..
         /// </summary>
@@ -771,7 +780,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("NumberOfCompositeComponentsExceeded", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Only equal comparator is supported for this search type..
         /// </summary>
@@ -780,7 +789,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("OnlyEqualComparatorIsSupported", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Only one modifier separator can be specified..
         /// </summary>
@@ -789,7 +798,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("OnlyOneModifierSeparatorSupported", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Only one active or paused reindex job allowed.  Cancel job with id: {0} before submitting a new job..
         /// </summary>
@@ -798,7 +807,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("OnlyOneResourceJobAllowed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Failed to retrieve the OpenId configuration from the authentication provider..
         /// </summary>
@@ -807,7 +816,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("OpenIdConfiguration", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {0} operation failed for reason: {1}.
         /// </summary>
@@ -816,7 +825,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("OperationFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to  or .
         /// </summary>
@@ -825,7 +834,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("OrDelimiter", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Patching immutable properties is not allowed..
         /// </summary>
@@ -834,7 +843,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("PatchImmutablePropertiesIsNotValid", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Error patching resource: &apos;{0}&apos;..
         /// </summary>
@@ -843,7 +852,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("PatchResourceError", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The resource to patch must be in JSON format..
         /// </summary>
@@ -852,7 +861,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("PatchResourceMustBeJson", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Patching a specific record version is not supported..
         /// </summary>
@@ -861,7 +870,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("PatchVersionNotAllowed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to X-Provenance header is malformed and can&apos;t be parsed.
         /// </summary>
@@ -870,7 +879,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ProvenanceHeaderMalformed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to X-Provenance header shall not have a specified `Provenance.target`.
         /// </summary>
@@ -879,7 +888,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ProvenanceHeaderShouldntHaveTarget", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to ReadHistory is disabled for resources of type &apos;{0}&apos;..
         /// </summary>
@@ -888,7 +897,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ReadHistoryDisabled", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Resource type &apos;{0}&apos; in the reference &apos;{1}&apos; is not supported..
         /// </summary>
@@ -897,7 +906,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ReferenceResourceTypeNotSupported", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to One or more resources to be reindexed were not found, indicating that they have been deleted since the reindex job kicked off..
         /// </summary>
@@ -906,7 +915,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ReindexingResourceNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to One or more resources failed to reindex due to a non-matching version..
         /// </summary>
@@ -915,7 +924,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ReindexingResourceVersionConflict", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {0} resource(s) failed to reindex due to a non-matching version..
         /// </summary>
@@ -924,7 +933,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ReindexingResourceVersionConflictWithCount", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Resubmit the same reindex job to finish indexing the remaining resources..
         /// </summary>
@@ -933,7 +942,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ReindexingUserAction", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Reindex job id {0} is in state {1} and cannot be cancelled..
         /// </summary>
@@ -942,7 +951,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ReindexJobInCompletedState", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The requested action is not allowed..
         /// </summary>
@@ -951,7 +960,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("RequestedActionNotAllowed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Resource creation is not allowed..
         /// </summary>
@@ -960,7 +969,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ResourceCreationNotAllowed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Resource type &apos;{0}&apos; with id &apos;{1}&apos; couldn&apos;t be found..
         /// </summary>
@@ -969,7 +978,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ResourceNotFoundById", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Resource type &apos;{0}&apos; with id &apos;{1}&apos; and version &apos;{2}&apos; couldn&apos;t be found..
         /// </summary>
@@ -978,7 +987,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ResourceNotFoundByIdAndVersion", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Resource type &apos;{0}&apos; is not supported..
         /// </summary>
@@ -987,7 +996,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ResourceNotSupported", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The requested resource exceeded the backing database&apos;s size limit..
         /// </summary>
@@ -996,7 +1005,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ResourceTooLarge", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The supplied version &apos;{0}&apos; did not match..
         /// </summary>
@@ -1005,7 +1014,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ResourceVersionConflict", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The reverse chain search is missing the reference to search..
         /// </summary>
@@ -1014,7 +1023,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ReverseChainMissingReference", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The reverse chain search is missing the type to search..
         /// </summary>
@@ -1023,7 +1032,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ReverseChainMissingType", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The &apos;_revinclude:iterate={0}&apos; search parameter has multiple target types. Please specify a target type..
         /// </summary>
@@ -1032,7 +1041,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("RevIncludeIterateTargetTypeNotSpecified", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The _revinclude search is missing the type to search..
         /// </summary>
@@ -1041,7 +1050,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("RevIncludeMissingType", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Comparator is not supported when multiple values are specified using OR search parameter..
         /// </summary>
@@ -1050,7 +1059,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchComparatorNotSupported", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The &apos;_count&apos; parameter exceeds limit configured for server. Current limit is {0} while `_count` parameter set to {1}..
         /// </summary>
@@ -1059,7 +1068,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParamaterCountExceedLimit", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The search parameter with definition URL &apos;{0}&apos; is not supported..
         /// </summary>
@@ -1068,7 +1077,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterByDefinitionUriNotSupported", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to SearchParameter[{0}].resource.base is not defined..
         /// </summary>
@@ -1077,7 +1086,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionBaseNotDefined", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to SearchParameter[{0}].component[{1}] cannot refer to a composite SearchParameter..
         /// </summary>
@@ -1086,7 +1095,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionComponentReferenceCannotBeComposite", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to A search parameter with the same code value &apos;{0}&apos; already exists for base type &apos;{1}&apos;..
         /// </summary>
@@ -1095,7 +1104,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionConflictingCodeValue", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The search parameter definition contains one or more invalid entries..
         /// </summary>
@@ -1104,7 +1113,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionContainsInvalidEntry", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to A search parameter with the same definition URL &apos;{0}&apos; already exists..
         /// </summary>
@@ -1113,7 +1122,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionDuplicatedEntry", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to SearchParameter[{0}].component is null or empty..
         /// </summary>
@@ -1122,7 +1131,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionInvalidComponent", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to SearchParameter[{0}].component[{1}].expression is null or empty..
         /// </summary>
@@ -1131,7 +1140,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionInvalidComponentExpression", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to SearchParameter[{0}].component[{1}].definition.reference is null or empty or does not refer to a valid SearchParameter resource..
         /// </summary>
@@ -1140,7 +1149,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionInvalidComponentReference", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to SearchParameter[{0}].url is invalid..
         /// </summary>
@@ -1149,7 +1158,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionInvalidDefinitionUri", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to SearchParameter[{0}].resource.expression is null or empty..
         /// </summary>
@@ -1158,7 +1167,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionInvalidExpression", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The search parameter defintion is missing the Uri..
         /// </summary>
@@ -1167,7 +1176,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionInvalidMissingUri", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Entry {0} is not a SearchParameter resource..
         /// </summary>
@@ -1176,7 +1185,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionInvalidResource", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to A search parameter with Uri &apos;{0}&apos; was not found..
         /// </summary>
@@ -1185,7 +1194,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterDefinitionNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Search parameter &apos;{0}&apos; is not common for &apos;{1}&apos; and &apos;{2}&apos;..
         /// </summary>
@@ -1194,7 +1203,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterMustBeCommon", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {0} So it cannot be marked enabled..
         /// </summary>
@@ -1203,7 +1212,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterNoLongerSupported", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The search parameter &apos;{0}&apos; is not supported for resource type &apos;{1}&apos;..
         /// </summary>
@@ -1212,7 +1221,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterNotSupported", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to A search parameter is no longer supported..
         /// </summary>
@@ -1221,7 +1230,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchParameterUnknownNotSupported", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Sorting by the &apos;{0}&apos; parameter is not supported..
         /// </summary>
@@ -1230,7 +1239,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SearchSortParameterNotSupported", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Microsoft FHIR Server.
         /// </summary>
@@ -1239,7 +1248,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ServerName", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The _sort parameter is not supported..
         /// </summary>
@@ -1248,7 +1257,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("SortNotSupported", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Include result was truncated.
         /// </summary>
@@ -1257,7 +1266,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("TruncatedIncludeMessage", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The _typeFilter segment &apos;{0}&apos; could not be parsed..
         /// </summary>
@@ -1266,7 +1275,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("TypeFilterUnparseable", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The _type parameter must be included when using the _typeFilter parameter..
         /// </summary>
@@ -1275,7 +1284,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("TypeFilterWithoutTypeIsUnsupported", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Bundle type is not present. Possible values are: transaction or batch.
         /// </summary>
@@ -1284,7 +1293,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("TypeNotPresent", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Unable to delete secret from SecretStore.
         /// </summary>
@@ -1293,7 +1302,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("UnableToDeleteSecret", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Unable to get secret from SecretStore.
         /// </summary>
@@ -1302,7 +1311,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("UnableToGetSecret", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Unable to set secret in SecretStore.
         /// </summary>
@@ -1311,7 +1320,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("UnableToSetSecret", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Attempt to update SearchParameter {0} failed..
         /// </summary>
@@ -1320,7 +1329,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("UnableToUpdateSearchParameter", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Unknown Error..
         /// </summary>
@@ -1329,7 +1338,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("UnknownError", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Unsupported configuration found..
         /// </summary>
@@ -1338,7 +1347,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("UnsupportedConfigurationMessage", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The &apos;_total&apos; parameter value &apos;{0}&apos; is not supported. The supported values are: {1}..
         /// </summary>
@@ -1347,7 +1356,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("UnsupportedTotalParameter", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Resource id is required for updates..
         /// </summary>
@@ -1356,7 +1365,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("UpdateRequestsRequireId", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to User requested cancellation of operation..
         /// </summary>
@@ -1365,7 +1374,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("UserRequestedCancellation", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to All OK.
         /// </summary>
@@ -1374,7 +1383,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("ValidationPassed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to VersionId should not be in the weak ETag format..
         /// </summary>
@@ -1383,7 +1392,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("VersionIdFormatNotETag", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to WeakETag must be in the weak ETag format..
         /// </summary>

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -286,6 +286,15 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The &apos;seealso&apos; link id cannot be null when a &apos;seealso&apos; link is being processed..
+        /// </summary>
+        internal static string CurrentSeeAlsoLinkIdShouldNotBeNull {
+            get {
+                return ResourceManager.GetString("CurrentSeeAlsoLinkIdShouldNotBeNull", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The prefix used to identify custom audit headers cannot be empty..
         /// </summary>
         internal static string CustomHeaderPrefixCannotBeEmpty {

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -395,6 +395,15 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The resource with the id &apos;{0}&apos; has more than {1} &apos;seealso&apos; links..
+        /// </summary>
+        internal static string EverythingOperationMaxSeeAlsoLinksReached {
+            get {
+                return ResourceManager.GetString("EverythingOperationMaxSeeAlsoLinksReached", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The patient with id `{0}` is no longer relevant. Use patient with id `{1}` instead..
         /// </summary>
         internal static string EverythingOperationResourceIrrelevant {

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -395,15 +395,6 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The resource with the id &apos;{0}&apos; has more than {1} &apos;seealso&apos; links..
-        /// </summary>
-        internal static string EverythingOperationMaxSeeAlsoLinksReached {
-            get {
-                return ResourceManager.GetString("EverythingOperationMaxSeeAlsoLinksReached", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The patient with id `{0}` is no longer relevant. Use patient with id `{1}` instead..
         /// </summary>
         internal static string EverythingOperationResourceIrrelevant {

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -613,4 +613,7 @@
   <data name="CurrentSeeAlsoLinkIdShouldNotBeNull" xml:space="preserve">
     <value>The 'seealso' link id cannot be null when a 'seealso' link is being processed.</value>
   </data>
+  <data name="EverythingOperationMaxSeeAlsoLinksReached" xml:space="preserve">
+    <value>The resource with the id '{0}' has more than {1} 'seealso' links.</value>
+  </data>
 </root>

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -610,4 +610,7 @@
   <data name="EverythingOperationResourceIrrelevant" xml:space="preserve">
     <value>The patient with id `{0}` is no longer relevant. Use patient with id `{1}` instead.</value>
   </data>
+  <data name="CurrentSeeAlsoLinkIdShouldNotBeNull" xml:space="preserve">
+    <value>The 'seealso' link id cannot be null when a 'seealso' link is being processed.</value>
+  </data>
 </root>

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -613,7 +613,4 @@
   <data name="CurrentSeeAlsoLinkIdShouldNotBeNull" xml:space="preserve">
     <value>The 'seealso' link id cannot be null when a 'seealso' link is being processed.</value>
   </data>
-  <data name="EverythingOperationMaxSeeAlsoLinksReached" xml:space="preserve">
-    <value>The resource with the id '{0}' has more than {1} 'seealso' links.</value>
-  </data>
 </root>

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -607,4 +607,7 @@
     <value>Can't find '{0}' in type '{1}'</value>
     <comment>{0}: expression we trying to resolve, {1}: FHIR type</comment>
   </data>
+  <data name="EverythingOperationResourceIrrelevant" xml:space="preserve">
+    <value>The patient with id `{0}` is no longer relevant. Use patient with id `{1}` instead.</value>
+  </data>
 </root>

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
@@ -146,8 +146,10 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
                         break;
                     case FetchTemplateCollectionFailedException _:
                     case ConvertDataUnhandledException _:
-                    case EverythingOperationException _:
                         operationOutcomeResult.StatusCode = HttpStatusCode.InternalServerError;
+                        break;
+                    case EverythingOperationException everythingOperationException:
+                        operationOutcomeResult.StatusCode = everythingOperationException.ResponseStatusCode;
                         break;
                     case ConvertDataTimeoutException _:
                         operationOutcomeResult.StatusCode = HttpStatusCode.GatewayTimeout;

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
@@ -150,6 +150,12 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
                         break;
                     case EverythingOperationException everythingOperationException:
                         operationOutcomeResult.StatusCode = everythingOperationException.ResponseStatusCode;
+
+                        if (!string.IsNullOrEmpty(everythingOperationException.ContentLocationHeaderValue))
+                        {
+                            operationOutcomeResult.Headers.Add(HeaderNames.ContentLocation, everythingOperationException.ContentLocationHeaderValue);
+                        }
+
                         break;
                     case ConvertDataTimeoutException _:
                         operationOutcomeResult.StatusCode = HttpStatusCode.GatewayTimeout;

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/EverythingOperationContinuationTokenTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/EverythingOperationContinuationTokenTests.cs
@@ -36,36 +36,24 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Everything
         }
 
         [Theory]
-        [InlineData(0, null)]
-        [InlineData(1, null)]
-        [InlineData(2, "abc")]
-        [InlineData(3, "abc")]
-        public void GivenEverythingOperationContinuationToken_WhenToString_ThenCorrectStringShouldBeReturned(int phase, string internalContinuationToken)
+        [InlineData(0, null, null)]
+        [InlineData(1, null, "test")]
+        [InlineData(2, "abc", null)]
+        [InlineData(3, "abc", "1234567890")]
+        public void GivenEverythingOperationContinuationToken_WhenToString_ThenCorrectStringShouldBeReturned(int phase, string internalContinuationToken, string currentSeeAlsoLinkId)
         {
             var token = new EverythingOperationContinuationToken
             {
                 Phase = phase,
                 InternalContinuationToken = internalContinuationToken,
+                CurrentSeeAlsoLinkId = currentSeeAlsoLinkId,
             };
 
-            // The internal continuation token value will be padded with quotes if it is not null
+            // Values will be padded with quotes if they are not null
             internalContinuationToken = string.IsNullOrEmpty(internalContinuationToken) ? "null" : "\"" + internalContinuationToken + "\"";
+            currentSeeAlsoLinkId = string.IsNullOrEmpty(currentSeeAlsoLinkId) ? "null" : "\"" + currentSeeAlsoLinkId + "\"";
 
-            Assert.Equal($"{{\"SeeAlsoLinks\":[],\"Phase\":{phase},\"InternalContinuationToken\":{internalContinuationToken},\"CurrentSeeAlsoLinkIndex\":-1}}", token.ToString());
-        }
-
-        [Fact]
-        public void GivenEverythingOperationContinuationTokenWithSeeAlsoLinks_WhenToString_ThenCorrectStringShouldBeReturned()
-        {
-            var token = new EverythingOperationContinuationToken();
-            token.SeeAlsoLinks.Add("link1");
-            token.SeeAlsoLinks.Add("link2");
-
-            token.ProcessNextSeeAlsoLink();
-            Assert.Equal($"{{\"SeeAlsoLinks\":[\"link1\",\"link2\"],\"Phase\":0,\"InternalContinuationToken\":null,\"CurrentSeeAlsoLinkIndex\":0}}", token.ToString());
-
-            token.ProcessNextSeeAlsoLink();
-            Assert.Equal($"{{\"SeeAlsoLinks\":[\"link1\",\"link2\"],\"Phase\":0,\"InternalContinuationToken\":null,\"CurrentSeeAlsoLinkIndex\":1}}", token.ToString());
+            Assert.Equal($"{{\"Phase\":{phase},\"InternalContinuationToken\":{internalContinuationToken},\"CurrentSeeAlsoLinkId\":{currentSeeAlsoLinkId}}}", token.ToString());
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/EverythingOperationContinuationTokenTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/EverythingOperationContinuationTokenTests.cs
@@ -13,24 +13,24 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Everything
         [Fact]
         public void GivenAString_WhenFromString_ThenCorrectEverythingOperationContinuationTokenShouldBeReturned()
         {
-            Assert.Null(EverythingOperationContinuationToken.FromString(null));
-            Assert.Null(EverythingOperationContinuationToken.FromString(string.Empty));
-            Assert.Null(EverythingOperationContinuationToken.FromString(" "));
-            Assert.Null(EverythingOperationContinuationToken.FromString("abc"));
+            Assert.Null(EverythingOperationContinuationToken.FromJson(null));
+            Assert.Null(EverythingOperationContinuationToken.FromJson(string.Empty));
+            Assert.Null(EverythingOperationContinuationToken.FromJson(" "));
+            Assert.Null(EverythingOperationContinuationToken.FromJson("abc"));
 
-            var token = EverythingOperationContinuationToken.FromString("{\"a\":\"b\"}");
+            var token = EverythingOperationContinuationToken.FromJson("{\"a\":\"b\"}");
             Assert.Equal(0, token.Phase);
             Assert.Null(token.InternalContinuationToken);
 
-            token = EverythingOperationContinuationToken.FromString("{\"Phase\":3}");
+            token = EverythingOperationContinuationToken.FromJson("{\"Phase\":3}");
             Assert.Equal(3, token.Phase);
             Assert.Null(token.InternalContinuationToken);
 
-            token = EverythingOperationContinuationToken.FromString("{\"Phase\":1,\"InternalContinuationToken\":null}");
+            token = EverythingOperationContinuationToken.FromJson("{\"Phase\":1,\"InternalContinuationToken\":null}");
             Assert.Equal(1, token.Phase);
             Assert.Null(token.InternalContinuationToken);
 
-            token = EverythingOperationContinuationToken.FromString("{\"Phase\":2,\"InternalContinuationToken\":\"abc\"}");
+            token = EverythingOperationContinuationToken.FromJson("{\"Phase\":2,\"InternalContinuationToken\":\"abc\"}");
             Assert.Equal(2, token.Phase);
             Assert.Equal("abc", token.InternalContinuationToken);
         }
@@ -53,7 +53,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Everything
             internalContinuationToken = string.IsNullOrEmpty(internalContinuationToken) ? "null" : "\"" + internalContinuationToken + "\"";
             currentSeeAlsoLinkId = string.IsNullOrEmpty(currentSeeAlsoLinkId) ? "null" : "\"" + currentSeeAlsoLinkId + "\"";
 
-            Assert.Equal($"{{\"Phase\":{phase},\"InternalContinuationToken\":{internalContinuationToken},\"CurrentSeeAlsoLinkId\":{currentSeeAlsoLinkId}}}", token.ToString());
+            Assert.Equal($"{{\"Phase\":{phase},\"InternalContinuationToken\":{internalContinuationToken},\"CurrentSeeAlsoLinkId\":{currentSeeAlsoLinkId}}}", token.ToJson());
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/EverythingOperationContinuationTokenTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/EverythingOperationContinuationTokenTests.cs
@@ -35,11 +35,19 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Everything
             Assert.Equal("abc", token.InternalContinuationToken);
         }
 
-        [Fact]
-        public void GivenEverythingOperationContinuationToken_WhenToString_ThenCorrectStringShouldBeReturned()
+        [Theory]
+        [InlineData(0, null)]
+        [InlineData(1, null)]
+        [InlineData(2, "abc")]
+        [InlineData(3, "abc")]
+        public void GivenEverythingOperationContinuationToken_WhenToString_ThenCorrectStringShouldBeReturned(int phase, string internalContinuationToken)
         {
-            Assert.Equal("{\"Phase\":1,\"InternalContinuationToken\":null}", EverythingOperationContinuationToken.ToString(1, null));
-            Assert.Equal("{\"Phase\":2,\"InternalContinuationToken\":\"abc\"}", EverythingOperationContinuationToken.ToString(2, "abc"));
+            var token = new EverythingOperationContinuationToken(phase, internalContinuationToken);
+
+            // The internal continuation token value will be padded with quotes if it is not null
+            internalContinuationToken = string.IsNullOrEmpty(internalContinuationToken) ? internalContinuationToken : "\"" + internalContinuationToken + "\"";
+
+            Assert.Equal($"{{\"Phase\":{phase},\"InternalContinuationToken\":{internalContinuationToken}}}", token.ToString());
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/EverythingOperationContinuationTokenTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/EverythingOperationContinuationTokenTests.cs
@@ -45,9 +45,23 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Everything
             var token = new EverythingOperationContinuationToken(phase, internalContinuationToken);
 
             // The internal continuation token value will be padded with quotes if it is not null
-            internalContinuationToken = string.IsNullOrEmpty(internalContinuationToken) ? internalContinuationToken : "\"" + internalContinuationToken + "\"";
+            internalContinuationToken = string.IsNullOrEmpty(internalContinuationToken) ? "null" : "\"" + internalContinuationToken + "\"";
 
-            Assert.Equal($"{{\"Phase\":{phase},\"InternalContinuationToken\":{internalContinuationToken}}}", token.ToString());
+            Assert.Equal($"{{\"SeeAlsoLinks\":[],\"CurrentSeeAlsoLinkIndex\":-1,\"CurrentSeeAlsoLinkId\":null,\"Phase\":{phase},\"InternalContinuationToken\":{internalContinuationToken},\"ProcessingSeeAlsoLink\":false,\"MoreSeeAlsoLinksToProcess\":false}}", token.ToString());
+        }
+
+        [Fact]
+        public void GivenEverythingOperationContinuationTokenWithSeeAlsoLinks_WhenToString_ThenCorrectStringShouldBeReturned()
+        {
+            var token = new EverythingOperationContinuationToken(0, null);
+            token.AddSeeAlsoLink("link1");
+            token.AddSeeAlsoLink("link2");
+
+            token.ProcessNextSeeAlsoLink();
+            Assert.Equal($"{{\"SeeAlsoLinks\":[\"link1\",\"link2\"],\"CurrentSeeAlsoLinkIndex\":0,\"CurrentSeeAlsoLinkId\":\"link1\",\"Phase\":0,\"InternalContinuationToken\":null,\"ProcessingSeeAlsoLink\":true,\"MoreSeeAlsoLinksToProcess\":true}}", token.ToString());
+
+            token.ProcessNextSeeAlsoLink();
+            Assert.Equal($"{{\"SeeAlsoLinks\":[\"link1\",\"link2\"],\"CurrentSeeAlsoLinkIndex\":1,\"CurrentSeeAlsoLinkId\":\"link2\",\"Phase\":0,\"InternalContinuationToken\":null,\"ProcessingSeeAlsoLink\":true,\"MoreSeeAlsoLinksToProcess\":false}}", token.ToString());
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/EverythingOperationContinuationTokenTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/EverythingOperationContinuationTokenTests.cs
@@ -47,21 +47,21 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Everything
             // The internal continuation token value will be padded with quotes if it is not null
             internalContinuationToken = string.IsNullOrEmpty(internalContinuationToken) ? "null" : "\"" + internalContinuationToken + "\"";
 
-            Assert.Equal($"{{\"SeeAlsoLinks\":[],\"CurrentSeeAlsoLinkIndex\":-1,\"CurrentSeeAlsoLinkId\":null,\"Phase\":{phase},\"InternalContinuationToken\":{internalContinuationToken},\"ProcessingSeeAlsoLink\":false,\"MoreSeeAlsoLinksToProcess\":false}}", token.ToString());
+            Assert.Equal($"{{\"SeeAlsoLinks\":[],\"Phase\":{phase},\"InternalContinuationToken\":{internalContinuationToken},\"CurrentSeeAlsoLinkIndex\":-1}}", token.ToString());
         }
 
         [Fact]
         public void GivenEverythingOperationContinuationTokenWithSeeAlsoLinks_WhenToString_ThenCorrectStringShouldBeReturned()
         {
             var token = new EverythingOperationContinuationToken(0, null);
-            token.AddSeeAlsoLink("link1");
-            token.AddSeeAlsoLink("link2");
+            token.SeeAlsoLinks.Add("link1");
+            token.SeeAlsoLinks.Add("link2");
 
             token.ProcessNextSeeAlsoLink();
-            Assert.Equal($"{{\"SeeAlsoLinks\":[\"link1\",\"link2\"],\"CurrentSeeAlsoLinkIndex\":0,\"CurrentSeeAlsoLinkId\":\"link1\",\"Phase\":0,\"InternalContinuationToken\":null,\"ProcessingSeeAlsoLink\":true,\"MoreSeeAlsoLinksToProcess\":true}}", token.ToString());
+            Assert.Equal($"{{\"SeeAlsoLinks\":[\"link1\",\"link2\"],\"Phase\":0,\"InternalContinuationToken\":null,\"CurrentSeeAlsoLinkIndex\":0}}", token.ToString());
 
             token.ProcessNextSeeAlsoLink();
-            Assert.Equal($"{{\"SeeAlsoLinks\":[\"link1\",\"link2\"],\"CurrentSeeAlsoLinkIndex\":1,\"CurrentSeeAlsoLinkId\":\"link2\",\"Phase\":0,\"InternalContinuationToken\":null,\"ProcessingSeeAlsoLink\":true,\"MoreSeeAlsoLinksToProcess\":false}}", token.ToString());
+            Assert.Equal($"{{\"SeeAlsoLinks\":[\"link1\",\"link2\"],\"Phase\":0,\"InternalContinuationToken\":null,\"CurrentSeeAlsoLinkIndex\":1}}", token.ToString());
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/EverythingOperationContinuationTokenTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/EverythingOperationContinuationTokenTests.cs
@@ -42,7 +42,11 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Everything
         [InlineData(3, "abc")]
         public void GivenEverythingOperationContinuationToken_WhenToString_ThenCorrectStringShouldBeReturned(int phase, string internalContinuationToken)
         {
-            var token = new EverythingOperationContinuationToken(phase, internalContinuationToken);
+            var token = new EverythingOperationContinuationToken
+            {
+                Phase = phase,
+                InternalContinuationToken = internalContinuationToken,
+            };
 
             // The internal continuation token value will be padded with quotes if it is not null
             internalContinuationToken = string.IsNullOrEmpty(internalContinuationToken) ? "null" : "\"" + internalContinuationToken + "\"";
@@ -53,7 +57,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Everything
         [Fact]
         public void GivenEverythingOperationContinuationTokenWithSeeAlsoLinks_WhenToString_ThenCorrectStringShouldBeReturned()
         {
-            var token = new EverythingOperationContinuationToken(0, null);
+            var token = new EverythingOperationContinuationToken();
             token.SeeAlsoLinks.Add("link1");
             token.SeeAlsoLinks.Add("link2");
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/PatientEverythingServiceTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/PatientEverythingServiceTests.cs
@@ -11,6 +11,7 @@ using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Operations.Everything;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Microsoft.Health.Fhir.Core.Features.Routing;
 using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
 using Microsoft.Health.Fhir.Core.UnitTests.Extensions;
@@ -28,12 +29,13 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Everything
         private readonly ICompartmentDefinitionManager _compartmentDefinitionManager = Substitute.For<ICompartmentDefinitionManager>();
         private readonly IReferenceSearchValueParser _referenceSearchValueParser = Substitute.For<IReferenceSearchValueParser>();
         private readonly IResourceDeserializer _resourceDeserializer = Substitute.For<IResourceDeserializer>();
+        private readonly IUrlResolver _urlResolver = Substitute.For<IUrlResolver>();
 
         private readonly PatientEverythingService _patientEverythingService;
 
         public PatientEverythingServiceTests()
         {
-            _patientEverythingService = new PatientEverythingService(() => _searchService.CreateMockScope(), _searchOptionsFactory, _searchParameterDefinitionManager, _compartmentDefinitionManager, _referenceSearchValueParser, _resourceDeserializer);
+            _patientEverythingService = new PatientEverythingService(() => _searchService.CreateMockScope(), _searchOptionsFactory, _searchParameterDefinitionManager, _compartmentDefinitionManager, _referenceSearchValueParser, _resourceDeserializer, _urlResolver);
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/PatientEverythingServiceTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/PatientEverythingServiceTests.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Operations.Everything;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
 using Microsoft.Health.Fhir.Core.UnitTests.Extensions;
@@ -26,12 +27,13 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Everything
         private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager = Substitute.For<ISearchParameterDefinitionManager>();
         private readonly ICompartmentDefinitionManager _compartmentDefinitionManager = Substitute.For<ICompartmentDefinitionManager>();
         private readonly IReferenceSearchValueParser _referenceSearchValueParser = Substitute.For<IReferenceSearchValueParser>();
+        private readonly IResourceDeserializer _resourceDeserializer = Substitute.For<IResourceDeserializer>();
 
         private readonly PatientEverythingService _patientEverythingService;
 
         public PatientEverythingServiceTests()
         {
-            _patientEverythingService = new PatientEverythingService(() => _searchService.CreateMockScope(), _searchOptionsFactory, _searchParameterDefinitionManager, _compartmentDefinitionManager, _referenceSearchValueParser);
+            _patientEverythingService = new PatientEverythingService(() => _searchService.CreateMockScope(), _searchOptionsFactory, _searchParameterDefinitionManager, _compartmentDefinitionManager, _referenceSearchValueParser, _resourceDeserializer);
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/PatientEverythingServiceTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/PatientEverythingServiceTests.cs
@@ -11,6 +11,7 @@ using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Operations.Everything;
 using Microsoft.Health.Fhir.Core.Features.Search;
+using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
 using Microsoft.Health.Fhir.Core.UnitTests.Extensions;
 using NSubstitute;
 using Xunit;
@@ -24,12 +25,13 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Everything
         private readonly ISearchOptionsFactory _searchOptionsFactory = Substitute.For<ISearchOptionsFactory>();
         private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager = Substitute.For<ISearchParameterDefinitionManager>();
         private readonly ICompartmentDefinitionManager _compartmentDefinitionManager = Substitute.For<ICompartmentDefinitionManager>();
+        private readonly IReferenceSearchValueParser _referenceSearchValueParser = Substitute.For<IReferenceSearchValueParser>();
 
         private readonly PatientEverythingService _patientEverythingService;
 
         public PatientEverythingServiceTests()
         {
-            _patientEverythingService = new PatientEverythingService(() => _searchService.CreateMockScope(), _searchOptionsFactory, _searchParameterDefinitionManager, _compartmentDefinitionManager);
+            _patientEverythingService = new PatientEverythingService(() => _searchService.CreateMockScope(), _searchOptionsFactory, _searchParameterDefinitionManager, _compartmentDefinitionManager, _referenceSearchValueParser);
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/EverythingOperationContinuationToken.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/EverythingOperationContinuationToken.cs
@@ -41,6 +41,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
         {
             get
             {
+                // If we are not processing a "seealso" link
+                if (CurrentSeeAlsoLinkIndex < 0)
+                {
+                    return null;
+                }
+
                 return SeeAlsoLinks[CurrentSeeAlsoLinkIndex];
             }
         }
@@ -84,7 +90,16 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
 
         internal void ProcessNextSeeAlsoLink()
         {
-            CurrentSeeAlsoLinkIndex++;
+            // If there are more links to process
+            if (CurrentSeeAlsoLinkIndex < SeeAlsoLinks.Count - 1)
+            {
+                CurrentSeeAlsoLinkIndex++;
+            }
+            else
+            {
+                // This will set the flag that indicates if we are processing "seealso" links to false
+                CurrentSeeAlsoLinkIndex = -1;
+            }
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/EverythingOperationContinuationToken.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/EverythingOperationContinuationToken.cs
@@ -3,25 +3,24 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
 {
     internal class EverythingOperationContinuationToken
     {
+        // The $everything operation continuation token is used to retrieve the next phase of results when running the
+        // Patient $everything operation. The information stored in this class is serialized, encoded and returned as
+        // part of the "next" URL in the result set bundle.
+        // The length of the serialized token must not exceed the limit of the URL (2083 characters), so we need to
+        // avoid using the continuation token to store large amounts of data. This is why we only store the current
+        // "seealso" link id in the token (opposed to all "seealso" links).
         [JsonConstructor]
         internal EverythingOperationContinuationToken()
         {
             Phase = 0;
             InternalContinuationToken = null;
-
-            SeeAlsoLinks = new List<string>();
-            CurrentSeeAlsoLinkIndex = -1;
         }
-
-        [JsonProperty]
-        internal List<string> SeeAlsoLinks { get; }
 
         [JsonProperty]
         internal int Phase { get; set; }
@@ -29,38 +28,16 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
         [JsonProperty]
         internal string InternalContinuationToken { get; set; }
 
-        internal bool MoreSeeAlsoLinksToProcess
-        {
-            get
-            {
-                return CurrentSeeAlsoLinkIndex < SeeAlsoLinks.Count - 1;
-            }
-        }
-
-        internal string CurrentSeeAlsoLinkId
-        {
-            get
-            {
-                // If we are not processing a "seealso" link
-                if (CurrentSeeAlsoLinkIndex < 0)
-                {
-                    return null;
-                }
-
-                return SeeAlsoLinks[CurrentSeeAlsoLinkIndex];
-            }
-        }
+        [JsonProperty]
+        internal string CurrentSeeAlsoLinkId { get; set; }
 
         internal bool IsProcessingSeeAlsoLink
         {
             get
             {
-                return CurrentSeeAlsoLinkIndex > -1;
+                return CurrentSeeAlsoLinkId != null;
             }
         }
-
-        [JsonProperty]
-        private int CurrentSeeAlsoLinkIndex { get; set; }
 
         public override string ToString()
         {
@@ -86,20 +63,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
             }
 
             return token;
-        }
-
-        internal void ProcessNextSeeAlsoLink()
-        {
-            // If there are more links to process
-            if (CurrentSeeAlsoLinkIndex < SeeAlsoLinks.Count - 1)
-            {
-                CurrentSeeAlsoLinkIndex++;
-            }
-            else
-            {
-                // This will set the flag that indicates if we are processing "seealso" links to false
-                CurrentSeeAlsoLinkIndex = -1;
-            }
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/EverythingOperationContinuationToken.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/EverythingOperationContinuationToken.cs
@@ -11,10 +11,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
     internal class EverythingOperationContinuationToken
     {
         [JsonConstructor]
-        internal EverythingOperationContinuationToken(int phase, string internalContinuationToken)
+        internal EverythingOperationContinuationToken()
         {
-            Phase = phase;
-            InternalContinuationToken = internalContinuationToken;
+            Phase = 0;
+            InternalContinuationToken = null;
 
             SeeAlsoLinks = new List<string>();
             CurrentSeeAlsoLinkIndex = -1;

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/EverythingOperationContinuationToken.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/EverythingOperationContinuationToken.cs
@@ -39,12 +39,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
             }
         }
 
-        public override string ToString()
+        public string ToJson()
         {
             return JsonConvert.SerializeObject(this);
         }
 
-        internal static EverythingOperationContinuationToken FromString(string json)
+        internal static EverythingOperationContinuationToken FromJson(string json)
         {
             if (string.IsNullOrEmpty(json))
             {

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/EverythingOperationContinuationToken.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/EverythingOperationContinuationToken.cs
@@ -66,7 +66,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
 
         public void AddSeeAlsoLink(string link)
         {
-            SeeAlsoLinks.Add(link);
+            // Safe to linear search on addition as it isn't common for a patient to have many "seealso" links
+            if (!SeeAlsoLinks.Contains(link))
+            {
+                SeeAlsoLinks.Add(link);
+            }
         }
 
         public void ProcessNextSeeAlsoLink()

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/EverythingOperationContinuationToken.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/EverythingOperationContinuationToken.cs
@@ -8,40 +8,28 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
 {
-    public class EverythingOperationContinuationToken
+    internal class EverythingOperationContinuationToken
     {
-        public EverythingOperationContinuationToken(int phase, string internalContinuationToken)
+        [JsonConstructor]
+        internal EverythingOperationContinuationToken(int phase, string internalContinuationToken)
         {
             Phase = phase;
             InternalContinuationToken = internalContinuationToken;
 
             SeeAlsoLinks = new List<string>();
             CurrentSeeAlsoLinkIndex = -1;
-            CurrentSeeAlsoLinkId = null;
         }
 
         [JsonProperty]
-        private List<string> SeeAlsoLinks { get; }
+        internal List<string> SeeAlsoLinks { get; }
 
         [JsonProperty]
-        private int CurrentSeeAlsoLinkIndex { get; set; }
+        internal int Phase { get; set; }
 
         [JsonProperty]
-        public string CurrentSeeAlsoLinkId { get; private set; }
+        internal string InternalContinuationToken { get; set; }
 
-        public int Phase { get; set; }
-
-        public string InternalContinuationToken { get; set; }
-
-        public bool ProcessingSeeAlsoLink
-        {
-            get
-            {
-                return !string.IsNullOrEmpty(CurrentSeeAlsoLinkId);
-            }
-        }
-
-        public bool MoreSeeAlsoLinksToProcess
+        internal bool MoreSeeAlsoLinksToProcess
         {
             get
             {
@@ -49,12 +37,31 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
             }
         }
 
+        internal string CurrentSeeAlsoLinkId
+        {
+            get
+            {
+                return SeeAlsoLinks[CurrentSeeAlsoLinkIndex];
+            }
+        }
+
+        internal bool IsProcessingSeeAlsoLink
+        {
+            get
+            {
+                return CurrentSeeAlsoLinkIndex > -1;
+            }
+        }
+
+        [JsonProperty]
+        private int CurrentSeeAlsoLinkIndex { get; set; }
+
         public override string ToString()
         {
             return JsonConvert.SerializeObject(this);
         }
 
-        public static EverythingOperationContinuationToken FromString(string json)
+        internal static EverythingOperationContinuationToken FromString(string json)
         {
             if (string.IsNullOrEmpty(json))
             {
@@ -65,7 +72,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
 
             try
             {
-                 token = JsonConvert.DeserializeObject<EverythingOperationContinuationToken>(json);
+                token = JsonConvert.DeserializeObject<EverythingOperationContinuationToken>(json);
             }
             catch (JsonException)
             {
@@ -75,19 +82,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
             return token;
         }
 
-        public void AddSeeAlsoLink(string link)
-        {
-            // Safe to linear search on addition as it isn't common for a patient to have many "seealso" links
-            if (!SeeAlsoLinks.Contains(link))
-            {
-                SeeAlsoLinks.Add(link);
-            }
-        }
-
-        public void ProcessNextSeeAlsoLink()
+        internal void ProcessNextSeeAlsoLink()
         {
             CurrentSeeAlsoLinkIndex++;
-            CurrentSeeAlsoLinkId = SeeAlsoLinks[CurrentSeeAlsoLinkIndex];
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/EverythingOperationContinuationToken.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/EverythingOperationContinuationToken.cs
@@ -61,7 +61,18 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
                 return null;
             }
 
-            return JsonConvert.DeserializeObject<EverythingOperationContinuationToken>(json);
+            EverythingOperationContinuationToken token;
+
+            try
+            {
+                 token = JsonConvert.DeserializeObject<EverythingOperationContinuationToken>(json);
+            }
+            catch (JsonException)
+            {
+                return null;
+            }
+
+            return token;
         }
 
         public void AddSeeAlsoLink(string link)

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
@@ -418,7 +418,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
             if (token.IsProcessingSeeAlsoLink)
             {
                 // Add a parameter to prevent this, since we already returned the parent patient resource in a previous call
-                searchParameters.Add(Tuple.Create(KnownQueryParameterNames.Id, $"ne{parentPatientId}"));
+                searchParameters.Add(Tuple.Create($"{KnownQueryParameterNames.Id}:not", parentPatientId));
             }
 
             using IScoped<ISearchService> search = _searchServiceFactory();
@@ -462,7 +462,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
             if (token.IsProcessingSeeAlsoLink)
             {
                 // Add a parameter to prevent this, since we already returned the parent patient resource in a previous call
-                searchParameters.Add(Tuple.Create(KnownQueryParameterNames.Id, $"ne{parentPatientId}"));
+                searchParameters.Add(Tuple.Create($"{KnownQueryParameterNames.Id}:not", parentPatientId));
             }
 
             using IScoped<ISearchService> search = _searchServiceFactory();

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
@@ -370,7 +370,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
                 int indexOfCurrent = seeAlsoLinkIdsSorted.FindIndex(id => id == token.CurrentSeeAlsoLinkId);
                 int indexOfNext = indexOfCurrent + 1;
 
-                if (indexOfNext < seeAlsoLinkIdsSorted.Count - 1)
+                if (indexOfNext < seeAlsoLinkIdsSorted.Count)
                 {
                     token.CurrentSeeAlsoLinkId = seeAlsoLinkIdsSorted[indexOfNext];
                 }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
@@ -68,18 +68,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
             string continuationToken,
             CancellationToken cancellationToken)
         {
-            EverythingOperationContinuationToken token;
-
-            try
-            {
-                token = string.IsNullOrEmpty(continuationToken)
-                    ? new EverythingOperationContinuationToken(0, null)
-                    : EverythingOperationContinuationToken.FromString(ContinuationTokenConverter.Decode(continuationToken));
-            }
-            catch (JsonReaderException)
-            {
-                throw new BadRequestException(Core.Resources.InvalidContinuationToken);
-            }
+            EverythingOperationContinuationToken token = string.IsNullOrEmpty(continuationToken)
+                ? new EverythingOperationContinuationToken(0, null)
+                : EverythingOperationContinuationToken.FromString(ContinuationTokenConverter.Decode(continuationToken));
 
             if (token == null || token.Phase < 0 || token.Phase > 3)
             {

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
@@ -252,11 +252,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
             // resource that contains the "replaced-by" link.
             foreach (Patient.LinkComponent link in links)
             {
-                ReferenceSearchValue referenceSearchValue = _referenceSearchValueParser.Parse(link.Other.Reference);
-
                 // Regardless of the other links present, we throw an error if we find a "replaced-by" link.
                 if (link.Type == Patient.LinkType.ReplacedBy)
                 {
+                    ReferenceSearchValue referenceSearchValue = _referenceSearchValueParser.Parse(link.Other.Reference);
+
                     // Specify the url that must be used instead.
                     Uri url = _urlResolver.ResolveOperationResultUrl(OperationsConstants.PatientEverything, referenceSearchValue.ResourceId);
 

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
@@ -91,7 +91,16 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
             var parentPatientId = resourceId;
 
             // Check if we are currently processing a Patient's "seealso" link
-            resourceId = token.IsProcessingSeeAlsoLink ? token.CurrentSeeAlsoLinkId : resourceId;
+            if (token.IsProcessingSeeAlsoLink)
+            {
+                if (token.CurrentSeeAlsoLinkId == null)
+                {
+                    // The current "seealso" link id should never be null when we are processing a "seealso" link
+                    throw new EverythingOperationException(Core.Resources.CurrentSeeAlsoLinkIdShouldNotBeNull, HttpStatusCode.InternalServerError);
+                }
+
+                resourceId = token.CurrentSeeAlsoLinkId;
+            }
 
             var phase = token.Phase;
             switch (phase)

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
         {
             EverythingOperationContinuationToken token = string.IsNullOrEmpty(continuationToken)
                 ? new EverythingOperationContinuationToken()
-                : EverythingOperationContinuationToken.FromString(ContinuationTokenConverter.Decode(continuationToken));
+                : EverythingOperationContinuationToken.FromJson(ContinuationTokenConverter.Decode(continuationToken));
 
             if (token == null || token.Phase < 0 || token.Phase > 3)
             {
@@ -165,14 +165,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
                 // Keep processing the remaining results for the current phase.
                 token.InternalContinuationToken = searchResult.ContinuationToken;
 
-                nextContinuationToken = token.ToString();
+                nextContinuationToken = token.ToJson();
             }
             else if (phase < 3)
             {
                 token.Phase = phase + 1;
                 token.InternalContinuationToken = null;
 
-                nextContinuationToken = token.ToString();
+                nextContinuationToken = token.ToJson();
             }
             else
             {
@@ -384,7 +384,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
             token.Phase = 0;
             token.InternalContinuationToken = null;
 
-            return token.ToString();
+            return token.ToJson();
         }
 
         private async Task<SearchResult> SearchRevinclude(

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
@@ -190,7 +190,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
             EverythingOperationContinuationToken token,
             CancellationToken cancellationToken)
         {
-            using IScoped<ISearchService> search = _searchServiceFactory();
+            using IScoped<ISearchService> search = _searchServiceFactory.Invoke();
             var searchResultEntries = new List<SearchResultEntry>();
 
             // Build the search parameters to add to the query.
@@ -202,7 +202,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
             searchParameters.AddRange(_includes.Select(include => Tuple.Create(SearchParameterNames.Include, $"{ResourceType.Patient}:{include}")));
 
             // Search for the patient and all the resources it references directly.
-            SearchOptions searchOptions = _searchOptionsFactory.Create(ResourceType.Patient.ToString(), searchParameters);
+            SearchOptions searchOptions = _searchOptionsFactory.Create(KnownResourceTypes.Patient, searchParameters);
             SearchResult searchResult = await search.Value.SearchAsync(searchOptions, cancellationToken);
             searchResultEntries.AddRange(searchResult.Results.Select(x => new SearchResultEntry(x.Resource)));
 
@@ -210,7 +210,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
             if (!token.IsProcessingSeeAlsoLink)
             {
                 SearchResultEntry parentPatientResource = searchResultEntries.FirstOrDefault(s =>
-                    string.Equals(s.Resource.ResourceTypeName, ResourceType.Patient.ToString(), StringComparison.Ordinal));
+                    string.Equals(s.Resource.ResourceTypeName, KnownResourceTypes.Patient, StringComparison.Ordinal));
 
                 CheckForReplacedByLinks(parentPatientId, parentPatientResource);
             }
@@ -290,7 +290,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
         private async Task<string> CheckForNextSeeAlsoLinkAndSetToken(string parentPatientId, EverythingOperationContinuationToken token, CancellationToken cancellationToken)
         {
             // Retrieve the parent patient so that we can extract its links and process the next "seealso" link.
-            using IScoped<ISearchService> search = _searchServiceFactory();
+            using IScoped<ISearchService> search = _searchServiceFactory.Invoke();
 
             // To do so, first create the search parameter to add to the query
             var searchParameters = new List<Tuple<string, string>>
@@ -299,11 +299,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
             };
 
             // And then execute the search.
-            SearchOptions searchOptions = _searchOptionsFactory.Create(ResourceType.Patient.ToString(), searchParameters);
+            SearchOptions searchOptions = _searchOptionsFactory.Create(KnownResourceTypes.Patient, searchParameters);
             SearchResult searchResult = await search.Value.SearchAsync(searchOptions, cancellationToken);
 
             // The search result entries should contain one patient resource - the parent patient.
-            SearchResultEntry parentPatientResource = searchResult.Results.FirstOrDefault(s => string.Equals(s.Resource.ResourceTypeName, ResourceType.Patient.ToString(), StringComparison.Ordinal));
+            SearchResultEntry parentPatientResource = searchResult.Results.FirstOrDefault(s => string.Equals(s.Resource.ResourceTypeName, KnownResourceTypes.Patient, StringComparison.Ordinal));
 
             List<Patient.LinkComponent> links = ExtractLinksFromParentPatient(parentPatientResource);
 
@@ -337,7 +337,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
 
                 // Links can be of type Patient or RelatedPerson. Only follow the links that point to patients.
                 // Note: we plan to include RelatedPerson resources in the result set in AB#85142.
-                if (string.Equals(referenceSearchValue.ResourceType, ResourceType.Patient.ToString(), StringComparison.Ordinal))
+                if (string.Equals(referenceSearchValue.ResourceType, KnownResourceTypes.Patient, StringComparison.Ordinal))
                 {
                     if (!seeAlsoLinkIdsHash.Contains(referenceSearchValue.ResourceId))
                     {
@@ -418,7 +418,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
             }
 
             // We do not use Patient?_revinclude here since it depends on the existence of the parent resource
-            using IScoped<ISearchService> search = _searchServiceFactory();
+            using IScoped<ISearchService> search = _searchServiceFactory.Invoke();
             SearchOptions searchOptions = _searchOptionsFactory.Create(_revinclude.resourceType, searchParameters);
             return await search.Value.SearchAsync(searchOptions, cancellationToken);
         }
@@ -467,8 +467,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
                 searchParameters.Add(Tuple.Create(KnownQueryParameterNames.ContinuationToken, continuationToken));
             }
 
-            using IScoped<ISearchService> search = _searchServiceFactory();
-            SearchOptions searchOptions = _searchOptionsFactory.Create(ResourceType.Patient.ToString(), resourceId, null, searchParameters);
+            using IScoped<ISearchService> search = _searchServiceFactory.Invoke();
+            SearchOptions searchOptions = _searchOptionsFactory.Create(KnownResourceTypes.Patient, resourceId, null, searchParameters);
             return await search.Value.SearchAsync(searchOptions, cancellationToken);
         }
 
@@ -513,8 +513,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
 
             CheckForParentPatientDuplicate(parentPatientId, token, searchParameters);
 
-            using IScoped<ISearchService> search = _searchServiceFactory();
-            SearchOptions searchOptions = _searchOptionsFactory.Create(ResourceType.Patient.ToString(), resourceId, null, searchParameters);
+            using IScoped<ISearchService> search = _searchServiceFactory.Invoke();
+            SearchOptions searchOptions = _searchOptionsFactory.Create(KnownResourceTypes.Patient, resourceId, null, searchParameters);
             return await search.Value.SearchAsync(searchOptions, cancellationToken);
         }
 
@@ -552,8 +552,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
 
             CheckForParentPatientDuplicate(parentPatientId, token, searchParameters);
 
-            using IScoped<ISearchService> search = _searchServiceFactory();
-            SearchOptions searchOptions = _searchOptionsFactory.Create(ResourceType.Patient.ToString(), resourceId, null, searchParameters);
+            using IScoped<ISearchService> search = _searchServiceFactory.Invoke();
+            SearchOptions searchOptions = _searchOptionsFactory.Create(KnownResourceTypes.Patient, resourceId, null, searchParameters);
             return await search.Value.SearchAsync(searchOptions, cancellationToken);
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
@@ -291,7 +291,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
         {
             // Retrieve the parent patient so that we can extract its links and process the next "seealso" link.
             using IScoped<ISearchService> search = _searchServiceFactory();
-            var searchResultEntries = new List<SearchResultEntry>();
 
             // To do so, first create the search parameter to add to the query
             var searchParameters = new List<Tuple<string, string>>
@@ -302,10 +301,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
             // And then execute the search.
             SearchOptions searchOptions = _searchOptionsFactory.Create(ResourceType.Patient.ToString(), searchParameters);
             SearchResult searchResult = await search.Value.SearchAsync(searchOptions, cancellationToken);
-            searchResultEntries.AddRange(searchResult.Results.Select(x => new SearchResultEntry(x.Resource)));
 
             // The search result entries should contain one patient resource - the parent patient.
-            SearchResultEntry parentPatientResource = searchResultEntries.FirstOrDefault(s => string.Equals(s.Resource.ResourceTypeName, ResourceType.Patient.ToString(), StringComparison.Ordinal));
+            SearchResultEntry parentPatientResource = searchResult.Results.FirstOrDefault(s => string.Equals(s.Resource.ResourceTypeName, ResourceType.Patient.ToString(), StringComparison.Ordinal));
 
             List<Patient.LinkComponent> links = ExtractLinksFromParentPatient(parentPatientResource);
 

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
             CancellationToken cancellationToken)
         {
             EverythingOperationContinuationToken token = string.IsNullOrEmpty(continuationToken)
-                ? new EverythingOperationContinuationToken(0, null)
+                ? new EverythingOperationContinuationToken()
                 : EverythingOperationContinuationToken.FromString(ContinuationTokenConverter.Decode(continuationToken));
 
             if (token == null || token.Phase < 0 || token.Phase > 3)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTestFixture.cs
@@ -33,8 +33,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
         public Patient PatientReferencedBySeeAlsoLink { get; private set; }
 
-        public Patient PatientWithMultipleSeeAlsoLinks { get; private set; }
-
         public Patient PatientReferencedByReferLink { get; private set; }
 
         public Patient PatientReferencedByReplacesLink { get; private set; }
@@ -140,45 +138,24 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             observationToCreate = Samples.GetJsonSample<Observation>("Observation-For-Patient-f001");
             observationToCreate.Subject.Reference = $"Patient/{PatientReferencedBySeeAlsoLink.Id}";
             ObservationOfPatientReferencedBySeeAlsoLink = await TestFhirClient.CreateAsync(observationToCreate);
-
-            // Create a patient with many "seealso" links
-            patientToCreate = Samples.GetJsonSample<Patient>("PatientWithMinimalData");
-
-            for (int i = 0; i <= 10; i++)
-            {
-                AddLink(patientToCreate, Patient.LinkType.Seealso, $"test{i}");
-            }
-
-            PatientWithMultipleSeeAlsoLinks = await TestFhirClient.CreateAsync(patientToCreate);
         }
 
         private async Task<Patient> CreatePatientWithLink(Patient.LinkType linkType, Patient patientReferencedByLink)
         {
             Patient patientWithLink = Samples.GetJsonSample<Patient>("PatientWithMinimalData");
-            AddLink(patientWithLink, linkType, patientReferencedByLink.Id);
 
-            return await TestFhirClient.CreateAsync(patientWithLink);
-        }
-
-        private void AddLink(Patient patientWithLink, Patient.LinkType linkType, string patientReferencedByLinkId)
-        {
             var link = new Patient.LinkComponent
             {
                 Type = linkType,
-                Other = new ResourceReference($"Patient/{patientReferencedByLinkId}"),
+                Other = new ResourceReference($"Patient/{patientReferencedByLink.Id}"),
             };
 
-            if (patientWithLink.Link == null)
+            patientWithLink.Link = new List<Patient.LinkComponent>
             {
-                patientWithLink.Link = new List<Patient.LinkComponent>
-                {
-                    link,
-                };
-            }
-            else
-            {
-                patientWithLink.Link.Add(link);
-            }
+                link,
+            };
+
+            return await TestFhirClient.CreateAsync(patientWithLink);
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Net;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Client;
+using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.E2E.Rest.Search;
 using Microsoft.Health.Test.Utilities;
@@ -259,7 +260,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             // Confirm header location contains url for the correct request
             string id = Fixture.PatientReferencedByReplacedByLink.Id;
-            string uri = $"/{ResourceType.Patient.ToString()}/{id}/$everything";
+            string uri = $"/{KnownResourceTypes.Patient}/{id}/$everything";
 
             Assert.Contains(uri, ex.Content.Headers.GetValues(HeaderNames.ContentLocation).First());
             Assert.Equal(HttpStatusCode.MovedPermanently, ex.StatusCode);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTests.cs
@@ -261,12 +261,9 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             // Confirm header location contains url for the correct request
             string id = Fixture.PatientReferencedByReplacedByLink.Id;
-            var patientEverythingOperationUrl = new Uri($"http://localhost/{ResourceType.Patient.ToString()}/{id}/$everything");
+            string uri = $"/{ResourceType.Patient.ToString()}/{id}/$everything";
 
-            IUrlResolver urlResolver = Substitute.For<IUrlResolver>();
-            urlResolver.ResolveOperationResultUrl(Arg.Any<string>(), Arg.Any<string>()).Returns(patientEverythingOperationUrl);
-
-            Assert.Equal(patientEverythingOperationUrl.AbsoluteUri, ex.Content.Headers.GetValues(HeaderNames.ContentLocation).First());
+            Assert.Contains(uri, ex.Content.Headers.GetValues(HeaderNames.ContentLocation).First());
             Assert.Equal(HttpStatusCode.MovedPermanently, ex.StatusCode);
             Assert.Contains(string.Format(Core.Resources.EverythingOperationResourceIrrelevant, Fixture.PatientWithReplacedByLink.Id, Fixture.PatientReferencedByReplacedByLink.Id), ex.Message);
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTests.cs
@@ -221,18 +221,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
-        public async Task GivenPatientWithMoreThanMaxAllowedSeeAlsoLinks_WhenRunningPatientEverything_ThenBadRequestIsReturned()
-        {
-            string searchUrl = $"Patient/{Fixture.PatientWithMultipleSeeAlsoLinks.Id}/$everything";
-
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.SearchAsync(searchUrl));
-
-            Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
-            Assert.Contains(string.Format(Core.Resources.EverythingOperationMaxSeeAlsoLinksReached, Fixture.PatientWithMultipleSeeAlsoLinks.Id, 10), ex.Message);
-        }
-
-        [Fact]
-        [Trait(Traits.Priority, Priority.One)]
         public async Task GivenPatientWithReplacedByLink_WhenRunningPatientEverything_ThenMovedPermanentlyIsReturned()
         {
             string searchUrl = $"Patient/{Fixture.PatientWithReplacedByLink.Id}/$everything";

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTests.cs
@@ -208,11 +208,15 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             nextLink = secondBundle.Resource.NextLink.ToString();
             FhirResponse<Bundle> thirdBundle = await Client.SearchAsync(nextLink);
-            ValidateBundle(thirdBundle, Fixture.PatientReferencedByLink);
+            ValidateBundle(thirdBundle, Fixture.PatientReferencedBySeeAlsoLink);
 
             nextLink = thirdBundle.Resource.NextLink.ToString();
             FhirResponse<Bundle> fourthBundle = await Client.SearchAsync(nextLink);
-            Assert.Empty(fourthBundle.Resource.Entry);
+            ValidateBundle(fourthBundle, Fixture.ObservationOfPatientReferencedBySeeAlsoLink);
+
+            nextLink = fourthBundle.Resource.NextLink.ToString();
+            FhirResponse<Bundle> fifthBundle = await Client.SearchAsync(nextLink);
+            Assert.Empty(fifthBundle.Resource.Entry);
         }
 
         [Fact]
@@ -225,15 +229,16 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             // Confirm header location contains url for the correct request
             string operationName = OperationsConstants.PatientEverything;
-            string id = Fixture.PatientReferencedByLink.Id;
+            string id = Fixture.PatientReferencedByReplacedByLink.Id;
             var patientEverythingOperationUrl = new Uri($"http://localhost/{OperationsConstants.Operations}/{operationName}/{id}");
 
             IUrlResolver urlResolver = Substitute.For<IUrlResolver>();
             urlResolver.ResolveOperationResultUrl(Arg.Any<string>(), Arg.Any<string>()).Returns(patientEverythingOperationUrl);
 
-            Assert.Equal(patientEverythingOperationUrl.AbsoluteUri, ex.Headers.GetValues(HeaderNames.ContentLocation).First());
+            // TODO: investigate how to pull content type header from response in test env
+            // Assert.Equal(patientEverythingOperationUrl.AbsoluteUri, ex.Headers.GetValues(HeaderNames.ContentLocation).First());
             Assert.Equal(HttpStatusCode.MovedPermanently, ex.StatusCode);
-            Assert.Contains(string.Format(Core.Resources.EverythingOperationResourceIrrelevant, Fixture.PatientWithReplacedByLink.Id, Fixture.PatientReferencedByLink.Id), ex.Message);
+            Assert.Contains(string.Format(Core.Resources.EverythingOperationResourceIrrelevant, Fixture.PatientWithReplacedByLink.Id, Fixture.PatientReferencedByReplacedByLink.Id), ex.Message);
         }
 
         [Fact]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTests.cs
@@ -8,12 +8,10 @@ using System.Linq;
 using System.Net;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Client;
-using Microsoft.Health.Fhir.Core.Features.Routing;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.E2E.Rest.Search;
 using Microsoft.Health.Test.Utilities;
 using Microsoft.Net.Http.Headers;
-using NSubstitute;
 using Xunit;
 using Task = System.Threading.Tasks.Task;
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTests.cs
@@ -208,9 +208,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             nextLink = thirdBundle.Resource.NextLink.ToString();
             FhirResponse<Bundle> fourthBundle = await Client.SearchAsync(nextLink);
-
-            // All the patients that have links to the "patient-reference" patient will be in its patient compartment
-            ValidateBundle(fourthBundle, Fixture.PatientWithSeeAlsoLink, Fixture.PatientWithReplacedByLink, Fixture.PatientWithReferLink, Fixture.PatientWithReplacesLink);
+            Assert.Empty(fourthBundle.Resource.Entry);
         }
 
         [Fact]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTests.cs
@@ -221,6 +221,18 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenPatientWithMoreThanMaxAllowedSeeAlsoLinks_WhenRunningPatientEverything_ThenBadRequestIsReturned()
+        {
+            string searchUrl = $"Patient/{Fixture.PatientWithMultipleSeeAlsoLinks.Id}/$everything";
+
+            using FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.SearchAsync(searchUrl));
+
+            Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
+            Assert.Contains(string.Format(Core.Resources.EverythingOperationMaxSeeAlsoLinksReached, Fixture.PatientWithMultipleSeeAlsoLinks.Id, 10), ex.Message);
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
         public async Task GivenPatientWithReplacedByLink_WhenRunningPatientEverything_ThenMovedPermanentlyIsReturned()
         {
             string searchUrl = $"Patient/{Fixture.PatientWithReplacedByLink.Id}/$everything";

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTests.cs
@@ -228,15 +228,13 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             using FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.SearchAsync(searchUrl));
 
             // Confirm header location contains url for the correct request
-            string operationName = OperationsConstants.PatientEverything;
             string id = Fixture.PatientReferencedByReplacedByLink.Id;
-            var patientEverythingOperationUrl = new Uri($"http://localhost/{OperationsConstants.Operations}/{operationName}/{id}");
+            var patientEverythingOperationUrl = new Uri($"http://localhost/{ResourceType.Patient.ToString()}/{id}/$everything");
 
             IUrlResolver urlResolver = Substitute.For<IUrlResolver>();
             urlResolver.ResolveOperationResultUrl(Arg.Any<string>(), Arg.Any<string>()).Returns(patientEverythingOperationUrl);
 
-            // TODO: investigate how to pull content type header from response in test env
-            // Assert.Equal(patientEverythingOperationUrl.AbsoluteUri, ex.Headers.GetValues(HeaderNames.ContentLocation).First());
+            Assert.Equal(patientEverythingOperationUrl.AbsoluteUri, ex.Content.Headers.GetValues(HeaderNames.ContentLocation).First());
             Assert.Equal(HttpStatusCode.MovedPermanently, ex.StatusCode);
             Assert.Contains(string.Format(Core.Resources.EverythingOperationResourceIrrelevant, Fixture.PatientWithReplacedByLink.Id, Fixture.PatientReferencedByReplacedByLink.Id), ex.Message);
         }


### PR DESCRIPTION
## Description
As outlined in [the spec](http://hl7.org/fhir/patient-definitions.html#Patient.link), Patient resources can contain links to other Patient or RelatedPerson resources that concern the same actual patient. This PR adds functionality to process these links when the [patient $everything](http://hl7.org/fhir/patient-operation-everything.html) operation is run. Functionality differs depending on the [link type](http://hl7.org/fhir/valueset-link-type.html):

* `seealso`:  run the patient $everything operation on these links as well (note: this will only go one level deep, so we do not run patient $everything on a `seealso` link's `seealso` links)
* `replaced-by`: return an operation outcome that indicates that the patient is no longer a relevant patient, and provide the id for the correct patient
* `replaces`/`refer`: ignore these links

## Related issues
Addresses [AB#82651](https://microsofthealth.visualstudio.com/Health/_workitems/edit/82651).

There is an upcoming task ([AB#85142](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Resolute/Stories/?workitem=85142)) to return RelatedPerson resources that are included in a patient's `seealso` links (currently, they are ignored). 

## Testing
Added e2e tests and an `http` file for manual testing/demos.

## FHIR Team Checklist
- ✅ **Update the title** of the PR to be succinct and less than 50 characters
- ✅ **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- ✅ Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- ✅ Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- ✅ Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Feature (new functionality)
