### PR TITLE
Use AS SELF

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/42.diff.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/42.diff.sql
@@ -1,7 +1,7 @@
 ﻿GO
 CREATE OR ALTER PROCEDURE [dbo].[GetIndexCommands]
 @Tbl VARCHAR (100), @Ind VARCHAR (200), @AddPartClause BIT, @IncludeClustered BIT, @Txt VARCHAR (MAX)=NULL OUTPUT
-WITH EXECUTE AS 'dbo'
+WITH EXECUTE AS SELF
 AS
 SET NOCOUNT ON;
 DECLARE @SP AS VARCHAR (100) = 'GetIndexCommands', @Mode AS VARCHAR (200) = 'Tbl=' + isnull(@Tbl, 'NULL') + ' Ind=' + isnull(@Ind, 'NULL'), @st AS DATETIME = getUTCdate();

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/42.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/42.sql
@@ -2272,7 +2272,7 @@ WHERE  ParentTaskId = @importTaskId
 GO
 CREATE PROCEDURE dbo.GetIndexCommands
 @Tbl VARCHAR (100), @Ind VARCHAR (200), @AddPartClause BIT, @IncludeClustered BIT, @Txt VARCHAR (MAX)=NULL OUTPUT
-WITH EXECUTE AS 'dbo'
+WITH EXECUTE AS SELF
 AS
 SET NOCOUNT ON;
 DECLARE @SP AS VARCHAR (100) = 'GetIndexCommands', @Mode AS VARCHAR (200) = 'Tbl=' + isnull(@Tbl, 'NULL') + ' Ind=' + isnull(@Ind, 'NULL'), @st AS DATETIME = getUTCdate();

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/43.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/43.sql
@@ -2461,7 +2461,7 @@ WHERE  ParentTaskId = @importTaskId
 GO
 CREATE PROCEDURE dbo.GetIndexCommands
 @Tbl VARCHAR (100), @Ind VARCHAR (200), @AddPartClause BIT, @IncludeClustered BIT, @Txt VARCHAR (MAX)=NULL OUTPUT
-WITH EXECUTE AS 'dbo'
+WITH EXECUTE AS SELF
 AS
 SET NOCOUNT ON;
 DECLARE @SP AS VARCHAR (100) = 'GetIndexCommands', @Mode AS VARCHAR (200) = 'Tbl=' + isnull(@Tbl, 'NULL') + ' Ind=' + isnull(@Ind, 'NULL'), @st AS DATETIME = getUTCdate();

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Sql/Sprocs/GetIndexCommands.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Sql/Sprocs/GetIndexCommands.sql
@@ -1,7 +1,7 @@
 ﻿--IF object_id('GetIndexCommands') IS NOT NULL DROP PROCEDURE dbo.GetIndexCommands
 GO
 CREATE PROCEDURE dbo.GetIndexCommands @Tbl varchar(100), @Ind varchar(200), @AddPartClause bit, @IncludeClustered bit, @Txt varchar(max) = NULL OUT
-WITH EXECUTE AS 'dbo'
+WITH EXECUTE AS SELF
 AS
 set nocount on
 DECLARE @SP varchar(100) = 'GetIndexCommands'


### PR DESCRIPTION
## Description
Changes schema 42 to use AS SELF instead of AS 'dbo'

## Related issues
This was causing the following issue in managed service: 
Microsoft.Data.SqlClient.SqlException (0x80131904): Cannot execute as the user 'dbo', because it does not exist or you do not have permission. The module 'GetIndexCommands' depends on the missing object 'dbo.LogEvent'. The module will still be created; however, it cannot run successfully until the object exists.

## Testing

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
