### PR TITLE
Validation added for Target resource type for include and revinclude search options

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -575,6 +575,15 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid TargetResourceType : value cannot be empty..
+        /// </summary>
+        internal static string IncludeRevIncludeInvalidTargetResourceType {
+            get {
+                return ResourceManager.GetString("IncludeRevIncludeInvalidTargetResourceType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Field &apos;{0}&apos; with value &apos;{1}&apos; is not supported..
         /// </summary>
         internal static string InvalidBooleanConfigSetting {

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -573,9 +573,9 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("IncludeMissingType", resourceCulture);
             }
         }
-        
+
         /// <summary>
-        ///   Looks up a localized string similar to Invalid TargetResourceType : value cannot be empty..
+        ///   Looks up a localized string similar to The target resource type cannot be empty..
         /// </summary>
         internal static string IncludeRevIncludeInvalidTargetResourceType {
             get {

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -243,6 +243,10 @@
     <value>The '_revinclude:iterate={0}' search parameter has multiple target types. Please specify a target type.</value>
     <comment>_revinclude:iterate is a query parameter.</comment>
   </data>
+  <data name="IncludeRevIncludeInvalidTargetResourceType" xml:space="preserve">
+    <value>Invalid TargetResourceType : value cannot be empty.</value>
+    <comment>TargetResourceType is an optional parameter</comment>
+  </data>
   <data name="InvalidBooleanConfigSetting" xml:space="preserve">
     <value>Field '{0}' with value '{1}' is not supported.</value>
   </data>

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -244,7 +244,7 @@
     <comment>_revinclude:iterate is a query parameter.</comment>
   </data>
   <data name="IncludeRevIncludeInvalidTargetResourceType" xml:space="preserve">
-    <value>Invalid TargetResourceType : value cannot be empty.</value>
+    <value>The target resource type cannot be empty.</value>
     <comment>TargetResourceType is an optional parameter</comment>
   </data>
   <data name="InvalidBooleanConfigSetting" xml:space="preserve">

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -425,7 +425,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                     if (expression.TargetResourceType != null &&
                        string.IsNullOrWhiteSpace(expression.TargetResourceType))
                     {
-                        throw Error.Format($"Invalid TargetResourceType : value cannot be empty");
+                        throw new BadRequestException(
+                            string.Format(Core.Resources.IncludeRevIncludeInvalidTargetResourceType, expression.TargetResourceType));
                     }
 
                     if (expression.TargetResourceType != null && !ModelInfoProvider.IsKnownResource(expression.TargetResourceType))

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using EnsureThat;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
+using Hl7.Fhir.Utility;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Core.Features.Context;
@@ -417,7 +418,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                     }
 
                     if (expression.TargetResourceType != null &&
-                        !ModelInfoProvider.IsKnownResource(expression.TargetResourceType))
+                       string.IsNullOrWhiteSpace(expression.TargetResourceType))
+                    {
+                        throw Error.Format($"Invalid TargetResourceType : value cannot be empty");
+                    }
+
+                    if (expression.TargetResourceType != null && !ModelInfoProvider.IsKnownResource(expression.TargetResourceType))
                     {
                         throw new ResourceNotSupportedException(expression.TargetResourceType);
                     }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -416,6 +416,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                             string.Format(Core.Resources.RevIncludeIterateTargetTypeNotSpecified, p.query));
                     }
 
+                    if (expression.TargetResourceType != null &&
+                        !ModelInfoProvider.IsKnownResource(expression.TargetResourceType))
+                    {
+                        throw new ResourceNotSupportedException(expression.TargetResourceType);
+                    }
+
                     // For circular include iterate expressions, add an informational issue indicating that a single iteration is supported.
                     // See https://www.hl7.org/fhir/search.html#revinclude.
                     if (expression.Iterate && expression.CircularReference)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
@@ -1352,11 +1352,13 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             };
         }
 
-        [Fact]
+        [InlineData("_include")]
+        [InlineData("_revinclude")]
+        [Theory]
         [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer)]
-        public async Task GivenARevIncludeIterateSearchExpressionWithInvalidTargetResourceType_WhenSearched_ShouldThrowResourceNotSupportedException()
+        public async Task GivenAIncludeOrRevIncludeIterateSearchExpressionWithInvalidTargetResourceType_WhenSearched_ShouldThrowResourceNotSupportedException(string include)
         {
-            string query = $"_revinclude=Observation:subject:NotAResourceType";
+            string query = "$" + include + "=Observation:subject:NotAResourceType";
 
             using var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await Client.SearchAsync(ResourceType.Patient, query));
             Assert.Equal(HttpStatusCode.BadRequest, fhirException.StatusCode);
@@ -1367,26 +1369,13 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             ValidateOperationOutcome(expectedDiagnostics, expectedIssueSeverities, expectedCodeTypes, fhirException.OperationOutcome);
         }
 
-        [Fact]
+        [InlineData("_include")]
+        [InlineData("_revinclude")]
+        [Theory]
         [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer)]
-        public async Task GivenAIncludeIterateSearchExpressionWithInvalidTargetResourceType_WhenSearched_ShouldThrowResourceNotSupportedException()
+        public async Task GivenAIncludeOrRevIncludeIterateSearchExpressionWithEmptyTargetResourceType_WhenSearched_ShouldThrowErrorFormat(string include)
         {
-            string query = $"_include=Observation:subject:NotAResourceType";
-
-            using var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await Client.SearchAsync(ResourceType.Patient, query));
-            Assert.Equal(HttpStatusCode.BadRequest, fhirException.StatusCode);
-
-            string[] expectedDiagnostics = { string.Format(Core.Resources.ResourceNotSupported, "NotAResourceType") };
-            IssueSeverity[] expectedIssueSeverities = { IssueSeverity.Error };
-            IssueType[] expectedCodeTypes = { IssueType.NotSupported };
-            ValidateOperationOutcome(expectedDiagnostics, expectedIssueSeverities, expectedCodeTypes, fhirException.OperationOutcome);
-        }
-
-        [Fact]
-        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer)]
-        public async Task GivenAIncludeIterateSearchExpressionWithEmptyTargetResourceType_WhenSearched_ShouldThrowErrorFormat()
-        {
-            string query = $"_include=Observation:subject:";
+            string query = "$" + include + "=Observation:subject:";
 
             using var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await Client.SearchAsync(ResourceType.Patient, query));
             Assert.Equal(HttpStatusCode.BadRequest, fhirException.StatusCode);
@@ -1397,41 +1386,13 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             ValidateOperationOutcome(expectedDiagnostics, expectedIssueSeverities, expectedCodeTypes, fhirException.OperationOutcome);
         }
 
-        [Fact]
+        [InlineData("_include")]
+        [InlineData("_revinclude")]
+        [Theory]
         [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer)]
-        public async Task GivenAIncludeIterateSearchExpressionWithWhiteSpaceTargetResourceType_WhenSearched_ShouldThrowErrorFormat()
+        public async Task GivenAIncludeOrRevIncludeIterateSearchExpressionWithWhiteSpaceTargetResourceType_WhenSearched_ShouldThrowErrorFormat(string include)
         {
-            string query = $"_include=Observation:subject: ";
-
-            using var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await Client.SearchAsync(ResourceType.Patient, query));
-            Assert.Equal(HttpStatusCode.BadRequest, fhirException.StatusCode);
-
-            string[] expectedDiagnostics = { string.Format("Invalid TargetResourceType : value cannot be empty") };
-            IssueSeverity[] expectedIssueSeverities = { IssueSeverity.Error };
-            IssueType[] expectedCodeTypes = { IssueType.Invalid };
-            ValidateOperationOutcome(expectedDiagnostics, expectedIssueSeverities, expectedCodeTypes, fhirException.OperationOutcome);
-        }
-
-        [Fact]
-        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer)]
-        public async Task GivenARevIncludeIterateSearchExpressionWithEmptyTargetResourceType_WhenSearched_ShouldThrowErrorFormat()
-        {
-            string query = $"_revinclude=Observation:subject:";
-
-            using var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await Client.SearchAsync(ResourceType.Patient, query));
-            Assert.Equal(HttpStatusCode.BadRequest, fhirException.StatusCode);
-
-            string[] expectedDiagnostics = { string.Format("Invalid TargetResourceType : value cannot be empty") };
-            IssueSeverity[] expectedIssueSeverities = { IssueSeverity.Error };
-            IssueType[] expectedCodeTypes = { IssueType.Invalid };
-            ValidateOperationOutcome(expectedDiagnostics, expectedIssueSeverities, expectedCodeTypes, fhirException.OperationOutcome);
-        }
-
-        [Fact]
-        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer)]
-        public async Task GivenARevIncludeIterateSearchExpressionWithWhiteSpaceTargetResourceType_WhenSearched_ShouldThrowErrorFormat()
-        {
-            string query = $"_revinclude=Observation:subject: ";
+            string query = "$" + include + "=Observation:subject: ";
 
             using var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await Client.SearchAsync(ResourceType.Patient, query));
             Assert.Equal(HttpStatusCode.BadRequest, fhirException.StatusCode);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
@@ -1356,6 +1356,21 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer)]
         public async Task GivenARevIncludeIterateSearchExpressionWithInvalidTargetResourceType_WhenSearched_ShouldThrowResourceNotSupportedException()
         {
+            string query = $"_revinclude=Observation:subject:NotAResourceType";
+
+            using var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await Client.SearchAsync(ResourceType.Patient, query));
+            Assert.Equal(HttpStatusCode.BadRequest, fhirException.StatusCode);
+
+            string[] expectedDiagnostics = { string.Format(Core.Resources.ResourceNotSupported, "NotAResourceType") };
+            IssueSeverity[] expectedIssueSeverities = { IssueSeverity.Error };
+            IssueType[] expectedCodeTypes = { IssueType.NotSupported };
+            ValidateOperationOutcome(expectedDiagnostics, expectedIssueSeverities, expectedCodeTypes, fhirException.OperationOutcome);
+        }
+
+        [Fact]
+        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer)]
+        public async Task GivenAIncludeIterateSearchExpressionWithInvalidTargetResourceType_WhenSearched_ShouldThrowResourceNotSupportedException()
+        {
             string query = $"_include=Observation:subject:NotAResourceType";
 
             using var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await Client.SearchAsync(ResourceType.Patient, query));
@@ -1364,6 +1379,66 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             string[] expectedDiagnostics = { string.Format(Core.Resources.ResourceNotSupported, "NotAResourceType") };
             IssueSeverity[] expectedIssueSeverities = { IssueSeverity.Error };
             IssueType[] expectedCodeTypes = { IssueType.NotSupported };
+            ValidateOperationOutcome(expectedDiagnostics, expectedIssueSeverities, expectedCodeTypes, fhirException.OperationOutcome);
+        }
+
+        [Fact]
+        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer)]
+        public async Task GivenAIncludeIterateSearchExpressionWithEmptyTargetResourceType_WhenSearched_ShouldThrowErrorFormat()
+        {
+            string query = $"_include=Observation:subject:";
+
+            using var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await Client.SearchAsync(ResourceType.Patient, query));
+            Assert.Equal(HttpStatusCode.BadRequest, fhirException.StatusCode);
+
+            string[] expectedDiagnostics = { string.Format("Invalid TargetResourceType : value cannot be empty") };
+            IssueSeverity[] expectedIssueSeverities = { IssueSeverity.Error };
+            IssueType[] expectedCodeTypes = { IssueType.Invalid };
+            ValidateOperationOutcome(expectedDiagnostics, expectedIssueSeverities, expectedCodeTypes, fhirException.OperationOutcome);
+        }
+
+        [Fact]
+        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer)]
+        public async Task GivenAIncludeIterateSearchExpressionWithWhiteSpaceTargetResourceType_WhenSearched_ShouldThrowErrorFormat()
+        {
+            string query = $"_include=Observation:subject: ";
+
+            using var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await Client.SearchAsync(ResourceType.Patient, query));
+            Assert.Equal(HttpStatusCode.BadRequest, fhirException.StatusCode);
+
+            string[] expectedDiagnostics = { string.Format("Invalid TargetResourceType : value cannot be empty") };
+            IssueSeverity[] expectedIssueSeverities = { IssueSeverity.Error };
+            IssueType[] expectedCodeTypes = { IssueType.Invalid };
+            ValidateOperationOutcome(expectedDiagnostics, expectedIssueSeverities, expectedCodeTypes, fhirException.OperationOutcome);
+        }
+
+        [Fact]
+        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer)]
+        public async Task GivenARevIncludeIterateSearchExpressionWithEmptyTargetResourceType_WhenSearched_ShouldThrowErrorFormat()
+        {
+            string query = $"_revinclude=Observation:subject:";
+
+            using var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await Client.SearchAsync(ResourceType.Patient, query));
+            Assert.Equal(HttpStatusCode.BadRequest, fhirException.StatusCode);
+
+            string[] expectedDiagnostics = { string.Format("Invalid TargetResourceType : value cannot be empty") };
+            IssueSeverity[] expectedIssueSeverities = { IssueSeverity.Error };
+            IssueType[] expectedCodeTypes = { IssueType.Invalid };
+            ValidateOperationOutcome(expectedDiagnostics, expectedIssueSeverities, expectedCodeTypes, fhirException.OperationOutcome);
+        }
+
+        [Fact]
+        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer)]
+        public async Task GivenARevIncludeIterateSearchExpressionWithWhiteSpaceTargetResourceType_WhenSearched_ShouldThrowErrorFormat()
+        {
+            string query = $"_revinclude=Observation:subject: ";
+
+            using var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await Client.SearchAsync(ResourceType.Patient, query));
+            Assert.Equal(HttpStatusCode.BadRequest, fhirException.StatusCode);
+
+            string[] expectedDiagnostics = { string.Format("Invalid TargetResourceType : value cannot be empty") };
+            IssueSeverity[] expectedIssueSeverities = { IssueSeverity.Error };
+            IssueType[] expectedCodeTypes = { IssueType.Invalid };
             ValidateOperationOutcome(expectedDiagnostics, expectedIssueSeverities, expectedCodeTypes, fhirException.OperationOutcome);
         }
 


### PR DESCRIPTION
## Description
Invalid Target resource type was not handled when search with "include" and "revinclude" options. 

## Related issues
[76141](https://microsofthealth.visualstudio.com/Health/_workitems/edit/76141)

## Testing
**Test 1:** 
Test URL : Patient/?revinclude=Observation:subject:NotAResourceType
Returned below error:
"issue": [
        {
            "severity": "error",
            "code": "not-supported",
            "diagnostics": "Resource type 'NotAResourceType' is not supported.'."
        }
    ]

**Test 2:** 
Test URL : Patient/?include=Observation:subject:NotAResourceType
Returned below error:
"issue": [
        {
            "severity": "error",
            "code": "not-supported",
            "diagnostics": "Resource type 'NotAResourceType' is not supported.'."
        }
    ]

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
