### PR TITLE
Fix setup AAD pipeline step

### DIFF
--- a/build/build-variables.yml
+++ b/build/build-variables.yml
@@ -23,7 +23,8 @@ variables:
   TestClientUrl: 'https://$(DeploymentEnvironmentName)-client/'
   ConnectedServiceName: 'Microsoft Health Open Source Subscription'
   WindowsVmImage: 'windows-latest'
-  LinuxVmImage: 'ubuntu-latest'
+  LinuxVmImage: 'ubuntu-latest'  
+  TestApplicationResource: 'https://$(DeploymentEnvironmentName).resoluteopensource.onmicrosoft.com'
   # The following is set by a build Pipeline variable:
   # DefaultLinuxPool: 'Azure Pipelines'
   # SharedLinuxPool: 'Azure Pipelines'

--- a/build/jobs/add-aad-test-environment.yml
+++ b/build/jobs/add-aad-test-environment.yml
@@ -61,4 +61,4 @@ steps:
       Import-Module $(System.DefaultWorkingDirectory)/release/scripts/PowerShell/FhirServerRelease/FhirServerRelease.psd1
 
       Write-Host "Imported modules"
-      $output = Add-AadTestAuthEnvironment -TestAuthEnvironmentPath $(System.DefaultWorkingDirectory)/testauthenvironment.json -EnvironmentName $environmentName -ResourceGroupName $(ResourceGroupName) -TenantAdminCredential $adminCredential
+      $output = Add-AadTestAuthEnvironment -TestAuthEnvironmentPath $(System.DefaultWorkingDirectory)/testauthenvironment.json -EnvironmentName $environmentName -ResourceGroupName $(ResourceGroupName) -TenantAdminCredential $adminCredential -WebAppSuffix $tenantId

--- a/build/jobs/e2e-tests.yml
+++ b/build/jobs/e2e-tests.yml
@@ -69,7 +69,7 @@ steps:
         Write-Host "##vso[task.setvariable variable=TestIntegrationStoreUri]$($integrationStoreUri)"
         Write-Host "##vso[task.setvariable variable=TestIntegrationStoreKey]$($integrationStoreKey.Value)"
 
-        Write-Host "##vso[task.setvariable variable=Resource]$(TestEnvironmentUrl)"
+        Write-Host "##vso[task.setvariable variable=Resource]$(TestApplicationResource)"
         
         $secrets = Get-AzKeyVaultSecret -VaultName resolute-oss-tenant-info
  

--- a/samples/scripts/PowerShell/FhirServer/Public/New-FhirServerApiApplicationRegistration.ps1
+++ b/samples/scripts/PowerShell/FhirServer/Public/New-FhirServerApiApplicationRegistration.ps1
@@ -65,8 +65,8 @@ function New-FhirServerApiApplicationRegistration {
     }
 
     # Create the App Registration
-    $apiAppReg = New-AzureADApplication -DisplayName $FhirServiceAudience -IdentifierUris $FhirServiceAudience -AppRoles $desiredAppRoles
-    New-AzureAdServicePrincipal -AppId $apiAppReg.AppId | Out-Null
+    $apiAppReg = New-AzADApplication -DisplayName $FhirServiceAudience -IdentifierUris $FhirServiceAudience -AppRoles $desiredAppRoles
+    New-AzAdServicePrincipal -AppId $apiAppReg.AppId | Out-Null
 
     $aadEndpoint = (Get-AzureADCurrentSessionInfo).Environment.Endpoints["ActiveDirectory"]
     $aadTenantId = (Get-AzureADCurrentSessionInfo).Tenant.Id.ToString()


### PR DESCRIPTION
## Description
Fixes the setup AAD pipeline step.

## Related issues

## Testing
Run the PR pipeline

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
