### PR TITLE
Handle missing resource body in bundles

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
@@ -321,9 +321,12 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
             {
                 httpContext.Request.Headers.Add(HeaderNames.ContentType, new StringValues(KnownContentTypes.JsonContentType));
 
-                var memoryStream = new MemoryStream(_fhirJsonSerializer.SerializeToBytes(entry.Resource));
-                memoryStream.Seek(0, SeekOrigin.Begin);
-                httpContext.Request.Body = memoryStream;
+                if (entry.Resource != null)
+                {
+                    var memoryStream = new MemoryStream(_fhirJsonSerializer.SerializeToBytes(entry.Resource));
+                    memoryStream.Seek(0, SeekOrigin.Begin);
+                    httpContext.Request.Body = memoryStream;
+                }
             }
 #if !STU3
             // Allow JSON Patch to be an encoded Binary in a Bundle (See: https://chat.fhir.org/#narrow/stream/179166-implementers/topic/Transaction.20with.20PATCH.20request)


### PR DESCRIPTION
## Description
Prevents null pointer exception when a resource body is not included in a Post/Put request in a bundle.

## Related issues
Addresses 73773.

## Testing
Manually

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
