### PR TITLE
PutJobHeartbeatFireAndForget exceptions should be handled

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Watchdogs/DefragWatchdog.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Watchdogs/DefragWatchdog.cs
@@ -24,7 +24,7 @@ using Microsoft.Health.SqlServer.Features.Schema;
 
 namespace Microsoft.Health.Fhir.SqlServer.Features.Watchdogs
 {
-    public sealed class DefragWatchdog : Watchdog<DefragWatchdog>, INotificationHandler<StorageInitializedNotification>
+    public sealed class DefragWatchdog : Watchdog<DefragWatchdog>
     {
         private const byte QueueType = (byte)Core.Features.Operations.QueueType.Defrag;
         private int _threads;


### PR DESCRIPTION
## Description
PutJobHeartbeatFireAndForget exceptions should be handled so they don't bubble up to the main thread.
Looks to be happening reasonably frequently in unit tests:

<img width="561" alt="image" src="https://user-images.githubusercontent.com/197221/201993024-0272aa3f-bfb3-43e1-8821-5e94a93f6082.png">

## Testing
Tests reliability should improve for `ExecuteWithHeartbeat`

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
