### PR TITLE
Rebuild Metadata

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
@@ -338,6 +338,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
         public ICapabilityStatementBuilder SyncProfiles(bool disableCacheRefresh = false)
         {
             _statement.Profile.Clear();
+
+            if (!disableCacheRefresh)
+            {
+                _supportedProfiles.Refresh();
+            }
+
             foreach (string resource in _modelInfoProvider.GetResourceTypeNames())
             {
                 // Parameters is a non-persisted resource used to pass information into and back from an operation

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
@@ -33,14 +33,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
         private readonly IModelInfoProvider _modelInfoProvider;
         private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager;
         private readonly CoreFeatureConfiguration _configuration;
-        private readonly IKnowSupportedProfiles _supportedProfiles;
+        private readonly ISupportedProfilesStore _supportedProfiles;
 
         private CapabilityStatementBuilder(
             ListedCapabilityStatement statement,
             IModelInfoProvider modelInfoProvider,
             ISearchParameterDefinitionManager searchParameterDefinitionManager,
             IOptions<CoreFeatureConfiguration> configuration,
-            IKnowSupportedProfiles supportedProfiles)
+            ISupportedProfilesStore supportedProfiles)
         {
             EnsureArg.IsNotNull(statement, nameof(statement));
             EnsureArg.IsNotNull(modelInfoProvider, nameof(modelInfoProvider));
@@ -55,7 +55,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
             _supportedProfiles = supportedProfiles;
         }
 
-        public static ICapabilityStatementBuilder Create(IModelInfoProvider modelInfoProvider, ISearchParameterDefinitionManager searchParameterDefinitionManager, IOptions<CoreFeatureConfiguration> configuration, IKnowSupportedProfiles supportedProfiles)
+        public static ICapabilityStatementBuilder Create(IModelInfoProvider modelInfoProvider, ISearchParameterDefinitionManager searchParameterDefinitionManager, IOptions<CoreFeatureConfiguration> configuration, ISupportedProfilesStore supportedProfiles)
         {
             EnsureArg.IsNotNull(modelInfoProvider, nameof(modelInfoProvider));
             EnsureArg.IsNotNull(searchParameterDefinitionManager, nameof(searchParameterDefinitionManager));

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/SystemConformanceProvider.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/SystemConformanceProvider.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
         private static SemaphoreSlim _metadataSemaphore = new SemaphoreSlim(1, 1);
         private readonly List<Action<ListedCapabilityStatement>> _configurationUpdates = new List<Action<ListedCapabilityStatement>>();
         private readonly IOptions<CoreFeatureConfiguration> _configuration;
-        private readonly IKnowSupportedProfiles _supportedProfiles;
+        private readonly ISupportedProfilesStore _supportedProfiles;
         private readonly ILogger _logger;
 
         public SystemConformanceProvider(
@@ -46,7 +46,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
             ISearchParameterDefinitionManager.SearchableSearchParameterDefinitionManagerResolver searchParameterDefinitionManagerResolver,
             Func<IScoped<IEnumerable<IProvideCapability>>> capabilityProviders,
             IOptions<CoreFeatureConfiguration> configuration,
-            IKnowSupportedProfiles supportedProfiles,
+            ISupportedProfilesStore supportedProfiles,
             ILogger<SystemConformanceProvider> logger)
         {
             EnsureArg.IsNotNull(modelInfoProvider, nameof(modelInfoProvider));

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/SystemConformanceProvider.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/SystemConformanceProvider.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
                 {
                     await Task.Delay(TimeSpan.FromMinutes(1));
 
-                    if (!_cancellationTokenSource.IsCancellationRequested)
+                    if (_cancellationTokenSource.IsCancellationRequested)
                     {
                         return;
                     }

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/SystemConformanceProvider.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/SystemConformanceProvider.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
     public sealed class SystemConformanceProvider
         : ConformanceProviderBase, IConfiguredConformanceProvider, INotificationHandler<RebuildCapabilityStatement>, IDisposable
     {
-        private readonly int _rebuildDelay = 60 * 1000; // 4 hours in milliseconds
+        private readonly int _rebuildDelay = 4 * 60 * 60 * 1000; // 4 hours in milliseconds
         private readonly IModelInfoProvider _modelInfoProvider;
         private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager;
         private readonly Func<IScoped<IEnumerable<IProvideCapability>>> _capabilityProviders;

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/SystemConformanceProvider.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/SystemConformanceProvider.cs
@@ -203,6 +203,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
                 try
                 {
                     _metadata = _builder.Build().ToResourceElement();
+                    return _metadata;
                 }
                 finally
                 {
@@ -210,7 +211,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
                 }
             }
 
-            // There is a chance that the RebuildCapabilityStatement handler sets metadata to null between when it is checked and returned, but the alternative was leading to deadlocks where the creation of metadata could trigger a rebuild. The rebuild handler had to wait on the metadata semaphore, which wouldn't be released until the metadata could be built. But the metadata builder was waiting on the rebuild handler.
+            // There is a chance that the BackgroundLoop handler sets metadata to null between when it is checked and returned, but the alternative was leading to deadlocks where the creation of metadata could trigger a rebuild. The rebuild handler had to wait on the metadata semaphore, which wouldn't be released until the metadata could be built. But the metadata builder was waiting on the rebuild handler.
             return _metadata;
         }
     }

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/SystemConformanceProvider.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/SystemConformanceProvider.cs
@@ -25,7 +25,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
     public sealed class SystemConformanceProvider
         : ConformanceProviderBase, IConfiguredConformanceProvider, INotificationHandler<RebuildCapabilityStatement>, IDisposable
     {
-        private readonly int _rebuildDelay = 4 * 60 * 60 * 1000; // 4 hours in milliseconds
+        private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
+        private readonly TimeSpan _rebuildDelay = TimeSpan.FromHours(4);
         private readonly IModelInfoProvider _modelInfoProvider;
         private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager;
         private readonly Func<IScoped<IEnumerable<IProvideCapability>>> _capabilityProviders;

--- a/src/Microsoft.Health.Fhir.Core/Features/Validation/IKnowSupportedProfiles.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Validation/IKnowSupportedProfiles.cs
@@ -15,5 +15,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
         /// <param name="resourceType">Resource type to get profiles.</param>
         /// <param name="disableCacheRefresh">Should we check server for new updates or get data out of cache.</param>
         IEnumerable<string> GetSupportedProfiles(string resourceType, bool disableCacheRefresh = false);
+
+        void Refresh();
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Validation/ISupportedProfilesStore.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Validation/ISupportedProfilesStore.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.Health.Fhir.Core.Features.Validation
 {
-    public interface IKnowSupportedProfiles
+    public interface ISupportedProfilesStore
     {
         /// <summary>
         /// Provide supported profiles for specified <paramref name="resourceType"/>.

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/ValidationModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/ValidationModule.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Health.Fhir.Api.Modules
             services.AddSingleton<IModelAttributeValidator, ModelAttributeValidator>();
 
             services.AddSingleton<ServerProvideProfileValidation>();
-            services.AddSingleton<IKnowSupportedProfiles>(x => x.GetRequiredService<ServerProvideProfileValidation>());
+            services.AddSingleton<ISupportedProfilesStore>(x => x.GetRequiredService<ServerProvideProfileValidation>());
             services.AddSingleton<IProvideProfilesForValidation>(x => x.GetRequiredService<ServerProvideProfileValidation>());
 
             services.AddSingleton<IProfileValidator, ProfileValidator>();

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Conformance/ConformanceBuilderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Conformance/ConformanceBuilderTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Conformance
     {
         private readonly ICapabilityStatementBuilder _builder;
         private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager;
-        private readonly IKnowSupportedProfiles _supportedProfiles;
+        private readonly ISupportedProfilesStore _supportedProfiles;
 
         public ConformanceBuilderTests()
         {
@@ -39,7 +39,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Conformance
             configuration.Value.Returns(new CoreFeatureConfiguration());
 
             _searchParameterDefinitionManager = Substitute.For<ISearchParameterDefinitionManager>();
-            _supportedProfiles = Substitute.For<IKnowSupportedProfiles>();
+            _supportedProfiles = Substitute.For<ISupportedProfilesStore>();
             _builder = CapabilityStatementBuilder.Create(
                 ModelInfoProvider.Instance,
                 _searchParameterDefinitionManager,
@@ -76,7 +76,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Conformance
             versionConfig.ResourceTypeOverrides.Add("Patient", "no-version");
 
             configuration.Value.Returns(new CoreFeatureConfiguration() { Versioning = versionConfig });
-            var supportedProfiles = Substitute.For<IKnowSupportedProfiles>();
+            var supportedProfiles = Substitute.For<ISupportedProfilesStore>();
             var builder = CapabilityStatementBuilder.Create(
                 ModelInfoProvider.Instance,
                 _searchParameterDefinitionManager,
@@ -106,7 +106,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Conformance
             versionConfig.ResourceTypeOverrides.Add("blah", "no-version");
 
             configuration.Value.Returns(new CoreFeatureConfiguration() { Versioning = versionConfig });
-            var supportedProfiles = Substitute.For<IKnowSupportedProfiles>();
+            var supportedProfiles = Substitute.For<ISupportedProfilesStore>();
             var builder = CapabilityStatementBuilder.Create(
                 ModelInfoProvider.Instance,
                 _searchParameterDefinitionManager,
@@ -135,7 +135,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Conformance
             VersioningConfiguration versionConfig = new();
 
             configuration.Value.Returns(new CoreFeatureConfiguration() { Versioning = versionConfig });
-            var supportedProfiles = Substitute.For<IKnowSupportedProfiles>();
+            var supportedProfiles = Substitute.For<ISupportedProfilesStore>();
             var builder = CapabilityStatementBuilder.Create(
                 ModelInfoProvider.Instance,
                 _searchParameterDefinitionManager,

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Validation/IProvideProfilesForValidation.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Validation/IProvideProfilesForValidation.cs
@@ -8,7 +8,7 @@ using Hl7.Fhir.Specification.Source;
 
 namespace Microsoft.Health.Fhir.Core.Features.Validation
 {
-    public interface IProvideProfilesForValidation : IResourceResolver, IKnowSupportedProfiles
+    public interface IProvideProfilesForValidation : IResourceResolver, ISupportedProfilesStore
     {
         IReadOnlySet<string> GetProfilesTypes();
     }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Validation/IProvideProfilesForValidation.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Validation/IProvideProfilesForValidation.cs
@@ -11,7 +11,5 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
     public interface IProvideProfilesForValidation : IResourceResolver, IKnowSupportedProfiles
     {
         IReadOnlySet<string> GetProfilesTypes();
-
-        void Refresh();
     }
 }


### PR DESCRIPTION
## Description
Rebuild Metadata document every 4 hours to pull in changes to profiles and search parameters on different instances.

## Related issues
Addresses AB#93492: [Customer Impacting Issue][No Workaround] SupportedProfile was not showed up about 50% of the time when tried to get the metadata.

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
