### PR TITLE
Delete some resources before beginning custom search tests

### DIFF
--- a/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
+++ b/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
@@ -54,6 +54,7 @@
     <None Remove="TestFiles\Normative\Medication.json" />
     <None Remove="TestFiles\Normative\SearchParameter-AppointmentStatus.json" />
     <None Remove="TestFiles\Normative\SearchParameter-Patient-foo.json" />
+    <None Remove="TestFiles\Normative\SearchParameter-SpecimenStatus.json" />
     <None Remove="TestFiles\Normative\SearchParameterBadSyntax.json" />
     <None Remove="TestFiles\Normative\SearchParameterExpressionWrongProperty.json" />
     <None Remove="TestFiles\Normative\SearchParameterInvalidBase.json" />
@@ -62,6 +63,7 @@
     <None Remove="TestFiles\Normative\SearchParameterMissingExpression.json" />
     <None Remove="TestFiles\Normative\SearchParameterMissingType.json" />
     <None Remove="TestFiles\Normative\SearchParameterUnsupportedType.json" />
+    <None Remove="TestFiles\Normative\Specimen.json" />
     <None Remove="TestFiles\Normative\StructureDefinition-us-core-birthsex.json" />
     <None Remove="TestFiles\Normative\StructureDefinition-us-core-careplan.json" />
     <None Remove="TestFiles\Normative\StructureDefinition-us-core-ethnicity.json" />
@@ -265,6 +267,7 @@
     <EmbeddedResource Include="TestFiles\Normative\Medication.json" />
     <EmbeddedResource Include="TestFiles\Normative\SearchParameter-AppointmentStatus.json" />
     <EmbeddedResource Include="TestFiles\Normative\SearchParameter-Patient-foo.json" />
+    <EmbeddedResource Include="TestFiles\Normative\SearchParameter-SpecimenStatus.json" />
     <EmbeddedResource Include="TestFiles\Normative\SearchParameterInvalidBase.json" />
     <EmbeddedResource Include="TestFiles\Normative\SearchParameterMissingType.json" />
     <EmbeddedResource Include="TestFiles\Normative\SearchParameterInvalidType.json" />
@@ -273,6 +276,7 @@
     <EmbeddedResource Include="TestFiles\Normative\SearchParameterBadSyntax.json" />
     <EmbeddedResource Include="TestFiles\Normative\SearchParameterMissingExpression.json" />
     <EmbeddedResource Include="TestFiles\Normative\SearchParameterMissingBase.json" />
+    <EmbeddedResource Include="TestFiles\Normative\Specimen.json" />
     <EmbeddedResource Include="TestFiles\R4\CarePlan.json" />
     <EmbeddedResource Include="TestFiles\Normative\CodeSystem-careplan-category.json" />
     <EmbeddedResource Include="TestFiles\Normative\list-example-long.json" />

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/SearchParameter-SpecimenStatus.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/SearchParameter-SpecimenStatus.json
@@ -1,0 +1,42 @@
+{
+    "resourceType": "SearchParameter",
+    "id": "Specimen-foo",
+    "extension": [
+        {
+            "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+            "valueCode": "trial-use"
+        }
+    ],
+    "url": "http://hl7.org/fhir/SearchParameter/Specimen-foo",
+    "version": "4.0.1",
+    "name": "status",
+    "status": "draft",
+    "experimental": false,
+    "date": "2019-11-01T09:29:23+11:00",
+    "publisher": "Health Level Seven International (Orders and Observations)",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://hl7.org/fhir"
+                }
+            ]
+        },
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/orders/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "available | unavailable | unsatisfactory | entered-in-error",
+    "code": "foo",
+    "base": [ "Specimen" ],
+    "type": "token",
+    "expression": "Specimen.status",
+    "xpath": "f:Specimen/f:status",
+    "xpathUsage": "normal"
+}

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/Specimen.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/Specimen.json
@@ -1,0 +1,95 @@
+{
+    "resourceType": "Specimen",
+    "id": "101",
+    "text": {
+        "status": "generated",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: 101</p><p><b>contained</b>: </p><p><b>identifier</b>: 23234352356</p><p><b>accessionIdentifier</b>: X352356</p><p><b>status</b>: available</p><p><b>type</b>: Venous blood specimen <span>(Details : {SNOMED CT code '122555007' = 'Venous blood specimen', given as 'Venous blood specimen'})</span></p><p><b>subject</b>: <a>Peter Patient</a></p><p><b>receivedTime</b>: 04/03/2011 7:03:00 AM</p><p><b>request</b>: <a>ProcedureRequest/example</a></p><h3>Collections</h3><table><tr><td>-</td><td><b>Collector</b></td><td><b>Collected[x]</b></td><td><b>Quantity</b></td><td><b>Method</b></td><td><b>BodySite</b></td></tr><tr><td>*</td><td><a>Practitioner/example</a></td><td>30/05/2011 6:15:00 AM</td><td>6 mL</td><td>Line, Venous <span>(Details : {http://hl7.org/fhir/v2/0488 code 'LNV' = 'Line, Venous)</span></td><td>Right median cubital vein <span>(Details : {SNOMED CT code '49852007' = 'Median cubital vein', given as 'Structure of median cubital vein (body structure)'})</span></td></tr></table><h3>Containers</h3><table><tr><td>-</td><td><b>Identifier</b></td><td><b>Description</b></td><td><b>Type</b></td><td><b>Capacity</b></td><td><b>SpecimenQuantity</b></td><td><b>Additive[x]</b></td></tr><tr><td>*</td><td>48736-15394-75465</td><td>Green Gel tube</td><td>Vacutainer <span>(Details )</span></td><td>10 mL</td><td>6 mL</td><td>id: hep; Lithium/Li Heparin <span>(Details : {http://hl7.org/fhir/v3/EntityCode code 'HEPL' = 'Lithium/Li Heparin)</span></td></tr></table><p><b>note</b>: Specimen is grossly lipemic</p></div>"
+    },
+    "identifier": [
+        {
+            "system": "http://ehr.acme.org/identifiers/collections",
+            "value": "23234352356"
+        }
+    ],
+    "accessionIdentifier": {
+        "system": "http://lab.acme.org/specimens/2011",
+        "value": "X352356"
+    },
+    "status": "available",
+    "type": {
+        "coding": [
+            {
+                "system": "http://snomed.info/sct",
+                "code": "122555007",
+                "display": "Venous blood specimen"
+            }
+        ]
+    },
+    "subject": {
+        "reference": "Patient/example",
+        "display": "Peter Patient"
+    },
+    "receivedTime": "2011-03-04T07:03:00Z",
+    "request": [
+        {
+            "reference": "ProcedureRequest/example"
+        }
+    ],
+    "collection": {
+        "collector": {
+            "reference": "Practitioner/example"
+        },
+        "collectedDateTime": "2011-05-30T06:15:00Z",
+        "quantity": {
+            "value": 6,
+            "unit": "mL"
+        },
+        "method": {
+            "coding": [
+                {
+                    "system": "http://hl7.org/fhir/v2/0488",
+                    "code": "LNV"
+                }
+            ]
+        },
+        "bodySite": {
+            "coding": [
+                {
+                    "system": "http://snomed.info/sct",
+                    "code": "49852007",
+                    "display": "Structure of median cubital vein (body structure)"
+                }
+            ],
+            "text": "Right median cubital vein"
+        }
+    },
+    "container": [
+        {
+            "identifier": [
+                {
+                    "value": "48736-15394-75465"
+                }
+            ],
+            "description": "Green Gel tube",
+            "type": {
+                "text": "Vacutainer"
+            },
+            "capacity": {
+                "value": 10,
+                "unit": "mL"
+            },
+            "specimenQuantity": {
+                "value": 6,
+                "unit": "mL"
+            },
+            "additiveReference": {
+                "reference": "#hep"
+            }
+        }
+    ],
+    "note": [
+        {
+            "text": "Specimen is grossly lipemic"
+        }
+    ]
+}

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
     [Collection(Categories.CustomSearch)]
     [Trait(Traits.Category, Categories.CustomSearch)]
     [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.Json)]
-    public class CustomSearchParamTests : SearchTestsBase<HttpIntegrationTestFixture>
+    public class CustomSearchParamTests : SearchTestsBase<HttpIntegrationTestFixture>, IAsyncLifetime
     {
         private readonly HttpIntegrationTestFixture _fixture;
         private ITestOutputHelper _output;
@@ -36,6 +36,11 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         {
             _fixture = fixture;
             _output = output;
+        }
+
+        public async Task InitializeAsync()
+        {
+            await Client.DeleteAllResources(ResourceType.Appointment, null);
         }
 
         [SkippableFact]
@@ -529,5 +534,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 Assert.Contains("Gone", ex.Message);
             }
         }
+
+        public Task DisposeAsync() => Task.CompletedTask;
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
         public async Task InitializeAsync()
         {
-            await Client.DeleteAllResources(ResourceType.Appointment, null);
+            await Client.DeleteAllResources(ResourceType.Specimen, null);
             await Client.DeleteAllResources(ResourceType.Immunization, null);
         }
 
@@ -48,25 +48,25 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         public async Task GivenANewSearchParam_WhenReindexingComplete_ThenResourcesSearchedWithNewParamReturned()
         {
             var randomName = Guid.NewGuid().ToString().ComputeHash().Substring(0, 14).ToLower();
-            var searchParam = Samples.GetJsonSample<SearchParameter>("SearchParameter-AppointmentStatus");
+            var searchParam = Samples.GetJsonSample<SearchParameter>("SearchParameter-SpecimenStatus");
             searchParam.Name = randomName;
             searchParam.Url = searchParam.Url.Replace("foo", randomName);
             searchParam.Code = randomName + "Code";
 
-            // POST a new appointment
-            var appointment = Samples.GetJsonSample<Appointment>("Appointment");
-            appointment.Status = Appointment.AppointmentStatus.Noshow;
+            // POST a new Specimen
+            var specimen = Samples.GetJsonSample<Specimen>("Specimen");
+            specimen.Status = Specimen.SpecimenStatus.Available;
             var tag = new Coding(null, randomName);
-            appointment.Meta = new Meta();
-            appointment.Meta.Tag.Add(tag);
-            FhirResponse<Appointment> expectedAppointment = await Client.CreateAsync(appointment);
+            specimen.Meta = new Meta();
+            specimen.Meta.Tag.Add(tag);
+            FhirResponse<Specimen> expectedSpecimen = await Client.CreateAsync(specimen);
 
-            // POST a second appointment to show it is filtered and not returned when using the new search parameter
-            var appointment2 = Samples.GetJsonSample<Appointment>("Appointment");
-            appointment2.Status = Appointment.AppointmentStatus.Booked;
-            appointment2.Meta = new Meta();
-            appointment2.Meta.Tag.Add(tag);
-            await Client.CreateAsync(appointment2);
+            // POST a second Specimen to show it is filtered and not returned when using the new search parameter
+            var specimen2 = Samples.GetJsonSample<Specimen>("Specimen");
+            specimen2.Status = Specimen.SpecimenStatus.EnteredInError;
+            specimen2.Meta = new Meta();
+            specimen2.Meta.Tag.Add(tag);
+            await Client.CreateAsync(specimen2);
 
             // POST a new Search parameter
             FhirResponse<SearchParameter> searchParamPosted = null;
@@ -115,8 +115,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                     try
                     {
                         await ExecuteAndValidateBundle(
-                            $"Appointment?{searchParam.Code}={Appointment.AppointmentStatus.Noshow.ToString().ToLower()}&_tag={tag.Code}",
-                            expectedAppointment.Resource);
+                            $"Specimen?{searchParam.Code}={Specimen.SpecimenStatus.Available.ToString().ToLower()}&_tag={tag.Code}",
+                            expectedSpecimen.Resource);
                     }
                     catch (Exception ex)
                     {
@@ -247,13 +247,13 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             searchParam.Url = searchParam.Url.Replace("foo", randomName);
             searchParam.Code = randomName + "Code";
 
-            // POST a new appointment
-            var appointment = Samples.GetJsonSample<Appointment>("Appointment");
-            FhirResponse<Appointment> expectedAppointment = await Client.CreateAsync(appointment);
+            // POST a new Specimen
+            var specimen = Samples.GetJsonSample<Specimen>("Specimen");
+            FhirResponse<Specimen> expectedSpecimen = await Client.CreateAsync(specimen);
 
-            // POST a second appointment to show it is filtered and not returned when using the new search parameter
-            var appointment2 = Samples.GetJsonSample<Appointment>("Appointment");
-            await Client.CreateAsync(appointment2);
+            // POST a second Specimen to show it is filtered and not returned when using the new search parameter
+            var specimen2 = Samples.GetJsonSample<Specimen>("Specimen");
+            await Client.CreateAsync(specimen2);
 
             // POST a new patient
             var patient = new Patient { Name = new List<HumanName> { new HumanName { Family = randomName } } };
@@ -270,7 +270,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
                 // Start a reindex job
                 var reindexParameters = new Parameters();
-                reindexParameters.Add("targetResourceTypes", new FhirString("Appointment"));
+                reindexParameters.Add("targetResourceTypes", new FhirString("Specimen"));
                 (_, reindexJobUri) = await Client.PostReindexJobAsync(reindexParameters);
 
                 await WaitForReindexStatus(reindexJobUri, "Completed");
@@ -286,10 +286,10 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 _output.WriteLine(serializer.SerializeToString(reindexJobResult.Resource));
 
                 Assert.Contains(searchParamPosted.Resource.Url, searchParamListParam?.Value?.ToString());
-                Assert.Equal("Appointment", targetResourcesParam?.Value?.ToString());
-                Assert.Equal("Appointment", resourcesParam?.Value?.ToString());
+                Assert.Equal("Specimen", targetResourcesParam?.Value?.ToString());
+                Assert.Equal("Specimen", resourcesParam?.Value?.ToString());
 
-                _output.WriteLine($"Reindex job is completed, it should have reindexed the resources of type Appointment only.");
+                _output.WriteLine($"Reindex job is completed, it should have reindexed the resources of type Specimen only.");
 
                 var floatParse = float.TryParse(
                     reindexJobResult.Resource.Parameter.FirstOrDefault(predicate => predicate.Name == "resourcesSuccessfullyReindexed").Value.ToString(),
@@ -313,9 +313,9 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                     try
                     {
                         await ExecuteAndValidateBundle(
-                            $"Appointment?{searchParam.Code}={expectedAppointment.Resource.Id}",
+                            $"Specimen?{searchParam.Code}={expectedSpecimen.Resource.Id}",
                             Tuple.Create("x-ms-use-partial-indices", "true"),
-                            expectedAppointment.Resource);
+                            expectedSpecimen.Resource);
                     }
                     catch (Exception ex)
                     {
@@ -365,15 +365,15 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             searchParam.Name = searchParam.Name.Replace("foo", randomName);
             searchParam.Url = searchParam.Url.Replace("foo", randomName);
             searchParam.Code = randomName + "Code";
-            searchParam.Base = new List<ResourceType?>() { ResourceType.Appointment, ResourceType.Immunization };
+            searchParam.Base = new List<ResourceType?>() { ResourceType.Specimen, ResourceType.Immunization };
 
-            // POST a new appointment
-            var appointment = Samples.GetJsonSample<Appointment>("Appointment");
-            FhirResponse<Appointment> expectedAppointment = await Client.CreateAsync(appointment);
+            // POST a new Specimen
+            var specimen = Samples.GetJsonSample<Specimen>("Specimen");
+            FhirResponse<Specimen> expectedSpecimen = await Client.CreateAsync(specimen);
 
-            // POST a second appointment to show it is filtered and not returned when using the new search parameter
-            var appointment2 = Samples.GetJsonSample<Appointment>("Appointment");
-            await Client.CreateAsync(appointment2);
+            // POST a second Specimen to show it is filtered and not returned when using the new search parameter
+            var specimen2 = Samples.GetJsonSample<Specimen>("Specimen");
+            await Client.CreateAsync(specimen2);
 
             // POST a new Immunization
             var immunization = Samples.GetJsonSample<Immunization>("Immunization");
@@ -390,7 +390,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
                 // Start a reindex job
                 var reindexParameters = new Parameters();
-                reindexParameters.Add("targetResourceTypes", new FhirString("Appointment,Immunization"));
+                reindexParameters.Add("targetResourceTypes", new FhirString("Specimen,Immunization"));
                 (_, reindexJobUri) = await Client.PostReindexJobAsync(reindexParameters);
 
                 await WaitForReindexStatus(reindexJobUri, "Completed");
@@ -406,12 +406,12 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 _output.WriteLine(serializer.SerializeToString(reindexJobResult.Resource));
 
                 Assert.Contains(searchParamPosted.Resource.Url, searchParamListParam?.Value?.ToString());
-                Assert.Contains("Appointment", targetResourcesParam?.Value?.ToString());
-                Assert.Contains("Appointment", resourcesParam?.Value?.ToString());
+                Assert.Contains("Specimen", targetResourcesParam?.Value?.ToString());
+                Assert.Contains("Specimen", resourcesParam?.Value?.ToString());
                 Assert.Contains("Immunization", targetResourcesParam?.Value?.ToString());
                 Assert.Contains("Immunization", resourcesParam?.Value?.ToString());
 
-                _output.WriteLine($"Reindex job is completed, it should have reindexed the resources of type Appointment and Immunization only.");
+                _output.WriteLine($"Reindex job is completed, it should have reindexed the resources of type Specimen and Immunization only.");
 
                 var floatParse = float.TryParse(
                     reindexJobResult.Resource.Parameter.FirstOrDefault(predicate => predicate.Name == "resourcesSuccessfullyReindexed").Value.ToString(),
@@ -435,8 +435,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                     try
                     {
                         await ExecuteAndValidateBundle(
-                            $"Appointment?{searchParam.Code}={expectedAppointment.Resource.Id}",
-                            expectedAppointment.Resource);
+                            $"Specimen?{searchParam.Code}={expectedSpecimen.Resource.Id}",
+                            expectedSpecimen.Resource);
 
                         await ExecuteAndValidateBundle(
                             $"Immunization?{searchParam.Code}={expectedImmunization.Resource.Id}",

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         public async Task InitializeAsync()
         {
             await Client.DeleteAllResources(ResourceType.Appointment, null);
+            await Client.DeleteAllResources(ResourceType.Immunization, null);
         }
 
         [SkippableFact]


### PR DESCRIPTION
## Description
Custom search tests run a reindex job and if there are many resources the job will run long and the test will timeout.
This change removes all previous appointment resources so that the test will execute quickly.

## Related issues
Addresses [issue [AB#89679](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/89679)].

## Testing
Test was rerun several times.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [x] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
