### PR TITLE
Updates to failing history test

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HistoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HistoryTests.cs
@@ -215,7 +215,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
                     newResources.Add(await CreateResourceWithTag(Samples.GetDefaultPatient().ToPoco(), tag));
                     newResources.Add(await CreateResourceWithTag(Samples.GetDefaultOrganization().ToPoco(), tag));
-                    await Task.Delay(1000);
+                    await Task.Delay(100);
                     newResources.Add(await CreateResourceWithTag(Samples.GetJsonSample("BloodGlucose").ToPoco(), tag));
                     newResources.Add(await CreateResourceWithTag(Samples.GetJsonSample("BloodPressure").ToPoco(), tag));
                     newResources.Add(await CreateResourceWithTag(Samples.GetJsonSample("Patient-f001").ToPoco(), tag));
@@ -233,7 +233,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
                     var before = lastUpdatedTimes.ToList()[4];
                     var beforeUriString = HttpUtility.UrlEncode(before.Value.ToString("o"));
-                    await Task.Delay(500);
+                    await Task.Delay(500); // wait 500 milliseconds to make sure that the value passed to the server for _before is not a time in the future
                     var firstSet = await _client.SearchAsync($"_history?_tag={tag}&_since={sinceUriString}&_before={beforeUriString}");
 
                     AssertCount(4, firstSet.Resource.Entry);


### PR DESCRIPTION
## Description
Attempts to improve the stability of the history test by changing thread.sleep to Task.Delay and also adding a retry loop.

## Related issues
Addresses [issue [AB#86231](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/86231)].

## Testing
Test was rerun many times

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [X] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [X] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
