### PR TITLE
Readds core to resource path

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Persistence/WeakETag.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Persistence/WeakETag.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
             if (!match.Success)
             {
                 // This throws a bad request exception because it was potentially supplied by an end user
-                throw new BadRequestException(string.Format(Resources.WeakETagFormatRequired, weakETag));
+                throw new BadRequestException(string.Format(Core.Resources.WeakETagFormatRequired, weakETag));
             }
 
             return new WeakETag(match.Groups[1].Value);


### PR DESCRIPTION
## Description
Part of the path to a string resource was accidentally removed in PR #2467. This PR adds it back in.

## FHIR Team Checklist
- ✅ **Update the title** of the PR to be succinct and less than 50 characters
- ✅ **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- ✅ Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- ✅ Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- ✅ Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- ✅ CI is green before merge
- ✅ Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
None (bug fix)
