### PR TITLE
Add fix for dispose

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/SystemConformanceProvider.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/SystemConformanceProvider.cs
@@ -154,8 +154,16 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
 
         public async ValueTask DisposeAsync()
         {
-            _cancellationTokenSource.Cancel();
-            await _rebuilder;
+            if (!_cancellationTokenSource.IsCancellationRequested)
+            {
+                _cancellationTokenSource.Cancel();
+            }
+
+            if (_rebuilder != null)
+            {
+                await _rebuilder;
+            }
+
             _cancellationTokenSource.Dispose();
             _rebuilder = null;
             _defaultCapabilitySemaphore?.Dispose();


### PR DESCRIPTION
## Description
Fixes exceptions thrown when references are null when dispose is called.

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [x] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
