### PR TITLE
Reduce chance of data record collisions in specific test

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -356,25 +356,26 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         public async Task GivenVariousTypesOfResources_WhenSearchingAcrossAllResourceTypesUsingCommonSearchParameter_ThenOnlyResourcesMatchingTypeAndCommonSearchParameterShouldBeReturned()
         {
             // Create various resources.
+            var tag = Guid.NewGuid().ToString();
             var suffix = Guid.NewGuid().ToString("N").Substring(0, 4);
-            Patient nonMatchingPatient = (await Client.CreateAsync(new Patient() { Name = new List<HumanName>() { new HumanName() { Family = $"Adams{suffix}" } } })).Resource;
-            Practitioner nonMatchingPractitioner = (await Client.CreateAsync(new Practitioner() { Name = new List<HumanName>() { new HumanName() { Family = $"Wilson{suffix}" } } })).Resource;
-            Patient matchingPatient = (await Client.CreateAsync(new Patient() { Name = new List<HumanName>() { new HumanName() { Family = $"Smith{suffix}" } } })).Resource;
-            Practitioner matchingPractitioner = (await Client.CreateAsync(new Practitioner() { Name = new List<HumanName>() { new HumanName() { Family = $"Smith{suffix}" } } })).Resource;
+            Patient nonMatchingPatient = (await Client.CreateAsync(new Patient() { Meta = new Meta { Tag = new List<Coding>() { new Coding("testTag", tag), } }, Name = new List<HumanName>() { new HumanName() { Family = $"Adams{suffix}" } } })).Resource;
+            Practitioner nonMatchingPractitioner = (await Client.CreateAsync(new Practitioner() { Meta = new Meta { Tag = new List<Coding>() { new Coding("testTag", tag), } }, Name = new List<HumanName>() { new HumanName() { Family = $"Wilson{suffix}" } } })).Resource;
+            Patient matchingPatient = (await Client.CreateAsync(new Patient() { Meta = new Meta { Tag = new List<Coding>() { new Coding("testTag", tag), } }, Name = new List<HumanName>() { new HumanName() { Family = $"Smith{suffix}" } } })).Resource;
+            Practitioner matchingPractitioner = (await Client.CreateAsync(new Practitioner() { Meta = new Meta { Tag = new List<Coding>() { new Coding("testTag", tag), } }, Name = new List<HumanName>() { new HumanName() { Family = $"Smith{suffix}" } } })).Resource;
 
-            var query = $"?_type=Patient,Practitioner&family={matchingPatient.Name[0].Family}";
+            var query = $"?_type=Patient,Practitioner&family={matchingPatient.Name[0].Family}&_tag={tag}";
             await ExecuteAndValidateBundle(query, matchingPatient, matchingPractitioner);
-            Bundle bundle = await Client.SearchPostAsync(null, default, ("_type", "Patient,Practitioner"), ("family", matchingPatient.Name[0].Family));
+            Bundle bundle = await Client.SearchPostAsync(null, default, ("_type", "Patient,Practitioner"), ("family", matchingPatient.Name[0].Family), ("_tag", tag));
             ValidateBundle(bundle, query, matchingPatient, matchingPractitioner);
 
-            query = $"?_type=Patient,Practitioner&family={nonMatchingPatient.Name[0].Family}";
+            query = $"?_type=Patient,Practitioner&family={nonMatchingPatient.Name[0].Family}&_tag={tag}";
             await ExecuteAndValidateBundle(query, nonMatchingPatient);
-            bundle = await Client.SearchPostAsync(null, default, ("_type", "Patient,Practitioner"), ("family", nonMatchingPatient.Name[0].Family));
+            bundle = await Client.SearchPostAsync(null, default, ("_type", "Patient,Practitioner"), ("family", nonMatchingPatient.Name[0].Family), ("_tag", tag));
             ValidateBundle(bundle, query, nonMatchingPatient);
 
-            query = $"?_type=Patient,Practitioner&family={nonMatchingPractitioner.Name[0].Family}";
+            query = $"?_type=Patient,Practitioner&family={nonMatchingPractitioner.Name[0].Family}&_tag={tag}";
             await ExecuteAndValidateBundle(query, nonMatchingPractitioner);
-            bundle = await Client.SearchPostAsync(null, default, ("_type", "Patient,Practitioner"), ("family", nonMatchingPractitioner.Name[0].Family));
+            bundle = await Client.SearchPostAsync(null, default, ("_type", "Patient,Practitioner"), ("family", nonMatchingPractitioner.Name[0].Family), ("_tag", tag));
             ValidateBundle(bundle, query, nonMatchingPractitioner);
         }
 


### PR DESCRIPTION
If database not cleaned after each test run we rely on uniqueness of string where only  36^4 different combinations.
Apparently that's not unique enough, so I'm adding `_tag ` to prevent collisions. (there is still chance of collision, but space is much bigger, now it's 36^4* 36^36)

## Description
Describe the changes in this PR.

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [x] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
