### PR TITLE
Record exception if SearchParameterStatus out of sync with resource

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
@@ -237,7 +237,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
 
                 if (_searchParameterDefinitionManager.TryGetSearchParameter(searchParam.Uri.OriginalString, out var existingSearchParam))
                 {
-                    // if the search parameter exists we should delete the old information currently stored
+                    // if the previous version of the search parameter exists we should delete the old information currently stored
                     DeleteSearchParameter(searchParam.Uri.OriginalString);
                 }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
@@ -206,7 +206,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
                     // and there is an entry in the list of updates with a delete status then it indicates
                     // the search parameter was deleted before it was added to this instance, and there is no issue
                     // however if there is no indication that the search parameter was deleted, then there is a problem
-                    throw new UnableToUpdateSearchParameterException(paramStatus.Uri);
+                    _logger.LogError(Resources.UnableToUpdateSearchParameter, paramStatus.Uri);
                 }
             }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
@@ -12,6 +12,7 @@ using EnsureThat;
 using MediatR;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.Core;
+using Microsoft.Health.Fhir.Core;
 using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Search.Parameters;
 using Microsoft.Health.Fhir.Core.Messages.Search;
@@ -206,7 +207,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
                     // and there is an entry in the list of updates with a delete status then it indicates
                     // the search parameter was deleted before it was added to this instance, and there is no issue
                     // however if there is no indication that the search parameter was deleted, then there is a problem
-                    _logger.LogError(Resources.UnableToUpdateSearchParameter, paramStatus.Uri);
+                    _logger.LogError(Core.Resources.UnableToUpdateSearchParameter, paramStatus.Uri);
                 }
             }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -909,7 +909,17 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
             var rawResource = new RawResource(searchParam.ToJson(), FhirResourceFormat.Json, isMetaSet: false);
             var resourceRequest = new ResourceRequest(WebRequestMethods.Http.Post);
             var compartmentIndices = Substitute.For<CompartmentIndices>();
-            var searchParamInfo = new SearchParameterInfo("url", "url", ValueSets.SearchParamType.Uri, new Uri("http://hl7.org/fhir/SearchParameter/conformance-url"));
+            SearchParameterInfo searchParamInfo = null;
+
+            if (ModelInfoProvider.Instance.Version == FhirSpecification.Stu3)
+            {
+                searchParamInfo = new SearchParameterInfo("url", "url", ValueSets.SearchParamType.Uri, new Uri("http://hl7.org/fhir/SearchParameter/SearchParameter-url"));
+            }
+            else
+            {
+                searchParamInfo = new SearchParameterInfo("url", "url", ValueSets.SearchParamType.Uri, new Uri("http://hl7.org/fhir/SearchParameter/conformance-url"));
+            }
+
             var searchParamValue = new UriSearchValue(searchParam.Url, false);
             List<SearchIndexEntry> searchIndices = null;
             if (!deleted)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -567,7 +567,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
 
             SearchParameter searchParam = await CreateSearchParam(searchParamName, SearchParamType.String, ResourceType.Patient, "Patient.name", searchParamCode);
 
-            var searchParamWrapper = CreateSearchParamResourceWrapper(searchParam, id: randomName);
+            var searchParamWrapper = CreateSearchParamResourceWrapper(searchParam);
 
             await _scopedDataStore.Value.UpsertAsync(searchParamWrapper, null, true, true, CancellationToken.None);
 
@@ -902,7 +902,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
             return wrapper;
         }
 
-        private ResourceWrapper CreateSearchParamResourceWrapper(SearchParameter searchParam, string id = "searchParam1", bool deleted = false)
+        private ResourceWrapper CreateSearchParamResourceWrapper(SearchParameter searchParam, bool deleted = false)
         {
             searchParam.Id = "searchParam1";
             var resourceElement = searchParam.ToResourceElement();

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -681,13 +681,11 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                     keepHistory: true,
                     cancellationToken: CancellationToken.None);
 
-                await _searchParameterStatusManager.DeleteSearchParameterStatusAsync(searchParam.Url, CancellationToken.None);
-
                 await _searchParameterOperations2.GetAndApplySearchParameterUpdates(CancellationToken.None);
 
                 // After trying to sync the new "supported" status, but finding the resource missing, we should not add it to the
                 // searchparameterdefinitionmanager
-                tryGetSearchParamResult = _searchParameterDefinitionManager2.TryGetSearchParameter(searchParam.Url, out searchParamInfo);
+                var tryGetSearchParamResult = _searchParameterDefinitionManager2.TryGetSearchParameter(searchParam.Url, out searchParamInfo);
                 Assert.False(tryGetSearchParamResult);
             }
             finally


### PR DESCRIPTION
## Description
It is possible with failures during certain race conditions between multiple FHIR instances to get the SearchParameterStatus out of sync with the underlying SearchParamterResource object.  Currently the service throws an exception, but we will now log the error.

Also added integration tests which replicate the issue.

## Related issues
Addresses [issue [AB#87426](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/87426)].

## Testing
New integration tests added which simulate a second FHIR service instance.

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [X] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [X] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
