### PR TITLE
Fixes 500 on metadata endpoint when schema is not initialized

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
@@ -463,7 +463,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
         private void ThrowIfCurrentSchemaVersionIsNull()
         {
-            if (_schemaInformation.Current == null || _schemaInformation.Current == 0)
+            if (_schemaInformation.Current == null)
             {
                 _logger.LogError($"The SQL schema is yet to be initialized.");
                 throw new ServiceUnavailableException();

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
@@ -463,10 +463,17 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
         private void ThrowIfCurrentSchemaVersionIsNull()
         {
-            // While applying the full schema, CurrentVersion is set as 0 in InstanceSchema table
             if (_schemaInformation.Current == null || _schemaInformation.Current == 0)
             {
-                throw new InvalidOperationException(Resources.SchemaVersionShouldNotBeNull);
+                _logger.LogError($"The SQL schema is yet to be initialized.");
+                throw new ServiceUnavailableException();
+            }
+
+            // During schema initialization, once the base schema is initialized, CurrentVersion is set as 0 in InstanceSchema table and making progress to apply full schema snapshot file.
+            if (_schemaInformation.Current == 0)
+            {
+                _logger.LogError($"The SQL Schema initialization is in progress.");
+                throw new ServiceUnavailableException();
             }
         }
     }


### PR DESCRIPTION
## Description
Fixes 500 on metadata endpoint when schema is not initialized

## Related issues
Addresses [9306](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Olympus/Stories/?workitem=93076)

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
