### PR TITLE
Enable convert data for AKS deployments

### DIFF
--- a/samples/kubernetes/README.md
+++ b/samples/kubernetes/README.md
@@ -246,6 +246,17 @@ which should have something like:
 
 to work with the settings above.
 
+## Enabling `$convert-data`
+
+To use the `$convert-data` operation, you can simply enable the feature with the `convertData.enabled` parameter by switching the value of it to `true` in `values.yaml`.
+
+```yaml
+convertData:
+  enabled: true
+```
+
+For more detailed usages of `$convert-data`, you can refer to [this document](https://github.com/microsoft/fhir-server/blob/main/docs/ConvertDataOperation.md).
+
 ## Enabling `$export`
 
 To use the `$export` operation, the FHIR server must be configured with a [pod identity](https://github.com/Azure/aad-pod-identity) and the identity of the FHIR server must have access to an existing storage account.

--- a/samples/kubernetes/helm/fhir-server/templates/deployment.yaml
+++ b/samples/kubernetes/helm/fhir-server/templates/deployment.yaml
@@ -35,6 +35,10 @@ spec:
           env:
             - name: ASPNETCORE_FORWARDEDHEADERS_ENABLED
               value: "true"
+            {{- if .Values.convertData.enabled }}
+            - name: FhirServer__Operations__ConvertData_Enabled
+              value: "true"
+            {{- end }}
             {{- if .Values.export.enabled }}
             - name: FhirServer__Operations__Export__Enabled
               value: "true"

--- a/samples/kubernetes/helm/fhir-server/values.yaml
+++ b/samples/kubernetes/helm/fhir-server/values.yaml
@@ -19,6 +19,9 @@ podIdentity:
   # identityClientId: my-id
   # identityResourceId: my-identity-resource-id
 
+convertData:
+  enabled: false
+
 export:
   enabled: false
   blobStorageUri: https://mystorageaccount.blob.core.windows.net


### PR DESCRIPTION
## Description
Add an option to enable $convert-data for AKS deployments.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
