### PR TITLE
Add checks in custom search E2E tests to ensure reindex job starts

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 var serializer = new FhirJsonSerializer();
                 _output.WriteLine(serializer.SerializeToString(reindexJobResult.Resource));
 
-                Assert.Contains(searchParamPosted.Resource.Url, param.Value.ToString());
+                Assert.Contains(searchParamPosted.Resource.Url, param?.Value?.ToString());
 
                 reindexJobResult = await WaitForReindexStatus(reindexJobUri, "Completed");
                 _output.WriteLine($"Reindex job is completed, it should have reindexed the resources with {randomName}");
@@ -279,9 +279,9 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 var serializer = new FhirJsonSerializer();
                 _output.WriteLine(serializer.SerializeToString(reindexJobResult.Resource));
 
-                Assert.Contains(searchParamPosted.Resource.Url, searchParamListParam.Value.ToString());
-                Assert.Equal("Appointment", targetResourcesParam.Value.ToString());
-                Assert.Equal("Appointment", resourcesParam.Value.ToString());
+                Assert.Contains(searchParamPosted.Resource.Url, searchParamListParam?.Value?.ToString());
+                Assert.Equal("Appointment", targetResourcesParam?.Value?.ToString());
+                Assert.Equal("Appointment", resourcesParam?.Value?.ToString());
 
                 _output.WriteLine($"Reindex job is completed, it should have reindexed the resources of type Appointment only.");
 
@@ -399,11 +399,11 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 var serializer = new FhirJsonSerializer();
                 _output.WriteLine(serializer.SerializeToString(reindexJobResult.Resource));
 
-                Assert.Contains(searchParamPosted.Resource.Url, searchParamListParam.Value.ToString());
-                Assert.Contains("Appointment", targetResourcesParam.Value.ToString());
-                Assert.Contains("Appointment", resourcesParam.Value.ToString());
-                Assert.Contains("Immunization", targetResourcesParam.Value.ToString());
-                Assert.Contains("Immunization", resourcesParam.Value.ToString());
+                Assert.Contains(searchParamPosted.Resource.Url, searchParamListParam?.Value?.ToString());
+                Assert.Contains("Appointment", targetResourcesParam?.Value?.ToString());
+                Assert.Contains("Appointment", resourcesParam?.Value?.ToString());
+                Assert.Contains("Immunization", targetResourcesParam?.Value?.ToString());
+                Assert.Contains("Immunization", resourcesParam?.Value?.ToString());
 
                 _output.WriteLine($"Reindex job is completed, it should have reindexed the resources of type Appointment and Immunization only.");
 
@@ -479,6 +479,11 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 await Task.Delay(1000);
             }
             while (!desiredStatus.Contains(currentStatus) && checkReindexCount < 20);
+
+            if (checkReindexCount >= 20)
+            {
+                throw new Exception("ReindexJob did not complete within 20 seconds.");
+            }
 
             return reindexJobResult;
         }


### PR DESCRIPTION
## Description
Adds an exception if we wait for the reindex job to start and it does not.  Also adds some null checks.

## Related issues
Addresses [issue [AB#83531](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/83531)].

## Testing
Test was rerun several times.

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [X] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [X] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
