### PR TITLE
Fix Null Reference Exception

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ImportControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ImportControllerTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using Hl7.Fhir.Model;
 using MediatR;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -44,6 +45,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
                 GetBulkImportRequestConfigurationWithUnsupportedStorageType(),
                 GetBulkImportRequestConfigurationWithUnsupportedResourceType(),
                 GetBulkImportRequestConfigurationWithNoInputFile(),
+                GetBulkImportRequestConfigurationWithNoInputUrl(),
             };
 
         [Theory]
@@ -73,6 +75,14 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
             var bulkImportController = GetController(new ImportTaskConfiguration() { Enabled = true });
 
             await Assert.ThrowsAsync<RequestNotValidException>(() => bulkImportController.Import(body.ToParameters()));
+        }
+
+        [Fact]
+        public async Task GivenAnBulkImportRequest_WhenRequestWithNullParameters_ThenRequestNotValidExceptionShouldBeThrown()
+        {
+            Parameters parameters = null;
+            var bulkImportController = GetController(new ImportTaskConfiguration() { Enabled = true });
+            await Assert.ThrowsAsync<RequestNotValidException>(() => bulkImportController.Import(parameters));
         }
 
         private static CreateImportResponse CreateBulkImportResponse()
@@ -193,6 +203,24 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
         {
             var input = new List<InputResource>();
 
+            var bulkImportRequestConfiguration = new ImportRequest();
+            bulkImportRequestConfiguration.InputFormat = "application/fhir+ndjson";
+            bulkImportRequestConfiguration.InputSource = new Uri("https://other-server.example.org");
+            bulkImportRequestConfiguration.Input = input;
+
+            return bulkImportRequestConfiguration;
+        }
+
+        private static ImportRequest GetBulkImportRequestConfigurationWithNoInputUrl()
+        {
+            var input = new List<InputResource>
+            {
+                new InputResource
+                {
+                    Type = "Patient",
+                    Url = null,
+                },
+            };
             var bulkImportRequestConfiguration = new ImportRequest();
             bulkImportRequestConfiguration.InputFormat = "application/fhir+ndjson";
             bulkImportRequestConfiguration.InputSource = new Uri("https://other-server.example.org");

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ImportController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ImportController.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         {
             CheckIfImportIsEnabled();
 
-            ImportRequest importRequest = importTaskParameters.ExtractImportRequest();
+            ImportRequest importRequest = importTaskParameters?.ExtractImportRequest();
             ValidateImportRequestConfiguration(importRequest);
 
             if (!ImportConstants.InitialLoadMode.Equals(importRequest.Mode, StringComparison.Ordinal))


### PR DESCRIPTION
## Description
There is a null reference exception in function ExtractImportRequest. While testing import function, I found that it lacks validation for null case caused by some unexpected situations such as irregular json writing.
This PR will add null case check for Parameters to fix the exception and make sure the check is efficient by adding a test.

## Testing
For the case that Parameters is null, I have added test and confirmed all are passing:

- ImportControllerTest

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [X] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [X] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
