### PR TITLE
Adds resource specific versioning configuration

### DIFF
--- a/docs/rest/ResourceSpecificDisableHistory.http
+++ b/docs/rest/ResourceSpecificDisableHistory.http
@@ -1,0 +1,332 @@
+# Before running this, update the versioning policy in appsettings.json to:
+#
+#"Versioning": {
+#     "Default": "versioned",
+#     "ResourceTypeOverrides":
+#         {
+#             "Observation": "no-version",
+#             "Patient": "no-version"
+#         }
+#     }
+
+@hostname = localhost:44348
+
+###
+# Get the capability statement.
+# Note that the "versioning" property of every resource type is set to "versioned"
+# except for Observation and Patient where it is set to "no-version".
+GET https://{{hostname}}/metadata
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+### Get the bearer token, if authentication is enabled
+# @name bearer
+POST https://{{hostname}}/connect/token
+content-type: application/x-www-form-urlencoded
+
+grant_type=client_credentials
+&client_id=globalAdminServicePrincipal
+&client_secret=globalAdminServicePrincipal
+&scope=fhir-api
+
+###
+# Create a patient resource that we will update.
+PUT https://{{hostname}}/Patient/patient-to-update
+Content-Type: application/json
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+{
+  "resourceType": "Patient",
+  "id": "patient-to-update",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: newborn</p><p><b>gender</b>: male</p><p><b>birthDate</b>: 05/09/2017</p></div>"
+  },
+  "gender": "male",
+  "birthDate": "2017-09-05"
+}
+
+###
+# Update the patient.
+PUT https://{{hostname}}/Patient/patient-to-update
+Content-Type: application/json
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+{
+  "resourceType": "Patient",
+  "id": "patient-to-update",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: newborn</p><p><b>gender</b>: male</p><p><b>birthDate</b>: 05/09/2017</p></div>"
+  },
+  "gender": "male",
+  "birthDate": "2017-09-05",
+  "_birthDate": {
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/StructureDefinition/patient-birthTime",
+        "valueDateTime": "2017-05-09T17:11:00+01:00"
+      }
+    ]
+  }
+}
+
+###
+# Create an observation resource that we will update.
+PUT https://{{hostname}}/Observation/observation-to-update
+Content-Type: application/json
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+{
+  "resourceType": "Observation",
+  "id": "observation-to-update",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: bgpanel</p><p><b>status</b>: final</p><p><b>category</b>: Laboratory <span>(Details : {http://terminology.hl7.org/CodeSystem/observation-category code 'laboratory' = 'Laboratory', given as 'Laboratory'})</span></p><p><b>code</b>: Blood Group Panel <span>(Details : {LOINC code '34532-2' = 'Blood type and Indirect antibody screen panel - Blood', given as ' Blood type and Indirect antibody screen panel - Blood'})</span></p><p><b>subject</b>: <a>Patient/infant</a></p><p><b>effective</b>: 11/03/2018 4:07:54 PM</p><p><b>hasMember</b>: </p><ul><li><a>Observation/bloodgroup</a></li><li><a>Observation/rhstatus</a></li></ul></div>"
+  },
+  "status": "final",
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+          "code": "laboratory",
+          "display": "Laboratory"
+        }
+      ],
+      "text": "Laboratory"
+    }
+  ],
+  "code": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "34532-2",
+        "display": " Blood type and Indirect antibody screen panel - Blood"
+      }
+    ],
+    "text": "Blood Group Panel"
+  },
+  "subject": {
+    "reference": "Patient/infant"
+  },
+  "effectiveDateTime": "2018-03-11T16:07:54+00:00",
+  "hasMember": [
+    {
+      "reference": "Observation/bloodgroup"
+    },
+    {
+      "reference": "Observation/rhstatus"
+    }
+  ]
+}
+
+###
+# Update the observation.
+PUT https://{{hostname}}/Observation/observation-to-update
+Content-Type: application/json
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+{
+  "resourceType": "Observation",
+  "id": "observation-to-update",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: bgpanel</p><p><b>status</b>: final</p><p><b>category</b>: Laboratory <span>(Details : {http://terminology.hl7.org/CodeSystem/observation-category code 'laboratory' = 'Laboratory', given as 'Laboratory'})</span></p><p><b>code</b>: Blood Group Panel <span>(Details : {LOINC code '34532-2' = 'Blood type and Indirect antibody screen panel - Blood', given as ' Blood type and Indirect antibody screen panel - Blood'})</span></p><p><b>subject</b>: <a>Patient/infant</a></p><p><b>effective</b>: 11/03/2018 4:07:54 PM</p><p><b>hasMember</b>: </p><ul><li><a>Observation/bloodgroup</a></li><li><a>Observation/rhstatus</a></li></ul></div>"
+  },
+  "status": "final",
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+          "code": "laboratory",
+          "display": "Laboratory"
+        }
+      ],
+      "text": "Laboratory"
+    }
+  ],
+  "code": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "34532-2",
+        "display": " Blood type and Indirect antibody screen panel - Blood"
+      }
+    ],
+    "text": "Blood Group Panel"
+  },
+  "subject": {
+    "reference": "Patient/patient-to-update"
+  },
+  "effectiveDateTime": "2018-03-11T16:07:54+00:00",
+  "hasMember": [
+    {
+      "reference": "Observation/bloodgroup"
+    },
+    {
+      "reference": "Observation/rhstatus"
+    }
+  ]
+}
+
+###
+# Create a practitioner resource that we will update.
+PUT https://{{hostname}}/Practitioner/practitioner-to-update
+Content-Type: application/json
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+{
+  "resourceType": "Practitioner",
+  "id": "practitioner-to-update",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n      <p>Dr Adam Careful is a Referring Practitioner for Acme Hospital from 1-Jan 2012 to 31-Mar\n        2012</p>\n    </div>"
+  },
+  "identifier": [
+    {
+      "system": "http://www.acme.org/practitioners",
+      "value": "23"
+    }
+  ],
+  "active": true,
+  "name": [
+    {
+      "family": "Careful",
+      "given": [
+        "Adam"
+      ],
+      "prefix": [
+        "Dr"
+      ]
+    }
+  ],
+  "address": [
+    {
+      "use": "home",
+      "line": [
+        "534 Erewhon St"
+      ],
+      "city": "PleasantVille",
+      "state": "Vic",
+      "postalCode": "3999"
+    }
+  ],
+  "qualification": [
+    {
+      "identifier": [
+        {
+          "system": "http://example.org/UniversityIdentifier",
+          "value": "12345"
+        }
+      ],
+      "code": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0360/2.7",
+            "code": "BS",
+            "display": "Bachelor of Science"
+          }
+        ],
+        "text": "Bachelor of Science"
+      },
+      "period": {
+        "start": "1995"
+      },
+      "issuer": {
+        "display": "Example University"
+      }
+    }
+  ]
+}
+
+###
+# Update the practitioner.
+PUT https://{{hostname}}/Practitioner/practitioner-to-update
+Content-Type: application/json
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+{
+  "resourceType": "Practitioner",
+  "id": "practitioner-to-update",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n      <p>Dr Adam Careful is a Referring Practitioner for Acme Hospital from 1-Jan 2012 to 31-Mar\n        2012</p>\n    </div>"
+  },
+  "identifier": [
+    {
+      "system": "http://www.acme.org/practitioners",
+      "value": "23"
+    }
+  ],
+  "active": true,
+  "name": [
+    {
+      "family": "Extracareful",
+      "given": [
+        "Adam"
+      ],
+      "prefix": [
+        "Dr"
+      ]
+    }
+  ],
+  "address": [
+    {
+      "use": "home",
+      "line": [
+        "534 Erewhon St"
+      ],
+      "city": "PleasantVille",
+      "state": "Vic",
+      "postalCode": "3999"
+    }
+  ],
+  "qualification": [
+    {
+      "identifier": [
+        {
+          "system": "http://example.org/UniversityIdentifier",
+          "value": "12345"
+        }
+      ],
+      "code": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0360/2.7",
+            "code": "BS",
+            "display": "Bachelor of Science"
+          }
+        ],
+        "text": "Bachelor of Science"
+      },
+      "period": {
+        "start": "1995"
+      },
+      "issuer": {
+        "display": "Example University"
+      }
+    }
+  ]
+}
+
+###
+# Because of how we modified appsettings.json, patient history should NOT be kept.
+# Only the latest version is returned in the history bundle.
+GET https://{{hostname}}/Patient/patient-to-update/_history
+Content-Type: application/json
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+###
+# Because of how we modified appsettings.json, observation history should NOT be kept.
+# Only the latest version is returned in the history bundle.
+GET https://{{hostname}}/Observation/observation-to-update/_history
+Content-Type: application/json
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+###
+# Because of how we modified appsettings.json, practitioner history SHOULD be kept.
+# All versions are returned in the history bundle.
+GET https://{{hostname}}/Practitioner/practitioner-to-update/_history
+Content-Type: application/json
+Authorization: Bearer {{bearer.response.body.access_token}}

--- a/src/Microsoft.Health.Fhir.Core/Configs/VersioningConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/VersioningConfiguration.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
 using Microsoft.Health.Fhir.ValueSets;
 
 namespace Microsoft.Health.Fhir.Core.Configs
@@ -10,5 +11,7 @@ namespace Microsoft.Health.Fhir.Core.Configs
     public class VersioningConfiguration
     {
         public string Default { get; set; } = ResourceVersionPolicy.Versioned;
+
+        public Dictionary<string, string> ResourceTypeOverrides { get; } = new();
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
 
             if (resourceComponent == null)
             {
-                resourceComponent = new ListedResourceComponent(_configuration)
+                resourceComponent = new ListedResourceComponent(_configuration, resourceType)
                 {
                     Type = resourceType,
                     Profile = new ReferenceComponent

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
 
             if (resourceComponent == null)
             {
-                resourceComponent = new ListedResourceComponent(_configuration)
+                resourceComponent = new ListedResourceComponent()
                 {
                     Type = resourceType,
                     Profile = new ReferenceComponent

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
 
             if (resourceComponent == null)
             {
-                resourceComponent = new ListedResourceComponent(_configuration, resourceType)
+                resourceComponent = new ListedResourceComponent(_configuration)
                 {
                     Type = resourceType,
                     Profile = new ReferenceComponent
@@ -107,7 +107,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
                         Reference = $"http://hl7.org/fhir/StructureDefinition/{resourceType}",
                     },
                 };
-
+                ((DefaultOptionHashSet<string>)resourceComponent.Versioning).DefaultOption = _configuration.Versioning.ResourceTypeOverrides.ContainsKey(resourceType) ? _configuration.Versioning.ResourceTypeOverrides[resourceType] : _configuration.Versioning.Default;
                 listedRestComponent.Resource.Add(resourceComponent);
             }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/Models/DefaultOptionHashSet.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/Models/DefaultOptionHashSet.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance.Models
             DefaultOption = defaultOption;
         }
 
-        public T DefaultOption { get; }
+        public T DefaultOption { get; set; }
 
         object IDefaultOption.DefaultOption
         {

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/Models/ListedResourceComponent.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/Models/ListedResourceComponent.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance.Models
 {
     public class ListedResourceComponent
     {
-        public ListedResourceComponent(CoreFeatureConfiguration configuration)
+        public ListedResourceComponent(CoreFeatureConfiguration configuration, string resourceType)
         {
             Interaction = new HashSet<ResourceInteractionComponent>(new PropertyEqualityComparer<ResourceInteractionComponent>(x => x.Code));
             SearchParam = new HashSet<SearchParamComponent>(new PropertyEqualityComparer<SearchParamComponent>(x => x.Name, x => x.Type.ToString()));
@@ -21,7 +21,16 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance.Models
             SearchRevInclude = new HashSet<string>(StringComparer.Ordinal);
             SearchInclude = new HashSet<string>(StringComparer.Ordinal);
             ReferencePolicy = new HashSet<string>(StringComparer.Ordinal);
-            Versioning = new DefaultOptionHashSet<string>(configuration.Versioning.Default, StringComparer.Ordinal);
+
+            var versioningPolicy = configuration.Versioning.Default;
+
+            // Override the default versioning policy if a matching resource type override exists
+            if (configuration.Versioning.ResourceTypeOverrides.ContainsKey(resourceType))
+            {
+                versioningPolicy = configuration.Versioning.ResourceTypeOverrides[resourceType];
+            }
+
+            Versioning = new DefaultOptionHashSet<string>(versioningPolicy, StringComparer.Ordinal);
             SupportedProfile = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             Operation = new HashSet<OperationComponent>(new PropertyEqualityComparer<OperationComponent>(x => x.Name, x => x.Definition.ToString()));
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/Models/ListedResourceComponent.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/Models/ListedResourceComponent.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance.Models
 {
     public class ListedResourceComponent
     {
-        public ListedResourceComponent(CoreFeatureConfiguration configuration, string resourceType)
+        public ListedResourceComponent(CoreFeatureConfiguration configuration)
         {
             Interaction = new HashSet<ResourceInteractionComponent>(new PropertyEqualityComparer<ResourceInteractionComponent>(x => x.Code));
             SearchParam = new HashSet<SearchParamComponent>(new PropertyEqualityComparer<SearchParamComponent>(x => x.Name, x => x.Type.ToString()));
@@ -23,12 +23,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance.Models
             ReferencePolicy = new HashSet<string>(StringComparer.Ordinal);
 
             var versioningPolicy = configuration.Versioning.Default;
-
-            // Override the default versioning policy if a matching resource type override exists
-            if (configuration.Versioning.ResourceTypeOverrides.ContainsKey(resourceType))
-            {
-                versioningPolicy = configuration.Versioning.ResourceTypeOverrides[resourceType];
-            }
 
             Versioning = new DefaultOptionHashSet<string>(versioningPolicy, StringComparer.Ordinal);
             SupportedProfile = new HashSet<string>(StringComparer.OrdinalIgnoreCase);

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/Models/ListedResourceComponent.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/Models/ListedResourceComponent.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.ValueSets;
 
@@ -13,7 +12,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance.Models
 {
     public class ListedResourceComponent
     {
-        public ListedResourceComponent(CoreFeatureConfiguration configuration)
+        public ListedResourceComponent()
         {
             Interaction = new HashSet<ResourceInteractionComponent>(new PropertyEqualityComparer<ResourceInteractionComponent>(x => x.Code));
             SearchParam = new HashSet<SearchParamComponent>(new PropertyEqualityComparer<SearchParamComponent>(x => x.Name, x => x.Type.ToString()));
@@ -22,9 +21,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance.Models
             SearchInclude = new HashSet<string>(StringComparer.Ordinal);
             ReferencePolicy = new HashSet<string>(StringComparer.Ordinal);
 
-            var versioningPolicy = configuration.Versioning.Default;
-
-            Versioning = new DefaultOptionHashSet<string>(versioningPolicy, StringComparer.Ordinal);
+            Versioning = new DefaultOptionHashSet<string>(ResourceVersionPolicy.Versioned, StringComparer.Ordinal);
             SupportedProfile = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             Operation = new HashSet<OperationComponent>(new PropertyEqualityComparer<OperationComponent>(x => x.Name, x => x.Definition.ToString()));
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Conformance/ConformanceBuilderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Conformance/ConformanceBuilderTests.cs
@@ -17,10 +17,10 @@ using Microsoft.Health.Fhir.Core.Features.Conformance.Models;
 using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Validation;
 using Microsoft.Health.Fhir.Core.Models;
-using Microsoft.Health.Fhir.ValueSets;
 using NSubstitute;
 using Xunit;
 using SearchParamType = Microsoft.Health.Fhir.ValueSets.SearchParamType;
+using TypeRestfulInteraction = Microsoft.Health.Fhir.ValueSets.TypeRestfulInteraction;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Conformance
 {

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Conformance/ConformanceBuilderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Conformance/ConformanceBuilderTests.cs
@@ -4,17 +4,23 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Model;
 using Hl7.FhirPath;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Core.Configs;
+using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Conformance;
+using Microsoft.Health.Fhir.Core.Features.Conformance.Models;
 using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Validation;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.ValueSets;
 using NSubstitute;
 using Xunit;
+using SearchParamType = Microsoft.Health.Fhir.ValueSets.SearchParamType;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Conformance
 {
@@ -59,6 +65,95 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Conformance
         public void GivenAConformanceBuilder_WhenApplyToUnknownResource_ThenAnArgumentExceptionIsThrown()
         {
             Assert.Throws<ArgumentException>(() => _builder.ApplyToResource("foo", c => c.ConditionalCreate = true));
+        }
+
+        [Fact]
+        public void GivenAConformanceBuilder_WhenVersionofResourceIsDifferentFromDefault_ThenResourceUsesResourceSpecificVersionLogic()
+        {
+            IOptions<CoreFeatureConfiguration> configuration = Substitute.For<IOptions<CoreFeatureConfiguration>>();
+            Dictionary<string, string> overrides = new();
+            VersioningConfiguration versionConfig = new();
+            versionConfig.ResourceTypeOverrides.Add("Patient", "no-version");
+
+            configuration.Value.Returns(new CoreFeatureConfiguration() { Versioning = versionConfig });
+            var supportedProfiles = Substitute.For<IKnowSupportedProfiles>();
+            var builder = CapabilityStatementBuilder.Create(
+                ModelInfoProvider.Instance,
+                _searchParameterDefinitionManager,
+                configuration,
+                supportedProfiles);
+            ICapabilityStatementBuilder capabilityStatement = builder.ApplyToResource("Patient", c =>
+            {
+                c.Interaction.Add(new ResourceInteractionComponent
+                {
+                    Code = "create",
+                });
+            });
+            ITypedElement resource = capabilityStatement.Build();
+
+            var patientResource = ((CapabilityStatement)resource.ToPoco()).Rest.First().Resource.First();
+
+            Assert.True(patientResource.Type == ResourceType.Patient);
+            Assert.True(patientResource.Versioning == CapabilityStatement.ResourceVersionPolicy.NoVersion);
+        }
+
+        [Fact]
+        public void GivenAConformanceBuilder_WhenResourceTypeOverridesContainsResourcesThatDontMatch_ThenResourceUsesDefaultVersionLogic()
+        {
+            IOptions<CoreFeatureConfiguration> configuration = Substitute.For<IOptions<CoreFeatureConfiguration>>();
+            Dictionary<string, string> overrides = new();
+            VersioningConfiguration versionConfig = new();
+            versionConfig.ResourceTypeOverrides.Add("blah", "no-version");
+
+            configuration.Value.Returns(new CoreFeatureConfiguration() { Versioning = versionConfig });
+            var supportedProfiles = Substitute.For<IKnowSupportedProfiles>();
+            var builder = CapabilityStatementBuilder.Create(
+                ModelInfoProvider.Instance,
+                _searchParameterDefinitionManager,
+                configuration,
+                supportedProfiles);
+            ICapabilityStatementBuilder capabilityStatement = builder.ApplyToResource("Patient", c =>
+            {
+                c.Interaction.Add(new ResourceInteractionComponent
+                {
+                    Code = "create",
+                });
+            });
+            ITypedElement resource = capabilityStatement.Build();
+
+            var patientResource = ((CapabilityStatement)resource.ToPoco()).Rest.First().Resource.First();
+
+            Assert.True(patientResource.Type == ResourceType.Patient);
+            Assert.True(patientResource.Versioning == CapabilityStatement.ResourceVersionPolicy.Versioned);
+        }
+
+        [Fact]
+        public void GivenAConformanceBuilder_WhenResourceTypeOverridesIsEmpty_ThenResourceUsesDefaultVersionLogic()
+        {
+            IOptions<CoreFeatureConfiguration> configuration = Substitute.For<IOptions<CoreFeatureConfiguration>>();
+            Dictionary<string, string> overrides = new();
+            VersioningConfiguration versionConfig = new();
+
+            configuration.Value.Returns(new CoreFeatureConfiguration() { Versioning = versionConfig });
+            var supportedProfiles = Substitute.For<IKnowSupportedProfiles>();
+            var builder = CapabilityStatementBuilder.Create(
+                ModelInfoProvider.Instance,
+                _searchParameterDefinitionManager,
+                configuration,
+                supportedProfiles);
+            ICapabilityStatementBuilder capabilityStatement = builder.ApplyToResource("Patient", c =>
+            {
+                c.Interaction.Add(new ResourceInteractionComponent
+                {
+                    Code = "create",
+                });
+            });
+            ITypedElement resource = capabilityStatement.Build();
+
+            var patientResource = ((CapabilityStatement)resource.ToPoco()).Rest.First().Resource.First();
+
+            Assert.True(patientResource.Type == ResourceType.Patient);
+            Assert.True(patientResource.Versioning == CapabilityStatement.ResourceVersionPolicy.Versioned);
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -29,11 +29,7 @@
             "SupportsResourceChangeCapture": false,
             "Versioning": {
                 "Default": "versioned",
-                "ResourceTypeOverrides":
-                {
-                    "Observation": "no-version",
-                    "Patient": "no-version"
-                }
+                "ResourceTypeOverrides": null
             }
         },
         "CosmosDb": {

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -28,7 +28,12 @@
             "ProfileValidationOnUpdate": false,
             "SupportsResourceChangeCapture": false,
             "Versioning": {
-                "Default": "versioned"
+                "Default": "versioned",
+                "ResourceTypeOverrides":
+                {
+                    "Observation": "no-version",
+                    "Patient": "no-version"
+                }
             }
         },
         "CosmosDb": {


### PR DESCRIPTION
## Description
This PR adds the ability to specify resource-specific versioning in `appsettings.json`. @PTaladay will kindly be taking over this PR as I will be OOF next week.

## Related issues
- Addresses [AB#86649](https://microsofthealth.visualstudio.com/Health/_workitems/edit/86649).

## Up next

- We need to add the ability to deserialize the versioning configuration object so that we can pull this configuration info into PaaS ([AB#86832](https://microsofthealth.visualstudio.com/Health/_workitems/edit/86832))
- Check to see if there are any automated tests that we can add here ([AB#86833](https://microsofthealth.visualstudio.com/Health/_workitems/edit/86833))

## Testing
Added a new `.http` test file that outlines a manual test flow.

## FHIR Team Checklist
- ✅ **Update the title** of the PR to be succinct and less than 50 characters
- ✅ **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- ✅ Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- ✅ Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- ✅ Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- ✅ Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Feature (new disable history functionality)
