### PR TITLE
Fix search tests

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                     {
                         _output.WriteLine($"Failed to validate bundle: {ex}");
                         success = false;
-                        await Task.Delay(TimeSpan.FromSeconds(500));
+                        await Task.Delay(TimeSpan.FromSeconds(10));
                     }
                 }
                 while (!success && retryCount < 10);
@@ -315,7 +315,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                     {
                         _output.WriteLine($"Failed to validate bundle: {ex}");
                         success = false;
-                        await Task.Delay(TimeSpan.FromSeconds(500));
+                        await Task.Delay(TimeSpan.FromSeconds(10);
                     }
 
                     // now searching for patient with same search parameter should not work
@@ -440,7 +440,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                     {
                         _output.WriteLine($"Failed to validate bundle: {ex}");
                         success = false;
-                        await Task.Delay(TimeSpan.FromSeconds(500));
+                        await Task.Delay(TimeSpan.FromSeconds(10));
                     }
                 }
                 while (!success && retryCount < 3);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -351,7 +351,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             }
         }
 
-        [Fact(Skip = "Re-enable this test when https://microsofthealth.visualstudio.com/Health/_boards/board/t/Olympus/Stories/?workitem=83531 is fixed")]
+        [Fact]
         public async Task GivenASearchParameterWithMultipleBaseResourceTypes_WhenTargetingReindexJobToSameListOfResourceTypes_ThenSearchParametersMarkedFullyIndexed()
         {
             var randomName = Guid.NewGuid().ToString().ComputeHash().Substring(0, 14).ToLower();

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                     {
                         _output.WriteLine($"Failed to validate bundle: {ex}");
                         success = false;
-                        await Task.Delay(10000);
+                        await Task.Delay(TimeSpan.FromSeconds(500));
                     }
                 }
                 while (!success && retryCount < 10);
@@ -315,7 +315,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                     {
                         _output.WriteLine($"Failed to validate bundle: {ex}");
                         success = false;
-                        await Task.Delay(10000);
+                        await Task.Delay(TimeSpan.FromSeconds(500));
                     }
 
                     // now searching for patient with same search parameter should not work
@@ -440,7 +440,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                     {
                         _output.WriteLine($"Failed to validate bundle: {ex}");
                         success = false;
-                        await Task.Delay(10000);
+                        await Task.Delay(TimeSpan.FromSeconds(500));
                     }
                 }
                 while (!success && retryCount < 3);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -315,7 +315,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                     {
                         _output.WriteLine($"Failed to validate bundle: {ex}");
                         success = false;
-                        await Task.Delay(TimeSpan.FromSeconds(10);
+                        await Task.Delay(TimeSpan.FromSeconds(10));
                     }
 
                     // now searching for patient with same search parameter should not work


### PR DESCRIPTION
## Description
Enabling below custom search test - GivenASearchParameterWithMultipleBaseResourceTypes_WhenTargetingReindexJobToSameListOfResourceTypes_ThenSearchParametersMarkedFullyIndexed

Logging collection contents while validating the bundle. This could help while investigating failed test cases where the count doesn't match the expected collection count.

When the reindex job completes, we search for resources using the new parameter.  In the case of multiple instances of the fhir-server running, it could take some time for the search parameter/reindex updates to propagate to all instances. Hence we have added some retries to account for that delay. Increasing the delay to 10 seconds between these retries. (In the pipeline logs, noticed that the earlier 10000 ms delay was not that helpful)

## Related issues
Addresses [[83531](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Olympus/Stories/?workitem=83531)].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [x] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
