### PR TITLE
collect code coverage

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,6 +36,12 @@
         <IsPackable>false</IsPackable>
         <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)\CustomAnalysisRules.Test.ruleset</CodeAnalysisRuleSet>
       </PropertyGroup>
+      <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+      </ItemGroup>
     </When>
     <Otherwise>
       <PropertyGroup>

--- a/build/Run-Tests-WithCoverage.ps1
+++ b/build/Run-Tests-WithCoverage.ps1
@@ -1,0 +1,20 @@
+## Suggested workaround for merging coverage results: https://github.com/coverlet-coverage/coverlet/pull/225#issuecomment-573896446
+$testResultsDirectory="$Env:AGENT_BUILDDIRECTORY/TestResults"
+$coverageJsonFullPath = "$testResultsDirectory/coverage.json"
+$coverageCoberturaFullPath = "$testResultsDirectory/coverage.cobertura.xml"
+$buildConfiguration = "Release"
+
+Write-Host "Test directory: $testResultsDirectory"
+
+# calculate code coverage
+Get-ChildItem -Recurse -Filter *UnitTests*.csproj | 
+Foreach-Object {
+  $dir = "$testResultsDirectory/$($_.BaseName)"
+  dotnet test $_.FullName --configuration $buildConfiguration --no-build --logger trx --results-directory "$dir" --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format="json,cobertura" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Include="[Microsoft.Health.Fhir.*]*" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Exclude="[*Tests*]*,[*.Web]*,[*.ValueSets]*" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.MergeWith="$coverageJsonFullPath"
+
+  # by copying back the current set of coverage results and using MergeWith, the results will be aggregated
+  if (Test-Path -Path $dir){
+    Copy-Item -Path "$dir/*/coverage.json" -Destination $coverageJsonFullPath -Force
+    Copy-Item -Path "$dir/*/coverage.cobertura.xml" -Destination $coverageCoberturaFullPath -Force
+  }
+}

--- a/build/Run-Tests-WithCoverage.ps1
+++ b/build/Run-Tests-WithCoverage.ps1
@@ -10,7 +10,7 @@ Write-Host "Test directory: $testResultsDirectory"
 Get-ChildItem -Recurse -Filter *UnitTests*.csproj | 
 Foreach-Object {
   $dir = "$testResultsDirectory/$($_.BaseName)"
-  dotnet test $_.FullName --configuration $buildConfiguration --no-build --logger trx --results-directory "$dir" --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format="json,cobertura" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Include="[Microsoft.Health.Fhir.*]*" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Exclude="[*Tests*]*,[*.Web]*,[*.ValueSets]*" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.MergeWith="$coverageJsonFullPath"
+  dotnet test $_.FullName --configuration $buildConfiguration --no-build --logger trx --results-directory "$dir" --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format="json,cobertura" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Include="[Microsoft.Health.Fhir.*]*" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Exclude="[*Tests*]*,[*.Web]*,[*.ValueSets]*,[*.SqlServer]*.Schema.Model.*" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.MergeWith="$coverageJsonFullPath"
 
   # by copying back the current set of coverage results and using MergeWith, the results will be aggregated
   if (Test-Path -Path $dir){

--- a/build/jobs/build.yml
+++ b/build/jobs/build.yml
@@ -19,8 +19,15 @@ steps:
   inputs:
     command: test
     projects: '**/*UnitTests/*.csproj'
-    arguments: '--configuration $(buildConfiguration) --no-build'
+    arguments: '--configuration $(buildConfiguration) --no-build --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Exclude="[*.Tests.*]*,[*.UnitTests]*,[*.Web]*" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Include="[Microsoft.Health.Fhir.*]*"'
     testRunTitle: 'Unit Tests'
+
+- ${{ if eq(parameters.packageArtifacts, 'true') }}:
+  - task: PublishCodeCoverageResults@1
+    displayName: 'Publish code coverage results'
+    inputs:
+      codeCoverageTool: 'Cobertura'
+      summaryFileLocation: $(Agent.TempDirectory)/**/coverage.cobertura.xml
 
 - ${{ if eq(parameters.packageArtifacts, 'true') }}:
   - template: package.yml

--- a/build/jobs/build.yml
+++ b/build/jobs/build.yml
@@ -14,20 +14,35 @@ steps:
     command: build
     arguments: '--configuration $(buildConfiguration) -p:ContinuousIntegrationBuild=true -p:AssemblyVersion="$(assemblySemVer)" -p:FileVersion="$(assemblySemFileVer)" -p:InformationalVersion="$(informationalVersion)" -p:Version="$(majorMinorPatch)" -warnaserror'
 
-- task: DotNetCoreCLI@2
-  displayName: 'dotnet test UnitTests'
-  inputs:
-    command: test
-    projects: '**/*UnitTests/*.csproj'
-    arguments: '--configuration $(buildConfiguration) --no-build --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Exclude="[*.Tests.*]*,[*.UnitTests]*,[*.Web]*" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Include="[Microsoft.Health.Fhir.*]*"'
-    testRunTitle: 'Unit Tests'
+- ${{ if eq(parameters.packageArtifacts, 'false') }}:
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet test'
+    inputs:
+      command: test
+      projects: '**/*UnitTests/*.csproj'
+      arguments: '--configuration $(buildConfiguration) --no-build'
+      testRunTitle: 'Unit Tests'
 
 - ${{ if eq(parameters.packageArtifacts, 'true') }}:
+  - task: PowerShell@2
+    inputs:
+      targetType: 'filePath'
+      filePath: $(System.DefaultWorkingDirectory)/build/Run-Tests-WithCoverage.ps1
+    displayName: 'dotnet test with coverage'
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: 'VSTest'
+      testResultsFiles: '**/*.trx'
+      searchFolder: '$(Agent.BuildDirectory)/TestResults/'
   - task: PublishCodeCoverageResults@1
-    displayName: 'Publish code coverage results'
+    displayName: 'publish code coverage results'
     inputs:
       codeCoverageTool: 'Cobertura'
-      summaryFileLocation: $(Agent.TempDirectory)/**/coverage.cobertura.xml
-
-- ${{ if eq(parameters.packageArtifacts, 'true') }}:
+      summaryFileLocation: '$(Agent.BuildDirectory)/TestResults/coverage.cobertura.xml'
+  - task: PublishBuildArtifacts@1
+    displayName: 'publish coverage.json'
+    inputs:
+      pathToPublish: '$(Agent.BuildDirectory)/TestResults/coverage.json'
+      artifactName: 'IntegrationTests'
+      artifactType: 'container'
   - template: package.yml

--- a/build/jobs/package.yml
+++ b/build/jobs/package.yml
@@ -83,3 +83,22 @@ steps:
       pathToPublish: '$(build.binariesdirectory)/IntegrationTests'
       artifactName: 'IntegrationTests'
       artifactType: 'container'
+
+  - task: CopyFiles@2
+    displayName: 'copy symbols'
+    inputs:
+      sourceFolder: '$(build.sourcesDirectory)'
+      contents: |
+        **/*.pdb
+        !**/*.UnitTests.pdb
+      targetFolder: '$(build.artifactStagingDirectory)/symbols'
+      cleanTargetFolder: true
+      flattenFolders: true
+      overWrite: true
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'publish symbol artifacts'
+    inputs:
+      pathtoPublish: '$(build.artifactStagingDirectory)/symbols'
+      artifactName: 'symbols'
+      publishLocation: 'container'


### PR DESCRIPTION
## Description
- Collects code coverage for Unit Tests (coverage not collected for Integration or E2E tests)
- Collects symbols as build artifacts

Notes:
Coverage stats will now show up on the overview page:
![image](https://user-images.githubusercontent.com/197221/187001526-70b45ff0-bea3-4a3b-9819-e6768fc0b3ed.png) Most of the core assemblies have reasonable coverage:
![image](https://user-images.githubusercontent.com/197221/186768825-3427b6c0-7972-421c-9baf-e5f53e80e027.png)



## Testing
Adds test coverage collection to unit tests.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [x] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip
