### PR TITLE
Enable Reindex in tests

### DIFF
--- a/build/ci-deploy.yml
+++ b/build/ci-deploy.yml
@@ -97,6 +97,7 @@ stages:
       testEnvironmentUrl: $(TestApplicationResource)
       imageTag: $(ImageTag)
       schemaAutomaticUpdatesEnabled: 'auto'
+      reindexEnabled: true
 
 - stage: deployR4
   displayName: 'Deploy R4 Site'
@@ -134,6 +135,7 @@ stages:
       testEnvironmentUrl: $(TestApplicationResource)
       imageTag: $(ImageTag)
       schemaAutomaticUpdatesEnabled: 'auto'
+      reindexEnabled: true
 
 - stage: deployR5
   displayName: 'Deploy R5 Site'
@@ -171,3 +173,4 @@ stages:
       testEnvironmentUrl: $(TestApplicationResource)
       imageTag: $(ImageTag)
       schemaAutomaticUpdatesEnabled: 'auto'
+      reindexEnabled: true

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -24,7 +24,7 @@ parameters:
   default: 'tool'
 - name: reindexEnabled
   type: boolean
-  default: false
+  default: true
 
 jobs:
 - job: provisionEnvironment


### PR DESCRIPTION
## Description
Reindex wasn't enabled on the CI SQL servers and this started failing tests.

## Related issues
Addresses failing CI builds.

## Testing
CI is running with reindex enabled.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip (Build job related changes)
