### PR TITLE
Use retryable wrappers instead of using SqlConnection string

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/ChangeFeed/SqlServerFhirResourceChangeDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/ChangeFeed/SqlServerFhirResourceChangeDataStore.cs
@@ -16,7 +16,7 @@ using Microsoft.Health.Abstractions.Data;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.SqlServer.Features.Schema;
 using Microsoft.Health.Fhir.SqlServer.Features.Schema.Model;
-using Microsoft.Health.SqlServer;
+using Microsoft.Health.SqlServer.Features.Client;
 using Microsoft.Health.SqlServer.Features.Schema;
 using Microsoft.Health.SqlServer.Features.Storage;
 
@@ -27,7 +27,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.ChangeFeed
     /// </summary>
     public class SqlServerFhirResourceChangeDataStore : IChangeFeedSource<ResourceChangeData>
     {
-        private readonly ISqlConnectionBuilder _sqlConnectionFactory;
+        private readonly SqlConnectionWrapperFactory _sqlConnectionWrapperFactory;
         private readonly ILogger<SqlServerFhirResourceChangeDataStore> _logger;
         private static readonly ConcurrentDictionary<short, string> ResourceTypeIdToTypeNameMap = new ConcurrentDictionary<short, string>();
 
@@ -39,16 +39,16 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.ChangeFeed
         /// <summary>
         /// Creates a new instance of the <see cref="SqlServerFhirResourceChangeDataStore"/> class.
         /// </summary>
-        /// <param name="sqlConnectionFactory">The SQL Connection factory.</param>
+        /// <param name="sqlConnectionWrapperFactory">The SQL Connection wrapper factory.</param>
         /// <param name="logger">The logger.</param>
         /// <param name="schemaInformation">The database schema information.</param>
-        public SqlServerFhirResourceChangeDataStore(ISqlConnectionBuilder sqlConnectionFactory, ILogger<SqlServerFhirResourceChangeDataStore> logger, SchemaInformation schemaInformation)
+        public SqlServerFhirResourceChangeDataStore(SqlConnectionWrapperFactory sqlConnectionWrapperFactory, ILogger<SqlServerFhirResourceChangeDataStore> logger, SchemaInformation schemaInformation)
         {
-            EnsureArg.IsNotNull(sqlConnectionFactory, nameof(sqlConnectionFactory));
+            EnsureArg.IsNotNull(sqlConnectionWrapperFactory, nameof(sqlConnectionWrapperFactory));
             EnsureArg.IsNotNull(logger, nameof(logger));
             EnsureArg.IsNotNull(schemaInformation, nameof(schemaInformation));
 
-            _sqlConnectionFactory = sqlConnectionFactory;
+            _sqlConnectionWrapperFactory = sqlConnectionWrapperFactory;
             _logger = logger;
             _schemaInformation = schemaInformation;
         }
@@ -98,49 +98,43 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.ChangeFeed
                 // The GetRecordsAsync function would be called every second by one agent.
                 // So, it would be a good option that opens and closes a connection for each call,
                 // and there is no database connection pooling in the Application at this time.
-                using (SqlConnection sqlConnection = await _sqlConnectionFactory.GetSqlConnectionAsync(cancellationToken: cancellationToken))
+                using (SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken, true))
+                using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateSqlCommand())
                 {
-                    await sqlConnection.OpenAsync(cancellationToken);
                     if (ResourceTypeIdToTypeNameMap.IsEmpty)
                     {
                         lock (ResourceTypeIdToTypeNameMap)
                         {
-                            if (ResourceTypeIdToTypeNameMap.IsEmpty)
-                            {
-                                UpdateResourceTypeMapAsync(sqlConnection);
-                            }
+                            UpdateResourceTypeMapAsync(sqlCommandWrapper);
                         }
                     }
 
-                    using (SqlCommand sqlCommand = sqlConnection.CreateCommand())
+                    PopulateFetchResourceChangesCommand(sqlCommandWrapper, startId, lastProcessedDateTime, pageSize);
+
+                    using (SqlDataReader sqlDataReader = await sqlCommandWrapper.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken))
                     {
-                        PopulateFetchResourceChangesCommand(sqlCommand, startId, lastProcessedDateTime, pageSize);
-
-                        using (SqlDataReader sqlDataReader = await sqlCommand.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken))
+                        while (await sqlDataReader.ReadAsync(cancellationToken))
                         {
-                            while (await sqlDataReader.ReadAsync(cancellationToken))
-                            {
-                                (long id, DateTime timestamp, string resourceId, short resourceTypeId, int resourceVersion, byte resourceChangeTypeId) = sqlDataReader.ReadRow(
-                                        VLatest.ResourceChangeData.Id,
-                                        VLatest.ResourceChangeData.Timestamp,
-                                        VLatest.ResourceChangeData.ResourceId,
-                                        VLatest.ResourceChangeData.ResourceTypeId,
-                                        VLatest.ResourceChangeData.ResourceVersion,
-                                        VLatest.ResourceChangeData.ResourceChangeTypeId);
+                            (long id, DateTime timestamp, string resourceId, short resourceTypeId, int resourceVersion, byte resourceChangeTypeId) = sqlDataReader.ReadRow(
+                                    VLatest.ResourceChangeData.Id,
+                                    VLatest.ResourceChangeData.Timestamp,
+                                    VLatest.ResourceChangeData.ResourceId,
+                                    VLatest.ResourceChangeData.ResourceTypeId,
+                                    VLatest.ResourceChangeData.ResourceVersion,
+                                    VLatest.ResourceChangeData.ResourceChangeTypeId);
 
-                                listResourceChangeData.Add(new ResourceChangeData(
-                                    id: id,
-                                    timestamp: DateTime.SpecifyKind(timestamp, DateTimeKind.Utc),
-                                    resourceId: resourceId,
-                                    resourceTypeId: resourceTypeId,
-                                    resourceVersion: resourceVersion,
-                                    resourceChangeTypeId: resourceChangeTypeId,
-                                    resourceTypeName: ResourceTypeIdToTypeNameMap[resourceTypeId]));
-                            }
+                            listResourceChangeData.Add(new ResourceChangeData(
+                                id: id,
+                                timestamp: DateTime.SpecifyKind(timestamp, DateTimeKind.Utc),
+                                resourceId: resourceId,
+                                resourceTypeId: resourceTypeId,
+                                resourceVersion: resourceVersion,
+                                resourceChangeTypeId: resourceChangeTypeId,
+                                resourceTypeName: ResourceTypeIdToTypeNameMap[resourceTypeId]));
                         }
-
-                        return listResourceChangeData;
                     }
+
+                    return listResourceChangeData;
                 }
             }
             catch (Exception ex) when ((ex is OperationCanceledException || ex is TaskCanceledException) && cancellationToken.IsCancellationRequested)
@@ -166,38 +160,35 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.ChangeFeed
             }
         }
 
-        private void PopulateFetchResourceChangesCommand(SqlCommand sqlCommand, long startId, DateTime lastProcessedDateTime, short pageSize)
+        private void PopulateFetchResourceChangesCommand(SqlCommandWrapper sqlCommandWrapper, long startId, DateTime lastProcessedDateTime, short pageSize)
         {
-            sqlCommand.CommandType = CommandType.StoredProcedure;
-            sqlCommand.Parameters.AddWithValue("@startId", SqlDbType.BigInt).Value = startId;
-            sqlCommand.Parameters.AddWithValue("@pageSize", SqlDbType.SmallInt).Value = pageSize;
+            sqlCommandWrapper.CommandType = CommandType.StoredProcedure;
+            sqlCommandWrapper.Parameters.AddWithValue("@startId", SqlDbType.BigInt).Value = startId;
+            sqlCommandWrapper.Parameters.AddWithValue("@pageSize", SqlDbType.SmallInt).Value = pageSize;
             if (_schemaInformation.Current >= SchemaVersionConstants.SupportsClusteredIdOnResourceChangesVersion)
             {
-                sqlCommand.CommandText = "dbo.FetchResourceChanges_3";
-                sqlCommand.Parameters.AddWithValue("@lastProcessedUtcDateTime", SqlDbType.DateTime2).Value = lastProcessedDateTime;
+                sqlCommandWrapper.CommandText = "dbo.FetchResourceChanges_3";
+                sqlCommandWrapper.Parameters.AddWithValue("@lastProcessedUtcDateTime", SqlDbType.DateTime2).Value = lastProcessedDateTime;
             }
             else if (_schemaInformation.Current >= SchemaVersionConstants.SupportsPartitionedResourceChangeDataVersion)
             {
-                sqlCommand.CommandText = "dbo.FetchResourceChanges_2";
-                sqlCommand.Parameters.AddWithValue("@lastProcessedDateTime", SqlDbType.DateTime2).Value = lastProcessedDateTime;
+                sqlCommandWrapper.CommandText = "dbo.FetchResourceChanges_2";
+                sqlCommandWrapper.Parameters.AddWithValue("@lastProcessedDateTime", SqlDbType.DateTime2).Value = lastProcessedDateTime;
             }
             else
             {
-                sqlCommand.CommandText = "dbo.FetchResourceChanges";
+                sqlCommandWrapper.CommandText = "dbo.FetchResourceChanges";
             }
         }
 
-        private static void UpdateResourceTypeMapAsync(SqlConnection sqlConnection)
+        private static void UpdateResourceTypeMapAsync(SqlCommandWrapper sqlCommandWrapper)
         {
-            using (SqlCommand sqlCommand = new SqlCommand("SELECT ResourceTypeId, Name FROM dbo.ResourceType", sqlConnection))
+            sqlCommandWrapper.CommandText = "SELECT ResourceTypeId, Name FROM dbo.ResourceType";
+            using (SqlDataReader sqlDataReader = sqlCommandWrapper.ExecuteReader(CommandBehavior.SequentialAccess))
             {
-                sqlCommand.CommandType = CommandType.Text;
-                using (SqlDataReader sqlDataReader = sqlCommand.ExecuteReader(CommandBehavior.SequentialAccess))
+                while (sqlDataReader.Read())
                 {
-                    while (sqlDataReader.Read())
-                    {
-                        ResourceTypeIdToTypeNameMap.TryAdd((short)sqlDataReader["ResourceTypeId"], (string)sqlDataReader["Name"]);
-                    }
+                    ResourceTypeIdToTypeNameMap.TryAdd((short)sqlDataReader["ResourceTypeId"], (string)sqlDataReader["Name"]);
                 }
             }
         }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/ChangeFeed/SqlServerFhirResourceChangeDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/ChangeFeed/SqlServerFhirResourceChangeDataStore.cs
@@ -105,7 +105,10 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.ChangeFeed
                     {
                         lock (ResourceTypeIdToTypeNameMap)
                         {
-                            UpdateResourceTypeMapAsync(sqlCommandWrapper);
+                            if (ResourceTypeIdToTypeNameMap.IsEmpty)
+                            {
+                                UpdateResourceTypeMapAsync(sqlCommandWrapper);
+                            }
                         }
                     }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
@@ -25,7 +25,7 @@ using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.SqlServer.Features.Schema;
 using Microsoft.Health.Fhir.SqlServer.Features.Schema.Model;
 using Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry;
-using Microsoft.Health.SqlServer;
+using Microsoft.Health.SqlServer.Features.Client;
 using Microsoft.Health.SqlServer.Features.Schema;
 using Microsoft.Health.SqlServer.Features.Schema.Model;
 using Microsoft.Health.SqlServer.Features.Storage;
@@ -45,7 +45,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
         private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager;
         private readonly ISearchParameterStatusDataStore _filebasedSearchParameterStatusDataStore;
         private readonly SecurityConfiguration _securityConfiguration;
-        private readonly ISqlConnectionBuilder _sqlConnectionFactory;
+        private readonly Func<IScoped<SqlConnectionWrapperFactory>> _scopedSqlConnectionWrapperFactory;
         private readonly IMediator _mediator;
         private readonly ILogger<SqlServerFhirModel> _logger;
         private Dictionary<string, short> _resourceTypeToId;
@@ -64,7 +64,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             ISearchParameterDefinitionManager searchParameterDefinitionManager,
             FilebasedSearchParameterStatusDataStore.Resolver filebasedRegistry,
             IOptions<SecurityConfiguration> securityConfiguration,
-            ISqlConnectionBuilder sqlConnectionFactory,
+            Func<IScoped<SqlConnectionWrapperFactory>> scopedSqlConnectionWrapperFactory,
             IMediator mediator,
             ILogger<SqlServerFhirModel> logger)
         {
@@ -72,14 +72,14 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             EnsureArg.IsNotNull(searchParameterDefinitionManager, nameof(searchParameterDefinitionManager));
             EnsureArg.IsNotNull(filebasedRegistry, nameof(filebasedRegistry));
             EnsureArg.IsNotNull(securityConfiguration?.Value, nameof(securityConfiguration));
-            EnsureArg.IsNotNull(sqlConnectionFactory, nameof(sqlConnectionFactory));
+            EnsureArg.IsNotNull(scopedSqlConnectionWrapperFactory, nameof(scopedSqlConnectionWrapperFactory));
             EnsureArg.IsNotNull(logger, nameof(logger));
 
             _schemaInformation = schemaInformation;
             _searchParameterDefinitionManager = searchParameterDefinitionManager;
             _filebasedSearchParameterStatusDataStore = filebasedRegistry.Invoke();
             _securityConfiguration = securityConfiguration.Value;
-            _sqlConnectionFactory = sqlConnectionFactory;
+            _scopedSqlConnectionWrapperFactory = scopedSqlConnectionWrapperFactory;
             _mediator = mediator;
             _logger = logger;
         }
@@ -187,8 +187,12 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                 return;
             }
 
-            var sqlConnection = await _sqlConnectionFactory.GetSqlConnectionAsync(cancellationToken: cancellationToken);
-            _logger.LogInformation("Initializing {Server} {Database} to version {Version}", sqlConnection.DataSource, sqlConnection.Database, version);
+            using (IScoped<SqlConnectionWrapperFactory> scopedSqlConnectionWrapperFactory = _scopedSqlConnectionWrapperFactory())
+            using (SqlConnectionWrapper sqlConnectionWrapper = await scopedSqlConnectionWrapperFactory.Value.ObtainSqlConnectionWrapperAsync(cancellationToken, true))
+            using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateSqlCommand())
+            {
+                 _logger.LogInformation("Initializing {Server} {Database} to version {Version}", sqlCommandWrapper.Connection.DataSource, sqlCommandWrapper.Connection.Database, version);
+            }
 
             // If we are applying a full snap shot schema file, or if the server is just starting up
             if (runAllInitialization || _highestInitializedVersion == 0)
@@ -217,15 +221,13 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
         private async Task InitializeBase(CancellationToken cancellationToken)
         {
-            using (var connection = await _sqlConnectionFactory.GetSqlConnectionAsync(cancellationToken: cancellationToken))
+            using (IScoped<SqlConnectionWrapperFactory> scopedSqlConnectionWrapperFactory = _scopedSqlConnectionWrapperFactory())
+            using (SqlConnectionWrapper sqlConnectionWrapper = await scopedSqlConnectionWrapperFactory.Value.ObtainSqlConnectionWrapperAsync(cancellationToken, true))
+            using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateSqlCommand())
             {
-                connection.Open();
-
                 // Synchronous calls are used because this code is executed on startup and doesn't need to be async.
                 // Additionally, XUnit task scheduler constraints prevent async calls from being easily tested.
-                using (SqlCommand sqlCommand = connection.CreateCommand())
-                {
-                    sqlCommand.CommandText = @"
+                sqlCommandWrapper.CommandText = @"
                         SET XACT_ABORT ON
                         BEGIN TRANSACTION
 
@@ -266,114 +268,111 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                         -- result set 6
                         SELECT Value, QuantityCodeId FROM dbo.QuantityCode";
 
-                    string searchParametersJson = JsonConvert.SerializeObject(_searchParameterDefinitionManager.AllSearchParameters.Select(p => new { Uri = p.Url }));
-                    string commaSeparatedResourceTypes = string.Join(",", ModelInfoProvider.GetResourceTypeNames());
-                    string commaSeparatedClaimTypes = string.Join(',', _securityConfiguration.PrincipalClaims);
-                    string commaSeparatedCompartmentTypes = string.Join(',', ModelInfoProvider.GetCompartmentTypeNames());
+                string searchParametersJson = JsonConvert.SerializeObject(_searchParameterDefinitionManager.AllSearchParameters.Select(p => new { Uri = p.Url }));
+                string commaSeparatedResourceTypes = string.Join(",", ModelInfoProvider.GetResourceTypeNames());
+                string commaSeparatedClaimTypes = string.Join(',', _securityConfiguration.PrincipalClaims);
+                string commaSeparatedCompartmentTypes = string.Join(',', ModelInfoProvider.GetCompartmentTypeNames());
 
-                    sqlCommand.Parameters.AddWithValue("@searchParams", searchParametersJson);
-                    sqlCommand.Parameters.AddWithValue("@resourceTypes", commaSeparatedResourceTypes);
-                    sqlCommand.Parameters.AddWithValue("@claimTypes", commaSeparatedClaimTypes);
-                    sqlCommand.Parameters.AddWithValue("@compartmentTypes", commaSeparatedCompartmentTypes);
+                sqlCommandWrapper.Parameters.AddWithValue("@searchParams", searchParametersJson);
+                sqlCommandWrapper.Parameters.AddWithValue("@resourceTypes", commaSeparatedResourceTypes);
+                sqlCommandWrapper.Parameters.AddWithValue("@claimTypes", commaSeparatedClaimTypes);
+                sqlCommandWrapper.Parameters.AddWithValue("@compartmentTypes", commaSeparatedCompartmentTypes);
 
-                    using (SqlDataReader reader = sqlCommand.ExecuteReader(CommandBehavior.SequentialAccess))
+                using (SqlDataReader reader = sqlCommandWrapper.ExecuteReader(CommandBehavior.SequentialAccess))
+                {
+                    var resourceTypeToId = new Dictionary<string, short>(StringComparer.Ordinal);
+                    var resourceTypeIdToTypeName = new Dictionary<short, string>();
+                    var searchParamUriToId = new Dictionary<Uri, short>();
+                    var systemToId = new ConcurrentDictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+                    var quantityCodeToId = new ConcurrentDictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+                    var claimNameToId = new Dictionary<string, byte>(StringComparer.Ordinal);
+                    var compartmentTypeToId = new Dictionary<string, byte>();
+
+                    // result set 1
+                    short lowestResourceTypeId = short.MaxValue;
+                    short highestResourceTypeId = short.MinValue;
+                    while (reader.Read())
                     {
-                        var resourceTypeToId = new Dictionary<string, short>(StringComparer.Ordinal);
-                        var resourceTypeIdToTypeName = new Dictionary<short, string>();
-                        var searchParamUriToId = new Dictionary<Uri, short>();
-                        var systemToId = new ConcurrentDictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-                        var quantityCodeToId = new ConcurrentDictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-                        var claimNameToId = new Dictionary<string, byte>(StringComparer.Ordinal);
-                        var compartmentTypeToId = new Dictionary<string, byte>();
+                        (short id, string resourceTypeName) = reader.ReadRow(VLatest.ResourceType.ResourceTypeId, VLatest.ResourceType.Name);
 
-                        // result set 1
-                        short lowestResourceTypeId = short.MaxValue;
-                        short highestResourceTypeId = short.MinValue;
-                        while (reader.Read())
+                        resourceTypeToId.Add(resourceTypeName, id);
+                        if (id > highestResourceTypeId)
                         {
-                            (short id, string resourceTypeName) = reader.ReadRow(VLatest.ResourceType.ResourceTypeId, VLatest.ResourceType.Name);
-
-                            resourceTypeToId.Add(resourceTypeName, id);
-                            if (id > highestResourceTypeId)
-                            {
-                                highestResourceTypeId = id;
-                            }
-
-                            if (id < lowestResourceTypeId)
-                            {
-                                lowestResourceTypeId = id;
-                            }
-
-                            resourceTypeIdToTypeName.Add(id, resourceTypeName);
+                            highestResourceTypeId = id;
                         }
 
-                        // result set 2
-                        reader.NextResult();
-
-                        while (reader.Read())
+                        if (id < lowestResourceTypeId)
                         {
-                            (string uri, short searchParamId) = reader.ReadRow(VLatest.SearchParam.Uri, VLatest.SearchParam.SearchParamId);
-                            searchParamUriToId.Add(new Uri(uri), searchParamId);
+                            lowestResourceTypeId = id;
                         }
 
-                        // result set 3
-                        reader.NextResult();
-
-                        while (reader.Read())
-                        {
-                            (byte id, string claimTypeName) = reader.ReadRow(VLatest.ClaimType.ClaimTypeId, VLatest.ClaimType.Name);
-                            claimNameToId.Add(claimTypeName, id);
-                        }
-
-                        // result set 4
-                        reader.NextResult();
-
-                        while (reader.Read())
-                        {
-                            (byte id, string compartmentName) = reader.ReadRow(VLatest.CompartmentType.CompartmentTypeId, VLatest.CompartmentType.Name);
-                            compartmentTypeToId.Add(compartmentName, id);
-                        }
-
-                        // result set 5
-                        reader.NextResult();
-
-                        while (reader.Read())
-                        {
-                            var (value, systemId) = reader.ReadRow(VLatest.System.Value, VLatest.System.SystemId);
-                            systemToId.TryAdd(value, systemId);
-                        }
-
-                        // result set 6
-                        reader.NextResult();
-
-                        while (reader.Read())
-                        {
-                            (string value, int quantityCodeId) = reader.ReadRow(VLatest.QuantityCode.Value, VLatest.QuantityCode.QuantityCodeId);
-                            quantityCodeToId.TryAdd(value, quantityCodeId);
-                        }
-
-                        _resourceTypeToId = resourceTypeToId;
-                        _resourceTypeIdToTypeName = resourceTypeIdToTypeName;
-                        _searchParamUriToId = searchParamUriToId;
-                        _systemToId = systemToId;
-                        _quantityCodeToId = quantityCodeToId;
-                        _claimNameToId = claimNameToId;
-                        _compartmentTypeToId = compartmentTypeToId;
-                        _resourceTypeIdRange = (lowestResourceTypeId, highestResourceTypeId);
+                        resourceTypeIdToTypeName.Add(id, resourceTypeName);
                     }
+
+                    // result set 2
+                    reader.NextResult();
+
+                    while (reader.Read())
+                    {
+                        (string uri, short searchParamId) = reader.ReadRow(VLatest.SearchParam.Uri, VLatest.SearchParam.SearchParamId);
+                        searchParamUriToId.Add(new Uri(uri), searchParamId);
+                    }
+
+                    // result set 3
+                    reader.NextResult();
+
+                    while (reader.Read())
+                    {
+                        (byte id, string claimTypeName) = reader.ReadRow(VLatest.ClaimType.ClaimTypeId, VLatest.ClaimType.Name);
+                        claimNameToId.Add(claimTypeName, id);
+                    }
+
+                    // result set 4
+                    reader.NextResult();
+
+                    while (reader.Read())
+                    {
+                        (byte id, string compartmentName) = reader.ReadRow(VLatest.CompartmentType.CompartmentTypeId, VLatest.CompartmentType.Name);
+                        compartmentTypeToId.Add(compartmentName, id);
+                    }
+
+                    // result set 5
+                    reader.NextResult();
+
+                    while (reader.Read())
+                    {
+                        var (value, systemId) = reader.ReadRow(VLatest.System.Value, VLatest.System.SystemId);
+                        systemToId.TryAdd(value, systemId);
+                    }
+
+                    // result set 6
+                    reader.NextResult();
+
+                    while (reader.Read())
+                    {
+                        (string value, int quantityCodeId) = reader.ReadRow(VLatest.QuantityCode.Value, VLatest.QuantityCode.QuantityCodeId);
+                        quantityCodeToId.TryAdd(value, quantityCodeId);
+                    }
+
+                    _resourceTypeToId = resourceTypeToId;
+                    _resourceTypeIdToTypeName = resourceTypeIdToTypeName;
+                    _searchParamUriToId = searchParamUriToId;
+                    _systemToId = systemToId;
+                    _quantityCodeToId = quantityCodeToId;
+                    _claimNameToId = claimNameToId;
+                    _compartmentTypeToId = compartmentTypeToId;
+                    _resourceTypeIdRange = (lowestResourceTypeId, highestResourceTypeId);
                 }
             }
         }
 
         private async Task InitializeSearchParameterStatuses(CancellationToken cancellationToken)
         {
-            using (var connection = await _sqlConnectionFactory.GetSqlConnectionAsync(cancellationToken: cancellationToken))
+            using (IScoped<SqlConnectionWrapperFactory> scopedSqlConnectionWrapperFactory = _scopedSqlConnectionWrapperFactory())
+            using (SqlConnectionWrapper sqlConnectionWrapper = await scopedSqlConnectionWrapperFactory.Value.ObtainSqlConnectionWrapperAsync(cancellationToken, true))
+            using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateSqlCommand())
             {
-                connection.Open();
-
-                using (SqlCommand sqlCommand = connection.CreateCommand())
-                {
-                    sqlCommand.CommandText = @"
+                sqlCommandWrapper.CommandText = @"
                         SET XACT_ABORT ON
                         BEGIN TRANSACTION
                         DECLARE @lastUpdated datetimeoffset(7) = SYSDATETIMEOFFSET()
@@ -384,24 +383,23 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                         ON dbo.SearchParam.Uri = sps.Uri
                         COMMIT TRANSACTION";
 
-                    IEnumerable<ResourceSearchParameterStatus> statuses = _filebasedSearchParameterStatusDataStore
-                        .GetSearchParameterStatuses(cancellationToken).GetAwaiter().GetResult();
+                IEnumerable<ResourceSearchParameterStatus> statuses = _filebasedSearchParameterStatusDataStore
+                    .GetSearchParameterStatuses(cancellationToken).GetAwaiter().GetResult();
 
-                    var collection = new SearchParameterStatusCollection();
-                    collection.AddRange(statuses);
+                var collection = new SearchParameterStatusCollection();
+                collection.AddRange(statuses);
 
-                    var tableValuedParameter = new SqlParameter
-                    {
-                        ParameterName = "searchParamStatuses",
-                        SqlDbType = SqlDbType.Structured,
-                        Value = collection,
-                        Direction = ParameterDirection.Input,
-                        TypeName = "dbo.SearchParamTableType_1",
-                    };
+                var tableValuedParameter = new SqlParameter
+                {
+                    ParameterName = "searchParamStatuses",
+                    SqlDbType = SqlDbType.Structured,
+                    Value = collection,
+                    Direction = ParameterDirection.Input,
+                    TypeName = "dbo.SearchParamTableType_1",
+                };
 
-                    sqlCommand.Parameters.Add(tableValuedParameter);
-                    sqlCommand.ExecuteNonQuery();
-                }
+                sqlCommandWrapper.Parameters.Add(tableValuedParameter);
+                await sqlCommandWrapper.ExecuteNonQueryAsync(cancellationToken);
             }
         }
 
@@ -417,16 +415,14 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             // Forgive me father, I have sinned.
             // In ideal world I should make this method async, but that spirals out of control and forces changes in all RowGenerators (about 35 files)
             // and overall logic of preparing data for insert.
-            using (var connection = _sqlConnectionFactory.GetSqlConnectionAsync().GetAwaiter().GetResult())
+            using (IScoped<SqlConnectionWrapperFactory> scopedSqlConnectionWrapperFactory = _scopedSqlConnectionWrapperFactory())
+            using (SqlConnectionWrapper sqlConnectionWrapper = scopedSqlConnectionWrapperFactory.Value.ObtainSqlConnectionWrapperAsync(CancellationToken.None, true).Result)
+            using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateSqlCommand())
             {
-                connection.Open();
-
-                using (SqlCommand sqlCommand = connection.CreateCommand())
-                {
-                    // This command are not using any user arguments, and can't be rewritten to parametrized command string
-                    // because you can't parameterize column or table.
+                // This command are not using any user arguments, and can't be rewritten to parametrized command string
+                // because you can't parameterize column or table.
 #pragma warning disable CA2100
-                    sqlCommand.CommandText = $@"
+                sqlCommandWrapper.CommandText = $@"
                         SET TRANSACTION ISOLATION LEVEL SERIALIZABLE
                         BEGIN TRANSACTION
 
@@ -444,14 +440,13 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
                         SELECT @id";
 
-                    sqlCommand.Parameters.AddWithValue("@stringValue", stringValue);
+                sqlCommandWrapper.Parameters.AddWithValue("@stringValue", stringValue);
 
 #pragma warning restore CA2100
-                    id = (int)sqlCommand.ExecuteScalar();
+                id = (int)sqlCommandWrapper.ExecuteScalarAsync(CancellationToken.None).Result;
 
-                    cache.TryAdd(stringValue, id);
-                    return id;
-                }
+                cache.TryAdd(stringValue, id);
+                return id;
             }
         }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/ChangeFeed/SqlServerFhirResourceChangeCaptureDisabledTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/ChangeFeed/SqlServerFhirResourceChangeCaptureDisabledTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.ChangeFeed
                 var deletedResourceKey = await mediator.DeleteResourceAsync(new ResourceKey("Observation", saveResult.RawResourceElement.Id), DeleteOperation.SoftDelete);
 
                 // get resource changes
-                var resourceChangeDataStore = new SqlServerFhirResourceChangeDataStore(sqlFixture.SqlConnectionBuilder, NullLogger<SqlServerFhirResourceChangeDataStore>.Instance, sqlFixture.SchemaInformation);
+                var resourceChangeDataStore = new SqlServerFhirResourceChangeDataStore(sqlFixture.SqlConnectionWrapperFactory, NullLogger<SqlServerFhirResourceChangeDataStore>.Instance, sqlFixture.SchemaInformation);
                 var resourceChanges = await resourceChangeDataStore.GetRecordsAsync(1, 200, CancellationToken.None);
 
                 Assert.NotNull(resourceChanges);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/ChangeFeed/SqlServerFhirResourceChangeCaptureEnabledTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/ChangeFeed/SqlServerFhirResourceChangeCaptureEnabledTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.ChangeFeed
             var deserialized = saveResult.RawResourceElement.ToResourceElement(Deserializers.ResourceDeserializer);
 
             // get resource changes
-            var resourceChangeDataStore = new SqlServerFhirResourceChangeDataStore(_fixture.SqlConnectionBuilder, NullLogger<SqlServerFhirResourceChangeDataStore>.Instance, _fixture.SchemaInformation);
+            var resourceChangeDataStore = new SqlServerFhirResourceChangeDataStore(_fixture.SqlConnectionWrapperFactory, NullLogger<SqlServerFhirResourceChangeDataStore>.Instance, _fixture.SchemaInformation);
             var resourceChanges = await resourceChangeDataStore.GetRecordsAsync(1, 200, CancellationToken.None);
 
             Assert.NotNull(resourceChanges);
@@ -70,7 +70,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.ChangeFeed
             var deserialized = updateResult.RawResourceElement.ToResourceElement(Deserializers.ResourceDeserializer);
 
             // get resource changes
-            var resourceChangeDataStore = new SqlServerFhirResourceChangeDataStore(_fixture.SqlConnectionBuilder, NullLogger<SqlServerFhirResourceChangeDataStore>.Instance, _fixture.SchemaInformation);
+            var resourceChangeDataStore = new SqlServerFhirResourceChangeDataStore(_fixture.SqlConnectionWrapperFactory, NullLogger<SqlServerFhirResourceChangeDataStore>.Instance, _fixture.SchemaInformation);
             var resourceChanges = await resourceChangeDataStore.GetRecordsAsync(1, 200, CancellationToken.None);
 
             Assert.NotNull(resourceChanges);
@@ -97,7 +97,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.ChangeFeed
             var deletedResourceKey = await _fixture.Mediator.DeleteResourceAsync(new ResourceKey("Observation", saveResult.RawResourceElement.Id), DeleteOperation.SoftDelete);
 
             // get resource changes
-            var resourceChangeDataStore = new SqlServerFhirResourceChangeDataStore(_fixture.SqlConnectionBuilder, NullLogger<SqlServerFhirResourceChangeDataStore>.Instance, _fixture.SchemaInformation);
+            var resourceChangeDataStore = new SqlServerFhirResourceChangeDataStore(_fixture.SqlConnectionWrapperFactory, NullLogger<SqlServerFhirResourceChangeDataStore>.Instance, _fixture.SchemaInformation);
             var resourceChanges = await resourceChangeDataStore.GetRecordsAsync(1, 200, CancellationToken.None);
 
             Assert.NotNull(resourceChanges);
@@ -121,7 +121,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.ChangeFeed
             var deserialized = saveResult.RawResourceElement.ToResourceElement(Deserializers.ResourceDeserializer);
 
             // get resource types
-            var resourceChangeDataStore = new SqlServerFhirResourceChangeDataStore(_fixture.SqlConnectionBuilder, NullLogger<SqlServerFhirResourceChangeDataStore>.Instance, _fixture.SchemaInformation);
+            var resourceChangeDataStore = new SqlServerFhirResourceChangeDataStore(_fixture.SqlConnectionWrapperFactory, NullLogger<SqlServerFhirResourceChangeDataStore>.Instance, _fixture.SchemaInformation);
             var resourceChanges = await resourceChangeDataStore.GetRecordsAsync(1, 200, CancellationToken.None);
 
             Assert.NotNull(resourceChanges);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/ChangeFeed/SqlServerFhirResourceChangeCaptureFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/ChangeFeed/SqlServerFhirResourceChangeCaptureFixture.cs
@@ -12,6 +12,7 @@ using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.SqlServer.Features.Schema;
 using Microsoft.Health.Fhir.Tests.Integration.Persistence;
 using Microsoft.Health.SqlServer;
+using Microsoft.Health.SqlServer.Features.Client;
 using Microsoft.Health.SqlServer.Features.Schema;
 using Xunit;
 
@@ -37,7 +38,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.ChangeFeed
 
         public Mediator Mediator => _storageFixture.Mediator;
 
-        public ISqlConnectionBuilder SqlConnectionBuilder => _sqlFixture.SqlConnectionBuilder;
+        public SqlConnectionWrapperFactory SqlConnectionWrapperFactory => _sqlFixture.SqlConnectionWrapperFactory;
 
         public SchemaInformation SchemaInformation => _sqlFixture.SchemaInformation;
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -100,12 +100,15 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
             var securityConfiguration = new SecurityConfiguration { PrincipalClaims = { "oid" } };
 
+            SqlTransactionHandler = new SqlTransactionHandler();
+            SqlConnectionWrapperFactory = new SqlConnectionWrapperFactory(SqlTransactionHandler, new SqlCommandWrapperFactory(), SqlConnectionBuilder);
+
             var sqlServerFhirModel = new SqlServerFhirModel(
                 SchemaInformation,
                 _searchParameterDefinitionManager,
                 () => _filebasedSearchParameterStatusDataStore,
                 Options.Create(securityConfiguration),
-                SqlConnectionBuilder,
+                () => SqlConnectionWrapperFactory.CreateMockScope(),
                 Substitute.For<IMediator>(),
                 NullLogger<SqlServerFhirModel>.Instance);
             SqlServerFhirModel = sqlServerFhirModel;
@@ -133,9 +136,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             var upsertSearchParamsTvpGenerator = serviceProvider.GetRequiredService<VLatest.UpsertSearchParamsTvpGenerator<List<ResourceSearchParameterStatus>>>();
 
             _supportedSearchParameterDefinitionManager = new SupportedSearchParameterDefinitionManager(_searchParameterDefinitionManager);
-
-            SqlTransactionHandler = new SqlTransactionHandler();
-            SqlConnectionWrapperFactory = new SqlConnectionWrapperFactory(SqlTransactionHandler, new SqlCommandWrapperFactory(), SqlConnectionBuilder);
 
             SqlServerSearchParameterStatusDataStore = new SqlServerSearchParameterStatusDataStore(
                 () => SqlConnectionWrapperFactory.CreateMockScope(),

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
@@ -23,8 +23,10 @@ using Microsoft.Health.Fhir.SqlServer.Features.Schema;
 using Microsoft.Health.Fhir.SqlServer.Features.Storage;
 using Microsoft.Health.SqlServer;
 using Microsoft.Health.SqlServer.Configs;
+using Microsoft.Health.SqlServer.Features.Client;
 using Microsoft.Health.SqlServer.Features.Schema;
 using Microsoft.Health.SqlServer.Features.Schema.Manager;
+using Microsoft.Health.SqlServer.Features.Storage;
 using Microsoft.SqlServer.Dac.Compare;
 using NSubstitute;
 using Xunit;
@@ -128,12 +130,15 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             var defaultSqlConnectionBuilder = new DefaultSqlConnectionBuilder(sqlConnectionStringProvider, config);
             var securityConfiguration = new SecurityConfiguration { PrincipalClaims = { "oid" } };
 
+            var sqlTransactionHandler = new SqlTransactionHandler();
+            var defaultSqlConnectionWrapperFactory = new SqlConnectionWrapperFactory(sqlTransactionHandler, new SqlCommandWrapperFactory(), defaultSqlConnectionBuilder);
+
             SqlServerFhirModel sqlServerFhirModel = new SqlServerFhirModel(
                 schemaInformation,
                 defManager,
                 () => statusStore,
                 Options.Create(securityConfiguration),
-                defaultSqlConnectionBuilder,
+                () => defaultSqlConnectionWrapperFactory.CreateMockScope(),
                 Substitute.For<IMediator>(),
                 NullLogger<SqlServerFhirModel>.Instance);
 


### PR DESCRIPTION
## Description
Use retryable wrappers instead of using SqlConnection string to create SqlConnection and SqlCommand which fails with transient issues today.

Using scoped SqlConnectionWrapperFactory in SqlServerFhirModel . SqlServerFhirModel is registered as a singleton service and SqlConnectionWrapperFactory is registered as scoped service. In this change, we are using SqlConnectionWrapperFactory in SqlServerFhirModel but we can not consume scoped service or transient service from a singleton. (You should also avoid consuming transient service from a scoped service.)

Your singleton SqlServerFhirModel would get an instance of SqlConnectionWrapperFactory, and every other time you try to get an instance of SqlServerFhirModel since it’s a singleton it will have the same state, and it will always contain the same instance of SqlConnectionWrapperFactory, meaning that SqlConnectionWrapperFactory effectively becomes a singleton inside of SqlServerFhirModel.

What is happening when you consume scoped service from a singleton service is known as a captive dependency. It occurs when a service intended to live for a short(er) amount of time gets held by a service that lives for a more extended amount of time. This almost always suggests that you should change something in your design.

## Related issues
Addresses [[87996](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Olympus/Stories/?workitem=87996)].

## Testing
Existing tests pass and some manually testing

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
