### PR TITLE
Fixes range convertors for Number and Quantity search values

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Converters/RangeToNumberSearchValueConverter.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Converters/RangeToNumberSearchValueConverter.cs
@@ -23,8 +23,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Converters
 
         protected override IEnumerable<ISearchValue> Convert(ITypedElement value)
         {
-            var lowValue = (decimal?)value.Scalar("low");
-            var highValue = (decimal?)value.Scalar("high");
+            var lowValue = (decimal?)value.Scalar("low.value");
+            var highValue = (decimal?)value.Scalar("high.value");
 
             if (lowValue.HasValue || highValue.HasValue)
             {

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Converters/RangeToQuantitySearchValueConverter.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Converters/RangeToQuantitySearchValueConverter.cs
@@ -3,9 +3,9 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
 using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Model;
 using Hl7.FhirPath;
 using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
 
@@ -23,18 +23,18 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Converters
 
         protected override IEnumerable<ISearchValue> Convert(ITypedElement value)
         {
-            var highValue = (ITypedElement)value.Scalar("high");
-            var lowValue = (ITypedElement)value.Scalar("low");
+            var highValue = (decimal?)value.Scalar("high.value");
+            var lowValue = (decimal?)value.Scalar("low.value");
 
-            var quantityRepresentativeValue = lowValue ?? highValue;
+            var quantityRepresentativeValue = (lowValue != null) ? "low" : (highValue != null) ? "high" : null;
 
             if (quantityRepresentativeValue != null)
             {
-                var system = quantityRepresentativeValue.Scalar("system") as string;
-                var code = quantityRepresentativeValue.Scalar("code") as string;
+                var system = value.Scalar($"{quantityRepresentativeValue}.system") as string;
+                var code = value.Scalar($"{quantityRepresentativeValue}.code") as string;
 
                 // FROM https://www.hl7.org/fhir/datatypes.html#Range: "The unit and code/system elements of the low or high elements SHALL match."
-                yield return new QuantitySearchValue(system, code, (decimal?)lowValue?.Scalar("value"), (decimal?)highValue?.Scalar("value"));
+                yield return new QuantitySearchValue(system, code, lowValue, highValue);
             }
         }
     }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/RangeToNumberSearchValueConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/RangeToNumberSearchValueConverterTests.cs
@@ -1,0 +1,69 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Hl7.Fhir.Model;
+using Microsoft.Health.Fhir.Core.Features.Search.Converters;
+using Xunit;
+using static Microsoft.Health.Fhir.Tests.Common.Search.SearchValueValidationHelper;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
+{
+    public class RangeToNumberSearchValueConverterTests : FhirTypedElementToSearchValueConverterTests<RangeToNumberSearchValueConverter, Range>
+    {
+        [Fact]
+        public async Task GivenARangeWithNoValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
+        {
+            await Test(
+                r =>
+                {
+                    r.Low = null;
+                    r.High = null;
+                });
+        }
+
+        [Fact]
+        public async Task GivenARangeWithValue_WhenConverted_ThenANumberValueShouldBeCreated()
+        {
+            const decimal lowValue = 100.123456m;
+            const decimal highValue = 200.123456m;
+
+            var lowQuantity = new Quantity(lowValue, null, null);
+            var highQuantity = new Quantity(highValue, null, null);
+            await Test(
+                r =>
+                {
+                    r.Low = lowQuantity;
+                    r.High = highQuantity;
+                },
+                ValidateNumberRange,
+                new Range
+                {
+                    Low = lowQuantity,
+                    High = highQuantity,
+                });
+        }
+
+        [Fact]
+        public async Task GivenARangeWithOnlyLowValue_WhenConverted_ThenANumberWithLowValueShouldBeCreated()
+        {
+            const decimal lowValue = 100.123456m;
+            var lowQuanity = new Quantity(lowValue, null, null);
+
+            await Test(
+                r =>
+                {
+                    r.Low = lowQuanity;
+                    r.High = null;
+                },
+                ValidateNumberRange,
+                new Range
+                {
+                    Low = lowQuanity,
+                    High = null,
+                });
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/RangeToQuantitySearchValueConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Converters/RangeToQuantitySearchValueConverterTests.cs
@@ -1,0 +1,73 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Hl7.Fhir.Model;
+using Microsoft.Health.Fhir.Core.Features.Search.Converters;
+using Xunit;
+using static Microsoft.Health.Fhir.Tests.Common.Search.SearchValueValidationHelper;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Converters
+{
+    public class RangeToQuantitySearchValueConverterTests : FhirTypedElementToSearchValueConverterTests<RangeToQuantitySearchValueConverter, Range>
+    {
+        [Fact]
+        public async Task GivenARangeWithNoValue_WhenConverted_ThenNoSearchValueShouldBeCreated()
+        {
+            await Test(
+                r =>
+                {
+                    r.Low = null;
+                    r.High = null;
+                });
+        }
+
+        [Fact]
+        public async Task GivenARangeWithValue_WhenConverted_ThenAQuantityValueShouldBeCreated()
+        {
+            const string system = "qs";
+            const string code = "qc";
+            const decimal lowValue = 100.123456m;
+            const decimal highValue = 200.123456m;
+            Quantity lowQuantity = new Quantity(lowValue, code, system);
+            Quantity highQuantity = new Quantity(highValue, code, system);
+
+            await Test(
+                r =>
+                {
+                    r.Low = lowQuantity;
+                    r.High = highQuantity;
+                },
+                ValidateQuantityRange,
+                new Range
+                {
+                    Low = lowQuantity,
+                    High = highQuantity,
+                });
+        }
+
+        [Fact]
+        public async Task GivenARangeWithOnlyLowValue_WhenConverted_ThenAQuantityWithLowValueShouldBeCreated()
+        {
+            const string system = "qs";
+            const string code = "qc";
+            const decimal lowValue = 100.123456m;
+            Quantity lowQuantity = new Quantity(lowValue, code, system);
+
+            await Test(
+                r =>
+                {
+                    r.Low = lowQuantity;
+                    r.High = null;
+                },
+                ValidateQuantityRange,
+                new Range
+                {
+                    Low = lowQuantity,
+                    High = null,
+                });
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
@@ -24,6 +24,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Create\CreateResourceValidatorTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\MemberMatch\MemberMatchResourceValidatorTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\ResourceHandlerTests_ConditionalDelete.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Search\Converters\RangeToNumberSearchValueConverterTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Search\Converters\RangeToQuantitySearchValueConverterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\ExtensionToNumberSearchValueConverterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\ExtensionToDateTimeSearchValueConverterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\ExtensionToQuantitySearchValueConverterTests.cs" />

--- a/src/Microsoft.Health.Fhir.Shared.Tests/Search/SearchValueValidationHelper.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Tests/Search/SearchValueValidationHelper.cs
@@ -8,6 +8,7 @@ using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Features.Search.SearchValues;
 using Microsoft.Health.Fhir.Core.Models;
 using Xunit;
+using Range = Hl7.Fhir.Model.Range;
 
 namespace Microsoft.Health.Fhir.Tests.Common.Search
 {
@@ -96,6 +97,24 @@ namespace Microsoft.Health.Fhir.Tests.Common.Search
             Assert.True(usv.IsCanonical);
 
             Assert.Equal(expected, usv.ToString());
+        }
+
+        public static void ValidateQuantityRange(Range expected, ISearchValue sv)
+        {
+            QuantitySearchValue qsv = Assert.IsType<QuantitySearchValue>(sv);
+
+            Assert.Equal(expected.Low?.System, qsv.System);
+            Assert.Equal(expected.Low?.Code, qsv.Code);
+            Assert.Equal(expected.Low?.Value, qsv.Low);
+            Assert.Equal(expected.High?.Value, qsv.High);
+        }
+
+        public static void ValidateNumberRange(Range expected, ISearchValue sv)
+        {
+            NumberSearchValue qsv = Assert.IsType<NumberSearchValue>(sv);
+
+            Assert.Equal(expected.Low?.Value, qsv.Low);
+            Assert.Equal(expected.High?.Value, qsv.High);
         }
 
         public class Token


### PR DESCRIPTION
## Description
Currently, for the below statement, the highValue is always fetched null even though its present inside the high object and similary for the low value. Due to which, the range search parameters for quantity and number are never saved to the corresponding tables.
var highValue =  (ITypedElement)value.Scalar("high")

So in this PR, updating the expression to fetch low and high values for range convertors.
Adds missing unit tests

## Related issues
Addresses [#86763](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Olympus/Stories/?workitem=86763)

## Testing
Unit test is added and manually tested to verify if the lowValue and highValue are populated if they exists in the POSTed resource.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
