### PR TITLE
If the fhirUser claim not present, look for fhirUser in custom header

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Core.Features.Security.Authorization;
 using Microsoft.Health.Fhir.Core.Configs;
+using Microsoft.Health.Fhir.Core.Features;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Security;
 using Microsoft.Health.Fhir.Core.Models;
@@ -126,6 +127,16 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
                     if (includeFhirUserClaim)
                     {
                         var fhirUser = principal.FindFirstValue(authorizationConfiguration.FhirUserClaim);
+                        if (string.IsNullOrEmpty(fhirUser))
+                        {
+                            // look for the fhirUser info in a header
+                            if (context.Request.Headers.ContainsKey(KnownHeaders.FhirUserHeader)
+                                && context.Request.Headers.TryGetValue(KnownHeaders.FhirUserHeader, out var hValue))
+                            {
+                                fhirUser = hValue.ToString();
+                            }
+                        }
+
                         try
                         {
                             fhirRequestContext.AccessControlContext.FhirUserClaim = new System.Uri(fhirUser, UriKind.RelativeOrAbsolute);

--- a/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
 
             if (fhirRequestContextAccessor.RequestContext.Principal != null
                 && securityConfigurationOptions.Value.Enabled
-                && authorizationConfiguration.Enabled)
+                && (authorizationConfiguration.Enabled || authorizationConfiguration.EnableSmartWithoutAuth))
             {
                 var fhirRequestContext = fhirRequestContextAccessor.RequestContext;
                 var principal = fhirRequestContext.Principal;

--- a/src/Microsoft.Health.Fhir.Core/Configs/AuthorizationConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/AuthorizationConfiguration.cs
@@ -22,5 +22,7 @@ namespace Microsoft.Health.Fhir.Core.Configs
         public string FhirUserClaim { get; set; } = "fhirUser";
 
         public bool ErrorOnMissingFhirUserClaim { get; set; } = false;
+
+        public bool EnableSmartWithoutAuth { get; set; } = false;
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/KnownHeaders.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/KnownHeaders.cs
@@ -28,5 +28,6 @@ namespace Microsoft.Health.Fhir.Core.Features
         public const string EnableChainSearch = "x-ms-enable-chained-search";
         public const string ProfileValidation = "x-ms-profile-validation";
         public const string CustomAuditHeaderPrefix = "X-MS-AZUREFHIR-AUDIT-";
+        public const string FhirUserHeader = "x-ms-fhiruser";
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Security.Claims;
@@ -19,6 +20,7 @@ using Microsoft.Health.Core.Features.Security.Authorization;
 using Microsoft.Health.Fhir.Api.Configs;
 using Microsoft.Health.Fhir.Api.Features.Smart;
 using Microsoft.Health.Fhir.Core.Configs;
+using Microsoft.Health.Fhir.Core.Features;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Security;
 using Microsoft.Health.Fhir.Core.Features.Security.Authorization;
@@ -162,6 +164,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
 
             var fhirConfiguration = new FhirServerConfiguration();
             var authorizationConfiguration = fhirConfiguration.Security.Authorization;
+            fhirConfiguration.Security.Enabled = true;
             authorizationConfiguration.Enabled = true;
             await LoadRoles(authorizationConfiguration);
 
@@ -178,6 +181,41 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
 
             await _smartClinicalScopesMiddleware.Invoke(httpContext, fhirRequestContextAccessor, Options.Create(fhirConfiguration.Security), _authorizationService);
             Assert.Empty(fhirRequestContext.AccessControlContext.AllowedResourceActions);
+        }
+
+        [Fact]
+        public async Task GivenFhirUserInHeader_WhenRequestMade_ThenFhirUserIsSaved()
+        {
+            var fhirRequestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
+
+            var fhirRequestContext = new DefaultFhirRequestContext();
+
+            fhirRequestContextAccessor.RequestContext.Returns(fhirRequestContext);
+
+            HttpContext httpContext = new DefaultHttpContext();
+            httpContext.Request.Headers.Add(KnownHeaders.FhirUserHeader, "https://fhirServer/Patient/foo");
+
+            var fhirConfiguration = new FhirServerConfiguration();
+            fhirConfiguration.Security.Enabled = true;
+            var authorizationConfiguration = fhirConfiguration.Security.Authorization;
+            authorizationConfiguration.Enabled = true;
+            await LoadRoles(authorizationConfiguration);
+
+            var rolesClaim = new Claim(authorizationConfiguration.RolesClaim, "smartUser");
+            var scopesClaim = new Claim(authorizationConfiguration.ScopesClaim, "patient.patient.read");
+            var claimsIdentity = new ClaimsIdentity(new List<Claim>() { scopesClaim, rolesClaim });
+            var expectedPrincipal = new ClaimsPrincipal(claimsIdentity);
+
+            httpContext.User = expectedPrincipal;
+            fhirRequestContext.Principal = expectedPrincipal;
+
+            _authorizationService = new RoleBasedFhirAuthorizationService(authorizationConfiguration, fhirRequestContextAccessor);
+
+            await _smartClinicalScopesMiddleware.Invoke(httpContext, fhirRequestContextAccessor, Options.Create(fhirConfiguration.Security), _authorizationService);
+
+            Assert.Equal(new Uri("https://fhirServer/Patient/foo"), fhirRequestContext.AccessControlContext.FhirUserClaim);
+            Assert.Equal("Patient", fhirRequestContext.AccessControlContext.CompartmentResourceType);
+            Assert.Equal("foo", fhirRequestContext.AccessControlContext.CompartmentId);
         }
 
         public static IEnumerable<object[]> GetTestScopes()

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
             var fhirConfiguration = new FhirServerConfiguration();
             fhirConfiguration.Security.Enabled = true;
             var authorizationConfiguration = fhirConfiguration.Security.Authorization;
-            authorizationConfiguration.Enabled = true;
+            authorizationConfiguration.EnableSmartWithoutAuth = true;
             await LoadRoles(authorizationConfiguration);
 
             var rolesClaim = new Claim(authorizationConfiguration.RolesClaim, "smartUser");


### PR DESCRIPTION
## Description
Attempt to read the fhirUser from the claims in the token, but if not present, then look for a custom header x-ms-fhiruser.

## Related issues
Addresses [issue AB#98435].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [X] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [X] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
