### PR TITLE
Return valid FHIR Resource from Throttling Middleware

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Throttling/ThrottlingMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Throttling/ThrottlingMiddleware.cs
@@ -300,7 +300,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Throttling
             await context.Response.Body.WriteAsync(body);
         }
 
-        private static Memory<byte> CreateThrottledBody(string message) => Encoding.UTF8.GetBytes($@"{{""severity"":""Error"",""code"":""Throttled"",""diagnostics"":""{message}""}}").AsMemory();
+        private static Memory<byte> CreateThrottledBody(string message) => Encoding.UTF8.GetBytes($@"{{""resourceType"":""OperationOutcome"",""issue"":[{{""severity"":""Error"",""code"":""Throttled"",""diagnostics"":""{message}""}}]}}").AsMemory();
 
         public async ValueTask DisposeAsync()
         {

--- a/src/Microsoft.Health.Fhir.Api/Features/Throttling/ThrottlingMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Throttling/ThrottlingMiddleware.cs
@@ -300,7 +300,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Throttling
             await context.Response.Body.WriteAsync(body);
         }
 
-        private static Memory<byte> CreateThrottledBody(string message) => Encoding.UTF8.GetBytes($@"{{""resourceType"":""OperationOutcome"",""issue"":[{{""severity"":""Error"",""code"":""Throttled"",""diagnostics"":""{message}""}}]}}").AsMemory();
+        private static Memory<byte> CreateThrottledBody(string message) => Encoding.UTF8.GetBytes($@"{{""resourceType"":""OperationOutcome"",""issue"":[{{""severity"":""error"",""code"":""throttled"",""diagnostics"":""{message}""}}]}}").AsMemory();
 
         public async ValueTask DisposeAsync()
         {


### PR DESCRIPTION
## Description
Returns a valid [OperationOutcome](http://www.hl7.org/fhir/operationoutcome.html) resource for 429 responses.

## Related issues
Fixes #2607 

## Testing
Added a unit test and ensured all existing ThrottlingMiddlewareTests are still passing. Images from manual testing below.

Old:
![old](https://user-images.githubusercontent.com/22577558/169426778-bd481024-afe1-4227-a5bb-51a2cf8b7b72.PNG)

New:
![new](https://user-images.githubusercontent.com/22577558/169426823-cc8a088c-5359-4c05-ad2e-a9df5e45aaeb.PNG)


## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch (minor change to code)
