### PR TITLE
Expand smart patient compartment

### DIFF
--- a/docs/rest/SMARTScopesExample.http
+++ b/docs/rest/SMARTScopesExample.http
@@ -21,9 +21,36 @@ grant_type=client_credentials
 &client_secret=globalAdminServicePrincipal
 &scope=patient/Observation.read fhirUser fhir-api user/Encounter.*
 
+### GET
+https://localhost:44348/_operations/export/a6abdbf4-f5a6-4feb-a795-7c76cabcca69
+content-type: application/json
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+### Export smart patient compartment
+GET https://{{hostname}}/Group/smart-group-1/$export
+content-type: application/json
+Authorization: Bearer {{bearer.response.body.access_token}}
+Accept: application/fhir+json
+Prefer: respond-async
+
+### Get the smartUser bearer token, for testing scopes
+# @name bearer
+POST https://{{hostname}}/connect/token
+content-type: application/x-www-form-urlencoded
+
+grant_type=client_credentials
+&client_id=smartUserClient
+&client_secret=smartUserClient
+&scope=patient/*.*
+
+
+### Get groups
+GET https://{{hostname}}/Group
+content-type: application/json
+Authorization: Bearer {{bearer.response.body.access_token}}
 
 ### Get all resource in a patient's compartment
-GET https://{{hostname}}/Patient/smartUserClient/*
+GET https://{{hostname}}/Location
 content-type: application/json
 Authorization: Bearer {{bearer.response.body.access_token}}
 

--- a/docs/rest/SMARTScopesExample.http
+++ b/docs/rest/SMARTScopesExample.http
@@ -56,6 +56,16 @@ grant_type=client_credentials
 &client_secret=smartUserClient
 &scope=patient/Patient.read
 
+### Get the smartUser bearer token, for testing scopes
+# @name bearer
+POST https://{{hostname}}/connect/token
+content-type: application/x-www-form-urlencoded
+
+grant_type=client_credentials
+&client_id=smartUserClient
+&client_secret=smartUserClient
+&scope=patient/all.read
+
 ### Get all Patient
 GET https://{{hostname}}/Patient?_id=smart-patient-A
 Authorization: Bearer {{bearer.response.body.access_token}}

--- a/docs/rest/SMARTScopesExample.http
+++ b/docs/rest/SMARTScopesExample.http
@@ -21,11 +21,6 @@ grant_type=client_credentials
 &client_secret=globalAdminServicePrincipal
 &scope=patient/Observation.read fhirUser fhir-api user/Encounter.*
 
-### GET
-https://localhost:44348/_operations/export/a6abdbf4-f5a6-4feb-a795-7c76cabcca69
-content-type: application/json
-Authorization: Bearer {{bearer.response.body.access_token}}
-
 ### Export smart patient compartment
 GET https://{{hostname}}/Group/smart-group-1/$export
 content-type: application/json

--- a/docs/rest/SMARTScopesExample.http
+++ b/docs/rest/SMARTScopesExample.http
@@ -64,10 +64,14 @@ content-type: application/x-www-form-urlencoded
 grant_type=client_credentials
 &client_id=smartUserClient
 &client_secret=smartUserClient
-&scope=patient/all.read
+&scope=patient/*.read
 
-### Get all Patient
+### Get the Patient
 GET https://{{hostname}}/Patient?_id=smart-patient-A
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+### Get the Patient
+GET https://{{hostname}}/Patient?_id=smartUserClient
 Authorization: Bearer {{bearer.response.body.access_token}}
 
 ### Get Observation

--- a/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
                                     break;
                                 case "*":
                                 case AllDataActions:
-                                    permittedDataActions |= DataActions.Read | DataActions.Write;
+                                    permittedDataActions |= DataActions.Read | DataActions.Write | DataActions.Export;
                                     break;
                             }
 

--- a/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
                 {
                     fhirRequestContext.AccessControlContext.ApplyFineGrainedAccessControl = true;
 
-                    bool skipFhirUserClaimForSystemScope = false;
+                    bool includeFhirUserClaim = true;
 
                     // examine the scopes claim for any SMART on FHIR clinical scopes
                     DataActions permittedDataActions = 0;
@@ -102,13 +102,13 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
 
                                 if (string.Equals("system", id, StringComparison.OrdinalIgnoreCase))
                                 {
-                                    skipFhirUserClaimForSystemScope = true;
+                                    includeFhirUserClaim = false; // we skip fhirUser claim for system scopes
                                 }
                             }
                         }
                     }
 
-                    if (!skipFhirUserClaimForSystemScope)
+                    if (includeFhirUserClaim)
                     {
                         var fhirUser = principal.FindFirstValue(authorizationConfiguration.FhirUserClaim);
                         try

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
@@ -12,10 +12,12 @@ using EnsureThat;
 using MediatR;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Core.Extensions;
+using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Core.Features.Security;
 using Microsoft.Health.Core.Features.Security.Authorization;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Exceptions;
+using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export.Models;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Security;
@@ -32,22 +34,26 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
         private readonly IFhirOperationDataStore _fhirOperationDataStore;
         private readonly IAuthorizationService<DataActions> _authorizationService;
         private readonly ExportJobConfiguration _exportJobConfiguration;
+        private readonly RequestContextAccessor<IFhirRequestContext> _contextAccessor;
 
         public CreateExportRequestHandler(
             IClaimsExtractor claimsExtractor,
             IFhirOperationDataStore fhirOperationDataStore,
             IAuthorizationService<DataActions> authorizationService,
-            IOptions<ExportJobConfiguration> exportJobConfiguration)
+            IOptions<ExportJobConfiguration> exportJobConfiguration,
+            RequestContextAccessor<IFhirRequestContext> fhirRequestContextAccessor)
         {
             EnsureArg.IsNotNull(claimsExtractor, nameof(claimsExtractor));
             EnsureArg.IsNotNull(fhirOperationDataStore, nameof(fhirOperationDataStore));
             EnsureArg.IsNotNull(authorizationService, nameof(authorizationService));
             EnsureArg.IsNotNull(exportJobConfiguration?.Value, nameof(exportJobConfiguration));
+            EnsureArg.IsNotNull(exportJobConfiguration?.Value, nameof(fhirRequestContextAccessor));
 
             _claimsExtractor = claimsExtractor;
             _fhirOperationDataStore = fhirOperationDataStore;
             _authorizationService = authorizationService;
             _exportJobConfiguration = exportJobConfiguration.Value;
+            _contextAccessor = fhirRequestContextAccessor;
         }
 
         public async Task<CreateExportResponse> Handle(CreateExportRequest request, CancellationToken cancellationToken)
@@ -89,7 +95,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                 _exportJobConfiguration.MaximumNumberOfResourcesPerQuery,
                 _exportJobConfiguration.NumberOfPagesPerCommit,
                 request.ContainerName,
-                request.Parallel);
+                request.Parallel,
+                smart: _contextAccessor?.RequestContext?.AccessControlContext?.ApplyFineGrainedAccessControl == true);
 
             var outcome = await _fhirOperationDataStore.CreateExportJobAsync(jobRecord, cancellationToken);
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                 _exportJobConfiguration.NumberOfPagesPerCommit,
                 request.ContainerName,
                 request.Parallel,
-                smart: _contextAccessor?.RequestContext?.AccessControlContext?.ApplyFineGrainedAccessControl == true);
+                smartRequest: _contextAccessor?.RequestContext?.AccessControlContext?.ApplyFineGrainedAccessControl == true);
 
             var outcome = await _fhirOperationDataStore.CreateExportJobAsync(jobRecord, cancellationToken);
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -625,7 +625,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                         resourceType: resourceType,
                         queryParametersList,
                         cancellationToken,
-                        true);
+                        true,
+                        _exportJobRecord.Smart);
                 }
 
                 ProcessSearchResults(searchResult.Results, anonymizer);

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -626,7 +626,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                         queryParametersList,
                         cancellationToken,
                         true,
-                        _exportJobRecord.Smart);
+                        _exportJobRecord.SmartRequest);
                 }
 
                 ProcessSearchResults(searchResult.Results, anonymizer);

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportOrchestratorJob.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportOrchestratorJob.cs
@@ -223,7 +223,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                         record.Parallel,
                         record.SchemaVersion,
                         (int)JobType.ExportProcessing,
-                        record.Smart);
+                        record.SmartRequest);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportOrchestratorJob.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportOrchestratorJob.cs
@@ -222,7 +222,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                         record.StorageAccountContainerName,
                         record.Parallel,
                         record.SchemaVersion,
-                        (int)JobType.ExportProcessing);
+                        (int)JobType.ExportProcessing,
+                        record.Smart);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobRecord.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobRecord.cs
@@ -40,7 +40,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
             string storageAccountContainerName = null,
             int parallel = 0,
             int schemaVersion = 2,
-            int typeId = (int)JobType.ExportOrchestrator)
+            int typeId = (int)JobType.ExportOrchestrator,
+            bool smart = false)
         {
             EnsureArg.IsNotNull(requestUri, nameof(requestUri));
             EnsureArg.IsNotNullOrWhiteSpace(hash, nameof(hash));
@@ -76,6 +77,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
 
             QueuedTime = Clock.UtcNow;
             Till = till ?? new PartialDateTime(Clock.UtcNow);
+
+            Smart = smart;
 
             if (string.IsNullOrWhiteSpace(storageAccountContainerName))
             {
@@ -176,6 +179,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
 
         [JsonProperty(JobRecordProperties.Parallel)]
         public int Parallel { get; private set; }
+
+        [JsonProperty(JobRecordProperties.Smart)]
+        public bool Smart { get; private set; }
 
         internal ExportJobRecord Clone()
         {

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobRecord.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobRecord.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
             int parallel = 0,
             int schemaVersion = 2,
             int typeId = (int)JobType.ExportOrchestrator,
-            bool smart = false)
+            bool smartRequest = false)
         {
             EnsureArg.IsNotNull(requestUri, nameof(requestUri));
             EnsureArg.IsNotNullOrWhiteSpace(hash, nameof(hash));
@@ -78,7 +78,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
             QueuedTime = Clock.UtcNow;
             Till = till ?? new PartialDateTime(Clock.UtcNow);
 
-            Smart = smart;
+            SmartRequest = smartRequest;
 
             if (string.IsNullOrWhiteSpace(storageAccountContainerName))
             {
@@ -180,8 +180,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
         [JsonProperty(JobRecordProperties.Parallel)]
         public int Parallel { get; private set; }
 
-        [JsonProperty(JobRecordProperties.Smart)]
-        public bool Smart { get; private set; }
+        [JsonProperty(JobRecordProperties.SmartRequest)]
+        public bool SmartRequest { get; private set; }
 
         internal ExportJobRecord Clone()
         {

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
@@ -136,5 +136,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations
         public const string TypeId = "typeId";
 
         public const string Parallel = "parallel";
+
+        public const string Smart = "smart";
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
@@ -137,6 +137,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations
 
         public const string Parallel = "parallel";
 
-        public const string Smart = "smart";
+        public const string SmartRequest = "smartRequest";
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/CompartmentSearchExpression.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/CompartmentSearchExpression.cs
@@ -20,9 +20,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// </summary>
         /// <param name="compartmentType">The compartment type.</param>
         /// <param name="compartmentId">The compartment id.</param>
-        /// <param name="smartUserCompartment">True is this compartment expression is being added due to smart restrictions</param>
         /// <param name="filteredResourceTypes">Resource types to filter</param>
-        public CompartmentSearchExpression(string compartmentType, string compartmentId, bool smartUserCompartment = false, params string[] filteredResourceTypes)
+        public CompartmentSearchExpression(string compartmentType, string compartmentId, params string[] filteredResourceTypes)
         {
             EnsureArg.IsTrue(ModelInfoProvider.IsKnownCompartmentType(compartmentType), nameof(compartmentType));
             EnsureArg.IsNotNullOrWhiteSpace(compartmentId, nameof(compartmentId));
@@ -30,7 +29,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
             CompartmentType = compartmentType;
             CompartmentId = compartmentId;
             FilteredResourceTypes = filteredResourceTypes ?? Array.Empty<string>();
-            SmartUserCompartment = smartUserCompartment;
         }
 
         /// <summary>
@@ -42,11 +40,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// The compartment id.
         /// </summary>
         public string CompartmentId { get; }
-
-        /// <summary>
-        /// Indicates if this compartment expression was added as a smart filter
-        /// </summary>
-        public bool SmartUserCompartment { get; }
 
         /// <summary>
         /// Resource types to filter for compartment search

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/CompartmentSearchRewriter.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/CompartmentSearchRewriter.cs
@@ -116,6 +116,23 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
                     {
                         compartmentSearchExpressionsGrouped.Add(
                             Expression.SearchParameter(idSearchParameter, Expression.StringEquals(FieldName.TokenCode, null, compartmentId, false)));
+
+                        // We want to add in the "universal" resources, which are resources that are not compartment specific
+                        var universalResourceTypes = new List<string>()
+                        {
+                            KnownResourceTypes.Location,
+                            KnownResourceTypes.Organization,
+                            KnownResourceTypes.Practitioner,
+                            KnownResourceTypes.Medication,
+                        };
+
+                        var inExpression = Expression.In(FieldName.TokenCode, null, universalResourceTypes);
+
+                        SearchParameterExpression universalResourceTypesExpression = Expression.SearchParameter(
+                            resourceTypeSearchParameter,
+                            inExpression);
+
+                        compartmentSearchExpressionsGrouped.Add(universalResourceTypesExpression);
                     }
 
                     if (compartmentSearchExpressionsGrouped.Count > 1)

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/CompartmentSearchRewriter.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/CompartmentSearchRewriter.cs
@@ -28,8 +28,25 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
 
         public override Expression VisitCompartment(CompartmentSearchExpression expression, object context)
         {
+            var compartmentSearchExpressionsGrouped = BuildCompartmentSearchExpressionsGroup(expression);
+
+            Expression compartmentExpression = null;
+
+            if (compartmentSearchExpressionsGrouped.Count > 1)
+            {
+                compartmentExpression = Expression.Union(UnionOperator.All, compartmentSearchExpressionsGrouped);
+            }
+            else if (compartmentSearchExpressionsGrouped.Count == 1)
+            {
+                compartmentExpression = compartmentSearchExpressionsGrouped[0];
+            }
+
+            return compartmentExpression;
+        }
+
+        internal List<Expression> BuildCompartmentSearchExpressionsGroup(CompartmentSearchExpression expression)
+        {
             SearchParameterInfo resourceTypeSearchParameter = _searchParameterDefinitionManager.Value.GetSearchParameter(KnownResourceTypes.Resource, SearchParameterNames.ResourceType);
-            SearchParameterInfo idSearchParameter = _searchParameterDefinitionManager.Value.GetSearchParameter(expression.CompartmentType, SearchParameterNames.Id);
 
             var compartmentType = expression.CompartmentType;
             var compartmentId = expression.CompartmentId;
@@ -86,10 +103,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
                     }
                 }
 
+                var compartmentSearchExpressionsGrouped = new List<Expression>();
+
                 if (compartmentSearchExpressions.Any())
                 {
-                    var compartmentSearchExpressionsGrouped = new List<Expression>();
-
                     foreach (var grouping in compartmentSearchExpressions)
                     {
                         // When we're searching more than 1 compartment resource type (i.e. Patient/abc/*) the search parameters need to list the applicable resource types
@@ -108,51 +125,18 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
                             compartmentSearchExpressionsGrouped.Add(grouping.Value.Expression);
                         }
                     }
-
-                    Expression compartmentExpression = null;
-
-                    // add in the resource which is the resource that identifies this compartment
-                    if (expression.SmartUserCompartment)
-                    {
-                        compartmentSearchExpressionsGrouped.Add(
-                            Expression.SearchParameter(idSearchParameter, Expression.StringEquals(FieldName.TokenCode, null, compartmentId, false)));
-
-                        // We want to add in the "universal" resources, which are resources that are not compartment specific
-                        var universalResourceTypes = new List<string>()
-                        {
-                            KnownResourceTypes.Location,
-                            KnownResourceTypes.Organization,
-                            KnownResourceTypes.Practitioner,
-                            KnownResourceTypes.Medication,
-                        };
-
-                        var inExpression = Expression.In(FieldName.TokenCode, null, universalResourceTypes);
-
-                        SearchParameterExpression universalResourceTypesExpression = Expression.SearchParameter(
-                            resourceTypeSearchParameter,
-                            inExpression);
-
-                        compartmentSearchExpressionsGrouped.Add(universalResourceTypesExpression);
-                    }
-
-                    if (compartmentSearchExpressionsGrouped.Count > 1)
-                    {
-                        compartmentExpression = Expression.Union(UnionOperator.All, compartmentSearchExpressionsGrouped);
-                    }
-                    else if (compartmentSearchExpressions.Count == 1)
-                    {
-                        compartmentExpression = compartmentSearchExpressionsGrouped[0];
-                    }
-
-                    return compartmentExpression;
                 }
+                else
+                {
+                    compartmentSearchExpressionsGrouped.Add(expression);
+                }
+
+                return compartmentSearchExpressionsGrouped;
             }
             else
             {
                 throw new InvalidSearchOperationException(string.Format(Core.Resources.CompartmentTypeIsInvalid, compartmentType));
             }
-
-            return expression;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/DefaultExpressionVisitor.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/DefaultExpressionVisitor.cs
@@ -49,6 +49,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
 
         public virtual TOutput VisitCompartment(CompartmentSearchExpression expression, TContext context) => default;
 
+        public virtual TOutput VisitSmartCompartment(SmartCompartmentSearchExpression expression, TContext context) => default;
+
+        public virtual TOutput VisitScmartCompartment(SmartCompartmentSearchExpression expression, TContext context) => default;
+
         public virtual TOutput VisitInclude(IncludeExpression expression, TContext context) => default;
 
         public virtual TOutput VisitSortParameter(SortExpression expression, TContext context) => default;

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/DefaultExpressionVisitor.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/DefaultExpressionVisitor.cs
@@ -51,8 +51,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
 
         public virtual TOutput VisitSmartCompartment(SmartCompartmentSearchExpression expression, TContext context) => default;
 
-        public virtual TOutput VisitScmartCompartment(SmartCompartmentSearchExpression expression, TContext context) => default;
-
         public virtual TOutput VisitInclude(IncludeExpression expression, TContext context) => default;
 
         public virtual TOutput VisitSortParameter(SortExpression expression, TContext context) => default;

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Expression.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Expression.cs
@@ -292,12 +292,22 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// </summary>
         /// <param name="compartmentType">The compartment type.</param>
         /// <param name="compartmentId">The compartment id.</param>
-        /// <param name="smartUserCompartment">True is this compartment expression is being added due to smart restrictions</param>
         /// <param name="filteredResourceTypes">Resource types to filter on</param>
         /// <returns>A <see cref="CompartmentSearchExpression"/> that represents a compartment search operation.</returns>
-        public static CompartmentSearchExpression CompartmentSearch(string compartmentType, string compartmentId, bool smartUserCompartment = false, params string[] filteredResourceTypes)
+        public static CompartmentSearchExpression CompartmentSearch(string compartmentType, string compartmentId, params string[] filteredResourceTypes)
         {
-            return new CompartmentSearchExpression(compartmentType, compartmentId, smartUserCompartment, filteredResourceTypes);
+            return new CompartmentSearchExpression(compartmentType, compartmentId, filteredResourceTypes);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="SmartCompartmentSearchExpression"/> that filters all results by the smart user's compartment.
+        /// </summary>
+        /// <param name="compartmentType">The compartment type.</param>
+        /// <param name="compartmentId">The compartment id.</param>
+        /// <returns>A <see cref="CompartmentSearchExpression"/> that represents a compartment search operation.</returns>
+        public static SmartCompartmentSearchExpression SmartCompartmentSearch(string compartmentType, string compartmentId)
+        {
+            return new SmartCompartmentSearchExpression(compartmentType, compartmentId);
         }
 
         public abstract TOutput AcceptVisitor<TContext, TOutput>(IExpressionVisitor<TContext, TOutput> visitor, TContext context);

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Expression.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Expression.cs
@@ -304,10 +304,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// </summary>
         /// <param name="compartmentType">The compartment type.</param>
         /// <param name="compartmentId">The compartment id.</param>
+        /// <param name="filteredResourceTypes">Resource types to filter on</param>
         /// <returns>A <see cref="CompartmentSearchExpression"/> that represents a compartment search operation.</returns>
-        public static SmartCompartmentSearchExpression SmartCompartmentSearch(string compartmentType, string compartmentId)
+        public static SmartCompartmentSearchExpression SmartCompartmentSearch(string compartmentType, string compartmentId, params string[] filteredResourceTypes)
         {
-            return new SmartCompartmentSearchExpression(compartmentType, compartmentId);
+            return new SmartCompartmentSearchExpression(compartmentType, compartmentId, filteredResourceTypes);
         }
 
         public abstract TOutput AcceptVisitor<TContext, TOutput>(IExpressionVisitor<TContext, TOutput> visitor, TContext context);

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/ExpressionRewriter.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/ExpressionRewriter.cs
@@ -93,6 +93,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
             return expression;
         }
 
+        public virtual Expression VisitSmartCompartment(SmartCompartmentSearchExpression expression, TContext context)
+        {
+            return expression;
+        }
+
         public virtual Expression VisitInclude(IncludeExpression expression, TContext context)
         {
             return expression;

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/IExpressionVisitor.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/IExpressionVisitor.cs
@@ -83,6 +83,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         TOutput VisitCompartment(CompartmentSearchExpression expression, TContext context);
 
         /// <summary>
+        /// Visits the <see cref="SmartCompartmentSearchExpression"/>.
+        /// </summary>
+        /// <param name="expression">The expression to visit.</param>
+        /// <param name="context">The input</param>
+        TOutput VisitSmartCompartment(SmartCompartmentSearchExpression expression, TContext context);
+
+        /// <summary>
         /// Visits the <see cref="IncludeExpression"/>
         /// </summary>
         /// <param name="expression">The expression to visit.</param>

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/SmartCompartmentSearchExpression.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/SmartCompartmentSearchExpression.cs
@@ -1,0 +1,46 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using EnsureThat;
+using Microsoft.Health.Fhir.Core.Models;
+
+namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
+{
+    /// <summary>
+    /// Represents an expression for search limited to a Smart user's compartment.
+    /// </summary>
+    public class SmartCompartmentSearchExpression : CompartmentSearchExpression
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SmartCompartmentSearchExpression"/> class.
+        /// </summary>
+        /// <param name="compartmentType">The Resource type of the smart user.</param>
+        /// <param name="compartmentId">The Resource id of the smart user.</param>
+        /// /// <param name="filteredResourceTypes">Resource types to filter</param>
+        public SmartCompartmentSearchExpression(string compartmentType, string compartmentId, params string[] filteredResourceTypes)
+            : base(compartmentType, compartmentId, filteredResourceTypes)
+        {
+        }
+
+        public override TOutput AcceptVisitor<TContext, TOutput>(IExpressionVisitor<TContext, TOutput> visitor, TContext context)
+        {
+            EnsureArg.IsNotNull(visitor, nameof(visitor));
+            return visitor.VisitSmartCompartment(this, context);
+        }
+
+        public override void AddValueInsensitiveHashCode(ref HashCode hashCode)
+        {
+            hashCode.Add(typeof(SmartCompartmentSearchExpression));
+            hashCode.Add(CompartmentType);
+        }
+
+        public override bool ValueInsensitiveEquals(Expression other)
+        {
+            return other is SmartCompartmentSearchExpression compartmentSearch && compartmentSearch.CompartmentType == CompartmentType;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/SmartCompartmentSearchExpression.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/SmartCompartmentSearchExpression.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// </summary>
         /// <param name="compartmentType">The Resource type of the smart user.</param>
         /// <param name="compartmentId">The Resource id of the smart user.</param>
-        /// /// <param name="filteredResourceTypes">Resource types to filter</param>
+        /// <param name="filteredResourceTypes">Resource types to filter</param>
         public SmartCompartmentSearchExpression(string compartmentType, string compartmentId, params string[] filteredResourceTypes)
             : base(compartmentType, compartmentId, filteredResourceTypes)
         {

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/SmartCompartmentSearchExpression.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/SmartCompartmentSearchExpression.cs
@@ -4,9 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using EnsureThat;
-using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
 {

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/SmartCompartmentSearchRewriter.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/SmartCompartmentSearchRewriter.cs
@@ -1,0 +1,67 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using EnsureThat;
+using Microsoft.Health.Fhir.Core.Features.Definition;
+using Microsoft.Health.Fhir.Core.Models;
+
+namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
+{
+    /// <summary>
+    /// Rewrites CompartmentSearchExpression to use main search index.
+    /// </summary>
+    public class SmartCompartmentSearchRewriter : ExpressionRewriterWithInitialContext<object>
+    {
+        private readonly Lazy<ISearchParameterDefinitionManager> _searchParameterDefinitionManager;
+        private readonly CompartmentSearchRewriter _compartmentSearchRewriter;
+
+        public SmartCompartmentSearchRewriter(CompartmentSearchRewriter compartmentSearchRewriter, Lazy<ISearchParameterDefinitionManager> searchParameterDefinitionManager)
+        {
+            _compartmentSearchRewriter = EnsureArg.IsNotNull(compartmentSearchRewriter, nameof(compartmentSearchRewriter));
+            _searchParameterDefinitionManager = EnsureArg.IsNotNull(searchParameterDefinitionManager, nameof(searchParameterDefinitionManager));
+        }
+
+        public override Expression VisitSmartCompartment(SmartCompartmentSearchExpression expression, object context)
+        {
+            SearchParameterInfo resourceTypeSearchParameter = _searchParameterDefinitionManager.Value.GetSearchParameter(KnownResourceTypes.Resource, SearchParameterNames.ResourceType);
+            SearchParameterInfo idSearchParameter = _searchParameterDefinitionManager.Value.GetSearchParameter(expression.CompartmentType, SearchParameterNames.Id);
+
+            var compartmentType = expression.CompartmentType;
+            var compartmentId = expression.CompartmentId;
+
+            // A smart user compartment is used to filter all search results by the resources available to the smart user
+            // The smart user has access to 3 things:
+            // 1 - any resource which refers to them
+            // 2 - their own resource
+            // 3 - any "uniersal" resources, such as Locations and Medications
+
+            // First a collection of any resources which refer to the smart user
+            // we use the CompartmentSearchRewriter to get this list as it matches what we want
+            var expressionList = _compartmentSearchRewriter.BuildCompartmentSearchExpressionsGroup(expression);
+
+            // Second the smart user's own resource
+            expressionList.Add(
+                Expression.SearchParameter(idSearchParameter, Expression.StringEquals(FieldName.TokenCode, null, compartmentId, false)));
+
+            // Finally we add in the "universal" resources, which are resources that are not compartment specific
+            var universalResourceTypes = new List<string>()
+            {
+                KnownResourceTypes.Location,
+                KnownResourceTypes.Organization,
+                KnownResourceTypes.Practitioner,
+                KnownResourceTypes.Medication,
+            };
+
+            var inExpression = Expression.In(FieldName.TokenCode, null, universalResourceTypes);
+
+            expressionList.Add(Expression.SearchParameter(resourceTypeSearchParameter, inExpression));
+
+            // new we union all those results together
+            return Expression.Union(UnionOperator.All, expressionList);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/SmartCompartmentSearchRewriter.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/SmartCompartmentSearchRewriter.cs
@@ -12,7 +12,7 @@ using Microsoft.Health.Fhir.Core.Models;
 namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
 {
     /// <summary>
-    /// Rewrites CompartmentSearchExpression to use main search index.
+    /// Builds on the CompartmentSearchRewriter to add additional resources for Smart access
     /// </summary>
     public class SmartCompartmentSearchRewriter : ExpressionRewriterWithInitialContext<object>
     {
@@ -60,7 +60,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
 
             expressionList.Add(Expression.SearchParameter(resourceTypeSearchParameter, inExpression));
 
-            // new we union all those results together
+            // union all those results together
             return Expression.Union(UnionOperator.All, expressionList);
         }
     }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/ISearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/ISearchOptionsFactory.cs
@@ -12,6 +12,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
     {
         SearchOptions Create(string resourceType, IReadOnlyList<Tuple<string, string>> queryParameters, bool isAsyncOperation = false);
 
-        SearchOptions Create(string compartmentType, string compartmentId, string resourceType, IReadOnlyList<Tuple<string, string>> queryParameters, bool isAsyncOperation = false);
+        SearchOptions Create(string compartmentType, string compartmentId, string resourceType, IReadOnlyList<Tuple<string, string>> queryParameters, bool isAsyncOperation = false, bool useSmartCompartmentDefinition = false);
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/ISearchService.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/ISearchService.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
         /// <param name="queryParameters">The search queries.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="isAsyncOperation">Whether the search is part of an async operation.</param>
+        /// <param name="useSmartCompartmentDefinition">Indicates wether to use the expanded SMART on FHIR definition of a compartment</param>
         /// <returns>A <see cref="SearchResult"/> representing the result.</returns>
         Task<SearchResult> SearchCompartmentAsync(
             string compartmentType,
@@ -56,7 +57,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             string resourceType,
             IReadOnlyList<Tuple<string, string>> queryParameters,
             CancellationToken cancellationToken,
-            bool isAsyncOperation = false);
+            bool isAsyncOperation = false,
+            bool useSmartCompartmentDefinition = false);
 
         Task<SearchResult> SearchHistoryAsync(
             string resourceType,

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/ISearchService.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/ISearchService.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
         /// <param name="queryParameters">The search queries.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="isAsyncOperation">Whether the search is part of an async operation.</param>
-        /// <param name="useSmartCompartmentDefinition">Indicates wether to use the expanded SMART on FHIR definition of a compartment</param>
+        /// <param name="useSmartCompartmentDefinition">Indicates wether to use the expanded SMART on FHIR definition of a compartment.</param>
         /// <returns>A <see cref="SearchResult"/> representing the result.</returns>
         Task<SearchResult> SearchCompartmentAsync(
             string compartmentType,

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchService.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchService.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             bool isAsyncOperation = false,
             bool useSmartCompartmentDefinition = false)
         {
-            SearchOptions searchOptions = _searchOptionsFactory.Create(compartmentType, compartmentId, resourceType, queryParameters, isAsyncOperation);
+            SearchOptions searchOptions = _searchOptionsFactory.Create(compartmentType, compartmentId, resourceType, queryParameters, isAsyncOperation, useSmartCompartmentDefinition);
 
             // Execute the actual search.
             return await SearchAsync(searchOptions, cancellationToken);

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchService.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchService.cs
@@ -59,7 +59,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             string resourceType,
             IReadOnlyList<Tuple<string, string>> queryParameters,
             CancellationToken cancellationToken,
-            bool isAsyncOperation = false)
+            bool isAsyncOperation = false,
+            bool useSmartCompartmentDefinition = false)
         {
             SearchOptions searchOptions = _searchOptionsFactory.Create(compartmentType, compartmentId, resourceType, queryParameters, isAsyncOperation);
 

--- a/src/Microsoft.Health.Fhir.Core/Microsoft.Health.Fhir.Core.csproj
+++ b/src/Microsoft.Health.Fhir.Core/Microsoft.Health.Fhir.Core.csproj
@@ -79,5 +79,4 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-  <ProjectExtensions><VisualStudio><UserProperties data_4r4_4search-parameters_1json__JsonSchema="https://beaujs.com/schema.json" /></VisualStudio></ProjectExtensions>
 </Project>

--- a/src/Microsoft.Health.Fhir.Core/Microsoft.Health.Fhir.Core.csproj
+++ b/src/Microsoft.Health.Fhir.Core/Microsoft.Health.Fhir.Core.csproj
@@ -79,4 +79,5 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
+  <ProjectExtensions><VisualStudio><UserProperties data_4r4_4search-parameters_1json__JsonSchema="https://beaujs.com/schema.json" /></VisualStudio></ProjectExtensions>
 </Project>

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
             ICosmosDbCollectionPhysicalPartitionInfo physicalPartitionInfo,
             QueryPartitionStatisticsCache queryPartitionStatisticsCache,
             CompartmentSearchRewriter compartmentSearchRewriter,
+            SmartCompartmentSearchRewriter smartCompartmentSearchRewriter,
             ILogger<FhirCosmosSearchService> logger)
             : base(searchOptionsFactory, fhirDataStore)
         {
@@ -64,6 +65,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
             EnsureArg.IsNotNull(physicalPartitionInfo, nameof(physicalPartitionInfo));
             EnsureArg.IsNotNull(queryPartitionStatisticsCache, nameof(queryPartitionStatisticsCache));
             EnsureArg.IsNotNull(compartmentSearchRewriter, nameof(compartmentSearchRewriter));
+            EnsureArg.IsNotNull(smartCompartmentSearchRewriter, nameof(smartCompartmentSearchRewriter));
             EnsureArg.IsNotNull(logger, nameof(logger));
 
             _fhirDataStore = fhirDataStore;
@@ -80,6 +82,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
                 new IExpressionVisitorWithInitialContext<object, Expression>[]
                 {
                     compartmentSearchRewriter,
+                    smartCompartmentSearchRewriter,
                     DateTimeEqualityRewriter.Instance,
                 });
         }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/ExpressionQueryBuilder.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/ExpressionQueryBuilder.cs
@@ -347,6 +347,12 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries
             return null;
         }
 
+        public object VisitSmartCompartment(SmartCompartmentSearchExpression expression, Context context)
+        {
+            AppendArrayContainsFilter(GetCompartmentIndicesParamName(expression.CompartmentType), expression.CompartmentId);
+            return null;
+        }
+
         public object VisitInclude(IncludeExpression expression, Context context)
         {
             throw new InvalidOperationException($"Include expression should have been removed before reaching {nameof(ExpressionQueryBuilder)}.");

--- a/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
@@ -227,6 +227,10 @@ namespace Microsoft.Extensions.DependencyInjection
                 .Singleton()
                 .AsSelf();
 
+            services.Add<SmartCompartmentSearchRewriter>()
+                .Singleton()
+                .AsSelf();
+
             return fhirServerBuilder;
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
@@ -186,12 +186,12 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
                 },
             };
 
-            yield return new object[] { "user/*.*", new List<ScopeRestriction>() { new ScopeRestriction(KnownResourceTypes.All, DataActions.Read | DataActions.Write, "user") } };
-            yield return new object[] { "user/Encounter.*", new List<ScopeRestriction>() { new ScopeRestriction("Encounter", DataActions.Read | DataActions.Write, "user") } };
-            yield return new object[] { "user/all.*", new List<ScopeRestriction>() { new ScopeRestriction(KnownResourceTypes.All, DataActions.Read | DataActions.Write, "user") } };
-            yield return new object[] { "user/all.all", new List<ScopeRestriction>() { new ScopeRestriction(KnownResourceTypes.All, DataActions.Read | DataActions.Write, "user") } };
+            yield return new object[] { "user/*.*", new List<ScopeRestriction>() { new ScopeRestriction(KnownResourceTypes.All, DataActions.Read | DataActions.Write | DataActions.Export, "user") } };
+            yield return new object[] { "user/Encounter.*", new List<ScopeRestriction>() { new ScopeRestriction("Encounter", DataActions.Read | DataActions.Write | DataActions.Export, "user") } };
+            yield return new object[] { "user/all.*", new List<ScopeRestriction>() { new ScopeRestriction(KnownResourceTypes.All, DataActions.Read | DataActions.Write | DataActions.Export, "user") } };
+            yield return new object[] { "user/all.all", new List<ScopeRestriction>() { new ScopeRestriction(KnownResourceTypes.All, DataActions.Read | DataActions.Write | DataActions.Export, "user") } };
             yield return new object[] { "patient.Patient.read", new List<ScopeRestriction>() { new ScopeRestriction("Patient", DataActions.Read, "patient") } };
-            yield return new object[] { "patient.Patient.all", new List<ScopeRestriction>() { new ScopeRestriction("Patient", DataActions.Read | DataActions.Write, "patient") } };
+            yield return new object[] { "patient.Patient.all", new List<ScopeRestriction>() { new ScopeRestriction("Patient", DataActions.Read | DataActions.Write | DataActions.Export, "patient") } };
             yield return new object[] { "patient.*.read", new List<ScopeRestriction>() { new ScopeRestriction(KnownResourceTypes.All, DataActions.Read, "patient") } };
             yield return new object[] { "patient.all.read", new List<ScopeRestriction>() { new ScopeRestriction(KnownResourceTypes.All, DataActions.Read, "patient") } };
             yield return new object[]
@@ -223,7 +223,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
                 {
                     new ScopeRestriction("Patient", DataActions.Read, "patient"),
                     new ScopeRestriction("Observation", DataActions.Read, "user"),
-                    new ScopeRestriction("Encounter", DataActions.Read | DataActions.Write, "user"),
+                    new ScopeRestriction("Encounter", DataActions.Read | DataActions.Write | DataActions.Export, "user"),
                 },
             };
         }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -70,7 +70,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
         }
 
         [SuppressMessage("Design", "CA1308", Justification = "ToLower() is required to format parameter output correctly.")]
-        public SearchOptions Create(string compartmentType, string compartmentId, string resourceType, IReadOnlyList<Tuple<string, string>> queryParameters, bool isAsyncOperation = false)
+        public SearchOptions Create(
+            string compartmentType,
+            string compartmentId,
+            string resourceType,
+            IReadOnlyList<Tuple<string, string>> queryParameters,
+            bool isAsyncOperation = false,
+            bool useSmartCompartmentDefinition = false)
         {
             var searchOptions = new SearchOptions();
 
@@ -295,7 +301,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                         throw new InvalidSearchOperationException(Core.Resources.CompartmentIdIsInvalid);
                     }
 
-                    searchExpressions.Add(Expression.CompartmentSearch(compartmentType, compartmentId, resourceTypesString));
+                    if (useSmartCompartmentDefinition)
+                    {
+                        searchExpressions.Add(Expression.SmartCompartmentSearch(compartmentType, compartmentId, resourceTypesString));
+                    }
+                    else
+                    {
+                        searchExpressions.Add(Expression.CompartmentSearch(compartmentType, compartmentId, resourceTypesString));
+                    }
                 }
                 else
                 {
@@ -316,7 +329,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                             string.Format(Core.Resources.FhirUserClaimIsNotAValidResource, _contextAccessor.RequestContext?.AccessControlContext.FhirUserClaim));
                     }
 
-                    searchExpressions.Add(Expression.SmartCompartmentSearch(smartCompartmentType, smartCompartmentId));
+                    searchExpressions.Add(Expression.SmartCompartmentSearch(smartCompartmentType, smartCompartmentId, null));
                 }
                 else
                 {

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -295,7 +295,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                         throw new InvalidSearchOperationException(Core.Resources.CompartmentIdIsInvalid);
                     }
 
-                    searchExpressions.Add(Expression.CompartmentSearch(compartmentType, compartmentId, smartUserCompartment: false, resourceTypesString));
+                    searchExpressions.Add(Expression.CompartmentSearch(compartmentType, compartmentId, resourceTypesString));
                 }
                 else
                 {
@@ -316,7 +316,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                             string.Format(Core.Resources.FhirUserClaimIsNotAValidResource, _contextAccessor.RequestContext?.AccessControlContext.FhirUserClaim));
                     }
 
-                    searchExpressions.Add(Expression.CompartmentSearch(smartCompartmentType, smartCompartmentId, smartUserCompartment: true, resourceTypesString));
+                    searchExpressions.Add(Expression.SmartCompartmentSearch(smartCompartmentType, smartCompartmentId));
                 }
                 else
                 {

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -349,7 +349,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
             // handle special case where we want to Union a specific resource to the results
             if (searchParameterExpressionPredicate != null &&
-                searchParameterExpressionPredicate.Parameter.Name == SearchParameterNames.Id)
+                searchParameterExpressionPredicate.Parameter.ColumnLocation().HasFlag(SearchParameterColumnLocation.ResourceTable))
             {
                 StringBuilder.Append("FROM ").AppendLine(new VLatest.ResourceTable());
             }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
         private readonly SchemaInformation _schemaInfo;
         private bool _sortVisited = false;
         private bool _unionVisited = false;
+        private bool _unionOnResourceTable = false;
         private HashSet<int> _cteToLimit = new HashSet<int>();
 
         public SqlQueryGenerator(
@@ -351,6 +352,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             if (searchParameterExpressionPredicate != null &&
                 searchParameterExpressionPredicate.Parameter.ColumnLocation().HasFlag(SearchParameterColumnLocation.ResourceTable))
             {
+                _unionOnResourceTable = true;
                 StringBuilder.Append("FROM ").AppendLine(new VLatest.ResourceTable());
             }
             else
@@ -406,10 +408,16 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             }
             else if (searchParamTableExpression.ChainLevel == 1 && _unionVisited)
             {
+                var tableName = searchParamTableExpression.QueryGenerator.Table;
+                if (_unionOnResourceTable)
+                {
+                    tableName = new VLatest.ResourceTable();
+                }
+
                 StringBuilder.Append("SELECT T1, Sid1, ")
                     .Append(VLatest.Resource.ResourceTypeId, null).AppendLine(" AS T2, ")
                     .Append(VLatest.Resource.ResourceSurrogateId, null).AppendLine(" AS Sid2")
-                    .Append("FROM ").AppendLine(searchParamTableExpression.QueryGenerator.Table)
+                    .Append("FROM ").AppendLine(tableName)
                     .Append("INNER JOIN ").AppendLine(TableExpressionName(FindRestrictingPredecessorTableExpressionIndex()));
 
                 using (var delimited = StringBuilder.BeginDelimitedOnClause())

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/SearchParamTableExpressionQueryGeneratorFactory.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/SearchParamTableExpressionQueryGeneratorFactory.cs
@@ -173,6 +173,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
             return CompartmentQueryGenerator.Instance;
         }
 
+        public SearchParamTableExpressionQueryGenerator VisitSmartCompartment(SmartCompartmentSearchExpression expression, object context)
+        {
+            return CompartmentQueryGenerator.Instance;
+        }
+
         public SearchParamTableExpressionQueryGenerator VisitInclude(IncludeExpression expression, object context)
         {
             return IncludeQueryGenerator.Instance;

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
         private readonly SortRewriter _sortRewriter;
         private readonly PartitionEliminationRewriter _partitionEliminationRewriter;
         private readonly CompartmentSearchRewriter _compartmentSearchRewriter;
+        private readonly SmartCompartmentSearchRewriter _smartCompartmentSearchRewriter;
         private readonly ChainFlatteningRewriter _chainFlatteningRewriter;
         private readonly ILogger<SqlServerSearchService> _logger;
         private readonly BitColumn _isMatch = new BitColumn("IsMatch");
@@ -70,6 +71,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
             SortRewriter sortRewriter,
             PartitionEliminationRewriter partitionEliminationRewriter,
             CompartmentSearchRewriter compartmentSearchRewriter,
+            SmartCompartmentSearchRewriter smartCompartmentSearchRewriter,
             SqlConnectionWrapperFactory sqlConnectionWrapperFactory,
             SchemaInformation schemaInformation,
             RequestContextAccessor<IFhirRequestContext> requestContextAccessor,
@@ -83,6 +85,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
             EnsureArg.IsNotNull(schemaInformation, nameof(schemaInformation));
             EnsureArg.IsNotNull(partitionEliminationRewriter, nameof(partitionEliminationRewriter));
             EnsureArg.IsNotNull(compartmentSearchRewriter, nameof(compartmentSearchRewriter));
+            EnsureArg.IsNotNull(smartCompartmentSearchRewriter, nameof(smartCompartmentSearchRewriter));
             EnsureArg.IsNotNull(requestContextAccessor, nameof(requestContextAccessor));
             EnsureArg.IsNotNull(logger, nameof(logger));
 
@@ -91,6 +94,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
             _sortRewriter = sortRewriter;
             _partitionEliminationRewriter = partitionEliminationRewriter;
             _compartmentSearchRewriter = compartmentSearchRewriter;
+            _smartCompartmentSearchRewriter = smartCompartmentSearchRewriter;
             _chainFlatteningRewriter = chainFlatteningRewriter;
             _sqlConnectionWrapperFactory = sqlConnectionWrapperFactory;
             _logger = logger;
@@ -266,6 +270,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
             SqlRootExpression expression = (SqlRootExpression)searchExpression
                                                ?.AcceptVisitor(LastUpdatedToResourceSurrogateIdRewriter.Instance)
                                                .AcceptVisitor(_compartmentSearchRewriter)
+                                               .AcceptVisitor(_smartCompartmentSearchRewriter)
                                                .AcceptVisitor(DateTimeEqualityRewriter.Instance)
                                                .AcceptVisitor(FlatteningRewriter.Instance)
                                                .AcceptVisitor(UntypedReferenceRewriter.Instance)

--- a/src/Microsoft.Health.Fhir.SqlServer/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
@@ -230,6 +230,10 @@ namespace Microsoft.Extensions.DependencyInjection
                 .Singleton()
                 .AsSelf();
 
+            services.Add<SmartCompartmentSearchRewriter>()
+                .Singleton()
+                .AsSelf();
+
             return fhirServerBuilder;
         }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Export/CreateExportRequestHandlerTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Export/CreateExportRequestHandlerTests.cs
@@ -9,9 +9,11 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
+using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Core.Features.Security;
 using Microsoft.Health.Fhir.Core;
 using Microsoft.Health.Fhir.Core.Configs;
+using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export.Models;
@@ -63,7 +65,9 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Export
             IOptions<ExportJobConfiguration> optionsExportConfig = Substitute.For<IOptions<ExportJobConfiguration>>();
             optionsExportConfig.Value.Returns(_exportJobConfiguration);
 
-            _createExportRequestHandler = new CreateExportRequestHandler(_claimsExtractor, _fhirOperationDataStore, DisabledFhirAuthorizationService.Instance, optionsExportConfig);
+            var contextAccess = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
+
+            _createExportRequestHandler = new CreateExportRequestHandler(_claimsExtractor, _fhirOperationDataStore, DisabledFhirAuthorizationService.Instance, optionsExportConfig, contextAccess);
         }
 
         public static IEnumerable<object[]> ExportUriForSameJobs

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
@@ -185,6 +185,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             var compartmentDefinitionManager = new CompartmentDefinitionManager(ModelInfoProvider.Instance);
             await compartmentDefinitionManager.StartAsync(CancellationToken.None);
             var compartmentSearchRewriter = new CompartmentSearchRewriter(new Lazy<ICompartmentDefinitionManager>(() => compartmentDefinitionManager), new Lazy<ISearchParameterDefinitionManager>(() => _searchParameterDefinitionManager));
+            var smartCompartmentSearchRewriter = new SmartCompartmentSearchRewriter(compartmentSearchRewriter, new Lazy<ISearchParameterDefinitionManager>(() => _searchParameterDefinitionManager));
 
             ICosmosDbCollectionPhysicalPartitionInfo cosmosDbPhysicalPartitionInfo = Substitute.For<ICosmosDbCollectionPhysicalPartitionInfo>();
             cosmosDbPhysicalPartitionInfo.PhysicalPartitionCount.Returns(1);
@@ -198,6 +199,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 cosmosDbPhysicalPartitionInfo,
                 new QueryPartitionStatisticsCache(),
                 compartmentSearchRewriter,
+                smartCompartmentSearchRewriter,
                 NullLogger<FhirCosmosSearchService>.Instance);
 
             await _searchParameterDefinitionManager.EnsureInitializedAsync(CancellationToken.None);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -219,6 +219,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             var compartmentDefinitionManager = new CompartmentDefinitionManager(ModelInfoProvider.Instance);
             compartmentDefinitionManager.StartAsync(CancellationToken.None).Wait();
             var compartmentSearchRewriter = new CompartmentSearchRewriter(new Lazy<ICompartmentDefinitionManager>(() => compartmentDefinitionManager), new Lazy<ISearchParameterDefinitionManager>(() => _searchParameterDefinitionManager));
+            var smartCompartmentSearchRewriter = new SmartCompartmentSearchRewriter(compartmentSearchRewriter, new Lazy<ISearchParameterDefinitionManager>(() => _searchParameterDefinitionManager));
 
             _searchService = new SqlServerSearchService(
                 searchOptionsFactory,
@@ -229,6 +230,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 sortRewriter,
                 partitionEliminationRewriter,
                 compartmentSearchRewriter,
+                smartCompartmentSearchRewriter,
                 SqlConnectionWrapperFactory,
                 SchemaInformation,
                 _fhirRequestContextAccessor,

--- a/testauthenvironment.json
+++ b/testauthenvironment.json
@@ -57,6 +57,36 @@
             "roles": [
                 "smartUser"
             ]
+        },
+        {
+            "id": "smart-practitioner-A",
+            "roles": [
+                "smartUser"
+            ]
+        },
+        {
+            "id": "smart-practitioner-B",
+            "roles": [
+                "smartUser"
+            ]
+        },
+        {
+            "id": "smart-patient-A",
+            "roles": [
+                "smartUser"
+            ]
+        },
+        {
+            "id": "smart-patient-B",
+            "roles": [
+                "smartUser"
+            ]
+        },
+        {
+            "id": "smart-patient-C",
+            "roles": [
+                "smartUser"
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Description
The resources a smart user should have access to include the standard definition of a compartment, plus a bit more.  This PR adds resources outside any compartment to be accessible to the smart user.

## Related issues
Addresses [issue AB#97983].

## Testing
Two additional integration tests were added for "universal" resources.

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [X] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
