### PR TITLE
Check current schema version for 0 

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
@@ -463,7 +463,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
         private void ThrowIfCurrentSchemaVersionIsNull()
         {
-            if (_schemaInformation.Current == null)
+            // While applying the full schema, CurrentVersion is set as 0 in InstanceSchema table
+            if (_schemaInformation.Current == null || _schemaInformation.Current == 0)
             {
                 throw new InvalidOperationException(Resources.SchemaVersionShouldNotBeNull);
             }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerTaskConsumer.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerTaskConsumer.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
         public bool EnsureInitializedAsync()
         {
-            return _schemaInformation.Current != null;
+            return _schemaInformation.Current != 0 && _schemaInformation.Current != null;
         }
 
         public async Task<TaskInfo> CompleteAsync(string taskId, TaskResultData taskResultData, string runId, CancellationToken cancellationToken)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerTaskConsumer.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerTaskConsumer.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
         public bool EnsureInitializedAsync()
         {
+            // While applying the full schema, CurrentVersion is set as 0 in InstanceSchema table
             return _schemaInformation.Current != 0 && _schemaInformation.Current != null;
         }
 


### PR DESCRIPTION
## Description
With this PR, we are fixing how the Schema initilized is verified. While applying the full schema, CurrentVersion is set as 0 in the InstanceSchema table.

## Related issues
Addresses [AB88126](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Olympus/Stories/?workitem=88126)

## How to reporduce
1. Ensure MaxVersion.sql script fails
2. Run the FHIR server
3. Check the InstanceSchema table, CurrentVersion wil be 0
4. Try \metadata request - Null reference exception as _resourceTypeToId is not yet initiliazed. Trying to access the FHIR server when it is not fully initialized yet

## Testing
Retest above and ensure null reference exception is not thrown, instead InvalidOperationException(Resources.SchemaVersionShouldNotBeNull) will be thrown

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
