### PR TITLE
Sql Search performance improvements 

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobWorker.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobWorker.cs
@@ -63,9 +63,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                         {
                             using (IScoped<IFhirOperationDataStore> store = _fhirOperationDataStoreFactory())
                             {
-                                ushort numberOfJobsToRequest = (ushort)(_exportJobConfiguration.MaximumNumberOfJobsPerInstance - runningTasks.Count);
                                 IReadOnlyCollection<ExportJobOutcome> jobs = await store.Value.AcquireExportJobsAsync(
-                                    numberOfJobsToRequest,
+                                    _exportJobConfiguration.MaximumNumberOfConcurrentJobsAllowed,
                                     _exportJobConfiguration.JobHeartbeatTimeoutThreshold,
                                     cancellationToken);
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobWorker.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobWorker.cs
@@ -63,8 +63,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                         {
                             using (IScoped<IFhirOperationDataStore> store = _fhirOperationDataStoreFactory())
                             {
+                                ushort numberOfJobsToRequest = (ushort)(_exportJobConfiguration.MaximumNumberOfJobsPerInstance - runningTasks.Count);
                                 IReadOnlyCollection<ExportJobOutcome> jobs = await store.Value.AcquireExportJobsAsync(
-                                    _exportJobConfiguration.MaximumNumberOfConcurrentJobsAllowed,
+                                    numberOfJobsToRequest,
                                     _exportJobConfiguration.JobHeartbeatTimeoutThreshold,
                                     cancellationToken);
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/ICompressedRawResourceConverter.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/ICompressedRawResourceConverter.cs
@@ -4,7 +4,6 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.IO;
-using System.Threading.Tasks;
 
 namespace Microsoft.Health.Fhir.Core.Features.Operations
 {
@@ -17,7 +16,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations
         /// Read from compressed resource stream to string
         /// </summary>
         /// <param name="compressedResourceStream">Compressed resource stream</param>
-        public Task<string> ReadCompressedRawResource(Stream compressedResourceStream);
+        public string ReadCompressedRawResource(Stream compressedResourceStream);
 
         /// <summary>
         /// Convert rawResource string to compressed stream

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -156,7 +156,7 @@
     },
     "DataStore": "CosmosDb",
     "SqlServer": {
-        "CommandTimeout": "00:00:30"
+        "CommandTimeout": "00:03:00"
     },
     "KeyVault": {
         "Endpoint": null

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/SqlCommandSimplifierTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/SqlCommandSimplifierTests.cs
@@ -1,0 +1,97 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+using System.Runtime.CompilerServices;
+using System.Text;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+using Microsoft.Health.Fhir.SqlServer.Features.Search;
+using Microsoft.Health.SqlServer;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search
+{
+    public class SqlCommandSimplifierTests
+    {
+        private ILogger _logger;
+
+        public SqlCommandSimplifierTests()
+        {
+            _logger = Substitute.For<ILogger>();
+        }
+
+        [Fact]
+        public void GivenACommandWithDistinct_WhenSimplified_ThenTheDistinctIsRemoved()
+        {
+            string startingString = "select distinct * from Resource where Resource.IsDeleted = 0 and Resource.IsHistory = 1 order by Resource.ResourceSurrogateId desc";
+            string expectedString = "select * from Resource where Resource.IsDeleted = 0 and Resource.IsHistory = 1 order by Resource.ResourceSurrogateId desc";
+            IndentedStringBuilder stringBuilder = new IndentedStringBuilder(new StringBuilder(startingString));
+            SqlParameterCollection sqlParameterCollection = RuntimeHelpers.GetUninitializedObject(typeof(SqlParameterCollection)) as SqlParameterCollection;
+            SqlCommandSimplifier.RemoveRedundantParameters(stringBuilder, sqlParameterCollection, _logger);
+            string actualString = stringBuilder.ToString();
+            Assert.Equal(expectedString, actualString);
+        }
+
+        [Fact]
+        public void GivenACommandWithRedundantConditions_WhenSimplified_ThenOnlyOneConditionIsLeft()
+        {
+            string startingString = "select distinct * from Resource where Resource.ResourceSurrogateId >= @p1 and Resource.ResourceSurrogateId > @p2 and Resource.ResourceSurrogateId <= @p3 and Resource.ResourceSurrogateId < @p4 and Resource.IsDeleted = 0 and Resource.IsHistory = 1 order by Resource.ResourceSurrogateId desc";
+            string expectedString = "select * from Resource where Resource.ResourceSurrogateId >= @p1 and 1 = 1 and 1 = 1 and Resource.ResourceSurrogateId < @p4 and Resource.IsDeleted = 0 and Resource.IsHistory = 1 order by Resource.ResourceSurrogateId desc";
+            IndentedStringBuilder stringBuilder = new IndentedStringBuilder(new StringBuilder(startingString));
+            SqlParameterCollection sqlParameterCollection = RuntimeHelpers.GetUninitializedObject(typeof(SqlParameterCollection)) as SqlParameterCollection;
+            sqlParameterCollection.Add(new SqlParameter("@p1", 5L));
+            sqlParameterCollection.Add(new SqlParameter("@p2", 4L));
+            sqlParameterCollection.Add(new SqlParameter("@p3", 13L));
+            sqlParameterCollection.Add(new SqlParameter("@p4", 11L));
+            SqlCommandSimplifier.RemoveRedundantParameters(stringBuilder, sqlParameterCollection, _logger);
+            string actualString = stringBuilder.ToString();
+            Assert.Equal(expectedString, actualString);
+        }
+
+        [Fact]
+        public void GivenACommandWithCTEs_WhenSimplified_ThenNothingIsChanged()
+        {
+            string startingString = "select distinct * from Resource where cte Resource.IsDeleted = 0 and Resource.IsHistory = 1 order by Resource.ResourceSurrogateId desc";
+            string expectedString = "select distinct * from Resource where cte Resource.IsDeleted = 0 and Resource.IsHistory = 1 order by Resource.ResourceSurrogateId desc";
+            IndentedStringBuilder stringBuilder = new IndentedStringBuilder(new StringBuilder(startingString));
+            SqlParameterCollection sqlParameterCollection = RuntimeHelpers.GetUninitializedObject(typeof(SqlParameterCollection)) as SqlParameterCollection;
+            SqlCommandSimplifier.RemoveRedundantParameters(stringBuilder, sqlParameterCollection, _logger);
+            string actualString = stringBuilder.ToString();
+            Assert.Equal(expectedString, actualString);
+        }
+
+        [Fact]
+        public void GivenACommandWithOrConditions_WhenSimplified_ThenConditionsAreNotChanged()
+        {
+            string startingString = "select distinct * from Resource where Resource.ResourceSurrogateId >= @p1 and Resource.ResourceSurrogateId > @p2 and Resource.ResourceSurrogateId <= @p3 and Resource.ResourceSurrogateId < @p4 and Resource.IsDeleted = 0 or Resource.IsHistory = 1 order by Resource.ResourceSurrogateId desc";
+            string expectedString = "select * from Resource where Resource.ResourceSurrogateId >= @p1 and Resource.ResourceSurrogateId > @p2 and Resource.ResourceSurrogateId <= @p3 and Resource.ResourceSurrogateId < @p4 and Resource.IsDeleted = 0 or Resource.IsHistory = 1 order by Resource.ResourceSurrogateId desc";
+            IndentedStringBuilder stringBuilder = new IndentedStringBuilder(new StringBuilder(startingString));
+            SqlParameterCollection sqlParameterCollection = RuntimeHelpers.GetUninitializedObject(typeof(SqlParameterCollection)) as SqlParameterCollection;
+            sqlParameterCollection.Add(new SqlParameter("@p1", 5L));
+            sqlParameterCollection.Add(new SqlParameter("@p2", 4L));
+            sqlParameterCollection.Add(new SqlParameter("@p3", 13L));
+            sqlParameterCollection.Add(new SqlParameter("@p4", 11L));
+            SqlCommandSimplifier.RemoveRedundantParameters(stringBuilder, sqlParameterCollection, _logger);
+            string actualString = stringBuilder.ToString();
+            Assert.Equal(expectedString, actualString);
+        }
+
+        [Fact]
+        public void GivenACommandThatFailsSimplification_WhenSimplified_ThenNothingIsChanged()
+        {
+            string startingString = "select distinct * from Resource where Resource.ResourceSurrogateId >= @p1 and Resource.ResourceSurrogateId > @p2 and Resource.IsDeleted = 0 and Resource.IsHistory = 1 order by Resource.ResourceSurrogateId desc";
+            string expectedString = "select distinct * from Resource where Resource.ResourceSurrogateId >= @p1 and Resource.ResourceSurrogateId > @p2 and Resource.IsDeleted = 0 and Resource.IsHistory = 1 order by Resource.ResourceSurrogateId desc";
+            IndentedStringBuilder stringBuilder = new IndentedStringBuilder(new StringBuilder(startingString));
+            SqlParameterCollection sqlParameterCollection = RuntimeHelpers.GetUninitializedObject(typeof(SqlParameterCollection)) as SqlParameterCollection;
+
+            // The simplifier expects surrogate ids to be longs.
+            sqlParameterCollection.Add(new SqlParameter("@p1", "test"));
+            sqlParameterCollection.Add(new SqlParameter("@p2", 4L));
+            SqlCommandSimplifier.RemoveRedundantParameters(stringBuilder, sqlParameterCollection, _logger);
+            string actualString = stringBuilder.ToString();
+            Assert.Equal(expectedString, actualString);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Storage/CompressedRawResourceConverterTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Storage/CompressedRawResourceConverterTests.cs
@@ -5,7 +5,6 @@
 
 using System.IO;
 using System.IO.Compression;
-using System.Threading.Tasks;
 using Microsoft.Health.Fhir.SqlServer.Features.Storage;
 using Xunit;
 
@@ -14,7 +13,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Storage
     public class CompressedRawResourceConverterTests
     {
         [Fact]
-        public async Task ResourceWithCurrentEncoding_WhenDecoded_ProducesCorrectResult()
+        public void ResourceWithCurrentEncoding_WhenDecoded_ProducesCorrectResult()
         {
             string data = "Hello 😊";
 
@@ -23,12 +22,12 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Storage
             converter.WriteCompressedRawResource(stream, data);
 
             stream.Seek(0, 0);
-            string actual = await converter.ReadCompressedRawResource(stream);
+            string actual = converter.ReadCompressedRawResource(stream);
             Assert.Equal(data, actual);
         }
 
         [Fact]
-        public async Task ResourceWithLegacyEncoding_WhenDecoded_ProducesCorrectResult()
+        public void ResourceWithLegacyEncoding_WhenDecoded_ProducesCorrectResult()
         {
             string data = "Hello 😊";
 
@@ -41,7 +40,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Storage
             writer.Flush();
 
             stream.Seek(0, 0);
-            string actual = await converter.ReadCompressedRawResource(stream);
+            string actual = converter.ReadCompressedRawResource(stream);
             Assert.Equal(data, actual);
         }
     }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlCommandSimplifier.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlCommandSimplifier.cs
@@ -1,0 +1,97 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+using Microsoft.Health.SqlServer;
+
+namespace Microsoft.Health.Fhir.SqlServer.Features.Search
+{
+    internal static class SqlCommandSimplifier
+    {
+        internal static void RemoveRedundantParameters(IndentedStringBuilder stringBuilder, SqlParameterCollection sqlParameterCollection, ILogger logger)
+        {
+            var commandText = stringBuilder.ToString();
+            if (commandText.Contains("cte", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            try
+            {
+                commandText = commandText.Replace("DISTINCT ", string.Empty, StringComparison.OrdinalIgnoreCase);
+                if (!commandText.Contains(" OR ", StringComparison.OrdinalIgnoreCase))
+                {
+                    commandText = RemoveRedundantComparisons(commandText, sqlParameterCollection, '>');
+                    commandText = RemoveRedundantComparisons(commandText, sqlParameterCollection, '<');
+                }
+            }
+            catch (Exception ex)
+            {
+                // Something went wrong simplifing the query, return the query unchanged.
+                logger.LogWarning(ex, "Exception simplifing SQL query");
+                return;
+            }
+
+            stringBuilder.Clear();
+            stringBuilder.Append(commandText);
+        }
+
+        private static string RemoveRedundantComparisons(string commandText, SqlParameterCollection sqlParameterCollection, char operatorChar)
+        {
+            var operatorMatch = new Regex("(\\w*\\.?\\w+) " + operatorChar + "=? (@p\\d+)");
+            var operatorMatches = operatorMatch.Matches(commandText);
+
+            var fieldToParameterComparisons = new Dictionary<string, List<(string, Match)>>();
+            foreach (Match match in operatorMatches)
+            {
+                var groups = match.Groups;
+                if (!fieldToParameterComparisons.ContainsKey(groups[1].Value))
+                {
+                    fieldToParameterComparisons.Add(groups[1].Value, new List<(string, Match)>());
+                }
+
+                fieldToParameterComparisons[groups[1].Value].Add((groups[2].Value, match));
+            }
+
+            foreach (string field in fieldToParameterComparisons.Keys)
+            {
+                long targetValue;
+                if (fieldToParameterComparisons[field].Count > 1)
+                {
+                    targetValue = (long)sqlParameterCollection[fieldToParameterComparisons[field][0].Item1].Value;
+                    int targetIndex = 0;
+                    for (int index = 1; index < fieldToParameterComparisons[field].Count; index++)
+                    {
+                        long value = (long)sqlParameterCollection[fieldToParameterComparisons[field][index].Item1].Value;
+                        if ((operatorChar == '>' && value > targetValue)
+                            || (operatorChar == '<' && value < targetValue)
+                            || (value == targetValue
+                                && !fieldToParameterComparisons[field][index].Item2.Value.Contains("=", StringComparison.OrdinalIgnoreCase)))
+                        {
+                            targetValue = value;
+                            targetIndex = index;
+                        }
+                    }
+
+                    for (int index = 0; index < fieldToParameterComparisons[field].Count; index++)
+                    {
+                        if (index == targetIndex)
+                        {
+                            continue;
+                        }
+
+                        commandText = commandText.Replace(fieldToParameterComparisons[field][index].Item2.Value, "1 = 1", StringComparison.OrdinalIgnoreCase);
+                    }
+                }
+            }
+
+            return commandText;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -301,7 +301,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
 
                 expression.AcceptVisitor(queryGenerator, clonedSearchOptions);
 
-                RemoveRedundantParameters(stringBuilder, sqlCommandWrapper.Parameters);
+                SqlCommandSimplifier.RemoveRedundantParameters(stringBuilder, sqlCommandWrapper.Parameters, _logger);
 
                 sqlCommandWrapper.CommandText = stringBuilder.ToString();
 
@@ -463,75 +463,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                     return new SearchResult(resources, continuationToken?.ToJson(), originalSort, clonedSearchOptions.UnsupportedSearchParams);
                 }
             }
-        }
-
-        private static void RemoveRedundantParameters(IndentedStringBuilder stringBuilder, SqlParameterCollection sqlParameterCollection)
-        {
-            var commandText = stringBuilder.ToString();
-            if (!commandText.Contains("cte", StringComparison.OrdinalIgnoreCase))
-            {
-                commandText = commandText.Replace("DISTINCT ", string.Empty, StringComparison.OrdinalIgnoreCase);
-                if (!commandText.Contains(" OR ", StringComparison.OrdinalIgnoreCase))
-                {
-                    commandText = RemoveRedundantComparisons(commandText, sqlParameterCollection, '>');
-                    commandText = RemoveRedundantComparisons(commandText, sqlParameterCollection, '<');
-                }
-            }
-
-            stringBuilder.Clear();
-            stringBuilder.Append(commandText);
-        }
-
-        private static string RemoveRedundantComparisons(string commandText, SqlParameterCollection sqlParameterCollection, char operatorChar)
-        {
-            var operatorMatch = new Regex("(\\w+) " + operatorChar + "=? (@p\\d+)");
-            var operatorMatches = operatorMatch.Matches(commandText);
-
-            var fieldToParameterComparisons = new Dictionary<string, List<(string, Match)>>();
-            foreach (Match match in operatorMatches)
-            {
-                var groups = match.Groups;
-                if (!fieldToParameterComparisons.ContainsKey(groups[1].Value))
-                {
-                    fieldToParameterComparisons.Add(groups[1].Value, new List<(string, Match)>());
-                }
-
-                fieldToParameterComparisons[groups[1].Value].Add((groups[2].Value, match));
-            }
-
-            foreach (string field in fieldToParameterComparisons.Keys)
-            {
-                long targetValue;
-                if (fieldToParameterComparisons[field].Count > 1)
-                {
-                    targetValue = (long)sqlParameterCollection[fieldToParameterComparisons[field][0].Item1].Value;
-                    int targetIndex = 0;
-                    for (int index = 1; index < fieldToParameterComparisons[field].Count; index++)
-                    {
-                        long value = (long)sqlParameterCollection[fieldToParameterComparisons[field][index].Item1].Value;
-                        if ((operatorChar == '>' && value > targetValue)
-                            || (operatorChar == '<' && value < targetValue)
-                            || (value == targetValue
-                                && !fieldToParameterComparisons[field][index].Item2.Value.Contains("=", StringComparison.OrdinalIgnoreCase)))
-                        {
-                            targetValue = value;
-                            targetIndex = index;
-                        }
-                    }
-
-                    for (int index = 0; index < fieldToParameterComparisons[field].Count; index++)
-                    {
-                        if (index == targetIndex)
-                        {
-                            continue;
-                        }
-
-                        commandText = commandText.Replace(fieldToParameterComparisons[field][index].Item2.Value, "1 = 1", StringComparison.OrdinalIgnoreCase);
-                    }
-                }
-            }
-
-            return commandText;
         }
 
         /// <summary>

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -12,6 +12,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
@@ -300,13 +301,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
 
                 expression.AcceptVisitor(queryGenerator, clonedSearchOptions);
 
-                var commandText = stringBuilder.ToString();
-                if (!commandText.Contains("cte", StringComparison.OrdinalIgnoreCase))
-                {
-                    commandText = commandText.Replace("DISTINCT ", string.Empty, StringComparison.OrdinalIgnoreCase);
-                }
+                RemoveRedundantParameters(stringBuilder, sqlCommandWrapper.Parameters);
 
-                sqlCommandWrapper.CommandText = commandText;
+                sqlCommandWrapper.CommandText = stringBuilder.ToString();
 
                 LogSqlCommand(sqlCommandWrapper);
 
@@ -466,6 +463,66 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                     return new SearchResult(resources, continuationToken?.ToJson(), originalSort, clonedSearchOptions.UnsupportedSearchParams);
                 }
             }
+        }
+
+        private static void RemoveRedundantParameters(IndentedStringBuilder stringBuilder, SqlParameterCollection sqlParameterCollection)
+        {
+            var commandText = stringBuilder.ToString();
+            if (!commandText.Contains("cte", StringComparison.OrdinalIgnoreCase))
+            {
+                commandText = commandText.Replace("DISTINCT ", string.Empty, StringComparison.OrdinalIgnoreCase);
+                if (!commandText.Contains(" OR ", StringComparison.OrdinalIgnoreCase))
+                {
+                    var greaterThanMatch = new Regex("(\\w+) >=? (@p\\d+)");
+                    var greaterThanMatches = greaterThanMatch.Matches(commandText);
+
+                    var fieldToParameterComparisons = new Dictionary<string, List<(string, Match)>>();
+                    foreach (Match match in greaterThanMatches)
+                    {
+                        var groups = match.Groups;
+                        if (!fieldToParameterComparisons.ContainsKey(groups[1].Value))
+                        {
+                            fieldToParameterComparisons.Add(groups[1].Value, new List<(string, Match)>());
+                        }
+
+                        fieldToParameterComparisons[groups[1].Value].Add((groups[2].Value, match));
+                    }
+
+                    foreach (string field in fieldToParameterComparisons.Keys)
+                    {
+                        long largestValue;
+                        if (fieldToParameterComparisons[field].Count > 1)
+                        {
+                            largestValue = (long)sqlParameterCollection[fieldToParameterComparisons[field][0].Item1].Value;
+                            int maxIndex = 0;
+                            for (int index = 1; index < fieldToParameterComparisons[field].Count; index++)
+                            {
+                                long value = (long)sqlParameterCollection[fieldToParameterComparisons[field][index].Item1].Value;
+                                if (value > largestValue
+                                    || (value == largestValue
+                                        && !fieldToParameterComparisons[field][index].Item2.Value.Contains("=", StringComparison.OrdinalIgnoreCase)))
+                                {
+                                    largestValue = value;
+                                    maxIndex = index;
+                                }
+                            }
+
+                            for (int index = 0; index < fieldToParameterComparisons[field].Count; index++)
+                            {
+                                if (index == maxIndex)
+                                {
+                                    continue;
+                                }
+
+                                commandText = commandText.Replace(fieldToParameterComparisons[field][index].Item2.Value, "1 = 1", StringComparison.OrdinalIgnoreCase);
+                            }
+                        }
+                    }
+                }
+            }
+
+            stringBuilder.Clear();
+            stringBuilder.Append(commandText);
         }
 
         /// <summary>

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -300,7 +300,13 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
 
                 expression.AcceptVisitor(queryGenerator, clonedSearchOptions);
 
-                sqlCommandWrapper.CommandText = stringBuilder.ToString();
+                var commandText = stringBuilder.ToString();
+                if (!commandText.Contains("cte", StringComparison.OrdinalIgnoreCase))
+                {
+                    commandText = commandText.Replace("DISTINCT ", string.Empty, StringComparison.OrdinalIgnoreCase);
+                }
+
+                sqlCommandWrapper.CommandText = commandText;
 
                 LogSqlCommand(sqlCommandWrapper);
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -371,7 +371,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                         string rawResource;
                         using (rawResourceStream)
                         {
-                            rawResource = await _compressedRawResourceConverter.ReadCompressedRawResource(rawResourceStream);
+                            rawResource = _compressedRawResourceConverter.ReadCompressedRawResource(rawResourceStream);
                         }
 
                         _logger.LogInformation($"{nameof(resourceSurrogateId)}: {resourceSurrogateId}; {nameof(resourceTypeId)}: {resourceTypeId}; decompressed length: {rawResource.Length}");

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/CompressedRawResourceConverter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/CompressedRawResourceConverter.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             // when there is no BOM
             using var reader = new StreamReader(gzipStream, LegacyResourceEncoding, detectEncodingFromByteOrderMarks: true);
 
+            // The synchronous method is being used as it was found to be ~10x faster than the asynchronous method.
             return reader.ReadToEnd();
         }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/CompressedRawResourceConverter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/CompressedRawResourceConverter.cs
@@ -6,7 +6,6 @@
 using System.IO;
 using System.IO.Compression;
 using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 
 namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
@@ -23,15 +22,15 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
         {
         }
 
-        public async Task<string> ReadCompressedRawResource(Stream compressedResourceStream)
+        public string ReadCompressedRawResource(Stream compressedResourceStream)
         {
-            await using var gzipStream = new GZipStream(compressedResourceStream, CompressionMode.Decompress, leaveOpen: true);
+            using var gzipStream = new GZipStream(compressedResourceStream, CompressionMode.Decompress, leaveOpen: true);
 
             // The current resource encoding uses byte-order marks. The legacy encoding does not, so we provide is as the fallback encoding
             // when there is no BOM
             using var reader = new StreamReader(gzipStream, LegacyResourceEncoding, detectEncodingFromByteOrderMarks: true);
 
-            return await reader.ReadToEndAsync();
+            return reader.ReadToEnd();
         }
 
         public void WriteCompressedRawResource(Stream outputStream, string rawResource)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -441,7 +441,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                         string rawResource;
                         using (rawResourceStream)
                         {
-                            rawResource = await _compressedRawResourceConverter.ReadCompressedRawResource(rawResourceStream);
+                            rawResource = _compressedRawResourceConverter.ReadCompressedRawResource(rawResourceStream);
                         }
 
                         _logger.LogInformation($"{nameof(resourceSurrogateId)}: {resourceSurrogateId}; {nameof(key.ResourceType)}: {key.ResourceType}; {nameof(rawResource)} length: {rawResource.Length}");


### PR DESCRIPTION
## Description
Streamlines SQL queries for basic searches by removing redundant query parameters and speeding up decompression.

## Related issues
Addresses part of [User Story 90388](https://microsofthealth.visualstudio.com/Health/_workitems/edit/90388): Bulk Export Parallelization Improvements Part 1

## Testing
Existing unit and E2E tests

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [x] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
