### PR TITLE
Handle the GET resource by ID case, and improve (rev)include

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Expression.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Expression.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// <returns>A <see cref="IncludeExpression"/> that represents an include on <param name="targetResourceType"> through <paramref name="referenceSearchParameter"/>.</param></returns>
         public static IncludeExpression Include(string[] resourceTypes, SearchParameterInfo referenceSearchParameter, string sourceResourceType, string targetResourceType, IEnumerable<string> referencedTypes, bool wildCard, bool reversed, bool iterate)
         {
-            return new IncludeExpression(resourceTypes, referenceSearchParameter, sourceResourceType, targetResourceType, referencedTypes, wildCard, reversed, iterate);
+            return new IncludeExpression(resourceTypes, referenceSearchParameter, sourceResourceType, targetResourceType, referencedTypes, wildCard, reversed, iterate, null);
         }
 
         /// <summary>

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/IncludeExpression.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/IncludeExpression.cs
@@ -18,7 +18,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
     {
         private IReadOnlyCollection<string> _requires;
         private IReadOnlyCollection<string> _produces;
-        private IEnumerable<string> _allowedResourceTypesByScope;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="IncludeExpression"/> class.
@@ -67,7 +66,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
                 ? SourceResourceType == TargetResourceType
                 : ReferenceSearchParameter?.TargetResourceTypes != null && ReferenceSearchParameter.TargetResourceTypes.Contains(sourceResourceType);
 
-            _allowedResourceTypesByScope = allowedResourceTypesByScope;
+            AllowedResourceTypesByScope = allowedResourceTypesByScope;
         }
 
         /// <summary>
@@ -125,6 +124,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
         /// Gets if the expression has a circular reference (source type = target type).
         /// </summary>
         public bool CircularReference { get; }
+
+        public IEnumerable<string> AllowedResourceTypesByScope { get; }
 
         public override TOutput AcceptVisitor<TContext, TOutput>(IExpressionVisitor<TContext, TOutput> visitor, TContext context)
         {
@@ -193,10 +194,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
                 }
             }
 
-            if (_allowedResourceTypesByScope != null &&
-                !_allowedResourceTypesByScope.Contains(KnownResourceTypes.All))
+            if (AllowedResourceTypesByScope != null &&
+                !AllowedResourceTypesByScope.Contains(KnownResourceTypes.All))
             {
-                producedResources = producedResources.Intersect(_allowedResourceTypesByScope).ToList();
+                producedResources = producedResources.Intersect(AllowedResourceTypesByScope).ToList();
             }
 
             return producedResources;

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/IncludeExpression.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/IncludeExpression.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions
             bool wildCard,
             bool reversed,
             bool iterate,
-            IEnumerable<string> allowedResourceTypesByScope)
+            IEnumerable<string> allowedResourceTypesByScope = null)
         {
             EnsureArg.HasItems(resourceTypes, nameof(resourceTypes));
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/IExpressionParser.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/IExpressionParser.cs
@@ -3,12 +3,14 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
+
 namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
 {
     public interface IExpressionParser
     {
         Expression Parse(string[] resourceTypes, string key, string value);
 
-        IncludeExpression ParseInclude(string[] resourceTypes, string includeValue, bool isReversed, bool iterate);
+        IncludeExpression ParseInclude(string[] resourceTypes, string includeValue, bool isReversed, bool iterate, IEnumerable<string> allowedResourceTypesByScope);
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/QueryBuilder.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/Queries/QueryBuilder.cs
@@ -13,6 +13,7 @@ using Microsoft.Health.Fhir.Core.Features;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
+using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.CosmosDb.Features.Queries;
 using Microsoft.Health.Fhir.CosmosDb.Features.Storage;
 
@@ -248,6 +249,17 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries
                                 .Append(" = '")
                                 .Append(includeExpression.TargetResourceType)
                                 .Append('\'');
+                        }
+                        else if (includeExpression.AllowedResourceTypesByScope != null &&
+                            !includeExpression.AllowedResourceTypesByScope.Contains(KnownResourceTypes.All))
+                        {
+                            var typesList = string.Join(",", includeExpression.Produces.Select(t => "'" + t + "'"));
+                            _queryBuilder
+                                .Append(" AND p.")
+                                .Append(SearchValueConstants.ReferenceResourceTypeName)
+                                .Append(" IN (")
+                                .Append(typesList)
+                                .Append(')');
                         }
 
                         _queryBuilder.Append(')');

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/ResourceHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/ResourceHandlerTests.cs
@@ -12,12 +12,14 @@ using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Core.Features.Security.Authorization;
 using Microsoft.Health.Core.Internal;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Conformance;
+using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Resources;
 using Microsoft.Health.Fhir.Core.Features.Resources.Create;
@@ -100,6 +102,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Resources
             _authorizationService = Substitute.For<IAuthorizationService<DataActions>>();
             _authorizationService.CheckAccess(Arg.Any<DataActions>(), Arg.Any<CancellationToken>()).Returns(ci => ci.Arg<DataActions>());
 
+            var contextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
+
             var referenceResolver = new ResourceReferenceResolver(_searchService, new TestQueryStringParser());
             _resourceIdProvider = new ResourceIdProvider();
             collection.Add(x => _mediator).Singleton().AsSelf();
@@ -108,7 +112,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Resources
             collection.Add(x => new ConditionalCreateResourceHandler(_fhirDataStore, lazyConformanceProvider, _resourceWrapperFactory, _searchService, x.GetService<IMediator>(), _resourceIdProvider, _authorizationService)).Singleton().AsSelf().AsImplementedInterfaces();
             collection.Add(x => new ConditionalUpsertResourceHandler(_fhirDataStore, lazyConformanceProvider, _resourceWrapperFactory, _searchService, x.GetService<IMediator>(), _resourceIdProvider, _authorizationService)).Singleton().AsSelf().AsImplementedInterfaces();
             collection.Add(x => new ConditionalDeleteResourceHandler(_fhirDataStore, lazyConformanceProvider, _resourceWrapperFactory, _searchService, x.GetService<IMediator>(), _resourceIdProvider, _authorizationService)).Singleton().AsSelf().AsImplementedInterfaces();
-            collection.Add(x => new GetResourceHandler(_fhirDataStore, lazyConformanceProvider, _resourceWrapperFactory, _resourceIdProvider, _dataResourceFilter, _authorizationService)).Singleton().AsSelf().AsImplementedInterfaces();
+            collection.Add(x => new GetResourceHandler(_fhirDataStore, lazyConformanceProvider, _resourceWrapperFactory, _resourceIdProvider, _dataResourceFilter, _authorizationService, contextAccessor, _searchService)).Singleton().AsSelf().AsImplementedInterfaces();
             collection.Add(x => new DeleteResourceHandler(_fhirDataStore, lazyConformanceProvider, _resourceWrapperFactory, _resourceIdProvider, _authorizationService)).Singleton().AsSelf().AsImplementedInterfaces();
 
             ServiceProvider provider = collection.BuildServiceProvider();

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -449,7 +449,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                         includeResourceTypeList = new[] { includeResourceType };
                     }
 
-                    var expression = _expressionParser.ParseInclude(includeResourceTypeList, p.query, isReversed, iterate);
+                    IEnumerable<string> allowedResourceTypesByScope = null;
+                    if (_contextAccessor.RequestContext?.AccessControlContext?.ApplyFineGrainedAccessControl == true)
+                    {
+                        allowedResourceTypesByScope = _contextAccessor.RequestContext?.AccessControlContext?.AllowedResourceActions.Select(s => s.Resource);
+                    }
+
+                    var expression = _expressionParser.ParseInclude(includeResourceTypeList, p.query, isReversed, iterate, allowedResourceTypesByScope);
 
                     // Reversed Iterate expressions (not wildcard) must specify target type if there is more than one possible target type
                     if (expression.Reversed && expression.Iterate && expression.TargetResourceType == null &&
@@ -483,9 +489,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                                 string.Format(Core.Resources.IncludeIterateCircularReferenceExecutedOnce, issueProperty, p.query)));
                     }
 
-                    if (_contextAccessor.RequestContext?.AccessControlContext?.ApplyFineGrainedAccessControl == true)
+                    if (_contextAccessor.RequestContext?.AccessControlContext?.ApplyFineGrainedAccessControl == true && expression.TargetResourceType != null)
                     {
-                        var allowedResourceTypesByScope = _contextAccessor.RequestContext?.AccessControlContext?.AllowedResourceActions.Select(s => s.Resource);
                         if (!allowedResourceTypesByScope.Contains(KnownResourceTypes.All) && !allowedResourceTypesByScope.Contains(expression.TargetResourceType))
                         {
                             _logger.LogTrace("Query restricted by clinical scopes.  Target resource type {ResourceType} not included in allowed resources.", expression.TargetResourceType);

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -489,11 +489,16 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                                 string.Format(Core.Resources.IncludeIterateCircularReferenceExecutedOnce, issueProperty, p.query)));
                     }
 
-                    if (_contextAccessor.RequestContext?.AccessControlContext?.ApplyFineGrainedAccessControl == true && expression.TargetResourceType != null)
+                    if (_contextAccessor.RequestContext?.AccessControlContext?.ApplyFineGrainedAccessControl == true && !allowedResourceTypesByScope.Contains(KnownResourceTypes.All))
                     {
-                        if (!allowedResourceTypesByScope.Contains(KnownResourceTypes.All) && !allowedResourceTypesByScope.Contains(expression.TargetResourceType))
+                        if (expression.TargetResourceType != null && !allowedResourceTypesByScope.Contains(expression.TargetResourceType))
                         {
                             _logger.LogTrace("Query restricted by clinical scopes.  Target resource type {ResourceType} not included in allowed resources.", expression.TargetResourceType);
+                            return null;
+                        }
+
+                        if (!expression.Produces.Any())
+                        {
                             return null;
                         }
                     }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
         private readonly SchemaInformation _schemaInfo;
         private bool _sortVisited = false;
         private bool _unionVisited = false;
-        private bool _unionOnResourceTable = false;
+        private bool _firstChainAfterUnionVisited = false;
         private HashSet<int> _cteToLimit = new HashSet<int>();
 
         public SqlQueryGenerator(
@@ -352,7 +352,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             if (searchParameterExpressionPredicate != null &&
                 searchParameterExpressionPredicate.Parameter.ColumnLocation().HasFlag(SearchParameterColumnLocation.ResourceTable))
             {
-                _unionOnResourceTable = true;
                 StringBuilder.Append("FROM ").AppendLine(new VLatest.ResourceTable());
             }
             else
@@ -409,7 +408,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             else if (searchParamTableExpression.ChainLevel == 1 && _unionVisited)
             {
                 var tableName = searchParamTableExpression.QueryGenerator.Table;
-                if (_unionOnResourceTable)
+
+                // handle special case where we want to Union a specific resource to the results
+                var searchParameterExpressionPredicate = CheckExpressionOrFirstChildIsSearchParam(searchParamTableExpression.Predicate);
+                if (searchParameterExpressionPredicate != null &&
+                    searchParameterExpressionPredicate.Parameter.ColumnLocation().HasFlag(SearchParameterColumnLocation.ResourceTable))
                 {
                     tableName = new VLatest.ResourceTable();
                 }
@@ -422,8 +425,12 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
                 using (var delimited = StringBuilder.BeginDelimitedOnClause())
                 {
-                    delimited.BeginDelimitedElement().Append(VLatest.Resource.ResourceTypeId, null).Append(" = ").Append("T1");
-                    delimited.BeginDelimitedElement().Append(VLatest.Resource.ResourceSurrogateId, null).Append(" = ").Append("Sid1");
+                    delimited.BeginDelimitedElement().Append(VLatest.Resource.ResourceTypeId, null).Append(" = ").Append(_firstChainAfterUnionVisited ? "T2" : "T1");
+                    delimited.BeginDelimitedElement().Append(VLatest.Resource.ResourceSurrogateId, null).Append(" = ").Append(_firstChainAfterUnionVisited ? "Sid2" : "Sid1");
+
+                    // once we have visited a table after the union all, the remained of the inner joins
+                    // should be on T1 and SID1
+                    _firstChainAfterUnionVisited = true;
                 }
             }
             else
@@ -748,6 +755,14 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     {
                         delimited.BeginDelimitedElement().Append(VLatest.ReferenceSearchParam.ReferenceResourceTypeId, referenceSourceTableAlias)
                             .Append(" = ").Append(Parameters.AddParameter(VLatest.ReferenceSearchParam.ReferenceResourceTypeId, Model.GetResourceTypeId(includeExpression.TargetResourceType), true));
+                    }
+                    else if (includeExpression.AllowedResourceTypesByScope != null &&
+                            !includeExpression.AllowedResourceTypesByScope.Contains(KnownResourceTypes.All))
+                    {
+                        delimited.BeginDelimitedElement().Append(VLatest.ReferenceSearchParam.ReferenceResourceTypeId, referenceSourceTableAlias)
+                            .Append(" IN (")
+                            .Append(string.Join(", ", includeExpression.AllowedResourceTypesByScope.Select(x => Parameters.AddParameter(VLatest.ReferenceSearchParam.ReferenceResourceTypeId, Model.GetResourceTypeId(x), true))))
+                            .Append(")");
                     }
                 }
 
@@ -1317,6 +1332,16 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             }
 
             return sortContext;
+        }
+
+        private static SearchParameterExpression CheckExpressionOrFirstChildIsSearchParam(Expression expression)
+        {
+            if (expression is MultiaryExpression)
+            {
+                expression = ((MultiaryExpression)expression).Expressions[0];
+            }
+
+            return expression as SearchParameterExpression;
         }
 
         /// <summary>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchTests.cs
@@ -560,6 +560,29 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
         }
 
         [SkippableFact]
+        public async Task GivenFhirUserClaimPatient_WhenAllPractitionersRequested_PractitionersReturned()
+        {
+            Skip.If(
+                ModelInfoProvider.Instance.Version != FhirSpecification.R4 &&
+                ModelInfoProvider.Instance.Version != FhirSpecification.R4B,
+                "This test is only valid for R4 and R4B");
+
+            var query = new List<Tuple<string, string>>();
+            query.Add(new Tuple<string, string>("_count", "100"));
+
+            var scopeRestriction = new ScopeRestriction("all", Core.Features.Security.DataActions.Read, "patient");
+
+            ConfigureFhirRequestContext(_contextAccessor, new List<ScopeRestriction>() { scopeRestriction });
+            _contextAccessor.RequestContext.AccessControlContext.CompartmentId = "smart-patient-A";
+            _contextAccessor.RequestContext.AccessControlContext.CompartmentResourceType = "Patient";
+
+            var results = await _searchService.Value.SearchAsync("Practitioner", query, CancellationToken.None);
+
+            Assert.Contains(results.Results, r => r.Resource.ResourceTypeName == KnownResourceTypes.Practitioner);
+            Assert.Equal(3, results.Results.Count());
+        }
+
+        [SkippableFact]
         public async Task GivenFhirUserClaimSystem_WhenAllResourcesRequested_ThenAllResourcesReturned()
         {
             Skip.If(

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchTests.cs
@@ -247,8 +247,9 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
             query.Add(new Tuple<string, string>("_include", "Observation:subject"));
 
             var scopeRestriction = new ScopeRestriction(KnownResourceTypes.Observation, Core.Features.Security.DataActions.Read, "patient");
+            var scopeRestriction2 = new ScopeRestriction(KnownResourceTypes.Medication, Core.Features.Security.DataActions.Read, "patient");
 
-            ConfigureFhirRequestContext(_contextAccessor, new List<ScopeRestriction>() { scopeRestriction });
+            ConfigureFhirRequestContext(_contextAccessor, new List<ScopeRestriction>() { scopeRestriction, scopeRestriction2 });
             _contextAccessor.RequestContext.AccessControlContext.CompartmentId = "smart-patient-A";
             _contextAccessor.RequestContext.AccessControlContext.CompartmentResourceType = "Patient";
 


### PR DESCRIPTION
## Description
SMART users could access resources outside their compartment using a direct GET using resource ID.  This is now fixed.  There were also errors in the way (rev)include was being handled.

## Related issues
Addresses [issue AB#95786].

## Testing
Some additional integration tests were added, as well as manual testing.

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [X] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
