### PR TITLE
Adds option to avoid processing $everything links 

### DIFF
--- a/docs/rest/PatientEverythingLinks.http
+++ b/docs/rest/PatientEverythingLinks.http
@@ -599,6 +599,22 @@ GET <paste next link here>
 Authorization: Bearer {{bearer.response.body.access_token}}
 
 ###
+# Run Patient $everything on the Patient "mum" but do not follow its links.
+# This should return:
+# - The Patient "mum" resource and the HL7 organization that it references directly
+# - The patient's compartment resources: the cashew allergy intolerance and the appendectomy procedure
+# - The device-mum device
+GET https://{{hostname}}/Patient/{{mum.response.body.id}}/$everything?excludeLinks=true
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+
+###
+# Paste the "next" link below
+GET <paste next link here>
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+
+###
 # Run Patient $everything, but only request Device resources.
 # This should return:
 # - The device-mum device

--- a/src/Microsoft.Health.Fhir.Core/Features/KnownQueryParameterNames.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/KnownQueryParameterNames.cs
@@ -71,5 +71,7 @@ namespace Microsoft.Health.Fhir.Core.Features
         public const string OutputFormat = "_outputFormat";
 
         public const string TypeFilter = "_typeFilter";
+
+        public const string ExcludeLinks = "excludeLinks";
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/KnownQueryParameterNames.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/KnownQueryParameterNames.cs
@@ -71,7 +71,5 @@ namespace Microsoft.Health.Fhir.Core.Features
         public const string OutputFormat = "_outputFormat";
 
         public const string TypeFilter = "_typeFilter";
-
-        public const string ExcludeLinks = "excludeLinks";
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Messages/Everything/EverythingOperationRequest.cs
+++ b/src/Microsoft.Health.Fhir.Core/Messages/Everything/EverythingOperationRequest.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Health.Fhir.Core.Messages.Everything
             PartialDateTime end = null,
             PartialDateTime since = null,
             string resourceTypes = null,
+            bool excludeLinks = false,
             string continuationToken = null,
             IReadOnlyList<Tuple<string, string>> unsupportedParameters = null)
         {
@@ -32,6 +33,7 @@ namespace Microsoft.Health.Fhir.Core.Messages.Everything
             End = end;
             Since = since;
             ResourceTypes = resourceTypes;
+            ExcludeLinks = excludeLinks;
             ContinuationToken = continuationToken;
             UnsupportedParameters = unsupportedParameters;
         }
@@ -47,6 +49,8 @@ namespace Microsoft.Health.Fhir.Core.Messages.Everything
         public PartialDateTime Since { get; }
 
         public string ResourceTypes { get; }
+
+        public bool ExcludeLinks { get; }
 
         public string ContinuationToken { get; }
 

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/EverythingControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/EverythingControllerTests.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
                 end: PartialDateTime.Parse("2020"),
                 since: PartialDateTime.Parse("2021"),
                 type: ResourceType.Observation.ToString(),
+                excludeLinks: false,
                 ct: null) as FhirResult;
 
             await _mediator.Received().Send(

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/EverythingController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/EverythingController.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             EverythingOperationParameterNames.End,
             KnownQueryParameterNames.Since,
             KnownQueryParameterNames.Type,
+            KnownQueryParameterNames.ExcludeLinks,
             KnownQueryParameterNames.ContinuationToken,
         };
 
@@ -90,7 +91,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                 .SelectMany(query => query.Value, (query, value) => Tuple.Create(query.Key, value))
                 .ToArray();
 
-            var unsupportedParameters = parameters.Where(x => !_supportedParameters.Contains(x.Item1.ToLower(CultureInfo.CurrentCulture))).ToList();
+            var unsupportedParameters = parameters.Where(x => !_supportedParameters.Contains(x.Item1)).ToList();
 
             foreach (Tuple<string, string> unsupportedParameter in unsupportedParameters)
             {

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/EverythingController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/EverythingController.cs
@@ -63,6 +63,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         /// <param name="end">The end date relates to care dates</param>
         /// <param name="since">Resources that have been updated since this time will be included in the response</param>
         /// <param name="type">Comma-delimited FHIR resource types to include in the return resources</param>
+        /// <param name="excludeLinks">True if patient links should not be processed, false otherwise. This defaults to false if not provided.</param>
         /// <param name="ct">The continuation token</param>
         [HttpGet]
         [Route(KnownRoutes.PatientEverythingById, Name = RouteNames.PatientEverythingById)]
@@ -73,11 +74,12 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             [FromQuery(Name = EverythingOperationParameterNames.End)] PartialDateTime end,
             [FromQuery(Name = KnownQueryParameterNames.Since)] PartialDateTime since,
             [FromQuery(Name = KnownQueryParameterNames.Type)] string type,
+            [FromQuery(Name = KnownQueryParameterNames.ExcludeLinks)] bool excludeLinks,
             string ct)
         {
             IReadOnlyList<Tuple<string, string>> unsupportedParameters = ReadUnsupportedParameters();
 
-            EverythingOperationResponse result = await _mediator.Send(new EverythingOperationRequest(ResourceType.Patient.ToString(), idParameter, start, end, since, type, ct, unsupportedParameters), HttpContext.RequestAborted);
+            EverythingOperationResponse result = await _mediator.Send(new EverythingOperationRequest(ResourceType.Patient.ToString(), idParameter, start, end, since, type, excludeLinks, ct, unsupportedParameters), HttpContext.RequestAborted);
 
             return FhirResult.Create(result.Bundle);
         }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/EverythingController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/EverythingController.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             EverythingOperationParameterNames.End,
             KnownQueryParameterNames.Since,
             KnownQueryParameterNames.Type,
-            KnownQueryParameterNames.ExcludeLinks,
+            EverythingOperationParameterNames.ExcludeLinks,
             KnownQueryParameterNames.ContinuationToken,
         };
 
@@ -75,7 +75,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             [FromQuery(Name = EverythingOperationParameterNames.End)] PartialDateTime end,
             [FromQuery(Name = KnownQueryParameterNames.Since)] PartialDateTime since,
             [FromQuery(Name = KnownQueryParameterNames.Type)] string type,
-            [FromQuery(Name = KnownQueryParameterNames.ExcludeLinks)] bool excludeLinks,
+            [FromQuery(Name = EverythingOperationParameterNames.ExcludeLinks)] bool excludeLinks,
             string ct)
         {
             IReadOnlyList<Tuple<string, string>> unsupportedParameters = ReadUnsupportedParameters();

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/EverythingOperationHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/EverythingOperationHandlerTests.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Everything
                 request.End,
                 request.Since,
                 request.ResourceTypes,
+                request.ExcludeLinks,
                 request.ContinuationToken,
                 CancellationToken.None).Returns(searchResult);
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/PatientEverythingServiceTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/PatientEverythingServiceTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Hl7.Fhir.Model;
+using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Operations.Everything;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
@@ -31,7 +32,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Everything
         private readonly IReferenceSearchValueParser _referenceSearchValueParser = Substitute.For<IReferenceSearchValueParser>();
         private readonly IResourceDeserializer _resourceDeserializer = Substitute.For<IResourceDeserializer>();
         private readonly IUrlResolver _urlResolver = Substitute.For<IUrlResolver>();
-        private readonly IFhirDataStore _fhirDataStore = Substitute.For<IFhirDataStore>();
+        private readonly Func<IScoped<IFhirDataStore>> _fhirDataStore = Substitute.For<Func<IScoped<IFhirDataStore>>>();
 
         private readonly PatientEverythingService _patientEverythingService;
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/PatientEverythingServiceTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/PatientEverythingServiceTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Everything
             var searchResult = new SearchResult(Enumerable.Empty<SearchResultEntry>(), null, null, new Tuple<string, string>[0]);
             _searchService.SearchAsync(Arg.Any<SearchOptions>(), CancellationToken.None).Returns(searchResult);
 
-            SearchResult actualResult = await _patientEverythingService.SearchAsync("123", null, null, null, null, null, CancellationToken.None);
+            SearchResult actualResult = await _patientEverythingService.SearchAsync("123", null, null, null, null, false, null, CancellationToken.None);
 
             Assert.Equal(searchResult.ContinuationToken, actualResult.ContinuationToken);
             Assert.Equal(searchResult.Results, actualResult.Results);

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/EverythingOperationHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/EverythingOperationHandler.cs
@@ -51,7 +51,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
             }
 
             SearchResult searchResult = await _patientEverythingService.SearchAsync(
-                request.ResourceId, request.Start, request.End, request.Since, request.ResourceTypes, request.ContinuationToken, cancellationToken);
+                request.ResourceId,
+                request.Start,
+                request.End,
+                request.Since,
+                request.ResourceTypes,
+                request.ExcludeLinks,
+                request.ContinuationToken,
+                cancellationToken);
 
             ResourceElement bundle = request.UnsupportedParameters != null && request.UnsupportedParameters.Any()
                 ? _bundleFactory.CreateSearchBundle(new SearchResult(searchResult.Results, searchResult.ContinuationToken, searchResult.SortOrder, request.UnsupportedParameters))

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/EverythingOperationParameterNames.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/EverythingOperationParameterNames.cs
@@ -13,5 +13,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
         public const string Start = "start";
 
         public const string End = "end";
+
+        public const string ExcludeLinks = "excludeLinks";
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/IPatientEverythingService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/IPatientEverythingService.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
             PartialDateTime end,
             PartialDateTime since,
             string type,
+            bool excludeLinks,
             string continuationToken,
             CancellationToken cancellationToken);
     }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
@@ -79,6 +79,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
             PartialDateTime end,
             PartialDateTime since,
             string type,
+            bool excludeLinks,
             string continuationToken,
             CancellationToken cancellationToken)
         {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTests.cs
@@ -298,5 +298,37 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.Empty(secondBundle.Resource.Entry);
             Assert.Null(secondBundle.Resource.NextLink);
         }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenPatientWithSeeAlsoLink_WhenRunningPatientEverythingWithExcludeLinksTrue_ThenPatientEverythingShouldNotRunOnLink()
+        {
+            string searchUrl = $"Patient/{Fixture.PatientWithSeeAlsoLink.Id}/$everything?excludeLinks=true";
+
+            FhirResponse<Bundle> firstBundle = await Client.SearchAsync(searchUrl);
+            ValidateBundle(firstBundle, Fixture.PatientWithSeeAlsoLink);
+
+            var nextLink = firstBundle.Resource.NextLink.ToString();
+            FhirResponse<Bundle> secondBundle = await Client.SearchAsync(nextLink);
+
+            Assert.Empty(secondBundle.Resource.Entry);
+            Assert.Null(secondBundle.Resource.NextLink);
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenPatientWithReplacedByLink_WhenRunningPatientEverythingWithExcludeLinksTrue_ThenNoErrorShouldBeReturned()
+        {
+            string searchUrl = $"Patient/{Fixture.PatientWithReplacedByLink.Id}/$everything?excludeLinks=true";
+
+            FhirResponse<Bundle> firstBundle = await Client.SearchAsync(searchUrl);
+            ValidateBundle(firstBundle, Fixture.PatientWithReplacedByLink);
+
+            var nextLink = firstBundle.Resource.NextLink.ToString();
+            FhirResponse<Bundle> secondBundle = await Client.SearchAsync(nextLink);
+
+            Assert.Empty(secondBundle.Resource.Entry);
+            Assert.Null(secondBundle.Resource.NextLink);
+        }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTests.cs
@@ -191,11 +191,13 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             ValidateBundle(secondBundle, Fixture.Observation);
         }
 
-        [Fact]
+        [Theory]
+        [InlineData("?excludeLinks=false")]
+        [InlineData("")]
         [Trait(Traits.Priority, Priority.One)]
-        public async Task GivenPatientWithSeeAlsoLink_WhenRunningPatientEverything_ThenPatientEverythingShouldRunOnLink()
+        public async Task GivenPatientWithSeeAlsoLink_WhenRunningPatientEverything_ThenPatientEverythingShouldRunOnLink(string queryParameters)
         {
-            string searchUrl = $"Patient/{Fixture.PatientWithSeeAlsoLink.Id}/$everything";
+            string searchUrl = $"Patient/{Fixture.PatientWithSeeAlsoLink.Id}/$everything{queryParameters}";
 
             FhirResponse<Bundle> firstBundle = await Client.SearchAsync(searchUrl);
             ValidateBundle(firstBundle, Fixture.PatientWithSeeAlsoLink);
@@ -217,11 +219,13 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.Empty(fifthBundle.Resource.Entry);
         }
 
-        [Fact]
+        [Theory]
+        [InlineData("?excludeLinks=false")]
+        [InlineData("")]
         [Trait(Traits.Priority, Priority.One)]
-        public async Task GivenPatientWithTwoSeeAlsoLinks_WhenRunningPatientEverything_ThenPatientEverythingShouldRunOnLinks()
+        public async Task GivenPatientWithTwoSeeAlsoLinks_WhenRunningPatientEverything_ThenPatientEverythingShouldRunOnLinks(string queryParameters)
         {
-            string searchUrl = $"Patient/{Fixture.PatientWithTwoSeeAlsoLinks.Id}/$everything";
+            string searchUrl = $"Patient/{Fixture.PatientWithTwoSeeAlsoLinks.Id}/$everything{queryParameters}";
 
             FhirResponse<Bundle> firstBundle = await Client.SearchAsync(searchUrl);
             ValidateBundle(firstBundle, Fixture.PatientWithTwoSeeAlsoLinks);
@@ -250,11 +254,13 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.Empty(sixthBundle.Resource.Entry);
         }
 
-        [Fact]
+        [Theory]
+        [InlineData("?excludeLinks=false")]
+        [InlineData("")]
         [Trait(Traits.Priority, Priority.One)]
-        public async Task GivenPatientWithReplacedByLink_WhenRunningPatientEverything_ThenMovedPermanentlyIsReturned()
+        public async Task GivenPatientWithReplacedByLink_WhenRunningPatientEverything_ThenMovedPermanentlyIsReturned(string queryParameters)
         {
-            string searchUrl = $"Patient/{Fixture.PatientWithReplacedByLink.Id}/$everything";
+            string searchUrl = $"Patient/{Fixture.PatientWithReplacedByLink.Id}/$everything{queryParameters}";
 
             using FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.SearchAsync(searchUrl));
 
@@ -267,11 +273,13 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.Contains(string.Format(Core.Resources.EverythingOperationResourceIrrelevant, Fixture.PatientWithReplacedByLink.Id, Fixture.PatientReferencedByReplacedByLink.Id), ex.Message);
         }
 
-        [Fact]
+        [Theory]
+        [InlineData("?excludeLinks=false")]
+        [InlineData("")]
         [Trait(Traits.Priority, Priority.One)]
-        public async Task GivenPatientWithReplacesLink_WhenRunningPatientEverything_ThenLinkShouldBeIgnored()
+        public async Task GivenPatientWithReplacesLink_WhenRunningPatientEverything_ThenLinkShouldBeIgnored(string queryParameters)
         {
-            string searchUrl = $"Patient/{Fixture.PatientWithReplacesLink.Id}/$everything";
+            string searchUrl = $"Patient/{Fixture.PatientWithReplacesLink.Id}/$everything{queryParameters}";
 
             FhirResponse<Bundle> firstBundle = await Client.SearchAsync(searchUrl);
             ValidateBundle(firstBundle, Fixture.PatientWithReplacesLink);
@@ -283,11 +291,13 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.Null(secondBundle.Resource.NextLink);
         }
 
-        [Fact]
+        [Theory]
+        [InlineData("?excludeLinks=false")]
+        [InlineData("")]
         [Trait(Traits.Priority, Priority.One)]
-        public async Task GivenPatientWithReferLink_WhenRunningPatientEverything_ThenLinkShouldBeIgnored()
+        public async Task GivenPatientWithReferLink_WhenRunningPatientEverything_ThenLinkShouldBeIgnored(string queryParameters)
         {
-            string searchUrl = $"Patient/{Fixture.PatientWithReferLink.Id}/$everything";
+            string searchUrl = $"Patient/{Fixture.PatientWithReferLink.Id}/$everything{queryParameters}";
 
             FhirResponse<Bundle> firstBundle = await Client.SearchAsync(searchUrl);
             ValidateBundle(firstBundle, Fixture.PatientWithReferLink);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTests.cs
@@ -219,13 +219,11 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.Empty(fifthBundle.Resource.Entry);
         }
 
-        [Theory]
-        [InlineData("?excludeLinks=false")]
-        [InlineData("")]
+        [Fact]
         [Trait(Traits.Priority, Priority.One)]
-        public async Task GivenPatientWithSeeAlsoLinkRemovedMidOperation_WhenRunningPatientEverything_ThenPatientEverythingShouldRunOnLink(string queryParameters)
+        public async Task GivenPatientWithSeeAlsoLinkRemovedMidOperation_WhenRunningPatientEverything_ThenPatientEverythingShouldRunOnLink()
         {
-            string searchUrl = $"Patient/{Fixture.PatientWithSeeAlsoLinkToRemove.Id}/$everything{queryParameters}";
+            string searchUrl = $"Patient/{Fixture.PatientWithSeeAlsoLinkToRemove.Id}/$everything";
 
             FhirResponse<Bundle> firstBundle = await Client.SearchAsync(searchUrl);
             ValidateBundle(firstBundle, Fixture.PatientWithSeeAlsoLinkToRemove);


### PR DESCRIPTION
## Description
Adds the ability to include an `excludeLinks` parameter to avoid processing a patient's links during a patient $everything operation.

Note: all link types will be ignored, including `replaced-by` links.

## Related issues
Addresses [AB#85562](https://microsofthealth.visualstudio.com/Health/_workitems/edit/85562).

## Testing
Adds e2e tests and a manual test case in the `.http` file.

## FHIR Team Checklist
- ✅ **Update the title** of the PR to be succinct and less than 50 characters
- ✅ **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- ✅ Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- ✅ Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- ✅ Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- ✅ Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Feature (new functionality)
