### PR TITLE
Adding log output for ReIndex related tests

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -12,6 +13,7 @@ using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using Microsoft.Health.Core.Extensions;
 using Microsoft.Health.Fhir.Client;
+using Microsoft.Health.Fhir.Core.Features;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
@@ -29,7 +31,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
     public class CustomSearchParamTests : SearchTestsBase<HttpIntegrationTestFixture>, IAsyncLifetime
     {
         private readonly HttpIntegrationTestFixture _fixture;
-        private ITestOutputHelper _output;
+        private readonly ITestOutputHelper _output;
         private const int MaxRetryCount = 10;
 
         public CustomSearchParamTests(HttpIntegrationTestFixture fixture, ITestOutputHelper output)
@@ -48,14 +50,16 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [SkippableFact]
         public async Task GivenANewSearchParam_WhenReindexingComplete_ThenResourcesSearchedWithNewParamReturned()
         {
-            var randomName = Guid.NewGuid().ToString().ComputeHash().Substring(0, 14).ToLower();
-            var searchParam = Samples.GetJsonSample<SearchParameter>("SearchParameter-SpecimenStatus");
+            Skip.If(!_fixture.IsUsingInProcTestServer, "Reindex is not enabled on this server.");
+
+            var randomName = Guid.NewGuid().ToString().ComputeHash()[..14].ToLower();
+            SearchParameter searchParam = Samples.GetJsonSample<SearchParameter>("SearchParameter-SpecimenStatus");
             searchParam.Name = randomName;
             searchParam.Url = searchParam.Url.Replace("foo", randomName);
             searchParam.Code = randomName + "Code";
 
             // POST a new Specimen
-            var specimen = Samples.GetJsonSample<Specimen>("Specimen");
+            Specimen specimen = Samples.GetJsonSample<Specimen>("Specimen");
             specimen.Status = Specimen.SpecimenStatus.Available;
             var tag = new Coding(null, randomName);
             specimen.Meta = new Meta();
@@ -63,7 +67,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             FhirResponse<Specimen> expectedSpecimen = await Client.CreateAsync(specimen);
 
             // POST a second Specimen to show it is filtered and not returned when using the new search parameter
-            var specimen2 = Samples.GetJsonSample<Specimen>("Specimen");
+            Specimen specimen2 = Samples.GetJsonSample<Specimen>("Specimen");
             specimen2.Status = Specimen.SpecimenStatus.EnteredInError;
             specimen2.Meta = new Meta();
             specimen2.Meta.Tag.Add(tag);
@@ -71,45 +75,20 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
             // POST a new Search parameter
             FhirResponse<SearchParameter> searchParamPosted = null;
+            int retryCount = 0;
+            bool success = true;
             try
             {
                 searchParamPosted = await Client.CreateAsync(searchParam);
                 _output.WriteLine($"SearchParameter is posted {searchParam.Url}");
 
-                Uri reindexJobUri;
-
                 // Start a reindex job
-                (_, reindexJobUri) = await Client.PostReindexJobAsync(new Parameters());
+                Uri reindexJobUri;
+                FhirResponse<Parameters> reindexJobResult;
+                (reindexJobResult, reindexJobUri) = await RunReindexToCompletion(new Parameters());
 
-                await WaitForReindexStatus(reindexJobUri, "Completed");
-
-                FhirResponse<Parameters> reindexJobResult = await Client.CheckReindexAsync(reindexJobUri);
-                Parameters.ParameterComponent param = reindexJobResult.Resource.Parameter.FirstOrDefault(p => p.Name == "searchParams");
-                _output.WriteLine("ReindexJobDocument:");
-                var serializer = new FhirJsonSerializer();
-                _output.WriteLine(serializer.SerializeToString(reindexJobResult.Resource));
-
+                Parameters.ParameterComponent param = reindexJobResult.Resource.Parameter.FirstOrDefault(p => p.Name == JobRecordProperties.SearchParams);
                 Assert.Contains(searchParamPosted.Resource.Url, param?.Value?.ToString());
-
-                reindexJobResult = await WaitForReindexStatus(reindexJobUri, "Completed");
-                _output.WriteLine($"Reindex job is completed, it should have reindexed the resources with {randomName}");
-
-                var floatParse = float.TryParse(
-                    reindexJobResult.Resource.Parameter.FirstOrDefault(predicate => predicate.Name == "resourcesSuccessfullyReindexed").Value.ToString(),
-                    out float resourcesReindexed);
-
-                _output.WriteLine($"Reindex job is completed, {resourcesReindexed} resources Reindexed");
-
-                Assert.True(floatParse);
-                Assert.True(resourcesReindexed > 0.0);
-
-                // When job complete, search for resources using new parameter
-                // When there are multiple instances of the fhir-server running, it could take some time
-                // for the search parameter/reindex updates to propogate to all instances. Hence we are
-                // adding some retries below to account for that delay.
-                int retryCount = 0;
-                bool success = true;
-                await Task.Delay(TimeSpan.FromSeconds(20));
 
                 do
                 {
@@ -120,6 +99,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                         await ExecuteAndValidateBundle(
                             $"Specimen?{searchParam.Code}={Specimen.SpecimenStatus.Available.ToString().ToLower()}&_tag={tag.Code}",
                             expectedSpecimen.Resource);
+
+                        _output.WriteLine($"Success on attempt {retryCount} of {MaxRetryCount}");
                     }
                     catch (Exception ex)
                     {
@@ -135,7 +116,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             }
             catch (FhirException ex) when (ex.StatusCode == HttpStatusCode.BadRequest && ex.Message.Contains("not enabled"))
             {
-                Skip.If(!_fixture.IsUsingInProcTestServer, "Reindex is not enabled on this server.");
+                _output.WriteLine($"Skipping because reindex is disabled.");
                 return;
             }
             catch (Exception e)
@@ -154,9 +135,11 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [SkippableFact]
         public async Task GivenASearchParam_WhenUpdatingParam_ThenResourcesIndexedWithUpdatedParam()
         {
-            var randomName = Guid.NewGuid().ToString().ComputeHash().Substring(28).ToLower();
+            Skip.If(!_fixture.IsUsingInProcTestServer, "Reindex is not enabled on this server.");
+
+            var randomName = Guid.NewGuid().ToString().ComputeHash()[28..].ToLower();
             var patient = new Patient { Name = new List<HumanName> { new HumanName { Family = randomName } } };
-            var searchParam = Samples.GetJsonSample<SearchParameter>("SearchParameter-Patient-foo");
+            SearchParameter searchParam = Samples.GetJsonSample<SearchParameter>("SearchParameter-Patient-foo");
             searchParam.Name = randomName;
             searchParam.Url = searchParam.Url.Replace("foo", randomName);
             searchParam.Code = randomName;
@@ -167,6 +150,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
             // POST a new Search parameter
             FhirResponse<SearchParameter> searchParamPosted = null;
+            int retryCount = 0;
+            bool success = true;
             try
             {
                 searchParamPosted = await Client.CreateAsync(searchParam);
@@ -182,11 +167,9 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 FhirResponse<Parameters> reindexJobResult;
 
                 // Reindex just a single patient, so we can try searching with a partially indexed search param
-                (reindexJobResult, reindexJobUri) = await Client.PostReindexJobAsync(new Parameters(), $"Patient/{expectedPatient.Resource.Id}/");
-                await Task.Delay(10000);
+                (reindexJobResult, reindexJobUri) = await RunReindexToCompletion(new Parameters(), $"Patient/{expectedPatient.Resource.Id}/");
 
                 Parameters.ParameterComponent param = reindexJobResult.Resource.Parameter.FirstOrDefault(p => p.Name == randomNameUpdated);
-
                 if (param == null)
                 {
                     _output.WriteLine($"Parameter with name equal to randomly generated name of this test case: {randomNameUpdated} not found in reindex result.");
@@ -195,15 +178,35 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 Assert.NotNull(param);
                 Assert.Equal(randomName, param.Value.ToString());
 
-                // When job complete, search for resources using new parameter
-                await ExecuteAndValidateBundle(
-                            $"Patient?{searchParamPosted.Resource.Code}:exact={randomName}",
-                            Tuple.Create("x-ms-use-partial-indices", "true"),
-                            expectedPatient.Resource);
+                do
+                {
+                    success = true;
+                    retryCount++;
+                    try
+                    {
+                        // When reindex job complete, search for resources using new parameter
+                        await ExecuteAndValidateBundle(
+                                    $"Patient?{searchParamPosted.Resource.Code}:exact={randomName}",
+                                    Tuple.Create(KnownHeaders.PartiallyIndexedParamsHeaderName, "true"),
+                                    expectedPatient.Resource);
+
+                        _output.WriteLine($"Success on attempt {retryCount} of {MaxRetryCount}");
+                    }
+                    catch (Exception ex)
+                    {
+                        string error = $"Attempt {retryCount} of {MaxRetryCount}: Failed to validate bundle: {ex}";
+                        _output.WriteLine(error);
+                        success = false;
+                        await Task.Delay(TimeSpan.FromSeconds(10));
+                    }
+                }
+                while (!success && retryCount < MaxRetryCount);
+
+                Assert.True(success);
             }
             catch (FhirException ex) when (ex.StatusCode == HttpStatusCode.BadRequest && ex.Message.Contains("not enabled"))
             {
-                Skip.If(!_fixture.IsUsingInProcTestServer, "Reindex is not enabled on this server.");
+                _output.WriteLine($"Skipping because reindex is disabled.");
                 return;
             }
             catch (Exception e)
@@ -245,72 +248,54 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [SkippableFact]
         public async Task GivenASearchParameterWithMultipleBaseResourceTypes_WhenTargetingReindexJobToResourceType_ThenOnlyTargetedTypesAreReindexed()
         {
-            var randomName = Guid.NewGuid().ToString().ComputeHash().Substring(0, 14).ToLower();
-            var searchParam = Samples.GetJsonSample<SearchParameter>("SearchParameter-Resource-idfoo");
+            Skip.If(!_fixture.IsUsingInProcTestServer, "Reindex is not enabled on this server.");
+
+            var randomName = Guid.NewGuid().ToString().ComputeHash()[..14].ToLower();
+            SearchParameter searchParam = Samples.GetJsonSample<SearchParameter>("SearchParameter-Resource-idfoo");
             searchParam.Name = searchParam.Name.Replace("foo", randomName);
             searchParam.Url = searchParam.Url.Replace("foo", randomName);
             searchParam.Code = randomName + "Code";
 
             // POST a new Specimen
-            var specimen = Samples.GetJsonSample<Specimen>("Specimen");
+            Specimen specimen = Samples.GetJsonSample<Specimen>("Specimen");
             FhirResponse<Specimen> expectedSpecimen = await Client.CreateAsync(specimen);
+            _output.WriteLine($"{nameof(expectedSpecimen)} Response.StatusCode is {expectedSpecimen.Response.StatusCode}");
 
             // POST a second Specimen to show it is filtered and not returned when using the new search parameter
-            var specimen2 = Samples.GetJsonSample<Specimen>("Specimen");
+            Specimen specimen2 = Samples.GetJsonSample<Specimen>("Specimen");
             await Client.CreateAsync(specimen2);
 
             // POST a new patient
             var patient = new Patient { Name = new List<HumanName> { new HumanName { Family = randomName } } };
             FhirResponse<Patient> expectedPatient = await Client.CreateAsync(patient);
+            _output.WriteLine($"{nameof(expectedPatient)} Response.StatusCode is {expectedPatient.Response.StatusCode}");
 
             // POST a new Search parameter
             FhirResponse<SearchParameter> searchParamPosted = null;
+            int retryCount = 0;
+            bool success = true;
             try
             {
                 searchParamPosted = await Client.CreateAsync(searchParam);
-                _output.WriteLine($"SearchParameter is posted {searchParam.Url}");
+                _output.WriteLine($"{nameof(searchParamPosted)} Response.StatusCode is {searchParamPosted.Response.StatusCode} and posted Url is {searchParam.Url}");
 
                 Uri reindexJobUri;
+                FhirResponse<Parameters> reindexJobResult;
 
                 // Start a reindex job
-                var reindexParameters = new Parameters();
-                reindexParameters.Add("targetResourceTypes", new FhirString("Specimen"));
-                (_, reindexJobUri) = await Client.PostReindexJobAsync(reindexParameters);
+                var reindexParameters = new Parameters
+                {
+                    { "targetResourceTypes", new FhirString("Specimen") },
+                };
+                (reindexJobResult, reindexJobUri) = await RunReindexToCompletion(reindexParameters);
 
-                await WaitForReindexStatus(reindexJobUri, "Completed");
-
-                FhirResponse<Parameters> reindexJobResult = await Client.CheckReindexAsync(reindexJobUri);
-                Parameters.ParameterComponent searchParamListParam = reindexJobResult.Resource.Parameter.FirstOrDefault(p => p.Name == "searchParams");
+                Parameters.ParameterComponent searchParamListParam = reindexJobResult.Resource.Parameter.FirstOrDefault(p => p.Name == JobRecordProperties.SearchParams);
                 Parameters.ParameterComponent targetResourcesParam = reindexJobResult.Resource.Parameter.FirstOrDefault(p => p.Name == JobRecordProperties.TargetResourceTypes);
                 Parameters.ParameterComponent resourcesParam = reindexJobResult.Resource.Parameter.FirstOrDefault(p => p.Name == JobRecordProperties.Resources);
-
-                // output reindex job for debugging
-                _output.WriteLine("ReindexJobDocument:");
-                var serializer = new FhirJsonSerializer();
-                _output.WriteLine(serializer.SerializeToString(reindexJobResult.Resource));
 
                 Assert.Contains(searchParamPosted.Resource.Url, searchParamListParam?.Value?.ToString());
                 Assert.Equal("Specimen", targetResourcesParam?.Value?.ToString());
                 Assert.Equal("Specimen", resourcesParam?.Value?.ToString());
-
-                _output.WriteLine($"Reindex job is completed, it should have reindexed the resources of type Specimen only.");
-
-                var floatParse = float.TryParse(
-                    reindexJobResult.Resource.Parameter.FirstOrDefault(predicate => predicate.Name == "resourcesSuccessfullyReindexed").Value.ToString(),
-                    out float resourcesReindexed);
-
-                _output.WriteLine($"Reindex job is completed, {resourcesReindexed} resources Reindexed");
-
-                Assert.True(floatParse);
-                Assert.True(resourcesReindexed > 0.0);
-
-                // When job complete, search for resources using new parameter
-                // When there are multiple instances of the fhir-server running, it could take some time
-                // for the search parameter/reindex updates to propogate to all instances. Hence we are
-                // adding some retries below to account for that delay.
-                int retryCount = 0;
-                bool success = true;
-                await Task.Delay(TimeSpan.FromSeconds(20));
 
                 do
                 {
@@ -320,8 +305,10 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                     {
                         await ExecuteAndValidateBundle(
                             $"Specimen?{searchParam.Code}={expectedSpecimen.Resource.Id}",
-                            Tuple.Create("x-ms-use-partial-indices", "true"),
+                            Tuple.Create(KnownHeaders.PartiallyIndexedParamsHeaderName, "true"),
                             expectedSpecimen.Resource);
+
+                        _output.WriteLine($"Success on attempt {retryCount} of {MaxRetryCount}");
                     }
                     catch (Exception ex)
                     {
@@ -332,7 +319,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
                     // now searching for patient with same search parameter should not work
                     var searchUrl = $"Patient?{searchParam.Code}={expectedPatient.Resource.Id}";
-                    Bundle bundle = await Client.SearchAsync(searchUrl, Tuple.Create("x-ms-use-partial-indices", "true"));
+                    Bundle bundle = await Client.SearchAsync(searchUrl, Tuple.Create(KnownHeaders.PartiallyIndexedParamsHeaderName, "true"));
                     Assert.Empty(bundle.Entry);
 
                     // finally searching with new SearchParam but without partial header should not use
@@ -347,7 +334,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             }
             catch (FhirException ex) when (ex.StatusCode == HttpStatusCode.BadRequest && ex.Message.Contains("not enabled"))
             {
-                Skip.If(!_fixture.IsUsingInProcTestServer, "Reindex is not enabled on this server.");
+                _output.WriteLine($"Skipping because reindex is disabled.");
                 return;
             }
             catch (Exception e)
@@ -359,82 +346,71 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             finally
             {
                 // Clean up new SearchParameter
-                await DeleteSearchParameterAndVerify(searchParamPosted?.Resource);
+                if (success)
+                {
+                    await DeleteSearchParameterAndVerify(searchParamPosted?.Resource);
+                }
+                else
+                {
+                    _output.WriteLine($"Test was not successful, check db for search params");
+                }
             }
         }
 
         [SkippableFact]
         public async Task GivenASearchParameterWithMultipleBaseResourceTypes_WhenTargetingReindexJobToSameListOfResourceTypes_ThenSearchParametersMarkedFullyIndexed()
         {
-            var randomName = Guid.NewGuid().ToString().ComputeHash().Substring(0, 14).ToLower();
-            var searchParam = Samples.GetJsonSample<SearchParameter>("SearchParameter-Resource-idfoo");
+            Skip.If(!_fixture.IsUsingInProcTestServer, "Reindex is not enabled on this server.");
+
+            var randomName = Guid.NewGuid().ToString().ComputeHash()[..14].ToLower();
+            SearchParameter searchParam = Samples.GetJsonSample<SearchParameter>("SearchParameter-Resource-idfoo");
             searchParam.Name = searchParam.Name.Replace("foo", randomName);
             searchParam.Url = searchParam.Url.Replace("foo", randomName);
             searchParam.Code = randomName + "Code";
             searchParam.Base = new List<ResourceType?>() { ResourceType.Specimen, ResourceType.Immunization };
 
             // POST a new Specimen
-            var specimen = Samples.GetJsonSample<Specimen>("Specimen");
+            Specimen specimen = Samples.GetJsonSample<Specimen>("Specimen");
             FhirResponse<Specimen> expectedSpecimen = await Client.CreateAsync(specimen);
+            _output.WriteLine($"{nameof(expectedSpecimen)} Response.StatusCode is {expectedSpecimen.Response.StatusCode}");
 
             // POST a second Specimen to show it is filtered and not returned when using the new search parameter
-            var specimen2 = Samples.GetJsonSample<Specimen>("Specimen");
+            Specimen specimen2 = Samples.GetJsonSample<Specimen>("Specimen");
             await Client.CreateAsync(specimen2);
 
             // POST a new Immunization
-            var immunization = Samples.GetJsonSample<Immunization>("Immunization");
+            Immunization immunization = Samples.GetJsonSample<Immunization>("Immunization");
             FhirResponse<Immunization> expectedImmunization = await Client.CreateAsync(immunization);
+            _output.WriteLine($"{nameof(expectedImmunization)} Response.StatusCode is {expectedImmunization.Response.StatusCode}");
 
             // POST a new Search parameter
             FhirResponse<SearchParameter> searchParamPosted = null;
+            int retryCount = 0;
+            bool success = true;
             try
             {
                 searchParamPosted = await Client.CreateAsync(searchParam);
-                _output.WriteLine($"SearchParameter is posted {searchParam.Url}");
+                _output.WriteLine($"{nameof(searchParamPosted)} Response.StatusCode is {searchParamPosted.Response.StatusCode} and posted Url is {searchParam.Url}");
 
                 Uri reindexJobUri;
+                FhirResponse<Parameters> reindexJobResult;
 
                 // Start a reindex job
-                var reindexParameters = new Parameters();
-                reindexParameters.Add("targetResourceTypes", new FhirString("Specimen,Immunization"));
-                (_, reindexJobUri) = await Client.PostReindexJobAsync(reindexParameters);
+                var reindexParameters = new Parameters
+                {
+                    { "targetResourceTypes", new FhirString("Specimen,Immunization") },
+                };
+                (reindexJobResult, reindexJobUri) = await RunReindexToCompletion(reindexParameters);
 
-                await WaitForReindexStatus(reindexJobUri, "Completed");
-
-                FhirResponse<Parameters> reindexJobResult = await Client.CheckReindexAsync(reindexJobUri);
-                Parameters.ParameterComponent searchParamListParam = reindexJobResult.Resource.Parameter.FirstOrDefault(p => p.Name == "searchParams");
+                Parameters.ParameterComponent searchParamListParam = reindexJobResult.Resource.Parameter.FirstOrDefault(p => p.Name == JobRecordProperties.SearchParams);
                 Parameters.ParameterComponent targetResourcesParam = reindexJobResult.Resource.Parameter.FirstOrDefault(p => p.Name == JobRecordProperties.TargetResourceTypes);
                 Parameters.ParameterComponent resourcesParam = reindexJobResult.Resource.Parameter.FirstOrDefault(p => p.Name == JobRecordProperties.Resources);
-
-                // output reindex job for debugging
-                _output.WriteLine("ReindexJobDocument:");
-                var serializer = new FhirJsonSerializer();
-                _output.WriteLine(serializer.SerializeToString(reindexJobResult.Resource));
 
                 Assert.Contains(searchParamPosted.Resource.Url, searchParamListParam?.Value?.ToString());
                 Assert.Contains("Specimen", targetResourcesParam?.Value?.ToString());
                 Assert.Contains("Specimen", resourcesParam?.Value?.ToString());
                 Assert.Contains("Immunization", targetResourcesParam?.Value?.ToString());
                 Assert.Contains("Immunization", resourcesParam?.Value?.ToString());
-
-                _output.WriteLine($"Reindex job is completed, it should have reindexed the resources of type Specimen and Immunization only.");
-
-                var floatParse = float.TryParse(
-                    reindexJobResult.Resource.Parameter.FirstOrDefault(predicate => predicate.Name == "resourcesSuccessfullyReindexed").Value.ToString(),
-                    out float resourcesReindexed);
-
-                _output.WriteLine($"Reindex job is completed, {resourcesReindexed} resources Reindexed");
-
-                Assert.True(floatParse);
-                Assert.True(resourcesReindexed > 0.0);
-
-                // When job complete, search for resources using new parameter
-                // When there are multiple instances of the fhir-server running, it could take some time
-                // for the search parameter/reindex updates to propogate to all instances. Hence we are
-                // adding some retries below to account for that delay.
-                int retryCount = 0;
-                bool success = true;
-                await Task.Delay(TimeSpan.FromSeconds(20));
 
                 do
                 {
@@ -450,6 +426,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                         await ExecuteAndValidateBundle(
                             $"Immunization?{searchParam.Code}={expectedImmunization.Resource.Id}",
                             expectedImmunization.Resource);
+
+                        _output.WriteLine($"Success on attempt {retryCount} of {MaxRetryCount}");
                     }
                     catch (Exception ex)
                     {
@@ -467,7 +445,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             catch (FhirException ex) when (ex.StatusCode == HttpStatusCode.BadRequest && ex.Message.Contains("not enabled"))
             {
                 _output.WriteLine($"Skipping because reindex is disabled.");
-                Skip.If(!_fixture.IsUsingInProcTestServer, "Reindex is not enabled on this server.");
                 return;
             }
             catch (Exception e)
@@ -479,7 +456,14 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             finally
             {
                 // Clean up new SearchParameter
-                await DeleteSearchParameterAndVerify(searchParamPosted?.Resource);
+                if (success)
+                {
+                    await DeleteSearchParameterAndVerify(searchParamPosted?.Resource);
+                }
+                else
+                {
+                    _output.WriteLine($"Test was not successful, check db for search params");
+                }
             }
         }
 
@@ -487,27 +471,73 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         public async Task GivenNonParametersRequestBody_WhenReindexSent_ThenBadRequest()
         {
             string body = Samples.GetJson("PatientWithMinimalData");
-            var ex = await Assert.ThrowsAsync<FhirException>(async () => await Client.PostAsync("$reindex", body));
+            FhirException ex = await Assert.ThrowsAsync<FhirException>(async () => await Client.PostAsync("$reindex", body));
             Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
         }
 
-        private async Task<FhirResponse<Parameters>> WaitForReindexStatus(System.Uri reindexJobUri, params string[] desiredStatus)
+        private async Task<(FhirResponse<Parameters> response, Uri uri)> RunReindexToCompletion(Parameters reindexParameters, string uniqueResource = null)
+        {
+            Uri reindexJobUri;
+            FhirResponse<Parameters> response;
+            (response, reindexJobUri) = await Client.PostReindexJobAsync(reindexParameters, uniqueResource);
+
+            // this becomes null when the uniqueResource gets passed in
+            if (reindexJobUri != null)
+            {
+                response = await WaitForReindexStatus(reindexJobUri, "Completed");
+
+                _output.WriteLine("ReindexJobDocument:");
+                var serializer = new FhirJsonSerializer();
+                serializer.Settings.Pretty = true;
+                _output.WriteLine(serializer.SerializeToString(response.Resource));
+
+                var floatParse = float.TryParse(
+                    response.Resource.Parameter.FirstOrDefault(p => p.Name == JobRecordProperties.ResourcesSuccessfullyReindexed).Value.ToString(),
+                    out float resourcesReindexed);
+
+                Assert.True(floatParse);
+                Assert.True(resourcesReindexed > 0.0);
+            }
+            else
+            {
+                _output.WriteLine("response.Resource.Parameter output:");
+                foreach (Parameters.ParameterComponent paramComponent in response.Resource.Parameter)
+                {
+                    _output.WriteLine($"  {paramComponent.Name}: {paramComponent.Value}");
+                }
+            }
+
+            return (response, reindexJobUri);
+        }
+
+        private async Task<FhirResponse<Parameters>> WaitForReindexStatus(Uri reindexJobUri, params string[] desiredStatus)
         {
             int checkReindexCount = 0;
+            int maxCount = 30;
+            var delay = TimeSpan.FromSeconds(10);
+            var sw = new Stopwatch();
             string currentStatus;
-            FhirResponse<Parameters> reindexJobResult = null;
+            FhirResponse<Parameters> reindexJobResult;
+            sw.Start();
+
             do
             {
-                reindexJobResult = await Client.CheckReindexAsync(reindexJobUri);
-                currentStatus = reindexJobResult.Resource.Parameter.FirstOrDefault(p => p.Name == "status")?.Value.ToString();
-                checkReindexCount++;
-                await Task.Delay(1000);
-            }
-            while (!desiredStatus.Contains(currentStatus) && checkReindexCount < 20);
+                if (checkReindexCount > 0)
+                {
+                    await Task.Delay(delay);
+                }
 
-            if (checkReindexCount >= 20)
+                reindexJobResult = await Client.CheckReindexAsync(reindexJobUri);
+                currentStatus = reindexJobResult.Resource.Parameter.FirstOrDefault(p => p.Name == JobRecordProperties.Status)?.Value.ToString();
+                checkReindexCount++;
+            }
+            while (!desiredStatus.Contains(currentStatus) && checkReindexCount < maxCount);
+
+            sw.Stop();
+
+            if (checkReindexCount >= maxCount)
             {
-                throw new Exception("ReindexJob did not complete within 20 seconds.");
+                throw new Exception($"ReindexJob did not complete within {checkReindexCount} attempts and a duration of {sw.Elapsed.Duration()}");
             }
 
             return reindexJobResult;
@@ -519,7 +549,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             {
                 // Clean up new SearchParameter
                 // When there are multiple instances of the fhir-server running, it could take some time
-                // for the search parameter/reindex updates to propogate to all instances. Hence we are
+                // for the search parameter/reindex updates to propagate to all instances. Hence we are
                 // adding some retries below to account for that delay.
                 int retryCount = 0;
                 bool success = true;
@@ -534,23 +564,22 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                     catch (Exception exp)
                     {
                         _output.WriteLine($"Attempt {retryCount} of {MaxRetryCount}: CustomSearchParameter test experienced issue attempted to clean up SearchParameter {searchParam.Url}.  The exception is {exp}");
-                        var fhirException = exp as FhirException;
-                        if (fhirException != null && fhirException.OperationOutcome?.Issue != null)
+                        if (exp is FhirException fhirException && fhirException.OperationOutcome?.Issue != null)
                         {
-                            foreach (var issue in fhirException.OperationOutcome.Issue)
+                            foreach (OperationOutcome.IssueComponent issueComponent in fhirException.OperationOutcome.Issue)
                             {
-                                _output.WriteLine("FhirException OperationOutome message from trying to delete SearchParameter is CustomSearchParam test: {0}", issue.Diagnostics);
+                                _output.WriteLine("FhirException OperationOutome message from trying to delete SearchParameter is CustomSearchParam test: {0}", issueComponent.Diagnostics);
                             }
                         }
 
                         success = false;
-                        await Task.Delay(10000);
+                        await Task.Delay(TimeSpan.FromSeconds(10));
                     }
                 }
                 while (!success && retryCount < MaxRetryCount);
 
                 Assert.True(success);
-                var ex = await Assert.ThrowsAsync<FhirException>(() => Client.ReadAsync<SearchParameter>(ResourceType.SearchParameter, searchParam.Id));
+                FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.ReadAsync<SearchParameter>(ResourceType.SearchParameter, searchParam.Id));
                 Assert.Contains("Gone", ex.Message);
             }
         }


### PR DESCRIPTION
## Description
Revised the way that reindex calls are handled in these tests so that they all call in the same manner. Also adding output for the reindex job as there have been times when this will fail for undetermined reasons besides not completing in the original 20 second limit.
What used to occur was a test that would call to reindex may fail when it doesn't complete in time and then if there were subsequent test that tried to update create a search param they would fail with the message of "Changes to search parameters is not allowed while a reindex job is ongoing".

## Related issues
This is related to [#93223](https://microsofthealth.visualstudio.com/Health/_workitems/edit/93223) such that they're transient issues that do come up in this class.

## Testing
Successfully ran all Microsoft.Health.Fhir.Tests.E2E.Rest.Search.CustomSearchParamTests locally.

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [X] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
