### PR TITLE
Fix dupliate profile issue in SQL

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
@@ -337,12 +337,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
 
         public ICapabilityStatementBuilder SyncProfiles(bool disableCacheRefresh = false)
         {
-            _statement.Profile.Clear();
-
             if (!disableCacheRefresh)
             {
                 _supportedProfiles.Refresh();
             }
+
+            // This line needs to come after the refresh because the refresh can trigger this method to run and can add duplicate values to the Profile in STU3.
+            _statement.Profile.Clear();
 
             foreach (string resource in _modelInfoProvider.GetResourceTypeNames())
             {


### PR DESCRIPTION
## Description
CI is failing because in STU3 the profiles can be duplicated in the metadata statement.

## Related issues
CI failing

## Testing
Issue was reproed locally and passed.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
