### PR TITLE
[Tests] Add operation ID as part of FHIR exception message

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Client/FhirException.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Client/FhirException.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Health.Fhir.Client
 
         public OperationOutcome OperationOutcome => Response.Resource;
 
-        public override string Message => $"{StatusCode} ({GetOperationId()}): {OperationOutcome?.Issue?.FirstOrDefault()?.Diagnostics}";
+        public override string Message => $"{StatusCode}: {OperationOutcome?.Issue?.FirstOrDefault()?.Diagnostics} ({GetOperationId()})";
 
         public void Dispose()
         {

--- a/src/Microsoft.Health.Fhir.Shared.Client/FhirException.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Client/FhirException.cs
@@ -29,8 +29,7 @@ namespace Microsoft.Health.Fhir.Client
 
         public OperationOutcome OperationOutcome => Response.Resource;
 
-        public override string Message
-            => $"{StatusCode}: {OperationOutcome?.Issue?.FirstOrDefault()?.Diagnostics}";
+        public override string Message => $"{StatusCode} ({GetOperationId()}): {OperationOutcome?.Issue?.FirstOrDefault()?.Diagnostics}";
 
         public void Dispose()
         {
@@ -45,6 +44,16 @@ namespace Microsoft.Health.Fhir.Client
                 // free managed resources
                 Response?.Dispose();
             }
+        }
+
+        private string GetOperationId()
+        {
+            if (Response.Headers.TryGetValues("X-Request-Id", out var values))
+            {
+                return values.First();
+            }
+
+            return string.Empty;
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BasicAuthTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BasicAuthTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         {
             TestFhirClient tempClient = _client.CreateClientForUser(TestUsers.ReadOnlyUser, TestApplications.NativeClient);
             FhirException fhirException = await Assert.ThrowsAsync<FhirException>(async () => await tempClient.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>()));
-            Assert.Equal(ForbiddenMessage, fhirException.Message);
+            Assert.StartsWith(ForbiddenMessage, fhirException.Message);
             Assert.Equal(HttpStatusCode.Forbidden, fhirException.StatusCode);
         }
 
@@ -66,7 +66,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             tempClient = _client.CreateClientForUser(TestUsers.ReadOnlyUser, TestApplications.NativeClient);
             FhirException fhirException = await Assert.ThrowsAsync<FhirException>(async () => await tempClient.UpdateAsync(createdResource));
-            Assert.Equal(ForbiddenMessage, fhirException.Message);
+            Assert.StartsWith(ForbiddenMessage, fhirException.Message);
             Assert.Equal(HttpStatusCode.Forbidden, fhirException.StatusCode);
         }
 
@@ -78,7 +78,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Observation createdResource = await tempClient.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>());
 
             FhirException fhirException = await Assert.ThrowsAsync<FhirException>(async () => await tempClient.HardDeleteAsync(createdResource));
-            Assert.Equal(ForbiddenMessage, fhirException.Message);
+            Assert.StartsWith(ForbiddenMessage, fhirException.Message);
             Assert.Equal(HttpStatusCode.Forbidden, fhirException.StatusCode);
         }
 
@@ -140,7 +140,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             TestFhirClient tempClient = _client.CreateClientForClientApplication(TestApplications.InvalidClient);
 
             FhirException fhirException = await Assert.ThrowsAsync<FhirException>(async () => await tempClient.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>()));
-            Assert.Equal(UnauthorizedMessage, fhirException.Message);
+            Assert.StartsWith(UnauthorizedMessage, fhirException.Message);
             Assert.Equal(HttpStatusCode.Unauthorized, fhirException.StatusCode);
 
             List<AuthenticationHeaderValue> wwwAuthenticationHeaderValues = fhirException.Headers.WwwAuthenticate.Where(h => h.Scheme == "Bearer").ToList();
@@ -168,7 +168,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         {
             TestFhirClient tempClient = _client.CreateClientForClientApplication(TestApplications.InvalidClient).Clone();
             FhirException fhirException = await Assert.ThrowsAsync<FhirException>(async () => await tempClient.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>()));
-            Assert.Equal(UnauthorizedMessage, fhirException.Message);
+            Assert.StartsWith(UnauthorizedMessage, fhirException.Message);
             Assert.Equal(HttpStatusCode.Unauthorized, fhirException.StatusCode);
         }
 
@@ -178,7 +178,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         {
             TestFhirClient tempClient = _client.CreateClientForClientApplication(TestApplications.WrongAudienceClient);
             FhirException fhirException = await Assert.ThrowsAsync<FhirException>(async () => await tempClient.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>()));
-            Assert.Equal(UnauthorizedMessage, fhirException.Message);
+            Assert.StartsWith(UnauthorizedMessage, fhirException.Message);
             Assert.Equal(HttpStatusCode.Unauthorized, fhirException.StatusCode);
         }
 
@@ -206,7 +206,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             TestFhirClient tempClient = _client.CreateClientForUser(TestUsers.ReadOnlyUser, TestApplications.NativeClient);
 
             FhirException fhirException = await Assert.ThrowsAsync<FhirException>(async () => await tempClient.ExportAsync());
-            Assert.Equal(ForbiddenMessage, fhirException.Message);
+            Assert.StartsWith(ForbiddenMessage, fhirException.Message);
             Assert.Equal(HttpStatusCode.Forbidden, fhirException.StatusCode);
         }
 
@@ -253,7 +253,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             TestFhirClient tempClient = _client.CreateClientForUser(TestUsers.ReadWriteUser, TestApplications.NativeClient);
             var resource = Samples.GetJsonSample("ValueSet").ToPoco<ValueSet>();
             FhirException fhirException = await Assert.ThrowsAsync<FhirException>(async () => await tempClient.CreateAsync<ValueSet>(resource));
-            Assert.Equal(ForbiddenMessage, fhirException.Message);
+            Assert.StartsWith(ForbiddenMessage, fhirException.Message);
             Assert.Equal(HttpStatusCode.Forbidden, fhirException.StatusCode);
         }
 
@@ -265,7 +265,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             var resource = Samples.GetJsonSample("ValueSet").ToPoco<ValueSet>();
             var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await tempClient.UpdateAsync<ValueSet>(resource));
 
-            Assert.Equal(ForbiddenMessage, fhirException.Message);
+            Assert.StartsWith(ForbiddenMessage, fhirException.Message);
             Assert.Equal(HttpStatusCode.Forbidden, fhirException.StatusCode);
         }
 
@@ -277,7 +277,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             var resource = Samples.GetJsonSample("ValueSet").ToPoco<ValueSet>();
             var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await tempClient.CreateAsync<ValueSet>(resource, "identifier=boo"));
 
-            Assert.Equal(ForbiddenMessage, fhirException.Message);
+            Assert.StartsWith(ForbiddenMessage, fhirException.Message);
             Assert.Equal(HttpStatusCode.Forbidden, fhirException.StatusCode);
         }
 
@@ -290,7 +290,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             var weakETag = "W/\"identifier=boo\"";
             var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await tempClient.UpdateAsync<ValueSet>(resource, weakETag));
 
-            Assert.Equal(ForbiddenMessage, fhirException.Message);
+            Assert.StartsWith(ForbiddenMessage, fhirException.Message);
             Assert.Equal(HttpStatusCode.Forbidden, fhirException.StatusCode);
         }
 
@@ -302,7 +302,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             var resource = Samples.GetJsonSample("ValueSet").ToPoco<ValueSet>();
             var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await tempClient.DeleteAsync<ValueSet>(resource));
 
-            Assert.Equal(ForbiddenMessage, fhirException.Message);
+            Assert.StartsWith(ForbiddenMessage, fhirException.Message);
             Assert.Equal(HttpStatusCode.Forbidden, fhirException.StatusCode);
         }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTests.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Import
             request.Mode = ImportConstants.InitialLoadMode;
             request.Force = true;
             FhirException fhirException = await Assert.ThrowsAsync<FhirException>(async () => await tempClient.ImportAsync(request.ToParameters(), CancellationToken.None));
-            Assert.Equal(ForbiddenMessage, fhirException.Message);
+            Assert.StartsWith(ForbiddenMessage, fhirException.Message);
             Assert.Equal(HttpStatusCode.Forbidden, fhirException.StatusCode);
         }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -616,7 +616,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
             var expectedErrorMessage = $"{expectedStatusCode}: " + string.Format(Core.Resources.ElementsAndSummaryParametersAreIncompatible, KnownQueryParameterNames.Summary, KnownQueryParameterNames.Elements);
 
-            Assert.Equal(expectedErrorMessage, ex.Message);
+            Assert.StartsWith(expectedErrorMessage, ex.Message);
         }
 
         [Fact]
@@ -798,7 +798,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             var supportedTotalTypes = new string($"'{TotalType.Accurate}', '{TotalType.None}'").ToLower(CultureInfo.CurrentCulture);
             var expectedErrorMessage = $"{expectedStatusCode}: " + string.Format(Core.Resources.UnsupportedTotalParameter, totalType, supportedTotalTypes);
 
-            Assert.Equal(expectedErrorMessage, ex.Message);
+            Assert.StartsWith(expectedErrorMessage, ex.Message);
         }
 
         [InlineData("_total", "count")]
@@ -815,7 +815,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             var supportedTotalTypes = new string($"'{TotalType.Accurate}', '{TotalType.None}'").ToLower(CultureInfo.CurrentCulture);
             var expectedErrorMessage = $"{expectedStatusCode}: " + string.Format(Core.Resources.InvalidTotalParameter, val, supportedTotalTypes);
 
-            Assert.Equal(expectedErrorMessage, ex.Message);
+            Assert.StartsWith(expectedErrorMessage, ex.Message);
         }
 
         [Fact]


### PR DESCRIPTION
## Description
Add operation ID as part of FHIR exception message.

## Related issues
Addresses [issue #].

## Testing
Running local tests.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
