### PR TITLE
Add 429 retry and logging in BundleHandler 

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
@@ -392,18 +392,14 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                         await request.Handler.Invoke(httpContext);
 
                         // we will retry a 429 one time per request in the bundle
-                        if (httpContext.Response.StatusCode == (int)HttpStatusCode.TooManyRequests
-                            && _bundleType == BundleType.Batch)
+                        if (httpContext.Response.StatusCode == (int)HttpStatusCode.TooManyRequests)
                         {
                             _logger.LogTrace("BundleHandler received 429 message, attempting retry.  HttpVerb:{httpVerb} BundleSize: {_requestCount} entryIndex:{entryIndex}", httpVerb, _requestCount, entryIndex);
                             int retryDelay = 2;
                             var retryAfterValues = httpContext.Response.Headers.GetCommaSeparatedValues("Retry-After");
-                            if (retryAfterValues != StringValues.Empty)
+                            if (retryAfterValues != StringValues.Empty && int.TryParse(retryAfterValues[0], out var retryHeaderValue))
                             {
-                                if (int.TryParse(retryAfterValues[0], out var retryHeaderValue))
-                                {
-                                    retryDelay = retryHeaderValue;
-                                }
+                                retryDelay = retryHeaderValue;
                             }
 
                             await Task.Delay(retryDelay);


### PR DESCRIPTION
## Description
We sometimes encounter 429 errors when processing a bundle.  If we receive a 429 at the BundleHandler layer, we abort processing of the bundle and skip the remaining resources.  Here we add an additional retry (in addition to the retry present in the data store layer) that will execute one time per resource which encounters a 429.  Also some logging is added to help us identify this occurrence.

## Related issues
Addresses [issue [AB#87196](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/87196)].

## Testing
Unit was updated.

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [X] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [X] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
