### PR TITLE
Rewrite CompartmentSearch to main search index in Cosmos

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/CompartmentSearchExpression.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/CompartmentSearchExpression.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using EnsureThat;
 using Microsoft.Health.Fhir.Core.Models;
 
@@ -19,13 +20,15 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// </summary>
         /// <param name="compartmentType">The compartment type.</param>
         /// <param name="compartmentId">The compartment id.</param>
-        public CompartmentSearchExpression(string compartmentType, string compartmentId)
+        /// <param name="filteredResourceTypes">Resource types to filter</param>
+        public CompartmentSearchExpression(string compartmentType, string compartmentId, params string[] filteredResourceTypes)
         {
             EnsureArg.IsTrue(ModelInfoProvider.IsKnownCompartmentType(compartmentType), nameof(compartmentType));
             EnsureArg.IsNotNullOrWhiteSpace(compartmentId, nameof(compartmentId));
 
             CompartmentType = compartmentType;
             CompartmentId = compartmentId;
+            FilteredResourceTypes = filteredResourceTypes ?? Array.Empty<string>();
         }
 
         /// <summary>
@@ -37,6 +40,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// The compartment id.
         /// </summary>
         public string CompartmentId { get; }
+
+        /// <summary>
+        /// Resource types to filter for compartment search
+        /// </summary>
+        public IReadOnlyCollection<string> FilteredResourceTypes { get; }
 
         public override TOutput AcceptVisitor<TContext, TOutput>(IExpressionVisitor<TContext, TOutput> visitor, TContext context)
         {

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Expression.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Expression.cs
@@ -269,10 +269,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// </summary>
         /// <param name="compartmentType">The compartment type.</param>
         /// <param name="compartmentId">The compartment id.</param>
+        /// <param name="filteredResourceTypes">Resource types to filter on</param>
         /// <returns>A <see cref="CompartmentSearchExpression"/> that represents a compartment search operation.</returns>
-        public static CompartmentSearchExpression CompartmentSearch(string compartmentType, string compartmentId)
+        public static CompartmentSearchExpression CompartmentSearch(string compartmentType, string compartmentId, params string[] filteredResourceTypes)
         {
-            return new CompartmentSearchExpression(compartmentType, compartmentId);
+            return new CompartmentSearchExpression(compartmentType, compartmentId, filteredResourceTypes);
         }
 
         public abstract TOutput AcceptVisitor<TContext, TOutput>(IExpressionVisitor<TContext, TOutput> visitor, TContext context);

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Expressions/CompartmentSearchRewriter.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Expressions/CompartmentSearchRewriter.cs
@@ -1,0 +1,133 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EnsureThat;
+using Microsoft.Health.Fhir.Core.Features.Definition;
+using Microsoft.Health.Fhir.Core.Features.Search;
+using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
+using Microsoft.Health.Fhir.Core.Models;
+
+namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Expressions
+{
+    /// <summary>
+    /// Rewrites CompartmentSearchExpression to use main search index.
+    /// </summary>
+    public class CompartmentSearchRewriter : ExpressionRewriterWithInitialContext<object>, ICosmosExpressionRewriter
+    {
+        private readonly Lazy<ICompartmentDefinitionManager> _compartmentDefinitionManager;
+        private readonly Lazy<ISearchParameterDefinitionManager> _searchParameterDefinitionManager;
+
+        public CompartmentSearchRewriter(Lazy<ICompartmentDefinitionManager> compartmentDefinitionManager, Lazy<ISearchParameterDefinitionManager> searchParameterDefinitionManager)
+        {
+            _compartmentDefinitionManager = EnsureArg.IsNotNull(compartmentDefinitionManager, nameof(compartmentDefinitionManager));
+            _searchParameterDefinitionManager = EnsureArg.IsNotNull(searchParameterDefinitionManager, nameof(searchParameterDefinitionManager));
+        }
+
+        public int Order { get; } = 0;
+
+        public override Expression VisitCompartment(CompartmentSearchExpression expression, object context)
+        {
+            SearchParameterInfo resourceTypeSearchParameter = _searchParameterDefinitionManager.Value.GetSearchParameter(KnownResourceTypes.Resource, SearchParameterNames.ResourceType);
+            var compartmentType = expression.CompartmentType;
+            var compartmentId = expression.CompartmentId;
+
+            if (Enum.TryParse(compartmentType, out ValueSets.CompartmentType parsedCompartmentType))
+            {
+                if (string.IsNullOrWhiteSpace(compartmentId))
+                {
+                    throw new InvalidSearchOperationException(Core.Resources.CompartmentIdIsInvalid);
+                }
+
+                var compartmentResourceTypesToSearch = new HashSet<string>();
+                var compartmentSearchExpressions = new Dictionary<string, (SearchParameterExpression Expression, HashSet<string> ResourceTypes)>();
+
+                if (_compartmentDefinitionManager.Value.TryGetResourceTypes(parsedCompartmentType, out HashSet<string> resourceTypes))
+                {
+                    if (expression.FilteredResourceTypes.Any(resourceType => !string.Equals(resourceType, KnownResourceTypes.DomainResource, StringComparison.Ordinal)))
+                    {
+                        resourceTypes = resourceTypes.Where(x => expression.FilteredResourceTypes.Contains(x)).ToHashSet();
+                    }
+
+                    foreach (var resourceFilter in resourceTypes)
+                    {
+                        compartmentResourceTypesToSearch.Add(resourceFilter);
+                    }
+                }
+
+                foreach (var compartmentResourceType in compartmentResourceTypesToSearch)
+                {
+                    var searchParamExpressionsForResourceType = new List<SearchParameterExpression>();
+                    if (_compartmentDefinitionManager.Value.TryGetSearchParams(compartmentResourceType, parsedCompartmentType, out HashSet<string> compartmentSearchParameters))
+                    {
+                        foreach (var compartmentSearchParameter in compartmentSearchParameters)
+                        {
+                            if (_searchParameterDefinitionManager.Value.TryGetSearchParameter(compartmentResourceType, compartmentSearchParameter, out SearchParameterInfo sp))
+                            {
+                                searchParamExpressionsForResourceType.Add(
+                                    Expression.SearchParameter(sp, Expression.And(Expression.StringEquals(FieldName.ReferenceResourceType, null, compartmentType, false), Expression.StringEquals(FieldName.ReferenceResourceId, null, compartmentId, false))));
+                            }
+                        }
+                    }
+
+                    foreach (var expr in searchParamExpressionsForResourceType)
+                    {
+                        if (compartmentSearchExpressions.TryGetValue(expr.ToString(), out var resourceTypeList))
+                        {
+                            resourceTypeList.ResourceTypes.Add(compartmentResourceType);
+                        }
+                        else
+                        {
+                            compartmentSearchExpressions[expr.ToString()] = (expr, new HashSet<string> { compartmentResourceType });
+                        }
+                    }
+                }
+
+                if (compartmentSearchExpressions.Any())
+                {
+                    var compartmentSearchExpressionsGrouped = new List<Expression>();
+
+                    foreach (var grouping in compartmentSearchExpressions)
+                    {
+                        // When we're searching more than 1 compartment resource type (i.e. Patient/abc/*) the search parameters need to list the applicable resource types
+                        if (compartmentResourceTypesToSearch.Count > 1)
+                        {
+                            var inExpression = new InExpression(FieldName.TokenCode, null, grouping.Value.ResourceTypes);
+
+                            SearchParameterExpression resourceTypesExpression = Expression.SearchParameter(
+                                resourceTypeSearchParameter,
+                                inExpression);
+
+                            compartmentSearchExpressionsGrouped.Add(Expression.And(grouping.Value.Expression, resourceTypesExpression));
+                        }
+                        else
+                        {
+                            compartmentSearchExpressionsGrouped.Add(grouping.Value.Expression);
+                        }
+                    }
+
+                    if (compartmentSearchExpressionsGrouped.Count > 1)
+                    {
+                        return Expression.Or(compartmentSearchExpressionsGrouped);
+                    }
+                    else if (compartmentSearchExpressions.Count == 1)
+                    {
+                        return compartmentSearchExpressionsGrouped[0];
+                    }
+
+                    return expression;
+                }
+            }
+            else
+            {
+                throw new InvalidSearchOperationException(string.Format(Core.Resources.CompartmentTypeIsInvalid, compartmentType));
+            }
+
+            return expression;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Expressions/ICosmosExpressionRewriter.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Expressions/ICosmosExpressionRewriter.cs
@@ -1,0 +1,14 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
+
+namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Expressions
+{
+    public interface ICosmosExpressionRewriter : IExpressionVisitorWithInitialContext<object, Expression>
+    {
+        int Order { get; }
+    }
+}

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
         private readonly CosmosDataStoreConfiguration _cosmosConfig;
         private readonly ICosmosDbCollectionPhysicalPartitionInfo _physicalPartitionInfo;
         private readonly QueryPartitionStatisticsCache _queryPartitionStatisticsCache;
+        private readonly Lazy<IReadOnlyCollection<IExpressionVisitorWithInitialContext<object, Expression>>> _expressionRewriters;
         private readonly ILogger<FhirCosmosSearchService> _logger;
         private readonly SearchParameterInfo _resourceTypeSearchParameter;
         private readonly SearchParameterInfo _resourceIdSearchParameter;
@@ -53,6 +54,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
             CosmosDataStoreConfiguration cosmosConfig,
             ICosmosDbCollectionPhysicalPartitionInfo physicalPartitionInfo,
             QueryPartitionStatisticsCache queryPartitionStatisticsCache,
+            IEnumerable<ICosmosExpressionRewriter> expressionRewriters,
             ILogger<FhirCosmosSearchService> logger)
             : base(searchOptionsFactory, fhirDataStore)
         {
@@ -62,6 +64,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
             EnsureArg.IsNotNull(cosmosConfig, nameof(cosmosConfig));
             EnsureArg.IsNotNull(physicalPartitionInfo, nameof(physicalPartitionInfo));
             EnsureArg.IsNotNull(queryPartitionStatisticsCache, nameof(queryPartitionStatisticsCache));
+            EnsureArg.IsNotNull(expressionRewriters, nameof(expressionRewriters));
             EnsureArg.IsNotNull(logger, nameof(logger));
 
             _fhirDataStore = fhirDataStore;
@@ -73,6 +76,12 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
             _logger = logger;
             _resourceTypeSearchParameter = SearchParameterInfo.ResourceTypeSearchParameter;
             _resourceIdSearchParameter = new SearchParameterInfo(SearchParameterNames.Id, SearchParameterNames.Id);
+
+            _expressionRewriters = new Lazy<IReadOnlyCollection<IExpressionVisitorWithInitialContext<object, Expression>>>(() => expressionRewriters
+                .OrderBy(x => x.Order)
+                .Cast<IExpressionVisitorWithInitialContext<object, Expression>>()
+                .Append(DateTimeEqualityRewriter.Instance)
+                .ToArray());
         }
 
         public override async Task<SearchResult> SearchAsync(
@@ -82,8 +91,12 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
             // we're going to mutate searchOptions, so clone it first so the caller of this method does not see the changes.
             searchOptions = searchOptions.Clone();
 
-            // rewrite DateTime range expressions to be more efficient
-            searchOptions.Expression = searchOptions.Expression?.AcceptVisitor(DateTimeEqualityRewriter.Instance);
+            if (searchOptions.Expression != null)
+            {
+                // Apply Cosmos specific expression rewriters
+                searchOptions.Expression = _expressionRewriters.Value
+                    .Aggregate(searchOptions.Expression, (e, rewriter) => e.AcceptVisitor(rewriter));
+            }
 
             // pull out the _include and _revinclude expressions.
             bool hasIncludeOrRevIncludeExpressions = ExtractIncludeAndChainedExpressions(

--- a/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
@@ -23,6 +23,7 @@ using Microsoft.Health.Fhir.CosmosDb.Features.Operations;
 using Microsoft.Health.Fhir.CosmosDb.Features.Operations.Reindex;
 using Microsoft.Health.Fhir.CosmosDb.Features.Queries;
 using Microsoft.Health.Fhir.CosmosDb.Features.Search;
+using Microsoft.Health.Fhir.CosmosDb.Features.Search.Expressions;
 using Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries;
 using Microsoft.Health.Fhir.CosmosDb.Features.Storage;
 using Microsoft.Health.Fhir.CosmosDb.Features.Storage.Operations;
@@ -221,6 +222,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Add<PurgeOperationCapabilityProvider>()
                 .Transient()
                 .AsImplementedInterfaces();
+
+            services.Add<CompartmentSearchRewriter>()
+                .Singleton()
+                .AsService<ICosmosExpressionRewriter>();
 
             return fhirServerBuilder;
         }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -286,7 +286,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                         throw new InvalidSearchOperationException(Core.Resources.CompartmentIdIsInvalid);
                     }
 
-                    searchExpressions.Add(Expression.CompartmentSearch(compartmentType, compartmentId));
+                    searchExpressions.Add(Expression.CompartmentSearch(compartmentType, compartmentId, resourceTypesString));
                 }
                 else
                 {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
@@ -29,6 +29,7 @@ using Microsoft.Health.Fhir.Core.UnitTests.Extensions;
 using Microsoft.Health.Fhir.CosmosDb.Configs;
 using Microsoft.Health.Fhir.CosmosDb.Features.Queries;
 using Microsoft.Health.Fhir.CosmosDb.Features.Search;
+using Microsoft.Health.Fhir.CosmosDb.Features.Search.Expressions;
 using Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries;
 using Microsoft.Health.Fhir.CosmosDb.Features.Storage;
 using Microsoft.Health.Fhir.CosmosDb.Features.Storage.Operations;
@@ -188,6 +189,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 _cosmosDataStoreConfiguration,
                 cosmosDbPhysicalPartitionInfo,
                 new QueryPartitionStatisticsCache(),
+                Enumerable.Empty<ICosmosExpressionRewriter>(),
                 NullLogger<FhirCosmosSearchService>.Instance);
 
             await _searchParameterDefinitionManager.EnsureInitializedAsync(CancellationToken.None);


### PR DESCRIPTION
## Description
Rewrite CompartmentSearch to main search index in Cosmos.

Example of expanded rewritten expressions:
![image](https://user-images.githubusercontent.com/197221/149232937-322db330-6f59-4e56-9807-bc32e4cca30d.png)

Rewriter uses type filtering information to only include the relevant search params.

## Related issues
Addresses [AB#87577](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/87577).

## Testing
- Existing Unit and E2E tests
- Manual test cases

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [x] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch (bug)
