### PR TITLE
93258: Status for R4 and Stu3 is changed to active where R5 will stay as "draft"

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
@@ -80,6 +80,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
                 Version = versionString,
             };
 
+            if (modelInfoProvider.Version.Equals(FhirSpecification.Stu3) || modelInfoProvider.Version.Equals(FhirSpecification.R4))
+            {
+                ((DefaultOptionHashSet<string>)statement.Status).DefaultOption = "active";
+            }
+
             statement.FhirVersion = modelInfoProvider.SupportedVersion.VersionString;
             statement.Date = ProductVersionInfo.CreationTime.ToString("O");
             return new CapabilityStatementBuilder(statement, modelInfoProvider, searchParameterDefinitionManager, configuration, supportedProfiles);


### PR DESCRIPTION
## Description
Status in CapabilityStatement returns as "draft" for all R4/R5 and Stu3 versions.
Requirement is to change Status for R4 and Stu3 to "active" and leaving R5 status as "draft".

## Related issues
[93258# ](https://microsofthealth.visualstudio.com/Health/_backlogs/backlog/Olympus/Stories/?workitem=93258)

## Testing
Called {{fhirURL}}/metadata for all three versions Stu3, R4 and R5.
Stu3 and R4 has "status": "active" and R5 has "status": "draft", in CapabilityStatement 

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with Azure API for FHIR if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with Azure Healthcare APIs if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
