### PR TITLE
Bypass not FHIR request for import lock

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Operations/Import/InitialImportLockMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Operations/Import/InitialImportLockMiddleware.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
+using Microsoft.Health.Fhir.Api.Extensions;
 using Microsoft.Health.Fhir.Core.Configs;
 
 namespace Microsoft.Health.Fhir.Api.Features.Operations.Import
@@ -43,7 +44,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Operations.Import
 
         public async Task Invoke(HttpContext context)
         {
-            if (!_importTaskConfiguration.Enabled || !_importTaskConfiguration.InitialImportMode)
+            if (!context.Request.IsFhirRequest() || !_importTaskConfiguration.Enabled || !_importTaskConfiguration.InitialImportMode)
             {
                 await _next(context);
                 return;

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Operations/Import/InitialImportLockMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Operations/Import/InitialImportLockMiddlewareTests.cs
@@ -27,6 +27,18 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Operations.Import
         }
 
         [Fact]
+        public async Task GivenCustomErrorRequest_WhenInitialImportModeEnabled_Then423ShouldNotBeReturned()
+        {
+            InitialImportLockMiddleware middleware = CreateInitialImportLockMiddleware(new ImportTaskConfiguration() { Enabled = true, InitialImportMode = true });
+            HttpContext httpContext = new DefaultHttpContext();
+            httpContext.Request.Path = "/CustomError";
+            httpContext.Request.Method = HttpMethods.Post.ToString();
+            await middleware.Invoke(httpContext);
+
+            Assert.Equal(200, httpContext.Response.StatusCode);
+        }
+
+        [Fact]
         public async Task GivenGetResourceRequest_WhenInitialImportModeEnabled_Then200ShouldBeReturned()
         {
             InitialImportLockMiddleware middleware = CreateInitialImportLockMiddleware(new ImportTaskConfiguration() { Enabled = false, InitialImportMode = true });


### PR DESCRIPTION
## Description
Bypass not FHIR request (CustomError) for import lock.


## Testing
Add Unit test

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [x] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
