### PR TITLE
Adds Publisher to CapabilityStatement.name

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
             FileVersionInfo version = ProductVersionInfo.Version;
             var versionString = $"{version.FileMajorPart}.{version.FileMinorPart}.{version.FileBuildPart}";
 
-            statement.Name = string.Format(Resources.CapabilityStatementNameFormat, configuration.Value.SoftwareName, versionString);
+            statement.Name = string.Format(Resources.CapabilityStatementNameFormat, statement.Publisher, configuration.Value.SoftwareName, versionString);
             statement.Software = new SoftwareComponent
             {
                 Name = configuration.Value.SoftwareName,

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} {1} Capability Statement.
+        ///   Looks up a localized string similar to {0} {1} {2} Capability Statement.
         /// </summary>
         internal static string CapabilityStatementNameFormat {
             get {

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -608,7 +608,7 @@
     <comment>{0}: expression we trying to resolve, {1}: FHIR type</comment>
   </data>
   <data name="CapabilityStatementNameFormat" xml:space="preserve">
-    <value>{0} {1} Capability Statement</value>
+    <value>{0} {1} {2} Capability Statement</value>
   </data>
   <data name="EverythingOperationResourceIrrelevant" xml:space="preserve">
     <value>The patient with id `{0}` is no longer relevant. Use patient with id `{1}` instead.</value>


### PR DESCRIPTION
## Description
Adds Publisher to CapabilityStatement.name

## Testing
Manually verified by looking at /metadata endpoint

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch (updating human-readable field format)
