### PR TITLE
Fixed failing audit unit tests - Added check to ensure that audit log is not created for custom error request

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Tests/Samples.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Tests/Samples.cs
@@ -96,6 +96,24 @@ namespace Microsoft.Health.Fhir.Tests.Common
             return batch.ToResourceElement();
         }
 
+        public static ResourceElement GetTransactionBundleWithValidEntries()
+        {
+            var batch = Samples.GetJsonSample("Bundle-TransactionWithValidBundleEntry").ToPoco<Bundle>();
+
+            // Make the criteria unique so that the tests behave consistently
+            var createGuid = Guid.NewGuid().ToString();
+            batch.Entry[1].Request.IfNoneExist = batch.Entry[1].Request.IfNoneExist + createGuid;
+            var createPatient = (Patient)batch.Entry[1].Resource;
+            createPatient.Identifier[0].Value = createPatient.Identifier[0].Value + createGuid;
+
+            var updateIdentifierGuid = Guid.NewGuid().ToString();
+            batch.Entry[3].Request.Url = batch.Entry[3].Request.Url + updateIdentifierGuid;
+            var updatePatient = (Patient)batch.Entry[3].Resource;
+            updatePatient.Identifier[0].Value = updatePatient.Identifier[0].Value + updateIdentifierGuid;
+
+            return batch.ToResourceElement();
+        }
+
         public static ResourceElement GetDefaultTransaction()
         {
             return GetJsonSample("Bundle-Transaction");

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/AuditTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/AuditTests.cs
@@ -509,22 +509,20 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenATransactionBundleWithValidEntries_WhenSuccessfulPost_ThenAuditLogEntriesShouldBeCreated()
         {
-            Patient existingPatient = Samples.GetDefaultPatient().ToPoco<Patient>();
-            existingPatient.Id = "123";
+            var requestBundle = Samples.GetTransactionBundleWithValidEntries();
+            var batch = requestBundle.ToPoco<Bundle>();
 
-            await _client.UpdateAsync<Patient>(existingPatient);
+            await _client.UpdateAsync<Patient>(batch.Entry[2].Resource as Patient);
 
             // Even entries are audit executed entry and odd entries are audit executing entry
             List<(string expectedActions, string expectedPathSegments, HttpStatusCode? expectedStatusCodes, ResourceType? resourceType)> expectedList = new List<(string, string, HttpStatusCode?, ResourceType?)>
             {
                 ("transaction", string.Empty, HttpStatusCode.OK, null),
-                ("create", "Patient", HttpStatusCode.Created, ResourceType.Patient),
-                ("conditional-create", "Patient", HttpStatusCode.OK, ResourceType.Patient),
-                ("update", $"Patient/{existingPatient.Id}", HttpStatusCode.OK, ResourceType.Patient),
-                ("conditional-update", "Patient?identifier=http:/example.org/fhir/ids|456456", HttpStatusCode.OK, ResourceType.Patient),
+                ("create", batch.Entry[0].Request.Url, HttpStatusCode.Created, ResourceType.Patient),
+                ("conditional-create", batch.Entry[1].Request.Url, HttpStatusCode.Created, ResourceType.Patient),
+                ("update", batch.Entry[2].Request.Url, HttpStatusCode.OK, ResourceType.Patient),
+                ("conditional-update", batch.Entry[3].Request.Url, HttpStatusCode.Created, ResourceType.Patient),
             };
-
-            var requestBundle = Samples.GetJsonSample("Bundle-TransactionWithValidBundleEntry");
 
             await ExecuteAndValidateBundle(
                () => _client.PostBundleAsync(requestBundle.ToPoco<Hl7.Fhir.Model.Bundle>()),


### PR DESCRIPTION
## Description
When running tests Microsoft.Health.Fhir.R4.Tests.E2E, following 4 tests fail:

1. Microsoft.Health.Fhir.Tests.E2E.Rest.Audit.AuditTests(CosmosDb, Json).GivenARequest_WhenInvalidAuthorizationTokenIsSupplied_ThenAuditLogEntriesShouldBeCreated
2. Microsoft.Health.Fhir.Tests.E2E.Rest.Audit.AuditTests(CosmosDb, Json).GivenARequest_WhenNoAuthorizationTokenIsSupplied_ThenAuditLogEntriesShouldBeCreated
3. Microsoft.Health.Fhir.Tests.E2E.Rest.Audit.AuditTests(CosmosDb, Json).GivenARequest_WhenValidAuthorizationTokenWithInvalidAudienceIsSupplied_ThenAuditLogEntriesShouldBeCreated
4. Microsoft.Health.Fhir.Tests.E2E.Rest.Audit.AuditTests(SqlServer, Json).GivenATransactionBundleWithValidEntries_WhenSuccessfulPost_ThenAuditLogEntriesShouldBeCreated

This PR fixes the above failing tests -
Top 3 audit tests are failing as the extra audit entries are created for custom error request occurring due to invalid authorization. Search criteria is made unique to fix 4th test. 

## Related issues
Addresses [[86422](https://microsofthealth.visualstudio.com/Health/_workitems/edit/86422)].
#[AB2311](https://github.com/microsoft/fhir-server/issues/2311)

## Testing
1. Run the unit tests locally twice/thrice to ensure tests are passing in every go

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
