### PR TITLE
Ordered patient resources based on the lastUpdated time

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SortTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SortTests.cs
@@ -771,7 +771,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 p => SetPatientInfo(p, "New York", "Williamas", tag, DateTime.Now.Subtract(TimeSpan.FromDays(40))),
                 p => SetPatientInfo(p, "Seattle", "Jones", tag, DateTime.Now.Subtract(TimeSpan.FromDays(30))));
 
-            return patients;
+            return patients.OrderBy(p => p.Meta.LastUpdated).ToArray();
         }
 
         private async Task<Patient[]> CreatePaginatedPatients(string tag)
@@ -791,7 +791,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 p => SetPatientInfo(p, "Portland", "Cathy", tag, new DateTime(1960, 09, 22)),
                 p => SetPatientInfo(p, "Seattle", "Jones", tag, new DateTime(1970, 05, 13)));
 
-            return patients;
+            return patients.OrderBy(p => p.Meta.LastUpdated).ToArray();
         }
 
         private async Task<Patient[]> CreatePatientsWithSameBirthdate(string tag)
@@ -804,7 +804,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 p => SetPatientInfo(p, "Seattle", "Alex", tag),
                 p => SetPatientInfo(p, "Portland", "Rock", tag));
 
-            return patients;
+            return patients.OrderBy(p => p.Meta.LastUpdated).ToArray();
         }
 
         private async Task<Patient[]> CreatePatientsWithMissingFamilyNames(string tag)
@@ -818,7 +818,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 p => SetPatientInfo(p, "Portland", "Cathy", tag),
                 p => SetPatientInfo(p, "Seattle", "Jones", tag));
 
-            return patients;
+            return patients.OrderBy(p => p.Meta.LastUpdated).ToArray();
         }
 
         private async Task<Patient[]> CreatePatientsWithMultipleFamilyNames(string tag)
@@ -833,7 +833,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 p => SetPatientInfo(p, "Portland", "Cathy", tag),
                 p => SetPatientInfo(p, "Seattle", "Jones", tag));
 
-            return patients;
+            return patients.OrderBy(p => p.Meta.LastUpdated).ToArray();
         }
 
         private void SetPatientInfo(Patient patient, string city, string family, string tag)


### PR DESCRIPTION
Ordered patient resources based on the lastUpdated time to ensure that the sort tests work as expected

## Related issues
Addresses [AB94292](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Olympus/Stories/?workitem=94294)

## Testing
Unit test pass

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
