### PR TITLE
Move Bundle notification to Core

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
             FileVersionInfo version = ProductVersionInfo.Version;
             var versionString = $"{version.FileMajorPart}.{version.FileMinorPart}.{version.FileBuildPart}";
 
-            statement.Name = string.Format(Resources.CapabilityStatementNameFormat, statement.Publisher, configuration.Value.SoftwareName, versionString);
+            statement.Name = string.Format(Core.Resources.CapabilityStatementNameFormat, statement.Publisher, configuration.Value.SoftwareName, versionString);
             statement.Software = new SoftwareComponent
             {
                 Name = configuration.Value.SoftwareName,

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/Serialization/DefaultOptionHashSetJsonConverter.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/Serialization/DefaultOptionHashSetJsonConverter.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance.Serialization
                     // When a list is specified, check that the default is an option
                     if (objects.Any() && !objects.Any(x => Equals(defaultOption, x)))
                     {
-                        throw new UnsupportedConfigurationException(string.Format(Resources.InvalidConfigSetting, defaultOption, string.Join(", ", objects.ToArray())));
+                        throw new UnsupportedConfigurationException(string.Format(Core.Resources.InvalidConfigSetting, defaultOption, string.Join(", ", objects.ToArray())));
                     }
                 }
             }

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionBuilder.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionBuilder.cs
@@ -146,12 +146,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
                 }
                 catch (FormatException)
                 {
-                    AddIssue(Resources.SearchParameterDefinitionInvalidDefinitionUri, entryIndex);
+                    AddIssue(Core.Resources.SearchParameterDefinitionInvalidDefinitionUri, entryIndex);
                     continue;
                 }
                 catch (ArgumentException)
                 {
-                    AddIssue(Resources.SearchParameterDefinitionDuplicatedEntry, searchParameter.Url);
+                    AddIssue(Core.Resources.SearchParameterDefinitionDuplicatedEntry, searchParameter.Url);
                     continue;
                 }
             }

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
@@ -200,7 +200,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
 
             if (!UrlLookup.TryRemove(url, out searchParameterInfo))
             {
-                throw new ResourceNotFoundException(string.Format(Resources.CustomSearchParameterNotfound, url));
+                throw new ResourceNotFoundException(string.Format(Core.Resources.CustomSearchParameterNotfound, url));
             }
 
             // for search parameters with a base resource type we need to delete the search parameter

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/ContainerRegistryTemplateProvider.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/ContainerRegistryTemplateProvider.cs
@@ -92,22 +92,22 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.ConvertData
                 _cache.Remove(GetCacheKey(request.RegistryServer));
 
                 _logger.LogWarning(authEx, "Failed to access container registry.");
-                throw new ContainerRegistryNotAuthorizedException(string.Format(Resources.ContainerRegistryNotAuthorized, request.RegistryServer), authEx);
+                throw new ContainerRegistryNotAuthorizedException(string.Format(Core.Resources.ContainerRegistryNotAuthorized, request.RegistryServer), authEx);
             }
             catch (ImageFetchException fetchEx)
             {
                 _logger.LogWarning(fetchEx, "Failed to fetch template image.");
-                throw new FetchTemplateCollectionFailedException(string.Format(Resources.FetchTemplateCollectionFailed, fetchEx.Message), fetchEx);
+                throw new FetchTemplateCollectionFailedException(string.Format(Core.Resources.FetchTemplateCollectionFailed, fetchEx.Message), fetchEx);
             }
             catch (TemplateManagementException templateEx)
             {
                 _logger.LogWarning(templateEx, "Template collection is invalid.");
-                throw new TemplateCollectionErrorException(string.Format(Resources.FetchTemplateCollectionFailed, templateEx.Message), templateEx);
+                throw new TemplateCollectionErrorException(string.Format(Core.Resources.FetchTemplateCollectionFailed, templateEx.Message), templateEx);
             }
             catch (Exception unhandledEx)
             {
                 _logger.LogError(unhandledEx, "Unhandled exception: failed to get template collection.");
-                throw new FetchTemplateCollectionFailedException(string.Format(Resources.FetchTemplateCollectionFailed, unhandledEx.Message), unhandledEx);
+                throw new FetchTemplateCollectionFailedException(string.Format(Core.Resources.FetchTemplateCollectionFailed, unhandledEx.Message), unhandledEx);
             }
         }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/ConvertDataEngine.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/ConvertDataEngine.cs
@@ -81,16 +81,16 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.ConvertData
                 if (convertException.FhirConverterErrorCode == FhirConverterErrorCode.TimeoutError)
                 {
                     _logger.LogError(convertException.InnerException, "Convert data operation timed out.");
-                    throw new ConvertDataTimeoutException(Resources.ConvertDataOperationTimeout, convertException.InnerException);
+                    throw new ConvertDataTimeoutException(Core.Resources.ConvertDataOperationTimeout, convertException.InnerException);
                 }
 
                 _logger.LogInformation(convertException, "Convert data failed.");
-                throw new ConvertDataFailedException(string.Format(Resources.ConvertDataFailed, convertException.Message), convertException);
+                throw new ConvertDataFailedException(string.Format(Core.Resources.ConvertDataFailed, convertException.Message), convertException);
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Unhandled exception: convert data process failed.");
-                throw new ConvertDataUnhandledException(string.Format(Resources.ConvertDataFailed, ex.Message), ex);
+                throw new ConvertDataUnhandledException(string.Format(Core.Resources.ConvertDataFailed, ex.Message), ex);
             }
         }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CancelExportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CancelExportRequestHandler.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                     outcome.JobRecord.Status = OperationStatus.Canceled;
                     outcome.JobRecord.CanceledTime = Clock.UtcNow;
 
-                    outcome.JobRecord.FailureDetails = new JobFailureDetails(Resources.UserRequestedCancellation, HttpStatusCode.NoContent);
+                    outcome.JobRecord.FailureDetails = new JobFailureDetails(Core.Resources.UserRequestedCancellation, HttpStatusCode.NoContent);
 
                     _logger.LogInformation($"Attempting to cancel export job {request.JobId}");
                     await _fhirOperationDataStore.UpdateExportJobAsync(outcome.JobRecord, outcome.ETag, cancellationToken);

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
                     if (parameterIndex < 0 || parameterIndex == filter.Length - 1)
                     {
-                        throw new BadRequestException(string.Format(Resources.TypeFilterUnparseable, filter));
+                        throw new BadRequestException(string.Format(Core.Resources.TypeFilterUnparseable, filter));
                     }
 
                     var filterType = filter.Substring(0, parameterIndex);
@@ -143,7 +143,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
                         if (keyValue.Length != 2)
                         {
-                            throw new BadRequestException(string.Format(Resources.TypeFilterUnparseable, filter));
+                            throw new BadRequestException(string.Format(Core.Resources.TypeFilterUnparseable, filter));
                         }
 
                         parameterTupleList.Add(new Tuple<string, string>(keyValue[0], keyValue[1]));
@@ -167,7 +167,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
                 if (formatConfiguration == null)
                 {
-                    throw new BadRequestException(string.Format(Resources.ExportFormatNotFound, formatName));
+                    throw new BadRequestException(string.Format(Core.Resources.ExportFormatNotFound, formatName));
                 }
             }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                     _exportJobRecord.Filters.Count > 0 &&
                     string.IsNullOrEmpty(_exportJobRecord.ResourceType))
                 {
-                    throw new BadRequestException(Resources.TypeFilterWithoutTypeIsUnsupported);
+                    throw new BadRequestException(Core.Resources.TypeFilterWithoutTypeIsUnsupported);
                 }
 
                 // Connect to export destination using appropriate client.
@@ -207,7 +207,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
             {
                 _logger.LogError(ex, "Failed to anonymize resource. The job will be marked as failed.");
 
-                _exportJobRecord.FailureDetails = new JobFailureDetails(string.Format(Resources.FailedToAnonymizeResource, ex.Message), HttpStatusCode.BadRequest);
+                _exportJobRecord.FailureDetails = new JobFailureDetails(string.Format(Core.Resources.FailedToAnonymizeResource, ex.Message), HttpStatusCode.BadRequest);
                 await CompleteJobAsync(OperationStatus.Failed, cancellationToken);
             }
             catch (AnonymizationConfigurationNotFoundException ex)
@@ -230,7 +230,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                 // Try to update the job to failed state.
                 _logger.LogError(ex, "Encountered an unhandled exception. The job will be marked as failed.");
 
-                _exportJobRecord.FailureDetails = new JobFailureDetails(Resources.UnknownError, HttpStatusCode.InternalServerError);
+                _exportJobRecord.FailureDetails = new JobFailureDetails(Core.Resources.UnknownError, HttpStatusCode.InternalServerError);
                 await CompleteJobAsync(OperationStatus.Failed, cancellationToken);
             }
             finally

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/GetExportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/GetExportRequestHandler.cs
@@ -67,11 +67,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
             }
             else if (outcome.JobRecord.Status == OperationStatus.Failed || outcome.JobRecord.Status == OperationStatus.Canceled)
             {
-                string failureReason = outcome.JobRecord.FailureDetails != null ? outcome.JobRecord.FailureDetails.FailureReason : Resources.UnknownError;
+                string failureReason = outcome.JobRecord.FailureDetails != null ? outcome.JobRecord.FailureDetails.FailureReason : Core.Resources.UnknownError;
                 HttpStatusCode failureStatusCode = outcome.JobRecord.FailureDetails != null ? outcome.JobRecord.FailureDetails.FailureStatusCode : HttpStatusCode.InternalServerError;
 
                 throw new OperationFailedException(
-                    string.Format(Resources.OperationFailed, OperationsConstants.Export, failureReason), failureStatusCode);
+                    string.Format(Core.Resources.OperationFailed, OperationsConstants.Export, failureReason), failureStatusCode);
             }
             else
             {

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/CancelImportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/CancelImportRequestHandler.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
 
                 if (taskInfo.Status == TaskManagement.TaskStatus.Completed)
                 {
-                    throw new OperationFailedException(Resources.ImportOperationCompleted, HttpStatusCode.Conflict);
+                    throw new OperationFailedException(Core.Resources.ImportOperationCompleted, HttpStatusCode.Conflict);
                 }
                 else
                 {
@@ -58,7 +58,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
             }
             catch (TaskNotExistException)
             {
-                throw new ResourceNotFoundException(string.Format(Resources.ImportTaskNotFound, request.TaskId));
+                throw new ResourceNotFoundException(string.Format(Core.Resources.ImportTaskNotFound, request.TaskId));
             }
         }
     }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/CreateImportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/CreateImportRequestHandler.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
             catch (TaskConflictException)
             {
                 _logger.LogInformation("Already a running import task.");
-                throw new OperationFailedException(Resources.ImportTaskIsRunning, HttpStatusCode.Conflict);
+                throw new OperationFailedException(Core.Resources.ImportTaskIsRunning, HttpStatusCode.Conflict);
             }
 
             return new CreateImportResponse(taskId);

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/GetImportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/GetImportRequestHandler.cs
@@ -44,14 +44,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
 
             if (taskInfo == null)
             {
-                throw new ResourceNotFoundException(string.Format(Resources.ImportTaskNotFound, request.TaskId));
+                throw new ResourceNotFoundException(string.Format(Core.Resources.ImportTaskNotFound, request.TaskId));
             }
 
             if (taskInfo.Status != TaskManagement.TaskStatus.Completed)
             {
                 if (taskInfo.IsCanceled)
                 {
-                    throw new OperationFailedException(Resources.UserRequestedCancellation, HttpStatusCode.BadRequest);
+                    throw new OperationFailedException(Core.Resources.UserRequestedCancellation, HttpStatusCode.BadRequest);
                 }
 
                 return new GetImportResponse(HttpStatusCode.Accepted);
@@ -72,11 +72,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
                     HttpStatusCode failureStatusCode = errorResult.HttpStatusCode;
 
                     throw new OperationFailedException(
-                        string.Format(Resources.OperationFailed, OperationsConstants.Import, failureReason), failureStatusCode);
+                        string.Format(Core.Resources.OperationFailed, OperationsConstants.Import, failureReason), failureStatusCode);
                 }
                 else
                 {
-                    throw new OperationFailedException(Resources.UserRequestedCancellation, HttpStatusCode.BadRequest);
+                    throw new OperationFailedException(Core.Resources.UserRequestedCancellation, HttpStatusCode.BadRequest);
                 }
             }
         }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/CancelReindexRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/CancelReindexRequestHandler.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                 if (outcome.JobRecord.Status.IsFinished())
                 {
                     throw new RequestNotValidException(
-                        string.Format(Resources.ReindexJobInCompletedState, outcome.JobRecord.Id, outcome.JobRecord.Status));
+                        string.Format(Core.Resources.ReindexJobInCompletedState, outcome.JobRecord.Id, outcome.JobRecord.Status));
                 }
 
                 // Try to cancel the job.

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/CreateReindexRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/CreateReindexRequestHandler.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             (var activeReindexJobs, var reindexJobId) = await _fhirOperationDataStore.CheckActiveReindexJobsAsync(cancellationToken);
             if (activeReindexJobs)
             {
-                throw new JobConflictException(string.Format(Resources.OnlyOneResourceJobAllowed, reindexJobId));
+                throw new JobConflictException(string.Format(Core.Resources.OnlyOneResourceJobAllowed, reindexJobId));
             }
 
             // We need to pull in latest search parameter updates from the data store before creating a reindex job.

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -226,7 +226,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                 _reindexJobRecord.Error.Add(new OperationOutcomeIssue(
                     OperationOutcomeConstants.IssueSeverity.Information,
                     OperationOutcomeConstants.IssueType.Informational,
-                    Resources.NoSearchParametersNeededToBeIndexed));
+                    Core.Resources.NoSearchParametersNeededToBeIndexed));
                 _reindexJobRecord.CanceledTime = Clock.UtcNow;
                 await MoveToFinalStatusAsync(OperationStatus.Canceled);
                 return false;
@@ -251,7 +251,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                 _reindexJobRecord.Error.Add(new OperationOutcomeIssue(
                     OperationOutcomeConstants.IssueSeverity.Information,
                     OperationOutcomeConstants.IssueType.Informational,
-                    Resources.NoResourcesNeedToBeReindexed));
+                    Core.Resources.NoResourcesNeedToBeReindexed));
                 await UpdateParametersAndCompleteJob();
                 return false;
             }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Validate/ValidateOperationHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Validate/ValidateOperationHandler.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
         public static readonly OperationOutcomeIssue ValidationPassed = new OperationOutcomeIssue(
               OperationOutcomeConstants.IssueSeverity.Information,
               OperationOutcomeConstants.IssueType.Informational,
-              Resources.ValidationPassed);
+              Core.Resources.ValidationPassed);
 
         private readonly IAuthorizationService<DataActions> _authorizationService;
         private readonly IProfileValidator _profileValidator;

--- a/src/Microsoft.Health.Fhir.Core/Features/Resources/Bundle/BundleMetricsNotification.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Resources/Bundle/BundleMetricsNotification.cs
@@ -6,16 +6,14 @@
 using System.Collections.Generic;
 using Microsoft.Health.Fhir.Core.Features.Metrics;
 using Microsoft.Health.Fhir.Core.Models;
-using Microsoft.Health.Fhir.ValueSets;
-using static Hl7.Fhir.Model.Bundle;
 
-namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
+namespace Microsoft.Health.Fhir.Core.Features.Resources.Bundle
 {
     public class BundleMetricsNotification : IMetricsNotification
     {
-        public BundleMetricsNotification(IDictionary<string, int> apiCallResults, BundleType bundleType)
+        public BundleMetricsNotification(IDictionary<string, int> apiCallResults, string bundleType)
         {
-            FhirOperation = bundleType == BundleType.Batch ? AuditEventSubType.Batch : AuditEventSubType.Transaction;
+            FhirOperation = bundleType;
             ResourceType = KnownResourceTypes.Bundle;
             ApiCallResults = apiCallResults;
         }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/ContinuationTokenConverter.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/ContinuationTokenConverter.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             }
             catch (FormatException)
             {
-                throw new BadRequestException(Resources.InvalidContinuationToken);
+                throw new BadRequestException(Core.Resources.InvalidContinuationToken);
             }
         }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/ExpressionParser.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/ExpressionParser.cs
@@ -71,12 +71,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
             var valueSpan = includeValue.AsSpan();
             if (!TrySplit(SearchSplitChar, ref valueSpan, out ReadOnlySpan<char> originalType))
             {
-                throw new InvalidSearchOperationException(isReversed ? Resources.RevIncludeMissingType : Resources.IncludeMissingType);
+                throw new InvalidSearchOperationException(isReversed ? Core.Resources.RevIncludeMissingType : Core.Resources.IncludeMissingType);
             }
 
             if (resourceTypes.Length == 1 && resourceTypes[0].Equals(KnownResourceTypes.DomainResource, StringComparison.OrdinalIgnoreCase))
             {
-                throw new InvalidSearchOperationException(Resources.IncludeCannotBeAgainstBase);
+                throw new InvalidSearchOperationException(Core.Resources.IncludeCannotBeAgainstBase);
             }
 
             SearchParameterInfo refSearchParameter;

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/SearchParameterExpressionParser.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/SearchParameterExpressionParser.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
                 if (!bool.TryParse(value, out bool isMissing))
                 {
                     // An invalid value was specified.
-                    throw new InvalidSearchOperationException(Resources.InvalidValueTypeForMissingModifier);
+                    throw new InvalidSearchOperationException(Core.Resources.InvalidValueTypeForMissingModifier);
                 }
 
                 return Expression.MissingSearchParameter(searchParameter, isMissing);
@@ -76,7 +76,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
                 if (searchParameter.Type != SearchParamType.Token)
                 {
                     throw new InvalidSearchOperationException(
-                        string.Format(CultureInfo.InvariantCulture, Resources.ModifierNotSupported, modifier, searchParameter.Code));
+                        string.Format(CultureInfo.InvariantCulture, Core.Resources.ModifierNotSupported, modifier, searchParameter.Code));
                 }
 
                 outputExpression = Expression.StartsWith(FieldName.TokenText, null, value, true);
@@ -89,7 +89,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
                     if (modifier != null)
                     {
                         throw new InvalidSearchOperationException(
-                            string.Format(CultureInfo.InvariantCulture, Resources.ModifierNotSupported, modifier, searchParameter.Code));
+                            string.Format(CultureInfo.InvariantCulture, Core.Resources.ModifierNotSupported, modifier, searchParameter.Code));
                     }
 
                     IReadOnlyList<string> orParts = value.SplitByOrSeparator();
@@ -101,7 +101,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
                         if (compositeValueParts.Count > searchParameter.Component.Count)
                         {
                             throw new InvalidSearchOperationException(
-                                string.Format(CultureInfo.InvariantCulture, Resources.NumberOfCompositeComponentsExceeded, searchParameter.Code));
+                                string.Format(CultureInfo.InvariantCulture, Core.Resources.NumberOfCompositeComponentsExceeded, searchParameter.Code));
                         }
 
                         var compositeExpressions = new Expression[compositeValueParts.Count];
@@ -191,7 +191,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
             {
                 if (comparator != SearchComparator.Eq)
                 {
-                    throw new InvalidSearchOperationException(Resources.SearchComparatorNotSupported);
+                    throw new InvalidSearchOperationException(Core.Resources.SearchComparatorNotSupported);
                 }
 
                 // This is a multiple value expression.

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchOptions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchOptions.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             {
                 if (value <= 0)
                 {
-                    throw new InvalidOperationException(Resources.InvalidSearchCountSpecified);
+                    throw new InvalidOperationException(Core.Resources.InvalidSearchCountSpecified);
                 }
 
                 _maxItemCount = value;
@@ -97,7 +97,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             {
                 if (value <= 0)
                 {
-                    throw new InvalidOperationException(Resources.InvalidSearchCountSpecified);
+                    throw new InvalidOperationException(Core.Resources.InvalidSearchCountSpecified);
                 }
 
                 _includeCount = value;

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/TypedElementSearchIndexer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/TypedElementSearchIndexer.cs
@@ -180,7 +180,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                     /// If the body contains Coverage.status = , then after parsing Coverage.status = null & Coverage.statusElement = {value=null}, which passes the Firely validation and CodeToTokenSearchValueConverter returns null
                     /// In this case return BadRequestException with a valid message instead of 500
                     /// </remarks>
-                    throw new BadRequestException(string.Format(Resources.ValueCannotBeNull, searchParameter.Expression));
+                    throw new BadRequestException(string.Format(Core.Resources.ValueCannotBeNull, searchParameter.Expression));
                 }
             }
         }

--- a/src/Microsoft.Health.Fhir.Core/Features/Security/RoleLoader.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Security/RoleLoader.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Security
             };
 
             validatingReader.ValidationEventHandler += (sender, args) =>
-                throw new InvalidDefinitionException(string.Format(Resources.ErrorValidatingRoles, args.Message));
+                throw new InvalidDefinitionException(string.Format(Core.Resources.ErrorValidatingRoles, args.Message));
 
             RolesContract roleContract = jsonSerializer.Deserialize<RolesContract>(validatingReader);
 
@@ -72,7 +72,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Security
                 if (grouping.Count() > 1)
                 {
                     throw new InvalidDefinitionException(
-                        string.Format(CultureInfo.CurrentCulture, Resources.DuplicateRoleNames, grouping.Count(), grouping.Key));
+                        string.Format(CultureInfo.CurrentCulture, Core.Resources.DuplicateRoleNames, grouping.Count(), grouping.Key));
                 }
             }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Validation/ResourceElementValidator.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Validation/ResourceElementValidator.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
         public ResourceElementValidator(AbstractValidator<ResourceElement> contentValidator, INarrativeHtmlSanitizer narrativeHtmlSanitizer)
         {
             RuleFor(x => x.Id)
-              .SetValidator(new IdValidator<ResourceElement>()).WithMessage(Resources.IdRequirements);
+              .SetValidator(new IdValidator<ResourceElement>()).WithMessage(Core.Resources.IdRequirements);
             RuleFor(x => x)
                   .SetValidator(contentValidator);
             RuleFor(x => x)

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerTests.cs
@@ -31,6 +31,7 @@ using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Resources;
+using Microsoft.Health.Fhir.Core.Features.Resources.Bundle;
 using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Features.Security.Authorization;
 using Microsoft.Health.Fhir.Core.Messages.Bundle;

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
@@ -40,9 +40,11 @@ using Microsoft.Health.Fhir.Core.Features;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Resources;
+using Microsoft.Health.Fhir.Core.Features.Resources.Bundle;
 using Microsoft.Health.Fhir.Core.Features.Security;
 using Microsoft.Health.Fhir.Core.Messages.Bundle;
 using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.ValueSets;
 using static Hl7.Fhir.Model.Bundle;
 using Task = System.Threading.Tasks.Task;
 
@@ -254,7 +256,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                 }
             }
 
-            await _mediator.Publish(new BundleMetricsNotification(apiCallResults, bundleType), CancellationToken.None);
+            await _mediator.Publish(new BundleMetricsNotification(apiCallResults, bundleType == BundleType.Batch ? AuditEventSubType.Batch : AuditEventSubType.Transaction), CancellationToken.None);
         }
 
         private async Task<BundleResponse> ExecuteTransactionForAllRequests(Hl7.Fhir.Model.Bundle responseBundle)

--- a/src/Microsoft.Health.Fhir.Shared.Api/Microsoft.Health.Fhir.Shared.Api.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Microsoft.Health.Fhir.Shared.Api.projitems
@@ -29,7 +29,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\Import\ImportRequestExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\OperationsCapabilityProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\ParametersExtensions.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Bundle\BundleMetricsNotification.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Bundle\BundleSerializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\IProvenanceHeaderState.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\ProfileResourcesBehaviour.cs" />


### PR DESCRIPTION
## Description
Hotfix to move bundle notification to core. Do not merge the PR.
With the introduction of the Resource.Bundle namespace to Core the Resource references to the string resources file had to be made more explicit.

## Related issues
Addresses [Bug 88575](https://microsofthealth.visualstudio.com/Health/_workitems/edit/88575): Move Bundle Meter Notification to Core

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
