### PR TITLE
Member match and Reindex should return 400 if non-Parameter object is passed

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Filters/ValidateParametersResourceAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Filters/ValidateParametersResourceAttribute.cs
@@ -7,7 +7,7 @@ using System;
 using EnsureThat;
 using Hl7.Fhir.Model;
 using Microsoft.AspNetCore.Mvc.Filters;
-using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Microsoft.Health.Fhir.Core.Exceptions;
 
 namespace Microsoft.Health.Fhir.Api.Features.Filters
 {
@@ -24,9 +24,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
             context.ActionArguments.TryGetValue("inputParams", out var inputResource);
             if (inputResource is not Parameters)
             {
-                throw new BadRequestException(string.Format(
-                    "Expected input object to be of type 'Hl7.Fhir.Model.Parameters' instead of '{0}'",
-                    inputResource.GetType().FullName));
+                throw new RequestNotValidException(string.Format(Resources.UnsupportedResourceType, inputResource.GetType().ToString()));
             }
         }
     }

--- a/src/Microsoft.Health.Fhir.Api/Features/Filters/ValidateParametersResourceAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Filters/ValidateParametersResourceAttribute.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
     /// <summary>
     /// Validate that the deserialized request body object is of type Hl7.Fhir.Model.Parameters.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class)]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
     public sealed class ValidateParametersResourceAttribute : ActionFilterAttribute
     {
         public override void OnActionExecuting(ActionExecutingContext context)

--- a/src/Microsoft.Health.Fhir.Api/Features/Filters/ValidateParametersResourceAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Filters/ValidateParametersResourceAttribute.cs
@@ -1,0 +1,33 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using EnsureThat;
+using Hl7.Fhir.Model;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
+
+namespace Microsoft.Health.Fhir.Api.Features.Filters
+{
+    /// <summary>
+    /// Validate that the deserialized request body object is of type Hl7.Fhir.Model.Parameters.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class ValidateParametersResourceAttribute : ActionFilterAttribute
+    {
+        public override void OnActionExecuting(ActionExecutingContext context)
+        {
+            EnsureArg.IsNotNull(context, nameof(context));
+
+            context.ActionArguments.TryGetValue("inputParams", out var inputResource);
+            if (inputResource is not Parameters)
+            {
+                throw new BadRequestException(string.Format(
+                    "Expected input object to be of type 'Hl7.Fhir.Model.Parameters' instead of '{0}'",
+                    inputResource.GetType().FullName));
+            }
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/MemberMatchController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/MemberMatchController.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
     [ServiceFilter(typeof(OperationOutcomeExceptionFilterAttribute))]
     [ServiceFilter(typeof(ValidateFormatParametersAttribute))]
     [ValidateModelState]
+    [ValidateParametersResourceAttribute]
     public class MemberMatchController : Controller
     {
         private readonly IMediator _mediator;

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ReindexController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ReindexController.cs
@@ -32,7 +32,6 @@ namespace Microsoft.Health.Fhir.Api.Controllers
 {
     [ServiceFilter(typeof(AuditLoggingFilterAttribute))]
     [ServiceFilter(typeof(OperationOutcomeExceptionFilterAttribute))]
-    [ValidateParametersResourceAttribute]
     public class ReindexController : Controller
     {
         private readonly IMediator _mediator;
@@ -61,6 +60,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         [HttpPost]
         [Route(KnownRoutes.Reindex)]
         [ServiceFilter(typeof(ValidateReindexRequestFilterAttribute))]
+        [ServiceFilter(typeof(ValidateParametersResourceAttribute))]
         [AuditEventType(AuditEventSubType.Reindex)]
         public async Task<IActionResult> CreateReindexJob([FromBody] Parameters inputParams)
         {

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ReindexController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ReindexController.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
 {
     [ServiceFilter(typeof(AuditLoggingFilterAttribute))]
     [ServiceFilter(typeof(OperationOutcomeExceptionFilterAttribute))]
+    [ValidateParametersResourceAttribute]
     public class ReindexController : Controller
     {
         private readonly IMediator _mediator;

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs
@@ -103,6 +103,7 @@ namespace Microsoft.Health.Fhir.Api.Modules
             services.AddSingleton<ValidateExportRequestFilterAttribute>();
             services.AddSingleton<ValidateReindexRequestFilterAttribute>();
             services.AddSingleton<ValidateImportRequestFilterAttribute>();
+            services.AddSingleton<ValidateParametersResourceAttribute>();
 
             // Support for resolve()
             FhirPathCompiler.DefaultSymbolTable.AddFhirExtensions();

--- a/src/Microsoft.Health.Fhir.Shared.Client/FhirClient.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Client/FhirClient.cs
@@ -353,6 +353,7 @@ namespace Microsoft.Health.Fhir.Client
             {
                 Content = new StringContent(body, Encoding.UTF8, "application/json"),
             };
+            message.Headers.Accept.Add(_mediaType);
             HttpResponseMessage response = await HttpClient.SendAsync(message, cancellationToken);
 
             await EnsureSuccessStatusCodeAsync(response);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/MemberMatchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/MemberMatchTests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         }
 
         [Fact]
-        public async Task NonParametersRequestBody_ResultsInBadRequest()
+        public async Task GivenNonParametersRequestBody_WhenMemberMatchSent_ThenBadRequest()
         {
             string body = Samples.GetJson("PatientWithMinimalData");
             var ex = await Assert.ThrowsAsync<FhirException>(async () => await _client.PostAsync("Patient/$member-match", body));

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/MemberMatchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/MemberMatchTests.cs
@@ -79,5 +79,13 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.Equal(HttpStatusCode.UnprocessableEntity, ex.StatusCode);
             Assert.Equal(Core.Resources.MemberMatchNoMatchFound, ex.OperationOutcome.Issue.First().Diagnostics);
         }
+
+        [Fact]
+        public async Task NonParametersRequestBody_ResultsInBadRequest()
+        {
+            string body = Samples.GetJson("PatientWithMinimalData");
+            var ex = await Assert.ThrowsAsync<FhirException>(async () => await _client.PostAsync("Patient/$member-match", body));
+            Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
+        }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -472,6 +472,14 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             }
         }
 
+        [Fact]
+        public async Task GivenNonParametersRequestBody_WhenReindexSent_ThenBadRequest()
+        {
+            string body = Samples.GetJson("PatientWithMinimalData");
+            var ex = await Assert.ThrowsAsync<FhirException>(async () => await Client.PostAsync("$reindex", body));
+            Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
+        }
+
         private async Task<FhirResponse<Parameters>> WaitForReindexStatus(System.Uri reindexJobUri, params string[] desiredStatus)
         {
             int checkReindexCount = 0;


### PR DESCRIPTION
## Description
A new action filter, ValidateParametersResourceAttribute, has been created to check if the deserialized object from request body is of type Parameters (resource). The action filter has been added to the member match endpoint and Reindex endpoint. 

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
