### PR TITLE
Add fix for URL search

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/Registry/SearchParameterStatusManagerTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/Registry/SearchParameterStatusManagerTests.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Registry
             _searchParameterDefinitionManager.AllSearchParameters
                 .Returns(_searchParameterInfos);
 
-            _searchParameterDefinitionManager.GetSearchParameter(new Uri(ResourceQuery))
+            _searchParameterDefinitionManager.GetSearchParameter(ResourceQuery)
                 .Returns(_queryParameter);
 
             _searchParameterSupportResolver

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/ISearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/ISearchParameterDefinitionManager.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
 using Hl7.Fhir.ElementModel;
 using Microsoft.Health.Fhir.Core.Models;
@@ -60,14 +59,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         /// <param name="definitionUri">The search parameter definition URL.</param>
         /// <param name="value">The SearchParameterInfo pertaining to the specified <paramref name="definitionUri"/></param>
         /// <returns>True if the search parameter is found <paramref name="definitionUri"/>.</returns>
-        public bool TryGetSearchParameter(Uri definitionUri, out SearchParameterInfo value);
+        public bool TryGetSearchParameter(string definitionUri, out SearchParameterInfo value);
 
         /// <summary>
         /// Retrieves the search parameter with <paramref name="definitionUri"/>.
         /// </summary>
         /// <param name="definitionUri">The search parameter definition URL.</param>
         /// <returns>The search parameter with the given <paramref name="definitionUri"/>.</returns>
-        SearchParameterInfo GetSearchParameter(Uri definitionUri);
+        SearchParameterInfo GetSearchParameter(string definitionUri);
 
         /// <summary>
         /// Updates the existing resource type - search parameter hash mapping with the given new values.

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionBuilder.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionBuilder.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
 
         internal static void Build(
             IReadOnlyCollection<ITypedElement> searchParameters,
-            ConcurrentDictionary<Uri, SearchParameterInfo> uriDictionary,
+            ConcurrentDictionary<string, SearchParameterInfo> uriDictionary,
             ConcurrentDictionary<string, ConcurrentDictionary<string, SearchParameterInfo>> resourceTypeDictionary,
             IModelInfoProvider modelInfoProvider)
         {
@@ -99,10 +99,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             return new BundleWrapper(modelInfoProvider.ToTypedElement(rawResource));
         }
 
-        private static SearchParameterInfo GetOrCreateSearchParameterInfo(SearchParameterWrapper searchParameter, IDictionary<Uri, SearchParameterInfo> uriDictionary)
+        private static SearchParameterInfo GetOrCreateSearchParameterInfo(SearchParameterWrapper searchParameter, IDictionary<string, SearchParameterInfo> uriDictionary)
         {
             // Return SearchParameterInfo that has already been created for this Uri
-            if (uriDictionary.TryGetValue(new Uri(searchParameter.Url), out var spi))
+            if (uriDictionary.TryGetValue(searchParameter.Url, out var spi))
             {
                 return spi;
             }
@@ -112,7 +112,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
 
         private static List<(string ResourceType, SearchParameterInfo SearchParameter)> ValidateAndGetFlattenedList(
             IReadOnlyCollection<ITypedElement> searchParamCollection,
-            IDictionary<Uri, SearchParameterInfo> uriDictionary,
+            IDictionary<string, SearchParameterInfo> uriDictionary,
             IModelInfoProvider modelInfoProvider)
         {
             var issues = new List<OperationOutcomeIssue>();
@@ -142,7 +142,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
                 try
                 {
                     SearchParameterInfo searchParameterInfo = GetOrCreateSearchParameterInfo(searchParameter, uriDictionary);
-                    uriDictionary.Add(new Uri(searchParameter.Url), searchParameterInfo);
+                    uriDictionary.Add(searchParameter.Url, searchParameterInfo);
                 }
                 catch (FormatException)
                 {
@@ -195,7 +195,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
                         var definitionUrl = GetComponentDefinition(component);
 
                         if (definitionUrl == null ||
-                            !uriDictionary.TryGetValue(new Uri(definitionUrl), out SearchParameterInfo componentSearchParameter))
+                            !uriDictionary.TryGetValue(definitionUrl, out SearchParameterInfo componentSearchParameter))
                         {
                             AddIssue(
                                 Core.Resources.SearchParameterDefinitionInvalidComponentReference,

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
@@ -54,12 +54,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             _mediator = mediator;
             _resourceTypeSearchParameterHashMap = new ConcurrentDictionary<string, string>();
             TypeLookup = new ConcurrentDictionary<string, ConcurrentDictionary<string, SearchParameterInfo>>();
-            UrlLookup = new ConcurrentDictionary<Uri, SearchParameterInfo>();
+            UrlLookup = new ConcurrentDictionary<string, SearchParameterInfo>();
             _searchServiceFactory = searchServiceFactory;
             _logger = logger;
         }
 
-        internal ConcurrentDictionary<Uri, SearchParameterInfo> UrlLookup { get; set; }
+        internal ConcurrentDictionary<string, SearchParameterInfo> UrlLookup { get; set; }
 
         // TypeLookup key is: Resource type, the inner dictionary key is the Search Parameter code.
         internal ConcurrentDictionary<string, ConcurrentDictionary<string, SearchParameterInfo>> TypeLookup { get; }
@@ -122,7 +122,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
                 searchParameters.TryGetValue(code, out searchParameter);
         }
 
-        public SearchParameterInfo GetSearchParameter(Uri definitionUri)
+        public SearchParameterInfo GetSearchParameter(string definitionUri)
         {
             if (UrlLookup.TryGetValue(definitionUri, out SearchParameterInfo value))
             {
@@ -132,7 +132,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             throw new SearchParameterNotSupportedException(definitionUri);
         }
 
-        public bool TryGetSearchParameter(Uri definitionUri, out SearchParameterInfo value)
+        public bool TryGetSearchParameter(string definitionUri, out SearchParameterInfo value)
         {
             return UrlLookup.TryGetValue(definitionUri, out value);
         }
@@ -198,7 +198,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         {
             SearchParameterInfo searchParameterInfo = null;
 
-            if (!UrlLookup.TryRemove(new Uri(url), out searchParameterInfo))
+            if (!UrlLookup.TryRemove(url, out searchParameterInfo))
             {
                 throw new ResourceNotFoundException(string.Format(Resources.CustomSearchParameterNotfound, url));
             }

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchableSearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchableSearchParameterDefinitionManager.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             throw new SearchParameterNotSupportedException(resourceType, code);
         }
 
-        public SearchParameterInfo GetSearchParameter(Uri definitionUri)
+        public SearchParameterInfo GetSearchParameter(string definitionUri)
         {
             SearchParameterInfo parameter = _inner.GetSearchParameter(definitionUri);
 
@@ -123,7 +123,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             _inner.DeleteSearchParameter(searchParam);
         }
 
-        public bool TryGetSearchParameter(Uri definitionUri, out SearchParameterInfo value)
+        public bool TryGetSearchParameter(string definitionUri, out SearchParameterInfo value)
         {
             _inner.TryGetSearchParameter(definitionUri, out var parameter);
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SupportedSearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SupportedSearchParameterDefinitionManager.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             throw new SearchParameterNotSupportedException(resourceType, code);
         }
 
-        public SearchParameterInfo GetSearchParameter(Uri definitionUri)
+        public SearchParameterInfo GetSearchParameter(string definitionUri)
         {
             SearchParameterInfo parameter = _inner.GetSearchParameter(definitionUri);
             if (parameter.IsSupported)
@@ -97,7 +97,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             _inner.DeleteSearchParameter(searchParam);
         }
 
-        public bool TryGetSearchParameter(Uri definitionUri, out SearchParameterInfo value)
+        public bool TryGetSearchParameter(string definitionUri, out SearchParameterInfo value)
         {
             value = null;
             if (_inner.TryGetSearchParameter(definitionUri, out var parameter) && parameter.IsSupported)

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -239,7 +239,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             }
 
             // save the list of search parameters to the reindexjob document
-            foreach (var searchParams in notYetIndexedParams.Select(p => p.Url.ToString()))
+            foreach (var searchParams in notYetIndexedParams.Select(p => p.Url.OriginalString))
             {
                 _reindexJobRecord.SearchParams.Add(searchParams);
             }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -706,7 +706,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             var reindexedResourcesSet = new HashSet<string>(_reindexJobRecord.Resources);
             foreach (var searchParam in _reindexJobRecord.SearchParams)
             {
-                var searchParamInfo = _supportedSearchParameterDefinitionManager.GetSearchParameter(new Uri(searchParam));
+                var searchParamInfo = _supportedSearchParameterDefinitionManager.GetSearchParameter(searchParam);
                 if (reindexedResourcesSet.IsSupersetOf(searchParamInfo.BaseResourceTypes))
                 {
                     fullyIndexedParamUris.Add(searchParam);

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
@@ -219,7 +219,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
             // parameter will not cause conflicts
             foreach (var searchParam in updatedSearchParameterStatus.Where(p => p.Status == SearchParameterStatus.Deleted))
             {
-                DeleteSearchParameter(searchParam.Uri.ToString());
+                DeleteSearchParameter(searchParam.Uri.OriginalString);
             }
 
             var paramsToAdd = new List<ITypedElement>();

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
@@ -225,7 +225,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
             var paramsToAdd = new List<ITypedElement>();
             foreach (var searchParam in updatedSearchParameterStatus.Where(p => p.Status != SearchParameterStatus.Deleted))
             {
-                var searchParamResource = await GetSearchParameterByUrl(searchParam.Uri.AbsoluteUri, cancellationToken);
+                var searchParamResource = await GetSearchParameterByUrl(searchParam.Uri.OriginalString, cancellationToken);
 
                 if (searchParamResource == null)
                 {
@@ -238,7 +238,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
                 if (_searchParameterDefinitionManager.TryGetSearchParameter(searchParam.Uri, out var existingSearchParam))
                 {
                     // if the search parameter exists we should delete the old information currently stored
-                    DeleteSearchParameter(searchParam.Uri.AbsoluteUri);
+                    DeleteSearchParameter(searchParam.Uri.OriginalString);
                 }
 
                 paramsToAdd.Add(searchParamResource);

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
@@ -235,7 +235,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
                     continue;
                 }
 
-                if (_searchParameterDefinitionManager.TryGetSearchParameter(searchParam.Uri, out var existingSearchParam))
+                if (_searchParameterDefinitionManager.TryGetSearchParameter(searchParam.Uri.OriginalString, out var existingSearchParam))
                 {
                     // if the search parameter exists we should delete the old information currently stored
                     DeleteSearchParameter(searchParam.Uri.OriginalString);

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
@@ -225,7 +225,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
             var paramsToAdd = new List<ITypedElement>();
             foreach (var searchParam in updatedSearchParameterStatus.Where(p => p.Status != SearchParameterStatus.Deleted))
             {
-                var searchParamResource = await GetSearchParameterByUrl(searchParam.Uri.ToString(), cancellationToken);
+                var searchParamResource = await GetSearchParameterByUrl(searchParam.Uri.AbsoluteUri, cancellationToken);
 
                 if (searchParamResource == null)
                 {
@@ -238,7 +238,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
                 if (_searchParameterDefinitionManager.TryGetSearchParameter(searchParam.Uri, out var existingSearchParam))
                 {
                     // if the search parameter exists we should delete the old information currently stored
-                    DeleteSearchParameter(searchParam.Uri.ToString());
+                    DeleteSearchParameter(searchParam.Uri.AbsoluteUri);
                 }
 
                 paramsToAdd.Add(searchParamResource);

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Registry/CosmosDbSearchParameterStatusInitializer.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Registry/CosmosDbSearchParameterStatusInitializer.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Registry
             {
                 var statuses = await _filebasedSearchParameterStatusDataStore.GetSearchParameterStatuses(cancellationToken);
 
-                foreach (var status in statuses.Where(x => _configuration.InitialSortParameterUris.Contains(x.Uri.ToString())))
+                foreach (var status in statuses.Where(x => _configuration.InitialSortParameterUris.Contains(x.Uri.OriginalString)))
                 {
                     status.SortStatus = SortParameterStatus.Enabled;
                 }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Definition/SearchParameterDefinitionBuilderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Definition/SearchParameterDefinitionBuilderTests.cs
@@ -26,12 +26,12 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Definition
         private readonly string _invalidEntriesFile = "SearchParametersWithInvalidEntries.json";
         private readonly string _invalidDefinitionsFile = "SearchParametersWithInvalidDefinitions.json";
         private readonly string _validEntriesFile = "SearchParameters.json";
-        private readonly ConcurrentDictionary<Uri, SearchParameterInfo> _uriDictionary;
+        private readonly ConcurrentDictionary<string, SearchParameterInfo> _uriDictionary;
         private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, SearchParameterInfo>> _resourceTypeDictionary;
 
         public SearchParameterDefinitionBuilderTests()
         {
-            _uriDictionary = new ConcurrentDictionary<Uri, SearchParameterInfo>();
+            _uriDictionary = new ConcurrentDictionary<string, SearchParameterInfo>();
             _resourceTypeDictionary = new ConcurrentDictionary<string, ConcurrentDictionary<string, SearchParameterInfo>>();
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexUtilitiesTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexUtilitiesTests.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                 ValueSets.SearchParamType.String,
                 new Uri("http://searchParam"));
 
-            _searchParameterDefinitionManager.GetSearchParameter(Arg.Any<Uri>()).Returns(searchParam);
+            _searchParameterDefinitionManager.GetSearchParameter(Arg.Any<string>()).Returns(searchParam);
 
             var (success, error) = await _reindexUtilities.UpdateSearchParameterStatus(paramUris, CancellationToken.None);
 
@@ -102,7 +102,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
             var paramUris = new List<string>();
             paramUris.Add("http://searchParam");
 
-            _searchParameterDefinitionManager.When(s => s.GetSearchParameter(Arg.Any<Uri>()))
+            _searchParameterDefinitionManager.When(s => s.GetSearchParameter(Arg.Any<string>()))
                 .Do(e => throw new SearchParameterNotSupportedException("message"));
 
             var (success, error) = await _reindexUtilities.UpdateSearchParameterStatus(paramUris, CancellationToken.None);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/Parsers/SearchValueExpressionBuilderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/Parsers/SearchValueExpressionBuilderTests.cs
@@ -239,7 +239,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
                 components: components);
             SearchParameterInfo searchParameter = searchParameter1;
 
-            _searchParameterDefinitionManager.GetSearchParameter(quantityUri).Returns(
+            _searchParameterDefinitionManager.GetSearchParameter(quantityUri.OriginalString).Returns(
                 new SearchParameter
                 {
                     Name = "quantity",

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchConverterForAllSearchTypes.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchConverterForAllSearchTypes.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             SearchParameterDefinitionManager searchParameterDefinitionManager = await _fixture.GetSearchDefinitionManagerAsync();
 
             (SearchParamType Type, Expression, Uri DefinitionUrl)[] componentExpressions = parameterInfo.Component
-                .Select(x => (searchParameterDefinitionManager.UrlLookup[x.DefinitionUrl].Type,
+                .Select(x => (searchParameterDefinitionManager.UrlLookup[x.DefinitionUrl.OriginalString].Type,
                     SearchParameterFixtureData.Compiler.Parse(x.Expression),
                     x.DefinitionUrl))
                 .ToArray();

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
@@ -226,7 +226,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             _fhirRequestContext.IncludePartiallyIndexedSearchParams = false;
             var searchableDefinitionManager = new SearchableSearchParameterDefinitionManager(_searchParameterDefinitionManager, _fhirRequestContextAccessor);
 
-            Assert.Throws<SearchParameterNotSupportedException>(() => searchableDefinitionManager.GetSearchParameter(new Uri(ResourceSecurity)));
+            Assert.Throws<SearchParameterNotSupportedException>(() => searchableDefinitionManager.GetSearchParameter(ResourceSecurity));
 
             _fhirRequestContext.IncludePartiallyIndexedSearchParams = false;
         }
@@ -238,7 +238,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             _fhirRequestContext.IncludePartiallyIndexedSearchParams = true;
             var searchableDefinitionManager = new SearchableSearchParameterDefinitionManager(_searchParameterDefinitionManager, _fhirRequestContextAccessor);
 
-            var param = searchableDefinitionManager.GetSearchParameter(new Uri(ResourceSecurity));
+            var param = searchableDefinitionManager.GetSearchParameter(ResourceSecurity);
             SearchParameterInfo expectedSearchParam = _searchParameterInfos[3];
             ValidateSearchParam(expectedSearchParam, param);
 
@@ -289,7 +289,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         public void GivenASearchParameterDefinitionManager_WhenGettingExistingSearchParameterByUrl_CorrectParameterIsReturned()
         {
             SearchParameterInfo expectedSearchParam = _searchParameterInfos[0];
-            SearchParameterInfo actualSearchParam = _searchParameterDefinitionManager.GetSearchParameter(expectedSearchParam.Url);
+            SearchParameterInfo actualSearchParam = _searchParameterDefinitionManager.GetSearchParameter(expectedSearchParam.Url.OriginalString);
 
             ValidateSearchParam(expectedSearchParam, actualSearchParam);
         }
@@ -297,7 +297,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         [Fact]
         public void GivenASearchParameterDefinitionManager_WhenGettingNonexistentSearchParameterByUrl_ExceptionIsThrown()
         {
-            Assert.Throws<SearchParameterNotSupportedException>(() => _searchParameterDefinitionManager.GetSearchParameter(_testSearchParamInfo.Url));
+            Assert.Throws<SearchParameterNotSupportedException>(() => _searchParameterDefinitionManager.GetSearchParameter(_testSearchParamInfo.Url.OriginalString));
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterValidatorTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterValidatorTests.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using Hl7.Fhir.Model;
@@ -30,8 +29,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
         public SearchParameterValidatorTests()
         {
-            _searchParameterDefinitionManager.TryGetSearchParameter(Arg.Is<Uri>(uri => uri != new Uri("http://duplicate")), out _).Returns(false);
-            _searchParameterDefinitionManager.TryGetSearchParameter(new Uri("http://duplicate"), out _).Returns(true);
+            _searchParameterDefinitionManager.TryGetSearchParameter(Arg.Is<string>(uri => uri != "http://duplicate"), out _).Returns(false);
+            _searchParameterDefinitionManager.TryGetSearchParameter("http://duplicate", out _).Returns(true);
             _searchParameterDefinitionManager.TryGetSearchParameter("Patient", Arg.Is<string>(code => code != "duplicate"), out _).Returns(false);
             _searchParameterDefinitionManager.TryGetSearchParameter("Patient", "duplicate", out _).Returns(true);
             _fhirOperationDataStore.CheckActiveReindexJobsAsync(CancellationToken.None).Returns((false, string.Empty));

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
@@ -469,7 +469,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
             string continuationToken,
             CancellationToken cancellationToken)
         {
-            SearchParameterInfo clinicalDateInfo = _searchParameterDefinitionManager.GetSearchParameter(SearchParameterNames.ClinicalDateUri);
+            SearchParameterInfo clinicalDateInfo = _searchParameterDefinitionManager.GetSearchParameter(SearchParameterNames.ClinicalDateUri.OriginalString);
             List<string> dateResourceTypes = types.Any()
                 ? clinicalDateInfo.BaseResourceTypes.Intersect(types).ToList()
                 : clinicalDateInfo.BaseResourceTypes.ToList();
@@ -519,7 +519,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
             CancellationToken cancellationToken)
         {
             var nonDateResourceTypes = new List<string>();
-            SearchParameterInfo clinicalDateInfo = _searchParameterDefinitionManager.GetSearchParameter(SearchParameterNames.ClinicalDateUri);
+            SearchParameterInfo clinicalDateInfo = _searchParameterDefinitionManager.GetSearchParameter(SearchParameterNames.ClinicalDateUri.OriginalString);
 
             if (_compartmentDefinitionManager.TryGetResourceTypes(CompartmentType.Patient, out HashSet<string> compartmentResourceTypes))
             {

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Parameters/SearchParameterValidator.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Parameters/SearchParameterValidator.cs
@@ -72,10 +72,18 @@ namespace Microsoft.Health.Fhir.Shared.Core.Features.Search.Parameters
             }
             else
             {
-                try
+                // Checks if the url is a valid url
+                if (!Uri.TryCreate(searchParam.Url, UriKind.Absolute, out _))
+                {
+                    validationFailures.Add(
+                          new ValidationFailure(
+                              nameof(searchParam.Url),
+                              string.Format(Resources.SearchParameterDefinitionInvalidDefinitionUri, searchParam.Url)));
+                }
+                else
                 {
                     // If a search parameter with the same uri exists already
-                    if (_searchParameterDefinitionManager.TryGetSearchParameter(new Uri(searchParam.Url), out _))
+                    if (_searchParameterDefinitionManager.TryGetSearchParameter(searchParam.Url, out _))
                     {
                         // And if this is a request to create a new search parameter
                         if (method.Equals(HttpPostName, StringComparison.OrdinalIgnoreCase))
@@ -106,13 +114,6 @@ namespace Microsoft.Health.Fhir.Shared.Core.Features.Search.Parameters
 
                         CheckForConflictingCodeValue(searchParam, validationFailures);
                     }
-                }
-                catch (FormatException)
-                {
-                    validationFailures.Add(
-                          new ValidationFailure(
-                              nameof(searchParam.Url),
-                              string.Format(Resources.SearchParameterDefinitionInvalidDefinitionUri, searchParam.Url)));
                 }
             }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SearchParameterStatusCollection.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SearchParameterStatusCollection.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry
 
             foreach (ResourceSearchParameterStatus status in this)
             {
-                sqlRow.SetString(0, status.Uri.ToString());
+                sqlRow.SetString(0, status.Uri.OriginalString);
                 sqlRow.SetString(1, status.Status.ToString());
                 sqlRow.SetSqlBoolean(2, status.IsPartiallySupported);
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerSearchParameterStatusDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerSearchParameterStatusDataStore.cs
@@ -228,7 +228,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry
                 var status = (SqlServerResourceSearchParameterStatus)resourceSearchParameterStatus;
 
                 // Add the new search parameters to the FHIR model dictionary.
-                _fhirModel.TryAddSearchParamIdToUriMapping(status.Uri.ToString(), status.Id);
+                _fhirModel.TryAddSearchParamIdToUriMapping(status.Uri.OriginalString, status.Id);
             }
         }
     }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerSearchParameterStatusDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerSearchParameterStatusDataStore.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry
                             SearchParameterInfo paramInfo = null;
                             try
                             {
-                                paramInfo = _searchParameterDefinitionManager.GetSearchParameter(resourceSearchParameterStatus.Uri);
+                                paramInfo = _searchParameterDefinitionManager.GetSearchParameter(resourceSearchParameterStatus.Uri.OriginalString);
                             }
                             catch (SearchParameterNotSupportedException)
                             {

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/TvpRowGeneration/SearchParameterStatusV1RowGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/TvpRowGeneration/SearchParameterStatusV1RowGenerator.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.TvpRowGeneration
         public IEnumerable<SearchParamTableTypeV1Row> GenerateRows(List<ResourceSearchParameterStatus> searchParameterStatuses)
         {
             return searchParameterStatuses.Select(searchParameterStatus => new SearchParamTableTypeV1Row(
-                    searchParameterStatus.Uri.ToString(),
+                    searchParameterStatus.Uri.OriginalString,
                     searchParameterStatus.Status.ToString(),
                     searchParameterStatus.IsPartiallySupported))
                 .ToList();

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/SearchParameter-AppointmentStatus.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/SearchParameter-AppointmentStatus.json
@@ -7,7 +7,7 @@
             "valueCode": "trial-use"
         }
     ],
-    "url": "http://hl7.org/fhir/SearchParameter/Appointment-foo",
+    "url": "http://hl7.org/fhir/SearchParameter/Appointment-foo%20",
     "version": "4.0.1",
     "name": "status",
     "status": "draft",

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -275,7 +275,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
         [Fact]
         public async Task GivenNoMatchingResources_WhenRunningReindexJob_ThenJobIsCompleted()
         {
-            var searchParam = _supportedSearchParameterDefinitionManager.GetSearchParameter(new Uri("http://hl7.org/fhir/SearchParameter/Measure-name"));
+            var searchParam = _supportedSearchParameterDefinitionManager.GetSearchParameter("http://hl7.org/fhir/SearchParameter/Measure-name");
             searchParam.IsSearchable = false;
             var request = new CreateReindexRequest(new List<string>());
 


### PR DESCRIPTION
## Description
In the Reindex Worker if a search parameter's url is different escaped vs unescaped it can't be fetched when looking for new search parameters.

## Related issues
Addresses Bug [AB#87538](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/87538): Unable to update search parameters

## Testing
Manual testing

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [x] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
