### PR TITLE
Read and parse SMART clinical scopes from the claims

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Context/FhirRequestContextAuthenticationMiddlewareExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Context/FhirRequestContextAuthenticationMiddlewareExtensions.cs
@@ -5,6 +5,7 @@
 
 using EnsureThat;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.Health.Fhir.Api.Features.Smart;
 
 namespace Microsoft.Health.Fhir.Api.Features.Context
 {
@@ -20,6 +21,8 @@ namespace Microsoft.Health.Fhir.Api.Features.Context
             builder.UseAuthentication();
 
             builder.UseMiddleware<FhirRequestContextAfterAuthenticationMiddleware>();
+
+            builder.UseMiddleware<SmartClinicalScopesMiddleware>();
 
             return builder;
         }

--- a/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
@@ -1,0 +1,83 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Security.Claims;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using EnsureThat;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Health.Core.Features.Context;
+using Microsoft.Health.Fhir.Core.Configs;
+using Microsoft.Health.Fhir.Core.Features.Context;
+using Microsoft.Health.Fhir.Core.Features.Security;
+
+namespace Microsoft.Health.Fhir.Api.Features.Smart
+{
+    /// <summary>
+    /// Middleware that runs after authentication middleware so the scopes field in the token can be examined for SMART on FHIR clinical scopes
+    /// </summary>
+    public class SmartClinicalScopesMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        // Regex based on SMART on FHIR clinical scopes v1.0, http://hl7.org/fhir/smart-app-launch/1.0.0/scopes-and-launch-context/index.html#clinical-scope-syntax
+        private readonly Regex clinicalScopeRegEx = new Regex(@"(^|\s+)(?<id>patient|user)(/|\$|.)(?<resource>\*|([a-zA-Z]*))\.(?<accessLevel>read|write|\*)", RegexOptions.Compiled);
+
+        public SmartClinicalScopesMiddleware(RequestDelegate next)
+        {
+            EnsureArg.IsNotNull(next, nameof(next));
+
+            _next = next;
+        }
+
+        public async Task Invoke(HttpContext context, RequestContextAccessor<IFhirRequestContext> fhirRequestContextAccessor, AuthorizationConfiguration authorizationConfiguration)
+        {
+            if (fhirRequestContextAccessor.RequestContext.Principal != null
+                && authorizationConfiguration.Enabled)
+            {
+                var fhirRequestContext = fhirRequestContextAccessor.RequestContext;
+                var principal = fhirRequestContext.Principal;
+                fhirRequestContext.AccessControlContext.ApplyFineGrainedAccessControl = true;
+
+                // examine the scopes claim for any SMART on FHIR clinical scopes
+                DataActions permittedDataActions = 0;
+                foreach (Claim claim in principal.FindAll(authorizationConfiguration.ScopesClaim))
+                {
+                    var matches = clinicalScopeRegEx.Matches(claim.Value);
+                    foreach (Match match in matches)
+                    {
+                        fhirRequestContext.AccessControlContext.ClinicalScopes.Add(match.Value);
+
+                        var id = match.Groups["id"]?.Value;
+                        var resource = match.Groups["resource"]?.Value;
+                        var accessLevel = match.Groups["accessLevel"]?.Value;
+
+                        switch (accessLevel)
+                        {
+                            case "read":
+                                permittedDataActions |= DataActions.Read;
+                                break;
+                            case "write":
+                                permittedDataActions |= DataActions.Write;
+                                break;
+                            case "*":
+                                permittedDataActions |= DataActions.Read | DataActions.Write;
+                                break;
+                        }
+
+                        if (!string.IsNullOrEmpty(resource)
+                            && !string.IsNullOrEmpty(id))
+                        {
+                            fhirRequestContext.AccessControlContext.AllowedResourceActions.Add(new ScopeRestriction(resource, permittedDataActions, id));
+                        }
+                    }
+                }
+            }
+
+            // Call the next delegate/middleware in the pipeline
+            await _next(context);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Configs/AuthorizationConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/AuthorizationConfiguration.cs
@@ -16,5 +16,7 @@ namespace Microsoft.Health.Fhir.Core.Configs
         public bool Enabled { get; set; }
 
         public IReadOnlyList<Role> Roles { get; internal set; } = ImmutableList<Role>.Empty;
+
+        public string ScopesClaim { get; set; } = "scp";
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Context/AccessControlContext.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Context/AccessControlContext.cs
@@ -1,0 +1,27 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Health.Fhir.Core.Features.Context
+{
+    public class AccessControlContext
+    {
+        // Value indicated whether or not fine grained access control policies should be applied
+        public bool ApplyFineGrainedAccessControl { get; set; }
+
+        // the string values that were passed in as scopes
+        public ICollection<string> ClinicalScopes { get; } = new List<string>();
+
+        // A collection of the allowed resource types and which action is allowed on that type
+        public ICollection<ScopeRestriction> AllowedResourceActions { get; } = new List<ScopeRestriction>();
+
+        /// <summary>
+        /// A uri which points to a specific fhir resource in this Fhir server, and is associated with the current user
+        /// </summary>
+        public Uri FhirUserClaim { get; set; }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Context/AccessControlContext.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Context/AccessControlContext.cs
@@ -10,13 +10,19 @@ namespace Microsoft.Health.Fhir.Core.Features.Context
 {
     public class AccessControlContext
     {
-        // Value indicated whether or not fine grained access control policies should be applied
+        /// <summary>
+        /// Value indicated whether or not fine grained access control policies should be applied
+        /// </summary>
         public bool ApplyFineGrainedAccessControl { get; set; }
 
-        // the string values that were passed in as scopes
+        /// <summary>
+        /// the string values that were passed in as scopes
+        /// </summary>
         public ICollection<string> ClinicalScopes { get; } = new List<string>();
 
-        // A collection of the allowed resource types and which action is allowed on that type
+        /// <summary>
+        /// A collection of the allowed resource types and which action is allowed on that type
+        /// </summary>
         public ICollection<ScopeRestriction> AllowedResourceActions { get; } = new List<ScopeRestriction>();
 
         /// <summary>

--- a/src/Microsoft.Health.Fhir.Core/Features/Context/FhirRequestContext.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Context/FhirRequestContext.cs
@@ -73,5 +73,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Context
         public bool IsBackgroundTask { get; set; }
 
         public IDictionary<string, object> Properties => _properties ??= new Dictionary<string, object>();
+
+        public AccessControlContext AccessControlContext { get; set; } = new AccessControlContext();
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Context/IFhirRequestContext.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Context/IFhirRequestContext.cs
@@ -34,5 +34,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Context
         /// A weakly-typed property bag that can be used for communication between components in the context of a request.
         /// </summary>
         IDictionary<string, object> Properties { get; }
+
+        /// <summary>
+        /// Data informing the service how to apply fine grained access control
+        /// </summary>
+        AccessControlContext AccessControlContext { get; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Context/ScopeRestriction.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Context/ScopeRestriction.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using EnsureThat;
 using Microsoft.Health.Fhir.Core.Features.Security;
 
 namespace Microsoft.Health.Fhir.Core.Features.Context
@@ -12,6 +13,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Context
     {
         public ScopeRestriction(string resource, DataActions allowedAction, string user)
         {
+            EnsureArg.IsNotNull(resource, nameof(resource));
+
             Resource = resource;
             AllowedDataAction |= allowedAction;
             User = user;

--- a/src/Microsoft.Health.Fhir.Core/Features/Context/ScopeRestriction.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Context/ScopeRestriction.cs
@@ -1,0 +1,50 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.Health.Fhir.Core.Features.Security;
+
+namespace Microsoft.Health.Fhir.Core.Features.Context
+{
+    public class ScopeRestriction : IEquatable<ScopeRestriction>
+    {
+        public ScopeRestriction(string resource, DataActions allowedAction, string user)
+        {
+            Resource = resource;
+            AllowedDataAction |= allowedAction;
+            User = user;
+        }
+
+        public string Resource { get; }
+
+        // Indictes whether access to a resource should be restricted to the User, Patient or System levels
+        public string User { get; }
+
+        // read, write or both
+        public DataActions AllowedDataAction { get; }
+
+        public bool Equals(ScopeRestriction other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            return string.Equals(Resource, other.Resource, StringComparison.Ordinal) &&
+                   string.Equals(User, other.User, StringComparison.Ordinal) &&
+                   AllowedDataAction == other.AllowedDataAction;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as ScopeRestriction);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Resource, User, AllowedDataAction);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
@@ -1,0 +1,78 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Health.Core.Features.Context;
+using Microsoft.Health.Fhir.Api.Features.Smart;
+using Microsoft.Health.Fhir.Core.Configs;
+using Microsoft.Health.Fhir.Core.Features.Context;
+using Microsoft.Health.Fhir.Core.Features.Security;
+using Microsoft.Health.Fhir.Core.UnitTests.Features.Context;
+using NSubstitute;
+using Xunit;
+using Claim = System.Security.Claims.Claim;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
+{
+    public class SmartClinicalScopesMiddlewareTests
+    {
+        private readonly SmartClinicalScopesMiddleware _smartClinicalScopesMiddleware;
+
+        public SmartClinicalScopesMiddlewareTests()
+        {
+            _smartClinicalScopesMiddleware = new SmartClinicalScopesMiddleware(
+                httpContext => Task.CompletedTask);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestScopes))]
+        public async Task GivenSMARTScope_WhenInvoked_ThenScopeParsedandAddedtoContext(string scopes, ICollection<ScopeRestriction> expectedScopeRestrictions)
+        {
+            var fhirRequestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
+
+            var fhirRequestContext = new DefaultFhirRequestContext();
+
+            fhirRequestContextAccessor.RequestContext.Returns(fhirRequestContext);
+
+            HttpContext httpContext = new DefaultHttpContext();
+
+            var authorizationConfiguration = new AuthorizationConfiguration();
+            authorizationConfiguration.Enabled = true;
+
+            var scopesClaim = new Claim(authorizationConfiguration.ScopesClaim, scopes);
+            var claimsIdentity = new ClaimsIdentity(new List<Claim>() { scopesClaim });
+            var expectedPrincipal = new ClaimsPrincipal(claimsIdentity);
+
+            httpContext.User = expectedPrincipal;
+            fhirRequestContext.Principal = expectedPrincipal;
+
+            await _smartClinicalScopesMiddleware.Invoke(httpContext, fhirRequestContextAccessor, authorizationConfiguration);
+
+            Assert.Equal(expectedScopeRestrictions, fhirRequestContext.AccessControlContext.AllowedResourceActions);
+        }
+
+        public static IEnumerable<object[]> GetTestScopes()
+        {
+            yield return new object[] { "patient/Patient.read", new List<ScopeRestriction>() { new ScopeRestriction("Patient", DataActions.Read, "patient") } };
+            yield return new object[]
+            {
+                "patient/Patient.read patient/Observation.read",
+                new List<ScopeRestriction>()
+                {
+                    new ScopeRestriction("Patient", DataActions.Read, "patient"),
+                    new ScopeRestriction("Observation", DataActions.Read, "patient"),
+                },
+            };
+
+            yield return new object[] { "user/*.*", new List<ScopeRestriction>() { new ScopeRestriction("*", DataActions.Read | DataActions.Write, "user") } };
+            yield return new object[] { "user/Encounter.*", new List<ScopeRestriction>() { new ScopeRestriction("Encounter", DataActions.Read | DataActions.Write, "user") } };
+            yield return new object[] { "patient.Patient.read", new List<ScopeRestriction>() { new ScopeRestriction("Patient", DataActions.Read, "patient") } };
+            yield return new object[] { "patient.*.read", new List<ScopeRestriction>() { new ScopeRestriction("*", DataActions.Read, "patient") } };
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
@@ -73,6 +73,38 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
             yield return new object[] { "user/Encounter.*", new List<ScopeRestriction>() { new ScopeRestriction("Encounter", DataActions.Read | DataActions.Write, "user") } };
             yield return new object[] { "patient.Patient.read", new List<ScopeRestriction>() { new ScopeRestriction("Patient", DataActions.Read, "patient") } };
             yield return new object[] { "patient.*.read", new List<ScopeRestriction>() { new ScopeRestriction("*", DataActions.Read, "patient") } };
+            yield return new object[]
+            {
+                "patient$Patient.read practitioner/Observation.write",
+                new List<ScopeRestriction>()
+                {
+                    new ScopeRestriction("Patient", DataActions.Read, "patient"),
+                },
+            };
+            yield return new object[]
+            {
+                "patient$Patient.rd practitioner/Observation.wr",
+                new List<ScopeRestriction>()
+                {
+                },
+            };
+            yield return new object[]
+            {
+                "User$Patient.read patient/Observation.wr",
+                new List<ScopeRestriction>()
+                {
+                },
+            };
+            yield return new object[]
+            {
+                "patient/Patient.read launch/patient user/Observation.read offline_access openid user/Encounter.* fhirUser",
+                new List<ScopeRestriction>()
+                {
+                    new ScopeRestriction("Patient", DataActions.Read, "patient"),
+                    new ScopeRestriction("Observation", DataActions.Read, "user"),
+                    new ScopeRestriction("Encounter", DataActions.Read | DataActions.Write, "user"),
+                },
+            };
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Microsoft.Health.Fhir.Shared.Api.UnitTests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Microsoft.Health.Fhir.Shared.Api.UnitTests.projitems
@@ -58,6 +58,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Routing\RouteTestBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Routing\UrlResolverTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Security\RequestHandlerCheckAccessTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\SMART\SmartClinicalScopesMiddlewareTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Throttling\ThrottlingMiddlewareTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.Health.Fhir.Shared.Tests/Context/DefaultFhirRequestContext.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Tests/Context/DefaultFhirRequestContext.cs
@@ -43,5 +43,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Context
         public bool IsBackgroundTask { get; set; }
 
         public IDictionary<string, object> Properties { get; } = new Dictionary<string, object>();
+
+        public AccessControlContext AccessControlContext { get; set; } = new AccessControlContext();
     }
 }


### PR DESCRIPTION
## Description
Read the SMART clinical scopes from the claims of user principal.  Parses the resources, user and data action from the scopes and adds them to the FhirRequestContext

## Related issues
Addresses [issue AB#95435].

## Testing
Unit tests were added.  E2E tests will be added once more of the overall scenario is complete.

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [X] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
