### PR TITLE
Catch SqlExceptions at the Request level

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Microsoft.Health.Fhir.Api.csproj
+++ b/src/Microsoft.Health.Fhir.Api/Microsoft.Health.Fhir.Api.csproj
@@ -26,7 +26,6 @@
     <PackageReference Include="Microsoft.Health.Abstractions" Version="$(HealthcareSharedPackageVersion)" />
     <PackageReference Include="Microsoft.Health.Api" Version="$(HealthcareSharedPackageVersion)" />
     <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" Version="$(HealthcareSharedPackageVersion)" />
-    <PackageReference Include="Microsoft.Health.SqlServer" Version="$(HealthcareSharedPackageVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Health.Fhir.Core\Microsoft.Health.Fhir.Core.csproj" />

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
@@ -11,7 +11,6 @@ using EnsureThat;
 using Hl7.Fhir.Model;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Filters;
-using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.Abstractions.Exceptions;
 using Microsoft.Health.Api.Features.Audit;
@@ -29,7 +28,6 @@ using Microsoft.Health.Fhir.Core.Features.Operations.ConvertData.Models;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Features.Validation;
-using Microsoft.Health.SqlServer.Features.Storage;
 using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.Health.Fhir.Api.Features.Filters
@@ -223,11 +221,6 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
             else if (context.Exception is FormatException formatException)
             {
                 context.Result = CreateOperationOutcomeResult(formatException.Message, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid, HttpStatusCode.BadRequest);
-                context.ExceptionHandled = true;
-            }
-            else if (context.Exception is SqlException sqlException && sqlException.Number == SqlErrorCodes.TimeoutExpired)
-            {
-                context.Result = CreateOperationOutcomeResult(sqlException.Message, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Timeout, HttpStatusCode.RequestTimeout);
                 context.ExceptionHandled = true;
             }
             else if (context.Exception.InnerException != null)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/ChangeFeed/SqlServerFhirResourceChangeDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/ChangeFeed/SqlServerFhirResourceChangeDataStore.cs
@@ -150,14 +150,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.ChangeFeed
             }
             catch (SqlException ex)
             {
-                switch (ex.Number)
-                {
-                    case SqlErrorCodes.TimeoutExpired:
-                        throw new TimeoutException(ex.Message, ex);
-                    default:
-                        _logger.LogError(ex, string.Format(Resources.SqlExceptionOccurredWhenFetchingResourceChanges, ex.Number));
-                        throw;
-                }
+                _logger.LogError(ex, string.Format(Resources.SqlExceptionOccurredWhenFetchingResourceChanges, ex.Number));
+                throw;
             }
             catch (Exception ex)
             {

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlExceptionActionProcessor.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlExceptionActionProcessor.cs
@@ -1,0 +1,38 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using MediatR.Pipeline;
+using Microsoft.Data.SqlClient;
+using Microsoft.Health.Fhir.Core.Exceptions;
+using Microsoft.Health.SqlServer.Features.Storage;
+
+namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
+{
+    public class SqlExceptionActionProcessor<TRequest, TException> : IRequestExceptionAction<TRequest, TException>
+        where TRequest : IRequest
+        where TException : Exception
+    {
+        public Task Execute(TRequest request, TException exception, CancellationToken cancellationToken)
+        {
+            if (exception is SqlException sqlException)
+            {
+                if (sqlException.Number == SqlErrorCodes.TimeoutExpired)
+                {
+                    throw new RequestTimeoutException(Resources.ExecutionTimeoutExpired);
+                }
+                else if (sqlException.Number == SqlErrorCodes.MethodNotAllowed)
+                {
+                    throw new MethodNotAllowedException(Core.Resources.ResourceCreationNotAllowed);
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -174,10 +174,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                             }
 
                             goto default;
-                        case SqlErrorCodes.MethodNotAllowed:
-                            throw new MethodNotAllowedException(Core.Resources.ResourceCreationNotAllowed);
-                        case SqlErrorCodes.TimeoutExpired:
-                            throw new RequestTimeoutException(Resources.ExecutionTimeoutExpired);
                         case 50400: // TODO: Add this to SQL error codes in AB#88286
                             // The backwards compatibility behavior of Stu3 is to return 412 Precondition Failed instead of a 400 Bad Request
                             if (_modelInfoProvider.Version == FhirSpecification.Stu3)

--- a/src/Microsoft.Health.Fhir.SqlServer/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Linq;
 using EnsureThat;
+using MediatR.Pipeline;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Features.Search.Registry;
@@ -227,6 +228,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Add<PurgeOperationCapabilityProvider>()
                 .Transient()
                 .AsImplementedInterfaces();
+
+            services.Add(typeof(SqlExceptionActionProcessor<,>))
+                .Transient()
+                .AsService(typeof(IRequestExceptionAction<,>));
 
             return fhirServerBuilder;
         }

--- a/src/Microsoft.Health.Fhir.SqlServer/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Resources.Designer.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Health.Fhir.SqlServer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The exection timeout expired from SQL Server..
+        ///   Looks up a localized string similar to The execution timeout expired from SQL Server..
         /// </summary>
         internal static string ExecutionTimeoutExpired {
             get {

--- a/src/Microsoft.Health.Fhir.SqlServer/Resources.resx
+++ b/src/Microsoft.Health.Fhir.SqlServer/Resources.resx
@@ -156,7 +156,7 @@
     <value>A SQL exception occurred when fetching resource changes from SQL database. Error number is {0}.</value>
   </data>
   <data name="ExecutionTimeoutExpired" xml:space="preserve">
-    <value>The exection timeout expired from SQL Server.</value>
+    <value>The execution timeout expired from SQL Server.</value>
   </data>
   <data name="GetRecordsAsyncOperationIsCanceled" xml:space="preserve">
     <value>The operation to get resource changes has been canceled.</value>


### PR DESCRIPTION
## Description
The changes will remove the project dependency that was originally added to address the original issue.  Now we're registering a new class to the startup that handles Request exceptions 

## Related issues
Addresses [86829](https://microsofthealth.visualstudio.com/Health/_workitems/edit/86829)

## Testing
Testing was manually done since I had to inject a SQL script into the stored procedure being tested. For example, during local debugging I set a breakpoint at a point where the SQLCommand.CommandText was being set, then I revised that text by adding in this specific SQL, "WAITFOR DELAY '00:00:35';". The reason for that is the default SQLCommand.CommandTimeout is 30 seconds and given the script that I added, it will force the current SQL statement to take an additional 35 seconds thereby causing a SQL timeout.

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [X] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

