### PR TITLE
Updated minimum supported schema version to 32

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/36.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/36.sql
@@ -1752,7 +1752,7 @@ END CATCH
 GO
 CREATE PROCEDURE dbo.DisableIndex
 @tableName NVARCHAR (128), @indexName NVARCHAR (128)
-WITH EXECUTE AS 'dbo'
+WITH EXECUTE AS SELF
 AS
 DECLARE @errorTxt AS VARCHAR (1000), @sql AS NVARCHAR (1000), @isDisabled AS BIT;
 IF object_id(@tableName) IS NULL
@@ -2529,7 +2529,7 @@ ELSE
 GO
 CREATE PROCEDURE dbo.RebuildIndex
 @tableName NVARCHAR (128), @indexName NVARCHAR (128), @pageCompression BIT=0
-WITH EXECUTE AS 'dbo'
+WITH EXECUTE AS SELF
 AS
 DECLARE @errorTxt AS VARCHAR (1000), @sql AS NVARCHAR (1000), @isDisabled AS BIT, @isExecuted AS INT;
 IF object_id(@tableName) IS NULL

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaVersionConstants.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaVersionConstants.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema
 {
     public static class SchemaVersionConstants
     {
-        public const int Min = (int)SchemaVersion.V4;
+        public const int Min = (int)SchemaVersion.V32;
         public const int Max = (int)SchemaVersion.V36;
         public const int SearchParameterStatusSchemaVersion = (int)SchemaVersion.V6;
         public const int SupportForReferencesWithMissingTypeVersion = (int)SchemaVersion.V7;


### PR DESCRIPTION
## Description
Updated minimum supported schema version to 32. We introduced some breaking changes with Version 32 related to the export functionality. 

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
