### PR TITLE
Adding a configuration option for SqlCommand.CommandTimeout

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -151,7 +151,7 @@
         ],
         "ParallelQueryOptions": {
             "MaxQueryConcurrency": 500,
-            "EnableConcurrencyIfQueryExceedsTimeLimit":  true
+            "EnableConcurrencyIfQueryExceedsTimeLimit": true
         }
     },
     "DataStore": "CosmosDb",
@@ -174,7 +174,7 @@
     },
     "TaskHosting": {
         "Enabled": false,
-        "MaxRunningTaskCount":  1
+        "MaxRunningTaskCount": 1
     },
     "ApplicationInsights": {
         "InstrumentationKey": ""
@@ -186,5 +186,10 @@
         "dotnetRuntimeMetrics": true,
         "httpMetrics": true,
         "systemMetrics": true
+    },
+    "SqlServer": {
+        "SqlCommand": {
+            "CommandTimeout": 30
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Configuration/ISqlServerConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Configuration/ISqlServerConfiguration.cs
@@ -1,0 +1,15 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Fhir.SqlServer.Configuration
+{
+    /// <summary>
+    /// Configurations for SqlServer
+    /// </summary>
+    public interface ISqlServerConfiguration
+    {
+        int GetCommandTimeout();
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer/Configuration/SqlServerConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Configuration/SqlServerConfiguration.cs
@@ -1,0 +1,33 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using EnsureThat;
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.Health.Fhir.SqlServer.Configuration
+{
+    public class SqlServerConfiguration : ISqlServerConfiguration
+    {
+        private readonly IConfiguration _configuration;
+        private const int DefaultCommandTimeout = 30;
+
+        public SqlServerConfiguration(IConfiguration configuration)
+        {
+            EnsureArg.IsNotNull(configuration, nameof(configuration));
+
+            _configuration = configuration;
+        }
+
+        public int GetCommandTimeout()
+        {
+            if (int.TryParse(_configuration["SqlServer:SqlCommand:CommandTimeout"], out int commandTimeout) && commandTimeout >= 0)
+            {
+                return commandTimeout;
+            }
+
+            return DefaultCommandTimeout;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Features.Search.Registry;
 using Microsoft.Health.Fhir.Core.Registration;
+using Microsoft.Health.Fhir.SqlServer.Configuration;
 using Microsoft.Health.Fhir.SqlServer.Features.Operations;
 using Microsoft.Health.Fhir.SqlServer.Features.Operations.Import;
 using Microsoft.Health.Fhir.SqlServer.Features.Operations.Import.DataGenerator;
@@ -226,6 +227,10 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.Add<PurgeOperationCapabilityProvider>()
                 .Transient()
+                .AsImplementedInterfaces();
+
+            services.Add<SqlServerConfiguration>()
+                .Singleton()
                 .AsImplementedInterfaces();
 
             return fhirServerBuilder;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Microsoft.Health.Fhir.Shared.Tests.Integration.projitems
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Microsoft.Health.Fhir.Shared.Tests.Integration.projitems
@@ -25,6 +25,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\Import\TestSqlServerTransientFaultRetryPolicyFactory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\FhirStorageVersioningPolicyTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SearchParameterStatusDataStoreTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlServerConfigurationTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlServerSchemaUpgradeTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\CosmosDbFhirStorageTestHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\CosmosDbFhirStorageTestsFixture.cs" />

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerConfigurationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerConfigurationTests.cs
@@ -1,0 +1,61 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Health.Fhir.SqlServer.Configuration;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Microsoft.Health.SqlServer.Features.Client;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
+{
+    [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]
+    public class SqlServerConfigurationTests : IClassFixture<SqlServerFhirStorageTestsFixture>
+    {
+        private SqlServerFhirStorageTestsFixture _fixture;
+        private readonly ISqlServerConfiguration _sqlServerConfiguration = Substitute.For<ISqlServerConfiguration>();
+
+        public SqlServerConfigurationTests(SqlServerFhirStorageTestsFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Theory]
+        [InlineData(1, 5)]
+        [InlineData(0, 5)]
+        [InlineData(0, 0)]
+        [InlineData(15, 0)]
+        [InlineData(20, 25)]
+        [InlineData(45, 50)]
+        [InlineData(70, 75)]
+        public async Task Given_VariousCommandTimeoutSettings_TheyAllSucceed(int longRunningSqlDelayTimeout, int sqlCommandTimeout)
+        {
+            // regarding the Sql CommandTimeout
+            // A value of 0 indicates no limit (an attempt to execute a command will wait indefinitely).
+            // https://docs.microsoft.com/en-us/dotnet/api/system.data.sqlclient.sqlcommand.commandtimeout?view=dotnet-plat-ext-6.0
+
+            int selectValue = 1;
+            DateTime now = DateTime.Now;
+            string waitForDelay = new DateTime(now.Year, now.Month, now.Day).AddSeconds(longRunningSqlDelayTimeout).ToString("HH:mm:ss", CultureInfo.InvariantCulture);
+
+            _sqlServerConfiguration.GetCommandTimeout().Returns(sqlCommandTimeout);
+            using (SqlConnectionWrapper connectionWrapper = await _fixture.SqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(CancellationToken.None))
+            using (SqlCommandWrapper sqlCommandWrapper = connectionWrapper.CreateSqlCommand())
+            {
+                sqlCommandWrapper.CommandTimeout = sqlCommandTimeout;
+                sqlCommandWrapper.CommandText = $@"
+                            WAITFOR DELAY '{waitForDelay}';
+                            SELECT TOP 1 {selectValue} FROM ResourceType";
+
+                int selectResult = (int)await sqlCommandWrapper.ExecuteScalarAsync(CancellationToken.None);
+                Assert.Equal(selectValue, selectResult);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
There are some customers that need a longer timeout for some long running SQL queries. There is currently no way to override the timeout setting and this change will allow per customer setting via the configuration file.

## Related issues
Addresses [89901](https://microsofthealth.visualstudio.com/Health/_workitems/edit/89901).

## Testing
Created a new test to test various command timeout settings and also successfully ran the following tests:
Microsoft.Health.Fhir.R4.Tests.Integration
Microsoft.Health.Fhir.R5.Tests.Integration
Microsoft.Health.Fhir.Stu3.Tests.Integration


## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

Refs [AB#89901](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/89901)
+semver: patch
