### PR TITLE
Export tests can extract zip

### DIFF
--- a/build/jobs/e2e-tests-extract.yml
+++ b/build/jobs/e2e-tests-extract.yml
@@ -1,0 +1,10 @@
+parameters:
+- name: version
+  type: string
+
+steps:
+  - task: ExtractFiles@1
+    displayName: 'Extract E2E Test Binaries'
+    inputs:
+      archiveFilePatterns: '$(System.ArtifactsDirectory)/IntegrationTests/Microsoft.Health.Fhir.${{ parameters.version }}.Tests.E2E.zip'
+      destinationFolder: '$(Agent.TempDirectory)/E2ETests/'

--- a/build/jobs/e2e-tests.yml
+++ b/build/jobs/e2e-tests.yml
@@ -7,11 +7,9 @@ parameters:
   type: string
 
 steps:
-  - task: ExtractFiles@1
-    displayName: 'Extract E2E Test Binaries'
-    inputs:
-      archiveFilePatterns: '$(System.ArtifactsDirectory)/IntegrationTests/Microsoft.Health.Fhir.${{ parameters.version }}.Tests.E2E.zip'
-      destinationFolder: '$(Agent.TempDirectory)/E2ETests/'
+  - template: e2e-tests-extract.yml
+    parameters:
+      version: ${{parameters.version}}
 
   - task: AzurePowerShell@4
     displayName: 'Set Variables'

--- a/build/jobs/run-export-tests.yml
+++ b/build/jobs/run-export-tests.yml
@@ -12,6 +12,9 @@ jobs:
     vmImage: '$(LinuxVmImage)'
   steps:
   - template: e2e-setup.yml
+  - template: e2e-tests-extract.yml
+    parameters:
+      version: ${{parameters.version}}
 
   - task: AzurePowerShell@4
     displayName: 'Set Variables'
@@ -73,7 +76,7 @@ jobs:
     displayName: 'Export E2E ${{ parameters.version }} CosmosDB'
     inputs:
       command: test
-      arguments: '"**\*${{ parameters.version }}.Tests.E2E*.dll" --filter "FullyQualifiedName~CosmosDb&Category=ExportLongRunning"'
+      arguments: '"$(Agent.TempDirectory)/E2ETests/**/*${{ parameters.version }}.Tests.E2E*.dll" --filter "FullyQualifiedName~CosmosDb&Category=ExportLongRunning"'
       workingDirectory: "$(System.ArtifactsDirectory)"
       testRunTitle: 'Export ${{ parameters.version }} CosmosDB'
     env:
@@ -110,6 +113,9 @@ jobs:
     vmImage: '$(LinuxVmImage)'
   steps:
   - template: e2e-setup.yml
+  - template: e2e-tests-extract.yml
+    parameters:
+      version: ${{parameters.version}}
   
   - task: AzurePowerShell@4
     displayName: 'Set Variables'
@@ -171,7 +177,7 @@ jobs:
     displayName: 'Export E2E ${{ parameters.version }} SQL'
     inputs:
       command: test
-      arguments: '"**\*${{ parameters.version }}.Tests.E2E*.dll" --filter "FullyQualifiedName~SqlServer&Category=ExportLongRunning"'
+      arguments: '"$(Agent.TempDirectory)/E2ETests/**/*${{ parameters.version }}.Tests.E2E*.dll" --filter "FullyQualifiedName~SqlServer&Category=ExportLongRunning"'
       workingDirectory: "$(System.ArtifactsDirectory)"
       testRunTitle: 'Export ${{ parameters.version }} SQL'
     env:


### PR DESCRIPTION
## Description
To save time uploading e2e test assets these directories were zipped. This fixes the Bulk Export E2E tests by unzipping them before execution.

## Testing
Run in pipeline: https://microsofthealthoss.visualstudio.com/FhirServer/_build/results?buildId=24782&view=results

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
