### PR TITLE
CustomSearchTest will sometimes fail when writing out delete exception

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -508,17 +508,14 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                     }
                     catch (Exception exp)
                     {
+                        _output.WriteLine("CustomSearchParameter test experienced issue attempted to clean up SearchParameter {searchParamUrl}.  The exception message is {exp}", searchParam.Url, exp.Message);
                         var fhirException = exp as FhirException;
                         if (fhirException != null && fhirException.OperationOutcome?.Issue != null)
                         {
                             foreach (var issue in fhirException.OperationOutcome.Issue)
                             {
-                                _output.WriteLine("Issue: {message}", issue.Diagnostics);
+                                _output.WriteLine("FhirException OperationOutome message from trying to delete SearchParameter is CustomSearchParam test: {message}", issue.Diagnostics);
                             }
-                        }
-                        else
-                        {
-                            _output.WriteLine($"Failed to delete searchParameter: {exp}");
                         }
 
                         success = false;


### PR DESCRIPTION
## Description
During cleanup when trying to delete any added searchparameters from the test, the delete can have issues.  Sometimes the logging of the exception will also fail due to how we constructed the string.

## Related issues
Addresses [issue [AB#83531](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/83531)].

## Testing
Reran the tests

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [X] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [X] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
