### PR TITLE
Update Deploy to Azure image link

### DIFF
--- a/docs/DefaultDeployment.md
+++ b/docs/DefaultDeployment.md
@@ -64,7 +64,7 @@ The FHIR server can be deployed using all free Azure resources. When deploying s
     <img src="https://aka.ms/deploytoazurebutton"/>
 </a>
 
-Use this button if you want to deploy to the Azure Government Cloud.
+If you want to deploy to the Azure Government Cloud, use this button instead.
 
 <a href="https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FMicrosoft%2Ffhir-server%2Fmain%2Fsamples%2Ftemplates%2Fdefault-azuredeploy.json" target="_blank"> 
     <img src="https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.png">

--- a/docs/DefaultDeployment.md
+++ b/docs/DefaultDeployment.md
@@ -61,7 +61,7 @@ To deploy the backend SQL Server, Azure Web App, and FHIR server code, use the b
 The FHIR server can be deployed using all free Azure resources. When deploying select 'F1' as the App Service Plan Sku, 'Yes' to use the Cosmos DB Free Tier, and FhirServerCosmosDB as the Solution Type. The free app service plan and Cosmos Db account have restrictions that can be seen on their respective doc pages: [App Service plan overview](https://docs.microsoft.com/en-us/azure/app-service/overview-hosting-plans), [Cosmos DB free tier](https://docs.microsoft.com/en-us/azure/cosmos-db/optimize-dev-test#azure-cosmos-db-free-tier)
 
 <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FMicrosoft%2Ffhir-server%2Fmain%2Fsamples%2Ftemplates%2Fdefault-azuredeploy-docker.json" target="_blank">
-    <img src="https://azuredeploy.net/deploybutton.png"/>
+    <img src="https://aka.ms/deploytoazurebutton"/>
 </a>
 
 <a href="https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FMicrosoft%2Ffhir-server%2Fmain%2Fsamples%2Ftemplates%2Fdefault-azuredeploy.json" target="_blank"> 

--- a/docs/DefaultDeployment.md
+++ b/docs/DefaultDeployment.md
@@ -64,6 +64,8 @@ The FHIR server can be deployed using all free Azure resources. When deploying s
     <img src="https://aka.ms/deploytoazurebutton"/>
 </a>
 
+Use this button if you want to deploy to the Azure Government Cloud.
+
 <a href="https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FMicrosoft%2Ffhir-server%2Fmain%2Fsamples%2Ftemplates%2Fdefault-azuredeploy.json" target="_blank"> 
     <img src="https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.png">
 </a>


### PR DESCRIPTION
## Description

In [deployment](https://github.com/Microsoft/fhir-server/blob/main/docs/DefaultDeployment.md#deploying-the-fhir-server-template) page, **Deploy to Azure** button is crush from my side due to the security certificate error, the newest Azure document on [Deploy on github](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/deploy-to-azure-button) recommends to use **https://aka.ms/deploytoazurebutton** as the button image.
 
![image](https://user-images.githubusercontent.com/68055742/150078850-ac8c2d86-2e8f-428b-8232-d33786a01f62.png)

![image](https://user-images.githubusercontent.com/68055742/150076511-d1f976e7-36ec-40eb-aa4a-3092522451e3.png)

## Related issues

## Testing


## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip
