### PR TITLE
Tests disable history changes

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Conformance/ConformanceProviderExtensionTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Conformance/ConformanceProviderExtensionTests.cs
@@ -1,0 +1,67 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Threading;
+using Hl7.Fhir.Model;
+using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Core.Features.Conformance;
+using Microsoft.Health.Fhir.Tests.Common.Mocks;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Conformance
+{
+    public class ConformanceProviderExtensionTests
+    {
+        private readonly IConformanceProvider _conformanceProvider;
+
+        public ConformanceProviderExtensionTests()
+        {
+            _conformanceProvider = Substitute.For<ConformanceProviderBase>();
+        }
+
+        [Fact]
+        public async void GivenCoreConfigWithNoVersionVersioningPolicy_WhenCheckingIfKeepHistory_ThenFalseIsReturned()
+        {
+            const ResourceType resourceType = ResourceType.Patient;
+
+            CapabilityStatement statement = CapabilityStatementMock.GetMockedCapabilityStatement();
+            CapabilityStatementMock.SetupMockResource(statement, resourceType, null, null, CapabilityStatement.ResourceVersionPolicy.NoVersion);
+
+            _conformanceProvider.GetCapabilityStatementOnStartup().Returns(statement.ToResourceElement());
+
+            bool keepHistory = await _conformanceProvider.CanKeepHistory(resourceType.ToString(), CancellationToken.None);
+            Assert.False(keepHistory);
+        }
+
+        [Fact]
+        public async void GivenCoreConfigWithVersionedVersioningPolicy_WhenCheckingIfKeepHistory_ThenTrueIsReturned()
+        {
+            const ResourceType resourceType = ResourceType.Patient;
+
+            CapabilityStatement statement = CapabilityStatementMock.GetMockedCapabilityStatement();
+            CapabilityStatementMock.SetupMockResource(statement, resourceType, null, null, CapabilityStatement.ResourceVersionPolicy.Versioned);
+
+            _conformanceProvider.GetCapabilityStatementOnStartup().Returns(statement.ToResourceElement());
+
+            bool keepHistory = await _conformanceProvider.CanKeepHistory(resourceType.ToString(), CancellationToken.None);
+            Assert.True(keepHistory);
+        }
+
+        [Fact]
+        public async void GivenCoreConfigWithVersionedUpdateVersioningPolicy_WhenCheckingIfKeepHistory_ThenTrueIsReturned()
+        {
+            const ResourceType resourceType = ResourceType.Patient;
+
+            CapabilityStatement statement = CapabilityStatementMock.GetMockedCapabilityStatement();
+            CapabilityStatementMock.SetupMockResource(statement, resourceType, null, null, CapabilityStatement.ResourceVersionPolicy.VersionedUpdate);
+
+            _conformanceProvider.GetCapabilityStatementOnStartup().Returns(statement.ToResourceElement());
+
+            bool keepHistory = await _conformanceProvider.CanKeepHistory(resourceType.ToString(), CancellationToken.None);
+            Assert.True(keepHistory);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
@@ -12,6 +12,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Compartment\CompartmentIndexerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Compartment\SearchCompartmentHandlerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Conformance\ConformanceBuilderTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Conformance\ConformanceProviderExtensionTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\Everything\EverythingOperationContinuationTokenTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\Everything\EverythingOperationHandlerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\Everything\PatientEverythingServiceTests.cs" />

--- a/src/Microsoft.Health.Fhir.Shared.Tests/Mocks/CapabilityStatementMock.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Tests/Mocks/CapabilityStatementMock.cs
@@ -26,13 +26,19 @@ namespace Microsoft.Health.Fhir.Tests.Common.Mocks
             };
         }
 
-        public static void SetupMockResource(CapabilityStatement capability, ResourceType type, IEnumerable<TypeRestfulInteraction> interactions, IEnumerable<SearchParamComponent> searchParams = null)
+        public static void SetupMockResource(
+            CapabilityStatement capability,
+            ResourceType type,
+            IEnumerable<TypeRestfulInteraction> interactions,
+            IEnumerable<SearchParamComponent> searchParams = null,
+            ResourceVersionPolicy? versioningPolicy = null)
         {
             capability.Rest[0].Resource.Add(new ResourceComponent
             {
                 Type = type,
                 Interaction = interactions?.Select(x => new ResourceInteractionComponent { Code = x }).ToList(),
                 SearchParam = searchParams?.ToList(),
+                Versioning = versioningPolicy,
             });
         }
     }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -367,6 +367,45 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         }
 
         [Fact]
+        public async Task GivenAResourceTypeWithNoVersionVersioningPolicy_WhenSearchingHistory_ThenOnlyLatestVersionIsReturned()
+        {
+            // The FHIR storage fixture configures organization resources to have history disabled
+            SaveOutcome saveResult = await Mediator.UpsertResourceAsync(Samples.GetDefaultOrganization());
+
+            ResourceElement newResourceValues = Samples.GetDefaultOrganization().UpdateId(saveResult.RawResourceElement.Id);
+
+            SaveOutcome updateResult = await Mediator.UpsertResourceAsync(newResourceValues, WeakETag.FromVersionId(saveResult.RawResourceElement.VersionId));
+
+            ResourceElement historyResults = await Mediator.SearchResourceHistoryAsync(KnownResourceTypes.Organization, updateResult.RawResourceElement.Id);
+
+            // The history bundle only has one entry because resource history is not kept
+            Bundle bundle = historyResults.ToPoco<Bundle>();
+            Assert.Single(bundle.Entry);
+
+            Assert.Equal(WeakETag.FromVersionId(updateResult.RawResourceElement.VersionId).ToString(), bundle.Entry[0].Response.Etag);
+        }
+
+        [Fact]
+        public async Task GivenAResourceTypeWithVersionedVersioningPolicy_WhenSearchingHistory_ThenAllVersionsAreReturned()
+        {
+            // The FHIR storage fixture configures observation resources to have history enabled
+            SaveOutcome saveResult = await Mediator.UpsertResourceAsync(Samples.GetDefaultObservation());
+
+            ResourceElement newResourceValues = Samples.GetDefaultObservation().UpdateId(saveResult.RawResourceElement.Id);
+
+            SaveOutcome updateResult = await Mediator.UpsertResourceAsync(newResourceValues, WeakETag.FromVersionId(saveResult.RawResourceElement.VersionId));
+
+            ResourceElement historyResults = await Mediator.SearchResourceHistoryAsync(KnownResourceTypes.Observation, updateResult.RawResourceElement.Id);
+
+            // The history bundle has both versions because history is kept
+            Bundle bundle = historyResults.ToPoco<Bundle>();
+            Assert.Equal(2, bundle.Entry.Count);
+
+            Assert.Equal(WeakETag.FromVersionId(updateResult.RawResourceElement.VersionId).ToString(), bundle.Entry.Max(entry => entry.Response.Etag));
+            Assert.Equal(WeakETag.FromVersionId(saveResult.RawResourceElement.VersionId).ToString(), bundle.Entry.Min(entry => entry.Response.Etag));
+        }
+
+        [Fact]
         public async Task WhenDeletingAResource_ThenWeGetResourceGone()
         {
             var saveResult = await Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight"));

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTestsFixture.cs
@@ -9,10 +9,19 @@ using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Health.Abstractions.Features.Transactions;
+using Microsoft.Health.Core.Features.Context;
+using Microsoft.Health.Fhir.Api.Features.Bundle;
+using Microsoft.Health.Fhir.Api.Features.Routing;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Conformance;
+using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
@@ -27,6 +36,7 @@ using Microsoft.Health.Fhir.Core.Features.Security.Authorization;
 using Microsoft.Health.Fhir.Core.Messages.Create;
 using Microsoft.Health.Fhir.Core.Messages.Delete;
 using Microsoft.Health.Fhir.Core.Messages.Get;
+using Microsoft.Health.Fhir.Core.Messages.Search;
 using Microsoft.Health.Fhir.Core.Messages.Upsert;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Tests.Common;
@@ -145,12 +155,17 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                     return new ResourceWrapper(resource, rawResourceFactory.Create(resource, keepMeta: true), new ResourceRequest(HttpMethod.Post, "http://fhir"), x.ArgAt<bool>(1), null, null, null, searchParamHash);
                 });
 
+            var fhirRequestContextAccessor = _fixture.GetRequiredService<RequestContextAccessor<IFhirRequestContext>>();
+            UrlResolver urlResolver = CreateUrlResolver(fhirRequestContextAccessor);
+            var bundleFactory = new BundleFactory(urlResolver, fhirRequestContextAccessor, NullLogger<BundleFactory>.Instance);
+
             var collection = new ServiceCollection();
 
             collection.AddSingleton(typeof(IRequestHandler<CreateResourceRequest, UpsertResourceResponse>), new CreateResourceHandler(DataStore, new Lazy<IConformanceProvider>(() => ConformanceProvider), resourceWrapperFactory, _resourceIdProvider, new ResourceReferenceResolver(SearchService, new TestQueryStringParser()), DisabledFhirAuthorizationService.Instance));
             collection.AddSingleton(typeof(IRequestHandler<UpsertResourceRequest, UpsertResourceResponse>), new UpsertResourceHandler(DataStore, new Lazy<IConformanceProvider>(() => ConformanceProvider), resourceWrapperFactory, _resourceIdProvider, DisabledFhirAuthorizationService.Instance, ModelInfoProvider.Instance));
             collection.AddSingleton(typeof(IRequestHandler<GetResourceRequest, GetResourceResponse>), new GetResourceHandler(DataStore, new Lazy<IConformanceProvider>(() => ConformanceProvider), resourceWrapperFactory, _resourceIdProvider, DisabledFhirAuthorizationService.Instance));
             collection.AddSingleton(typeof(IRequestHandler<DeleteResourceRequest, DeleteResourceResponse>), new DeleteResourceHandler(DataStore, new Lazy<IConformanceProvider>(() => ConformanceProvider), resourceWrapperFactory, _resourceIdProvider, DisabledFhirAuthorizationService.Instance));
+            collection.AddSingleton(typeof(IRequestHandler<SearchResourceHistoryRequest, SearchResourceHistoryResponse>), new SearchResourceHistoryHandler(SearchService, bundleFactory, DisabledFhirAuthorizationService.Instance));
 
             ServiceProvider services = collection.BuildServiceProvider();
 
@@ -166,6 +181,41 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             {
                 await asyncLifetime.DisposeAsync();
             }
+        }
+
+        private static UrlResolver CreateUrlResolver(RequestContextAccessor<IFhirRequestContext> fhirRequestContextAccessor)
+        {
+            IUrlHelperFactory urlHelperFactory = Substitute.For<IUrlHelperFactory>();
+            IHttpContextAccessor httpContextAccessor = Substitute.For<IHttpContextAccessor>();
+            IActionContextAccessor actionContextAccessor = Substitute.For<IActionContextAccessor>();
+            IBundleHttpContextAccessor bundleHttpContextAccessor = Substitute.For<IBundleHttpContextAccessor>();
+            IUrlHelper urlHelper = Substitute.For<IUrlHelper>();
+
+            var httpContext = new DefaultHttpContext();
+            var actionContext = new ActionContext();
+
+            const string scheme = "scheme";
+            const string host = "test";
+
+            httpContextAccessor.HttpContext.Returns(httpContext);
+
+            httpContext.Request.Scheme = scheme;
+            httpContext.Request.Host = new HostString(host);
+
+            actionContextAccessor.ActionContext.Returns(actionContext);
+
+            urlHelper.RouteUrl(Arg.Do<UrlRouteContext>(_ => { }));
+            urlHelperFactory.GetUrlHelper(actionContext).Returns(urlHelper);
+            urlHelper.RouteUrl(Arg.Any<UrlRouteContext>()).Returns($"{scheme}://{host}");
+
+            bundleHttpContextAccessor.HttpContext.Returns((HttpContext)null);
+
+            return new UrlResolver(
+                fhirRequestContextAccessor,
+                urlHelperFactory,
+                httpContextAccessor,
+                actionContextAccessor,
+                bundleHttpContextAccessor);
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -62,6 +62,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         private readonly SupportedSearchParameterDefinitionManager _supportedSearchParameterDefinitionManager;
         private readonly SearchParameterStatusManager _searchParameterStatusManager;
         private readonly IMediator _mediator = Substitute.For<IMediator>();
+        private readonly RequestContextAccessor<IFhirRequestContext> _fhirRequestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
 
         public SqlServerFhirStorageTestsFixture()
             : this(SchemaVersionConstants.Max, $"FHIRINTEGRATIONTEST_{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}_{BigInteger.Abs(new BigInteger(Guid.NewGuid().ToByteArray()))}")
@@ -158,18 +159,18 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
             _fhirOperationDataStore = new SqlServerFhirOperationDataStore(SqlConnectionWrapperFactory, NullLogger<SqlServerFhirOperationDataStore>.Instance);
 
-            var fhirRequestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
-            fhirRequestContextAccessor.RequestContext.CorrelationId.Returns(Guid.NewGuid().ToString());
+            _fhirRequestContextAccessor.RequestContext.CorrelationId.Returns(Guid.NewGuid().ToString());
+            _fhirRequestContextAccessor.RequestContext.RouteName.Returns("routeName");
 
-            var searchableSearchParameterDefinitionManager = new SearchableSearchParameterDefinitionManager(_searchParameterDefinitionManager, fhirRequestContextAccessor);
-            var searchParameterExpressionParser = new SearchParameterExpressionParser(new ReferenceSearchValueParser(fhirRequestContextAccessor));
+            var searchableSearchParameterDefinitionManager = new SearchableSearchParameterDefinitionManager(_searchParameterDefinitionManager, _fhirRequestContextAccessor);
+            var searchParameterExpressionParser = new SearchParameterExpressionParser(new ReferenceSearchValueParser(_fhirRequestContextAccessor));
             var expressionParser = new ExpressionParser(() => searchableSearchParameterDefinitionManager, searchParameterExpressionParser);
 
             var searchOptionsFactory = new SearchOptionsFactory(
                 expressionParser,
                 () => searchableSearchParameterDefinitionManager,
                 options,
-                fhirRequestContextAccessor,
+                _fhirRequestContextAccessor,
                 Substitute.For<ISortingValidator>(),
                 NullLogger<SearchOptionsFactory>.Instance);
 
@@ -189,7 +190,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 partitionEliminationRewriter,
                 SqlConnectionWrapperFactory,
                 schemaInformation,
-                fhirRequestContextAccessor,
+                _fhirRequestContextAccessor,
                 new CompressedRawResourceConverter(),
                 NullLogger<SqlServerSearchService>.Instance);
 
@@ -294,6 +295,11 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             if (serviceType == typeof(SearchParameterStatusManager))
             {
                 return _searchParameterStatusManager;
+            }
+
+            if (serviceType == typeof(RequestContextAccessor<IFhirRequestContext>))
+            {
+                return _fhirRequestContextAccessor;
             }
 
             return null;


### PR DESCRIPTION
## Description
This PR adds two sets of disable history tests:
1. Conformance provider extension unit tests: these check that we are interpreting versioning information from the capability statement correctly
2. History search integration tests: these ensure that calls to retrieve resource history behave as intended

## Related issues
Addresses [AB#85366](https://microsofthealth.visualstudio.com/Health/_workitems/edit/85366).

## Testing
N/A

## FHIR Team Checklist
- ✅ **Update the title** of the PR to be succinct and less than 50 characters
- ✅ **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- ✅ Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- ✅ Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- ✅ Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- ✅ Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip (enhancement)
