### PR TITLE
Enforce max string value for SQL columns

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,7 +26,7 @@
   <PropertyGroup>
     <RuntimePackageVersion>5.0.0</RuntimePackageVersion>
     <AspNetPackageVersion>5.0.15</AspNetPackageVersion>
-    <HealthcareSharedPackageVersion>6.1.10</HealthcareSharedPackageVersion>
+    <HealthcareSharedPackageVersion>6.1.21</HealthcareSharedPackageVersion>
     <Hl7FhirVersion>3.8.2</Hl7FhirVersion>
   </PropertyGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,7 +26,7 @@
   <PropertyGroup>
     <RuntimePackageVersion>5.0.0</RuntimePackageVersion>
     <AspNetPackageVersion>5.0.15</AspNetPackageVersion>
-    <HealthcareSharedPackageVersion>6.1.21</HealthcareSharedPackageVersion>
+    <HealthcareSharedPackageVersion>6.1.22</HealthcareSharedPackageVersion>
     <Hl7FhirVersion>3.8.2</Hl7FhirVersion>
   </PropertyGroup>
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/CreateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/CreateTests.cs
@@ -263,6 +263,19 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             }
         }
 
+        [Fact]
+        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.All)]
+        public async Task GivenAResource_WhenPostingWithIdentifierLongerThan128Characters_ThenBadRequestIsReturned()
+        {
+            var observation = Samples.GetDefaultObservation()
+                .ToPoco<Observation>();
+            observation.Identifier.Add(new Identifier("system", "ReallyLongIdentifierWhichIsLongerThan128CharactersSoThatItWillThrowAnException00000000000000000000000000000000000000000000000000000000"));
+
+            var exception = await Assert.ThrowsAsync<FhirException>(async () => await _client.CreateAsync(observation));
+
+            Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
+        }
+
         /// <summary>
         /// Malicious Url Data Source
         /// </summary>


### PR DESCRIPTION
## Description
This updates healthcare-shared-component which pulls in a change to enforce max string length when inserting values into columns.  Previously the string would be silently truncated.

## Related issues
Addresses [issue [AB#91346](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/91346)].

## Testing
Unit tests added in 

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [X] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [X] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
