### PR TITLE
Add same resource as compartment definition to SMART results

### DIFF
--- a/docs/rest/Data/SmartCompartmentResources.json
+++ b/docs/rest/Data/SmartCompartmentResources.json
@@ -3271,6 +3271,43 @@
                 "url": "Patient/smart-patient-C"
             }
         },
+		{
+            "resource": {
+				"resourceType": "Patient",
+				"id": "smartUserClient",
+				"meta": {
+					"versionId": "1",
+					"lastUpdated": "2022-09-29T19:10:27.888+00:00",
+					"tag": [
+						{
+							"system": "testTag",
+							"code": "8d245743-e7ff-425d-b065-33e8886c60e8"
+						}
+					]
+				},
+				"name": [
+					{
+						"family": "SMART",
+						"given": [
+							"smartUserClient"
+						]
+					}
+				],
+				"birthDate": "1981-07-02",
+				"generalPractitioner": [
+					{
+						"reference": "Practitioner/smart-practitioner-B"
+					}
+				],
+				"managingOrganization": {
+					"reference": "Organization/smart-organization-C1"
+				}
+            },
+            "request": {
+                "method": "PUT",
+                "url": "Patient/smartUserClient"
+            }
+        },
         {
             "resource": {
 				"resourceType": "CareTeam",
@@ -4080,6 +4117,80 @@
             "request": {
                 "method": "PUT",
                 "url": "Provenance/smart-provenance-C2"
+            }
+        },
+		{
+            "resource": {
+			  "resourceType": "Observation",
+			  "id": "smart-observation-smartUserClient",
+			  "text": {
+				"status": "extensions",
+				"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource &quot;example-genetics-1&quot; </p></div><p><b>Gene</b>: EGFR <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-hgnc.html\">HUGO Gene Nomenclature</a>#3236)</span></p><p><b>DNARegionName</b>: Exon 21</p><p><b>GenomicSourceClass</b>: somatic <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#LA6684-0)</span></p><p><b>status</b>: final</p><p><b>code</b>: The material on this page will be removed in a future release. This content is deprecated and SHOULD NOT be used. Implementers are instead directed to the ([Genomics Reporting Implementation Guide](http://hl7.org/fhir/uv/genomics-reporting/index.html)) for guidance. Genetic analysis master panel-- This is the parent OBR for the panel holding all of the associated observations that can be reported with a molecular genetics analysis result. <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#55233-1)</span></p><p><b>subject</b>: <a href=\"patient-example.html\">Patient/example: Molecular Lab Patient ID: HOSP-23456</a> &quot;Peter CHALMERS&quot;</p><p><b>effective</b>: 2013-04-03T15:30:10+01:00</p><p><b>performer</b>: <a href=\"practitioner-example.html\">Practitioner/example: Molecular Diagnostics Laboratory</a> &quot;Adam CAREFUL&quot;</p><p><b>value</b>: Positive <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://browser.ihtsdotools.org/\">SNOMED CT</a>#10828004)</span></p><p><b>device</b>: <a href=\"device-example.html\">Device/example</a></p></div>"
+			  },
+			  "extension": [
+				{
+				  "url": "http://hl7.org/fhir/StructureDefinition/observation-geneticsGene",
+				  "valueCodeableConcept": {
+					"coding": [
+					  {
+						"system": "http://www.genenames.org",
+						"code": "3236",
+						"display": "EGFR"
+					  }
+					]
+				  }
+				},
+				{
+				  "url": "http://hl7.org/fhir/StructureDefinition/observation-geneticsDNARegionName",
+				  "valueString": "Exon 21"
+				},
+				{
+				  "url": "http://hl7.org/fhir/StructureDefinition/observation-geneticsGenomicSourceClass",
+				  "valueCodeableConcept": {
+					"coding": [
+					  {
+						"system": "http://loinc.org",
+						"code": "LA6684-0",
+						"display": "somatic"
+					  }
+					]
+				  }
+				}
+			  ],
+			  "status": "final",
+			  "code": {
+				"coding": [
+				  {
+					"system": "http://loinc.org",
+					"code": "55233-1",
+					"display": "The material on this page will be removed in a future release. This content is deprecated and SHOULD NOT be used. Implementers are instead directed to the ([Genomics Reporting Implementation Guide](http://hl7.org/fhir/uv/genomics-reporting/index.html)) for guidance. Genetic analysis master panel-- This is the parent OBR for the panel holding all of the associated observations that can be reported with a molecular genetics analysis result."
+				  }
+				]
+			  },
+			  "subject": {
+				"reference": "Patient/smartUserClient",
+				"display": "Molecular Lab Patient ID: HOSP-23456"
+			  },
+			  "effectiveDateTime": "2013-04-03T15:30:10+01:00",
+			  "performer": [
+				{
+				  "reference": "Practitioner/smart-practitioner-B",
+				  "display": "Molecular Diagnostics Laboratory"
+				}
+			  ],
+			  "valueCodeableConcept": {
+				"coding": [
+				  {
+					"system": "http://snomed.info/sct",
+					"code": "10828004",
+					"display": "Positive"
+				  }
+				]
+			  }
+			},
+			"request": {
+				"method": "PUT",
+				"url": "Observation/smart-observation-smartUserClient"
             }
         }
 	]

--- a/docs/rest/SMARTScopesExample.http
+++ b/docs/rest/SMARTScopesExample.http
@@ -22,6 +22,11 @@ grant_type=client_credentials
 &scope=patient/Observation.read fhirUser fhir-api user/Encounter.*
 
 
+### Get all resource in a patient's compartment
+GET https://{{hostname}}/Patient/smartUserClient/*
+content-type: application/json
+Authorization: Bearer {{bearer.response.body.access_token}}
+
 ### POST the test data
 # @name patient
 POST https://{{hostname}}
@@ -52,11 +57,11 @@ grant_type=client_credentials
 &scope=patient/Patient.read
 
 ### Get all Patient
-GET https://{{hostname}}/Patient
+GET https://{{hostname}}/Patient?_id=smart-patient-A
 Authorization: Bearer {{bearer.response.body.access_token}}
 
 ### Get Observation
-GET https://{{hostname}}/Observation
+GET https://{{hostname}}/Observation?_total=accurate
 Authorization: Bearer {{bearer.response.body.access_token}}
 
 ### Get Encounter
@@ -80,6 +85,11 @@ Authorization: Bearer {{bearer.response.body.access_token}}
 GET https://{{hostname}}/?_type=Patient
 Authorization: Bearer {{bearer.response.body.access_token}}
 
+### Chained search
+
+GET https://{{hostname}}/Observation?subject:Patient.name=SMARTGivenName1
+Authorization: Bearer {{bearer.response.body.access_token}}
+
 ### Reverse chained search
 GET https://{{hostname}}/Patient?_has:Observation:patient:code=4548-4
 Authorization: Bearer {{bearer.response.body.access_token}}
@@ -87,15 +97,5 @@ Authorization: Bearer {{bearer.response.body.access_token}}
 ### Get all resources
 GET https://{{hostname}}/
 Authorization: Bearer {{bearer.response.body.access_token}}
-
-### Scoped to be able to read all resources
-# @name bearer
-POST https://{{hostname}}/connect/token
-content-type: application/x-www-form-urlencoded
-
-grant_type=client_credentials
-&client_id=smartUserClient
-&client_secret=smartUserClient
-&scope=patient/*.read fhirUser fhir-api
 
 

--- a/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
@@ -4,7 +4,6 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Linq;
 using System.Security.Claims;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -54,7 +53,6 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
             {
                 var fhirRequestContext = fhirRequestContextAccessor.RequestContext;
                 var principal = fhirRequestContext.Principal;
-                var roles = principal.FindAll(authorizationConfiguration.RolesClaim).Select(r => r.Value);
 
                 var dataActions = await authorizationService.CheckAccess(DataActions.Smart, context.RequestAborted);
 

--- a/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
@@ -67,6 +67,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
                     try
                     {
                         fhirRequestContext.AccessControlContext.FhirUserClaim = new System.Uri(fhirUser, UriKind.RelativeOrAbsolute);
+                        FhirUserClaimParser.ParseFhirUserClaim(fhirRequestContext.AccessControlContext, authorizationConfiguration.ErrorOnMissingFhirUserClaim);
                     }
                     catch (UriFormatException)
                     {

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Context/FhirUserClaimParserTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Context/FhirUserClaimParserTests.cs
@@ -1,0 +1,63 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Health.Fhir.Core.Features.Context;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Test.Utilities;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Context
+{
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.SmartOnFhir)]
+    public class FhirUserClaimParserTests
+    {
+        [Theory]
+        [MemberData(nameof(GetFhirUserClaims))]
+        public void GivenAValidFhirUserClaim_WhenParsed_ThenResourceTypeAndIdStoredInContext(Uri fhirUserClaimUri, string expectedResourceType, string expectedId)
+        {
+            var fhirRequestContext = Substitute.For<IFhirRequestContext>();
+            var accessControlContext = new AccessControlContext();
+            fhirRequestContext.AccessControlContext.Returns(accessControlContext);
+            fhirRequestContext.AccessControlContext.FhirUserClaim = fhirUserClaimUri;
+
+            FhirUserClaimParser.ParseFhirUserClaim(fhirRequestContext.AccessControlContext, true);
+
+            Assert.Equal(expectedResourceType, fhirRequestContext.AccessControlContext.CompartmentResourceType);
+            Assert.Equal(expectedId, fhirRequestContext.AccessControlContext.CompartmentId);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetInvalidFhirUserClaims))]
+        public void GivenAnInvalidFhirUserClaim_WhenParsed_ThenExceptionIsThrown(Uri fhirUserClaimUri)
+        {
+            var fhirRequestContext = Substitute.For<IFhirRequestContext>();
+            var accessControlContext = new AccessControlContext();
+            fhirRequestContext.AccessControlContext.Returns(accessControlContext);
+            fhirRequestContext.AccessControlContext.FhirUserClaim = fhirUserClaimUri;
+
+            Assert.Throws<BadRequestException>(() => FhirUserClaimParser.ParseFhirUserClaim(fhirRequestContext.AccessControlContext, true));
+        }
+
+        public static IEnumerable<object[]> GetFhirUserClaims()
+        {
+            yield return new object[] { new Uri("Patient/id1", UriKind.RelativeOrAbsolute), "Patient", "id1" };
+            yield return new object[] { new Uri("https://fhirserver/Patient/id1", UriKind.RelativeOrAbsolute), "Patient", "id1" };
+            yield return new object[] { new Uri("https://fhirserver/Practitioner/foo1", UriKind.RelativeOrAbsolute), "Practitioner", "foo1" };
+            yield return new object[] { new Uri("Practitioner/foo1/", UriKind.RelativeOrAbsolute), "Practitioner", "foo1" };
+        }
+
+        public static IEnumerable<object[]> GetInvalidFhirUserClaims()
+        {
+            yield return new object[] { new Uri("Patient/", UriKind.RelativeOrAbsolute) };
+            yield return new object[] { new Uri("https://fhirserver/Observation/id1") };
+            yield return new object[] { new Uri("Foo", UriKind.RelativeOrAbsolute) };
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/CompartmentSearchExpression.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/CompartmentSearchExpression.cs
@@ -20,8 +20,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// </summary>
         /// <param name="compartmentType">The compartment type.</param>
         /// <param name="compartmentId">The compartment id.</param>
+        /// <param name="smartUserCompartment">True is this compartment expression is being added due to smart restrictions</param>
         /// <param name="filteredResourceTypes">Resource types to filter</param>
-        public CompartmentSearchExpression(string compartmentType, string compartmentId, params string[] filteredResourceTypes)
+        public CompartmentSearchExpression(string compartmentType, string compartmentId, bool smartUserCompartment = false, params string[] filteredResourceTypes)
         {
             EnsureArg.IsTrue(ModelInfoProvider.IsKnownCompartmentType(compartmentType), nameof(compartmentType));
             EnsureArg.IsNotNullOrWhiteSpace(compartmentId, nameof(compartmentId));
@@ -29,6 +30,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
             CompartmentType = compartmentType;
             CompartmentId = compartmentId;
             FilteredResourceTypes = filteredResourceTypes ?? Array.Empty<string>();
+            SmartUserCompartment = smartUserCompartment;
         }
 
         /// <summary>
@@ -40,6 +42,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// The compartment id.
         /// </summary>
         public string CompartmentId { get; }
+
+        /// <summary>
+        /// Indicates if this compartment expression was added as a smart filter
+        /// </summary>
+        public bool SmartUserCompartment { get; }
 
         /// <summary>
         /// Resource types to filter for compartment search

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Expression.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Expression.cs
@@ -292,11 +292,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// </summary>
         /// <param name="compartmentType">The compartment type.</param>
         /// <param name="compartmentId">The compartment id.</param>
+        /// <param name="smartUserCompartment">True is this compartment expression is being added due to smart restrictions</param>
         /// <param name="filteredResourceTypes">Resource types to filter on</param>
         /// <returns>A <see cref="CompartmentSearchExpression"/> that represents a compartment search operation.</returns>
-        public static CompartmentSearchExpression CompartmentSearch(string compartmentType, string compartmentId, params string[] filteredResourceTypes)
+        public static CompartmentSearchExpression CompartmentSearch(string compartmentType, string compartmentId, bool smartUserCompartment = false, params string[] filteredResourceTypes)
         {
-            return new CompartmentSearchExpression(compartmentType, compartmentId, filteredResourceTypes);
+            return new CompartmentSearchExpression(compartmentType, compartmentId, smartUserCompartment, filteredResourceTypes);
         }
 
         public abstract TOutput AcceptVisitor<TContext, TOutput>(IExpressionVisitor<TContext, TOutput> visitor, TContext context);

--- a/src/Microsoft.Health.Fhir.Core/Features/Security/Authorization/RoleBasedFhirAuthorizationService.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Security/Authorization/RoleBasedFhirAuthorizationService.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Security.Authorization
 
             if (applySMARTAccess)
             {
-                return new ValueTask<DataActions>(dataActions & permittedDataActions & SMARTScopeFhirAuthorizationService.CheckSMARTScopeAccess(_requestContextAccessor, dataActions));
+                return new ValueTask<DataActions>(dataActions & permittedDataActions & SmartScopeFhirAuthorizationService.CheckSMARTScopeAccess(_requestContextAccessor, dataActions));
             }
 
             return new ValueTask<DataActions>(dataActions & permittedDataActions);

--- a/src/Microsoft.Health.Fhir.Core/Features/Security/Authorization/SMARTScopeFhirAuthorizationService.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Security/Authorization/SMARTScopeFhirAuthorizationService.cs
@@ -23,7 +23,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Security.Authorization
             foreach (ScopeRestriction scopeRestriction in allowedResourceActions)
             {
                 // resourceRequested is null when the base route is queried, i.e. all resources
-                if (scopeRestriction.Resource == KnownResourceTypes.All || scopeRestriction.Resource == resourceRequested || resourceRequested == null)
+                // or resourceRequested is * when querying all resources in a compartment
+                if (scopeRestriction.Resource == KnownResourceTypes.All ||
+                    scopeRestriction.Resource == resourceRequested ||
+                    resourceRequested == null ||
+                    resourceRequested == "*")
                 {
                     permittedDataActions |= scopeRestriction.AllowedDataAction;
                     if (permittedDataActions == dataActions)

--- a/src/Microsoft.Health.Fhir.Core/Features/Security/Authorization/SMARTScopeFhirAuthorizationService.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Security/Authorization/SMARTScopeFhirAuthorizationService.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Security.Authorization
     /// <summary>
     /// determines access based on the SMART scope.
     /// </summary>
-    public static class SMARTScopeFhirAuthorizationService
+    public static class SmartScopeFhirAuthorizationService
     {
         public static DataActions CheckSMARTScopeAccess(this RequestContextAccessor<IFhirRequestContext> requestContextAccessor, DataActions dataActions)
         {

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -458,6 +458,15 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Provided fhirUser claim {0} is not a valid resource in this fhir server..
+        /// </summary>
+        internal static string FhirUserClaimIsNotAValidResource {
+            get {
+                return ResourceManager.GetString("FhirUserClaimIsNotAValidResource", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The given fhirUser claim:{0} is not valid.  It must have a resource type of Patient or Practicioner and a resource id..
         /// </summary>
         internal static string FhirUserClaimMustHaveResourceTypeAndId {

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -678,4 +678,8 @@
   <data name="FhirUserClaimInvalidFormat" xml:space="preserve">
     <value>The fhirUser claim must be a URI with an ending format of &lt;resourceType&gt;/&lt;resourceId&gt;.</value>
   </data>
+  <data name="FhirUserClaimIsNotAValidResource" xml:space="preserve">
+    <value>Provided fhirUser claim {0} is not a valid resource in this fhir server.</value>
+    <comment>{0} is a url of a fhir resource.</comment>
+  </data>
 </root>

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -343,8 +343,20 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
             StringBuilder.Append("SELECT ")
                 .Append(VLatest.Resource.ResourceTypeId, null).Append(" AS T1, ")
-                .Append(VLatest.Resource.ResourceSurrogateId, null).AppendLine(" AS Sid1")
-                .Append("FROM ").AppendLine(searchParamTableExpression.QueryGenerator.Table);
+                .Append(VLatest.Resource.ResourceSurrogateId, null).AppendLine(" AS Sid1");
+
+            var searchParameterExpressionPredicate = searchParamTableExpression.Predicate as SearchParameterExpression;
+
+            // handle special case where we want to Union a specific resource to the results
+            if (searchParameterExpressionPredicate != null &&
+                searchParameterExpressionPredicate.Parameter.Name == SearchParameterNames.Id)
+            {
+                StringBuilder.Append("FROM ").AppendLine(new VLatest.ResourceTable());
+            }
+            else
+            {
+                StringBuilder.Append("FROM ").AppendLine(searchParamTableExpression.QueryGenerator.Table);
+            }
 
             using (var delimited = StringBuilder.BeginDelimitedWhereClause())
             {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
@@ -183,6 +183,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             var searchOptionsFactory = new SearchOptionsFactory(expressionParser, () => searchableSearchParameterDefinitionManager, options, _fhirRequestContextAccessor, sortingValidator, NullLogger<SearchOptionsFactory>.Instance);
 
             var compartmentDefinitionManager = new CompartmentDefinitionManager(ModelInfoProvider.Instance);
+            await compartmentDefinitionManager.StartAsync(CancellationToken.None);
             var compartmentSearchRewriter = new CompartmentSearchRewriter(new Lazy<ICompartmentDefinitionManager>(() => compartmentDefinitionManager), new Lazy<ISearchParameterDefinitionManager>(() => _searchParameterDefinitionManager));
 
             ICosmosDbCollectionPhysicalPartitionInfo cosmosDbPhysicalPartitionInfo = Substitute.For<ICosmosDbCollectionPhysicalPartitionInfo>();

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -214,6 +214,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             var sortRewriter = new SortRewriter(searchParamTableExpressionQueryGeneratorFactory);
             var partitionEliminationRewriter = new PartitionEliminationRewriter(sqlServerFhirModel, SchemaInformation, () => searchableSearchParameterDefinitionManager);
             var compartmentDefinitionManager = new CompartmentDefinitionManager(ModelInfoProvider.Instance);
+            compartmentDefinitionManager.StartAsync(CancellationToken.None).Wait();
             var compartmentSearchRewriter = new CompartmentSearchRewriter(new Lazy<ICompartmentDefinitionManager>(() => compartmentDefinitionManager), new Lazy<ISearchParameterDefinitionManager>(() => _searchParameterDefinitionManager));
 
             _searchService = new SqlServerSearchService(


### PR DESCRIPTION
## Description
When using the compartment definition to filter results for a SMART query, we do not want to prohibit access to the same resource which is used to define the compartment.  In other words, a given Patient should be able to read their own Patient resource.

## Related issues
Addresses [issue AB#95786].

## Testing
Additional unit test and integration tests were added.

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [X] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [X] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
