### PR TITLE
Adds Versioning App Setting

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Configs/CoreFeatureConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/CoreFeatureConfiguration.cs
@@ -66,6 +66,6 @@ namespace Microsoft.Health.Fhir.Core.Configs
         /// <summary>
         /// Gets or sets the resource versioning policy.
         /// </summary>
-        public string Versioning { get; set; } = ResourceVersionPolicy.Versioned;
+        public VersioningConfiguration Versioning { get; set; } = new VersioningConfiguration();
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Configs/CoreFeatureConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/CoreFeatureConfiguration.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using Microsoft.Health.Fhir.Core.Features.Search;
+using Microsoft.Health.Fhir.ValueSets;
 
 namespace Microsoft.Health.Fhir.Core.Configs
 {
@@ -63,8 +64,8 @@ namespace Microsoft.Health.Fhir.Core.Configs
         public bool SupportsResourceChangeCapture { get; set; } = false;
 
         /// <summary>
-        /// Value indicating whether the datastore should retain history.
+        /// Gets or sets the resource versioning policy.
         /// </summary>
-        public bool KeepHistory { get; set; } = true;
+        public string Versioning { get; set; } = ResourceVersionPolicy.Versioned;
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Configs/CoreFeatureConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/CoreFeatureConfiguration.cs
@@ -61,5 +61,10 @@ namespace Microsoft.Health.Fhir.Core.Configs
         /// Gets or sets a value whether capturing resource change data is enabled or not.
         /// </summary>
         public bool SupportsResourceChangeCapture { get; set; } = false;
+
+        /// <summary>
+        /// Value indicating whether the datastore should retain history.
+        /// </summary>
+        public bool KeepHistory { get; set; } = true;
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Configs/VersioningConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/VersioningConfiguration.cs
@@ -1,0 +1,14 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Fhir.ValueSets;
+
+namespace Microsoft.Health.Fhir.Core.Configs
+{
+    public class VersioningConfiguration
+    {
+        public string Default { get; set; } = ResourceVersionPolicy.Versioned;
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/Models/ListedResourceComponent.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/Models/ListedResourceComponent.cs
@@ -18,12 +18,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance.Models
             Interaction = new HashSet<ResourceInteractionComponent>(new PropertyEqualityComparer<ResourceInteractionComponent>(x => x.Code));
             SearchParam = new HashSet<SearchParamComponent>(new PropertyEqualityComparer<SearchParamComponent>(x => x.Name, x => x.Type.ToString()));
 
-            // TODO: Not the right place for this? Is there a way to select the other options in the hash set?
-            Versioning = configuration != null && configuration.KeepHistory ? new DefaultOptionHashSet<string>(ResourceVersionPolicy.Versioned, StringComparer.Ordinal) : new DefaultOptionHashSet<string>(ResourceVersionPolicy.NoVersion, StringComparer.Ordinal);
-
             SearchRevInclude = new HashSet<string>(StringComparer.Ordinal);
             SearchInclude = new HashSet<string>(StringComparer.Ordinal);
             ReferencePolicy = new HashSet<string>(StringComparer.Ordinal);
+            Versioning = new DefaultOptionHashSet<string>(configuration.Versioning, StringComparer.Ordinal);
             SupportedProfile = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             Operation = new HashSet<OperationComponent>(new PropertyEqualityComparer<OperationComponent>(x => x.Name, x => x.Definition.ToString()));
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/Models/ListedResourceComponent.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/Models/ListedResourceComponent.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance.Models
             SearchRevInclude = new HashSet<string>(StringComparer.Ordinal);
             SearchInclude = new HashSet<string>(StringComparer.Ordinal);
             ReferencePolicy = new HashSet<string>(StringComparer.Ordinal);
-            Versioning = new DefaultOptionHashSet<string>(configuration.Versioning, StringComparer.Ordinal);
+            Versioning = new DefaultOptionHashSet<string>(configuration.Versioning.Default, StringComparer.Ordinal);
             SupportedProfile = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             Operation = new HashSet<OperationComponent>(new PropertyEqualityComparer<OperationComponent>(x => x.Name, x => x.Definition.ToString()));
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/Models/ListedResourceComponent.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/Models/ListedResourceComponent.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.ValueSets;
 
@@ -12,11 +13,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance.Models
 {
     public class ListedResourceComponent
     {
-        public ListedResourceComponent()
+        public ListedResourceComponent(CoreFeatureConfiguration configuration)
         {
             Interaction = new HashSet<ResourceInteractionComponent>(new PropertyEqualityComparer<ResourceInteractionComponent>(x => x.Code));
             SearchParam = new HashSet<SearchParamComponent>(new PropertyEqualityComparer<SearchParamComponent>(x => x.Name, x => x.Type.ToString()));
-            Versioning = new DefaultOptionHashSet<string>("versioned", StringComparer.Ordinal);
+
+            // TODO: Not the right place for this? Is there a way to select the other options in the hash set?
+            Versioning = configuration != null && configuration.KeepHistory ? new DefaultOptionHashSet<string>(ResourceVersionPolicy.Versioned, StringComparer.Ordinal) : new DefaultOptionHashSet<string>(ResourceVersionPolicy.NoVersion, StringComparer.Ordinal);
+
             SearchRevInclude = new HashSet<string>(StringComparer.Ordinal);
             SearchInclude = new HashSet<string>(StringComparer.Ordinal);
             ReferencePolicy = new HashSet<string>(StringComparer.Ordinal);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Conformance/ConformanceBuilderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Conformance/ConformanceBuilderTests.cs
@@ -6,6 +6,8 @@
 using System;
 using Hl7.Fhir.ElementModel;
 using Hl7.FhirPath;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features.Conformance;
 using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Validation;
@@ -27,11 +29,14 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Conformance
 
         public ConformanceBuilderTests()
         {
+            IOptions<CoreFeatureConfiguration> configuration = Substitute.For<IOptions<CoreFeatureConfiguration>>();
+
             _searchParameterDefinitionManager = Substitute.For<ISearchParameterDefinitionManager>();
             _supportedProfiles = Substitute.For<IKnowSupportedProfiles>();
             _builder = CapabilityStatementBuilder.Create(
                 ModelInfoProvider.Instance,
                 _searchParameterDefinitionManager,
+                configuration,
                 _supportedProfiles);
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Conformance/ConformanceBuilderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Conformance/ConformanceBuilderTests.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Conformance
         public ConformanceBuilderTests()
         {
             IOptions<CoreFeatureConfiguration> configuration = Substitute.For<IOptions<CoreFeatureConfiguration>>();
+            configuration.Value.Returns(new CoreFeatureConfiguration());
 
             _searchParameterDefinitionManager = Substitute.For<ISearchParameterDefinitionManager>();
             _supportedProfiles = Substitute.For<IKnowSupportedProfiles>();

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -27,7 +27,9 @@
             "ProfileValidationOnCreate": false,
             "ProfileValidationOnUpdate": false,
             "SupportsResourceChangeCapture": false,
-            "Versioning": "versioned"
+            "Versioning": {
+                "Default": "versioned"
+            }
         },
         "CosmosDb": {
             "CollectionId": null,

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -26,7 +26,8 @@
             "IncludeTotalInBundle": "None",
             "ProfileValidationOnCreate": false,
             "ProfileValidationOnUpdate": false,
-            "SupportsResourceChangeCapture": false
+            "SupportsResourceChangeCapture": false,
+            "KeepHistory": true
         },
         "CosmosDb": {
             "CollectionId": null,

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -27,7 +27,7 @@
             "ProfileValidationOnCreate": false,
             "ProfileValidationOnUpdate": false,
             "SupportsResourceChangeCapture": false,
-            "KeepHistory": true
+            "Versioning": "versioned"
         },
         "CosmosDb": {
             "CollectionId": null,


### PR DESCRIPTION
## Description
Adds a new app setting value for the [versioning policy](https://www.hl7.org/fhir/valueset-versioning-policy.html). This PR follows the draft PR #2237.

## Related issues
Addresses [AB#81153](https://microsofthealth.visualstudio.com/Health/_workitems/edit/81153).

Note: there is a story to remove support for the `VersionId` property when the versioning policy is set to `no-version` ([AB#85363](https://microsofthealth.visualstudio.com/Health/_workitems/edit/85363))

## Testing
Manual testing. Automated tests are in the works: [AB#85366](https://microsofthealth.visualstudio.com/Health/_workitems/edit/85366).

## FHIR Team Checklist
- ✅ **Update the title** of the PR to be succinct and less than 50 characters
- ✅ **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- ✅ Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- ✅ Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- ✅ Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Feature (enabling new feature functionality)
