### PR TITLE
Matched resources should not also be _included

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Persistence/ResourceKey.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Persistence/ResourceKey.cs
@@ -3,12 +3,13 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using EnsureThat;
 using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Core.Features.Persistence
 {
-    public class ResourceKey
+    public class ResourceKey : IEquatable<ResourceKey>
     {
         public ResourceKey(string resourceType, string id, string versionId = null)
         {
@@ -26,5 +27,47 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
         public string VersionId { get; }
 
         public string ResourceType { get; }
+
+        public bool Equals(ResourceKey other)
+        {
+            if (ReferenceEquals(null, other))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return Id == other.Id &&
+                   VersionId == other.VersionId &&
+                   ResourceType == other.ResourceType;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            if (obj.GetType() != this.GetType())
+            {
+                return false;
+            }
+
+            return Equals((ResourceKey)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Id, VersionId, ResourceType);
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -857,7 +857,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     StringBuilder.AppendLine();
                 }
 
-                StringBuilder.Append("FROM ").AppendLine(includeCte);
+                // Matched results should be excluded from included CTEs
+                StringBuilder.Append("FROM ").Append(includeCte)
+                    .Append(" WHERE NOT EXISTS (SELECT * FROM ").Append(_cteMainSelect)
+                    .Append(" WHERE ").Append(_cteMainSelect).Append(".Sid1 = ").Append(includeCte).Append(".Sid1")
+                    .Append(" AND ").Append(_cteMainSelect).Append(".T1 = ").Append(includeCte).AppendLine(".T1)");
             }
         }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTestFixture.cs
@@ -182,10 +182,7 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Search
                 Meta = meta,
             })).Resource;
 
-            LocationPartOfSelf = (await TestFhirClient.CreateAsync(new Location
-            {
-                Meta = meta,
-            })).Resource;
+            LocationPartOfSelf = (await TestFhirClient.CreateAsync(new Location())).Resource;
 
             LocationPartOfSelf.PartOf = new ResourceReference($"{LocationPartOfSelf.TypeName}/{LocationPartOfSelf.Id}");
             LocationPartOfSelf = (await TestFhirClient.UpdateAsync(LocationPartOfSelf)).Resource;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTestFixture.cs
@@ -98,6 +98,8 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Search
 
         public Location Location { get; private set; }
 
+        public Location LocationPartOfSelf { get; private set; }
+
         protected override async Task OnInitializedAsync()
         {
             Tag = Guid.NewGuid().ToString();
@@ -179,6 +181,14 @@ namespace Microsoft.Health.Fhir.Shared.Tests.E2E.Rest.Search
                 ManagingOrganization = new ResourceReference($"Organization/{Organization.Id}"),
                 Meta = meta,
             })).Resource;
+
+            LocationPartOfSelf = (await TestFhirClient.CreateAsync(new Location
+            {
+                Meta = meta,
+            })).Resource;
+
+            LocationPartOfSelf.PartOf = new ResourceReference($"{LocationPartOfSelf.TypeName}/{LocationPartOfSelf.Id}");
+            LocationPartOfSelf = (await TestFhirClient.UpdateAsync(LocationPartOfSelf)).Resource;
 
             var group = new Group
             {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
@@ -490,6 +490,25 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             ValidateBundleUrl(Client.HttpClient.BaseAddress, ResourceType.Patient, query, bundle.Link[0].Url);
         }
 
+        [InlineData("_include")]
+        [InlineData("_revinclude")]
+        [Theory]
+        public async Task GivenAnIncludeSearchExpressionWithLocationLinkedToItself_WhenSearched_ThenCorrectBundleShouldBeReturned(string includeType)
+        {
+            string query = $"_id={Fixture.LocationPartOfSelf.Id}&{includeType}=Location:partof";
+
+            Bundle bundle = await Client.SearchAsync(ResourceType.Location, query);
+
+            // The matched resource shouldn't be returned as an include
+            ValidateBundle(
+                bundle,
+                Fixture.LocationPartOfSelf);
+
+            ValidateSearchEntryMode(bundle, ResourceType.Location);
+
+            ValidateBundleUrl(Client.HttpClient.BaseAddress, ResourceType.Location, query, bundle.Link[0].Url);
+        }
+
         [Fact]
         public async Task GivenARevIncludeSearchExpressionWithMultipleResourceTableParametersAndTableParameters_WhenSearched_ThenCorrectBundleShouldBeReturned()
         {


### PR DESCRIPTION
## Description
Adds a filter so that if a resource is in the "matched" set of results, it should not also be there as an "include".

Limitation: this is only for the current page, it doesn't guarantee uniqueness across pages.

## Related issues
Addresses #2037.

## Testing
Adds E2E tests

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [x] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch (bug)
