### PR TITLE
SqlConnection pooling is sometimes preventing test databases from being deleted.

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
@@ -112,6 +112,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
         public async Task DeleteDatabase(string databaseName, CancellationToken cancellationToken = default)
         {
+            SqlConnection.ClearAllPools();
+
             await _dbSetupRetryPolicy.ExecuteAsync(async () =>
             {
                 await using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(_masterDatabaseName, cancellationToken);


### PR DESCRIPTION
## Description
Clears the sql connection pool before attempting to delete the integration test database.

## Related issues
I've been noticing a bit of a build up...
<img width="358" alt="image" src="https://user-images.githubusercontent.com/197221/199379195-f308b3b0-2bf9-4f2e-bfed-0482d5698cdd.png">

## Testing
Integration tests can exit immediately instead of waiting for exclusive database access that they don't get

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
