### PR TITLE
Prevent no impact updates from creating version

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -10,7 +10,6 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
@@ -555,7 +554,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
             }
         }
 
-        private static string RemoveTrailingZerosFromMilisecondsForAGivenDate(DateTimeOffset date)
+        private static string RemoveTrailingZerosFromMillisecondsForAGivenDate(DateTimeOffset date)
         {
             // 0000000+ -> +, 0010000+ -> 001+, 0100000+ -> 01+, 0180000+ -> 018+, 1000000 -> 1+, 1100000+ -> 11+, 1010000+ -> 101+
             // ToString("o") - Formats to 2022-03-09T01:40:52.0690000+02:00 but serialized value to string in dB is 2022-03-09T01:40:52.069+02:00
@@ -565,7 +564,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
             if (milliseconds.Equals("0000000", StringComparison.Ordinal))
             {
                 // when date = 2022-03-09T01:40:52.0000000+02:00, value in dB is 2022-03-09T01:40:52+02:00, we need to replace the . after second
-                return formattedDate.Replace("." + milliseconds, trimmedMilliseconds, StringComparison.Ordinal);
+                return formattedDate.Replace("." + milliseconds, string.Empty, StringComparison.Ordinal);
             }
 
             return formattedDate.Replace(milliseconds, trimmedMilliseconds, StringComparison.Ordinal);
@@ -574,7 +573,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
         private static string RemoveVersionIdAndLastUpdatedFromMeta(FhirCosmosResourceWrapper resourceWrapper)
         {
             var rawResource = resourceWrapper.RawResource.Data.Replace($"\"versionId\":\"{resourceWrapper.Version}\"", string.Empty, StringComparison.Ordinal);
-            return rawResource.Replace($"\"lastUpdated\":\"{RemoveTrailingZerosFromMilisecondsForAGivenDate(resourceWrapper.LastModified)}\"", string.Empty, StringComparison.Ordinal);
+            return rawResource.Replace($"\"lastUpdated\":\"{RemoveTrailingZerosFromMillisecondsForAGivenDate(resourceWrapper.LastModified)}\"", string.Empty, StringComparison.Ordinal);
         }
 
         public void Build(ICapabilityStatementBuilder builder)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BasicAuthTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BasicAuthTests.cs
@@ -115,6 +115,12 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Observation createdResource = await tempClient.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>());
 
             tempClient = _client.CreateClientForUser(TestUsers.ReadWriteUser, TestApplications.NativeClient);
+
+            createdResource.Text = new Narrative
+            {
+                Status = Narrative.NarrativeStatus.Generated,
+                Div = "<div>Updated resource content</div>",
+            };
             using FhirResponse<Observation> updateResponse = await tempClient.UpdateAsync(createdResource);
 
             Assert.Equal(HttpStatusCode.OK, updateResponse.StatusCode);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BatchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BatchTests.cs
@@ -102,11 +102,12 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.Equal(resource.Entry[2].Resource.VersionId, resourceAfterPostingSameBundle.Entry[2].Resource.VersionId);
             Assert.Equal("200", resourceAfterPostingSameBundle.Entry[3].Response.Status);
             Assert.Equal(resource.Entry[3].Resource.VersionId, resourceAfterPostingSameBundle.Entry[3].Resource.VersionId);
-            Assert.Equal("200", resourceAfterPostingSameBundle.Entry[8].Response.Status);
             Assert.Equal(((int)Constants.IfMatchFailureStatus).ToString(), resourceAfterPostingSameBundle.Entry[4].Response.Status);
             Assert.Equal("204", resourceAfterPostingSameBundle.Entry[5].Response.Status);
             Assert.Equal("204", resourceAfterPostingSameBundle.Entry[6].Response.Status);
             ValidateOperationOutcome(resourceAfterPostingSameBundle.Entry[7].Response.Status, resourceAfterPostingSameBundle.Entry[7].Response.Outcome as OperationOutcome, _statusCodeMap[HttpStatusCode.NotFound], "The route for \"/ValueSet/$lookup\" was not found.", IssueType.NotFound);
+            Assert.Equal("200", resourceAfterPostingSameBundle.Entry[8].Response.Status);
+            Assert.Equal(resource.Entry[8].Resource.VersionId, resourceAfterPostingSameBundle.Entry[8].Resource.VersionId);
             ValidateOperationOutcome(resourceAfterPostingSameBundle.Entry[9].Response.Status, resourceAfterPostingSameBundle.Entry[9].Response.Outcome as OperationOutcome, _statusCodeMap[HttpStatusCode.NotFound], "Resource type 'Patient' with id '12334' couldn't be found.", IssueType.NotFound);
         }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BatchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BatchTests.cs
@@ -66,6 +66,51 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         }
 
         [Fact]
+        [HttpIntegrationFixtureArgumentSets(dataStores: DataStore.CosmosDb)]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenAValidBundle_WhenSubmittingABatchTwiceWithAndWithoutChanges_ThenVersionIsCreatedWhenDataIsChanged()
+        {
+            var requestBundle = Samples.GetDefaultBatch().ToPoco<Bundle>();
+            using FhirResponse<Bundle> fhirResponse = await _client.PostBundleAsync(requestBundle);
+            Assert.NotNull(fhirResponse);
+            Assert.Equal(HttpStatusCode.OK, fhirResponse.StatusCode);
+
+            Bundle resource = fhirResponse.Resource;
+
+            Assert.Equal("201", resource.Entry[0].Response.Status);
+            Assert.Equal("201", resource.Entry[1].Response.Status);
+            Assert.Equal("201", resource.Entry[2].Response.Status);
+            Assert.Equal("1", resource.Entry[2].Resource.VersionId);
+            Assert.Equal("201", resource.Entry[3].Response.Status);
+            Assert.Equal(((int)Constants.IfMatchFailureStatus).ToString(), resource.Entry[4].Response.Status);
+            Assert.Equal("204", resource.Entry[5].Response.Status);
+            Assert.Equal("204", resource.Entry[6].Response.Status);
+            ValidateOperationOutcome(resource.Entry[7].Response.Status, resource.Entry[7].Response.Outcome as OperationOutcome, _statusCodeMap[HttpStatusCode.NotFound], "The route for \"/ValueSet/$lookup\" was not found.", IssueType.NotFound);
+            Assert.Equal("200", resource.Entry[8].Response.Status);
+            ValidateOperationOutcome(resource.Entry[9].Response.Status, resource.Entry[9].Response.Outcome as OperationOutcome, _statusCodeMap[HttpStatusCode.NotFound], "Resource type 'Patient' with id '12334' couldn't be found.", IssueType.NotFound);
+
+            // WhenSubmittingABatchTwiceWithNoDataChange_ThenServerShouldNotCreateAVersionSecondTimeAndSendOk
+            using FhirResponse<Bundle> fhirResponseAfterPostingSameBundle = await _client.PostBundleAsync(requestBundle);
+            Assert.NotNull(fhirResponseAfterPostingSameBundle);
+            Assert.Equal(HttpStatusCode.OK, fhirResponseAfterPostingSameBundle.StatusCode);
+
+            Bundle resourceAfterPostingSameBundle = fhirResponseAfterPostingSameBundle.Resource;
+
+            Assert.Equal("201", resourceAfterPostingSameBundle.Entry[0].Response.Status);
+            Assert.Equal("200", resourceAfterPostingSameBundle.Entry[1].Response.Status);
+            Assert.Equal("200", resourceAfterPostingSameBundle.Entry[2].Response.Status);
+            Assert.Equal(resource.Entry[2].Resource.VersionId, resourceAfterPostingSameBundle.Entry[2].Resource.VersionId);
+            Assert.Equal("200", resourceAfterPostingSameBundle.Entry[3].Response.Status);
+            Assert.Equal(resource.Entry[3].Resource.VersionId, resourceAfterPostingSameBundle.Entry[3].Resource.VersionId);
+            Assert.Equal("200", resourceAfterPostingSameBundle.Entry[8].Response.Status);
+            Assert.Equal(((int)Constants.IfMatchFailureStatus).ToString(), resourceAfterPostingSameBundle.Entry[4].Response.Status);
+            Assert.Equal("204", resourceAfterPostingSameBundle.Entry[5].Response.Status);
+            Assert.Equal("204", resourceAfterPostingSameBundle.Entry[6].Response.Status);
+            ValidateOperationOutcome(resourceAfterPostingSameBundle.Entry[7].Response.Status, resourceAfterPostingSameBundle.Entry[7].Response.Outcome as OperationOutcome, _statusCodeMap[HttpStatusCode.NotFound], "The route for \"/ValueSet/$lookup\" was not found.", IssueType.NotFound);
+            ValidateOperationOutcome(resourceAfterPostingSameBundle.Entry[9].Response.Status, resourceAfterPostingSameBundle.Entry[9].Response.Outcome as OperationOutcome, _statusCodeMap[HttpStatusCode.NotFound], "Resource type 'Patient' with id '12334' couldn't be found.", IssueType.NotFound);
+        }
+
+        [Fact]
         [Trait(Traits.Priority, Priority.One)]
         [Trait(Traits.Category, Categories.Authorization)]
         public async Task GivenAValidBundleWithReadonlyUser_WhenSubmittingABatch_ThenForbiddenAndOutcomeIsReturned()

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HistoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HistoryTests.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
     {
         private FhirResponse<Observation> _createdResource;
         private readonly TestFhirClient _client;
+        private const string ContentUpdated = "Updated resource content";
 
         public HistoryTests(HttpIntegrationTestFixture fixture)
         {
@@ -75,6 +76,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenATypeAndId_WhenGettingResourceHistory_TheServerShouldReturnTheAppropriateBundleSuccessfully()
         {
+            UpdateObservation(_createdResource.Resource);
             await _client.UpdateAsync(_createdResource.Resource);
 
             using FhirResponse<Bundle> readResponse = await _client.SearchAsync($"Observation/{_createdResource.Resource.Id}/_history");
@@ -98,6 +100,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             var weakETag = $"W/\"{int.Parse(newCreatedResource.Meta.VersionId).ToString()}\"";
 
+            UpdateObservation(newCreatedResource);
             await _client.UpdateAsync(newCreatedResource, weakETag);
             await _client.DeleteAsync(newCreatedResource);
             await _client.DeleteAsync(newCreatedResource);
@@ -412,7 +415,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         }
 
         /// <summary>
-        /// Get all the results for given search string
+        /// Get all the results for given search string matching the tag
         /// </summary>
         /// <returns>List<Bundle.EntryComponent> for the given search string</returns>
         private async Task<List<Bundle.EntryComponent>> GetAllResultsWithMatchingTagForGivenSearch(string searchString, string tag)
@@ -455,6 +458,15 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             }
 
             throw new XunitException(sb.ToString());
+        }
+
+        private static void UpdateObservation(Observation observationResource)
+        {
+            observationResource.Text = new Narrative
+            {
+                Status = Narrative.NarrativeStatus.Generated,
+                Div = $"<div>{ContentUpdated}</div>",
+            };
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -732,34 +732,21 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             }
         }
 
-        [Fact]
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
         [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb)]
-        public async Task GivenAValidResource_WhenUpdatingAResourceWithSameDataImmaterialKeepHistoryValue_ServerShouldNotCreateANewVersionAndReturnOk()
+        public async Task GivenAValidResource_WhenUpdatingAResourceWithSameDataImmaterialKeepHistoryValue_ServerShouldNotCreateANewVersionAndReturnOk(bool keepHistory)
         {
-            // Upserting a resource twice with no data change and KeepHistory as true
-            UpsertOutcome createResult = await _dataStore.UpsertAsync(CreateObservationResourceWrapper(Guid.NewGuid().ToString()), null, allowCreate: true, keepHistory: true, CancellationToken.None);
-            UpsertOutcome upsertResult = await _dataStore.UpsertAsync(CreateObservationResourceWrapper(createResult.Wrapper.ResourceId), null, allowCreate: true, keepHistory: true, CancellationToken.None);
+            // Upserting a resource twice with no data change
+            UpsertOutcome createResult = await _dataStore.UpsertAsync(CreateObservationResourceWrapper(Guid.NewGuid().ToString()), null, allowCreate: true, keepHistory: keepHistory, CancellationToken.None);
+            UpsertOutcome upsertResult = await _dataStore.UpsertAsync(CreateObservationResourceWrapper(createResult.Wrapper.ResourceId), null, allowCreate: true, keepHistory: keepHistory, CancellationToken.None);
 
             Assert.NotNull(createResult);
             Assert.NotNull(upsertResult);
 
             var createResource = new RawResourceElement(createResult.Wrapper);
             var updatedeResource = new RawResourceElement(upsertResult.Wrapper);
-
-            Assert.Equal(createResult.Wrapper.ResourceId, upsertResult.Wrapper.ResourceId);
-            Assert.Equal(createResult.Wrapper.Version, upsertResult.Wrapper.Version);
-            Assert.Equal(createResource.LastUpdated, updatedeResource.LastUpdated);
-            Assert.Equal(createResult.Wrapper.LastModified, upsertResult.Wrapper.LastModified);
-
-            // Upserting a resource twice with no data change and KeepHistory as false
-            createResult = await _dataStore.UpsertAsync(CreateObservationResourceWrapper(Guid.NewGuid().ToString()), null, allowCreate: true, keepHistory: false, CancellationToken.None);
-            upsertResult = await _dataStore.UpsertAsync(CreateObservationResourceWrapper(createResult.Wrapper.ResourceId), null, allowCreate: true, keepHistory: false, CancellationToken.None);
-
-            Assert.NotNull(createResult);
-            Assert.NotNull(upsertResult);
-
-            createResource = new RawResourceElement(createResult.Wrapper);
-            updatedeResource = new RawResourceElement(upsertResult.Wrapper);
 
             Assert.Equal(createResult.Wrapper.ResourceId, upsertResult.Wrapper.ResourceId);
             Assert.Equal(createResult.Wrapper.Version, upsertResult.Wrapper.Version);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -29,6 +30,7 @@ using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Test.Utilities;
+using NSubstitute;
 using Xunit;
 using Task = System.Threading.Tasks.Task;
 
@@ -47,6 +49,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         private readonly IFhirDataStore _dataStore;
         private readonly SearchParameterDefinitionManager _searchParameterDefinitionManager;
         private readonly ConformanceProviderBase _conformanceProvider;
+        private readonly ISearchIndexer _searchIndexer = Substitute.For<ISearchIndexer>();
+        private const string ContentUpdated = "Updated resource content";
 
         public FhirStorageTests(FhirStorageTestsFixture fixture)
         {
@@ -360,6 +364,11 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             var newResourceValues = Samples.GetDefaultOrganization()
                 .UpdateId(saveResult.RawResourceElement.Id);
 
+            newResourceValues.ToPoco<Organization>().Text = new Narrative
+            {
+                Status = Narrative.NarrativeStatus.Generated,
+                Div = $"<div>{ContentUpdated}</div>",
+            };
             var updateResult = await Mediator.UpsertResourceAsync(newResourceValues, WeakETag.FromVersionId(saveResult.RawResourceElement.VersionId));
 
             await Assert.ThrowsAsync<ResourceNotFoundException>(
@@ -660,7 +669,9 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
                 (ResourceWrapper original, ResourceWrapper updatedWithSearchParam1) = await CreateUpdatedWrapperFromExistingPatient(upsertResult, searchParam1, searchValue1);
 
-                await _dataStore.UpsertAsync(updatedWithSearchParam1, WeakETag.FromVersionId(original.Version), allowCreate: false, keepHistory: false, CancellationToken.None);
+                var deserializedResource = _fhirJsonParser.Parse<Patient>(original.RawResource.Data);
+                UpdatePatient(deserializedResource);
+                await _dataStore.UpsertAsync(UpdatePatientResourceWrapper(deserializedResource), WeakETag.FromVersionId(original.Version), allowCreate: false, keepHistory: false, CancellationToken.None);
 
                 // Let's update the resource again with new information
                 searchParam2 = await CreatePatientSearchParam(searchParamName2, SearchParamType.Token, "Patient.gender");
@@ -719,6 +730,41 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                     await _fixture.TestHelper.DeleteSearchParameterStatusAsync(searchParam.Url, CancellationToken.None);
                 }
             }
+        }
+
+        [Fact]
+        [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb)]
+        public async Task GivenAValidResource_WhenUpdatingAResourceWithSameDataImmaterialKeepHistoryValue_ServerShouldNotCreateANewVersionAndReturnOk()
+        {
+            // Upserting a resource twice with no data change and KeepHistory as true
+            UpsertOutcome createResult = await _dataStore.UpsertAsync(CreateObservationResourceWrapper(Guid.NewGuid().ToString()), null, allowCreate: true, keepHistory: true, CancellationToken.None);
+            UpsertOutcome upsertResult = await _dataStore.UpsertAsync(CreateObservationResourceWrapper(createResult.Wrapper.ResourceId), null, allowCreate: true, keepHistory: true, CancellationToken.None);
+
+            Assert.NotNull(createResult);
+            Assert.NotNull(upsertResult);
+
+            var createResource = new RawResourceElement(createResult.Wrapper);
+            var updatedeResource = new RawResourceElement(upsertResult.Wrapper);
+
+            Assert.Equal(createResult.Wrapper.ResourceId, upsertResult.Wrapper.ResourceId);
+            Assert.Equal(createResult.Wrapper.Version, upsertResult.Wrapper.Version);
+            Assert.Equal(createResource.LastUpdated, updatedeResource.LastUpdated);
+            Assert.Equal(createResult.Wrapper.LastModified, upsertResult.Wrapper.LastModified);
+
+            // Upserting a resource twice with no data change and KeepHistory as false
+            createResult = await _dataStore.UpsertAsync(CreateObservationResourceWrapper(Guid.NewGuid().ToString()), null, allowCreate: true, keepHistory: false, CancellationToken.None);
+            upsertResult = await _dataStore.UpsertAsync(CreateObservationResourceWrapper(createResult.Wrapper.ResourceId), null, allowCreate: true, keepHistory: false, CancellationToken.None);
+
+            Assert.NotNull(createResult);
+            Assert.NotNull(upsertResult);
+
+            createResource = new RawResourceElement(createResult.Wrapper);
+            updatedeResource = new RawResourceElement(upsertResult.Wrapper);
+
+            Assert.Equal(createResult.Wrapper.ResourceId, upsertResult.Wrapper.ResourceId);
+            Assert.Equal(createResult.Wrapper.Version, upsertResult.Wrapper.Version);
+            Assert.Equal(createResource.LastUpdated, updatedeResource.LastUpdated);
+            Assert.Equal(createResult.Wrapper.LastModified, upsertResult.Wrapper.LastModified);
         }
 
         [Fact]
@@ -788,14 +834,21 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 (ResourceWrapper original1, ResourceWrapper updated1) = await CreateUpdatedWrapperFromExistingPatient(upsertResult1, searchParam1, searchValue1);
                 (ResourceWrapper original2, ResourceWrapper updated2) = await CreateUpdatedWrapperFromExistingPatient(upsertResult2, searchParam1, searchValue1);
 
-                await _dataStore.UpsertAsync(updated1, WeakETag.FromVersionId(original1.Version), allowCreate: false, keepHistory: false, CancellationToken.None);
-                await _dataStore.UpsertAsync(updated2, WeakETag.FromVersionId(original2.Version), allowCreate: false, keepHistory: false, CancellationToken.None);
+                var deserializedResource = _fhirJsonParser.Parse<Patient>(original1.RawResource.Data);
+                UpdatePatient(deserializedResource);
+                await _dataStore.UpsertAsync(UpdatePatientResourceWrapper(deserializedResource), WeakETag.FromVersionId(original1.Version), allowCreate: false, keepHistory: false, CancellationToken.None);
+
+                deserializedResource = _fhirJsonParser.Parse<Patient>(original2.RawResource.Data);
+                UpdatePatient(deserializedResource);
+                await _dataStore.UpsertAsync(UpdatePatientResourceWrapper(deserializedResource), WeakETag.FromVersionId(original2.Version), allowCreate: false, keepHistory: false, CancellationToken.None);
 
                 // Let's update the resources again with new information
                 searchParam2 = await CreatePatientSearchParam(searchParamName2, SearchParamType.Token, "Patient.gender");
                 ISearchValue searchValue2 = new TokenSearchValue("system", "code", "text");
 
                 // Create the updated wrappers using the original resource and its outdated version
+                UpdatePatient(upsertResult1.RawResourceElement.ToPoco<Patient>(Deserializers.ResourceDeserializer));
+                UpdatePatient(upsertResult2.RawResourceElement.ToPoco<Patient>(Deserializers.ResourceDeserializer));
                 (_, ResourceWrapper updated1WithSearchParam2) = await CreateUpdatedWrapperFromExistingPatient(upsertResult1, searchParam2, searchValue2, original1);
                 (_, ResourceWrapper updated2WithSearchParam2) = await CreateUpdatedWrapperFromExistingPatient(upsertResult2, searchParam2, searchValue2, original2);
 
@@ -971,6 +1024,45 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 observation.UpdateCreate = originalValue;
                 _conformanceProvider.ClearCache();
             }
+        }
+
+        private ResourceWrapper CreateObservationResourceWrapper(string observationId)
+        {
+            Observation observationResource = Samples.GetDefaultObservation().ToPoco<Observation>();
+            observationResource.Id = observationId;
+            observationResource.VersionId = "1";
+
+            var resourceElement = observationResource.ToResourceElement();
+            var rawResource = new RawResource(observationResource.ToJson(), FhirResourceFormat.Json, isMetaSet: false);
+            var resourceRequest = new ResourceRequest(WebRequestMethods.Http.Put);
+            var compartmentIndices = Substitute.For<CompartmentIndices>();
+            var searchIndices = _searchIndexer.Extract(resourceElement);
+            var wrapper = new ResourceWrapper(resourceElement, rawResource, resourceRequest, false, searchIndices, compartmentIndices, new List<KeyValuePair<string, string>>(), _searchParameterDefinitionManager.GetSearchParameterHashForResourceType("Observation"));
+            wrapper.SearchParameterHash = "hash";
+
+            return wrapper;
+        }
+
+        private ResourceWrapper UpdatePatientResourceWrapper(Patient patientResource)
+        {
+            var resourceElement = patientResource.ToResourceElement();
+            var rawResource = new RawResource(patientResource.ToJson(), FhirResourceFormat.Json, isMetaSet: false);
+            var resourceRequest = new ResourceRequest(WebRequestMethods.Http.Put);
+            var compartmentIndices = Substitute.For<CompartmentIndices>();
+            var searchIndices = _searchIndexer.Extract(resourceElement);
+            var wrapper = new ResourceWrapper(resourceElement, rawResource, resourceRequest, false, searchIndices, compartmentIndices, new List<KeyValuePair<string, string>>(), _searchParameterDefinitionManager.GetSearchParameterHashForResourceType("Observation"));
+            wrapper.SearchParameterHash = "hash";
+
+            return wrapper;
+        }
+
+        private static void UpdatePatient(Patient patientResource)
+        {
+            patientResource.Text = new Narrative
+            {
+                Status = Narrative.NarrativeStatus.Generated,
+                Div = $"<div>{ContentUpdated}</div>",
+            };
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageVersioningPolicyTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageVersioningPolicyTests.cs
@@ -25,6 +25,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
     [FhirStorageTestsFixtureArgumentSets(DataStore.All)]
     public partial class FhirStorageVersioningPolicyTests : IClassFixture<FhirStorageTestsFixture>
     {
+        private const string ContentUpdated = "Updated resource content";
+
         public FhirStorageVersioningPolicyTests(FhirStorageTestsFixture fixture)
         {
             Mediator = fixture?.Mediator;
@@ -59,6 +61,11 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
             ResourceElement newResourceValues = Samples.GetDefaultObservation().UpdateId(observationResource.Id);
 
+            newResourceValues.ToPoco<Observation>().Text = new Narrative
+            {
+                Status = Narrative.NarrativeStatus.Generated,
+                Div = $"<div>{ContentUpdated}</div>",
+            };
             SaveOutcome updateResult = await Mediator.UpsertResourceAsync(newResourceValues, WeakETag.FromVersionId(observationResource.VersionId));
 
             ResourceElement historyResults = await Mediator.SearchResourceHistoryAsync(KnownResourceTypes.Observation, updateResult.RawResourceElement.Id);
@@ -79,6 +86,11 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
             ResourceElement newResourceValues = Samples.GetDefaultMedication().UpdateId(medicationResource.Id);
 
+            newResourceValues.ToPoco<Medication>().Text = new Narrative
+            {
+                Status = Narrative.NarrativeStatus.Generated,
+                Div = $"<div>{ContentUpdated}</div>",
+            };
             SaveOutcome updateResult = await Mediator.UpsertResourceAsync(newResourceValues, WeakETag.FromVersionId(medicationResource.VersionId));
 
             ResourceElement historyResults = await Mediator.SearchResourceHistoryAsync(KnownResourceTypes.Medication, updateResult.RawResourceElement.Id);


### PR DESCRIPTION
## Description
If a user updates a record that already exists and nothing changes in the content, the user should get a 200 but nothing should update the record. With this PR we are only covering Cosmos DB changes. (SQL changes might be a little bit more involved so will be covered in different PR). Updated UpsertAsync method to check the existing resource rawData with new resource rawData by ignoring meta.versionId and meta.lastUpdated. If its an absolute match then we simply return Ok with existing resource information without updating VersionId and lastUpdated. If the strings do not match then we proceed with further steps of creating a new version.

We are forming versionId and lastUpdated strings to use String.Replace on raw resource data. Forming lastUpdated with a valid date format is little tricky. We set the value of lastUpdated by using ToString("o") which formats the datetimeoffset to Formats to **2022-03-09T01:40:52.0690000+02:00**. [String serializer](https://github.com/microsoft/fhir-server/blob/main/src/Microsoft.Health.Fhir.Shared.Core/Features/Persistence/RawResourceFactory.cs#:~:text=return%20new%20RawResource(_fhirJsonSerializer.SerializeToString(poco)%2C%20FhirResourceFormat.Json%2C%20keepMeta)%3B) converts this to **2022-03-09T01:40:52.069+02:00** and saves it.

In C#, millisecond vlaue can range from [0 to 999]. Below are some useful examples of how date is stored in rawResource data in DB.
0000000+ -> +, 0010000+ -> 001+, 0100000+ -> 01+, 0180000+ -> 018+, 1000000 -> 1+, 1100000+ -> 11+, 1010000+ -> 101+


## Related issues
Addresses [[88658](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Olympus/Stories/?workitem=88658)].

## Testing
Added new tests and Existing tests passed.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
