### PR TITLE
Avoids empty bundles during patient $everything

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
@@ -183,6 +183,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
             else
             {
                 nextContinuationToken = await CheckForNextSeeAlsoLinkAndSetToken(parentPatientId, token, !excludeLinks, cancellationToken);
+
+                // If the last phase returned no results and there are links to process
+                if (!searchResult.Results.Any() && nextContinuationToken != null)
+                {
+                    // Run patient $everything on links.
+                    return await SearchAsync(parentPatientId, start, end, since, type, excludeLinks, ContinuationTokenConverter.Encode(nextContinuationToken), cancellationToken);
+                }
             }
 
             return new SearchResult(searchResult.Results, nextContinuationToken, searchResult.SortOrder, searchResult.UnsupportedSearchParameters);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTests.cs
@@ -204,19 +204,15 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             var nextLink = firstBundle.Resource.NextLink.ToString();
             FhirResponse<Bundle> secondBundle = await Client.SearchAsync(nextLink);
-            Assert.Empty(secondBundle.Resource.Entry);
+            ValidateBundle(secondBundle, Fixture.PatientReferencedBySeeAlsoLink);
 
             nextLink = secondBundle.Resource.NextLink.ToString();
             FhirResponse<Bundle> thirdBundle = await Client.SearchAsync(nextLink);
-            ValidateBundle(thirdBundle, Fixture.PatientReferencedBySeeAlsoLink);
+            ValidateBundle(thirdBundle, Fixture.ObservationOfPatientReferencedBySeeAlsoLink);
 
             nextLink = thirdBundle.Resource.NextLink.ToString();
             FhirResponse<Bundle> fourthBundle = await Client.SearchAsync(nextLink);
-            ValidateBundle(fourthBundle, Fixture.ObservationOfPatientReferencedBySeeAlsoLink);
-
-            nextLink = fourthBundle.Resource.NextLink.ToString();
-            FhirResponse<Bundle> fifthBundle = await Client.SearchAsync(nextLink);
-            Assert.Empty(fifthBundle.Resource.Entry);
+            Assert.Empty(fourthBundle.Resource.Entry);
         }
 
         [Fact]
@@ -236,19 +232,15 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             FhirResponse<Bundle> secondBundle = await Client.SearchAsync(nextLink);
             ValidateBundle(secondBundle, Fixture.ObservationOfPatientWithSeeAlsoLinkToRemove);
 
-            nextLink = secondBundle.Resource.NextLink.ToString();
-            FhirResponse<Bundle> thirdBundle = await Client.SearchAsync(nextLink);
-            Assert.Empty(thirdBundle.Resource.Entry);
-
             // Subsequent $everything API calls use the version of the patient passed in on the first API call.
             // The update to remove the "seealso" link is not recognized.
+            nextLink = secondBundle.Resource.NextLink.ToString();
+            FhirResponse<Bundle> thirdBundle = await Client.SearchAsync(nextLink);
+            ValidateBundle(thirdBundle, Fixture.PatientReferencedByRemovedSeeAlsoLink);
+
             nextLink = thirdBundle.Resource.NextLink.ToString();
             FhirResponse<Bundle> fourthBundle = await Client.SearchAsync(nextLink);
-            ValidateBundle(fourthBundle, Fixture.PatientReferencedByRemovedSeeAlsoLink);
-
-            nextLink = fourthBundle.Resource.NextLink.ToString();
-            FhirResponse<Bundle> fifthBundle = await Client.SearchAsync(nextLink);
-            Assert.Empty(fifthBundle.Resource.Entry);
+            Assert.Empty(fourthBundle.Resource.Entry);
         }
 
         [Theory]
@@ -262,28 +254,20 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             FhirResponse<Bundle> firstBundle = await Client.SearchAsync(searchUrl);
             ValidateBundle(firstBundle, Fixture.PatientWithTwoSeeAlsoLinks);
 
-            var nextLink = firstBundle.Resource.NextLink.ToString();
-            FhirResponse<Bundle> secondBundle = await Client.SearchAsync(nextLink);
-            Assert.Empty(secondBundle.Resource.Entry);
-
             // The "seealso" links will be processed in sorted order by id
             var orderedPatientsReferencedByLink = Fixture.PatientsReferencedBySeeAlsoLink.OrderBy(p => p.Id).ToList();
 
+            var nextLink = firstBundle.Resource.NextLink.ToString();
+            FhirResponse<Bundle> secondBundle = await Client.SearchAsync(nextLink);
+            ValidateBundle(secondBundle, orderedPatientsReferencedByLink[0]);
+
             nextLink = secondBundle.Resource.NextLink.ToString();
             FhirResponse<Bundle> thirdBundle = await Client.SearchAsync(nextLink);
-            ValidateBundle(thirdBundle, orderedPatientsReferencedByLink[0]);
+            ValidateBundle(thirdBundle, orderedPatientsReferencedByLink[1]);
 
             nextLink = thirdBundle.Resource.NextLink.ToString();
             FhirResponse<Bundle> fourthBundle = await Client.SearchAsync(nextLink);
             Assert.Empty(fourthBundle.Resource.Entry);
-
-            nextLink = fourthBundle.Resource.NextLink.ToString();
-            FhirResponse<Bundle> fifthBundle = await Client.SearchAsync(nextLink);
-            ValidateBundle(fifthBundle, orderedPatientsReferencedByLink[1]);
-
-            nextLink = fifthBundle.Resource.NextLink.ToString();
-            FhirResponse<Bundle> sixthBundle = await Client.SearchAsync(nextLink);
-            Assert.Empty(sixthBundle.Resource.Entry);
         }
 
         [Theory]


### PR DESCRIPTION
## Description
The patient $everything operation returns results asynchronously in bundles and relies on the user to follow the `next` link in each returned bundle to retrieve the subsequent set of results. In some scenarios, we returned empty bundles mid-operation - this happened right before we started processing a `seealso` link. 

This PR adds a check to see if the current result set is empty, and it immediately jumps into link processing if there are remaining unvisited `seealso` links.

Note: there are still cases where the last bundle we return will be empty. This is unavoidable, as we don't always know that there aren't remaining resources until we process the next call.

## Related issues
Addresses [AB#85777](https://microsofthealth.visualstudio.com/Health/_workitems/edit/85777).

## Testing
Updates existing tests.

## FHIR Team Checklist
- ✅ **Update the title** of the PR to be succinct and less than 50 characters
- ✅ **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- ✅ Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- ✅ Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- ✅ Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- ✅ Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip (bug fix)
