### PR TITLE
_sort can cause ChainedSearch to return incorrect results

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
@@ -183,6 +183,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
             chainedOptions.CountOnly = false;
             chainedOptions.MaxItemCount = _chainedSearchMaxSubqueryItemLimit;
             chainedOptions.MaxItemCountSpecifiedByClient = false;
+            chainedOptions.Sort = Array.Empty<(SearchParameterInfo searchParameterInfo, SortOrder sortOrder)>();
 
             // Loop over all chained expressions in the search query and pass them into the local recursion function
             foreach (ChainedExpression item in chainedExpressions)


### PR DESCRIPTION
## Description
Fixes bug where _sort can cause Chained Search not to return correct results.

Previously, the sort options from the chained search's SearchOption object was not cleared, causing the sorting options to be passed through to the chained sub-search, which are not valid.

> SELECT r.resourceId, r.resourceTypeName
> FROM root r
> WHERE r.isSystem = @param0
> AND r.resourceTypeName = @param1
> AND EXISTS (SELECT VALUE si FROM si IN r.searchIndices WHERE si.p = @param2 AND si.c = @param3)
> AND r.isHistory = @param0
> AND r.isDeleted = @param0
> **ORDER BY r.sort["birthdate"].l ASC**

## Related issues
Addresses #2344, [AB#86544](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/86544)

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
