### PR TITLE
Use DataAction check to test for Smart user status

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
@@ -15,6 +15,7 @@ using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Security;
+using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Api.Features.Smart
 {
@@ -26,7 +27,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
         private readonly RequestDelegate _next;
 
         // Regex based on SMART on FHIR clinical scopes v1.0, http://hl7.org/fhir/smart-app-launch/1.0.0/scopes-and-launch-context/index.html#clinical-scope-syntax
-        private static readonly Regex ClinicalScopeRegEx = new Regex(@"(^|\s+)(?<id>patient|user)(/|\$|.)(?<resource>\*|([a-zA-Z]*))\.(?<accessLevel>read|write|\*)", RegexOptions.Compiled);
+        private static readonly Regex ClinicalScopeRegEx = new Regex(@"(^|\s+)(?<id>patient|user)(/|\$|\.)(?<resource>\*|([a-zA-Z]*)|all)\.(?<accessLevel>read|write|\*|all)", RegexOptions.Compiled);
 
         public SmartClinicalScopesMiddleware(RequestDelegate next)
         {
@@ -90,6 +91,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
                                     permittedDataActions |= DataActions.Write;
                                     break;
                                 case "*":
+                                case KnownResourceTypes.All:
                                     permittedDataActions |= DataActions.Read | DataActions.Write;
                                     break;
                             }
@@ -97,6 +99,11 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
                             if (!string.IsNullOrEmpty(resource)
                                 && !string.IsNullOrEmpty(id))
                             {
+                                if (resource.Equals("*", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    resource = KnownResourceTypes.All;
+                                }
+
                                 fhirRequestContext.AccessControlContext.AllowedResourceActions.Add(new ScopeRestriction(resource, permittedDataActions, id));
                             }
                         }

--- a/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
 
                 var dataActions = await authorizationService.CheckAccess(DataActions.Smart, context.RequestAborted);
 
-                // Only read and apply SMART clinical scopes if has Smart data action
+                // Only read and apply SMART clinical scopes if the user has the Smart Data action
                 if (dataActions.HasFlag(DataActions.Smart))
                 {
                     fhirRequestContext.AccessControlContext.ApplyFineGrainedAccessControl = true;

--- a/src/Microsoft.Health.Fhir.Core/Configs/AuthorizationConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/AuthorizationConfiguration.cs
@@ -21,8 +21,6 @@ namespace Microsoft.Health.Fhir.Core.Configs
 
         public string FhirUserClaim { get; set; } = "fhirUser";
 
-        public string SmartUserRole { get; set; } = "smartUser";
-
-        public string AllResourcesInScope { get; set; } = "all";
+        public bool ErrorOnMissingFhirUserClaim { get; set; } = false;
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Configs/AuthorizationConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/AuthorizationConfiguration.cs
@@ -22,5 +22,7 @@ namespace Microsoft.Health.Fhir.Core.Configs
         public string FhirUserClaim { get; set; } = "fhirUser";
 
         public string SmartUserRole { get; set; } = "smartUser";
+
+        public string AllResourcesInScope { get; set; } = "all";
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Context/AccessControlContext.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Context/AccessControlContext.cs
@@ -29,5 +29,16 @@ namespace Microsoft.Health.Fhir.Core.Features.Context
         /// A uri which points to a specific fhir resource in this Fhir server, and is associated with the current user
         /// </summary>
         public Uri FhirUserClaim { get; set; } = null;
+
+        /// <summary>
+        /// For a SMART on FHIR request, this is the resource type of the user's compartment.  Searches will be restricted to this compartment.
+        /// </summary>
+        public string CompartmentResourceType { get; set; } = null;
+
+        /// <summary>
+        /// For a SMART on FHIR request, this is the id of the resource which is associated with the user, and
+        /// identifies the user's compartment.  Searches will be restricted to this compartment.
+        /// </summary>
+        public string CompartmentId { get; set; } = null;
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Context/FhirUserClaimParser.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Context/FhirUserClaimParser.cs
@@ -1,0 +1,59 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using EnsureThat;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Microsoft.Health.Fhir.Core.Models;
+
+namespace Microsoft.Health.Fhir.Core.Features.Context
+{
+    public static class FhirUserClaimParser
+    {
+        public static void ParseFhirUserClaim(
+            AccessControlContext accessControlContext,
+            bool errorOnInvalidFhirUserClaim)
+        {
+            EnsureArg.IsNotNull(accessControlContext, nameof(accessControlContext));
+
+            // The fhirUser claim is a URI that points to the FHIR resource that represents the user.
+            // The URI is of the form <base URL>/<resource type>/<resource id>.
+            // The resource type must be one of Patient, Practitioner.  In the future it may be extended to include RelatedPerson.
+
+            if (accessControlContext.FhirUserClaim == null ||
+                accessControlContext.FhirUserClaim.Segments.Length < 2)
+            {
+                if (errorOnInvalidFhirUserClaim)
+                {
+                    throw new BadRequestException(Core.Resources.FhirUserClaimInvalidFormat);
+                }
+                else
+                {
+                    return;
+                }
+            }
+
+            string fhirUserId = accessControlContext.FhirUserClaim.Segments.Last().TrimEnd('/');
+            string fhirUserResourceType = accessControlContext.FhirUserClaim.Segments[accessControlContext.FhirUserClaim.Segments.Length - 2].TrimEnd('/');
+
+            if (fhirUserResourceType != KnownResourceTypes.Patient &&
+                fhirUserResourceType != KnownResourceTypes.Practitioner)
+            {
+                if (errorOnInvalidFhirUserClaim)
+                {
+                    throw new BadRequestException(string.Format(Core.Resources.FhirUserClaimMustHaveResourceTypeAndId, accessControlContext.FhirUserClaim.ToString()));
+                }
+                else
+                {
+                    return;
+                }
+            }
+
+            accessControlContext.CompartmentId = fhirUserId;
+            accessControlContext.CompartmentResourceType = fhirUserResourceType;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/ExpressionParser.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/ExpressionParser.cs
@@ -405,7 +405,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
         {
             var resourceTypes = _contextAccessor.RequestContext?.AccessControlContext.AllowedResourceActions.Select(r => r.Resource).Distinct().ToList();
 
-            if (resourceTypes.Contains("*") || resourceTypes.Contains(resourceType))
+            if (resourceTypes.Contains(KnownResourceTypes.All) || resourceTypes.Contains(resourceType))
             {
                 return true;
             }

--- a/src/Microsoft.Health.Fhir.Core/Features/Security/Authorization/SMARTScopeFhirAuthorizationService.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Security/Authorization/SMARTScopeFhirAuthorizationService.cs
@@ -5,6 +5,7 @@
 
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Context;
+using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Core.Features.Security.Authorization
 {
@@ -22,7 +23,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Security.Authorization
             foreach (ScopeRestriction scopeRestriction in allowedResourceActions)
             {
                 // resousourceRequested is null when the base route is queried, i.e. all resources
-                if (scopeRestriction.Resource == "*" || scopeRestriction.Resource == resourceRequested || resourceRequested == null)
+                if (scopeRestriction.Resource == KnownResourceTypes.All || scopeRestriction.Resource == resourceRequested || resourceRequested == null)
                 {
                     permittedDataActions |= scopeRestriction.AllowedDataAction;
                     if (permittedDataActions == dataActions)

--- a/src/Microsoft.Health.Fhir.Core/Features/Security/Authorization/SMARTScopeFhirAuthorizationService.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Security/Authorization/SMARTScopeFhirAuthorizationService.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Security.Authorization
             DataActions permittedDataActions = 0;
             foreach (ScopeRestriction scopeRestriction in allowedResourceActions)
             {
-                // resousourceRequested is null when the base route is queried, i.e. all resources
+                // resourceRequested is null when the base route is queried, i.e. all resources
                 if (scopeRestriction.Resource == KnownResourceTypes.All || scopeRestriction.Resource == resourceRequested || resourceRequested == null)
                 {
                     permittedDataActions |= scopeRestriction.AllowedDataAction;

--- a/src/Microsoft.Health.Fhir.Core/Features/Security/DataActions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Security/DataActions.cs
@@ -26,6 +26,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Security
         EditProfileDefinitions = 1 << 8, // Allows to Create/Update/Delete resources related to profile's resources.
         Import = 1 << 9,
 
+        Smart = 1 << 30, // Do not include Smart in the '*' case.  We only want smart for a user if explicitly added to the role or user
+
         [EnumMember(Value = "*")]
         All = (Import << 1) - 1,
     }

--- a/src/Microsoft.Health.Fhir.Core/Features/Security/roles.schema.json
+++ b/src/Microsoft.Health.Fhir.Core/Features/Security/roles.schema.json
@@ -14,7 +14,8 @@
                 "reindex",
                 "convertData",
                 "import",
-                "editProfileDefinitions"
+                "editProfileDefinitions",
+                "smart"
             ]
         }
     },

--- a/src/Microsoft.Health.Fhir.Core/Models/KnownResourceTypes.cs
+++ b/src/Microsoft.Health.Fhir.Core/Models/KnownResourceTypes.cs
@@ -60,5 +60,7 @@ namespace Microsoft.Health.Fhir.Core.Models
         public const string Coverage = "Coverage";
 
         public const string QuestionnaireResponse = "QuestionnaireResponse";
+
+        public const string All = "all";
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -449,6 +449,24 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The fhirUser claim must be a URI with an ending format of &lt;resourceType&gt;/&lt;resourceId&gt;..
+        /// </summary>
+        internal static string FhirUserClaimInvalidFormat {
+            get {
+                return ResourceManager.GetString("FhirUserClaimInvalidFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The given fhirUser claim:{0} is not valid.  It must have a resource type of Patient or Practicioner and a resource id..
+        /// </summary>
+        internal static string FhirUserClaimMustHaveResourceTypeAndId {
+            get {
+                return ResourceManager.GetString("FhirUserClaimMustHaveResourceTypeAndId", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Authorization failed..
         /// </summary>
         internal static string Forbidden {

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -671,4 +671,11 @@
   <data name="OperationCanceled" xml:space="preserve">
     <value>The attempted operation was cancelled, please retry the request. If you believe you have received this message in error, please contact Customer Support.</value>
   </data>
+  <data name="FhirUserClaimMustHaveResourceTypeAndId" xml:space="preserve">
+    <value>The given fhirUser claim:{0} is not valid.  It must have a resource type of Patient or Practicioner and a resource id.</value>
+    <comment>{0} is a string value of given fhirUser claim.</comment>
+  </data>
+  <data name="FhirUserClaimInvalidFormat" xml:space="preserve">
+    <value>The fhirUser claim must be a URI with an ending format of &lt;resourceType&gt;/&lt;resourceId&gt;.</value>
+  </data>
 </root>

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
@@ -9,8 +9,6 @@ using System.Security.Claims;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Hl7.Fhir.Specification.Navigation;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
@@ -50,7 +48,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
 
         [Theory]
         [MemberData(nameof(GetTestScopes))]
-        public async Task GivenSMARTScope_WhenInvoked_ThenScopeParsedandAddedtoContext(string scopes, ICollection<ScopeRestriction> expectedScopeRestrictions)
+        public async Task GivenSmartScope_WhenInvoked_ThenScopeParsedandAddedtoContext(string scopes, ICollection<ScopeRestriction> expectedScopeRestrictions)
         {
             var fhirRequestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
 
@@ -84,7 +82,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
         [Theory]
         [InlineData("smartUser", true)]
         [InlineData("globalAdmin", false)]
-        public async Task GivenSmartUserRole_WhenInvoked_ThenApplyFineGrainedAccessControlIsSet(string role, bool expectedApplyFineGrainedAccessControl)
+        public async Task GivenSmartDataAction_WhenInvoked_ThenApplyFineGrainedAccessControlIsSet(string role, bool expectedApplyFineGrainedAccessControl)
         {
             var fhirRequestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
 
@@ -115,7 +113,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
         }
 
         [Fact]
-        public async Task GivenSmartUserRole_WhenFhirUserNotProvided_ThenBadRequestExceptionThrown()
+        public async Task GivenSmartDataAction_WhenFhirUserNotProvided_ThenBadRequestExceptionThrown()
         {
             var fhirRequestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
 
@@ -128,6 +126,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
             var fhirConfiguration = new FhirServerConfiguration();
             var authorizationConfiguration = fhirConfiguration.Security.Authorization;
             authorizationConfiguration.Enabled = true;
+            authorizationConfiguration.ErrorOnMissingFhirUserClaim = true;
             await LoadRoles(authorizationConfiguration);
 
             var rolesClaim = new Claim(authorizationConfiguration.RolesClaim, "smartUser");
@@ -144,7 +143,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
         }
 
         [Fact]
-        public async Task GivenAdminUserRole_WhenScopesProvided_ThenScopeRestrictionsNotApplied()
+        public async Task GivenAllDataActionExceptSmart_WhenScopesProvided_ThenScopeRestrictionsNotApplied()
         {
             var fhirRequestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
 

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
@@ -12,6 +12,7 @@ using Microsoft.Health.Fhir.Api.Configs;
 using Microsoft.Health.Fhir.Api.Features.Smart;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Security;
+using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Core.UnitTests.Features.Context;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Test.Utilities;
@@ -133,10 +134,14 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
                 },
             };
 
-            yield return new object[] { "user/*.*", new List<ScopeRestriction>() { new ScopeRestriction("*", DataActions.Read | DataActions.Write, "user") } };
+            yield return new object[] { "user/*.*", new List<ScopeRestriction>() { new ScopeRestriction(KnownResourceTypes.All, DataActions.Read | DataActions.Write, "user") } };
             yield return new object[] { "user/Encounter.*", new List<ScopeRestriction>() { new ScopeRestriction("Encounter", DataActions.Read | DataActions.Write, "user") } };
+            yield return new object[] { "user/all.*", new List<ScopeRestriction>() { new ScopeRestriction(KnownResourceTypes.All, DataActions.Read | DataActions.Write, "user") } };
+            yield return new object[] { "user/all.all", new List<ScopeRestriction>() { new ScopeRestriction(KnownResourceTypes.All, DataActions.Read | DataActions.Write, "user") } };
             yield return new object[] { "patient.Patient.read", new List<ScopeRestriction>() { new ScopeRestriction("Patient", DataActions.Read, "patient") } };
-            yield return new object[] { "patient.*.read", new List<ScopeRestriction>() { new ScopeRestriction("*", DataActions.Read, "patient") } };
+            yield return new object[] { "patient.Patient.all", new List<ScopeRestriction>() { new ScopeRestriction("Patient", DataActions.Read | DataActions.Write, "patient") } };
+            yield return new object[] { "patient.*.read", new List<ScopeRestriction>() { new ScopeRestriction(KnownResourceTypes.All, DataActions.Read, "patient") } };
+            yield return new object[] { "patient.all.read", new List<ScopeRestriction>() { new ScopeRestriction(KnownResourceTypes.All, DataActions.Read, "patient") } };
             yield return new object[]
             {
                 "patient$Patient.read practitioner/Observation.write",

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Security/Authorization/RoleBasedFhirAuthorizationServiceTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Security/Authorization/RoleBasedFhirAuthorizationServiceTests.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Security.Authorization
             defaultFhirRequestContext.Principal = expectedPrincipal;
 
             _fhirRequestContextAccessor.RequestContext.Returns(defaultFhirRequestContext);
-            _fhirRequestContextAccessor.RequestContext.AccessControlContext.AllowedResourceActions.Add(new ScopeRestriction("*", DataActions.Read, "user1"));
+            _fhirRequestContextAccessor.RequestContext.AccessControlContext.AllowedResourceActions.Add(new ScopeRestriction(KnownResourceTypes.All, DataActions.Read, "user1"));
 
             var result = await _roleBasedFhirAuthorizationService.CheckAccess(DataActions.Read, CancellationToken.None);
             Assert.Equal(DataActions.Read, result);

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -66,6 +66,20 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
 
         public SearchOptions Create(string resourceType, IReadOnlyList<Tuple<string, string>> queryParameters, bool isAsyncOperation = false)
         {
+            if (_contextAccessor.RequestContext?.AccessControlContext?.ApplyFineGrainedAccessControl == true)
+            {
+                if (_contextAccessor.RequestContext?.AccessControlContext.CompartmentResourceType != null &&
+                    _contextAccessor.RequestContext?.AccessControlContext.CompartmentId != null)
+                {
+                    return Create(
+                        _contextAccessor.RequestContext.AccessControlContext.CompartmentResourceType,
+                        _contextAccessor.RequestContext.AccessControlContext.CompartmentId,
+                        resourceType,
+                        queryParameters,
+                        isAsyncOperation);
+                }
+            }
+
             return Create(null, null, resourceType, queryParameters, isAsyncOperation);
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -451,7 +451,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                     if (_contextAccessor.RequestContext?.AccessControlContext?.ApplyFineGrainedAccessControl == true)
                     {
                         var allowedResourceTypesByScope = _contextAccessor.RequestContext?.AccessControlContext?.AllowedResourceActions.Select(s => s.Resource);
-                        if (!allowedResourceTypesByScope.Contains("*") && !allowedResourceTypesByScope.Contains(expression.TargetResourceType))
+                        if (!allowedResourceTypesByScope.Contains(KnownResourceTypes.All) && !allowedResourceTypesByScope.Contains(expression.TargetResourceType))
                         {
                             _logger.LogTrace("Query restricted by clinical scopes.  Target resource type {ResourceType} not included in allowed resources.", expression.TargetResourceType);
                             return null;
@@ -482,7 +482,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
 
                 foreach (ScopeRestriction restriction in _contextAccessor.RequestContext?.AccessControlContext.AllowedResourceActions)
                 {
-                    if (restriction.Resource == "*")
+                    if (restriction.Resource == KnownResourceTypes.All)
                     {
                         allowAllResourceTypes = true;
                         break;

--- a/src/Microsoft.Health.Fhir.Shared.Web/roles.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/roles.json
@@ -71,7 +71,8 @@
         {
             "name": "smartUser",
             "dataActions": [
-                "*"
+                "*",
+                "smart"
             ],
             "notDataActions": [],
             "scopes": [

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchTests.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
             query.Add(new Tuple<string, string>("_id", "smart-patient-A"));
             query.Add(new Tuple<string, string>("_revinclude", "Observation:subject"));
 
-            var scopeRestriction = new ScopeRestriction("*", Core.Features.Security.DataActions.Read, "patient");
+            var scopeRestriction = new ScopeRestriction(KnownResourceTypes.All, Core.Features.Security.DataActions.Read, "patient");
 
             ConfigureFhirRequestContext(_contextAccessor, new List<ScopeRestriction>() { scopeRestriction });
 
@@ -270,7 +270,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
             var query = new List<Tuple<string, string>>();
             query.Add(new Tuple<string, string>("_has:Observation:subject:code", "4548-4"));
 
-            var scopeRestriction = new ScopeRestriction("*", Core.Features.Security.DataActions.Read, "patient");
+            var scopeRestriction = new ScopeRestriction(KnownResourceTypes.All, Core.Features.Security.DataActions.Read, "patient");
 
             ConfigureFhirRequestContext(_contextAccessor, new List<ScopeRestriction>() { scopeRestriction });
 


### PR DESCRIPTION
## Description
Rather than rely on the role name to determine if a user is a "SMART on FHIR" user, we will use a new specific DataAction which can be assigned to a role.

This also includes the changes to handle the change from * to all for scopes.

## Related issues
Addresses [issue AB#95787].

## Testing
Unit tests, integration and manual E2E tests were updated to check the new DataAction, and the "all" value

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [X] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [X] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
