### PR TITLE
Changes Chained Search to use ARRAY_CONTAINS

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Expressions/ICosmosExpressionVisitor.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Expressions/ICosmosExpressionVisitor.cs
@@ -1,0 +1,19 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
+
+namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Expressions
+{
+    public interface ICosmosExpressionVisitor<in TContext, out TOutput> : IExpressionVisitor<TContext, TOutput>
+    {
+        /// <summary>
+        /// Visits the <see cref="InExpression"/>.
+        /// </summary>
+        /// <param name="expression">The expression to visit.</param>
+        /// <param name="context">The input</param>
+        TOutput VisitIn(InExpression expression, TContext context);
+    }
+}

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Expressions/InExpression.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Expressions/InExpression.cs
@@ -1,0 +1,55 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using EnsureThat;
+using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
+
+namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Expressions
+{
+    /// <summary>
+    /// In CosmosDB, allows for use of ARRAY_CONTAINS to group known values instead of multiple ORs.
+    /// </summary>
+    public class InExpression : Expression, IFieldExpression
+    {
+        public InExpression(FieldName fieldName, int? componentIndex, IEnumerable<string> values)
+        {
+            FieldName = fieldName;
+            ComponentIndex = componentIndex;
+            Values = EnsureArg.IsNotNull(values, nameof(values));
+        }
+
+        public FieldName FieldName { get; }
+
+        public int? ComponentIndex { get; }
+
+        public IEnumerable<string> Values { get; }
+
+        public override TOutput AcceptVisitor<TContext, TOutput>(IExpressionVisitor<TContext, TOutput> visitor, TContext context)
+        {
+            return ((ICosmosExpressionVisitor<TContext, TOutput>)visitor).VisitIn(this, context);
+        }
+
+        public override string ToString()
+        {
+            return $"({(ComponentIndex == null ? null : $"[{ComponentIndex}].")}{FieldName} IN ({string.Join(", ", Values)}))";
+        }
+
+        public override void AddValueInsensitiveHashCode(ref HashCode hashCode)
+        {
+            hashCode.Add(typeof(InExpression));
+            hashCode.Add(FieldName);
+            hashCode.Add(ComponentIndex);
+        }
+
+        public override bool ValueInsensitiveEquals(Expression other)
+        {
+            return other is InExpression expression &&
+                   expression.FieldName == FieldName &&
+                   expression.ComponentIndex == ComponentIndex;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
@@ -23,6 +23,7 @@ using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.CosmosDb.Configs;
+using Microsoft.Health.Fhir.CosmosDb.Features.Search.Expressions;
 using Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries;
 using Microsoft.Health.Fhir.CosmosDb.Features.Storage;
 using Microsoft.Health.Fhir.ValueSets;
@@ -294,7 +295,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
                     .Select(g =>
                         Expression.And(
                             Expression.SearchParameter(_resourceTypeSearchParameter, Expression.Equals(FieldName.TokenCode, null, g.Key)),
-                            Expression.Or(g.Select(m => Expression.SearchParameter(_resourceIdSearchParameter, Expression.Equals(FieldName.TokenCode, null, m.ResourceId))).ToList())));
+                            Expression.SearchParameter(_resourceIdSearchParameter, new InExpression(FieldName.TokenCode, null, g.Select(x => x.ResourceId)))));
 
                 return typeAndResourceExpressions.Count() == 1 ? typeAndResourceExpressions.First() : Expression.Or(typeAndResourceExpressions.ToArray());
             }
@@ -310,7 +311,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
                         .Select(g =>
                             Expression.And(
                                 Expression.Equals(FieldName.ReferenceResourceType, null, g.Key),
-                                Expression.Or(g.Select(m => Expression.Equals(FieldName.ReferenceResourceId, null, m.ResourceId)).ToList()))).ToList()));
+                                new InExpression(FieldName.ReferenceResourceId, null, g.Select(x => x.ResourceId)))).ToList()));
         }
 
         protected override async Task<SearchResult> SearchHistoryInternalAsync(
@@ -701,7 +702,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
                         break;
                 }
 
-                if (includes.Count >= maxCount)
+                if (includes.Count > maxCount)
                 {
                     int toRemove = includes.Count - maxCount;
                     includes.RemoveRange(includes.Count - toRemove, toRemove);


### PR DESCRIPTION
## Description
Changes Chained Search to use ARRAY_CONTAINS

Old expression:

```
SELECT VALUE COUNT(1)
FROM root r
WHERE r.isSystem = @param0
AND r.resourceTypeName = @param1
AND EXISTS (SELECT VALUE si FROM si IN r.searchIndices WHERE si.p = @param2 AND si.ri = @param3)
AND EXISTS (SELECT VALUE si FROM si IN r.searchIndices WHERE si.p = @param4 AND (si.rt = @param5 AND (si.ri = @param6 OR si.ri = @param7 OR si.ri = @param8 OR si.ri = @param9 OR si.ri = @param10 OR si.ri = @param11 OR si.ri = @param12 OR si.ri = @param13 OR si.ri = @param14 OR si.ri = @param15 OR si.ri = @param16 OR si.ri = @param17 OR si.ri = @param18 OR si.ri = @param19  /* SNIP */ si.ri = @param986 OR si.ri = @param987)))
AND r.isHistory = @param0
AND r.isDeleted = @param0
```

New expression:

```
SELECT VALUE COUNT(1)
FROM root r
WHERE r.isSystem = @param0
AND r.resourceTypeName = @param1
AND EXISTS (SELECT VALUE si FROM si IN r.searchIndices WHERE si.p = @param2 AND (si.rt = @param3 AND ARRAY_CONTAINS([@param4,@param5,@param6,@param7,@param8,@param9,@param10,@param11,@param12,@param13,@param14,@param15,@param16,@param17,@param18,@param19,@param20,@param21,@param22,@param23,@param24,@param25,@param26,@param27,@param28,@param29,@param30,@param31,@param32,@param33, /*SNIP*/ ,@param1263,@param1264], si.ri)
```

The OR expressions eventually hit a limit in Cosmos somewhere ~980 ORs in resulting in:

> Exception Microsoft.Azure.Documents.BadRequestException: Message: {"errors":[{"severity":"Error","location":{"start":1211,"end":1213},"code":"SC1030","message":"The query is too complex to be processed. This is most likely due to a very deeply nested (or complex) expression in the query. Consider breaking the query into multiple smaller queries, or simplifying the complex expression."}]}

Even though the current limit is still 1000 filtered items, I was successfully able to use ARRAY_CONTAINS with up to 5000 items.

## Related issues
Addresses [AB#86619](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/86619), #2349

## Testing
* Should pass all existing Chained Search tests
* Manually tested with up to 10,000 chained item ids (fails somewhere between 5-10K)

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
