### PR TITLE
Correct the Canonical URL for the validate operation

### DIFF
--- a/src/Microsoft.Health.Fhir.ValueSets/OperationTypes.cs
+++ b/src/Microsoft.Health.Fhir.ValueSets/OperationTypes.cs
@@ -9,6 +9,6 @@ namespace Microsoft.Health.Fhir.ValueSets
     {
         public const string Validate = "validate";
 
-        public const string ValidateUri = "https://www.hl7.org/fhir/operation-resource-validate.html";
+        public const string ValidateUri = "http://hl7.org/fhir/OperationDefinition/Resource-validate";
     }
 }


### PR DESCRIPTION
## Description
Update the canonical URL for the validate operation to the correct fhir value as documented
http://hl7.org/fhir/R4B/operation-resource-validate.html
(the Canonical is a specific value documented on the page, not the address of the webpage itself)

## Related issues
Addresses #2810

## Testing
Manually checked that the output CapabilityStatement resource from the /metadata endpoint returned the correct value.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [x] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
None - minor bug/correction
