### PR TITLE
Fixed issue where ResourceTypeOverride were not being set because of string casing issue

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Configs/VersioningConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/VersioningConfiguration.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using Microsoft.Health.Fhir.ValueSets;
 
@@ -12,6 +13,6 @@ namespace Microsoft.Health.Fhir.Core.Configs
     {
         public string Default { get; set; } = ResourceVersionPolicy.Versioned;
 
-        public Dictionary<string, string> ResourceTypeOverrides { get; } = new();
+        public Dictionary<string, string> ResourceTypeOverrides { get; } = new(StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Conformance/ConformanceBuilderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Conformance/ConformanceBuilderTests.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Conformance
             IOptions<CoreFeatureConfiguration> configuration = Substitute.For<IOptions<CoreFeatureConfiguration>>();
             Dictionary<string, string> overrides = new();
             VersioningConfiguration versionConfig = new();
-            versionConfig.ResourceTypeOverrides.Add("Patient", "no-version");
+            versionConfig.ResourceTypeOverrides.Add("patient", "no-version");
 
             configuration.Value.Returns(new CoreFeatureConfiguration() { Versioning = versionConfig });
             var supportedProfiles = Substitute.For<IKnowSupportedProfiles>();

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Conformance/ConformanceBuilderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Conformance/ConformanceBuilderTests.cs
@@ -67,13 +67,16 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Conformance
             Assert.Throws<ArgumentException>(() => _builder.ApplyToResource("foo", c => c.ConditionalCreate = true));
         }
 
-        [Fact]
-        public void GivenAConformanceBuilder_WhenVersionofResourceIsDifferentFromDefault_ThenResourceUsesResourceSpecificVersionLogic()
+        [Theory]
+        [InlineData("patient")]
+        [InlineData("Patient")]
+        [InlineData("PaTient")]
+        public void GivenAConformanceBuilder_WhenVersionofResourceIsDifferentFromDefault_ThenResourceUsesResourceSpecificVersionLogic(string resourceType)
         {
             IOptions<CoreFeatureConfiguration> configuration = Substitute.For<IOptions<CoreFeatureConfiguration>>();
             Dictionary<string, string> overrides = new();
             VersioningConfiguration versionConfig = new();
-            versionConfig.ResourceTypeOverrides.Add("patient", "no-version");
+            versionConfig.ResourceTypeOverrides.Add(resourceType, "no-version");
 
             configuration.Value.Returns(new CoreFeatureConfiguration() { Versioning = versionConfig });
             var supportedProfiles = Substitute.For<IKnowSupportedProfiles>();


### PR DESCRIPTION
Noticed an issue where the configuration values that were being sent from the portal were lowercase. The resource types in the FHIR Serivce code are Pascal casing. This resulted in there no longer being a match, so the override would not be set. I updated the dictionary these values get stored in to use the ordinalInvariantCase string comparer so that this is no longer an issue. 

## Description
Describe the changes in this PR.

## Related issues
Addresses [issue #].

## Testing
I updated the unit test we have for resource type override to use a lowercase config value, and validated the override is now set.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [x] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
