### PR TITLE
Update smart middleware to use security config

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
@@ -8,6 +8,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features.Context;
@@ -32,10 +33,12 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
             _next = next;
         }
 
-        public async Task Invoke(HttpContext context, RequestContextAccessor<IFhirRequestContext> fhirRequestContextAccessor, AuthorizationConfiguration authorizationConfiguration)
+        public async Task Invoke(HttpContext context, RequestContextAccessor<IFhirRequestContext> fhirRequestContextAccessor, IOptions<SecurityConfiguration> securityConfigurationOptions)
         {
             EnsureArg.IsNotNull(fhirRequestContextAccessor, nameof(fhirRequestContextAccessor));
-            EnsureArg.IsNotNull(authorizationConfiguration, nameof(authorizationConfiguration));
+            EnsureArg.IsNotNull(securityConfigurationOptions, nameof(securityConfigurationOptions));
+
+            var authorizationConfiguration = securityConfigurationOptions.Value.Authorization;
 
             if (fhirRequestContextAccessor.RequestContext.Principal != null
                 && authorizationConfiguration.Enabled)

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
@@ -6,9 +6,10 @@
 using System.Collections.Generic;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 using Microsoft.Health.Core.Features.Context;
+using Microsoft.Health.Fhir.Api.Configs;
 using Microsoft.Health.Fhir.Api.Features.Smart;
-using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Security;
 using Microsoft.Health.Fhir.Core.UnitTests.Features.Context;
@@ -45,7 +46,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
 
             HttpContext httpContext = new DefaultHttpContext();
 
-            var authorizationConfiguration = new AuthorizationConfiguration();
+            var fhirConfiguration = new FhirServerConfiguration();
+            var authorizationConfiguration = fhirConfiguration.Security.Authorization;
             authorizationConfiguration.Enabled = true;
 
             var scopesClaim = new Claim(authorizationConfiguration.ScopesClaim, scopes);
@@ -55,7 +57,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
             httpContext.User = expectedPrincipal;
             fhirRequestContext.Principal = expectedPrincipal;
 
-            await _smartClinicalScopesMiddleware.Invoke(httpContext, fhirRequestContextAccessor, authorizationConfiguration);
+            await _smartClinicalScopesMiddleware.Invoke(httpContext, fhirRequestContextAccessor, Options.Create(fhirConfiguration.Security));
 
             Assert.Equal(expectedScopeRestrictions, fhirRequestContext.AccessControlContext.AllowedResourceActions);
         }


### PR DESCRIPTION
## Description
FHIR server will not run with authentication set to false due to SMART middleware requesting non-existent authorization config.
This PR changes the middleware to use security configuration which is available.

## Related issues
Addresses [issue AB#96061].

## Testing
Manually tested.

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [X] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [X] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
