### PR TITLE
Change import resource version from 0 => 1

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/ImportResourceSqlExtentions.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/ImportResourceSqlExtentions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
     {
         internal static BulkImportResourceTypeV1Row ExtractBulkImportResourceTypeV1Row(this ImportResource importResource, short resourceTypeId)
         {
-            return new BulkImportResourceTypeV1Row(resourceTypeId, importResource.Resource.ResourceId, 0, false, importResource.Id, false, "POST", importResource.CompressedStream, true, importResource.Resource.SearchParameterHash);
+            return new BulkImportResourceTypeV1Row(resourceTypeId, importResource.Resource.ResourceId, 1, false, importResource.Id, false, "POST", importResource.CompressedStream, true, importResource.Resource.SearchParameterHash);
         }
 
         internal static bool ContainsError(this ImportResource importResource)


### PR DESCRIPTION
## Description
Currently the resources created by POST version start from 1, keep same behavior change import resource version to 1.

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [x] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
