### PR TITLE
Allow import request with prefix for initial import mode

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Operations/Import/InitialImportLockMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Operations/Import/InitialImportLockMiddleware.cs
@@ -36,8 +36,8 @@ namespace Microsoft.Health.Fhir.Api.Features.Operations.Import
             _excludedEndpoints = new HashSet<(string method, string pathRegex)>()
             {
                 (HttpMethods.Get, ".*"), // Exclude all read operations
-                (HttpMethods.Post, "/\\$import"),
-                (HttpMethods.Delete, "/_operations/import/.+"),
+                (HttpMethods.Post, ".*/\\$import"),
+                (HttpMethods.Delete, ".*/_operations/import/.+"),
             };
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Operations/Import/InitialImportLockMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Operations/Import/InitialImportLockMiddlewareTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Operations.Import
         }
 
         [Fact]
-        public async Task GivenStartImportRequestWithPrefix_WhenInitialImportModeEnabled_Then200ShouldBeReturned()
+        public async Task GivenImportRequestWithPrefix_WhenInitialImportModeEnabled_Then200ShouldBeReturned()
         {
             InitialImportLockMiddleware middleware = CreateInitialImportLockMiddleware(new ImportTaskConfiguration() { Enabled = false, InitialImportMode = true });
             HttpContext httpContext = new DefaultHttpContext();

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Operations/Import/InitialImportLockMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Operations/Import/InitialImportLockMiddlewareTests.cs
@@ -51,11 +51,35 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Operations.Import
         }
 
         [Fact]
+        public async Task GivenStartImportRequestWithPrefix_WhenInitialImportModeEnabled_Then200ShouldBeReturned()
+        {
+            InitialImportLockMiddleware middleware = CreateInitialImportLockMiddleware(new ImportTaskConfiguration() { Enabled = false, InitialImportMode = true });
+            HttpContext httpContext = new DefaultHttpContext();
+            httpContext.Request.Path = "/prefix/$import";
+            httpContext.Request.Method = HttpMethods.Post.ToString();
+            await middleware.Invoke(httpContext);
+
+            Assert.Equal(200, httpContext.Response.StatusCode);
+        }
+
+        [Fact]
         public async Task GivenCancelImportRequest_WhenInitialImportModeEnabled_Then200ShouldBeReturned()
         {
             InitialImportLockMiddleware middleware = CreateInitialImportLockMiddleware(new ImportTaskConfiguration() { Enabled = false, InitialImportMode = true });
             HttpContext httpContext = new DefaultHttpContext();
             httpContext.Request.Path = "/_operations/import/abc";
+            httpContext.Request.Method = HttpMethods.Delete.ToString();
+            await middleware.Invoke(httpContext);
+
+            Assert.Equal(200, httpContext.Response.StatusCode);
+        }
+
+        [Fact]
+        public async Task GivenCancelImportRequestWithPrefix_WhenInitialImportModeEnabled_Then200ShouldBeReturned()
+        {
+            InitialImportLockMiddleware middleware = CreateInitialImportLockMiddleware(new ImportTaskConfiguration() { Enabled = false, InitialImportMode = true });
+            HttpContext httpContext = new DefaultHttpContext();
+            httpContext.Request.Path = "/prefix/_operations/import/abc";
             httpContext.Request.Method = HttpMethods.Delete.ToString();
             await middleware.Invoke(httpContext);
 


### PR DESCRIPTION
## Description
Allow import request with prefix for initial import mode. For PaaS environment the request have prefix for service fabric url.

## Testing
Add unit tests to cover prefix url requests

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [X] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
