### PR TITLE
Allow specifying sort order on _history

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Models/HistoryModel.cs
+++ b/src/Microsoft.Health.Fhir.Api/Models/HistoryModel.cs
@@ -1,0 +1,31 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Health.Fhir.Core.Features;
+using Microsoft.Health.Fhir.Core.Models;
+
+namespace Microsoft.Health.Fhir.Api.Models;
+
+public class HistoryModel
+{
+    [FromQuery(Name = KnownQueryParameterNames.At)]
+    public PartialDateTime At { get; set; }
+
+    [FromQuery(Name = KnownQueryParameterNames.Since)]
+    public PartialDateTime Since { get; set; }
+
+    [FromQuery(Name = KnownQueryParameterNames.Before)]
+    public PartialDateTime Before { get; set; }
+
+    [FromQuery(Name = KnownQueryParameterNames.Count)]
+    public int? Count { get; set; }
+
+    [FromQuery(Name = KnownQueryParameterNames.ContinuationToken)]
+    public string ContinuationToken { get; set; }
+
+    [FromQuery(Name = KnownQueryParameterNames.Sort)]
+    public string Sort { get; set; }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/ISearchService.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/ISearchService.cs
@@ -35,7 +35,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
         /// </summary>
         /// <param name="searchOptions">The options to use during the search.</param>
         /// <param name="cancellationToken">The cancellationToken.</param>
-        /// <param name="isAsyncOperation">Whether the search is part of an async operation.</param>
         /// <returns>The search result.</returns>
         Task<SearchResult> SearchAsync(
             SearchOptions searchOptions,
@@ -67,6 +66,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             PartialDateTime before,
             int? count,
             string continuationToken,
+            string sort,
             CancellationToken cancellationToken,
             bool isAsyncOperation = false);
 

--- a/src/Microsoft.Health.Fhir.Core/Messages/Search/SearchResourceHistoryRequest.cs
+++ b/src/Microsoft.Health.Fhir.Core/Messages/Search/SearchResourceHistoryRequest.cs
@@ -15,19 +15,20 @@ namespace Microsoft.Health.Fhir.Core.Messages.Search
     {
         private readonly string _capability;
 
-        public SearchResourceHistoryRequest(PartialDateTime since = null, PartialDateTime before = null, PartialDateTime at = null, int? count = null, string continuationToken = null)
+        public SearchResourceHistoryRequest(PartialDateTime since = null, PartialDateTime before = null, PartialDateTime at = null, int? count = null, string continuationToken = null, string sort = null)
         {
             Since = since;
             Before = before;
             At = at;
             Count = count;
             ContinuationToken = continuationToken;
+            Sort = sort;
 
             _capability = "CapabilityStatement.rest.interaction.where(code = 'history-system').exists()";
         }
 
-        public SearchResourceHistoryRequest(string resourceType, PartialDateTime since = null, PartialDateTime before = null, PartialDateTime at = null, int? count = null, string continuationToken = null)
-            : this(since, before, at, count, continuationToken)
+        public SearchResourceHistoryRequest(string resourceType, PartialDateTime since = null, PartialDateTime before = null, PartialDateTime at = null, int? count = null, string continuationToken = null, string sort = null)
+            : this(since, before, at, count, continuationToken, sort)
         {
             EnsureArg.IsNotNullOrWhiteSpace(resourceType, nameof(resourceType));
 
@@ -36,8 +37,8 @@ namespace Microsoft.Health.Fhir.Core.Messages.Search
             _capability = $"CapabilityStatement.rest.resource.where(type = '{resourceType}').interaction.where(code = 'history-type').exists()";
         }
 
-        public SearchResourceHistoryRequest(string resourceType, string resourceId, PartialDateTime since = null, PartialDateTime before = null, PartialDateTime at = null, int? count = null, string continuationToken = null)
-            : this(resourceType, since, before, at, count, continuationToken)
+        public SearchResourceHistoryRequest(string resourceType, string resourceId, PartialDateTime since = null, PartialDateTime before = null, PartialDateTime at = null, int? count = null, string continuationToken = null, string sort = null)
+            : this(resourceType, since, before, at, count, continuationToken, sort)
         {
             EnsureArg.IsNotNullOrWhiteSpace(resourceType, nameof(resourceType));
             EnsureArg.IsNotNullOrWhiteSpace(resourceId, nameof(resourceId));
@@ -60,6 +61,8 @@ namespace Microsoft.Health.Fhir.Core.Messages.Search
         public int? Count { get; }
 
         public string ContinuationToken { get; }
+
+        public string Sort { get; }
 
         public IEnumerable<CapabilityQuery> RequiredCapabilities()
         {

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/QueryBuilder.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/QueryBuilder.cs
@@ -139,12 +139,14 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries
                     searchOptions.Expression.AcceptVisitor(expressionQueryBuilder);
                 }
 
-                _queryBuilder
-                    .Append("ORDER BY ")
+                _queryBuilder.Append("ORDER BY ");
+                var sortOption = searchOptions.Sort[0];
+
 #pragma warning disable CA1834 // Consider using 'StringBuilder.Append(char)' when applicable
-                    .Append(SearchValueConstants.RootAliasName).Append('.').Append(KnownResourceWrapperProperties.LastModified)
+                _queryBuilder.Append(SearchValueConstants.RootAliasName).Append('.')
 #pragma warning restore CA1834 // Consider using 'StringBuilder.Append(char)' when applicable
-                    .AppendLine(" DESC");
+                    .Append(KnownResourceWrapperProperties.LastModified).Append(' ')
+                    .AppendLine(sortOption.sortOrder == SortOrder.Ascending ? "ASC" : "DESC");
 
                 var query = new QueryDefinition(_queryBuilder.ToString());
                 _queryParameterManager.AddToQuery(query);

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
@@ -29,6 +29,7 @@ using Microsoft.Health.Fhir.Api.Features.AnonymousOperations;
 using Microsoft.Health.Fhir.Api.Features.Filters;
 using Microsoft.Health.Fhir.Api.Features.Headers;
 using Microsoft.Health.Fhir.Api.Features.Routing;
+using Microsoft.Health.Fhir.Api.Models;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features;
 using Microsoft.Health.Fhir.Core.Features.Context;
@@ -262,22 +263,20 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         /// <summary>
         /// Returns the history of all resources in the system
         /// </summary>
-        /// <param name="at">Instant for history to return.</param>
-        /// <param name="since">Starting time for history to return (inclusive).</param>
-        /// <param name="before">Ending time for history to return (exclusive)</param>
-        /// <param name="count">Number of items to return.</param>
-        /// <param name="ct">Continuation token.</param>
+        /// <param name="historyModel">Model for history parameters.</param>
         [HttpGet]
         [Route(KnownRoutes.History, Name = RouteNames.History)]
         [AuditEventType(AuditEventSubType.HistorySystem)]
-        public async Task<IActionResult> SystemHistory(
-            [FromQuery(Name = KnownQueryParameterNames.At)] PartialDateTime at,
-            [FromQuery(Name = KnownQueryParameterNames.Since)] PartialDateTime since,
-            [FromQuery(Name = KnownQueryParameterNames.Before)] PartialDateTime before,
-            [FromQuery(Name = KnownQueryParameterNames.Count)] int? count,
-            string ct)
+        public async Task<IActionResult> SystemHistory(HistoryModel historyModel)
         {
-            ResourceElement response = await _mediator.SearchResourceHistoryAsync(since, before, at, count, ct, HttpContext.RequestAborted);
+            ResourceElement response = await _mediator.SearchResourceHistoryAsync(
+                historyModel.Since,
+                historyModel.Before,
+                historyModel.At,
+                historyModel.Count,
+                historyModel.ContinuationToken,
+                historyModel.Sort,
+                HttpContext.RequestAborted);
 
             return FhirResult.Create(response);
         }
@@ -286,23 +285,23 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         /// Returns the history of a specific resource type
         /// </summary>
         /// <param name="typeParameter">The resource type.</param>
-        /// <param name="at">Instant for history to return.</param>
-        /// <param name="since">Starting time for history to return (inclusive).</param>
-        /// <param name="before">Ending time for history to return (exclusive).</param>
-        /// <param name="count">Number of items to return.</param>
-        /// <param name="ct">Continuation token.</param>
+        /// <param name="historyModel">Model for history parameters.</param>
         [HttpGet]
         [Route(KnownRoutes.ResourceTypeHistory, Name = RouteNames.HistoryType)]
         [AuditEventType(AuditEventSubType.HistoryType)]
         public async Task<IActionResult> TypeHistory(
             string typeParameter,
-            [FromQuery(Name = KnownQueryParameterNames.At)] PartialDateTime at,
-            [FromQuery(Name = KnownQueryParameterNames.Since)] PartialDateTime since,
-            [FromQuery(Name = KnownQueryParameterNames.Before)] PartialDateTime before,
-            [FromQuery(Name = KnownQueryParameterNames.Count)] int? count,
-            string ct)
+            HistoryModel historyModel)
         {
-            ResourceElement response = await _mediator.SearchResourceHistoryAsync(typeParameter, since, before, at, count, ct, HttpContext.RequestAborted);
+            ResourceElement response = await _mediator.SearchResourceHistoryAsync(
+                typeParameter,
+                historyModel.Since,
+                historyModel.Before,
+                historyModel.At,
+                historyModel.Count,
+                historyModel.ContinuationToken,
+                historyModel.Sort,
+                HttpContext.RequestAborted);
 
             return FhirResult.Create(response);
         }
@@ -312,24 +311,25 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         /// </summary>
         /// <param name="typeParameter">The resource type.</param>
         /// <param name="idParameter">The identifier.</param>
-        /// <param name="at">Instant for history to return.</param>
-        /// <param name="since">Starting time for history to return (inclusive).</param>
-        /// <param name="before">Ending time for hitory to return (exclusive).</param>
-        /// <param name="count">Number of items to return.</param>
-        /// <param name="ct">Continuation token.</param>
+        /// <param name="historyModel">Model for history parameters.</param>
         [HttpGet]
         [Route(KnownRoutes.ResourceTypeByIdHistory, Name = RouteNames.HistoryTypeId)]
         [AuditEventType(AuditEventSubType.HistoryInstance)]
         public async Task<IActionResult> History(
             string typeParameter,
             string idParameter,
-            [FromQuery(Name = KnownQueryParameterNames.At)] PartialDateTime at,
-            [FromQuery(Name = KnownQueryParameterNames.Since)] PartialDateTime since,
-            [FromQuery(Name = KnownQueryParameterNames.Before)] PartialDateTime before,
-            [FromQuery(Name = KnownQueryParameterNames.Count)] int? count,
-            string ct)
+            HistoryModel historyModel)
         {
-            ResourceElement response = await _mediator.SearchResourceHistoryAsync(typeParameter, idParameter, since, before, at, count, ct, HttpContext.RequestAborted);
+            ResourceElement response = await _mediator.SearchResourceHistoryAsync(
+                typeParameter,
+                idParameter,
+                historyModel.Since,
+                historyModel.Before,
+                historyModel.At,
+                historyModel.Count,
+                historyModel.ContinuationToken,
+                historyModel.Sort,
+                HttpContext.RequestAborted);
 
             return FhirResult.Create(response);
         }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/PatientEverythingServiceTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/PatientEverythingServiceTests.cs
@@ -55,7 +55,17 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Everything
 
             var searchResult = new SearchResult(Enumerable.Empty<SearchResultEntry>(), null, null, new Tuple<string, string>[0]);
             _searchService.SearchAsync(Arg.Any<SearchOptions>(), CancellationToken.None).Returns(searchResult);
-            _searchService.SearchHistoryAsync(KnownResourceTypes.Patient, Arg.Any<string>(), null, null, null, null, Arg.Any<string>(), CancellationToken.None).Returns(searchResult);
+            _searchService.SearchHistoryAsync(
+                KnownResourceTypes.Patient,
+                Arg.Any<string>(),
+                Arg.Any<PartialDateTime>(),
+                Arg.Any<PartialDateTime>(),
+                Arg.Any<PartialDateTime>(),
+                Arg.Any<int?>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                CancellationToken.None,
+                Arg.Any<bool>()).Returns(searchResult);
 
             SearchResult actualResult = await _patientEverythingService.SearchAsync("123", null, null, null, null, null, CancellationToken.None);
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchResourceHistoryHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchResourceHistoryHandlerTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
             var searchResult = new SearchResult(Enumerable.Empty<SearchResultEntry>(), null, null, new Tuple<string, string>[0]);
 
-            _searchService.SearchHistoryAsync(request.ResourceType, null, null, null, null, null, null, CancellationToken.None).Returns(searchResult);
+            _searchService.SearchHistoryAsync(request.ResourceType, null, null, null, null, null, null, null, CancellationToken.None).Returns(searchResult);
 
             var expectedBundle = new Bundle().ToResourceElement();
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchServiceTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchServiceTests.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
             _searchService.SearchImplementation = options => SearchResult.Empty(_unsupportedQueryParameters);
 
-            await Assert.ThrowsAsync<ResourceNotFoundException>(() => _searchService.SearchHistoryAsync(resourceType, resourceId, null, null, null, null, null, CancellationToken.None));
+            await Assert.ThrowsAsync<ResourceNotFoundException>(() => _searchService.SearchHistoryAsync(resourceType, resourceId, null, null, null, null, null, null, CancellationToken.None));
         }
 
         [Fact]
@@ -120,7 +120,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
             _fhirDataStore.GetAsync(Arg.Any<ResourceKey>(), Arg.Any<CancellationToken>()).Returns(resourceWrapper);
 
-            SearchResult searchResult = await _searchService.SearchHistoryAsync(resourceType, resourceId, PartialDateTime.Parse("2018"), null, null, null, null, CancellationToken.None);
+            SearchResult searchResult = await _searchService.SearchHistoryAsync(resourceType, resourceId, PartialDateTime.Parse("2018"), null, null, null, null, null, CancellationToken.None);
 
             Assert.Empty(searchResult.Results);
         }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Extensions/FhirMediatorExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Extensions/FhirMediatorExtensions.cs
@@ -97,29 +97,29 @@ namespace Microsoft.Health.Fhir.Core.Extensions
             return result.Bundle;
         }
 
-        public static async Task<ResourceElement> SearchResourceHistoryAsync(this IMediator mediator, PartialDateTime since = null, PartialDateTime before = null, PartialDateTime at = null, int? count = null, string continuationToken = null, CancellationToken cancellationToken = default)
+        public static async Task<ResourceElement> SearchResourceHistoryAsync(this IMediator mediator, PartialDateTime since = null, PartialDateTime before = null, PartialDateTime at = null, int? count = null, string continuationToken = null, string sort = null, CancellationToken cancellationToken = default)
         {
             EnsureArg.IsNotNull(mediator, nameof(mediator));
 
-            var result = await mediator.Send(new SearchResourceHistoryRequest(since, before, at, count, continuationToken), cancellationToken);
+            var result = await mediator.Send(new SearchResourceHistoryRequest(since, before, at, count, continuationToken, sort), cancellationToken);
 
             return result.Bundle;
         }
 
-        public static async Task<ResourceElement> SearchResourceHistoryAsync(this IMediator mediator, string resourceType, PartialDateTime since = null, PartialDateTime before = null, PartialDateTime at = null, int? count = null, string continuationToken = null, CancellationToken cancellationToken = default)
+        public static async Task<ResourceElement> SearchResourceHistoryAsync(this IMediator mediator, string resourceType, PartialDateTime since = null, PartialDateTime before = null, PartialDateTime at = null, int? count = null, string continuationToken = null, string sort = null, CancellationToken cancellationToken = default)
         {
             EnsureArg.IsNotNull(mediator, nameof(mediator));
 
-            var result = await mediator.Send(new SearchResourceHistoryRequest(resourceType, since, before, at, count, continuationToken), cancellationToken);
+            var result = await mediator.Send(new SearchResourceHistoryRequest(resourceType, since, before, at, count, continuationToken, sort), cancellationToken);
 
             return result.Bundle;
         }
 
-        public static async Task<ResourceElement> SearchResourceHistoryAsync(this IMediator mediator, string resourceType, string resourceId, PartialDateTime since = null, PartialDateTime before = null, PartialDateTime at = null, int? count = null, string continuationToken = null, CancellationToken cancellationToken = default)
+        public static async Task<ResourceElement> SearchResourceHistoryAsync(this IMediator mediator, string resourceType, string resourceId, PartialDateTime since = null, PartialDateTime before = null, PartialDateTime at = null, int? count = null, string continuationToken = null, string sort = null, CancellationToken cancellationToken = default)
         {
             EnsureArg.IsNotNull(mediator, nameof(mediator));
 
-            var result = await mediator.Send(new SearchResourceHistoryRequest(resourceType, resourceId, since, before, at, count, continuationToken), cancellationToken);
+            var result = await mediator.Send(new SearchResourceHistoryRequest(resourceType, resourceId, since, before, at, count, continuationToken, sort), cancellationToken);
 
             return result.Bundle;
         }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchResourceHistoryHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchResourceHistoryHandler.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                 request.Before,
                 request.Count,
                 request.ContinuationToken,
+                request.Sort,
                 cancellationToken);
 
             ResourceElement bundle = _bundleFactory.CreateHistoryBundle(searchResult);

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -488,11 +488,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                 // history is always sorted by _lastUpdated.
                 newSearchOptions = searchOptions.CloneSqlSearchOptions();
 
-                newSearchOptions.Sort = new (SearchParameterInfo searchParameterInfo, SortOrder sortOrder)[]
-                {
-                    (_fakeLastUpdate, SortOrder.Ascending),
-                };
-
                 return newSearchOptions;
             }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Configs;
+using Microsoft.Health.Fhir.Core.Features;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Operations;
@@ -177,7 +178,9 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
             var searchParameterExpressionParser = new SearchParameterExpressionParser(new ReferenceSearchValueParser(_fhirRequestContextAccessor));
             var expressionParser = new ExpressionParser(() => searchableSearchParameterDefinitionManager, searchParameterExpressionParser);
-            var searchOptionsFactory = new SearchOptionsFactory(expressionParser, () => searchableSearchParameterDefinitionManager, options, _fhirRequestContextAccessor, Substitute.For<ISortingValidator>(), NullLogger<SearchOptionsFactory>.Instance);
+            ISortingValidator sortingValidator = Substitute.For<ISortingValidator>();
+            sortingValidator.ValidateSorting(Arg.Is<IReadOnlyList<(SearchParameterInfo searchParameter, SortOrder sortOrder)>>(x => x[0].searchParameter.Name == KnownQueryParameterNames.LastUpdated), out Arg.Any<IReadOnlyList<string>>()).Returns(true);
+            var searchOptionsFactory = new SearchOptionsFactory(expressionParser, () => searchableSearchParameterDefinitionManager, options, _fhirRequestContextAccessor, sortingValidator, NullLogger<SearchOptionsFactory>.Instance);
 
             ICosmosDbCollectionPhysicalPartitionInfo cosmosDbPhysicalPartitionInfo = Substitute.For<ICosmosDbCollectionPhysicalPartitionInfo>();
             cosmosDbPhysicalPartitionInfo.PhysicalPartitionCount.Returns(1);


### PR DESCRIPTION
## Description
- Allow specifying sort order in history
- Fixes default sort order for SQL

If the existing behavior is needed for SQL endpoints the following parameter will be a consistent way to keep it:
```
/_history?_sort=_lastUpdated
```

`/_history?_sort=-_lastUpdated` is the same as the default where most recent items are displayed first.

- Works for all _history endpoints
- No other _sort options are added or supported on _history.

## Related issues
Addresses #2689.

## Testing
Adds e2e tests

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [x] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
