### PR TITLE
Checks version when fetching "seealso" links

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/EverythingOperationContinuationTokenTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/EverythingOperationContinuationTokenTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Everything
             internalContinuationToken = string.IsNullOrEmpty(internalContinuationToken) ? "null" : "\"" + internalContinuationToken + "\"";
             currentSeeAlsoLinkId = string.IsNullOrEmpty(currentSeeAlsoLinkId) ? "null" : "\"" + currentSeeAlsoLinkId + "\"";
 
-            Assert.Equal($"{{\"Phase\":{phase},\"InternalContinuationToken\":{internalContinuationToken},\"CurrentSeeAlsoLinkId\":{currentSeeAlsoLinkId}}}", token.ToJson());
+            Assert.Equal($"{{\"Phase\":{phase},\"InternalContinuationToken\":{internalContinuationToken},\"CurrentSeeAlsoLinkId\":{currentSeeAlsoLinkId},\"ParentPatientVersionId\":null}}", token.ToJson());
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/PatientEverythingServiceTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/PatientEverythingServiceTests.cs
@@ -31,12 +31,13 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Everything
         private readonly IReferenceSearchValueParser _referenceSearchValueParser = Substitute.For<IReferenceSearchValueParser>();
         private readonly IResourceDeserializer _resourceDeserializer = Substitute.For<IResourceDeserializer>();
         private readonly IUrlResolver _urlResolver = Substitute.For<IUrlResolver>();
+        private readonly IFhirDataStore _fhirDataStore = Substitute.For<IFhirDataStore>();
 
         private readonly PatientEverythingService _patientEverythingService;
 
         public PatientEverythingServiceTests()
         {
-            _patientEverythingService = new PatientEverythingService(() => _searchService.CreateMockScope(), _searchOptionsFactory, _searchParameterDefinitionManager, _compartmentDefinitionManager, _referenceSearchValueParser, _resourceDeserializer, _urlResolver);
+            _patientEverythingService = new PatientEverythingService(() => _searchService.CreateMockScope(), _searchOptionsFactory, _searchParameterDefinitionManager, _compartmentDefinitionManager, _referenceSearchValueParser, _resourceDeserializer, _urlResolver, _fhirDataStore);
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/PatientEverythingServiceTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/PatientEverythingServiceTests.cs
@@ -14,6 +14,7 @@ using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Routing;
 using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
+using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Core.UnitTests.Extensions;
 using NSubstitute;
 using Xunit;
@@ -49,6 +50,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Everything
 
             var searchResult = new SearchResult(Enumerable.Empty<SearchResultEntry>(), null, null, new Tuple<string, string>[0]);
             _searchService.SearchAsync(Arg.Any<SearchOptions>(), CancellationToken.None).Returns(searchResult);
+            _searchService.SearchHistoryAsync(KnownResourceTypes.Patient, Arg.Any<string>(), null, null, null, null, Arg.Any<string>(), CancellationToken.None).Returns(searchResult);
 
             SearchResult actualResult = await _patientEverythingService.SearchAsync("123", null, null, null, null, null, CancellationToken.None);
 

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/EverythingOperationContinuationToken.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/EverythingOperationContinuationToken.cs
@@ -31,6 +31,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
         [JsonProperty]
         internal string CurrentSeeAlsoLinkId { get; set; }
 
+        [JsonProperty]
+        internal string ParentPatientVersionId { get; set; }
+
         internal bool IsProcessingSeeAlsoLink
         {
             get

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
@@ -292,9 +292,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
 
         private async Task<string> CheckForNextSeeAlsoLinkAndSetToken(string parentPatientId, EverythingOperationContinuationToken token, CancellationToken cancellationToken)
         {
-            // Retrieve the parent patient so that we can extract its links and process the next "seealso" link.
-            using IScoped<ISearchService> search = _searchServiceFactory.Invoke();
-
             // Get the version of the parent patient we recorded in the first $everything operation API call.
             ResourceWrapper parentPatientResource = await _fhirDataStore.GetAsync(new ResourceKey(KnownResourceTypes.Patient, parentPatientId, token.ParentPatientVersionId), cancellationToken);
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTestFixture.cs
@@ -55,6 +55,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
         public Observation Observation { get; private set; }
 
+        public Observation ObservationOfPatientWithSeeAlsoLinkToRemove { get; private set; }
+
         public Observation ObservationOfNonExistentPatient { get; private set; }
 
         public Observation ObservationOfPatientReferencedBySeeAlsoLink { get; private set; }
@@ -158,6 +160,10 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             observationToCreate = Samples.GetJsonSample<Observation>("Observation-For-Patient-f001");
             observationToCreate.Subject.Reference = $"Patient/{PatientReferencedBySeeAlsoLink.Id}";
             ObservationOfPatientReferencedBySeeAlsoLink = await TestFhirClient.CreateAsync(observationToCreate);
+
+            observationToCreate = Samples.GetJsonSample<Observation>("Observation-For-Patient-f001");
+            observationToCreate.Subject.Reference = $"Patient/{PatientWithSeeAlsoLinkToRemove.Id}";
+            ObservationOfPatientWithSeeAlsoLinkToRemove = await TestFhirClient.CreateAsync(observationToCreate);
         }
 
         private async Task<Patient> CreatePatientWithLinks(Patient.LinkType linkType, List<Patient> patientsReferencedByLink)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTestFixture.cs
@@ -27,6 +27,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
         public Patient PatientWithTwoSeeAlsoLinks { get; private set; }
 
+        public Patient PatientWithSeeAlsoLinkToRemove { get; private set; }
+
         public Patient PatientWithReplacedByLink { get; private set; }
 
         public Patient PatientWithReferLink { get; private set; }
@@ -34,6 +36,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         public Patient PatientWithReplacesLink { get; private set; }
 
         public Patient PatientReferencedBySeeAlsoLink { get; private set; }
+
+        public Patient PatientReferencedByRemovedSeeAlsoLink { get; private set; }
 
         public List<Patient> PatientsReferencedBySeeAlsoLink { get; private set; }
 
@@ -58,6 +62,11 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         public Encounter Encounter { get; private set; }
 
         public Appointment Appointment { get; private set; }
+
+        internal async Task UpdatePatient(Patient patientToUpdate)
+        {
+            await TestFhirClient.UpdateAsync(patientToUpdate);
+        }
 
         protected override async Task OnInitializedAsync()
         {
@@ -126,6 +135,9 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             PatientsReferencedBySeeAlsoLink.Add(await TestFhirClient.CreateAsync(patientToCreate));
 
             patientToCreate = Samples.GetJsonSample<Patient>("PatientWithMinimalData");
+            PatientReferencedByRemovedSeeAlsoLink = await TestFhirClient.CreateAsync(patientToCreate);
+
+            patientToCreate = Samples.GetJsonSample<Patient>("PatientWithMinimalData");
             PatientReferencedByReplacedByLink = await TestFhirClient.CreateAsync(patientToCreate);
 
             patientToCreate = Samples.GetJsonSample<Patient>("PatientWithMinimalData");
@@ -137,6 +149,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             // Create patients with different types of links
             PatientWithSeeAlsoLink = await CreatePatientWithLinks(Patient.LinkType.Seealso, new List<Patient> { PatientReferencedBySeeAlsoLink });
             PatientWithTwoSeeAlsoLinks = await CreatePatientWithLinks(Patient.LinkType.Seealso, PatientsReferencedBySeeAlsoLink);
+            PatientWithSeeAlsoLinkToRemove = await CreatePatientWithLinks(Patient.LinkType.Seealso, new List<Patient> { PatientReferencedByRemovedSeeAlsoLink });
             PatientWithReplacedByLink = await CreatePatientWithLinks(Patient.LinkType.ReplacedBy, new List<Patient> { PatientReferencedByReplacedByLink });
             PatientWithReplacesLink = await CreatePatientWithLinks(Patient.LinkType.Replaces, new List<Patient> { PatientReferencedByReplacesLink });
             PatientWithReferLink = await CreatePatientWithLinks(Patient.LinkType.Refer, new List<Patient> { PatientReferencedByReferLink });

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTests.cs
@@ -219,6 +219,31 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenPatientWithSeeAlsoLinkRemovedMidOperation_WhenRunningPatientEverything_ThenPatientEverythingShouldRunOnLink()
+        {
+            string searchUrl = $"Patient/{Fixture.PatientWithSeeAlsoLinkToRemove.Id}/$everything";
+
+            FhirResponse<Bundle> firstBundle = await Client.SearchAsync(searchUrl);
+            ValidateBundle(firstBundle, Fixture.PatientWithSeeAlsoLinkToRemove);
+
+            Fixture.PatientWithSeeAlsoLinkToRemove.Link.Clear();
+            await Fixture.UpdatePatient(Fixture.PatientWithSeeAlsoLinkToRemove);
+
+            var nextLink = firstBundle.Resource.NextLink.ToString();
+            FhirResponse<Bundle> secondBundle = await Client.SearchAsync(nextLink);
+            Assert.Empty(secondBundle.Resource.Entry);
+
+            nextLink = secondBundle.Resource.NextLink.ToString();
+            FhirResponse<Bundle> thirdBundle = await Client.SearchAsync(nextLink);
+            ValidateBundle(thirdBundle, Fixture.PatientReferencedByRemovedSeeAlsoLink);
+
+            nextLink = thirdBundle.Resource.NextLink.ToString();
+            FhirResponse<Bundle> fourthBundle = await Client.SearchAsync(nextLink);
+            Assert.Empty(fourthBundle.Resource.Entry);
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
         public async Task GivenPatientWithTwoSeeAlsoLinks_WhenRunningPatientEverything_ThenPatientEverythingShouldRunOnLinks()
         {
             string searchUrl = $"Patient/{Fixture.PatientWithTwoSeeAlsoLinks.Id}/$everything";


### PR DESCRIPTION
## Description
Previously, if a patient was updated during a patient $everything operation, the latest version of patient would be used to fetch `seealso` links. This could lead to unexpected results if `seealso` links were updated, added or removed. 

This PR adds a version check which ensures that asynchronous $everything operation results always reference the version of the patient captured at the time of the very first API call.

## Related issues
Addresses [AB#85686](https://microsofthealth.visualstudio.com/Health/_workitems/edit/85686).

## Testing
Updates unit tests and adds E2E test.

## FHIR Team Checklist
- ✅ **Update the title** of the PR to be succinct and less than 50 characters
- ✅ **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- ✅ Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- ✅ Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- ✅ Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip (minor bug fix)
