### PR TITLE
Log 500's to Request Metric

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
@@ -153,6 +153,8 @@ namespace Microsoft.Extensions.DependencyInjection
                     // which will be used in other middlewares.
                     app.UseFhirRequestContext();
 
+                    app.UseApiNotifications();
+
                     if (env.IsDevelopment())
                     {
                         app.UseDeveloperExceptionPage();
@@ -175,7 +177,6 @@ namespace Microsoft.Extensions.DependencyInjection
 
                     // The audit module needs to come after the exception handler because we need to catch the response before it gets converted to custom error.
                     app.UseAudit();
-                    app.UseApiNotifications();
 
                     app.UseFhirRequestContextAuthentication();
 


### PR DESCRIPTION
## Description
When any unknown/unhandled error occurs, the context get's updated after the ApiResponseNotification is published. Due to this 500s or any unknown/unhandled errors are not getting logged in RequestMetric. 

## Related issues
Addresses [81035](https://microsofthealth.visualstudio.com/Health/_workitems/edit/81035).

## Testing
Test if 500s are getting logged in RequestMetric table

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
