### PR TITLE
Fixes schema version should be null error from _schema apis

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,7 +26,7 @@
   <PropertyGroup>
     <RuntimePackageVersion>5.0.0</RuntimePackageVersion>
     <AspNetPackageVersion>5.0.17</AspNetPackageVersion>
-    <HealthcareSharedPackageVersion>6.1.44</HealthcareSharedPackageVersion>
+    <HealthcareSharedPackageVersion>6.1.47</HealthcareSharedPackageVersion>
     <Hl7FhirVersion>4.0.0</Hl7FhirVersion>
   </PropertyGroup>
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SchemaUpgradedHandler.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SchemaUpgradedHandler.cs
@@ -27,6 +27,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             EnsureArg.IsNotNull(notification, nameof(notification));
 
             // If it is a snapshot upgrade, then we need to run initialization for all schema versions up to the current version.
+            // When schema is run via tool, then the notification will be sent out from SqlSchemaManager.cs and if schema is initialized
+            // by the fhir-server itself on startup then the notification will be sent out from SchemaInitializer.cs
             await _sqlServerFhirModel.Initialize(notification.Version, notification.IsFullSchemaSnapshot, cancellationToken);
         }
     }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
     /// many many times in the database. For more compact storage, we use IDs instead of the strings when referencing these.
     /// Also, because the number of distinct values is small, we can maintain all values in memory and avoid joins when querying.
     /// </summary>
-    public sealed class SqlServerFhirModel : IRequireInitializationOnFirstRequest, ISqlServerFhirModel
+    public sealed class SqlServerFhirModel : ISqlServerFhirModel
     {
         private readonly SchemaInformation _schemaInformation;
         private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager;


### PR DESCRIPTION
## Description
Describe the changes in this PR.

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
