### PR TITLE
Fixes PatchResourceHandler to pass through client supplied Etag

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/Patch/PatchResourceHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/Patch/PatchResourceHandlerTests.cs
@@ -1,0 +1,85 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
+using MediatR;
+using Microsoft.Health.Core.Features.Security.Authorization;
+using Microsoft.Health.Fhir.Core.Exceptions;
+using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Microsoft.Health.Fhir.Core.Features.Resources.Patch;
+using Microsoft.Health.Fhir.Core.Features.Security;
+using Microsoft.Health.Fhir.Core.Messages.Patch;
+using Microsoft.Health.Fhir.Core.Messages.Upsert;
+using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Test.Utilities;
+using NSubstitute;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Resources.Patch;
+
+[Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+[Trait(Traits.Category, Categories.Patch)]
+public class PatchResourceHandlerTests
+{
+    private readonly PatchResourceHandler _patchHandler;
+    private readonly IMediator _mediator;
+
+    public PatchResourceHandlerTests()
+    {
+        IAuthorizationService<DataActions> authService = Substitute.For<IAuthorizationService<DataActions>>();
+        IFhirDataStore fhirDataStore = Substitute.For<IFhirDataStore>();
+        _mediator = Substitute.For<IMediator>();
+
+        _patchHandler = Mock.TypeWithArguments<PatchResourceHandler>(_mediator, authService, fhirDataStore);
+
+        authService
+            .CheckAccess(Arg.Any<DataActions>(), CancellationToken.None)
+            .Returns(x => ValueTask.FromResult((DataActions)x[0]));
+
+        ResourceElement patient = Samples.GetDefaultPatient().UpdateVersion("1");
+
+        var wrapper = new ResourceWrapper(
+            patient,
+            new RawResource(patient.Instance.ToJson(), FhirResourceFormat.Json, false),
+            new ResourceRequest(HttpMethod.Get),
+            false,
+            null,
+            null,
+            null);
+
+        fhirDataStore.GetAsync(Arg.Any<ResourceKey>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(wrapper));
+    }
+
+    [Fact]
+    public async Task GivenAPatchResourceHandler_WhenHandlingAPatchResourceRequestWithETag_ThenTheRequestIsForwardedToTheMediator()
+    {
+        var etag = WeakETag.FromWeakETag("W/\"1\"");
+
+        var request = new PatchResourceRequest(new ResourceKey("Patient", "123"), new FhirPathPatchPayload(new Parameters()), etag);
+        await _patchHandler.Handle(request, CancellationToken.None);
+
+        await _mediator
+            .Received()
+            .Send<UpsertResourceResponse>(Arg.Is<UpsertResourceRequest>(x => x.WeakETag.VersionId == etag.VersionId), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GivenAPatchResourceHandler_WhenHandlingAPatchResourceRequestWithMismatchingETag_ThenTheAnExceptionIsThrown()
+    {
+        var etag = WeakETag.FromWeakETag("W/\"2\"");
+
+        var request = new PatchResourceRequest(new ResourceKey("Patient", "123"), new FhirPathPatchPayload(new Parameters()), etag);
+
+        await Assert.ThrowsAsync<PreconditionFailedException>(async () => await _patchHandler.Handle(request, CancellationToken.None));
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
@@ -24,6 +24,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\Export\GroupMemberExtractorTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Create\CreateResourceValidatorTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\MemberMatch\MemberMatchResourceValidatorTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Patch\PatchResourceHandlerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\ResourceHandlerTests_ConditionalDelete.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\Converters\RangeToNumberSearchValueConverterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\Converters\RangeToQuantitySearchValueConverterTests.cs" />

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Patch/PatchResourceHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Patch/PatchResourceHandler.cs
@@ -15,6 +15,7 @@ using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Security;
 using Microsoft.Health.Fhir.Core.Messages.Patch;
 using Microsoft.Health.Fhir.Core.Messages.Upsert;
+using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Core.Features.Resources.Patch
 {
@@ -67,8 +68,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Patch
                 throw new PreconditionFailedException(string.Format(Core.Resources.ResourceVersionConflict, request.WeakETag.VersionId));
             }
 
-            var patchedResource = request.Payload.Patch(currentDoc);
-            return await _mediator.Send<UpsertResourceResponse>(new UpsertResourceRequest(patchedResource), cancellationToken);
+            ResourceElement patchedResource = request.Payload.Patch(currentDoc);
+            return await _mediator.Send<UpsertResourceResponse>(new UpsertResourceRequest(patchedResource, request.WeakETag), cancellationToken);
         }
     }
 }


### PR DESCRIPTION
## Description
Fixes PatchResourceHandler to pass through client supplied Etag

## Related issues
Addresses #2877.

## Testing
Adds unit tests

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch (Bug fix)
