### PR TITLE
[Tests] Improve FhirException details during pipeline executions

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Client/FhirException.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Client/FhirException.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Text;
 using Hl7.Fhir.Model;
 
 namespace Microsoft.Health.Fhir.Client
@@ -29,7 +30,7 @@ namespace Microsoft.Health.Fhir.Client
 
         public OperationOutcome OperationOutcome => Response.Resource;
 
-        public override string Message => $"{StatusCode}: {OperationOutcome?.Issue?.FirstOrDefault()?.Diagnostics} ({GetOperationId()})";
+        public override string Message => FormatMessage();
 
         public void Dispose()
         {
@@ -46,6 +47,31 @@ namespace Microsoft.Health.Fhir.Client
             }
         }
 
+        private string FormatMessage()
+        {
+            StringBuilder message = new StringBuilder();
+
+            string diagnostic = OperationOutcome?.Issue?.FirstOrDefault()?.Diagnostics;
+            string operationId = GetOperationId();
+
+            message.Append(StatusCode);
+            if (!string.IsNullOrWhiteSpace(diagnostic))
+            {
+                message.Append(": ").Append(diagnostic);
+            }
+
+            message.Append(" (").Append(operationId).Append(')');
+
+            message.AppendLine("==============================================");
+            message.Append("Url: ").AppendLine(Response.Response.RequestMessage?.RequestUri.ToString() ?? "NO_URI_AVAILABLE");
+            message.Append("Response code: ").AppendLine(Response.Response.StatusCode.ToString());
+            message.Append("Reason phrase: ").AppendLine(Response.Response.ReasonPhrase ?? "NO_REASON_PHRASE");
+
+            message.AppendLine("==============================================");
+
+            return message.ToString();
+        }
+
         private string GetOperationId()
         {
             if (Response.Headers.TryGetValues("X-Request-Id", out var values))
@@ -53,7 +79,7 @@ namespace Microsoft.Health.Fhir.Client
                 return values.First();
             }
 
-            return string.Empty;
+            return "NO_FHIR_OPERATION_ID_FOR_THIS_TRANSACTION";
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Client/FhirException.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Client/FhirException.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Health.Fhir.Client
             StringBuilder message = new StringBuilder();
 
             string diagnostic = OperationOutcome?.Issue?.FirstOrDefault()?.Diagnostics;
-            string operationId = GetOperationId();
+            string operationId = GetActivityId();
 
             message.Append(StatusCode);
             if (!string.IsNullOrWhiteSpace(diagnostic))
@@ -60,26 +60,26 @@ namespace Microsoft.Health.Fhir.Client
                 message.Append(": ").Append(diagnostic);
             }
 
-            message.Append(" (").Append(operationId).Append(')');
+            message.Append(" (").Append(operationId).AppendLine(")");
 
             message.AppendLine("==============================================");
-            message.Append("Url: ").AppendLine(Response.Response.RequestMessage?.RequestUri.ToString() ?? "NO_URI_AVAILABLE");
-            message.Append("Response code: ").AppendLine(Response.Response.StatusCode.ToString());
+            message.Append("Url: (").Append(Response.Response.RequestMessage?.Method.Method ?? "NO_HTTP_METHOD_AVAILABLE").Append(") ").AppendLine(Response.Response.RequestMessage?.RequestUri.ToString() ?? "NO_URI_AVAILABLE");
+            message.Append("Response code: ").Append(Response.Response.StatusCode.ToString()).Append('(').Append((int)Response.Response.StatusCode).AppendLine(")");
             message.Append("Reason phrase: ").AppendLine(Response.Response.ReasonPhrase ?? "NO_REASON_PHRASE");
-
+            message.Append("Timestamp: ").AppendLine(DateTime.UtcNow.ToString("o"));
             message.AppendLine("==============================================");
 
             return message.ToString();
         }
 
-        private string GetOperationId()
+        private string GetActivityId()
         {
             if (Response.Headers.TryGetValues("X-Request-Id", out var values))
             {
                 return values.First();
             }
 
-            return "NO_FHIR_OPERATION_ID_FOR_THIS_TRANSACTION";
+            return "NO_FHIR_ACTIVITY_ID_FOR_THIS_TRANSACTION";
         }
     }
 }


### PR DESCRIPTION
Improving FhirExcception details during pipeline executions: it's common to see "InternalServerError" errors during pipeline execution with no further details. These changes in the FhirExcception will provide more information, like the Uri being consumed, reason phrase, timestamp, etc. These changes will only affect Tests, and the FhirException **is not** used on the FHIR service.  
## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
