### PR TITLE
Update System.Drawing.Common to address component governance alert

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Microsoft.Health.Fhir.Core.csproj
+++ b/src/Microsoft.Health.Fhir.Core/Microsoft.Health.Fhir.Core.csproj
@@ -59,6 +59,10 @@
     <PackageReference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
+    <!-- Transitive Dependency of Microsoft.Health.SqlServer. Fixing version to mitigate CVE -->
+    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\Microsoft.Health.TaskManagement\Microsoft.Health.TaskManagement.csproj" />
     <ProjectReference Include="..\Microsoft.Health.Fhir.ValueSets\Microsoft.Health.Fhir.ValueSets.csproj" />
   </ItemGroup>

--- a/src/Microsoft.Health.Fhir.SchemaManager/Microsoft.Health.Fhir.SchemaManager.csproj
+++ b/src/Microsoft.Health.Fhir.SchemaManager/Microsoft.Health.Fhir.SchemaManager.csproj
@@ -21,6 +21,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Transitive Dependency of Microsoft.Health.SqlServer. Fixing version to mitigate CVE -->
+    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Microsoft.Health.Fhir.SqlServer\Microsoft.Health.Fhir.SqlServer.csproj" />
   </ItemGroup>
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Microsoft.Health.Fhir.SqlServer.csproj
+++ b/src/Microsoft.Health.Fhir.SqlServer/Microsoft.Health.Fhir.SqlServer.csproj
@@ -18,6 +18,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Transitive Dependency of Microsoft.SqlServer.SqlManagementObjects. Fixing version to mitigate CVE -->
+    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <EmbeddedResource Include="Features\Schema\Migrations\*.diff.sql" />
     <EmbeddedResource Include="Features\Schema\Migrations\*.sql" Exclude="Features\Schema\Migrations\*.diff.sql">
       <InputToImmutableSqlGenerator>true</InputToImmutableSqlGenerator>


### PR DESCRIPTION
## Description
Update System.Drawing.Common to address component governance alert

## Related issues
Addresses [issue AB#97813].

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [X] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
