### PR TITLE
Added error message for RequestEntityTooLargeException in Export

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportJobTaskTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportJobTaskTests.cs
@@ -1363,6 +1363,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
         [InlineData(typeof(AnonymizationConfigurationNotFoundException), "config not found", HttpStatusCode.BadRequest)]
         [InlineData(typeof(FailedToParseAnonymizationConfigurationException), "cannot parse the config", HttpStatusCode.BadRequest)]
         [InlineData(typeof(InvalidOperationException), "Unknown Error.", HttpStatusCode.InternalServerError)]
+        [InlineData(typeof(RequestEntityTooLargeException), "Timespan in export request contains too much data to export in a single request. Please try reducing the time range and try again.", HttpStatusCode.RequestEntityTooLarge)]
         public async Task GivenExceptionThrowFromAnonymizerFactory_WhenExecuted_ThenJobStatusShouldBeUpdatedToFailed(Type exceptionType, string expectedErrorMessage, HttpStatusCode expectedHttpStatusCode)
         {
             // Setup export destination client.

--- a/src/Microsoft.Health.Fhir.Core/Exceptions/RequestEntityTooLargeException.cs
+++ b/src/Microsoft.Health.Fhir.Core/Exceptions/RequestEntityTooLargeException.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Core.Exceptions
@@ -15,6 +16,24 @@ namespace Microsoft.Health.Fhir.Core.Exceptions
                     OperationOutcomeConstants.IssueSeverity.Error,
                     OperationOutcomeConstants.IssueType.Invalid,
                     Resources.ResourceTooLarge));
+        }
+
+        public RequestEntityTooLargeException(string message)
+            : base(message)
+        {
+            Issues.Add(new Models.OperationOutcomeIssue(
+                OperationOutcomeConstants.IssueSeverity.Error,
+                OperationOutcomeConstants.IssueType.Invalid,
+                message));
+        }
+
+        public RequestEntityTooLargeException(string message, Exception exception)
+            : base(message, exception)
+        {
+            Issues.Add(new Models.OperationOutcomeIssue(
+                OperationOutcomeConstants.IssueSeverity.Error,
+                OperationOutcomeConstants.IssueType.Invalid,
+                message));
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -232,6 +232,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                 _exportJobRecord.FailureDetails = new JobFailureDetails(ex.Message, HttpStatusCode.BadRequest);
                 await CompleteJobAsync(OperationStatus.Failed, cancellationToken);
             }
+            catch (RequestEntityTooLargeException)
+            {
+                _exportJobRecord.FailureDetails = new JobFailureDetails(Core.Resources.RequestEntityTooLargeExceptionDuringExport, HttpStatusCode.RequestEntityTooLarge);
+                await CompleteJobAsync(OperationStatus.Failed, cancellationToken);
+            }
             catch (Exception ex)
             {
                 // The job has encountered an error it cannot recover from.

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -232,8 +232,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                 _exportJobRecord.FailureDetails = new JobFailureDetails(ex.Message, HttpStatusCode.BadRequest);
                 await CompleteJobAsync(OperationStatus.Failed, cancellationToken);
             }
-            catch (RequestEntityTooLargeException)
+            catch (RequestEntityTooLargeException retle)
             {
+                _logger.LogError(retle, "Unable to update the ExportJobRecord as it exceeds CosmosDb document max size. The job will be marked as failed.");
+
                 _exportJobRecord.FailureDetails = new JobFailureDetails(Core.Resources.RequestEntityTooLargeExceptionDuringExport, HttpStatusCode.RequestEntityTooLarge);
                 await CompleteJobAsync(OperationStatus.Failed, cancellationToken);
             }

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -573,7 +573,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("IncludeMissingType", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The target resource type cannot be empty..
         /// </summary>
@@ -1012,6 +1012,15 @@ namespace Microsoft.Health.Fhir.Core {
         internal static string RequestedActionNotAllowed {
             get {
                 return ResourceManager.GetString("RequestedActionNotAllowed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Timespan in export request contains too much data to export in a single request. Please try reducing the time range and try again..
+        /// </summary>
+        internal static string RequestEntityTooLargeExceptionDuringExport {
+            get {
+                return ResourceManager.GetString("RequestEntityTooLargeExceptionDuringExport", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -646,4 +646,7 @@
     <value>Inner '{0}' are not supported</value>
     <comment>Union expression can't have other union expressions as children.</comment>
   </data>
+  <data name="RequestEntityTooLargeExceptionDuringExport" xml:space="preserve">
+    <value>Timespan in export request contains too much data to export in a single request. Please try reducing the time range and try again.</value>
+  </data>
 </root>


### PR DESCRIPTION
## Description
We now complete the JobReport as failed and return an actionable message instead of staying stuck as "accepted".

## Related issues
Addresses [95042].

## Testing
Updated Unit Tests.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [x] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
