### PR TITLE
Fixes rawResourceStream isn't always disposed

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -363,18 +363,18 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                             out Stream rawResourceStream);
                         numberOfColumnsRead = reader.FieldCount;
 
-                        // If we get to this point, we know there are more results so we need a continuation token
-                        // Additionally, this resource shouldn't be included in the results
-                        if (matchCount >= clonedSearchOptions.MaxItemCount && isMatch)
-                        {
-                            moreResults = true;
-
-                            continue;
-                        }
-
                         string rawResource;
-                        using (rawResourceStream)
+                        await using (rawResourceStream)
                         {
+                            // If we get to this point, we know there are more results so we need a continuation token
+                            // Additionally, this resource shouldn't be included in the results
+                            if (matchCount >= clonedSearchOptions.MaxItemCount && isMatch)
+                            {
+                                moreResults = true;
+
+                                continue;
+                            }
+
                             rawResource = _compressedRawResourceConverter.ReadCompressedRawResource(rawResourceStream);
                         }
 


### PR DESCRIPTION
## Description
When `continue` is called the `rawResourceStream` doesn't get disposed.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
