### PR TITLE
Fix how initial import lock works

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Operations/Import/InitialImportLockMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Operations/Import/InitialImportLockMiddleware.cs
@@ -45,7 +45,6 @@ namespace Microsoft.Health.Fhir.Api.Features.Operations.Import
             _filteredEndpoints = new HashSet<(string method, string pathRegex)>()
             {
                 (HttpMethods.Get, ".*/\\$reindex"), // New long running jobs shouldn't be started while import is running
-                (HttpMethods.Get, ".*/\\$export"),
             };
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Operations/Import/InitialImportLockMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Operations/Import/InitialImportLockMiddlewareTests.cs
@@ -124,9 +124,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Operations.Import
 
         [Theory]
         [InlineData("/Patient", "Post")]
-        [InlineData("/$export", "Get")]
         [InlineData("/$reindex", "Get")]
-        [InlineData("/Patient/$export", "Get")]
         [InlineData("/Observation", "Delete")]
         public async Task GivenLockedRequests_WhenInitialImportModeEnabled_Then423ShouldBeReturned(string path, string method)
         {
@@ -141,6 +139,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Operations.Import
 
         [Theory]
         [InlineData("/Patient", "Get")]
+        [InlineData("/$export", "Get")]
+        [InlineData("/Patient/$export", "Get")]
         [InlineData("/_operations/export/123", "Get")]
         [InlineData("/_operations/export/123", "Delete")]
         [InlineData("/_operations/reindex/123", "Get")]

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Operations/Import/InitialImportLockMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Operations/Import/InitialImportLockMiddlewareTests.cs
@@ -122,6 +122,42 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Operations.Import
             Assert.Equal(200, httpContext.Response.StatusCode);
         }
 
+        [Theory]
+        [InlineData("/Patient", "Post")]
+        [InlineData("/$export", "Get")]
+        [InlineData("/$reindex", "Get")]
+        [InlineData("/Patient/$export", "Get")]
+        [InlineData("/Observation", "Delete")]
+        public async Task GivenLockedRequests_WhenInitialImportModeEnabled_Then423ShouldBeReturned(string path, string method)
+        {
+            InitialImportLockMiddleware middleware = CreateInitialImportLockMiddleware(new ImportTaskConfiguration() { Enabled = true, InitialImportMode = true });
+            HttpContext httpContext = new DefaultHttpContext();
+            httpContext.Request.Path = path;
+            httpContext.Request.Method = method;
+            await middleware.Invoke(httpContext);
+
+            Assert.Equal(423, httpContext.Response.StatusCode);
+        }
+
+        [Theory]
+        [InlineData("/Patient", "Get")]
+        [InlineData("/_operations/export/123", "Get")]
+        [InlineData("/_operations/export/123", "Delete")]
+        [InlineData("/_operations/reindex/123", "Get")]
+        [InlineData("/_operations/reindex/123", "Delete")]
+        [InlineData("/_operations/import/123", "Get")]
+        [InlineData("/_operations/import/123", "Delete")]
+        public async Task GivenAllowedRequests_WhenInitialImportModeEnabled_Then200ShouldBeReturned(string path, string method)
+        {
+            InitialImportLockMiddleware middleware = CreateInitialImportLockMiddleware(new ImportTaskConfiguration() { Enabled = true, InitialImportMode = true });
+            HttpContext httpContext = new DefaultHttpContext();
+            httpContext.Request.Path = path;
+            httpContext.Request.Method = method;
+            await middleware.Invoke(httpContext);
+
+            Assert.Equal(200, httpContext.Response.StatusCode);
+        }
+
         private InitialImportLockMiddleware CreateInitialImportLockMiddleware(ImportTaskConfiguration importTaskConfiguration)
         {
             return new InitialImportLockMiddleware(


### PR DESCRIPTION
## Description
The lock on certain requests when import is running was blocking some legitimate requests and allowing some requests that could cause problems.

## Related issues
Addresses [Bug 94698](https://microsofthealth.visualstudio.com/Health/_workitems/edit/94698): Import job lock mishandling requests

## Testing
New unit tests were added to test this change.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [x] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
