### PR TITLE
Case insensitive distinct for token text import

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Import/ImportResourceParser.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Import/ImportResourceParser.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
 using System.Text;
 using EnsureThat;
 using Hl7.Fhir.Model;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Import/DataGeneratorsTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Import/DataGeneratorsTests.cs
@@ -8,6 +8,7 @@ using System.Data;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Health.Fhir.SqlServer.Features.Operations.Import;
+using Microsoft.Health.Fhir.SqlServer.Features.Operations.Import.DataGenerator;
 using Microsoft.Health.Fhir.SqlServer.Features.Schema.Model;
 using Microsoft.Health.SqlServer.Features.Schema.Model;
 using Xunit;
@@ -98,6 +99,22 @@ namespace Microsoft.Health.Fhir.Shared.Tests.Integration.Features.Operations.Imp
         {
             DataTable table = TestBulkDataProvider.GenerateTokenTextSearchParamsTable(1, 1000, 103);
             ValidataDataTable(VLatest.TokenText, table);
+        }
+
+        [Fact]
+        public void GivenListTokenTextSearchParams_WhenDinstict_ThenRecordShouldBeDistinctCaseInsensitive()
+        {
+            List<BulkTokenTextTableTypeV1Row> input = new List<BulkTokenTextTableTypeV1Row>()
+            {
+                new BulkTokenTextTableTypeV1Row(0, 1, "test"),
+                new BulkTokenTextTableTypeV1Row(0, 1, "Test"),
+                new BulkTokenTextTableTypeV1Row(0, 2, "Test"),
+                new BulkTokenTextTableTypeV1Row(0, 2, null),
+                new BulkTokenTextTableTypeV1Row(0, 3, "Test"),
+                new BulkTokenTextTableTypeV1Row(0, 3, string.Empty),
+            };
+
+            Assert.Equal(5, TokenTextSearchParamsTableBulkCopyDataGenerator.Distinct(input).Count());
         }
 
         [Fact]


### PR DESCRIPTION
## Description
Case insensitive distinct for token text import.
We are applying distinct while extracting SearchIndexes in TypedElementIndexer.cs in this [PR](https://github.com/microsoft/fhir-server/pull/2411/files#:~:text=return%20entries.Distinct().ToList()%3B). For the following resource we will still get duplicate rows for TokenText table as the codes are different 

`{
  "resourceType": "Observation",
  "status": "final",
    "code": {
    "coding": [
        {
            "code": "29463-7",
            "display": "Body Weight"
        },
        {
            "code": "29463-8",
            "display": "BODY Weight"
        },
        {
            "code": "29463-9",
            "display": "BODY WEIGHT"
        }
    ]
}
}`

While making an API call, after the extract logic we will go through the UpserResource SP, which has the DISTINCT before inserting rows in TokenText table resulting in the unique entry. (For SQL Text column is a case insensitive) Since Inport doesn't go through the SP we get duplicate rows. The RemoveDuplicate added in this [PR ](https://github.com/microsoft/fhir-server/pull/2408/files) is not enough to get the distinct records as it is case sensitive.

## Related issues
Addresses [issue #].

## Testing
Add unit tests for case insensitive distinct.

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [X] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [X] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
