### PR TITLE
Remove duplicate search params

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/SqlResourceBulkImporter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/SqlResourceBulkImporter.cs
@@ -361,6 +361,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
         {
             try
             {
+                table = RemoveDuplicatesRecords(table);
+
                 await Policy.Handle<SqlException>()
                     .WaitAndRetryAsync(
                         retryCount: 10,
@@ -396,6 +398,16 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
             importTasks.Enqueue(newTask);
 
             return newTask;
+        }
+
+        private static DataTable RemoveDuplicatesRecords(DataTable inputTable)
+        {
+            if (inputTable.Rows.Count == 0)
+            {
+                return inputTable;
+            }
+
+            return inputTable.DefaultView.ToTable(true);
         }
     }
 }


### PR DESCRIPTION
## Description
remove duplicate search params

## Related issues
Addresses [issue #87454].

## Testing
Add unit tests

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [X] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [x] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
