### PR TITLE
Adding task delay for transitory error

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Changes to seach parameters is not allowed while a reindex job is ongoing.  Wait for the reindex job with Id: {0} to finish, or cancel it..
+        ///   Looks up a localized string similar to Changes to search parameters is not allowed while a reindex job is ongoing.  Wait for the reindex job with Id: {0} to finish, or cancel it..
         /// </summary>
         internal static string ChangesToSearchParametersNotAllowedWhileReindexing {
             get {

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -476,7 +476,7 @@
     <value>A search parameter with Uri '{0}' was not found.</value>
   </data>
   <data name="ChangesToSearchParametersNotAllowedWhileReindexing" xml:space="preserve">
-    <value>Changes to seach parameters is not allowed while a reindex job is ongoing.  Wait for the reindex job with Id: {0} to finish, or cancel it.</value>
+    <value>Changes to search parameters is not allowed while a reindex job is ongoing.  Wait for the reindex job with Id: {0} to finish, or cancel it.</value>
     <comment>{0} Id of currently active Reindex job.</comment>
   </data>
   <data name="ConvertDataFailed" xml:space="preserve">

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -429,12 +429,17 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 const int maxRetryCount = 10;
                 int retryCount = 0;
                 bool success = true;
+                await Task.Delay(TimeSpan.FromSeconds(20));
+
                 do
                 {
                     success = true;
                     retryCount++;
+
                     try
                     {
+                        _output.WriteLine($"Attempt {retryCount} of {maxRetryCount}");
+
                         await ExecuteAndValidateBundle(
                             $"Specimen?{searchParam.Code}={expectedSpecimen.Resource.Id}",
                             expectedSpecimen.Resource);
@@ -445,7 +450,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                     }
                     catch (Exception ex)
                     {
-                        string error = $"Failed to validate bundle: {ex}";
+                        string error = $"Attempt {retryCount}: Failed to validate bundle: {ex}";
 
                         _output.WriteLine(error);
                         success = false;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
     {
         private readonly HttpIntegrationTestFixture _fixture;
         private ITestOutputHelper _output;
+        private const int MaxRetryCount = 10;
 
         public CustomSearchParamTests(HttpIntegrationTestFixture fixture, ITestOutputHelper output)
             : base(fixture)
@@ -108,6 +109,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 // adding some retries below to account for that delay.
                 int retryCount = 0;
                 bool success = true;
+                await Task.Delay(TimeSpan.FromSeconds(20));
+
                 do
                 {
                     success = true;
@@ -120,12 +123,13 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                     }
                     catch (Exception ex)
                     {
-                        _output.WriteLine($"Failed to validate bundle: {ex}");
+                        string error = $"Attempt {retryCount} of {MaxRetryCount}: Failed to validate bundle: {ex}";
+                        _output.WriteLine(error);
                         success = false;
                         await Task.Delay(TimeSpan.FromSeconds(10));
                     }
                 }
-                while (!success && retryCount < 10);
+                while (!success && retryCount < MaxRetryCount);
 
                 Assert.True(success);
             }
@@ -306,6 +310,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 // adding some retries below to account for that delay.
                 int retryCount = 0;
                 bool success = true;
+                await Task.Delay(TimeSpan.FromSeconds(20));
+
                 do
                 {
                     success = true;
@@ -335,7 +341,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                     bundle = await Client.SearchAsync(searchUrl);
                     Assert.DoesNotContain(searchParam.Code, bundle.SelfLink.ToString());
                 }
-                while (!success && retryCount < 10);
+                while (!success && retryCount < MaxRetryCount);
 
                 Assert.True(success);
             }
@@ -426,7 +432,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 // When there are multiple instances of the fhir-server running, it could take some time
                 // for the search parameter/reindex updates to propogate to all instances. Hence we are
                 // adding some retries below to account for that delay.
-                const int maxRetryCount = 10;
                 int retryCount = 0;
                 bool success = true;
                 await Task.Delay(TimeSpan.FromSeconds(20));
@@ -438,8 +443,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
                     try
                     {
-                        _output.WriteLine($"Attempt {retryCount} of {maxRetryCount}");
-
                         await ExecuteAndValidateBundle(
                             $"Specimen?{searchParam.Code}={expectedSpecimen.Resource.Id}",
                             expectedSpecimen.Resource);
@@ -450,16 +453,16 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                     }
                     catch (Exception ex)
                     {
-                        string error = $"Attempt {retryCount}: Failed to validate bundle: {ex}";
+                        string error = $"Attempt {retryCount} of {MaxRetryCount}: Failed to validate bundle: {ex}";
 
                         _output.WriteLine(error);
                         success = false;
                         await Task.Delay(TimeSpan.FromSeconds(10));
                     }
                 }
-                while (!success && retryCount < maxRetryCount);
+                while (!success && retryCount < MaxRetryCount);
 
-                Assert.True(success, $"There are bundle validation failures. {maxRetryCount} attempts reached. Check test logs.");
+                Assert.True(success, $"There are bundle validation failures. {retryCount} attempts reached. Check test logs.");
             }
             catch (FhirException ex) when (ex.StatusCode == HttpStatusCode.BadRequest && ex.Message.Contains("not enabled"))
             {
@@ -530,7 +533,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                     }
                     catch (Exception exp)
                     {
-                        _output.WriteLine("CustomSearchParameter test experienced issue attempted to clean up SearchParameter {0}.  The exception message is {1}", searchParam.Url, exp.Message);
+                        _output.WriteLine($"Attempt {retryCount} of {MaxRetryCount}: CustomSearchParameter test experienced issue attempted to clean up SearchParameter {searchParam.Url}.  The exception is {exp}");
                         var fhirException = exp as FhirException;
                         if (fhirException != null && fhirException.OperationOutcome?.Issue != null)
                         {
@@ -544,7 +547,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                         await Task.Delay(10000);
                     }
                 }
-                while (!success && retryCount < 5);
+                while (!success && retryCount < MaxRetryCount);
 
                 Assert.True(success);
                 var ex = await Assert.ThrowsAsync<FhirException>(() => Client.ReadAsync<SearchParameter>(ResourceType.SearchParameter, searchParam.Id));


### PR DESCRIPTION
## Description
This transitory error always seems to be related to the reindex job. Increasing the retry count didn't appear to help but adding a task delay appears to at this point. Added some additional logging to determine at what point a retry did help if this occurs in the future.
Fixed a small typo that showed up in [92014](https://microsofthealth.visualstudio.com/Health/_workitems/edit/92014)

## Related issues
Addresses [93223](https://microsofthealth.visualstudio.com/Health/_workitems/edit/93223).

## Testing
I have run multiple pipeline runs with this change and have not encountered the error.

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
