### PR TITLE
Refactor the CMK substatus codes to one location

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Health/CosmosHealthCheckTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Health/CosmosHealthCheckTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Health
         [Fact]
         public async Task GivenCosmosAccessIsForbidden_IsClientCmkError_WhenHealthIsChecked_ThenHealthyStateShouldBeReturned()
         {
-            foreach (int clientCmkIssue in new List<int>(Enum.GetValues(typeof(KnownCosmosDbCmkSubStatusValueClientIssue)).Cast<int>()).Concat(3))
+            foreach (int clientCmkIssue in new List<int>(Enum.GetValues(typeof(KnownCosmosDbCmkSubStatusValueClientIssue)).Cast<int>()))
             {
                 var cosmosException = new CosmosException("Some error message", HttpStatusCode.Forbidden, subStatusCode: clientCmkIssue, activityId: null, requestCharge: 0);
                 _testProvider.ClearSubstitute();

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosExceptionExtensions.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosExceptionExtensions.cs
@@ -63,11 +63,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
         /// <returns>True iff the error is due to client CMK setting.</returns>
         public static bool IsCmkClientError(this CosmosException exception)
         {
-            // NOTE: It has been confirmed that a SubStatusCode of value '3', although not listed in
-            // https://docs.microsoft.com/en-us/rest/api/cosmos-db/http-status-codes-for-cosmosdb#substatus-codes-for-end-user-issues
-            // as a possible CMK SubStatusCode by Cosmos DB, has been acknowledged as a possible value in some scenarios if the custtomer has disabled their key.
-            return exception.StatusCode == HttpStatusCode.Forbidden
-                && (Enum.IsDefined(typeof(KnownCosmosDbCmkSubStatusValueClientIssue), exception.SubStatusCode) || exception.SubStatusCode == 3);
+            return exception.StatusCode == HttpStatusCode.Forbidden && Enum.IsDefined(typeof(KnownCosmosDbCmkSubStatusValueClientIssue), exception.SubStatusCode);
         }
 
         /// <summary>

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/KnownCosmosDbCmkSubStatusValueClientIssue.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/KnownCosmosDbCmkSubStatusValueClientIssue.cs
@@ -11,6 +11,12 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
     public enum KnownCosmosDbCmkSubStatusValueClientIssue
     {
         // Customer-Managed Key (CMK) values
+
+        // It has been confirmed by the Cosmos DB team that a SubStatusCode of value '3', although not listed in
+        // https://docs.microsoft.com/en-us/rest/api/cosmos-db/http-status-codes-for-cosmosdb#substatus-codes-for-end-user-issues
+        // is a possible CMK SubStatusCode value in some scenarios if the customer has removed access to their key.
+        // This SubStatusCode value is associated with an "The requested operation cannot be performed at this region" error message.
+        RequestedOperationCannotBePerformedAtThisRegion = 3,
         KeyVaultAuthenticationFailure = 4002,
         KeyVaultKeyNotFound = 4003,
         KeyVaultWrapUnwrapFailure = 4005,


### PR DESCRIPTION
## Description
Refactoring of CMK known substatus values to include '3' in the enum

## Related issues
None

## Testing
Executed unit test that covers this refactoring.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
