### PR TITLE
Remove duplicate search parameters

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Persistence/ResourceWrapperFactory.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Persistence/ResourceWrapperFactory.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using EnsureThat;
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Core.Features.Security;
@@ -71,6 +72,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
         {
             RawResource rawResource = _rawResourceFactory.Create(resource, keepMeta);
             IReadOnlyCollection<SearchIndexEntry> searchIndices = _searchIndexer.Extract(resource);
+            searchIndices = searchIndices.Distinct().ToArray();
+
             string searchParamHash = _searchParameterDefinitionManager.GetSearchParameterHashForResourceType(resource.InstanceType);
 
             ExtractMinAndMaxValues(searchIndices);

--- a/src/Microsoft.Health.Fhir.Core/Features/Persistence/ResourceWrapperFactory.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Persistence/ResourceWrapperFactory.cs
@@ -72,7 +72,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
         {
             RawResource rawResource = _rawResourceFactory.Create(resource, keepMeta);
             IReadOnlyCollection<SearchIndexEntry> searchIndices = _searchIndexer.Extract(resource);
-            searchIndices = searchIndices.Distinct().ToArray();
 
             string searchParamHash = _searchParameterDefinitionManager.GetSearchParameterHashForResourceType(resource.InstanceType);
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Persistence/ResourceWrapperFactory.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Persistence/ResourceWrapperFactory.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using EnsureThat;
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Core.Features.Security;

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchIndexEntry.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchIndexEntry.cs
@@ -62,14 +62,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
 
         public bool Equals(SearchIndexEntry other)
         {
-            if (other == null)
+            if ((object)other == null)
             {
                 return false;
             }
 
             if (other.SearchParameter.Url == SearchParameter.Url &&
                 other.SearchParameter.Code.Equals(SearchParameter.Code, StringComparison.OrdinalIgnoreCase) &&
-                other.Value == Value)
+                other.Value.Equals(Value))
             {
                 return true;
             }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchIndexEntry.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchIndexEntry.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
 
         public bool Equals(SearchIndexEntry other)
         {
-            if ((object)other == null)
+            if (other == null)
             {
                 return false;
             }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/CompositeSearchValue.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/CompositeSearchValue.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -69,7 +70,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.SearchValues
         /// <inheritdoc />
         public override int GetHashCode()
         {
-            return Components.GetHashCode();
+            return HashCode.Combine(Components.Select(x => x.GetHashCode()));
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/CompositeSearchValue.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/CompositeSearchValue.cs
@@ -65,5 +65,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.SearchValues
         {
             return string.Join(" $ ", Components.Select(component => string.Join(", ", component.Select(v => $"({v})"))));
         }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return Components.GetHashCode();
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/DateTimeSearchValue.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/DateTimeSearchValue.cs
@@ -183,5 +183,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.SearchValues
 
             return $"{Start.ToString("o")}-{End.ToString("o")}";
         }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(
+                Start.GetHashCode(), End.GetHashCode());
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/NumberSearchValue.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/NumberSearchValue.cs
@@ -107,7 +107,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.SearchValues
         public override int GetHashCode()
         {
             return HashCode.Combine(
-                Low.GetHashCode(), High.GetHashCode());
+                Low != null ? Low.GetHashCode() : 0,
+                High != null ? High.GetHashCode() : 0);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/NumberSearchValue.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/NumberSearchValue.cs
@@ -102,5 +102,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.SearchValues
 
             return $"[{Low}, {High})";
         }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(
+                Low.GetHashCode(), High.GetHashCode());
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/QuantitySearchValue.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/QuantitySearchValue.cs
@@ -127,8 +127,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.SearchValues
 
             return Low == quantitytSearchValueOther.Low &&
                    High == quantitytSearchValueOther.High &&
-                   System.Equals(quantitytSearchValueOther.System, StringComparison.OrdinalIgnoreCase) &&
-                   Code.Equals(quantitytSearchValueOther.Code, StringComparison.OrdinalIgnoreCase);
+                   string.Equals(System, quantitytSearchValueOther.System, StringComparison.OrdinalIgnoreCase) &&
+                   string.Equals(Code, quantitytSearchValueOther.Code, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/QuantitySearchValue.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/QuantitySearchValue.cs
@@ -162,5 +162,15 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.SearchValues
 
             return sb.ToString();
         }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(
+                Low.GetHashCode(),
+                High.GetHashCode(),
+                System.GetHashCode(StringComparison.OrdinalIgnoreCase),
+                Code.GetHashCode(StringComparison.OrdinalIgnoreCase));
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/QuantitySearchValue.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/QuantitySearchValue.cs
@@ -167,10 +167,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.SearchValues
         public override int GetHashCode()
         {
             return HashCode.Combine(
-                Low.GetHashCode(),
-                High.GetHashCode(),
-                System.GetHashCode(StringComparison.OrdinalIgnoreCase),
-                Code.GetHashCode(StringComparison.OrdinalIgnoreCase));
+                Low != null ? Low.GetHashCode() : 0,
+                High != null ? High.GetHashCode() : 0,
+                System != null ? System.GetHashCode(StringComparison.OrdinalIgnoreCase) : 0,
+                Code != null ? Code.GetHashCode(StringComparison.OrdinalIgnoreCase) : 0);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/ReferenceSearchValue.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/ReferenceSearchValue.cs
@@ -103,5 +103,15 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.SearchValues
 
             return $"{ResourceType}/{ResourceId}";
         }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(
+                Kind.GetHashCode(),
+                BaseUri.GetHashCode(),
+                ResourceType.GetHashCode(StringComparison.OrdinalIgnoreCase),
+                ResourceId.GetHashCode(StringComparison.OrdinalIgnoreCase));
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/ReferenceSearchValue.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/ReferenceSearchValue.cs
@@ -86,8 +86,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.SearchValues
 
             return Kind == referenceSearchValueOther.Kind &&
                    BaseUri == referenceSearchValueOther.BaseUri &&
-                   ResourceType.Equals(referenceSearchValueOther.ResourceType, StringComparison.OrdinalIgnoreCase) &&
-                   ResourceId.Equals(referenceSearchValueOther.ResourceId, StringComparison.OrdinalIgnoreCase);
+                   string.Equals(ResourceType, referenceSearchValueOther.ResourceType, StringComparison.OrdinalIgnoreCase) &&
+                   string.Equals(ResourceId, referenceSearchValueOther.ResourceId, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/ReferenceSearchValue.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/ReferenceSearchValue.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using EnsureThat;
 using Microsoft.Health.Fhir.Core.Models;
@@ -109,9 +110,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.SearchValues
         {
             return HashCode.Combine(
                 Kind.GetHashCode(),
-                BaseUri.GetHashCode(),
-                ResourceType.GetHashCode(StringComparison.OrdinalIgnoreCase),
-                ResourceId.GetHashCode(StringComparison.OrdinalIgnoreCase));
+                BaseUri != null ? BaseUri.GetHashCode() : 0,
+                ResourceType != null ? ResourceType.GetHashCode(StringComparison.OrdinalIgnoreCase) : 0,
+                ResourceId != null ? ResourceId.GetHashCode(StringComparison.OrdinalIgnoreCase) : 0);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/StringSearchValue.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/StringSearchValue.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.SearchValues
 
         public override int GetHashCode()
         {
-            return String != null ? String.GetHashCode(StringComparison.OrdinalIgnoreCase) : 0;
+            return String.GetHashCode(StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/StringSearchValue.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/StringSearchValue.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.SearchValues
 
         public override int GetHashCode()
         {
-            return String.GetHashCode(StringComparison.OrdinalIgnoreCase);
+            return String != null ? String.GetHashCode(StringComparison.OrdinalIgnoreCase) : 0;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/StringSearchValue.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/StringSearchValue.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.SearchValues
                 return false;
             }
 
-            return String.Equals(stringSearchValueOther.String, StringComparison.OrdinalIgnoreCase);
+            return string.Equals(String, stringSearchValueOther.String, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/StringSearchValue.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/StringSearchValue.cs
@@ -105,5 +105,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.SearchValues
         {
             return String.EscapeSearchParameterValue();
         }
+
+        public override int GetHashCode()
+        {
+            return String.GetHashCode(StringComparison.OrdinalIgnoreCase);
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/TokenSearchValue.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/TokenSearchValue.cs
@@ -122,5 +122,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.SearchValues
 
             return $"{System.EscapeSearchParameterValue()}|{Code.EscapeSearchParameterValue()}";
         }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(
+                System.GetHashCode(StringComparison.OrdinalIgnoreCase),
+                Code.GetHashCode(StringComparison.OrdinalIgnoreCase),
+                Text.GetHashCode(StringComparison.OrdinalIgnoreCase));
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/TokenSearchValue.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/TokenSearchValue.cs
@@ -107,9 +107,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.SearchValues
                 return false;
             }
 
-            return System.Equals(tokenSearchValueOther.System, StringComparison.OrdinalIgnoreCase) &&
-                   Code.Equals(tokenSearchValueOther.Code, StringComparison.OrdinalIgnoreCase) &&
-                   Text.Equals(tokenSearchValueOther.Text, StringComparison.OrdinalIgnoreCase);
+            return string.Equals(System, tokenSearchValueOther.System, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(Code, tokenSearchValueOther.Code, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(Text, tokenSearchValueOther.Text, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/TokenSearchValue.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/TokenSearchValue.cs
@@ -126,9 +126,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.SearchValues
         public override int GetHashCode()
         {
             return HashCode.Combine(
-                System.GetHashCode(StringComparison.OrdinalIgnoreCase),
-                Code.GetHashCode(StringComparison.OrdinalIgnoreCase),
-                Text.GetHashCode(StringComparison.OrdinalIgnoreCase));
+                System != null ? System.GetHashCode(StringComparison.OrdinalIgnoreCase) : 0,
+                Code != null ? Code.GetHashCode(StringComparison.OrdinalIgnoreCase) : 0,
+                Text != null ? Text.GetHashCode(StringComparison.OrdinalIgnoreCase) : 0);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/UriSearchValue.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/UriSearchValue.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.SearchValues
 
         public override int GetHashCode()
         {
-            return Uri != null ? Uri.ToString().GetHashCode(StringComparison.Ordinal) : 0;
+            return Uri.GetHashCode(StringComparison.Ordinal);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/UriSearchValue.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/UriSearchValue.cs
@@ -143,5 +143,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.SearchValues
 
             return asString.ToString();
         }
+
+        public override int GetHashCode()
+        {
+            return Uri.ToString().GetHashCode(StringComparison.Ordinal);
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/UriSearchValue.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/UriSearchValue.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.SearchValues
 
         public override int GetHashCode()
         {
-            return Uri.ToString().GetHashCode(StringComparison.Ordinal);
+            return Uri != null ? Uri.ToString().GetHashCode(StringComparison.Ordinal) : 0;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/TypedElementSearchIndexer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/TypedElementSearchIndexer.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                 }
             }
 
-            return entries;
+            return entries.Distinct().ToList();
         }
 
         private IEnumerable<SearchIndexEntry> ProcessCompositeSearchParameter(SearchParameterInfo searchParameter, ITypedElement resource, EvaluationContext context)


### PR DESCRIPTION
## Description
Remove duplicate search indices and added hashcode implementation for search values in parity with equals() implementation 
so that searchIndices.Distinct() method returns appropriate results.

## Related issues
Addresses [#87453](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Olympus/Stories/?workitem=87453)

## Testing
Verified manually and existing tests should continue to pass

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
