### PR TITLE
Updates .devcontainer/codespaces for CosmosDB

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -18,22 +18,29 @@ ARG USERNAME=automatic
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
-COPY library-scripts/*.sh /tmp/library-scripts/
-COPY library-scripts/fix-cert.sh /tmp/fix-cert.sh
+RUN sudo mkdir -p /setup
+COPY .devcontainer/library-scripts/*.sh /setup/library-scripts/
+COPY .devcontainer/library-scripts/fix-cert.sh /setup/fix-cert.sh
+COPY global.json /setup/global.json
 
 RUN apt-get update \
-    && /bin/bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" "true" "true" \
+    && apt-get install -y dos2unix \
+    && dos2unix /setup/library-scripts/*.sh \
+    && /bin/bash /setup/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" "true" "true" \
     # Use Docker script from script library to set things up
-    && /bin/bash /tmp/library-scripts/docker-debian.sh "${ENABLE_NONROOT_DOCKER}" "/var/run/docker-host.sock" "/var/run/docker.sock" "${USERNAME}" \
+    && /bin/bash /setup/library-scripts/docker-debian.sh "${ENABLE_NONROOT_DOCKER}" "/var/run/docker-host.sock" "/var/run/docker.sock" "${USERNAME}" \
     # Clean up
-    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts/
+    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* /setup/library-scripts/
 
 
 # Install .net SDK
 RUN wget https://dot.net/v1/dotnet-install.sh -O $HOME/dotnet-install.sh
 RUN chmod +x $HOME/dotnet-install.sh
+RUN dos2unix /setup/global.json
+RUN dos2unix /setup/*.sh
+RUN chmod +x /setup/*.sh
 RUN sudo mkdir -p /usr/share/dotnet
-RUN $HOME/dotnet-install.sh -c 5.0 --install-dir /usr/share/dotnet
+RUN $HOME/dotnet-install.sh --install-dir /usr/share/dotnet --jsonfile /setup/global.json
 RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
 # Setting the ENTRYPOINT to docker-init.sh will configure non-root access 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
 
 	// Use this environment variable if you need to bind mount your local source code into a new container.
 	"remoteEnv": {
-		"LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}",
+		"LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}"
 	},
 	
 	// Set *default* container specific settings.json values on container create.
@@ -18,12 +18,19 @@
 	"extensions": [
 		"ms-azuretools.vscode-docker",
 		"ms-dotnettools.csharp",
-		"ms-azuretools.vscode-cosmosdb"
+		"ms-azuretools.vscode-cosmosdb",
+		"humao.rest-client"
 	],
 
 	// Install the certificate for the emulator
-	"postCreateCommand": "/tmp/fix-cert.sh",
+	"postCreateCommand": "/setup/fix-cert.sh",
 
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode"
+	"remoteUser": "vscode",
+
+	"portsAttributes": {
+		"44348": {
+			"protocol": "https"
+		}
+	}
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     mem_limit: 3g
     cpu_count: 2
     environment:
-        AZURE_COSMOS_EMULATOR_PARTITION_COUNT: 10
+        AZURE_COSMOS_EMULATOR_PARTITION_COUNT: 2
         AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE: "true"
     volumes:
         - /var/run/docker.sock:/var/run/docker-host.sock
@@ -15,8 +15,8 @@ services:
     depends_on:
       - "cosmos"
     build: 
-      context: .
-      dockerfile: Dockerfile
+      context: ../
+      dockerfile: .devcontainer/Dockerfile
       args:
         # On Linux, you may need to update USER_UID and USER_GID below if not your local UID is not 1000.
         USER_UID: 1000

--- a/.devcontainer/library-scripts/docker-debian.sh
+++ b/.devcontainer/library-scripts/docker-debian.sh
@@ -179,4 +179,6 @@ exec "\$@"
 EOF
 chmod +x /usr/local/share/docker-init.sh
 chown ${USERNAME}:root /usr/local/share/docker-init.sh
+mkdir /workspace && chown ${USERNAME}:root /workspace
+mkdir /home && chown ${USERNAME}:root /home
 echo "Done!"

--- a/.devcontainer/library-scripts/fix-cert.sh
+++ b/.devcontainer/library-scripts/fix-cert.sh
@@ -2,6 +2,14 @@
 
 # Download and install the emulator cert so the fhir server can communicate with TLS/SSL
 # https://docs.microsoft.com/en-us/azure/cosmos-db/linux-emulator?tabs=ssl-netstd21#run-on-macos
+
+HTTPD="0"
+until [ "$HTTPD" == "200" ]; do
+    printf '.'
+    sleep 3
+    HTTPD=`curl -A "Web Check" -sLk --connect-timeout 3 -w "%{http_code}\n" "https://cosmos:8081/_explorer/emulator.pem" -o /dev/null`
+done
+
 curl -k https://cosmos:8081/_explorer/emulator.pem > ~/emulatorcert.crt
 sudo cp ~/emulatorcert.crt /usr/local/share/ca-certificates/
 sudo update-ca-certificates

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "buildR4",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/Microsoft.Health.Fhir.R4.Web/bin/Debug/net5.0/Microsoft.Health.Fhir.R4.Web.dll",
+            "program": "${workspaceFolder}/src/Microsoft.Health.Fhir.R4.Web/bin/Debug/net6.0/Microsoft.Health.Fhir.R4.Web.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/Microsoft.Health.Fhir.R4.Web",
             "stopAtEntry": false,
@@ -33,7 +33,7 @@
             "request": "launch",
             "preLaunchTask": "buildR4",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/Microsoft.Health.Fhir.R4.Web/bin/Debug/net5.0/Microsoft.Health.Fhir.R4.Web.dll",
+            "program": "${workspaceFolder}/src/Microsoft.Health.Fhir.R4.Web/bin/Debug/net6.0/Microsoft.Health.Fhir.R4.Web.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/Microsoft.Health.Fhir.R4.Web",
             "stopAtEntry": false,
@@ -57,7 +57,7 @@
             "request": "launch",
             "preLaunchTask": "buildSTU3",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/Microsoft.Health.Fhir.Stu3.Web/bin/Debug/net5.0/Microsoft.Health.Fhir.Stu3.Web.dll",
+            "program": "${workspaceFolder}/src/Microsoft.Health.Fhir.Stu3.Web/bin/Debug/net6.0/Microsoft.Health.Fhir.Stu3.Web.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/Microsoft.Health.Fhir.Stu3.Web",
             "stopAtEntry": false,
@@ -80,7 +80,7 @@
             "request": "launch",
             "preLaunchTask": "buildSTU3",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/Microsoft.Health.Fhir.Stu3.Web/bin/Debug/net5.0/Microsoft.Health.Fhir.Stu3.Web.dll",
+            "program": "${workspaceFolder}/src/Microsoft.Health.Fhir.Stu3.Web/bin/Debug/net6.0/Microsoft.Health.Fhir.Stu3.Web.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/Microsoft.Health.Fhir.Stu3.Web",
             "stopAtEntry": false,
@@ -104,7 +104,7 @@
             "request": "launch",
             "preLaunchTask": "buildR5",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/Microsoft.Health.Fhir.R5.Web/bin/Debug/net5.0/Microsoft.Health.Fhir.R5.Web.dll",
+            "program": "${workspaceFolder}/src/Microsoft.Health.Fhir.R5.Web/bin/Debug/net6.0/Microsoft.Health.Fhir.R5.Web.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/Microsoft.Health.Fhir.R5.Web",
             "stopAtEntry": false,
@@ -127,7 +127,7 @@
             "request": "launch",
             "preLaunchTask": "buildR5",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/Microsoft.Health.Fhir.R5.Web/bin/Debug/net5.0/Microsoft.Health.Fhir.R5.Web.dll",
+            "program": "${workspaceFolder}/src/Microsoft.Health.Fhir.R5.Web/bin/Debug/net6.0/Microsoft.Health.Fhir.R5.Web.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/Microsoft.Health.Fhir.R5.Web",
             "stopAtEntry": false,


### PR DESCRIPTION
## Description
Updates .devcontainer/codespaces for CosmosDB
- installs the right version of .net
- waits until cosmos emulator is ready to download cert

## Testing
Tested by creating a codespace (https://github.com/codespaces)

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
