### PR TITLE
Compress continuation tokens

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportJobTaskTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportJobTaskTests.cs
@@ -1260,7 +1260,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
                     {
                         // The ids aren't in the query parameters because of the reset
                         ids = new string[] { "1", "2", "3" };
-                        continuationTokenIndex = int.Parse(Encoding.UTF8.GetString(Convert.FromBase64String(x.ArgAt<IReadOnlyList<Tuple<string, string>>>(1)[2].Item2)).Substring(2));
+                        continuationTokenIndex = int.Parse(ContinuationTokenConverter.Decode(x.ArgAt<IReadOnlyList<Tuple<string, string>>>(1)[2].Item2).Substring(2));
                     }
 
                     return CreateSearchResult(

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/ContinuationTokenConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/ContinuationTokenConverterTests.cs
@@ -45,5 +45,15 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
             Assert.Throws<BadRequestException>(() => ContinuationTokenConverter.Decode(encodedPrevious));
         }
+
+        [Fact]
+        public void GivenShortBase64WhenDecoding_ThenCorrectValueIsReturned()
+        {
+            var data = "YWJj";
+
+            var decoded = ContinuationTokenConverter.Decode(data);
+
+            Assert.Equal("abc", decoded);
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/ContinuationTokenConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/ContinuationTokenConverterTests.cs
@@ -1,0 +1,49 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Text;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Microsoft.Health.Fhir.Core.Features.Search;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
+{
+    public class ContinuationTokenConverterTests
+    {
+        [Fact]
+        public void GivenAString_WhenEcodingAndDecoding_ThenOriginalStringIsPreserved()
+        {
+            var data = Guid.NewGuid().ToString();
+
+            var encoded = ContinuationTokenConverter.Encode(data);
+            var decoded = ContinuationTokenConverter.Decode(encoded);
+
+            Assert.Equal(data, decoded);
+        }
+
+        [Fact]
+        public void GivenAnOldStringInBase64_WhenDecoding_ThenOriginalStringIsPreserved()
+        {
+            var data = Guid.NewGuid().ToString();
+
+            var encodedPrevious = Convert.ToBase64String(Encoding.UTF8.GetBytes(data));
+
+            var decoded = ContinuationTokenConverter.Decode(encodedPrevious);
+
+            Assert.Equal(data, decoded);
+        }
+
+        [Fact]
+        public void GivenAnInvalidString_WhenDecoding_ThenAnErrorIsThrown()
+        {
+            var data = Guid.NewGuid().ToString();
+
+            var encodedPrevious = Convert.ToBase64String(Encoding.UTF8.GetBytes(data)).Insert(5, "aaaafffff");
+
+            Assert.Throws<BadRequestException>(() => ContinuationTokenConverter.Decode(encodedPrevious));
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/ContinuationTokenConverter.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/ContinuationTokenConverter.cs
@@ -6,6 +6,7 @@
 using System;
 using System.IO;
 using System.IO.Compression;
+using System.Text;
 using EnsureThat;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.IO;
@@ -15,6 +16,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
     public sealed class ContinuationTokenConverter
     {
         private static readonly RecyclableMemoryStreamManager StreamManager = new();
+        private const string TokenVersion = "v2|";
 
         public static string Decode(string encodedContinuationToken)
         {
@@ -26,13 +28,20 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                 {
                     using MemoryStream memoryStream = StreamManager.GetStream(continuationTokenBytes);
                     using var deflate = new DeflateStream(memoryStream, CompressionMode.Decompress);
-                    using var reader = new StreamReader(deflate);
-                    return reader.ReadToEnd();
+                    using var reader = new StreamReader(deflate, Encoding.UTF8);
+
+                    var token = reader.ReadToEnd();
+                    if (token?.StartsWith(TokenVersion, StringComparison.Ordinal) == true)
+                    {
+                        return token.Substring(TokenVersion.Length);
+                    }
+
+                    return Encoding.UTF8.GetString(continuationTokenBytes);
                 }
                 catch (InvalidDataException)
                 {
                     // Fall back to compatibility with non-compressed tokens
-                    return System.Text.Encoding.UTF8.GetString(continuationTokenBytes);
+                    return Encoding.UTF8.GetString(continuationTokenBytes);
                 }
             }
             catch (FormatException)
@@ -45,12 +54,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
         {
             EnsureArg.IsNotEmptyOrWhiteSpace(continuationToken);
 
-            var buffer = System.Text.Encoding.UTF8.GetBytes(continuationToken);
-
             using MemoryStream memoryStream = StreamManager.GetStream();
             using var deflate = new DeflateStream(memoryStream, CompressionLevel.Fastest);
-            deflate.Write(buffer);
-            deflate.Flush();
+            using var writer = new StreamWriter(deflate, Encoding.UTF8);
+
+            writer.Write(TokenVersion);
+            writer.Write(continuationToken);
+            writer.Flush();
 
             return Convert.ToBase64String(memoryStream.ToArray());
         }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/ContinuationTokenConverter.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/ContinuationTokenConverter.cs
@@ -4,18 +4,36 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.IO;
+using System.IO.Compression;
 using EnsureThat;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Microsoft.IO;
 
 namespace Microsoft.Health.Fhir.Core.Features.Search
 {
     public sealed class ContinuationTokenConverter
     {
+        private static readonly RecyclableMemoryStreamManager StreamManager = new();
+
         public static string Decode(string encodedContinuationToken)
         {
             try
             {
-                return System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(encodedContinuationToken));
+                byte[] continuationTokenBytes = Convert.FromBase64String(encodedContinuationToken);
+
+                try
+                {
+                    using MemoryStream memoryStream = StreamManager.GetStream(continuationTokenBytes);
+                    using var deflate = new DeflateStream(memoryStream, CompressionMode.Decompress);
+                    using var reader = new StreamReader(deflate);
+                    return reader.ReadToEnd();
+                }
+                catch (InvalidDataException)
+                {
+                    // Fall back to compatibility with non-compressed tokens
+                    return System.Text.Encoding.UTF8.GetString(continuationTokenBytes);
+                }
             }
             catch (FormatException)
             {
@@ -26,7 +44,15 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
         public static string Encode(string continuationToken)
         {
             EnsureArg.IsNotEmptyOrWhiteSpace(continuationToken);
-            return Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(continuationToken));
+
+            var buffer = System.Text.Encoding.UTF8.GetBytes(continuationToken);
+
+            using MemoryStream memoryStream = StreamManager.GetStream();
+            using var deflate = new DeflateStream(memoryStream, CompressionLevel.Fastest);
+            deflate.Write(buffer);
+            deflate.Flush();
+
+            return Convert.ToBase64String(memoryStream.ToArray());
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexJobTaskTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexJobTaskTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
     [CollectionDefinition("ReindexTaskTests", DisableParallelization = true)]
     public class ReindexJobTaskTests : IClassFixture<SearchParameterFixtureData>, IAsyncLifetime
     {
-        private const string Base64EncodedToken = "dG9rZW4=";
+        private readonly string _base64EncodedToken = ContinuationTokenConverter.Encode("token");
         private const int _mockedSearchCount = 5;
 
         private static readonly WeakETag _weakETag = WeakETag.FromVersionId("0");
@@ -184,7 +184,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
             Assert.Collection<ReindexJobQueryStatus>(
                 job.QueryList.Keys.OrderBy(q => q.LastModified),
                 item => Assert.True(item.ContinuationToken == null && item.Status == OperationStatus.Completed),
-                item2 => Assert.True(item2.ContinuationToken == Base64EncodedToken && item2.Status == OperationStatus.Completed));
+                item2 => Assert.True(item2.ContinuationToken == _base64EncodedToken && item2.Status == OperationStatus.Completed));
 
             param.IsSearchable = true;
         }
@@ -253,7 +253,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
             await _searchService.Received().SearchForReindexAsync(
                 Arg.Is<IReadOnlyList<Tuple<string, string>>>(
                     l => l.Any(t => t.Item1 == "_type" && t.Item2 == "Appointment") &&
-                         l.Any(t => t.Item1 == KnownQueryParameterNames.ContinuationToken && t.Item2 == Base64EncodedToken)),
+                         l.Any(t => t.Item1 == KnownQueryParameterNames.ContinuationToken && t.Item2 == _base64EncodedToken)),
                 Arg.Is<string>("appointmentHash"),
                 false,
                 Arg.Any<CancellationToken>());
@@ -261,7 +261,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
             await _searchService.Received().SearchForReindexAsync(
                 Arg.Is<IReadOnlyList<Tuple<string, string>>>(
                     l => l.Any(t => t.Item1 == "_type" && t.Item2 == "AppointmentResponse") &&
-                         l.Any(t => t.Item1 == KnownQueryParameterNames.ContinuationToken && t.Item2 == Base64EncodedToken)),
+                         l.Any(t => t.Item1 == KnownQueryParameterNames.ContinuationToken && t.Item2 == _base64EncodedToken)),
                 Arg.Is<string>("appointmentResponseHash"),
                 false,
                 Arg.Any<CancellationToken>());
@@ -279,8 +279,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
             Assert.Equal(4, job.QueryList.Count);
             Assert.Contains(job.QueryList.Keys, item => item.ContinuationToken == null && item.Status == OperationStatus.Completed && item.ResourceType == "AppointmentResponse");
             Assert.Contains(job.QueryList.Keys, item => item.ContinuationToken == null && item.Status == OperationStatus.Completed && item.ResourceType == "Appointment");
-            Assert.Contains(job.QueryList.Keys, item => item.ContinuationToken == Base64EncodedToken && item.Status == OperationStatus.Completed && item.ResourceType == "AppointmentResponse");
-            Assert.Contains(job.QueryList.Keys, item => item.ContinuationToken == Base64EncodedToken && item.Status == OperationStatus.Completed && item.ResourceType == "Appointment");
+            Assert.Contains(job.QueryList.Keys, item => item.ContinuationToken == _base64EncodedToken && item.Status == OperationStatus.Completed && item.ResourceType == "AppointmentResponse");
+            Assert.Contains(job.QueryList.Keys, item => item.ContinuationToken == _base64EncodedToken && item.Status == OperationStatus.Completed && item.ResourceType == "Appointment");
 
             await _reindexUtilities.Received().UpdateSearchParameterStatus(
                 Arg.Is<IReadOnlyCollection<string>>(r => r.Any(s => s.Contains("Appointment")) && r.Any(s => s.Contains("AppointmentResponse"))),


### PR DESCRIPTION
## Description
To negate some of the impacts in using Base64 encoding, this PR uses a fast Deflate to reduce the overall size.

Findings for a selection of cases resulted in having the CT near or under the originally requested limit:
```
Original 2044, Continuation token Base64: 2728, Compressed+Base64: 1792
Original 2021, Continuation token Base64: 2696, Compressed+Base64: 1788
Original 621, Continuation token Base64: 828, Compressed+Base64: 464
Original 1929, Continuation token Base64: 2572, Compressed+Base64: 1040
```

## Related issues
Addresses #2250.

## Testing
* Should pass existing tests.
* Adds tests

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
