### PR TITLE
Added missing SearchParamTableExpressionKind

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -1172,6 +1172,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                 }
 
                 SearchParamTableExpression currentSearchParamTableExpression = _rootExpression.SearchParamTableExpressions[currentIndex];
+
+                // Include all the required SearchParamTableExpressionKind here
                 switch (currentSearchParamTableExpression.Kind)
                 {
                     case SearchParamTableExpressionKind.NotExists:

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -1164,7 +1164,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
         {
             int FindImpl(int currentIndex)
             {
-                // Due the UnionAll expressions, the number of the current index used to create new CTEs can be greater than
+                // Due to the UnionAll expressions, the number of the current index used to create new CTEs can be greater than
                 // the number of expressions in '_rootExpression.SearchParamTableExpressions'.
                 if (currentIndex >= _rootExpression.SearchParamTableExpressions.Count)
                 {
@@ -1185,6 +1185,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     case SearchParamTableExpressionKind.SortWithFilter:
                         return currentIndex - 1;
                     case SearchParamTableExpressionKind.All:
+                        return currentIndex - 1;
+                    case SearchParamTableExpressionKind.Include:
+                    case SearchParamTableExpressionKind.IncludeLimit:
+                    case SearchParamTableExpressionKind.Union:
+                    case SearchParamTableExpressionKind.IncludeUnionAll:
                         return currentIndex - 1;
                     default:
                         throw new ArgumentOutOfRangeException(currentSearchParamTableExpression.Kind.ToString());

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/CompartmentTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/CompartmentTests.cs
@@ -158,6 +158,26 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenAPatientCompartment_WhenSearchingForAResourceTypeUsingInclude_ThenResourcesShouldBeReturned()
+        {
+            string searchUrl = $"Patient/{Fixture.Patient.Id}/Observation?_include=Observation:performer:Practitioner&performer=Practitioner/f005";
+
+            Bundle bundle = await Client.SearchAsync(searchUrl);
+            ValidateBundle(bundle, searchUrl, Fixture.Observation);
+
+            searchUrl = $"Patient/{Fixture.Patient.Id}/Observation?_union=Observation:performer:Practitioner";
+
+            bundle = await Client.SearchAsync(searchUrl);
+            Assert.NotEmpty(bundle.Entry);
+
+            searchUrl = $"Patient/{Fixture.Patient.Id}/Observation?_includeunionall=Observation:performer:Practitioner";
+
+            bundle = await Client.SearchAsync(searchUrl);
+            Assert.NotEmpty(bundle.Entry);
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
         public async Task GivenMoreSearchResultsThanCount_WhenSearchingAPatientCompartment_ThenNextLinkShouldBePopulated()
         {
             string searchUrl = $"Patient/{Fixture.Patient.Id}/*?_count=1";


### PR DESCRIPTION
## Description
Added missing SearchParamTable expressin kinds for Include

## Related issues
Addresses [issue #[AB95810](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Olympus/Stories/?workitem=95810)

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
