### PR TITLE
Removes sql retry on upsert

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -123,8 +123,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
+                // ** We must use CreateNonRetrySqlCommand here because the retry will not reset the Stream containing the RawResource, resulting in a failure to save the data
                 using (SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken, true))
-                using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand())
+                using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateNonRetrySqlCommand())
                 using (var stream = new RecyclableMemoryStream(_memoryStreamManager))
                 {
                     // Read the latest resource


### PR DESCRIPTION
## Description
Removes Retry on sql command for Upsert. The error still occurs, but data is saved correctly in success cases.

## Related issues
Addresses [issue #].

## Testing
Manual testing using faults inserted into SQL Proc.
![image](https://user-images.githubusercontent.com/197221/165462585-821552c2-5357-4207-8179-0f3d101da338.png)
![image](https://user-images.githubusercontent.com/197221/165462454-b4806f8e-86ed-4385-b64b-39b49a005b75.png)


## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
