### PR TITLE
SmartClinicalScopeMiddleware should check if security is enabled/disabled

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
             var authorizationConfiguration = securityConfigurationOptions.Value.Authorization;
 
             if (fhirRequestContextAccessor.RequestContext.Principal != null
+                && securityConfigurationOptions.Value.Enabled
                 && authorizationConfiguration.Enabled)
             {
                 var fhirRequestContext = fhirRequestContextAccessor.RequestContext;

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
@@ -59,6 +59,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
             HttpContext httpContext = new DefaultHttpContext();
 
             var fhirConfiguration = new FhirServerConfiguration();
+            fhirConfiguration.Security.Enabled = true;
             var authorizationConfiguration = fhirConfiguration.Security.Authorization;
             authorizationConfiguration.Enabled = true;
             await LoadRoles(authorizationConfiguration);
@@ -80,9 +81,11 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
         }
 
         [Theory]
-        [InlineData("smartUser", true)]
-        [InlineData("globalAdmin", false)]
-        public async Task GivenSmartDataAction_WhenInvoked_ThenApplyFineGrainedAccessControlIsSet(string role, bool expectedApplyFineGrainedAccessControl)
+        [InlineData("smartUser", true, true)]
+        [InlineData("globalAdmin", true, false)]
+        [InlineData("smartUser", false, false)]
+        [InlineData("globalAdmin", false, false)]
+        public async Task GivenSmartDataAction_WhenInvoked_ThenApplyFineGrainedAccessControlIsSet(string role, bool securityEnabled, bool expectedApplyFineGrainedAccessControl)
         {
             var fhirRequestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
 
@@ -93,6 +96,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
             HttpContext httpContext = new DefaultHttpContext();
 
             var fhirConfiguration = new FhirServerConfiguration();
+            fhirConfiguration.Security.Enabled = securityEnabled;
             var authorizationConfiguration = fhirConfiguration.Security.Authorization;
             authorizationConfiguration.Enabled = true;
             await LoadRoles(authorizationConfiguration);
@@ -124,6 +128,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
             HttpContext httpContext = new DefaultHttpContext();
 
             var fhirConfiguration = new FhirServerConfiguration();
+            fhirConfiguration.Security.Enabled = true;
             var authorizationConfiguration = fhirConfiguration.Security.Authorization;
             authorizationConfiguration.Enabled = true;
             authorizationConfiguration.ErrorOnMissingFhirUserClaim = true;


### PR DESCRIPTION
## Description
SmartClinicalScopeMiddleware should check if security is enabled/disabled. Currently, when security is disabled, all searches return no results.

## Related issues
Addresses #2923.

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
