### PR TITLE
Fixes internal checks

### DIFF
--- a/build/.vsts-PRInternalChecks-azureBuild-pipeline.yml
+++ b/build/.vsts-PRInternalChecks-azureBuild-pipeline.yml
@@ -27,15 +27,6 @@ jobs:
     inputs:
       useGlobalJson: true
 
-  - task: DotNetCoreCLI@2
-    displayName: dotnet restore
-    inputs:
-      command: restore
-      projects: '**/*.sln'
-      selectOrConfig: config
-      feedRestore: d67b3357-eb1a-41c0-b5d2-52cd6271d320
-      nugetConfigPath: nuget.config
-
   - task: DotNetCoreCLI@1
     name: ''
     displayName: dotnet build

--- a/build/InternalChecksCI-azureBuild-pipeline.yml
+++ b/build/InternalChecksCI-azureBuild-pipeline.yml
@@ -54,13 +54,6 @@ jobs:
     inputs:
       useGlobalJson: true
 
-  - task: DotNetCoreCLI@2
-    displayName: dotnet restore
-    inputs:
-      command: restore
-      projects: '**/*.sln'
-      feedRestore: d67b3357-eb1a-41c0-b5d2-52cd6271d320
-      
   - task: DotNetCoreCLI@1
     name: ''
     displayName: dotnet build


### PR DESCRIPTION
## Description
Some old config in internal builds prevents restore using CPM

## Testing
See builds below

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [x] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
