### PR TITLE
add import metric notification

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/BackgroundTaskService/TaskFactory.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/BackgroundTaskService/TaskFactory.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using EnsureThat;
+using MediatR;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Context;
@@ -28,6 +29,7 @@ namespace Microsoft.Health.Fhir.Api.Features.BackgroundTaskService
         private readonly ITaskManager _taskmanager;
         private readonly IContextUpdaterFactory _contextUpdaterFactory;
         private readonly RequestContextAccessor<IFhirRequestContext> _contextAccessor;
+        private readonly IMediator _mediator;
         private readonly ILoggerFactory _loggerFactory;
 
         public TaskFactory(
@@ -40,6 +42,7 @@ namespace Microsoft.Health.Fhir.Api.Features.BackgroundTaskService
             ISequenceIdGenerator<long> sequenceIdGenerator,
             IIntegrationDataStoreClient integrationDataStoreClient,
             RequestContextAccessor<IFhirRequestContext> contextAccessor,
+            IMediator mediator,
             ILoggerFactory loggerFactory)
         {
             EnsureArg.IsNotNull(importResourceLoader, nameof(importResourceLoader));
@@ -51,6 +54,7 @@ namespace Microsoft.Health.Fhir.Api.Features.BackgroundTaskService
             EnsureArg.IsNotNull(sequenceIdGenerator, nameof(sequenceIdGenerator));
             EnsureArg.IsNotNull(integrationDataStoreClient, nameof(integrationDataStoreClient));
             EnsureArg.IsNotNull(contextAccessor, nameof(contextAccessor));
+            EnsureArg.IsNotNull(mediator, nameof(mediator));
             EnsureArg.IsNotNull(loggerFactory, nameof(loggerFactory));
 
             _importResourceLoader = importResourceLoader;
@@ -62,6 +66,7 @@ namespace Microsoft.Health.Fhir.Api.Features.BackgroundTaskService
             _taskmanager = taskmanager;
             _contextUpdaterFactory = contextUpdaterFactory;
             _contextAccessor = contextAccessor;
+            _mediator = mediator;
             _loggerFactory = loggerFactory;
         }
 
@@ -92,6 +97,7 @@ namespace Microsoft.Health.Fhir.Api.Features.BackgroundTaskService
                 ImportOrchestratorTaskContext orchestratorTaskProgress = string.IsNullOrEmpty(taskInfo.Context) ? new ImportOrchestratorTaskContext() : JsonConvert.DeserializeObject<ImportOrchestratorTaskContext>(taskInfo.Context);
 
                 return new ImportOrchestratorTask(
+                    _mediator,
                     inputData,
                     orchestratorTaskProgress,
                     _taskmanager,

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Import/ImportOrchestratorTaskTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Import/ImportOrchestratorTaskTests.cs
@@ -106,6 +106,16 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Import
             Assert.Equal(TaskResult.Fail, result.Result);
             Assert.Equal(HttpStatusCode.BadRequest, resultDetails.HttpStatusCode);
             Assert.NotEmpty(resultDetails.ErrorMessage);
+
+            _ = mediator.Received().Publish(
+                Arg.Is<ImportTaskMetricsNotification>(
+                    notification => notification.Id == importOrchestratorTaskInputData.TaskId &&
+                    notification.Status == TaskResult.Fail.ToString() &&
+                    notification.CreatedTime == importOrchestratorTaskInputData.TaskCreateTime &&
+                    notification.DataSize == null &&
+                    notification.SucceedCount == null &&
+                    notification.FailedCount == null),
+                Arg.Any<CancellationToken>());
         }
 
         [Fact]
@@ -160,6 +170,16 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Import
             Assert.Equal(TaskResult.Fail, result.Result);
             Assert.Equal(HttpStatusCode.Unauthorized, resultDetails.HttpStatusCode);
             Assert.NotEmpty(resultDetails.ErrorMessage);
+
+            _ = mediator.Received().Publish(
+                Arg.Is<ImportTaskMetricsNotification>(
+                    notification => notification.Id == importOrchestratorTaskInputData.TaskId &&
+                    notification.Status == TaskResult.Fail.ToString() &&
+                    notification.CreatedTime == importOrchestratorTaskInputData.TaskCreateTime &&
+                    notification.DataSize == null &&
+                    notification.SucceedCount == null &&
+                    notification.FailedCount == null),
+                Arg.Any<CancellationToken>());
         }
 
         [Fact]
@@ -240,6 +260,16 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Import
             await Assert.ThrowsAnyAsync<RetriableTaskException>(() => orchestratorTask.ExecuteAsync());
             ImportOrchestratorTaskContext context = JsonConvert.DeserializeObject<ImportOrchestratorTaskContext>(latestContext);
             Assert.Equal(ImportOrchestratorTaskProgress.InputResourcesValidated, context.Progress);
+
+            _ = mediator.Received().Publish(
+                Arg.Is<ImportTaskMetricsNotification>(
+                    notification => notification.Id == importOrchestratorTaskInputData.TaskId &&
+                    notification.Status == TaskResult.Fail.ToString() &&
+                    notification.CreatedTime == importOrchestratorTaskInputData.TaskCreateTime &&
+                    notification.DataSize == null &&
+                    notification.SucceedCount == null &&
+                    notification.FailedCount == null),
+                Arg.Any<CancellationToken>());
         }
 
         [Fact]
@@ -314,6 +344,16 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Import
             await Assert.ThrowsAnyAsync<RetriableTaskException>(() => orchestratorTask.ExecuteAsync());
             ImportOrchestratorTaskContext context = JsonConvert.DeserializeObject<ImportOrchestratorTaskContext>(latestContext);
             Assert.Equal(ImportOrchestratorTaskProgress.PreprocessCompleted, context.Progress);
+
+            _ = mediator.Received().Publish(
+                Arg.Is<ImportTaskMetricsNotification>(
+                    notification => notification.Id == importOrchestratorTaskInputData.TaskId &&
+                    notification.Status == TaskResult.Fail.ToString() &&
+                    notification.CreatedTime == importOrchestratorTaskInputData.TaskCreateTime &&
+                    notification.DataSize == null &&
+                    notification.SucceedCount == null &&
+                    notification.FailedCount == null),
+                Arg.Any<CancellationToken>());
         }
 
         [Fact]
@@ -382,6 +422,15 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Import
             await Assert.ThrowsAnyAsync<RetriableTaskException>(() => orchestratorTask.ExecuteAsync());
             ImportOrchestratorTaskContext context = JsonConvert.DeserializeObject<ImportOrchestratorTaskContext>(latestContext);
             Assert.Equal(ImportOrchestratorTaskProgress.SubTaskRecordsGenerated, context.Progress);
+
+            _ = mediator.Received().Publish(
+                Arg.Is<ImportTaskMetricsNotification>(
+                    notification => notification.Id == importOrchestratorTaskInputData.TaskId &&
+                    notification.Status == TaskResult.Fail.ToString() &&
+                    notification.CreatedTime == importOrchestratorTaskInputData.TaskCreateTime &&
+                    notification.SucceedCount == null &&
+                    notification.FailedCount == null),
+                Arg.Any<CancellationToken>());
         }
 
         [Fact]
@@ -464,6 +513,15 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Import
 
             ImportOrchestratorTaskContext context = JsonConvert.DeserializeObject<ImportOrchestratorTaskContext>(latestContext);
             Assert.Equal(ImportOrchestratorTaskProgress.SubTaskRecordsGenerated, context.Progress);
+
+            _ = mediator.Received().Publish(
+                Arg.Is<ImportTaskMetricsNotification>(
+                    notification => notification.Id == importOrchestratorTaskInputData.TaskId &&
+                    notification.Status == TaskResult.Fail.ToString() &&
+                    notification.CreatedTime == importOrchestratorTaskInputData.TaskCreateTime &&
+                    notification.SucceedCount == null &&
+                    notification.FailedCount == null),
+                Arg.Any<CancellationToken>());
         }
 
         [Fact]
@@ -554,6 +612,15 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Import
             ImportOrchestratorTaskContext context = JsonConvert.DeserializeObject<ImportOrchestratorTaskContext>(latestContext);
             Assert.Equal(ImportOrchestratorTaskProgress.SubTasksCompleted, context.Progress);
             Assert.Equal(1, context.DataProcessingTasks.Count);
+
+            _ = mediator.Received().Publish(
+                Arg.Is<ImportTaskMetricsNotification>(
+                    notification => notification.Id == importOrchestratorTaskInputData.TaskId &&
+                    notification.Status == TaskResult.Fail.ToString() &&
+                    notification.CreatedTime == importOrchestratorTaskInputData.TaskCreateTime &&
+                    notification.SucceedCount == 1 &&
+                    notification.FailedCount == 1),
+                Arg.Any<CancellationToken>());
         }
 
         [Fact]
@@ -637,6 +704,15 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Import
             orchestratorTask.Cancel();
             TaskResultData taskResult = await orchestratorTask.ExecuteAsync();
             Assert.Equal(TaskResult.Canceled, taskResult.Result);
+
+            _ = mediator.Received().Publish(
+                Arg.Is<ImportTaskMetricsNotification>(
+                    notification => notification.Id == importOrchestratorTaskInputData.TaskId &&
+                    notification.Status == TaskResult.Canceled.ToString() &&
+                    notification.CreatedTime == importOrchestratorTaskInputData.TaskCreateTime &&
+                    notification.SucceedCount == null &&
+                    notification.FailedCount == null),
+                Arg.Any<CancellationToken>());
         }
 
         private static async Task VerifyCommonOrchestratorTaskAsync(int inputFileCount, int concurrentCount, int resumeFrom = -1)
@@ -787,6 +863,15 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Import
                 Assert.True(orderedSurrogatedIdRanges[i].end > orderedSurrogatedIdRanges[i].begin);
                 Assert.True(orderedSurrogatedIdRanges[i].end <= orderedSurrogatedIdRanges[i + 1].begin);
             }
+
+            _ = mediator.Received().Publish(
+                Arg.Is<ImportTaskMetricsNotification>(
+                    notification => notification.Id == importOrchestratorTaskInputData.TaskId &&
+                    notification.Status == TaskResult.Success.ToString() &&
+                    notification.CreatedTime == importOrchestratorTaskInputData.TaskCreateTime &&
+                    notification.SucceedCount == resultDetails.Output.Sum(o => o.Count) &&
+                    notification.FailedCount == resultDetails.Error.Sum(e => e.Count)),
+                Arg.Any<CancellationToken>());
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Import/ImportOrchestratorTaskTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Import/ImportOrchestratorTaskTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using MediatR;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Health.Core;
@@ -62,6 +63,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Import
             ImportOrchestratorTaskInputData importOrchestratorTaskInputData = new ImportOrchestratorTaskInputData();
             ImportOrchestratorTaskContext importOrchestratorTaskContext = new ImportOrchestratorTaskContext();
             ITaskManager taskManager = Substitute.For<ITaskManager>();
+            IMediator mediator = Substitute.For<IMediator>();
 
             importOrchestratorTaskInputData.TaskId = Guid.NewGuid().ToString("N");
             importOrchestratorTaskInputData.TaskCreateTime = Clock.UtcNow;
@@ -87,6 +89,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Import
             sequenceIdGenerator.GetCurrentSequenceId().Returns(_ => 0L);
 
             ImportOrchestratorTask orchestratorTask = new ImportOrchestratorTask(
+                mediator,
                 importOrchestratorTaskInputData,
                 importOrchestratorTaskContext,
                 taskManager,
@@ -117,6 +120,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Import
             ImportOrchestratorTaskInputData importOrchestratorTaskInputData = new ImportOrchestratorTaskInputData();
             ImportOrchestratorTaskContext importOrchestratorTaskContext = new ImportOrchestratorTaskContext();
             ITaskManager taskManager = Substitute.For<ITaskManager>();
+            IMediator mediator = Substitute.For<IMediator>();
 
             importOrchestratorTaskInputData.TaskId = Guid.NewGuid().ToString("N");
             importOrchestratorTaskInputData.TaskCreateTime = Clock.UtcNow;
@@ -139,6 +143,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Import
             sequenceIdGenerator.GetCurrentSequenceId().Returns(_ => 0L);
 
             ImportOrchestratorTask orchestratorTask = new ImportOrchestratorTask(
+                mediator,
                 importOrchestratorTaskInputData,
                 importOrchestratorTaskContext,
                 taskManager,
@@ -166,6 +171,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Import
             ILoggerFactory loggerFactory = new NullLoggerFactory();
             IIntegrationDataStoreClient integrationDataStoreClient = Substitute.For<IIntegrationDataStoreClient>();
             ISequenceIdGenerator<long> sequenceIdGenerator = Substitute.For<ISequenceIdGenerator<long>>();
+            IMediator mediator = Substitute.For<IMediator>();
             ImportOrchestratorTaskInputData importOrchestratorTaskInputData = new ImportOrchestratorTaskInputData();
             ImportOrchestratorTaskContext importOrchestratorTaskContext = new ImportOrchestratorTaskContext();
             List<(long begin, long end)> surrogatedIdRanges = new List<(long begin, long end)>();
@@ -219,6 +225,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Import
             sequenceIdGenerator.GetCurrentSequenceId().Returns(_ => 0L);
 
             ImportOrchestratorTask orchestratorTask = new ImportOrchestratorTask(
+                mediator,
                 importOrchestratorTaskInputData,
                 importOrchestratorTaskContext,
                 taskManager,
@@ -244,6 +251,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Import
             ILoggerFactory loggerFactory = new NullLoggerFactory();
             IIntegrationDataStoreClient integrationDataStoreClient = Substitute.For<IIntegrationDataStoreClient>();
             ISequenceIdGenerator<long> sequenceIdGenerator = Substitute.For<ISequenceIdGenerator<long>>();
+            IMediator mediator = Substitute.For<IMediator>();
             ImportOrchestratorTaskInputData importOrchestratorTaskInputData = new ImportOrchestratorTaskInputData();
             ImportOrchestratorTaskContext importOrchestratorTaskContext = new ImportOrchestratorTaskContext();
             List<(long begin, long end)> surrogatedIdRanges = new List<(long begin, long end)>();
@@ -291,6 +299,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Import
             sequenceIdGenerator.GetCurrentSequenceId().Returns<long>(_ => throw new InvalidOperationException());
 
             ImportOrchestratorTask orchestratorTask = new ImportOrchestratorTask(
+                mediator,
                 importOrchestratorTaskInputData,
                 importOrchestratorTaskContext,
                 taskManager,
@@ -316,6 +325,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Import
             ILoggerFactory loggerFactory = new NullLoggerFactory();
             IIntegrationDataStoreClient integrationDataStoreClient = Substitute.For<IIntegrationDataStoreClient>();
             ISequenceIdGenerator<long> sequenceIdGenerator = Substitute.For<ISequenceIdGenerator<long>>();
+            IMediator mediator = Substitute.For<IMediator>();
             ImportOrchestratorTaskInputData importOrchestratorTaskInputData = new ImportOrchestratorTaskInputData();
             ImportOrchestratorTaskContext importOrchestratorTaskContext = new ImportOrchestratorTaskContext();
             List<(long begin, long end)> surrogatedIdRanges = new List<(long begin, long end)>();
@@ -357,6 +367,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Import
             sequenceIdGenerator.GetCurrentSequenceId().Returns<long>(_ => 0L);
 
             ImportOrchestratorTask orchestratorTask = new ImportOrchestratorTask(
+                mediator,
                 importOrchestratorTaskInputData,
                 importOrchestratorTaskContext,
                 taskManager,
@@ -382,6 +393,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Import
             ILoggerFactory loggerFactory = new NullLoggerFactory();
             IIntegrationDataStoreClient integrationDataStoreClient = Substitute.For<IIntegrationDataStoreClient>();
             ISequenceIdGenerator<long> sequenceIdGenerator = Substitute.For<ISequenceIdGenerator<long>>();
+            IMediator mediator = Substitute.For<IMediator>();
             ImportOrchestratorTaskInputData importOrchestratorTaskInputData = new ImportOrchestratorTaskInputData();
             ImportOrchestratorTaskContext importOrchestratorTaskContext = new ImportOrchestratorTaskContext();
             List<(long begin, long end)> surrogatedIdRanges = new List<(long begin, long end)>();
@@ -435,6 +447,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Import
             sequenceIdGenerator.GetCurrentSequenceId().Returns<long>(_ => 0L);
 
             ImportOrchestratorTask orchestratorTask = new ImportOrchestratorTask(
+                mediator,
                 importOrchestratorTaskInputData,
                 importOrchestratorTaskContext,
                 taskManager,
@@ -462,6 +475,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Import
             ILoggerFactory loggerFactory = new NullLoggerFactory();
             IIntegrationDataStoreClient integrationDataStoreClient = Substitute.For<IIntegrationDataStoreClient>();
             ISequenceIdGenerator<long> sequenceIdGenerator = Substitute.For<ISequenceIdGenerator<long>>();
+            IMediator mediator = Substitute.For<IMediator>();
             ImportOrchestratorTaskInputData importOrchestratorTaskInputData = new ImportOrchestratorTaskInputData();
             ImportOrchestratorTaskContext importOrchestratorTaskContext = new ImportOrchestratorTaskContext();
             List<(long begin, long end)> surrogatedIdRanges = new List<(long begin, long end)>();
@@ -524,6 +538,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Import
             sequenceIdGenerator.GetCurrentSequenceId().Returns<long>(_ => 0L);
 
             ImportOrchestratorTask orchestratorTask = new ImportOrchestratorTask(
+                mediator,
                 importOrchestratorTaskInputData,
                 importOrchestratorTaskContext,
                 taskManager,
@@ -550,6 +565,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Import
             ILoggerFactory loggerFactory = new NullLoggerFactory();
             IIntegrationDataStoreClient integrationDataStoreClient = Substitute.For<IIntegrationDataStoreClient>();
             ISequenceIdGenerator<long> sequenceIdGenerator = Substitute.For<ISequenceIdGenerator<long>>();
+            IMediator mediator = Substitute.For<IMediator>();
             ImportOrchestratorTaskInputData importOrchestratorTaskInputData = new ImportOrchestratorTaskInputData();
             ImportOrchestratorTaskContext importOrchestratorTaskContext = new ImportOrchestratorTaskContext();
             List<(long begin, long end)> surrogatedIdRanges = new List<(long begin, long end)>();
@@ -606,6 +622,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Import
             sequenceIdGenerator.GetCurrentSequenceId().Returns<long>(_ => 0L);
 
             ImportOrchestratorTask orchestratorTask = new ImportOrchestratorTask(
+                mediator,
                 importOrchestratorTaskInputData,
                 importOrchestratorTaskContext,
                 taskManager,
@@ -630,6 +647,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Import
             ILoggerFactory loggerFactory = new NullLoggerFactory();
             IIntegrationDataStoreClient integrationDataStoreClient = Substitute.For<IIntegrationDataStoreClient>();
             ISequenceIdGenerator<long> sequenceIdGenerator = Substitute.For<ISequenceIdGenerator<long>>();
+            IMediator mediator = Substitute.For<IMediator>();
             ImportOrchestratorTaskInputData importOrchestratorTaskInputData = new ImportOrchestratorTaskInputData();
             ImportOrchestratorTaskContext importOrchestratorTaskContext = new ImportOrchestratorTaskContext();
             List<(long begin, long end)> surrogatedIdRanges = new List<(long begin, long end)>();
@@ -727,6 +745,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Import
             sequenceIdGenerator.GetCurrentSequenceId().Returns(_ => 0L);
 
             ImportOrchestratorTask orchestratorTask = new ImportOrchestratorTask(
+                mediator,
                 importOrchestratorTaskInputData,
                 importOrchestratorTaskContext,
                 taskManager,

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportOrchestratorTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportOrchestratorTask.cs
@@ -13,6 +13,7 @@ using EnsureThat;
 using MediatR;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
+using Microsoft.Health.Core;
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.TaskManagement;
@@ -287,7 +288,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
                 _orchestratorInputData.TaskId,
                 taskResult.ToString(),
                 _orchestratorInputData.TaskCreateTime,
-                DateTimeOffset.Now.ToUniversalTime(),
+                Clock.UtcNow,
                 _orchestratorTaskContext.TotalSizeInBytes,
                 succeedCount,
                 failedCount);

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportOrchestratorTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportOrchestratorTask.cs
@@ -291,7 +291,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
                 _orchestratorInputData.TaskId,
                 taskResult.ToString(),
                 _orchestratorInputData.TaskCreateTime,
-                DateTimeOffset.Now,
+                DateTimeOffset.Now.ToUniversalTime(),
                 _orchestratorTaskContext.TotalSizeInBytes,
                 succeedCount,
                 failedCount);

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportOrchestratorTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportOrchestratorTask.cs
@@ -153,7 +153,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
 
                 await CancelProcessingTasksAsync();
                 taskResultData = new TaskResultData(TaskResult.Canceled, taskCanceledEx.Message);
-                await SendImportMetricsNotification(taskResultData.Result);
             }
             catch (OperationCanceledException canceledEx)
             {
@@ -161,7 +160,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
 
                 await CancelProcessingTasksAsync();
                 taskResultData = new TaskResultData(TaskResult.Canceled, canceledEx.Message);
-                await SendImportMetricsNotification(taskResultData.Result);
             }
             catch (IntegrationDataStoreException integrationDataStoreEx)
             {
@@ -174,7 +172,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
                 };
 
                 taskResultData = new TaskResultData(TaskResult.Fail, JsonConvert.SerializeObject(errorResult));
-                await SendImportMetricsNotification(taskResultData.Result);
             }
             catch (ImportFileEtagNotMatchException eTagEx)
             {
@@ -187,7 +184,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
                 };
 
                 taskResultData = new TaskResultData(TaskResult.Fail, JsonConvert.SerializeObject(errorResult));
-                await SendImportMetricsNotification(taskResultData.Result);
             }
             catch (ImportProcessingException processingEx)
             {
@@ -200,7 +196,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
                 };
 
                 taskResultData = new TaskResultData(TaskResult.Fail, JsonConvert.SerializeObject(errorResult));
-                await SendImportMetricsNotification(taskResultData.Result);
             }
             catch (Exception ex)
             {
@@ -248,8 +243,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
             if (taskResultData == null) // No exception
             {
                 taskResultData = new TaskResultData(TaskResult.Success, JsonConvert.SerializeObject(_orchestratorTaskContext.ImportResult));
-                await SendImportMetricsNotification(taskResultData.Result);
             }
+
+            await SendImportMetricsNotification(taskResultData.Result);
 
             return taskResultData;
         }
@@ -309,7 +305,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
             Dictionary<Uri, TaskInfo> result = new Dictionary<Uri, TaskInfo>();
 
             long beginSequenceId = _sequenceIdGenerator.GetCurrentSequenceId();
-            long totalSizeInBYtes = 0;
+            long totalSizeInBytes = 0;
 
             foreach (var input in _orchestratorInputData.Input)
             {
@@ -344,10 +340,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
 
                 beginSequenceId = endSequenceId;
 
-                totalSizeInBYtes += blobSizeInBytes;
+                totalSizeInBytes += blobSizeInBytes;
             }
 
-            _orchestratorTaskContext.TotalSizeInBytes = totalSizeInBYtes;
+            _orchestratorTaskContext.TotalSizeInBytes = totalSizeInBytes;
 
             return result;
         }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportOrchestratorTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportOrchestratorTask.cs
@@ -284,8 +284,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
 
         private async Task SendImportMetricsNotification(TaskResult taskResult)
         {
-            long succeedCount = _orchestratorTaskContext.ImportResult.Output.Sum(output => output.Count);
-            long failedCount = _orchestratorTaskContext.ImportResult.Error.Sum(error => error.Count);
+            long? succeedCount = _orchestratorTaskContext.ImportResult?.Output?.Sum(output => output.Count);
+            long? failedCount = _orchestratorTaskContext.ImportResult?.Error?.Sum(error => error.Count);
 
             ImportTaskMetricsNotification importTaskMetricsNotification = new ImportTaskMetricsNotification(
                 _orchestratorInputData.TaskId,
@@ -309,6 +309,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
             Dictionary<Uri, TaskInfo> result = new Dictionary<Uri, TaskInfo>();
 
             long beginSequenceId = _sequenceIdGenerator.GetCurrentSequenceId();
+            long totalSizeInBYtes = 0;
 
             foreach (var input in _orchestratorInputData.Input)
             {
@@ -343,8 +344,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
 
                 beginSequenceId = endSequenceId;
 
-                _orchestratorTaskContext.TotalSizeInBytes += blobSizeInBytes;
+                totalSizeInBYtes += blobSizeInBytes;
             }
+
+            _orchestratorTaskContext.TotalSizeInBytes = totalSizeInBYtes;
 
             return result;
         }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportOrchestratorTaskContext.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportOrchestratorTaskContext.cs
@@ -31,6 +31,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
         /// <summary>
         /// Import total file size
         /// </summary>
-        public long TotalSizeInBytes { get; set; }
+        public long? TotalSizeInBytes { get; set; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportOrchestratorTaskContext.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportOrchestratorTaskContext.cs
@@ -27,5 +27,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
         /// Import result during execution
         /// </summary>
         public ImportTaskResult ImportResult { get; set; }
+
+        /// <summary>
+        /// Import total file size
+        /// </summary>
+        public long TotalSizeInBytes { get; set; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportTaskMetricsNotification.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportTaskMetricsNotification.cs
@@ -1,0 +1,49 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.Health.Fhir.Core.Features.Metrics;
+
+namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
+{
+    public class ImportTaskMetricsNotification : IMetricsNotification
+    {
+        public ImportTaskMetricsNotification(
+            string id,
+            string status,
+            DateTimeOffset createdTime,
+            DateTimeOffset endTime,
+            long dataSize,
+            long succeedCount,
+            long failedCount)
+        {
+            Id = id;
+            Status = status;
+            CreatedTime = createdTime;
+            EndTime = endTime;
+            DataSize = dataSize;
+            SucceedCount = succeedCount;
+            FailedCount = failedCount;
+        }
+
+        public string FhirOperation { get; }
+
+        public string ResourceType { get; }
+
+        public string Id { get; }
+
+        public string Status { get; }
+
+        public DateTimeOffset CreatedTime { get; }
+
+        public DateTimeOffset EndTime { get; }
+
+        public long DataSize { get; }
+
+        public long SucceedCount { get; }
+
+        public long FailedCount { get; }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportTaskMetricsNotification.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportTaskMetricsNotification.cs
@@ -15,9 +15,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
             string status,
             DateTimeOffset createdTime,
             DateTimeOffset endTime,
-            long dataSize,
-            long succeedCount,
-            long failedCount)
+            long? dataSize,
+            long? succeedCount,
+            long? failedCount)
         {
             Id = id;
             Status = status;
@@ -40,10 +40,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
 
         public DateTimeOffset EndTime { get; }
 
-        public long DataSize { get; }
+        public long? DataSize { get; }
 
-        public long SucceedCount { get; }
+        public long? SucceedCount { get; }
 
-        public long FailedCount { get; }
+        public long? FailedCount { get; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportTaskMetricsNotification.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportTaskMetricsNotification.cs
@@ -5,6 +5,7 @@
 
 using System;
 using Microsoft.Health.Fhir.Core.Features.Metrics;
+using Microsoft.Health.Fhir.ValueSets;
 
 namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
 {
@@ -19,6 +20,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
             long? succeedCount,
             long? failedCount)
         {
+            FhirOperation = AuditEventSubType.Import;
+            ResourceType = null;
+
             Id = id;
             Status = status;
             CreatedTime = createdTime;

--- a/src/Microsoft.Health.Fhir.Shared.Client/FhirClient.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Client/FhirClient.cs
@@ -404,12 +404,12 @@ namespace Microsoft.Health.Fhir.Client
             return response.Content.Headers.ContentLocation;
         }
 
-        public async Task CancelImport(Uri contentLocation, CancellationToken cancellationToken = default)
+        public async Task<HttpResponseMessage> CancelImport(Uri contentLocation, CancellationToken cancellationToken = default)
         {
             using var message = new HttpRequestMessage(HttpMethod.Delete, contentLocation);
             message.Headers.Add("Prefer", "respond-async");
 
-            await HttpClient.SendAsync(message, cancellationToken);
+            return await HttpClient.SendAsync(message, cancellationToken);
         }
 
         public async Task<HttpResponseMessage> CheckImportAsync(Uri contentLocation, CancellationToken cancellationToken = default)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTestFixture.cs
@@ -4,15 +4,20 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using MediatR;
 using Microsoft.Azure.Storage;
 using Microsoft.Azure.Storage.Auth;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Health.Fhir.Core.Features.Operations.Import;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Microsoft.Health.Fhir.Tests.E2E.Rest.Metric;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Import
 {
     public class ImportTestFixture<T> : HttpIntegrationTestFixture<T>
     {
         private const string LocalIntegrationStoreConnectionString = "UseDevelopmentStorage=true";
+        private MetricHandler _metricHandler;
 
         public ImportTestFixture(DataStore dataStore, Format format, TestFhirServerFactory testFhirServerFactory)
             : base(dataStore, format, testFhirServerFactory)
@@ -39,6 +44,11 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Import
             }
 
             CloudStorageAccount = storageAccount;
+        }
+
+        public MetricHandler MetricHandler
+        {
+            get => _metricHandler ?? (_metricHandler = (MetricHandler)(TestFhirServer as InProcTestFhirServer)?.Server.Host.Services.GetRequiredService<INotificationHandler<ImportTaskMetricsNotification>>());
         }
 
         public CloudStorageAccount CloudStorageAccount { get; private set; }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/StartupForImportTestProvider.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/StartupForImportTestProvider.cs
@@ -3,10 +3,12 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using MediatR;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Health.Fhir.Shared.Tests.E2E;
-using Microsoft.Health.Fhir.Shared.Tests.E2E.Rest;
+using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Health.Fhir.Core.Features.Operations.Import;
+using Microsoft.Health.Fhir.Tests.E2E.Rest.Metric;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Import
 {
@@ -21,6 +23,10 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Import
         public override void ConfigureServices(IServiceCollection services)
         {
             base.ConfigureServices(services);
+
+            services.Add<MetricHandler>()
+                .Singleton()
+                .AsService<INotificationHandler<ImportTaskMetricsNotification>>();
         }
     }
 }


### PR DESCRIPTION
## Description
This PR used to send import operation metric notification using mediator, it only contains the send part, and receive part will be in PaaS side.

## Related issues
Addresses [issue #].

## Testing
Add several tests in both UT and E2E.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
