### PR TITLE
Updates and resolves nuget package versions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,7 +26,7 @@
   <PropertyGroup>
     <RuntimePackageVersion>5.0.0</RuntimePackageVersion>
     <AspNetPackageVersion>5.0.13</AspNetPackageVersion>
-    <HealthcareSharedPackageVersion>4.0.10</HealthcareSharedPackageVersion>
+    <HealthcareSharedPackageVersion>4.0.17</HealthcareSharedPackageVersion>
     <Hl7FhirVersion>3.6.0</Hl7FhirVersion>
   </PropertyGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,7 +26,7 @@
   <PropertyGroup>
     <RuntimePackageVersion>5.0.0</RuntimePackageVersion>
     <AspNetPackageVersion>5.0.13</AspNetPackageVersion>
-    <HealthcareSharedPackageVersion>4.0.17</HealthcareSharedPackageVersion>
+    <HealthcareSharedPackageVersion>4.0.24</HealthcareSharedPackageVersion>
     <Hl7FhirVersion>3.6.0</Hl7FhirVersion>
   </PropertyGroup>
 

--- a/src/Microsoft.Health.Fhir.Api.UnitTests/Microsoft.Health.Fhir.R4.Api.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.Api.UnitTests/Microsoft.Health.Fhir.R4.Api.UnitTests.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Health.Test.Utilities" Version="$(HealthcareSharedPackageVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="NSubstitute" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>

--- a/src/Microsoft.Health.Fhir.Api/Microsoft.Health.Fhir.Api.csproj
+++ b/src/Microsoft.Health.Fhir.Api/Microsoft.Health.Fhir.Api.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Ensure.That" Version="10.1.0" />
     <PackageReference Include="FluentValidation" Version="10.3.6" />
     <PackageReference Include="Hl7.Fhir.Serialization" Version="$(Hl7FhirVersion)" />
-    <PackageReference Include="MediatR" Version="10.0.1" />
+    <PackageReference Include="MediatR" Version="9.0.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(AspNetPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="$(AspNetPackageVersion)" />

--- a/src/Microsoft.Health.Fhir.Azure.UnitTests/Microsoft.Health.Fhir.Azure.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.Azure.UnitTests/Microsoft.Health.Fhir.Azure.UnitTests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="NSubstitute" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Microsoft.Health.Fhir.Core.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Microsoft.Health.Fhir.Core.UnitTests.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Health.Test.Utilities" Version="$(HealthcareSharedPackageVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="NSubstitute" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>

--- a/src/Microsoft.Health.Fhir.Core/Microsoft.Health.Fhir.Core.csproj
+++ b/src/Microsoft.Health.Fhir.Core/Microsoft.Health.Fhir.Core.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="AngleSharp" Version="0.16.1" />
     <PackageReference Include="Ensure.That" Version="10.1.0" />
     <PackageReference Include="FluentValidation" Version="10.3.6" />
-    <PackageReference Include="MediatR" Version="10.0.1" />
+    <PackageReference Include="MediatR" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="$(AspNetPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(RuntimePackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(RuntimePackageVersion)" />

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Microsoft.Health.Fhir.CosmosDb.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Microsoft.Health.Fhir.CosmosDb.UnitTests.csproj
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Health.Test.Utilities" Version="$(HealthcareSharedPackageVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="NSubstitute" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>

--- a/src/Microsoft.Health.Fhir.R4.Api/Microsoft.Health.Fhir.R4.Api.csproj
+++ b/src/Microsoft.Health.Fhir.R4.Api/Microsoft.Health.Fhir.R4.Api.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Ensure.That" Version="10.1.0" />
     <PackageReference Include="FluentValidation" Version="10.3.6" />
     <PackageReference Include="Hl7.Fhir.R4" Version="$(Hl7FhirVersion)" />
-    <PackageReference Include="MediatR" Version="10.0.1" />
+    <PackageReference Include="MediatR" Version="9.0.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="$(AspNetPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.1" />

--- a/src/Microsoft.Health.Fhir.R4.Core.UnitTests/Microsoft.Health.Fhir.R4.Core.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.R4.Core.UnitTests/Microsoft.Health.Fhir.R4.Core.UnitTests.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Health.Test.Utilities" Version="$(HealthcareSharedPackageVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="NSubstitute" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>

--- a/src/Microsoft.Health.Fhir.R4.Core/Microsoft.Health.Fhir.R4.Core.csproj
+++ b/src/Microsoft.Health.Fhir.R4.Core/Microsoft.Health.Fhir.R4.Core.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Ensure.That" Version="10.1.0" />
     <PackageReference Include="FluentValidation" Version="10.3.6" />
     <PackageReference Include="Hl7.Fhir.Specification.R4" Version="$(Hl7FhirVersion)" PrivateAssets="build;analyzers" />
-    <PackageReference Include="MediatR" Version="10.0.1" />
+    <PackageReference Include="MediatR" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(RuntimePackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="$(RuntimePackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(RuntimePackageVersion)" />

--- a/src/Microsoft.Health.Fhir.R5.Api.UnitTests/Microsoft.Health.Fhir.R5.Api.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.R5.Api.UnitTests/Microsoft.Health.Fhir.R5.Api.UnitTests.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Health.Test.Utilities" Version="$(HealthcareSharedPackageVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="NSubstitute" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>

--- a/src/Microsoft.Health.Fhir.R5.Api/Microsoft.Health.Fhir.R5.Api.csproj
+++ b/src/Microsoft.Health.Fhir.R5.Api/Microsoft.Health.Fhir.R5.Api.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Ensure.That" Version="10.1.0" />
     <PackageReference Include="FluentValidation" Version="10.3.6" />
     <PackageReference Include="Hl7.Fhir.R5" Version="$(Hl7FhirVersion)" />
-    <PackageReference Include="MediatR" Version="10.0.1" />
+    <PackageReference Include="MediatR" Version="9.0.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="$(AspNetPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.1" />

--- a/src/Microsoft.Health.Fhir.R5.Core.UnitTests/Microsoft.Health.Fhir.R5.Core.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.R5.Core.UnitTests/Microsoft.Health.Fhir.R5.Core.UnitTests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Health.Test.Utilities" Version="$(HealthcareSharedPackageVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="NSubstitute" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>

--- a/src/Microsoft.Health.Fhir.R5.Core/Microsoft.Health.Fhir.R5.Core.csproj
+++ b/src/Microsoft.Health.Fhir.R5.Core/Microsoft.Health.Fhir.R5.Core.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="AngleSharp" Version="0.16.1" />
     <PackageReference Include="Ensure.That" Version="10.1.0" />
     <PackageReference Include="FluentValidation" Version="10.3.6" />
-    <PackageReference Include="MediatR" Version="10.0.1" />
+    <PackageReference Include="MediatR" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(RuntimePackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="$(RuntimePackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(RuntimePackageVersion)" />

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/ChangeFeed/SqlServerFhirResourceChangeDataStoreTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/ChangeFeed/SqlServerFhirResourceChangeDataStoreTests.cs
@@ -24,14 +24,14 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.ChangeFeed
     {
         private readonly SqlServerFhirResourceChangeDataStore resourceChangeDataStore;
 
-        private ISqlConnectionFactory connectionFactory;
+        private ISqlConnectionBuilder sqlConnectionBuilder;
 
         public SqlServerFhirResourceChangeDataStoreTests()
         {
-            connectionFactory = Substitute.For<ISqlConnectionFactory>();
+            sqlConnectionBuilder = Substitute.For<ISqlConnectionBuilder>();
             var schemaInformation = new SchemaInformation(SchemaVersionConstants.Min, SchemaVersionConstants.Max);
             schemaInformation.Current = SchemaVersionConstants.Max;
-            resourceChangeDataStore = new SqlServerFhirResourceChangeDataStore(connectionFactory, NullLogger<SqlServerFhirResourceChangeDataStore>.Instance, schemaInformation);
+            resourceChangeDataStore = new SqlServerFhirResourceChangeDataStore(sqlConnectionBuilder, NullLogger<SqlServerFhirResourceChangeDataStore>.Instance, schemaInformation);
         }
 
         [Fact]
@@ -66,7 +66,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.ChangeFeed
         [Fact]
         public async Task GivenEmptyConnectionString_WhenGetResourceChanges_ThenInvalidOperationExceptionShouldBeThrown()
         {
-            connectionFactory.GetSqlConnectionAsync(default, default).Returns(new SqlConnection(string.Empty));
+            sqlConnectionBuilder.GetSqlConnectionAsync(default, default).Returns(new SqlConnection(string.Empty));
 
             try
             {
@@ -85,7 +85,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.ChangeFeed
             var token = source.Token;
             source.Cancel();
 
-            connectionFactory.GetSqlConnectionAsync(default, token).Returns(new SqlConnection());
+            sqlConnectionBuilder.GetSqlConnectionAsync(default, token).Returns(new SqlConnection());
 
             try
             {

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Import/SqlServerBulkImportOperationTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Import/SqlServerBulkImportOperationTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Import
 
             var schemaInformation = new SchemaInformation(SchemaVersionConstants.Min, SchemaVersionConstants.Max);
             SqlTransactionHandler sqlTransactionHandler = new SqlTransactionHandler();
-            SqlConnectionWrapperFactory sqlConnectionWrapperFactory = new SqlConnectionWrapperFactory(Substitute.For<SqlTransactionHandler>(), new SqlCommandWrapperFactory(), Substitute.For<ISqlConnectionFactory>());
+            SqlConnectionWrapperFactory sqlConnectionWrapperFactory = new SqlConnectionWrapperFactory(Substitute.For<SqlTransactionHandler>(), new SqlCommandWrapperFactory(), Substitute.For<ISqlConnectionBuilder>());
             var sqlServerTransient = Substitute.For<ISqlServerTransientFaultRetryPolicyFactory>();
 
             _sqlServerFhirDataBulkOperation = new SqlImportOperation(sqlConnectionWrapperFactory, sqlServerTransient, Substitute.For<ISqlServerFhirModel>(), operationsConfiguration, schemaInformation, NullLogger<SqlImportOperation>.Instance);

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/ChangeFeed/SqlServerFhirResourceChangeDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/ChangeFeed/SqlServerFhirResourceChangeDataStore.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.ChangeFeed
     /// </summary>
     public class SqlServerFhirResourceChangeDataStore : IChangeFeedSource<ResourceChangeData>
     {
-        private readonly ISqlConnectionFactory _sqlConnectionFactory;
+        private readonly ISqlConnectionBuilder _sqlConnectionFactory;
         private readonly ILogger<SqlServerFhirResourceChangeDataStore> _logger;
         private static readonly ConcurrentDictionary<short, string> ResourceTypeIdToTypeNameMap = new ConcurrentDictionary<short, string>();
 
@@ -42,7 +42,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.ChangeFeed
         /// <param name="sqlConnectionFactory">The SQL Connection factory.</param>
         /// <param name="logger">The logger.</param>
         /// <param name="schemaInformation">The database schema information.</param>
-        public SqlServerFhirResourceChangeDataStore(ISqlConnectionFactory sqlConnectionFactory, ILogger<SqlServerFhirResourceChangeDataStore> logger, SchemaInformation schemaInformation)
+        public SqlServerFhirResourceChangeDataStore(ISqlConnectionBuilder sqlConnectionFactory, ILogger<SqlServerFhirResourceChangeDataStore> logger, SchemaInformation schemaInformation)
         {
             EnsureArg.IsNotNull(sqlConnectionFactory, nameof(sqlConnectionFactory));
             EnsureArg.IsNotNull(logger, nameof(logger));

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
         private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager;
         private readonly ISearchParameterStatusDataStore _filebasedSearchParameterStatusDataStore;
         private readonly SecurityConfiguration _securityConfiguration;
-        private readonly ISqlConnectionFactory _sqlConnectionFactory;
+        private readonly ISqlConnectionBuilder _sqlConnectionFactory;
         private readonly IMediator _mediator;
         private readonly ILogger<SqlServerFhirModel> _logger;
         private Dictionary<string, short> _resourceTypeToId;
@@ -64,7 +64,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             ISearchParameterDefinitionManager searchParameterDefinitionManager,
             FilebasedSearchParameterStatusDataStore.Resolver filebasedRegistry,
             IOptions<SecurityConfiguration> securityConfiguration,
-            ISqlConnectionFactory sqlConnectionFactory,
+            ISqlConnectionBuilder sqlConnectionFactory,
             IMediator mediator,
             ILogger<SqlServerFhirModel> logger)
         {

--- a/src/Microsoft.Health.Fhir.Stu3.Api.UnitTests/Microsoft.Health.Fhir.Stu3.Api.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.Stu3.Api.UnitTests/Microsoft.Health.Fhir.Stu3.Api.UnitTests.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Health.Test.Utilities" Version="$(HealthcareSharedPackageVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="NSubstitute" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>

--- a/src/Microsoft.Health.Fhir.Stu3.Api/Microsoft.Health.Fhir.Stu3.Api.csproj
+++ b/src/Microsoft.Health.Fhir.Stu3.Api/Microsoft.Health.Fhir.Stu3.Api.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Ensure.That" Version="10.1.0" />
     <PackageReference Include="FluentValidation" Version="10.3.6" />
     <PackageReference Include="Hl7.Fhir.STU3" Version="$(Hl7FhirVersion)" />
-    <PackageReference Include="MediatR" Version="10.0.1" />
+    <PackageReference Include="MediatR" Version="9.0.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="$(AspNetPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.1" />

--- a/src/Microsoft.Health.Fhir.Stu3.Core.UnitTests/Microsoft.Health.Fhir.Stu3.Core.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.Stu3.Core.UnitTests/Microsoft.Health.Fhir.Stu3.Core.UnitTests.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Health.Test.Utilities" Version="$(HealthcareSharedPackageVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="NSubstitute" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>

--- a/src/Microsoft.Health.Fhir.Stu3.Core/Microsoft.Health.Fhir.Stu3.Core.csproj
+++ b/src/Microsoft.Health.Fhir.Stu3.Core/Microsoft.Health.Fhir.Stu3.Core.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="AngleSharp" Version="0.16.1" />
     <PackageReference Include="Ensure.That" Version="10.1.0" />
     <PackageReference Include="FluentValidation" Version="10.3.6" />
-    <PackageReference Include="MediatR" Version="10.0.1" />
+    <PackageReference Include="MediatR" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(RuntimePackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="$(RuntimePackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(RuntimePackageVersion)" />

--- a/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
+++ b/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
@@ -447,7 +447,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Health.Abstractions" Version="$(HealthcareSharedPackageVersion)" />
-    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="NSubstitute" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>

--- a/src/Microsoft.Health.TaskManagement.UnitTests/Microsoft.Health.TaskManagement.UnitTests.csproj
+++ b/src/Microsoft.Health.TaskManagement.UnitTests/Microsoft.Health.TaskManagement.UnitTests.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="NSubstitute" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TestFhirServer.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TestFhirServer.cs
@@ -22,6 +22,7 @@ using Microsoft.Health.Client;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Tests.E2E.Common;
+using NSubstitute;
 using Polly;
 using Polly.Retry;
 using Task = System.Threading.Tasks.Task;
@@ -127,7 +128,12 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
                     scope,
                     clientApplication.ClientId,
                     clientApplication.ClientSecret);
-                credentialProvider = new OAuth2ClientCredentialProvider(Options.Create(credentialConfiguration), authHttpClient);
+
+                var optionsMonitor = Substitute.For<IOptionsMonitor<OAuth2ClientCredentialConfiguration>>();
+                optionsMonitor.CurrentValue.Returns(credentialConfiguration);
+                optionsMonitor.Get(default).ReturnsForAnyArgs(credentialConfiguration);
+
+                credentialProvider = new OAuth2ClientCredentialProvider(optionsMonitor, authHttpClient);
             }
             else
             {
@@ -139,7 +145,12 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
                     clientApplication.ClientSecret,
                     user.UserId,
                     user.Password);
-                credentialProvider = new OAuth2UserPasswordCredentialProvider(Options.Create(credentialConfiguration), authHttpClient);
+
+                var optionsMonitor = Substitute.For<IOptionsMonitor<OAuth2UserPasswordCredentialConfiguration>>();
+                optionsMonitor.CurrentValue.Returns(credentialConfiguration);
+                optionsMonitor.Get(default).ReturnsForAnyArgs(credentialConfiguration);
+
+                credentialProvider = new OAuth2UserPasswordCredentialProvider(optionsMonitor, authHttpClient);
             }
 
             var authenticationHandler = new AuthenticationHttpMessageHandler(credentialProvider)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/ChangeFeed/SqlServerFhirResourceChangeCaptureDisabledTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/ChangeFeed/SqlServerFhirResourceChangeCaptureDisabledTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.ChangeFeed
                 var deletedResourceKey = await mediator.DeleteResourceAsync(new ResourceKey("Observation", saveResult.RawResourceElement.Id), DeleteOperation.SoftDelete);
 
                 // get resource changes
-                var resourceChangeDataStore = new SqlServerFhirResourceChangeDataStore(sqlFixture.SqlConnectionFactory, NullLogger<SqlServerFhirResourceChangeDataStore>.Instance, sqlFixture.SchemaInformation);
+                var resourceChangeDataStore = new SqlServerFhirResourceChangeDataStore(sqlFixture.SqlConnectionBuilder, NullLogger<SqlServerFhirResourceChangeDataStore>.Instance, sqlFixture.SchemaInformation);
                 var resourceChanges = await resourceChangeDataStore.GetRecordsAsync(1, 200, CancellationToken.None);
 
                 Assert.NotNull(resourceChanges);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/ChangeFeed/SqlServerFhirResourceChangeCaptureEnabledTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/ChangeFeed/SqlServerFhirResourceChangeCaptureEnabledTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.ChangeFeed
             var deserialized = saveResult.RawResourceElement.ToResourceElement(Deserializers.ResourceDeserializer);
 
             // get resource changes
-            var resourceChangeDataStore = new SqlServerFhirResourceChangeDataStore(_fixture.SqlConnectionFactory, NullLogger<SqlServerFhirResourceChangeDataStore>.Instance, _fixture.SchemaInformation);
+            var resourceChangeDataStore = new SqlServerFhirResourceChangeDataStore(_fixture.SqlConnectionBuilder, NullLogger<SqlServerFhirResourceChangeDataStore>.Instance, _fixture.SchemaInformation);
             var resourceChanges = await resourceChangeDataStore.GetRecordsAsync(1, 200, CancellationToken.None);
 
             Assert.NotNull(resourceChanges);
@@ -70,7 +70,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.ChangeFeed
             var deserialized = updateResult.RawResourceElement.ToResourceElement(Deserializers.ResourceDeserializer);
 
             // get resource changes
-            var resourceChangeDataStore = new SqlServerFhirResourceChangeDataStore(_fixture.SqlConnectionFactory, NullLogger<SqlServerFhirResourceChangeDataStore>.Instance, _fixture.SchemaInformation);
+            var resourceChangeDataStore = new SqlServerFhirResourceChangeDataStore(_fixture.SqlConnectionBuilder, NullLogger<SqlServerFhirResourceChangeDataStore>.Instance, _fixture.SchemaInformation);
             var resourceChanges = await resourceChangeDataStore.GetRecordsAsync(1, 200, CancellationToken.None);
 
             Assert.NotNull(resourceChanges);
@@ -97,7 +97,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.ChangeFeed
             var deletedResourceKey = await _fixture.Mediator.DeleteResourceAsync(new ResourceKey("Observation", saveResult.RawResourceElement.Id), DeleteOperation.SoftDelete);
 
             // get resource changes
-            var resourceChangeDataStore = new SqlServerFhirResourceChangeDataStore(_fixture.SqlConnectionFactory, NullLogger<SqlServerFhirResourceChangeDataStore>.Instance, _fixture.SchemaInformation);
+            var resourceChangeDataStore = new SqlServerFhirResourceChangeDataStore(_fixture.SqlConnectionBuilder, NullLogger<SqlServerFhirResourceChangeDataStore>.Instance, _fixture.SchemaInformation);
             var resourceChanges = await resourceChangeDataStore.GetRecordsAsync(1, 200, CancellationToken.None);
 
             Assert.NotNull(resourceChanges);
@@ -121,7 +121,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.ChangeFeed
             var deserialized = saveResult.RawResourceElement.ToResourceElement(Deserializers.ResourceDeserializer);
 
             // get resource types
-            var resourceChangeDataStore = new SqlServerFhirResourceChangeDataStore(_fixture.SqlConnectionFactory, NullLogger<SqlServerFhirResourceChangeDataStore>.Instance, _fixture.SchemaInformation);
+            var resourceChangeDataStore = new SqlServerFhirResourceChangeDataStore(_fixture.SqlConnectionBuilder, NullLogger<SqlServerFhirResourceChangeDataStore>.Instance, _fixture.SchemaInformation);
             var resourceChanges = await resourceChangeDataStore.GetRecordsAsync(1, 200, CancellationToken.None);
 
             Assert.NotNull(resourceChanges);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/ChangeFeed/SqlServerFhirResourceChangeCaptureFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/ChangeFeed/SqlServerFhirResourceChangeCaptureFixture.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.ChangeFeed
 
         public Mediator Mediator => _storageFixture.Mediator;
 
-        public ISqlConnectionFactory SqlConnectionFactory => _sqlFixture.SqlConnectionFactory;
+        public ISqlConnectionBuilder SqlConnectionBuilder => _sqlFixture.SqlConnectionBuilder;
 
         public SchemaInformation SchemaInformation => _sqlFixture.SchemaInformation;
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
@@ -31,22 +31,22 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         private readonly string _masterDatabaseName;
         private readonly string _initialConnectionString;
         private readonly SqlServerFhirModel _sqlServerFhirModel;
-        private readonly ISqlConnectionFactory _sqlConnectionFactory;
+        private readonly ISqlConnectionBuilder _sqlConnectionBuilder;
         private readonly AsyncRetryPolicy _dbSetupRetryPolicy;
 
         public SqlServerFhirStorageTestHelper(
             string initialConnectionString,
             string masterDatabaseName,
             SqlServerFhirModel sqlServerFhirModel,
-            ISqlConnectionFactory sqlConnectionFactory)
+            ISqlConnectionBuilder sqlConnectionBuilder)
         {
             EnsureArg.IsNotNull(sqlServerFhirModel, nameof(sqlServerFhirModel));
-            EnsureArg.IsNotNull(sqlConnectionFactory, nameof(sqlConnectionFactory));
+            EnsureArg.IsNotNull(sqlConnectionBuilder, nameof(sqlConnectionBuilder));
 
             _masterDatabaseName = masterDatabaseName;
             _initialConnectionString = initialConnectionString;
             _sqlServerFhirModel = sqlServerFhirModel;
-            _sqlConnectionFactory = sqlConnectionFactory;
+            _sqlConnectionBuilder = sqlConnectionBuilder;
 
             _dbSetupRetryPolicy = Policy
                 .Handle<SqlException>()
@@ -63,7 +63,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             await _dbSetupRetryPolicy.ExecuteAsync(async () =>
             {
                 // Create the database.
-                await using SqlConnection connection = await _sqlConnectionFactory.GetSqlConnectionAsync(_masterDatabaseName, cancellationToken);
+                await using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(_masterDatabaseName, cancellationToken);
                 await connection.OpenAsync(cancellationToken);
 
                 await using SqlCommand command = connection.CreateCommand();
@@ -80,7 +80,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
             await _dbSetupRetryPolicy.ExecuteAsync(async () =>
             {
-                await using SqlConnection connection = await _sqlConnectionFactory.GetSqlConnectionAsync(databaseName, cancellationToken);
+                await using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(databaseName, cancellationToken);
                 await connection.OpenAsync(cancellationToken);
                 await using SqlCommand sqlCommand = connection.CreateCommand();
                 sqlCommand.CommandText = "SELECT 1";
@@ -95,7 +95,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         {
             await _dbSetupRetryPolicy.ExecuteAsync(async () =>
             {
-                await using SqlConnection connection = await _sqlConnectionFactory.GetSqlConnectionAsync(_masterDatabaseName, cancellationToken);
+                await using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(_masterDatabaseName, cancellationToken);
                 await connection.OpenAsync(cancellationToken);
                 SqlConnection.ClearAllPools();
 
@@ -108,7 +108,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
         public async Task DeleteAllExportJobRecordsAsync(CancellationToken cancellationToken = default)
         {
-            await using SqlConnection connection = await _sqlConnectionFactory.GetSqlConnectionAsync(cancellationToken: cancellationToken);
+            await using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(cancellationToken: cancellationToken);
             var command = new SqlCommand("DELETE FROM dbo.ExportJob", connection);
 
             await command.Connection.OpenAsync(cancellationToken);
@@ -117,7 +117,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
         public async Task DeleteExportJobRecordAsync(string id, CancellationToken cancellationToken = default)
         {
-            await using SqlConnection connection = await _sqlConnectionFactory.GetSqlConnectionAsync(cancellationToken: cancellationToken);
+            await using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(cancellationToken: cancellationToken);
             var command = new SqlCommand("DELETE FROM dbo.ExportJob WHERE Id = @id", connection);
 
             var parameter = new SqlParameter { ParameterName = "@id", Value = id };
@@ -129,7 +129,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
         public async Task DeleteSearchParameterStatusAsync(string uri, CancellationToken cancellationToken = default)
         {
-            await using SqlConnection connection = await _sqlConnectionFactory.GetSqlConnectionAsync(cancellationToken: cancellationToken);
+            await using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(cancellationToken: cancellationToken);
             var command = new SqlCommand("DELETE FROM dbo.SearchParam WHERE Uri = @uri", connection);
             command.Parameters.AddWithValue("@uri", uri);
 
@@ -141,7 +141,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
         public async Task DeleteAllReindexJobRecordsAsync(CancellationToken cancellationToken = default)
         {
-            await using SqlConnection connection = await _sqlConnectionFactory.GetSqlConnectionAsync(cancellationToken: cancellationToken);
+            await using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(cancellationToken: cancellationToken);
             var command = new SqlCommand("DELETE FROM dbo.ReindexJob", connection);
 
             await command.Connection.OpenAsync(cancellationToken);
@@ -150,7 +150,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
         public async Task DeleteReindexJobRecordAsync(string id, CancellationToken cancellationToken = default)
         {
-            await using SqlConnection connection = await _sqlConnectionFactory.GetSqlConnectionAsync(cancellationToken: cancellationToken);
+            await using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(cancellationToken: cancellationToken);
             var command = new SqlCommand("DELETE FROM dbo.ReindexJob WHERE Id = @id", connection);
 
             var parameter = new SqlParameter { ParameterName = "@id", Value = id };
@@ -162,7 +162,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
         async Task<object> IFhirStorageTestHelper.GetSnapshotToken()
         {
-            await using SqlConnection connection = await _sqlConnectionFactory.GetSqlConnectionAsync();
+            await using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync();
             await connection.OpenAsync();
 
             SqlCommand command = connection.CreateCommand();
@@ -172,7 +172,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
         async Task IFhirStorageTestHelper.ValidateSnapshotTokenIsCurrent(object snapshotToken)
         {
-            await using SqlConnection connection = await _sqlConnectionFactory.GetSqlConnectionAsync();
+            await using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync();
             await connection.OpenAsync();
 
             var sb = new StringBuilder();
@@ -221,11 +221,11 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             var baseScriptProvider = new BaseScriptProvider();
             var mediator = Substitute.For<IMediator>();
             var sqlConnectionStringProvider = new DefaultSqlConnectionStringProvider(config);
-            var sqlConnectionFactory = new DefaultSqlConnectionFactory(sqlConnectionStringProvider);
-            var schemaManagerDataStore = new SchemaManagerDataStore(sqlConnectionFactory, config, NullLogger<SchemaManagerDataStore>.Instance);
-            var schemaUpgradeRunner = new SchemaUpgradeRunner(scriptProvider, baseScriptProvider, NullLogger<SchemaUpgradeRunner>.Instance, sqlConnectionFactory, schemaManagerDataStore);
+            var defaultSqlConnectionBuilder = new DefaultSqlConnectionBuilder(sqlConnectionStringProvider, config);
+            var schemaManagerDataStore = new SchemaManagerDataStore(defaultSqlConnectionBuilder, config, NullLogger<SchemaManagerDataStore>.Instance);
+            var schemaUpgradeRunner = new SchemaUpgradeRunner(scriptProvider, baseScriptProvider, NullLogger<SchemaUpgradeRunner>.Instance, defaultSqlConnectionBuilder, schemaManagerDataStore);
 
-            return new SchemaInitializer(config, schemaManagerDataStore, schemaUpgradeRunner, schemaInformation, sqlConnectionFactory, sqlConnectionStringProvider, mediator, NullLogger<SchemaInitializer>.Instance);
+            return new SchemaInitializer(config, schemaManagerDataStore, schemaUpgradeRunner, schemaInformation, defaultSqlConnectionBuilder, sqlConnectionStringProvider, mediator, NullLogger<SchemaInitializer>.Instance);
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -87,10 +87,10 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             var sqlSortingValidator = new SqlServerSortingValidator(SchemaInformation);
 
             var sqlConnectionStringProvider = new DefaultSqlConnectionStringProvider(config);
-            SqlConnectionFactory = new DefaultSqlConnectionFactory(sqlConnectionStringProvider);
-            var schemaManagerDataStore = new SchemaManagerDataStore(SqlConnectionFactory, config, NullLogger<SchemaManagerDataStore>.Instance);
-            _schemaUpgradeRunner = new SchemaUpgradeRunner(scriptProvider, baseScriptProvider, NullLogger<SchemaUpgradeRunner>.Instance, SqlConnectionFactory, schemaManagerDataStore);
-            _schemaInitializer = new SchemaInitializer(config, schemaManagerDataStore, _schemaUpgradeRunner, SchemaInformation, SqlConnectionFactory, sqlConnectionStringProvider, mediator, NullLogger<SchemaInitializer>.Instance);
+            SqlConnectionBuilder = new DefaultSqlConnectionBuilder(sqlConnectionStringProvider, config);
+            var schemaManagerDataStore = new SchemaManagerDataStore(SqlConnectionBuilder, config, NullLogger<SchemaManagerDataStore>.Instance);
+            _schemaUpgradeRunner = new SchemaUpgradeRunner(scriptProvider, baseScriptProvider, NullLogger<SchemaUpgradeRunner>.Instance, SqlConnectionBuilder, schemaManagerDataStore);
+            _schemaInitializer = new SchemaInitializer(config, schemaManagerDataStore, _schemaUpgradeRunner, SchemaInformation, SqlConnectionBuilder, sqlConnectionStringProvider, mediator, NullLogger<SchemaInitializer>.Instance);
 
             _searchParameterDefinitionManager = new SearchParameterDefinitionManager(ModelInfoProvider.Instance, _mediator, () => _searchService.CreateMockScope(), NullLogger<SearchParameterDefinitionManager>.Instance);
 
@@ -105,7 +105,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 _searchParameterDefinitionManager,
                 () => _filebasedSearchParameterStatusDataStore,
                 Options.Create(securityConfiguration),
-                SqlConnectionFactory,
+                SqlConnectionBuilder,
                 Substitute.For<IMediator>(),
                 NullLogger<SqlServerFhirModel>.Instance);
             SqlServerFhirModel = sqlServerFhirModel;
@@ -134,7 +134,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             _supportedSearchParameterDefinitionManager = new SupportedSearchParameterDefinitionManager(_searchParameterDefinitionManager);
 
             SqlTransactionHandler = new SqlTransactionHandler();
-            SqlConnectionWrapperFactory = new SqlConnectionWrapperFactory(SqlTransactionHandler, new SqlCommandWrapperFactory(), SqlConnectionFactory);
+            SqlConnectionWrapperFactory = new SqlConnectionWrapperFactory(SqlTransactionHandler, new SqlCommandWrapperFactory(), SqlConnectionBuilder);
 
             SqlServerSearchParameterStatusDataStore = new SqlServerSearchParameterStatusDataStore(
                 () => SqlConnectionWrapperFactory.CreateMockScope(),
@@ -212,7 +212,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 mediator,
                 NullLogger<SearchParameterStatusManager>.Instance);
 
-            _testHelper = new SqlServerFhirStorageTestHelper(initialConnectionString, MasterDatabaseName, sqlServerFhirModel, SqlConnectionFactory);
+            _testHelper = new SqlServerFhirStorageTestHelper(initialConnectionString, MasterDatabaseName, sqlServerFhirModel, SqlConnectionBuilder);
         }
 
         public string TestConnectionString { get; }
@@ -221,7 +221,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
         internal SqlConnectionWrapperFactory SqlConnectionWrapperFactory { get; }
 
-        internal ISqlConnectionFactory SqlConnectionFactory { get; }
+        internal ISqlConnectionBuilder SqlConnectionBuilder { get; }
 
         internal SqlServerSearchParameterStatusDataStore SqlServerSearchParameterStatusDataStore { get; }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
@@ -123,9 +123,9 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             var connectionString = new SqlConnectionStringBuilder(initialConnectionString) { InitialCatalog = databaseName }.ToString();
 
             var schemaOptions = new SqlServerSchemaOptions { AutomaticUpdatesEnabled = true };
-            var config = Options.Create(new SqlServerDataStoreConfiguration { ConnectionString = connectionString, Initialize = true, SchemaOptions = schemaOptions, StatementTimeout = TimeSpan.FromMinutes(10) });
+            IOptions<SqlServerDataStoreConfiguration> config = Options.Create(new SqlServerDataStoreConfiguration { ConnectionString = connectionString, Initialize = true, SchemaOptions = schemaOptions, StatementTimeout = TimeSpan.FromMinutes(10) });
             var sqlConnectionStringProvider = new DefaultSqlConnectionStringProvider(config);
-            var sqlConnectionFactory = new DefaultSqlConnectionFactory(sqlConnectionStringProvider);
+            var defaultSqlConnectionBuilder = new DefaultSqlConnectionBuilder(sqlConnectionStringProvider, config);
             var securityConfiguration = new SecurityConfiguration { PrincipalClaims = { "oid" } };
 
             SqlServerFhirModel sqlServerFhirModel = new SqlServerFhirModel(
@@ -133,7 +133,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 defManager,
                 () => statusStore,
                 Options.Create(securityConfiguration),
-                sqlConnectionFactory,
+                defaultSqlConnectionBuilder,
                 Substitute.For<IMediator>(),
                 NullLogger<SqlServerFhirModel>.Instance);
 
@@ -141,21 +141,21 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 initialConnectionString,
                 MasterDatabaseName,
                 sqlServerFhirModel,
-                sqlConnectionFactory);
+                defaultSqlConnectionBuilder);
 
             var scriptProvider = new ScriptProvider<SchemaVersion>();
             var baseScriptProvider = new BaseScriptProvider();
             var mediator = Substitute.For<IMediator>();
 
             var schemaManagerDataStore = new SchemaManagerDataStore(
-                sqlConnectionFactory,
+                defaultSqlConnectionBuilder,
                 config,
                 NullLogger<SchemaManagerDataStore>.Instance);
             var schemaUpgradeRunner = new SchemaUpgradeRunner(
                 scriptProvider,
                 baseScriptProvider,
                 NullLogger<SchemaUpgradeRunner>.Instance,
-                sqlConnectionFactory,
+                defaultSqlConnectionBuilder,
                 schemaManagerDataStore);
 
             var schemaInitializer = new SchemaInitializer(
@@ -163,7 +163,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 schemaManagerDataStore,
                 schemaUpgradeRunner,
                 schemaInformation,
-                sqlConnectionFactory,
+                defaultSqlConnectionBuilder,
                 sqlConnectionStringProvider,
                 mediator,
                 NullLogger<SchemaInitializer>.Instance);


### PR DESCRIPTION
## Description

To pull in changes from the healthcare-shared-components repo, the NSubstitute package needs to be bumped to 4.3.0.

To bump NSubstitute from 4.2.2 to 4.3.0, a change to `Mock.cs` needed to be made in the healthcare-shared-components repo ([PR#406](https://github.com/microsoft/healthcare-shared-components/pull/406)).

This PR bumps NSubsitute to 4.3.0 and pulls in a release of HealthcareSharedPackageVersion that includes the change to `Mock.cs` (see release [4.0.24](https://github.com/microsoft/healthcare-shared-components/releases/tag/4.0.24)).

Release 4.0.24 includes additional changes that required updates to the fhir-server:
- `ISqlConnectionFactory` was renamed to `ISqlConnectionBuilder` and `DefaultSqlConnectionFactory` was renamed to `DefaultSqlConnectionBuilder` in PR [#397](https://github.com/microsoft/healthcare-shared-components/pull/397)
- MediatR was downgraded to 9.0.1 in PR [#403](https://github.com/microsoft/healthcare-shared-components/pull/403) (this can be upgraded once the fhir-server upgrades to .NET 6.0)
- Auth providers were updated to take in `IOptionsMonitor` in PR [#405](https://github.com/microsoft/healthcare-shared-components/pull/405)

## Testing
All tests should pass as before.

## FHIR Team Checklist
- ✅ **Update the title** of the PR to be succinct and less than 50 characters
- ✅ **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- ✅ Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- ✅ Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- ✅ Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- ✅ CI is green before merge
- ✅ Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
None (updates a minor nuget package version)
