### PR TITLE
Add Private Assets back

### DIFF
--- a/src/Microsoft.Health.Fhir.R4.Core/Microsoft.Health.Fhir.R4.Core.csproj
+++ b/src/Microsoft.Health.Fhir.R4.Core/Microsoft.Health.Fhir.R4.Core.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="AngleSharp" />
     <PackageReference Include="Ensure.That" />
     <PackageReference Include="FluentValidation" />
-    <PackageReference Include="Hl7.Fhir.Specification.R4" />
+    <PackageReference Include="Hl7.Fhir.Specification.R4" PrivateAssets="build;analyzers"/>
     <PackageReference Include="MediatR" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
     <PackageReference Include="Microsoft.Extensions.Http" />

--- a/src/Microsoft.Health.Fhir.R5.Core/Microsoft.Health.Fhir.R5.Core.csproj
+++ b/src/Microsoft.Health.Fhir.R5.Core/Microsoft.Health.Fhir.R5.Core.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Hl7.Fhir.R5" />
-    <PackageReference Include="Hl7.Fhir.Specification.R5"/>
+    <PackageReference Include="Hl7.Fhir.Specification.R5" PrivateAssets="build;analyzers"/>
     <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="System.Net.Http" />
   </ItemGroup>

--- a/src/Microsoft.Health.Fhir.Stu3.Core/Microsoft.Health.Fhir.Stu3.Core.csproj
+++ b/src/Microsoft.Health.Fhir.Stu3.Core/Microsoft.Health.Fhir.Stu3.Core.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Hl7.Fhir.STU3" />
-    <PackageReference Include="Hl7.Fhir.Specification.STU3" />
+    <PackageReference Include="Hl7.Fhir.Specification.STU3" PrivateAssets="build;analyzers"/>
     <PackageReference Include="Microsoft.Health.Fhir.Anonymizer.Stu3.Core" />
     <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="System.Net.Http" />


### PR DESCRIPTION
## Description
Adds private assets back to the build

## Related issues
Without this the specification.zip file was missing from the nuget packages.

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
