### PR TITLE
Search/sort when "Prefer handling=strict"

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Persistence/BadRequestException.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Persistence/BadRequestException.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Models;
 
@@ -17,6 +18,17 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
                     OperationOutcomeConstants.IssueSeverity.Error,
                     OperationOutcomeConstants.IssueType.Invalid,
                     errorMessage));
+        }
+
+        public BadRequestException(IEnumerable<string> errorMessages)
+        {
+            foreach (string errorMessage in errorMessages)
+            {
+                Issues.Add(new OperationOutcomeIssue(
+                        OperationOutcomeConstants.IssueSeverity.Error,
+                        OperationOutcomeConstants.IssueType.Invalid,
+                        errorMessage));
+            }
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Persistence/BadRequestException.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Persistence/BadRequestException.cs
@@ -3,7 +3,9 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Models;
@@ -27,7 +29,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
         /// <param name="errorMessages">Collection of error strings that are used to initialize OperationOutcomeIssue collection.
         /// Must be non-null and non-empty</param>
         public BadRequestException(ICollection<string> errorMessages)
-            : base((errorMessages == null || errorMessages.Count < 2) ? errorMessages.First() : "Multiple bad request errors.")
+            : base(((Func<string>)(() =>
+            {
+                Debug.Assert(errorMessages != null, "Parameter errorMessages must not be null.");
+                Debug.Assert(errorMessages == null || errorMessages.Any(), "Parameter errorMessages must not be empty.");
+                return (errorMessages == null || errorMessages.Count < 2) ? errorMessages.First() : "Multiple bad request errors."; // "Multiple bad request errors." message is used only internally, no need to add it to the Resources.resx file.
+            }))())
         {
             foreach (string errorMessage in errorMessages)
             {

--- a/src/Microsoft.Health.Fhir.Core/Features/Persistence/BadRequestException.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Persistence/BadRequestException.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
         /// <param name="errorMessages">Collection of error strings that are used to initialize OperationOutcomeIssue collection.
         /// Must be non-null and non-empty</param>
         public BadRequestException(ICollection<string> errorMessages)
-            : base((errorMessages.Count < 2) ? errorMessages.First() : "Multiple bad request errors.")
+            : base((errorMessages == null || errorMessages.Count < 2) ? errorMessages.First() : "Multiple bad request errors.")
         {
             foreach (string errorMessage in errorMessages)
             {

--- a/src/Microsoft.Health.Fhir.Core/Features/Persistence/BadRequestException.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Persistence/BadRequestException.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Models;
 
@@ -20,7 +21,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
                     errorMessage));
         }
 
-        public BadRequestException(IEnumerable<string> errorMessages)
+        /// <summary>
+        /// Constructor creates BadRequestException from collection of error strings.
+        /// </summary>
+        /// <param name="errorMessages">Collection of error strings that are used to initialize OperationOutcomeIssue collection.
+        /// Must be non-null and non-empty</param>
+        public BadRequestException(ICollection<string> errorMessages)
+            : base((errorMessages.Count < 2) ? errorMessages.First() : "Multiple bad request errors.")
         {
             foreach (string errorMessage in errorMessages)
             {

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -1277,6 +1277,15 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Sort parameter value &apos;{0}&apos; is invalid, must be a subset of valid search parameters for resource type &apos;{1}&apos;..
+        /// </summary>
+        internal static string SortParameterValueIsNotValidSearchParameter {
+            get {
+                return ResourceManager.GetString("SortParameterValueIsNotValidSearchParameter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Include result was truncated.
         /// </summary>
         internal static string TruncatedIncludeMessage {

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -615,5 +615,9 @@
   </data>
   <data name="CurrentSeeAlsoLinkIdShouldNotBeNull" xml:space="preserve">
     <value>The 'seealso' link id cannot be null when a 'seealso' link is being processed.</value>
+  </data>
+  <data name="SortParameterValueIsNotValidSearchParameter" xml:space="preserve">
+    <value>Sort parameter value '{0}' is invalid, must be a subset of valid search parameters for resource type '{1}'.</value>
+    <comment>Clarifies confusing situation when sort parameter value is not a valid search parameter (do we return search parameter or sort parameter value error).</comment>
   </data>
 </root>

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -311,7 +311,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                 var sortings = new List<(SearchParameterInfo, SortOrder)>(searchParams.Sort.Count);
                 bool sortingsValid = true;
 
-                // Check if sort parameters are valid search parameters.
+                // Only parameters that are valid for searching can also be used for sorting. Therefore first check if sort parameters are valid as search parameters.
                 foreach ((string, Hl7.Fhir.Rest.SortOrder) sorting in searchParams.Sort)
                 {
                     try
@@ -326,7 +326,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                     }
                 }
 
-                // Check if sort parameters are valid and can be used for sorting.
+                // Sort parameters are valid search parameters. Now verify that sort parameters are also valid for sorting.
                 if (sortingsValid)
                 {
                     if (!_sortingValidator.ValidateSorting(sortings, out IReadOnlyList<string> errorMessages))

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -386,6 +386,19 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                             string.Format(CultureInfo.InvariantCulture, Core.Resources.SearchParameterNotSupported, unsupported.Item1, string.Join(",", resourceTypesString))));
                 }
 
+                /*if (unsupportedSearchParameters.Any())
+                {
+                    string error = string.Format(
+                            Core.Resources.SearchParameterNotSupported,
+                            string.Join(",", unsupportedSearchParameters.Select(x => x.Item1)),
+                            string.Join(",", resourceTypesString));
+
+                    _contextAccessor.RequestContext?.BundleIssues.Add(new OperationOutcomeIssue(
+                            OperationOutcomeConstants.IssueSeverity.Warning,
+                            OperationOutcomeConstants.IssueType.NotSupported,
+                            error));
+                }*/
+
                 foreach (string unsupported in searchSortErrors)
                 {
                     _contextAccessor.RequestContext?.BundleIssues.Add(new OperationOutcomeIssue(

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -326,7 +326,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                     }
                 }
 
-                // Sort parameter values are valid search parameters. Now verify that sort paremeter values are also valid for sorting.
+                // Sort parameter values are valid search parameters. Now verify that sort parameter values are also valid for sorting.
                 if (sortingsValid)
                 {
                     if (!_sortingValidator.ValidateSorting(sortings, out IReadOnlyList<string> errorMessages))

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -361,15 +361,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             // depending on the state of the "Prefer" header.
             if (unsupportedSearchParameters.Any() || searchSortErrors.Any())
             {
-                // Put all errors into a set to avoid duplicate error messages, because search code and sort code may generate same error string.
-                // For example if non-searchable parameter is used both as a search and as a sort parameter then two same "non-searchable error" strings will be generated.
-                var allErrors = new SortedSet<string>();
+                var allErrors = new List<string>();
                 foreach (Tuple<string, string> unsupported in unsupportedSearchParameters)
                 {
                     allErrors.Add(string.Format(CultureInfo.InvariantCulture, Core.Resources.SearchParameterNotSupported, unsupported.Item1, string.Join(",", resourceTypesString)));
                 }
 
-                allErrors.UnionWith(searchSortErrors);
+                allErrors.AddRange(searchSortErrors);
 
                 if (_contextAccessor.GetIsStrictHandlingEnabled())
                 {

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -311,7 +311,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                 var sortings = new List<(SearchParameterInfo, SortOrder)>(searchParams.Sort.Count);
                 bool sortingsValid = true;
 
-                // Only parameters that are valid for searching can also be used for sorting. Therefore first check if sort parameters are valid as search parameters.
+                // Only parameters that are valid for searching can also be used as sort parameter values. Therefore first check if the sort parameter values are valid as search parameters.
                 foreach ((string, Hl7.Fhir.Rest.SortOrder) sorting in searchParams.Sort)
                 {
                     try
@@ -322,11 +322,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                     catch (SearchParameterNotSupportedException)
                     {
                         sortingsValid = false;
-                        searchSortErrors.Add(string.Format(CultureInfo.InvariantCulture, Core.Resources.SearchParameterNotSupported, sorting.Item1, string.Join(", ", resourceTypesString)));
+                        searchSortErrors.Add(string.Format(CultureInfo.InvariantCulture, Core.Resources.SortParameterValueIsNotValidSearchParameter, sorting.Item1, string.Join(", ", resourceTypesString)));
                     }
                 }
 
-                // Sort parameters are valid search parameters. Now verify that sort parameters are also valid for sorting.
+                // Sort parameter values are valid search parameters. Now verify that sort paremeter values are also valid for sorting.
                 if (sortingsValid)
                 {
                     if (!_sortingValidator.ValidateSorting(sortings, out IReadOnlyList<string> errorMessages))

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SearchTestsBase.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SearchTestsBase.cs
@@ -11,6 +11,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Web;
 using Hl7.Fhir.Model;
+using Microsoft.Health.Fhir.Client;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Tests.E2E.Common;
 using Xunit;
@@ -48,6 +49,17 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             return await ExecuteAndValidateBundle(searchUrl, actualDecodedUrl, sort, null, pageSize: 10, expectedResources);
         }
 
+        protected async Task<Bundle> ExecuteAndValidateBundle(
+            string searchUrl,
+            bool sort,
+            bool invalidSortParameter,
+            Tuple<string, string> customHeader,
+            params Resource[] expectedResources)
+        {
+            var actualDecodedUrl = WebUtility.UrlDecode(searchUrl);
+            return await ExecuteAndValidateBundle(searchUrl, actualDecodedUrl, sort, invalidSortParameter, customHeader, pageSize: 10, expectedResources);
+        }
+
         protected async Task<Bundle> ExecuteAndValidateBundle(string searchUrl, bool sort, int pageSize, params Resource[] expectedResources)
         {
             var actualDecodedUrl = WebUtility.UrlDecode(searchUrl);
@@ -62,11 +74,23 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             int pageSize = 10,
             params Resource[] expectedResources)
         {
+            return await ExecuteAndValidateBundle(searchUrl, selfLink, sort, false, customHeader, pageSize, expectedResources);
+        }
+
+        protected async Task<Bundle> ExecuteAndValidateBundle(
+            string searchUrl,
+            string selfLink,
+            bool sort,
+            bool invalidSortParameter,
+            Tuple<string, string> customHeader = null,
+            int pageSize = 10,
+            params Resource[] expectedResources)
+        {
             Bundle firstBundle = await Client.SearchAsync(searchUrl, customHeader);
 
             var expectedFirstBundle = expectedResources.Length > pageSize ? expectedResources[0..pageSize] : expectedResources;
 
-            ValidateBundle(firstBundle, selfLink, sort, expectedFirstBundle);
+            ValidateBundle(firstBundle, selfLink, sort, invalidSortParameter, expectedFirstBundle);
 
             var nextLink = firstBundle.NextLink?.ToString();
             int pageNumber = 1;
@@ -87,7 +111,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                     checkedAllResources = true;
                 }
 
-                ValidateBundle(nextBundle, nextLink, sort, remainingResources);
+                ValidateBundle(nextBundle, nextLink, sort, invalidSortParameter, remainingResources);
 
                 nextLink = nextBundle.NextLink?.ToString();
                 pageNumber++;
@@ -96,12 +120,25 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             return firstBundle;
         }
 
-        protected void ValidateBundle(Bundle bundle, string selfLink, params Resource[] expectedResources)
+        protected async Task<OperationOutcome> ExecuteAndValidateErrorOperationOutcomeAsync(
+            string searchUrl,
+            Tuple<string, string> customHeader,
+            HttpStatusCode expectedStatusCode,
+            OperationOutcome expectedOperationOutcome)
         {
-            ValidateBundle(bundle, selfLink, true, expectedResources);
+            FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.SearchAsync(searchUrl, customHeader));
+            Assert.Equal(expectedStatusCode, ex.StatusCode);
+            ex.OperationOutcome.Id = null;
+            Assert.True(expectedOperationOutcome.IsExactly(expectedOperationOutcome), "Deep compare detected expected and actual OperationOutcome mismatch.");
+            return ex.OperationOutcome;
         }
 
-        protected void ValidateBundle(Bundle bundle, string selfLink, bool sort, params Resource[] expectedResources)
+        protected void ValidateBundle(Bundle bundle, string selfLink, params Resource[] expectedResources)
+        {
+            ValidateBundle(bundle, selfLink, true, false, expectedResources);
+        }
+
+        protected void ValidateBundle(Bundle bundle, string selfLink, bool sort, bool invalidSortParameter, params Resource[] expectedResources)
         {
             string actualUrl;
 
@@ -117,21 +154,34 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 actualUrl = WebUtility.UrlDecode(bundle.SelfLink.AbsoluteUri);
             }
 
-            Skip.If(selfLink.Contains("_sort") && !actualUrl.Contains("_sort"), "This server does not support the supplied _sort parameter.");
+            if (!invalidSortParameter)
+            {
+                Skip.If(selfLink.Contains("_sort") && !actualUrl.Contains("_sort"), "This server does not support the supplied _sort parameter.");
 
-            Assert.Equal(Fixture.GenerateFullUrl(selfLink), actualUrl);
+                Assert.Equal(Fixture.GenerateFullUrl(selfLink), actualUrl);
+            }
+            else
+            {
+                Assert.DoesNotContain("_sort", actualUrl);
+            }
 
-            ValidateBundle(bundle, sort, expectedResources);
+            ValidateBundle(bundle, sort, invalidSortParameter, expectedResources);
         }
 
         protected void ValidateBundle(Bundle bundle, params Resource[] expectedResources)
         {
-            ValidateBundle(bundle, true, expectedResources);
+            ValidateBundle(bundle, true, false, expectedResources);
         }
 
-        protected void ValidateBundle(Bundle bundle, bool sort, params Resource[] expectedResources)
+        protected void ValidateBundle(Bundle bundle, bool sort, bool invalidSortParameter, params Resource[] expectedResources)
         {
             Assert.NotNull(bundle);
+
+            if (invalidSortParameter)
+            {
+                Assert.Equal(KnownResourceTypes.OperationOutcome, bundle.Entry[0].Resource.TypeName);
+                bundle.Entry[0].Resource.Id = null;
+            }
 
             if (sort)
             {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SearchTestsBase.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SearchTestsBase.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.SearchAsync(searchUrl, customHeader));
             Assert.Equal(expectedStatusCode, ex.StatusCode);
             ex.OperationOutcome.Id = null;
-            Assert.True(expectedOperationOutcome.IsExactly(expectedOperationOutcome), "Deep compare detected expected and actual OperationOutcome mismatch.");
+            Assert.True(expectedOperationOutcome.IsExactly(ex.OperationOutcome), "Deep compare detected expected and actual OperationOutcome mismatch.");
             return ex.OperationOutcome;
         }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SearchTestsBase.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SearchTestsBase.cs
@@ -179,8 +179,9 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
             if (invalidSortParameter)
             {
-                Assert.Equal(KnownResourceTypes.OperationOutcome, bundle.Entry[0].Resource.TypeName);
-                bundle.Entry[0].Resource.Id = null;
+                Bundle.EntryComponent entry = Assert.Single(bundle.Entry, e => e.Resource.TypeName == KnownResourceTypes.OperationOutcome); // Exactly one OperationOutcome is returned.
+                Assert.Equal(bundle.Entry[0].Resource.TypeName, KnownResourceTypes.OperationOutcome); // OperationOutcome is the first resource.
+                entry.Resource.Id = null; // Set OperationOutcome id returned by the server to null before comparing with the expected resources.
             }
 
             if (sort)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SortTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SortTests.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             var patients = await CreatePatients(tag);
             OperationOutcome expectedOperationOutcome = OperationOutcome.ForMessage(
                 string.Format(CultureInfo.InvariantCulture, Core.Resources.SearchSortParameterNotSupported, _unsupportedSortParam),
-                OperationOutcome.IssueType.NotSupported,
+                OperationOutcome.IssueType.Invalid,
                 OperationOutcome.IssueSeverity.Error);
 
             await ExecuteAndValidateErrorOperationOutcomeAsync(

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SortTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SortTests.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             Patient[] patients = await CreatePatients(tag);
             Resource[] expectedResources = new Resource[patients.Length + 1];
             expectedResources[0] = OperationOutcome.ForMessage(
-                string.Format(CultureInfo.InvariantCulture, Core.Resources.SearchParameterNotSupported, _unsupportedSearchAndSortParam, "Patient"),
+                string.Format(CultureInfo.InvariantCulture, Core.Resources.SortParameterValueIsNotValidSearchParameter, _unsupportedSearchAndSortParam, "Patient"),
                 OperationOutcome.IssueType.NotSupported,
                 OperationOutcome.IssueSeverity.Warning);
             patients.Cast<Resource>().ToArray().CopyTo(expectedResources, 1);
@@ -200,7 +200,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             var tag = Guid.NewGuid().ToString();
             var patients = await CreatePatients(tag);
             OperationOutcome expectedOperationOutcome = OperationOutcome.ForMessage(
-                string.Format(CultureInfo.InvariantCulture, Core.Resources.SearchParameterNotSupported, _unsupportedSearchAndSortParam, "Patient"),
+                string.Format(CultureInfo.InvariantCulture, Core.Resources.SortParameterValueIsNotValidSearchParameter, _unsupportedSearchAndSortParam, "Patient"),
                 OperationOutcome.IssueType.Invalid,
                 OperationOutcome.IssueSeverity.Error);
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SortTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SortTests.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
-        public async Task GivenPatients_WhenSearchedWithInvalidSerchAndSortParamsAndHandlingLenient_ThenPatientsAreReturnedUnsortedWithWarning()
+        public async Task GivenPatients_WhenSearchedWithInvalidSearchAndSortParamsAndHandlingLenient_ThenPatientsAreReturnedUnsortedWithWarning()
         {
             var tag = Guid.NewGuid().ToString();
             Patient[] patients = await CreatePatients(tag);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SortTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SortTests.cs
@@ -5,7 +5,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using System.Web;
 using Hl7.Fhir.Model;
@@ -20,6 +22,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
     [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.Json)]
     public class SortTests : SearchTestsBase<HttpIntegrationTestFixture>
     {
+        private static readonly string _unsupportedSortParam = "link"; // Link parameter is of reference type so sorting by link will always fail.
+
         public SortTests(HttpIntegrationTestFixture fixture)
             : base(fixture)
         {
@@ -126,6 +130,45 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 $"Patient?_tag={tag}&_sort=family",
                 false,
                 patients.OrderBy(x => x.Name.Min(n => n.Family)).Cast<Resource>().ToArray());
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenPatients_WhenSearchedWithInvalidSortParamsAndHandlingLenient_ThenPatientsAreReturnedUnsortedWithWarning()
+        {
+            var tag = Guid.NewGuid().ToString();
+            Patient[] patients = await CreatePatients(tag);
+            Resource[] expectedResources = new Resource[patients.Length + 1];
+            expectedResources[0] = OperationOutcome.ForMessage(
+                string.Format(CultureInfo.InvariantCulture, Core.Resources.SearchSortParameterNotSupported, _unsupportedSortParam),
+                OperationOutcome.IssueType.NotSupported,
+                OperationOutcome.IssueSeverity.Warning);
+            patients.Cast<Resource>().ToArray().CopyTo(expectedResources, 1);
+
+            await ExecuteAndValidateBundle(
+                $"Patient?_tag={tag}&_sort={_unsupportedSortParam}",
+                true, // Server sort will fail, so sort expected result and actual result before comparing.
+                true, // Turn on test logic for invalid sort parameter.
+                new Tuple<string, string>("Prefer", "handling=lenient"),
+                expectedResources);
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenPatients_WhenSearchedWithInvalidSortParamsAndHandlingStrict_ThenErrorReturnedWithMessage()
+        {
+            var tag = Guid.NewGuid().ToString();
+            var patients = await CreatePatients(tag);
+            OperationOutcome expectedOperationOutcome = OperationOutcome.ForMessage(
+                string.Format(CultureInfo.InvariantCulture, Core.Resources.SearchSortParameterNotSupported, _unsupportedSortParam),
+                OperationOutcome.IssueType.NotSupported,
+                OperationOutcome.IssueSeverity.Error);
+
+            await ExecuteAndValidateErrorOperationOutcomeAsync(
+                $"Patient?_tag={tag}&_sort={_unsupportedSortParam}",
+                new Tuple<string, string>("Prefer", "handling=strict"),
+                HttpStatusCode.BadRequest,
+                expectedOperationOutcome);
         }
 
         [SkippableFact]


### PR DESCRIPTION
## Description
Changes sort so it returns 400 with error message if
Prefer handling=strict. Adds unit tests to check both cases
Prefer handling=strict and Prefer handling=lenient return proper error
code and OperationOutcome, with deep compare of returned and expected
OperationOutcome.

## Related issues
Fixes #2208

## Testing
Unit tests Microsoft.Health.Fhir.R4.Tests.E2E were ran.
