### PR TITLE
Disable connection pooling in sql tests

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Microsoft.Health.Fhir.Shared.Tests.Integration.projitems
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Microsoft.Health.Fhir.Shared.Tests.Integration.projitems
@@ -27,6 +27,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Smart\SmartSearchTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\FhirStorageVersioningPolicyTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SearchParameterStatusDataStoreTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Persistence\SimpleSqlConnectionBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlServerWatchdogTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlServerSchemaUpgradeTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\CosmosDbFhirStorageTestHelper.cs" />

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SimpleSqlConnectionBuilder.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SimpleSqlConnectionBuilder.cs
@@ -1,0 +1,60 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
+using Microsoft.Health.SqlServer;
+
+namespace Microsoft.Health.Fhir.Tests.Integration.Persistence;
+
+public class SimpleSqlConnectionBuilder : ISqlConnectionBuilder, IDisposable
+{
+    private readonly string _connectionString;
+    private readonly IList<WeakReference<SqlConnection>> _connections = new List<WeakReference<SqlConnection>>();
+
+    public SimpleSqlConnectionBuilder(string connectionString)
+    {
+        _connectionString = connectionString;
+    }
+
+    public Task<SqlConnection> GetSqlConnectionAsync(string initialCatalog = null, CancellationToken cancellationToken = default)
+    {
+        var connectionBuilder = new SqlConnectionStringBuilder(_connectionString);
+
+        if (!string.IsNullOrEmpty(initialCatalog))
+        {
+            connectionBuilder.InitialCatalog = initialCatalog;
+        }
+
+        // Pooling is causing issues when deleting the test database at the end of the fixture run.
+        connectionBuilder.Pooling = false;
+
+        var result = new SqlConnection(connectionBuilder.ToString());
+        _connections.Add(new WeakReference<SqlConnection>(result));
+        return Task.FromResult(result);
+    }
+
+    public void Dispose()
+    {
+        foreach (var connection in _connections)
+        {
+            if (connection.TryGetTarget(out SqlConnection target))
+            {
+                if (target.State == ConnectionState.Open)
+                {
+                    Debug.WriteLine("WARNING: Connection was not closed.");
+                    target.Close();
+                }
+
+                target.Dispose();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
SqlConnection pooling is sometimes preventing test databases from being deleted.

## Testing
Run integration tests

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
