### PR TITLE
Use Sql ErrorCode const instead of hard coding

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlExceptionActionProcessor.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlExceptionActionProcessor.cs
@@ -17,8 +17,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
     public class SqlExceptionActionProcessor<TRequest, TException> : IRequestExceptionAction<TRequest, TException>
         where TException : Exception
     {
-        private const short QueryProcessorNoQueryPlan = 8623;
-
         public Task Execute(TRequest request, TException exception, CancellationToken cancellationToken)
         {
             if (exception is SqlException sqlException)
@@ -31,7 +29,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                 {
                     throw new MethodNotAllowedException(Core.Resources.ResourceCreationNotAllowed);
                 }
-                else if (sqlException.Number == QueryProcessorNoQueryPlan)
+                else if (sqlException.Number == SqlErrorCodes.QueryProcessorNoQueryPlan)
                 {
                     throw new SqlQueryPlanException(Core.Resources.SqlQueryProcessorRanOutOfInternalResourcesException);
                 }


### PR DESCRIPTION
## Description
Removing the hard coded value for checking the sql exception number and instead using the SqlErrorCodes.QueryProcessorNoQueryPlan instead.

## Related issues
Addresses [#95860](https://microsofthealth.visualstudio.com/Health/_workitems/edit/95860).

## Testing
Tested locally by introducing sql that would throw the exception referenced.

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
