### PR TITLE
Update to healthcare-shared-components 6.1.61, to avoid 128 character limit

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,7 +26,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <RuntimePackageVersion>6.0.0</RuntimePackageVersion>
-    <HealthcareSharedPackageVersion>6.1.59</HealthcareSharedPackageVersion>
+    <HealthcareSharedPackageVersion>6.1.61</HealthcareSharedPackageVersion>
     <AspNetPackageVersion>6.0.0</AspNetPackageVersion>
     <Hl7FhirVersion>4.0.0</Hl7FhirVersion>
   </PropertyGroup>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E.Common/TestAuthenticationHttpMessageHandler.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E.Common/TestAuthenticationHttpMessageHandler.cs
@@ -7,7 +7,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Health.Client;
+using Microsoft.Health.Client.Authentication;
 using NSubstitute;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Common

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E.Common/TestFhirClient.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E.Common/TestFhirClient.cs
@@ -6,7 +6,7 @@
 using System.Net.Http;
 using EnsureThat;
 using Hl7.Fhir.Rest;
-using Microsoft.Health.Client;
+using Microsoft.Health.Client.Authentication;
 using Microsoft.Health.Fhir.Tests.E2E.Rest;
 using FhirClient = Microsoft.Health.Fhir.Client.FhirClient;
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TestFhirServer.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TestFhirServer.cs
@@ -18,7 +18,7 @@ using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using Hl7.Fhir.Serialization;
 using Microsoft.Extensions.Options;
-using Microsoft.Health.Client;
+using Microsoft.Health.Client.Authentication;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Tests.E2E.Common;
@@ -122,14 +122,14 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             ICredentialProvider credentialProvider;
             if (user == null)
             {
-                var credentialConfiguration = new OAuth2ClientCredentialConfiguration(
+                var credentialConfiguration = new OAuth2ClientCredentialOptions(
                     TokenUri,
                     resource,
                     scope,
                     clientApplication.ClientId,
                     clientApplication.ClientSecret);
 
-                var optionsMonitor = Substitute.For<IOptionsMonitor<OAuth2ClientCredentialConfiguration>>();
+                var optionsMonitor = Substitute.For<IOptionsMonitor<OAuth2ClientCredentialOptions>>();
                 optionsMonitor.CurrentValue.Returns(credentialConfiguration);
                 optionsMonitor.Get(default).ReturnsForAnyArgs(credentialConfiguration);
 
@@ -137,7 +137,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             }
             else
             {
-                var credentialConfiguration = new OAuth2UserPasswordCredentialConfiguration(
+                var credentialConfiguration = new OAuth2UserPasswordCredentialOptions(
                     TokenUri,
                     resource,
                     scope,
@@ -146,7 +146,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
                     user.UserId,
                     user.Password);
 
-                var optionsMonitor = Substitute.For<IOptionsMonitor<OAuth2UserPasswordCredentialConfiguration>>();
+                var optionsMonitor = Substitute.For<IOptionsMonitor<OAuth2UserPasswordCredentialOptions>>();
                 optionsMonitor.CurrentValue.Returns(credentialConfiguration);
                 optionsMonitor.Get(default).ReturnsForAnyArgs(credentialConfiguration);
 


### PR DESCRIPTION
## Description
Add necessary changes to update to healthcare-shared-components 6.1.61

## Related issues
Addresses [issue [AB#92775](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/92775)].

## Testing
Automated tests were run

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [X] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [X] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
