### PR TITLE
Adds versioned update test flow

### DIFF
--- a/docs/rest/VersionedUpdateExample.http
+++ b/docs/rest/VersionedUpdateExample.http
@@ -1,0 +1,151 @@
+# Before running this, update the versioning policy in appsettings.json to:
+#
+#"Versioning": {
+#     "Default": "versioned-update",
+#     "ResourceTypeOverrides":null
+#     }
+
+@hostname = localhost:44348
+
+###
+# Get the capability statement.
+# Note that the "versioning" property of every resource type is set to 
+# "versioned-update"
+GET https://{{hostname}}/metadata
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+### Get the bearer token, if authentication is enabled
+# @name bearer
+POST https://{{hostname}}/connect/token
+content-type: application/x-www-form-urlencoded
+
+grant_type=client_credentials
+&client_id=globalAdminServicePrincipal
+&client_secret=globalAdminServicePrincipal
+&scope=fhir-api
+
+###
+# Create a patient resource that we will update.
+# This will create version 1 of a patient resource.
+# @name patient
+POST https://{{hostname}}/Patient
+Content-Type: application/json
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+{
+  "resourceType": "Patient",
+  "id": "patient-to-update",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: newborn</p><p><b>gender</b>: male</p><p><b>birthDate</b>: 05/09/2017</p></div>"
+  },
+  "gender": "male",
+  "birthDate": "2017-09-05"
+}
+
+###
+# Attempt to update the patient without specifying the if-match header.
+# This should result in an error.
+PUT https://{{hostname}}/Patient/{{patient.response.body.id}}
+Content-Type: application/json
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+{
+  "resourceType": "Patient",
+  "id": "{{patient.response.body.id}}",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: newborn</p><p><b>gender</b>: male</p><p><b>birthDate</b>: 05/09/2017</p></div>"
+  },
+  "gender": "male",
+  "birthDate": "2017-09-05",
+  "_birthDate": {
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/StructureDefinition/patient-birthTime",
+        "valueDateTime": "2017-05-09T17:11:00+01:00"
+      }
+    ]
+  }
+}
+
+###
+# Update the patient, now setting the if-match header to version 1.
+# This should successfully create version 2 of the resource.
+PUT https://{{hostname}}/Patient/{{patient.response.body.id}}
+Content-Type: application/json
+Authorization: Bearer {{bearer.response.body.access_token}}
+If-Match: W/"1"
+
+{
+  "resourceType": "Patient",
+  "id": "{{patient.response.body.id}}",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: newborn</p><p><b>gender</b>: male</p><p><b>birthDate</b>: 05/09/2017</p></div>"
+  },
+  "gender": "male",
+  "birthDate": "2017-09-05",
+  "_birthDate": {
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/StructureDefinition/patient-birthTime",
+        "valueDateTime": "2017-05-09T17:11:00+01:00"
+      }
+    ]
+  }
+}
+
+###
+# Attempt to update the patient, but do not set the if-match header to the most
+# recent version. This should return an error.
+PUT https://{{hostname}}/Patient/{{patient.response.body.id}}
+Content-Type: application/json
+Authorization: Bearer {{bearer.response.body.access_token}}
+If-Match: W/"1"
+
+{
+  "resourceType": "Patient",
+  "id": "{{patient.response.body.id}}",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: newborn</p><p><b>gender</b>: male</p><p><b>birthDate</b>: 05/09/2017</p></div>"
+  },
+  "gender": "male",
+  "birthDate": "2017-09-05",
+  "_birthDate": {
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/StructureDefinition/patient-birthTime",
+        "valueDateTime": "2017-05-09T17:11:00+01:00"
+      }
+    ]
+  }
+}
+
+###
+# Re-attempt, now setting the if-match header to version 2.
+# This should successfully create version 3.
+PUT https://{{hostname}}/Patient/{{patient.response.body.id}}
+Content-Type: application/json
+Authorization: Bearer {{bearer.response.body.access_token}}
+If-Match: W/"2"
+
+{
+  "resourceType": "Patient",
+  "id": "{{patient.response.body.id}}",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: newborn</p><p><b>gender</b>: male</p><p><b>birthDate</b>: 05/09/2017</p></div>"
+  },
+  "gender": "male",
+  "birthDate": "2017-09-05",
+  "_birthDate": {
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/StructureDefinition/patient-birthTime",
+        "valueDateTime": "2017-05-09T17:11:00+01:00"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Description
With the disable history feature allowing users to set the versioning policy in app settings, the versioning policy can be configured to _versioned-update_, where users must provide the most recent version of the resource they would like to update in the `if-match` header. This PR adds an .http file outlining a manual test flow.

## Related issues
Automated tests: [AB#87688](https://microsofthealth.visualstudio.com/Health/_workitems/edit/87688).

## FHIR Team Checklist
- ✅ **Update the title** of the PR to be succinct and less than 50 characters
- ✅ **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- ✅ Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- ✅ Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- ✅ Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- ✅ CI is green before merge
- ✅ Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
None (added test file)
