### PR TITLE
Handle search counts greater than int.MaxValue for sql and cosmos

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -1079,6 +1079,15 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Search count returned {0} and exceeds the maximum defined limit of {1}..
+        /// </summary>
+        internal static string SearchCountResultsExceedLimit {
+            get {
+                return ResourceManager.GetString("SearchCountResultsExceedLimit", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The &apos;_count&apos; parameter exceeds limit configured for server. Current limit is {0} while `_count` parameter set to {1}..
         /// </summary>
         internal static string SearchParamaterCountExceedLimit {

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -627,4 +627,8 @@
   <data name="SearchParameterDefinitionNullorEmptyCodeValue" xml:space="preserve">
     <value>Code value cannot be null or empty</value>
   </data>
+  <data name="SearchCountResultsExceedLimit" xml:space="preserve">
+    <value>Search count returned {0} and exceeds the maximum defined limit of {1}.</value>
+    <comment>{0} is the rows returned by the query, {1} is the defined limit of the bundle.Total field.</comment>
+  </data>
 </root>

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
@@ -542,6 +542,12 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
             long count = (await _fhirDataStore.ExecuteDocumentQueryAsync<long>(sqlQuerySpec, feedOptions, continuationToken: null, cancellationToken: cancellationToken)).results.Single();
             if (count > int.MaxValue)
             {
+                _requestContextAccessor.RequestContext.BundleIssues.Add(
+                    new OperationOutcomeIssue(
+                        OperationOutcomeConstants.IssueSeverity.Error,
+                        OperationOutcomeConstants.IssueType.NotSupported,
+                        string.Format(Core.Resources.SearchCountResultsExceedLimit, count, int.MaxValue)));
+
                 throw new InvalidSearchOperationException(string.Format(Core.Resources.SearchCountResultsExceedLimit, count, int.MaxValue));
             }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -108,13 +108,13 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     // The last CTE has all the surrogate IDs that match the results.
                     // We just need to count those and don't need to join with the Resource table
                     selectingFromResourceTable = false;
-                    StringBuilder.AppendLine("SELECT COUNT(DISTINCT Sid1)");
+                    StringBuilder.AppendLine("SELECT COUNT_BIG(DISTINCT Sid1)");
                 }
                 else
                 {
                     // We will be counting over the Resource table.
                     selectingFromResourceTable = true;
-                    StringBuilder.AppendLine("SELECT COUNT(*)");
+                    StringBuilder.AppendLine("SELECT COUNT_BIG(*)");
                 }
             }
             else
@@ -812,7 +812,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
             if (isRev)
             {
-                StringBuilder.Append("CASE WHEN count(*) over() > ")
+                StringBuilder.Append("CASE WHEN COUNT_BIG(*) over() > ")
                     .Append(Parameters.AddParameter(context.IncludeCount, true))
                     .AppendLine(" THEN 1 ELSE 0 END AS IsPartial ");
             }
@@ -962,7 +962,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             StringBuilder.Append("TOP (").Append(Parameters.AddParameter(context.IncludeCount, true)).Append(") ");
 
             StringBuilder.Append("T1, Sid1, IsMatch, ");
-            StringBuilder.Append("CASE WHEN count(*) over() > ")
+            StringBuilder.Append("CASE WHEN COUNT_BIG(*) over() > ")
                 .Append(Parameters.AddParameter(context.IncludeCount, true))
                 .AppendLine(" THEN 1 ELSE 0 END AS IsPartial ");
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -312,6 +312,12 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                         long count = reader.GetInt64(0);
                         if (count > int.MaxValue)
                         {
+                            _requestContextAccessor.RequestContext.BundleIssues.Add(
+                                new OperationOutcomeIssue(
+                                    OperationOutcomeConstants.IssueSeverity.Error,
+                                    OperationOutcomeConstants.IssueType.NotSupported,
+                                    string.Format(Core.Resources.SearchCountResultsExceedLimit, count, int.MaxValue)));
+
                             throw new InvalidSearchOperationException(string.Format(Core.Resources.SearchCountResultsExceedLimit, count, int.MaxValue));
                         }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -309,7 +309,13 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                     if (clonedSearchOptions.CountOnly)
                     {
                         await reader.ReadAsync(cancellationToken);
-                        var searchResult = new SearchResult(reader.GetInt32(0), clonedSearchOptions.UnsupportedSearchParams);
+                        long count = reader.GetInt64(0);
+                        if (count > int.MaxValue)
+                        {
+                            throw new InvalidSearchOperationException(string.Format(Core.Resources.SearchCountResultsExceedLimit, count, int.MaxValue));
+                        }
+
+                        var searchResult = new SearchResult((int)count, clonedSearchOptions.UnsupportedSearchParams);
 
                         // call NextResultAsync to get the info messages
                         await reader.NextResultAsync(cancellationToken);


### PR DESCRIPTION
Changes support returning a count value that exceeds an int32 from both sql and cosmos

## Description
On large databases (with > 2.3B resources) this query Get {{fhir}}?_summary=count results in the error "Arithmetic overflow error converting expression to data type int." This has been verified as an issue for both sql and cosmos. 
Investigating this issue shows that the underlying bundle object has a property called Total which is what the resulting count gets assigned to. The problem is that property is of type int and since it's owned by the hl7.org spec we're unable to fully account for the root issue. What we can do is gracefully handle it at this point.

For reference:
http://hl7.org/fhir/R4/bundle-definitions.html#Bundle.total
http://hl7.org/fhir/R4/datatypes.html#unsignedInt
TLDR: their specification for the size of an unsignedInt is "Any non-negative integer in the range 0..2,147,483,647"

## Related issues
Addresses [89072](https://microsofthealth.visualstudio.com/Health/_workitems/edit/89072)

## Testing
Since my local resources don't have > 2.3B resources this is how I tested each data source.
I used our rest http files and after getting an access token, I made a GET request like so to make sure we are doing a search for count.
GET {{hostname}}/?_summary=count 
Authorization: Bearer {{bearer.response.body.access_token}}

SQL: I temporarily revised the SqlCommand.CommandText to "SELECT CAST(999999999999 AS bigint)" for this scenario to validate the sql change.
Cosmos: I temporarily revised the QueryBuilder.BuildSqlQuerySpec() so that it only returns "SELECT value 99999999999999 " to validate the cosmos change.

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [X] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

Refs [AB#89072](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/89072)
+semver: skip


