### PR TITLE
Personal/rajitha/continuation token limit

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Constants.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Constants.cs
@@ -9,5 +9,8 @@ namespace Microsoft.Health.Fhir.CosmosDb
     {
         public const string CollectionConfigurationName = "fhirCosmosDb";
         public const string CosmosDbResponseMessagesProperty = nameof(CosmosDbResponseMessagesProperty);
+        public const int ContinuationTokenMinLimit = 1;
+        public const int ContinuationTokenMaxLimit = 3;
+        public const int ContinuationTokenDefaultLimit = 3;
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosDbHeaders.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosDbHeaders.cs
@@ -14,5 +14,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
         public const string RequestCharge = "x-ms-request-charge";
 
         public const string SubStatus = "x-ms-substatus";
+
+        public const string CosmosContinuationTokenSize = "x-ms-continuation-token-size";
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/FhirCosmosResponseHandler.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/FhirCosmosResponseHandler.cs
@@ -66,12 +66,13 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
                 return;
             }
 
+            _cosmosDataStoreConfiguration.ContinuationTokenSizeLimitInKb = Constants.ContinuationTokenDefaultLimit;
             if (fhirRequestContext.RequestHeaders.TryGetValue(CosmosDbHeaders.CosmosContinuationTokenSize, out var tokenSize))
             {
                 var intTokenSize = int.TryParse(tokenSize, out var count) ? count : 0;
                 if (intTokenSize != 0)
                 {
-                    if (intTokenSize < 1 || intTokenSize > 3)
+                    if (intTokenSize < Constants.ContinuationTokenMinLimit || intTokenSize > Constants.ContinuationTokenMaxLimit)
                     {
                         throw new BadRequestException(string.Format(Resources.InvalidCosmosContinuationTokenSize, tokenSize));
                     }
@@ -80,7 +81,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
                 }
                 else
                 {
-                   throw new BadRequestException(string.Format(Resources.InvalidCosmosContinuationTokenSize, tokenSize));
+                    throw new BadRequestException(string.Format(Resources.InvalidCosmosContinuationTokenSize, tokenSize));
                 }
             }
 

--- a/src/Microsoft.Health.Fhir.CosmosDb/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Resources.Designer.cs
@@ -203,5 +203,11 @@ namespace Microsoft.Health.Fhir.CosmosDb {
                 return ResourceManager.GetString("UnrecognizedConsistencyLevel", resourceCulture);
             }
         }
+
+        internal static string InvalidCosmosContinuationTokenSize {
+            get {
+                return ResourceManager.GetString("InvalidCosmosContinuationTokenSize", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Resources.resx
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Resources.resx
@@ -165,4 +165,7 @@
   <data name="ChainedExpressionSubqueryLimit" xml:space="preserve">
     <value>Sub-queries in a chained expression cannot return more than {0} results, please use a more selective criteria.</value>
   </data>
+  <data name="InvalidCosmosContinuationTokenSize" xml:space="preserve">
+    <value>ContinuationTokenSize '{0}'Kb specified in the request is invalid. Valid limits re between 1 - 3 Kb.</value>
+  </data>
 </root>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/CustomHeadersTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/CustomHeadersTests.cs
@@ -8,6 +8,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Health.Fhir.Core.Features;
+using Microsoft.Health.Fhir.CosmosDb.Features.Storage;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.E2E.Common;
@@ -55,6 +56,39 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.NotEmpty(response.Headers.GetValues(KnownHeaders.RequestId));
             Assert.False(response.Headers.Contains(KnownHeaders.CorrelationId));
+        }
+
+        [Theory]
+        [InlineData("1")]
+        [InlineData("2")]
+        [InlineData("3")]
+        [Trait(Traits.Priority, Priority.One)]
+        [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb)]
+        public async Task GivenValidContinuationTokenLimitHeader_WhenSendRequest_TheServerShouldReturnSuccess(string tokenSize)
+        {
+            var message = new HttpRequestMessage(HttpMethod.Get, "Patient");
+            message.Headers.Add(CosmosDbHeaders.CosmosContinuationTokenSize, tokenSize);
+
+            using HttpResponseMessage response = await _client.HttpClient.SendAsync(message);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Theory]
+        [InlineData("invalid")]
+        [InlineData("5")]
+        [InlineData("-1")]
+        [InlineData("9999999999999999999999999999")]
+        [InlineData("1.0")]
+        [Trait(Traits.Priority, Priority.One)]
+        [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb)]
+        public async Task GivenInValidContinuationTokenLimitHeader_WhenSendRequest_ThenBadRequestShouldBeReturned(string tokenSize)
+        {
+            var message = new HttpRequestMessage(HttpMethod.Get, "Patient");
+            message.Headers.Add(CosmosDbHeaders.CosmosContinuationTokenSize, tokenSize);
+
+            using HttpResponseMessage response = await _client.HttpClient.SendAsync(message);
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         }
     }
 }


### PR DESCRIPTION
## Description

- In health PaaS, we currently have a default value of 3Kb for Cosmos DB Continuation Token limit.
- Changes in this PR allow customers to send Cosmos DB Continuation Token limit in the header.
- Valid range is 1 - 3 Kb. When not specified default value 3Kb will be used. 
- Header value to use to send this value is x-ms-continuation-token-size

## Related issues
Addresses [issue [97548](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Olympus/Stories/?workitem=97548)].

## Testing

- Added few more E2E tests to CustomHeaderTests class.
- Tested in Postman with setting MaxItemCount per search to 1 and different valid/invalid values for Continuation Token size header.
- Confirmed token size limit uses default value when it is not specified in the header.


## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
