### PR TITLE
Fix for registered services not calling AsSelf()

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
@@ -241,10 +241,12 @@ namespace Microsoft.Extensions.DependencyInjection
 
             fhirServerBuilder.Services.Add<CosmosDbSortingValidator>()
                 .Singleton()
+                .AsSelf()
                 .AsImplementedInterfaces();
 
             fhirServerBuilder.Services.Add<CosmosDbSearchParameterValidator>()
                 .Singleton()
+                .AsSelf()
                 .AsImplementedInterfaces();
 
             return fhirServerBuilder;

--- a/src/Microsoft.Health.Fhir.SqlServer/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
@@ -114,6 +114,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.Add<ReindexJobSqlThrottlingController>()
                 .Singleton()
+                .AsSelf()
                 .AsImplementedInterfaces();
 
             services.Add<SqlQueueClient>()


### PR DESCRIPTION
## Description
We have a few services that were not calling AsSelf() when they were using AsImplementedInterfaces(). For reference the logic behind this lives in Microsoft.Health.Extensions.DependencyInjection.TypeRegistrationBuilder.


## Related issues
Addresses [92947](https://microsofthealth.visualstudio.com/Health/_workitems/edit/92947)

## Testing
This was tested by having a local build of healthcare-shared-components by utilizing the [Publish-LocalChanges.ps1](https://github.com/microsoft/healthcare-shared-components/blob/main/scripts/Publish-LocalChanges.ps1), then have fhir-server consume use the nuget pkg. Without this change in place you'll hit the Debug.Assert message that are in [TypeRegistrationBuilder.cs](https://github.com/microsoft/healthcare-shared-components/blob/995063fa171bd6c686d40f6c2d2ac6a6d4d79afc/src/Microsoft.Health.Extensions.DependencyInjection/TypeRegistrationBuilder.cs#L123)

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip
