### PR TITLE
Update assert condition of test GivenContinuationToken_WhenExecuted_ThenAdditionalQueryAdded

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexJobTaskTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexJobTaskTests.cs
@@ -179,7 +179,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
 
             Assert.Equal(OperationStatus.Completed, job.Status);
             Assert.Equal(_mockedSearchCount, job.Count);
-            Assert.Equal(expectedResourceType, job.ResourceList);
+            Assert.Contains(expectedResourceType, job.ResourceList);
             Assert.Equal(param.Url.ToString(), job.SearchParamList);
             Assert.Collection<ReindexJobQueryStatus>(
                 job.QueryList.Keys.OrderBy(q => q.LastModified),


### PR DESCRIPTION
## Description
Test assert was too restrictive.  Assert updated to check that resource type was contained in list.

## Related issues
Addresses [issue [AB#90315](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/90315)].

## Testing
Reran the test several times.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [x] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
