### PR TITLE
Added MemberMatchResourceValidator for MemberMatchRequest

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/MemberMatch/MemberMatchResourceValidatorTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/MemberMatch/MemberMatchResourceValidatorTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Resources.MemberMatch
     {
 #if !Stu3
         [Fact]
-        public void GivenAnInvalidResourceResourc_WhenValidatingMemberMatch_ThenInvalidShouldBeReturned()
+        public void GivenAnInvalidResource_WhenValidatingMemberMatch_ThenInvalidShouldBeReturned()
         {
             var contextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
             var profileValidator = Substitute.For<IProfileValidator>();

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/MemberMatch/MemberMatchResourceValidatorTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/MemberMatch/MemberMatchResourceValidatorTests.cs
@@ -19,13 +19,14 @@ using Microsoft.Health.Fhir.Core.Features.Resources.MemberMatch;
 using Microsoft.Health.Fhir.Core.Features.Validation;
 using Microsoft.Health.Fhir.Core.Features.Validation.Narratives;
 using Microsoft.Health.Fhir.Core.Messages.MemberMatch;
+using Microsoft.Health.Fhir.Core.UnitTests.Features.Validation.Narratives;
 using Microsoft.Health.Fhir.Tests.Common;
 using NSubstitute;
 using Xunit;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Resources.MemberMatch
 {
-    public class MemberMatchResourceValidatorTests
+    public class MemberMatchResourceValidatorTests : NarrativeDataTestBase
     {
 #if !Stu3
         [Fact]
@@ -56,11 +57,11 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Resources.MemberMatch
 #endif
 
         [Theory]
-        [InlineData("")]
-        [InlineData("1+1")]
-        [InlineData("11|")]
-        [InlineData("00000000000000000000000000000000000000000000000000000000000000065")]
-        public void GivenAResourceWithInvalidId_WhenValidatingMemberMatch_ThenInvalidShouldBeReturned(string id)
+        [InlineData("", nameof(XssStrings))]
+        [InlineData("1+1", nameof(XssStrings))]
+        [InlineData("11|", nameof(XssStrings))]
+        [InlineData("00000000000000000000000000000000000000000000000000000000000000065", nameof(XssStrings))]
+        public void GivenAResourceWithInvalidId_WhenValidatingMemberMatch_ThenInvalidShouldBeReturned(string id, string maliciousNarrative)
         {
             var contextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
             var profileValidator = Substitute.For<IProfileValidator>();
@@ -77,8 +78,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Resources.MemberMatch
             var defaultCoverage = Samples.GetDefaultCoverage().ToPoco<Coverage>();
             var defaultPatient = Samples.GetDefaultPatient().ToPoco<Patient>();
 
-            defaultCoverage.Text.Div = MaliciousNarrative().ToString();
-            defaultPatient.Text.Div = MaliciousNarrative().ToString();
+            defaultCoverage.Text.Div = maliciousNarrative;
+            defaultPatient.Text.Div = maliciousNarrative;
 
             var coverageResource = defaultCoverage.ToResourceElement()
                             .UpdateId(id);
@@ -132,27 +133,6 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Resources.MemberMatch
             {
                 profileValidator.DidNotReceive().TryValidate(Arg.Any<ITypedElement>(), Arg.Any<string>());
             }
-        }
-
-        public static IEnumerable<object[]> MaliciousNarrative()
-        {
-            return new object[]
-            {
-                            "<div>'';!--\"<XSS>=&{()}</div>",
-                            "<div><?xml version=\"1.0\" encoding=\"ISO-8859-1\"?><foo><![CDATA[<]]>SCRIPT<![CDATA[>]]>alert('gotcha');<![CDATA[<]]>/SCRIPT<![CDATA[>]]></foo></div>",
-                            "<div><a onclick=\"alert('gotcha');\"></a></div>",
-                            "<div><div id=\"nested\"><span><a onclick=\"alert('gotcha');\"></a></span></div></div>",
-                            "<div><IMG SRC=\"jav &#x0D;ascript:alert(<WBR>'XSS');\"></div>",
-                            "<div><img%20src%3D%26%23x6a;%26%23x61;%26%23x76;%26%23x61;%26%23x73;%26%23x63;%26%23x72;%26%23x69;%26%23x70;%26%23x74;%26%23x3a;alert(%26quot;%26%23x20;XSS%26%23x20;Test%26%23x20;Successful%26quot;)></div>",
-                            "<div><IMGSRC=&#106;&#97;&#118;&#97;&<WBR>#115;&#99;&#114;&#105;&#112;&<WBR>#116;&#58;&#97;&#108;&#101;&<WBR>#114;&#116;&#40;&#39;&#88;&#83<WBR>;&#83;&#39;&#41></div>",
-                            "<div><script src=http://www.example.com/malicious-code.js></script></div>",
-                            "<div>%22%27><img%20src%3d%22javascript:alert(%27%20XSS%27)%22></div>",
-                            "<div>\"'><img%20src%3D%26%23x6a;%26%23x61;%26%23x76;%26%23x61;%26%23x73;%26%23x63;%26%23x72;%26%23x69;%26%23x70;%26%23x74;%26%23x3a;</div>",
-                            "<div>\"><script>alert(\"XSS\")</script>&</div>",
-                            "<div>\"><STYLE>@import\"javascript:alert('XSS')\";</ STYLE ></div>",
-                            "<div>http://www.example.com/>\"><script>alert(\"XSS\")</script>&</div>",
-                            "<div onmouseover=\"alert('gotcha');\"></div>",
-            }.Select(x => new[] { x });
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
@@ -22,6 +22,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\Reindex\ReindexJobTaskTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\Export\GroupMemberExtractorTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Create\CreateResourceValidatorTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\MemberMatch\MemberMatchResourceValidatorTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\ResourceHandlerTests_ConditionalDelete.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\ExtensionToNumberSearchValueConverterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\ExtensionToDateTimeSearchValueConverterTests.cs" />

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/MemberMatch/MemberMatchResourceValidator.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/MemberMatch/MemberMatchResourceValidator.cs
@@ -1,0 +1,39 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using FluentValidation;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Core.Features.Context;
+using Microsoft.Health.Fhir.Core.Configs;
+using Microsoft.Health.Fhir.Core.Features.Context;
+using Microsoft.Health.Fhir.Core.Features.Validation;
+using Microsoft.Health.Fhir.Core.Features.Validation.Narratives;
+using Microsoft.Health.Fhir.Core.Messages.MemberMatch;
+
+namespace Microsoft.Health.Fhir.Core.Features.Resources.MemberMatch
+{
+    public class MemberMatchResourceValidator : AbstractValidator<MemberMatchRequest>
+    {
+        public MemberMatchResourceValidator(
+            IModelAttributeValidator modelAttributeValidator,
+            INarrativeHtmlSanitizer narrativeHtmlSanitizer,
+            IProfileValidator profileValidator,
+            RequestContextAccessor<IFhirRequestContext> fhirRequestContextAccessor,
+            IOptions<CoreFeatureConfiguration> config)
+        {
+            var contentValidator = new ResourceProfileValidator(
+                modelAttributeValidator,
+                profileValidator,
+                fhirRequestContextAccessor,
+                config.Value.ProfileValidationOnCreate);
+
+            RuleFor(x => x.Coverage)
+                  .SetValidator(new ResourceElementValidator(contentValidator, narrativeHtmlSanitizer));
+
+            RuleFor(x => x.Patient)
+                  .SetValidator(new ResourceElementValidator(contentValidator, narrativeHtmlSanitizer));
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Core/Microsoft.Health.Fhir.Shared.Core.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Microsoft.Health.Fhir.Shared.Core.projitems
@@ -43,6 +43,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Delete\DeleteResourceValidator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Get\GetResourceHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Get\GetResourceValidator.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\MemberMatch\MemberMatchResourceValidator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Patch\ConditionalPatchResourceHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Patch\PatchResourceHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Patch\JsonPatchService.cs" />


### PR DESCRIPTION
## Description
With this PR we are adding MemberMatchResourceValidator which will be responsible for multiple validators like ResourceContentValidator, ResourceElementValidator, ResourceProfileValidator etc. so that the request is passed through basic resource validation.

## Related issues
Addresses [86184](https://microsofthealth.visualstudio.com/Health/_workitems/edit/86184).

## Testing
1. Manual Testing -
   a .Make a request to patient/$member-match with Request body's coverage status as "" e.g.
        {   
           "resourceType": "Coverage",
            "status": "",
            "payor": {
                "reference": "something"
            },
            "beneficiary": {
               "reference": "something"
           }
       }
   b. Above should return 400 with minimum cardinality message but currently we proceed with further steps
2. Unit tests

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
