### PR TITLE
Fix queries with the "_sort" operator 

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -453,7 +453,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             }
 
             // Everything in the top expression is considered a match
-            string selectStatement = sortExpression == null ? "SELECT DISTINCT" : "SELECT";
+            const string selectStatement = "SELECT DISTINCT";
             StringBuilder.Append(selectStatement).Append(" TOP (").Append(Parameters.AddParameter(context.MaxItemCount + 1, includeInHash: false)).Append(") T1, Sid1, 1 AS IsMatch, 0 AS IsPartial ")
                 .AppendLine(sortExpression == null ? string.Empty : $", {sortExpression}")
                 .Append("FROM ").AppendLine(tableExpressionName);


### PR DESCRIPTION
Fix queries with the "_sort" operator not returning the same results as other queries without the "_sort" operator.

## Description
This PR includes the distinct operator at the latest SQL CTE ran in a query with the "_sort" operator. 
This new distinct operator is the same one used by the same queries without the "_sort" operator. 

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
