### PR TITLE
Add setting to control whether Cosmos DB will retain history

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Configs/CosmosDataStoreConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Configs/CosmosDataStoreConfiguration.cs
@@ -61,5 +61,10 @@ namespace Microsoft.Health.Fhir.CosmosDb.Configs
         /// Options to determine if the parallel query execution is needed across physical partitions to speed up the selective queries
         /// </summary>
         public CosmosDataStoreParallelQueryOptions ParallelQueryOptions { get; } = new CosmosDataStoreParallelQueryOptions { MaxQueryConcurrency = 500 };
+
+        /// <summary>
+        /// Value indicating whether this Comsos data store retains history
+        /// </summary>
+        public bool KeepHistory { get; set; } = true;
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -111,6 +111,15 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
         {
             EnsureArg.IsNotNull(resource, nameof(resource));
 
+            // override the incoming keepHistory flag if the overall cosmos configuration
+            // is set to false.  When the overall config is true, some upsert requests may
+            // still have this flag set to false for specific documents, so we only
+            // override when the overall config is false.
+            if (_cosmosDataStoreConfiguration.KeepHistory == false)
+            {
+                keepHistory = _cosmosDataStoreConfiguration.KeepHistory;
+            }
+
             var cosmosWrapper = new FhirCosmosResourceWrapper(resource);
             UpdateSortIndex(cosmosWrapper);
 

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -147,8 +147,9 @@
         ],
         "ParallelQueryOptions": {
             "MaxQueryConcurrency": 500,
-            "EnableConcurrencyIfQueryExceedsTimeLimit":  true
-        }
+            "EnableConcurrencyIfQueryExceedsTimeLimit": true
+        },
+        "KeepHistory": true
     },
     "DataStore": "CosmosDb",
     "KeyVault": {


### PR DESCRIPTION
## Description
Adds a configuration setting for Cosmos DB data store, which will alter the behavior such that historical versions of resources are not retained when changes are made to a resource.

## Related issues
Addresses [issue #].

## Testing
Manual testing done only.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
