### PR TITLE
Origin/feature/smart/rajitha/restrict resource type

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Security/Authorization/SMARTScopeFhirAuthorizationService.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Security/Authorization/SMARTScopeFhirAuthorizationService.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Security.Authorization
             DataActions permittedDataActions = 0;
             foreach (ScopeRestriction scopeRestriction in allowedResourceActions)
             {
-                if (scopeRestriction.Resource == resourceRequested)
+                if (scopeRestriction.Resource == "*" || scopeRestriction.Resource == resourceRequested)
                 {
                     permittedDataActions |= scopeRestriction.AllowedDataAction;
                     if (permittedDataActions == dataActions)

--- a/src/Microsoft.Health.Fhir.Core/Features/Security/Authorization/SMARTScopeFhirAuthorizationService.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Security/Authorization/SMARTScopeFhirAuthorizationService.cs
@@ -1,0 +1,37 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Core.Features.Context;
+using Microsoft.Health.Fhir.Core.Features.Context;
+
+namespace Microsoft.Health.Fhir.Core.Features.Security.Authorization
+{
+    /// <summary>
+    /// determines access based on the SMART scope.
+    /// </summary>
+    public static class SMARTScopeFhirAuthorizationService
+    {
+        public static DataActions CheckSMARTScopeAccess(RequestContextAccessor<IFhirRequestContext> requestContextAccessor, DataActions dataActions)
+        {
+            var allowedResourceActions = requestContextAccessor.RequestContext.AccessControlContext.AllowedResourceActions;
+            var resourceRequested = requestContextAccessor.RequestContext.ResourceType;
+
+            DataActions permittedDataActions = 0;
+            foreach (ScopeRestriction scopeRestriction in allowedResourceActions)
+            {
+                if (scopeRestriction.Resource == resourceRequested)
+                {
+                    permittedDataActions |= scopeRestriction.AllowedDataAction;
+                    if (permittedDataActions == dataActions)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            return dataActions & permittedDataActions;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Security/Authorization/RoleBasedFhirAuthorizationServiceTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Security/Authorization/RoleBasedFhirAuthorizationServiceTests.cs
@@ -1,0 +1,164 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading;
+using Microsoft.Health.Core.Features.Context;
+using Microsoft.Health.Fhir.Api.Configs;
+using Microsoft.Health.Fhir.Core.Configs;
+using Microsoft.Health.Fhir.Core.Features.Context;
+using Microsoft.Health.Fhir.Core.Features.Security;
+using Microsoft.Health.Fhir.Core.Features.Security.Authorization;
+using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.Core.UnitTests.Features.Context;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Test.Utilities;
+using NSubstitute;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Security.Authorization
+{
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.SmartOnFhir)]
+    public class RoleBasedFhirAuthorizationServiceTests
+    {
+        private readonly RoleBasedFhirAuthorizationService _roleBasedFhirAuthorizationService;
+        private readonly RequestContextAccessor<IFhirRequestContext> _fhirRequestContextAccessor;
+        private readonly AuthorizationConfiguration _authorizationConfiguration;
+
+        public RoleBasedFhirAuthorizationServiceTests()
+        {
+            var fhirConfiguration = new FhirServerConfiguration();
+            _authorizationConfiguration = fhirConfiguration.Security.Authorization;
+            _authorizationConfiguration.Enabled = true;
+            List<Role> roles = new List<Role>();
+            roles.Add(new Role("Read", DataActions.Read, "/"));
+            roles.Add(new Role("Write", DataActions.Write, "/"));
+            _authorizationConfiguration.Roles = roles;
+
+            _fhirRequestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
+
+            _roleBasedFhirAuthorizationService = new RoleBasedFhirAuthorizationService(
+                _authorizationConfiguration, _fhirRequestContextAccessor);
+        }
+
+        [Fact]
+        public async Task GivenUserReadDA_WhenInvoked_ForReadDA_NoSMARTScope_ThenReturnedReadDataAction()
+        {
+            var defaultFhirRequestContext = new DefaultFhirRequestContext();
+            defaultFhirRequestContext.AccessControlContext.ApplyFineGrainedAccessControl = false;
+
+            var claims = new List<Claim>();
+            claims.Add(new Claim("roles", "Read"));
+            var expectedPrincipal = new ClaimsPrincipal(new ClaimsIdentity(claims));
+
+            defaultFhirRequestContext.Principal = expectedPrincipal;
+            _fhirRequestContextAccessor.RequestContext.Returns(defaultFhirRequestContext);
+
+            var result = await _roleBasedFhirAuthorizationService.CheckAccess(DataActions.Read, CancellationToken.None);
+            Assert.Equal(DataActions.Read, result);
+        }
+
+        [Fact]
+        public async Task GivenUserReadDA_WhenInvoked_ForWriteDA_NoSMARTScope_ThenReturnedNoneDataAction()
+        {
+            var defaultFhirRequestContext = new DefaultFhirRequestContext();
+            defaultFhirRequestContext.AccessControlContext.ApplyFineGrainedAccessControl = false;
+
+            var claims = new List<Claim>();
+            claims.Add(new Claim("roles", "Read"));
+            var expectedPrincipal = new ClaimsPrincipal(new ClaimsIdentity(claims));
+
+            defaultFhirRequestContext.Principal = expectedPrincipal;
+            _fhirRequestContextAccessor.RequestContext.Returns(defaultFhirRequestContext);
+
+            var result = await _roleBasedFhirAuthorizationService.CheckAccess(DataActions.Write, CancellationToken.None);
+            Assert.Equal(DataActions.None, result);
+        }
+
+        [Fact]
+        public async Task GivenUserReadDA_WhenInvokedForPatientRead_SMARTScopePatientRead_ThenReturnedReadDataAction()
+        {
+            var defaultFhirRequestContext = new DefaultFhirRequestContext();
+            defaultFhirRequestContext.AccessControlContext.ApplyFineGrainedAccessControl = true;
+
+            var claims = new List<Claim>();
+            claims.Add(new Claim("roles", "Read"));
+            var expectedPrincipal = new ClaimsPrincipal(new ClaimsIdentity(claims));
+
+            defaultFhirRequestContext.ResourceType = KnownResourceTypes.Patient;
+            defaultFhirRequestContext.Principal = expectedPrincipal;
+
+            _fhirRequestContextAccessor.RequestContext.Returns(defaultFhirRequestContext);
+            _fhirRequestContextAccessor.RequestContext.AccessControlContext.AllowedResourceActions.Add(new ScopeRestriction(KnownResourceTypes.Patient, DataActions.Read, "user1"));
+
+            var result = await _roleBasedFhirAuthorizationService.CheckAccess(DataActions.Read, CancellationToken.None);
+            Assert.Equal(DataActions.Read, result);
+        }
+
+        [Fact]
+        public async Task GivenUserReadDA_WhenInvokedForPatientRead_SMARTScopeMedicationRead_ThenReturnedNoneDataAction()
+        {
+            var defaultFhirRequestContext = new DefaultFhirRequestContext();
+            defaultFhirRequestContext.AccessControlContext.ApplyFineGrainedAccessControl = true;
+
+            var claims = new List<Claim>();
+            claims.Add(new Claim("roles", "Read"));
+            var expectedPrincipal = new ClaimsPrincipal(new ClaimsIdentity(claims));
+
+            defaultFhirRequestContext.ResourceType = KnownResourceTypes.Patient;
+            defaultFhirRequestContext.Principal = expectedPrincipal;
+
+            _fhirRequestContextAccessor.RequestContext.Returns(defaultFhirRequestContext);
+            _fhirRequestContextAccessor.RequestContext.AccessControlContext.AllowedResourceActions.Add(new ScopeRestriction(KnownResourceTypes.Medication, DataActions.Read, "user1"));
+
+            var result = await _roleBasedFhirAuthorizationService.CheckAccess(DataActions.Read, CancellationToken.None);
+            Assert.Equal(DataActions.None, result);
+        }
+
+        [Fact]
+        public async Task GivenUserWriteDA_WhenInvokedForPatientWrite_SMARTScopePatientRead_ThenReturnedNoneDataAction()
+        {
+            var defaultFhirRequestContext = new DefaultFhirRequestContext();
+            defaultFhirRequestContext.AccessControlContext.ApplyFineGrainedAccessControl = true;
+
+            var claims = new List<Claim>();
+            claims.Add(new Claim("roles", "Write"));
+            var expectedPrincipal = new ClaimsPrincipal(new ClaimsIdentity(claims));
+
+            defaultFhirRequestContext.ResourceType = KnownResourceTypes.Patient;
+            defaultFhirRequestContext.Principal = expectedPrincipal;
+
+            _fhirRequestContextAccessor.RequestContext.Returns(defaultFhirRequestContext);
+            _fhirRequestContextAccessor.RequestContext.AccessControlContext.AllowedResourceActions.Add(new ScopeRestriction(KnownResourceTypes.Patient, DataActions.Read, "user1"));
+
+            var result = await _roleBasedFhirAuthorizationService.CheckAccess(DataActions.Write, CancellationToken.None);
+            Assert.Equal(DataActions.None, result);
+        }
+
+        [Fact]
+        public async Task GivenUserWriteDA_WhenInvokedForPatientWrite_SMARTScopePatientReadAndWrite_ThenReturnedWriteDataAction()
+        {
+            var defaultFhirRequestContext = new DefaultFhirRequestContext();
+            defaultFhirRequestContext.AccessControlContext.ApplyFineGrainedAccessControl = true;
+
+            var claims = new List<Claim>();
+            claims.Add(new Claim("roles", "Write"));
+            var expectedPrincipal = new ClaimsPrincipal(new ClaimsIdentity(claims));
+
+            defaultFhirRequestContext.ResourceType = KnownResourceTypes.Patient;
+            defaultFhirRequestContext.Principal = expectedPrincipal;
+
+            _fhirRequestContextAccessor.RequestContext.Returns(defaultFhirRequestContext);
+            _fhirRequestContextAccessor.RequestContext.AccessControlContext.AllowedResourceActions.Add(new ScopeRestriction(KnownResourceTypes.Patient, DataActions.Read, "user1"));
+            _fhirRequestContextAccessor.RequestContext.AccessControlContext.AllowedResourceActions.Add(new ScopeRestriction(KnownResourceTypes.Patient, DataActions.Write, "user1"));
+
+            var result = await _roleBasedFhirAuthorizationService.CheckAccess(DataActions.Write, CancellationToken.None);
+            Assert.Equal(DataActions.Write, result);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Security/Authorization/RoleBasedFhirAuthorizationServiceTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Security/Authorization/RoleBasedFhirAuthorizationServiceTests.cs
@@ -160,5 +160,25 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Security.Authorization
             var result = await _roleBasedFhirAuthorizationService.CheckAccess(DataActions.Write, CancellationToken.None);
             Assert.Equal(DataActions.Write, result);
         }
+
+        [Fact]
+        public async Task GivenUserReadDA_WhenInvokedForPatientRead_SMARTScopeAllResourcesRead_ThenReturnedReadDataAction()
+        {
+            var defaultFhirRequestContext = new DefaultFhirRequestContext();
+            defaultFhirRequestContext.AccessControlContext.ApplyFineGrainedAccessControl = true;
+
+            var claims = new List<Claim>();
+            claims.Add(new Claim("roles", "Read"));
+            var expectedPrincipal = new ClaimsPrincipal(new ClaimsIdentity(claims));
+
+            defaultFhirRequestContext.ResourceType = KnownResourceTypes.Patient;
+            defaultFhirRequestContext.Principal = expectedPrincipal;
+
+            _fhirRequestContextAccessor.RequestContext.Returns(defaultFhirRequestContext);
+            _fhirRequestContextAccessor.RequestContext.AccessControlContext.AllowedResourceActions.Add(new ScopeRestriction("*", DataActions.Read, "user1"));
+
+            var result = await _roleBasedFhirAuthorizationService.CheckAccess(DataActions.Read, CancellationToken.None);
+            Assert.Equal(DataActions.Read, result);
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
@@ -35,6 +35,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\ExtensionToTokenSearchValueConverterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\ExtensionToUriSearchValueConverterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\TypedElementSearchIndexerTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Security\Authorization\RoleBasedFhirAuthorizationServiceTests.cs" />
     <Compile Include="..\Microsoft.Health.Fhir.Shared.Core.UnitTests\Features\Persistence\ResourceWrapperFactoryTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\Converters\AddressToStringSearchValueConverterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\Converters\BooleanToBooleanSearchValueConverterTests.cs" />


### PR DESCRIPTION
## Description
Extended existing Role Based authorization in OSS to perform SMART scope restrictions against Resource Type.

## Related issues
[Addresses [95438]](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Olympus/Stories/?workitem=95438)

## Testing
Created RoleBasedFhirAuthorizationServiceTests Unit tests.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
