### PR TITLE
Validation added to include _text search parameter in UnSupportedParameters List

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/KnownQueryParameterNames.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/KnownQueryParameterNames.cs
@@ -73,5 +73,7 @@ namespace Microsoft.Health.Fhir.Core.Features
         public const string OutputFormat = "_outputFormat";
 
         public const string TypeFilter = "_typeFilter";
+
+        public const string Text = "_text";
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchOptionsFactoryTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchOptionsFactoryTests.cs
@@ -473,7 +473,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         {
             var queryParameters = new[]
             {
-                Tuple.Create("_text", "mobile"),
+                Tuple.Create(KnownQueryParameterNames.Text, "mobile"),
             };
 
             SearchOptions options = CreateSearchOptions(ResourceType.Patient.ToString(), queryParameters);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchOptionsFactoryTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchOptionsFactoryTests.cs
@@ -469,7 +469,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         }
 
         [Fact]
-        public void GivenSearchParameter_Text_WhenCreated_ThenSearchParameterShouldBeAddedToUnsupportedList()
+        public void GivenSearchParameterText_WhenCreated_ThenSearchParameterShouldBeAddedToUnsupportedList()
         {
             var queryParameters = new[]
             {

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchOptionsFactoryTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchOptionsFactoryTests.cs
@@ -468,6 +468,19 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             Assert.Equal(_coreFeatures.DefaultIncludeCountPerSearch, options.IncludeCount);
         }
 
+        [Fact]
+        public void GivenSearchParameter_Text_WhenCreated_ThenSearchParameterShouldBeAddedToUnsupportedList()
+        {
+            var queryParameters = new[]
+            {
+                Tuple.Create("_text", "mobile"),
+            };
+
+            SearchOptions options = CreateSearchOptions(ResourceType.Patient.ToString(), queryParameters);
+            Assert.NotNull(options);
+            Assert.Equal(1, options.UnsupportedSearchParams.Count);
+        }
+
         private SearchOptions CreateSearchOptions(
             string resourceType = DefaultResourceType,
             IReadOnlyList<Tuple<string, string>> queryParameters = null,

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -138,6 +138,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                     // Query parameter with empty value is not supported.
                     unsupportedSearchParameters.Add(query);
                 }
+                else if (string.Equals(query.Item1, "_text", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Query parameter _text is not allowed for any resource.
+                    unsupportedSearchParameters.Add(query);
+                }
                 else if (string.Equals(query.Item1, KnownQueryParameterNames.Total, StringComparison.OrdinalIgnoreCase))
                 {
                     if (Enum.TryParse<TotalType>(query.Item2, true, out var totalType))

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                     // Query parameter with empty value is not supported.
                     unsupportedSearchParameters.Add(query);
                 }
-                else if (string.Equals(query.Item1, "_text", StringComparison.OrdinalIgnoreCase))
+                else if (string.Equals(query.Item1, KnownQueryParameterNames.Text, StringComparison.OrdinalIgnoreCase))
                 {
                     // Query parameter _text is not allowed for any resource.
                     unsupportedSearchParameters.Add(query);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -1044,7 +1044,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         }
 
         [Fact]
-        public async Task GivenASearchRequestWithParameter_TextAndLenientHandling_WhenHandled_ReturnsSearchResults()
+        public async Task GivenASearchRequestWithParameter_TextAndLenientHandling_WhenHandled_ReturnsSearchResultsWithWarning()
         {
             string[] expectedDiagnostics =
             {
@@ -1054,6 +1054,21 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             OperationOutcome.IssueSeverity[] expectedIssueSeverities = { OperationOutcome.IssueSeverity.Warning};
 
             Bundle bundle = await Client.SearchAsync("Patient?_text=mobile", Tuple.Create(KnownHeaders.Prefer, "handling=lenient"));
+            OperationOutcome outcome = GetAndValidateOperationOutcome(bundle);
+            ValidateOperationOutcome(expectedDiagnostics, expectedIssueSeverities, expectedCodeTypes, outcome);
+        }
+
+        [Fact]
+        public async Task GivenASearchRequestWithParameter_TextAndNoHandling_WhenHandled_ReturnsSearchResultsWithWarning()
+        {
+            string[] expectedDiagnostics =
+            {
+                string.Format(Core.Resources.SearchParameterNotSupported, "_text", "Patient"),
+            };
+            OperationOutcome.IssueType[] expectedCodeTypes = { OperationOutcome.IssueType.NotSupported };
+            OperationOutcome.IssueSeverity[] expectedIssueSeverities = { OperationOutcome.IssueSeverity.Warning };
+
+            Bundle bundle = await Client.SearchAsync("Patient?_text=mobile");
             OperationOutcome outcome = GetAndValidateOperationOutcome(bundle);
             ValidateOperationOutcome(expectedDiagnostics, expectedIssueSeverities, expectedCodeTypes, outcome);
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -1044,7 +1044,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         }
 
         [Fact]
-        public async Task GivenASearchRequestWithParameter_TextAndLenientHandling_WhenHandled_ReturnsSearchResultsWithWarning()
+        public async Task GivenASearchRequestWithParameterTextAndLenientHandling_WhenHandled_ReturnsSearchResultsWithWarning()
         {
             string[] expectedDiagnostics =
             {
@@ -1059,7 +1059,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         }
 
         [Fact]
-        public async Task GivenASearchRequestWithParameter_TextAndNoHandling_WhenHandled_ReturnsSearchResultsWithWarning()
+        public async Task GivenASearchRequestWithParameterTextAndNoHandling_WhenHandled_ReturnsSearchResultsWithWarning()
         {
             string[] expectedDiagnostics =
             {
@@ -1074,7 +1074,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         }
 
         [Fact]
-        public async Task GivenASearchRequestWithParameter_TextAndStrictHandling_WhenHandled_ReturnsBadRequest()
+        public async Task GivenASearchRequestWithParameterTextAndStrictHandling_WhenHandled_ReturnsBadRequest()
         {
             using FhirException ex = await Assert.ThrowsAsync<FhirException>(() =>
                 Client.SearchAsync("Patient?_text=mobile", Tuple.Create(KnownHeaders.Prefer, "handling=strict")));


### PR DESCRIPTION
## Description
When a Resource XXX is searched using _text parameter, we need to throw an error/warning depending on "Prefer handling" header option with a message "The search parameter '_text' is not supported for resource type 'XXX'."

## Related issues
[82463](https://microsofthealth.visualstudio.com/Health/_workitems/edit/82463)

## Testing
**Test 1:** 
https://localhost:44348/Observation?_text=MOBILE  with heading Prefer: handling:strict
**Returns below error message:**
"issue": [
        {
            "severity": "error",
            "code": "invalid",
            "diagnostics": "The search parameter '_text' is not supported for resource type 'Patient'."
        }
    ]

**Test 2:**
https://localhost:44348/Observation?_text=MOBILE  with heading Prefer: handling:lenient
Returns below warning message:
"resource": {
                "resourceType": "OperationOutcome",
                "id": "004ba8ef-470c-4ee5-9a72-6fe48e5f7069",
                "issue": [
                    {
                        "severity": "warning",
                        "code": "not-supported",
                        "diagnostics": "The search parameter '_text' is not supported for resource type 'Patient'."
                    }
                ]
            },
In both scenarios, _text is removed from Self URL in the response.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
