### PR TITLE
Fixes export tests build

### DIFF
--- a/build/export-pipeline.yml
+++ b/build/export-pipeline.yml
@@ -35,7 +35,7 @@ stages:
       inputs:
         command: build
         arguments: '--configuration $(buildConfiguration) /warnaserror'
-    - template: ./jobs/package.yml
+    - template: ./jobs/package-integration-tests.yml
 
 - stage: redeployStu3
   displayName: 'Redeploy STU3 Site'


### PR DESCRIPTION
## Description

In a [previous PR](https://github.com/microsoft/fhir-server/pull/2797) packaging integration tests was split into a new template, this PR fixes this dependency in the export tests.

![image](https://user-images.githubusercontent.com/197221/190679641-883bdc08-0d95-4a05-9456-ebe2fac6d845.png)

## Testing
Run export test pipeline

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [x] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip
