### PR TITLE
93624: Removed versionId from fullURL as per FHIR Spec

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/BundleFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/BundleFactory.cs
@@ -71,7 +71,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                 }
 #endif
 
-                // resource.FullUrlElement = new FhirUri(_urlResolver.ResolveResourceWrapperUrl(r.Resource, true));
                 resource.FullUrlElement = new FhirUri(_urlResolver.ResolveResourceWrapperUrl(r.Resource));
                 if (hasVerb)
                 {

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/BundleFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/BundleFactory.cs
@@ -70,7 +70,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                     httpVerb = Bundle.HTTPVerb.PUT;
                 }
 #endif
-                resource.FullUrlElement = new FhirUri(_urlResolver.ResolveResourceWrapperUrl(r.Resource, true));
+
+                // resource.FullUrlElement = new FhirUri(_urlResolver.ResolveResourceWrapperUrl(r.Resource, true));
+                resource.FullUrlElement = new FhirUri(_urlResolver.ResolveResourceWrapperUrl(r.Resource));
                 if (hasVerb)
                 {
                     resource.Request = new Bundle.RequestComponent


### PR DESCRIPTION
## Description
Bundle response should not have versionId in fullURL.
Refer to section 2.36.4.2 Constraints  in http://hl7.org/fhir/bundle.html
Bundle response has a constraint where fullURL should not have version Id in it.
Touchstone test scripts are failing now.

## Related issues
[issue](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Olympus/Stories/?workitem=93624) 

## Testing
Before the fix:
Request to Patient history https://localhost:44348/Patient/4dfcad93-cb2b-4ea5-aa08-6ee66623c592/_history
returns Bundle response with fullURL looking like "fullUrl": "https://localhost:44348/Patient/4dfcad93-cb2b-4ea5-aa08-6ee66623c592/1",

After the fix:
"fullUrl": "https://localhost:44348/Patient/4dfcad93-cb2b-4ea5-aa08-6ee66623c592",
version Id is removed from fullURL.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
