### PR TITLE
Bug Fix for Deployment Templates for SQL OSS

### DIFF
--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -154,7 +154,7 @@
         "sqlSchemaAutomaticUpdatesEnabled": {
             "type": "string",
             "allowedValues":["auto", "tool"],
-            "defaultValue": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), 'tool', '')]",
+            "defaultValue": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), 'tool', 'auto')]",
             "metadata": {
                 "description": "Determine whether the sql schema should be automatically upgraded on server startup. If set to 'tool', sql schema will not be initialized or upgraded on the server startup. The schema migration tool will be required to perform initialize or upgrade. If set to 'auto', sql schema will be upgraded to the maximum supported version."
             }

--- a/samples/templates/default-azuredeploy.json
+++ b/samples/templates/default-azuredeploy.json
@@ -161,7 +161,7 @@
         "sqlSchemaAutomaticUpdatesEnabled": {
             "type": "string",
             "allowedValues":["auto", "tool"],
-            "defaultValue": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), 'tool', '')]",
+            "defaultValue": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), 'tool', 'auto')]",
             "metadata": {
                 "description": "Determine whether the sql schema should be automatically upgraded on server startup. If set to 'tool', sql schema will not be initialized or upgraded on the server startup. The schema migration tool will be required to perform initialize or upgrade. If set to 'auto', sql schema will be upgraded to the maximum supported version."
             }


### PR DESCRIPTION
## Description
This PR fixes some ARM logic that determines if schema updates are automatically applied. Currently, the logic will result in an ARM template error for users trying to deploy the OSS. I changed the logic to default SQL OSS deploys to auto schema management.

## Testing
I tested by deploying the templates through the Azure Portal.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
