### PR TITLE
Tracing added for Smart code

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Core.Features.Security.Authorization;
@@ -39,11 +40,12 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
     {
         private readonly SmartClinicalScopesMiddleware _smartClinicalScopesMiddleware;
         private IAuthorizationService<DataActions> _authorizationService;
+        private ILogger<SmartClinicalScopesMiddleware> _logger = Substitute.For<ILogger<SmartClinicalScopesMiddleware>>();
 
         public SmartClinicalScopesMiddlewareTests()
         {
             _smartClinicalScopesMiddleware = new SmartClinicalScopesMiddleware(
-                httpContext => Task.CompletedTask);
+                httpContext => Task.CompletedTask, _logger);
         }
 
         [Theory]


### PR DESCRIPTION
## Description
Added tracing in Smart related code to help with debugging.

## Related issues
Addresses [97780](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Olympus/Stories/?workitem=97780)

## Testing
N/A

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
