### PR TITLE
refactor generated sql for 8623 error

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Tests/Samples.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Tests/Samples.cs
@@ -191,5 +191,10 @@ namespace Microsoft.Health.Fhir.Tests.Common
         {
             return EmbeddedResourceManager.GetStringContent(EmbeddedResourceSubNamespace, fileName, "ndjson");
         }
+
+        public static string GetFileContents(string fileName, string ext)
+        {
+            return EmbeddedResourceManager.GetStringContent(EmbeddedResourceSubNamespace, fileName, ext);
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -448,15 +448,15 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                 }
             }
 
+            if (searchParamTableExpression.ChainLevel == 0 && !IsInSortMode(context))
+            {
+                // if chainLevel > 0 or if in sort mode, the intersection is already handled in the JOIN
+                AppendIntersectionWithPredecessor(StringBuilder, searchParamTableExpression);
+            }
+
             using (var delimited = StringBuilder.BeginDelimitedWhereClause())
             {
                 AppendHistoryClause(delimited);
-
-                if (searchParamTableExpression.ChainLevel == 0 && !IsInSortMode(context))
-                {
-                    // if chainLevel > 0 or if in sort mode, the intersection is already handled in the JOIN
-                    AppendIntersectionWithPredecessor(delimited, searchParamTableExpression);
-                }
 
                 if (searchParamTableExpression.Predicate != null)
                 {
@@ -666,6 +666,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     delimited.BeginDelimitedElement().Append(VLatest.Resource.ResourceSurrogateId, chainedExpression.Reversed ? referenceTargetResourceTableAlias : referenceSourceTableAlias).Append(" = ").Append("Sid2");
                 }
             }
+            else if (searchParamTableExpression.ChainLevel == 1)
+            {
+                // if > 1, the intersection is handled by the JOIN
+                AppendIntersectionWithPredecessor(StringBuilder, searchParamTableExpression, chainedExpression.Reversed ? referenceTargetResourceTableAlias : referenceSourceTableAlias);
+            }
 
             using (var delimited = StringBuilder.BeginDelimitedWhereClause())
             {
@@ -684,12 +689,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     .Append(" IN (")
                     .Append(string.Join(", ", chainedExpression.TargetResourceTypes.Select(x => Parameters.AddParameter(VLatest.ReferenceSearchParam.ReferenceResourceTypeId, Model.GetResourceTypeId(x), true))))
                     .Append(")");
-
-                if (searchParamTableExpression.ChainLevel == 1)
-                {
-                    // if > 1, the intersection is handled by the JOIN
-                    AppendIntersectionWithPredecessor(delimited, searchParamTableExpression, chainedExpression.Reversed ? referenceTargetResourceTableAlias : referenceSourceTableAlias);
-                }
 
                 if (chainedExpression.ExpressionOnTarget != null && !expressionOnTargetHandledBySecondJoin)
                 {
@@ -997,6 +996,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     .Append(sortContext.SortColumnName, null).AppendLine(" as SortValue")
                     .Append("FROM ").AppendLine(searchParamTableExpression.QueryGenerator.Table);
 
+                AppendIntersectionWithPredecessor(StringBuilder, searchParamTableExpression);
+
                 using (var delimited = StringBuilder.BeginDelimitedWhereClause())
                 {
                     AppendHistoryClause(delimited);
@@ -1018,8 +1019,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                         StringBuilder.Append(" AND ").Append(VLatest.Resource.ResourceSurrogateId, null).Append(" > ").Append(Parameters.AddParameter(VLatest.Resource.ResourceSurrogateId, sortContext.ContinuationToken.ResourceSurrogateId, includeInHash: false)).Append(")");
                         StringBuilder.Append(" OR ").Append(sortContext.SortColumnName, null).Append(" ").Append(sortOperand).Append(" ").Append(Parameters.AddParameter(sortContext.SortColumnName, sortContext.SortValue, includeInHash: false)).AppendLine(")");
                     }
-
-                    AppendIntersectionWithPredecessor(delimited, searchParamTableExpression);
                 }
             }
 
@@ -1038,6 +1037,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     .Append(sortContext.SortColumnName, null).AppendLine(" as SortValue")
                     .Append("FROM ").AppendLine(searchParamTableExpression.QueryGenerator.Table);
 
+                AppendIntersectionWithPredecessor(StringBuilder, searchParamTableExpression);
+
                 using (var delimited = StringBuilder.BeginDelimitedWhereClause())
                 {
                     AppendHistoryClause(delimited);
@@ -1059,8 +1060,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                         StringBuilder.Append(" AND ").Append(VLatest.Resource.ResourceSurrogateId, null).Append(" > ").Append(Parameters.AddParameter(VLatest.Resource.ResourceSurrogateId, sortContext.ContinuationToken.ResourceSurrogateId, includeInHash: false)).Append(")");
                         StringBuilder.Append(" OR ").Append(sortContext.SortColumnName, null).Append(" ").Append(sortOperand).Append(" ").Append(Parameters.AddParameter(sortContext.SortColumnName, sortContext.SortValue, includeInHash: false)).AppendLine(")");
                     }
-
-                    AppendIntersectionWithPredecessor(delimited, searchParamTableExpression);
                 }
             }
 
@@ -1143,20 +1142,20 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             sb.Append(")");
         }
 
-        private void AppendIntersectionWithPredecessor(IndentedStringBuilder.DelimitedScope delimited, SearchParamTableExpression searchParamTableExpression, string tableAlias = null)
+        private void AppendIntersectionWithPredecessor(IndentedStringBuilder sb, SearchParamTableExpression searchParamTableExpression, string tableAlias = null)
         {
             int predecessorIndex = FindRestrictingPredecessorTableExpressionIndex();
 
-            if (predecessorIndex >= 0)
+            if (predecessorIndex >= 1)
             {
-                delimited.BeginDelimitedElement();
-
                 bool intersectWithFirst = (searchParamTableExpression.Kind == SearchParamTableExpressionKind.Chain ? searchParamTableExpression.ChainLevel - 1 : searchParamTableExpression.ChainLevel) == 0;
-
-                StringBuilder.Append("EXISTS(SELECT * FROM ").Append(TableExpressionName(predecessorIndex))
-                    .Append(" WHERE ").Append(VLatest.Resource.ResourceTypeId, tableAlias).Append(" = ").Append(intersectWithFirst ? "T1" : "T2")
-                    .Append(" AND ").Append(VLatest.Resource.ResourceSurrogateId, tableAlias).Append(" = ").Append(intersectWithFirst ? "Sid1" : "Sid2")
-                    .Append(')');
+                sb.AppendLine("INNER JOIN " + TableExpressionName(predecessorIndex - 0));
+                using (sb.BeginDelimitedOnClause())
+                {
+                    sb.Append(" ON ").Append(VLatest.Resource.ResourceTypeId, tableAlias).Append(" = ").Append(intersectWithFirst ? "T1" : "T2")
+                        .Append(" AND ").Append(VLatest.Resource.ResourceSurrogateId, tableAlias).Append(" = ").Append(intersectWithFirst ? "Sid1" : "Sid2")
+                        .AppendLine();
+                }
             }
         }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -1164,7 +1164,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
         {
             int FindImpl(int currentIndex)
             {
-                // Due the UnionAll expressions, the number of the current index used to create new CTEs can be greater than
+                // Due to the UnionAll expressions, the number of the current index used to create new CTEs can be greater than
                 // the number of expressions in '_rootExpression.SearchParamTableExpressions'.
                 if (currentIndex >= _rootExpression.SearchParamTableExpressions.Count)
                 {
@@ -1172,6 +1172,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                 }
 
                 SearchParamTableExpression currentSearchParamTableExpression = _rootExpression.SearchParamTableExpressions[currentIndex];
+
+                // Include all the required SearchParamTableExpressionKind here
                 switch (currentSearchParamTableExpression.Kind)
                 {
                     case SearchParamTableExpressionKind.NotExists:
@@ -1185,6 +1187,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     case SearchParamTableExpressionKind.SortWithFilter:
                         return currentIndex - 1;
                     case SearchParamTableExpressionKind.All:
+                        return currentIndex - 1;
+                    case SearchParamTableExpressionKind.Include:
+                    case SearchParamTableExpressionKind.IncludeLimit:
+                    case SearchParamTableExpressionKind.Union:
+                    case SearchParamTableExpressionKind.IncludeUnionAll:
                         return currentIndex - 1;
                     default:
                         throw new ArgumentOutOfRangeException(currentSearchParamTableExpression.Kind.ToString());

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -1146,7 +1146,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
         {
             int predecessorIndex = FindRestrictingPredecessorTableExpressionIndex();
 
-            if (predecessorIndex >= 1)
+            if (predecessorIndex >= 0)
             {
                 bool intersectWithFirst = (searchParamTableExpression.Kind == SearchParamTableExpressionKind.Chain ? searchParamTableExpression.ChainLevel - 1 : searchParamTableExpression.ChainLevel) == 0;
                 sb.AppendLine("INNER JOIN " + TableExpressionName(predecessorIndex - 0));

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -383,8 +383,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                             rawResource = _compressedRawResourceConverter.ReadCompressedRawResource(rawResourceStream);
                         }
 
-                        _logger.LogInformation("{NameOfResourceSurrogateId}: {ResourceSurrogateId}; {NameOfResourceTypeId}: {ResourceTypeId}; Decompressed length: {RawResourceLength}", nameof(resourceSurrogateId), resourceSurrogateId, nameof(resourceTypeId), resourceTypeId, rawResource.Length);
-
                         if (string.IsNullOrEmpty(rawResource))
                         {
                             rawResource = MissingResourceFactory.CreateJson(resourceId, _model.GetResourceTypeName(resourceTypeId), "warning", "incomplete");
@@ -647,7 +645,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                     .Append(p)
                     .Append(' ')
                     .Append(p.SqlDbType)
-                    .Append(p.Value is string ? $"({p.Size})" : p.Value is decimal ? $"({p.Precision},{p.Scale})" : null)
+                    .Append(p.Value is string ? (p.Size == -1 ? "(MAX)" : $"({p.Size})") : p.Value is decimal ? $"({p.Precision},{p.Scale})" : null)
                     .Append(" = ")
                     .Append(p.SqlDbType == SqlDbType.NChar || p.SqlDbType == SqlDbType.NText || p.SqlDbType == SqlDbType.NVarChar ? "N" : null)
                     .Append(p.Value is string || p.Value is DateTime ? $"'{p.Value:O}'" : p.Value.ToString())
@@ -657,6 +655,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
             sb.AppendLine();
 
             sb.AppendLine(sqlCommandWrapper.CommandText);
+            sb.AppendLine($"{nameof(sqlCommandWrapper.CommandTimeout)} = " + TimeSpan.FromSeconds(sqlCommandWrapper.CommandTimeout).Duration().ToString());
             _logger.LogInformation("{SqlQuery}", sb.ToString());
         }
 

--- a/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
+++ b/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
@@ -37,11 +37,13 @@
     <EmbeddedResource Include="TestFiles\Normative\Import-Patient.ndjson" />
     <EmbeddedResource Include="TestFiles\Normative\Import-SinglePatientTemplate.ndjson" />
     <EmbeddedResource Include="TestFiles\Normative\Medication.json" />
+    <EmbeddedResource Include="TestFiles\Normative\MemberMatch.json" />
     <EmbeddedResource Include="TestFiles\Normative\Profile-Patient-uscore-noidentifier.json" />
     <EmbeddedResource Include="TestFiles\Normative\Profile-Patient-uscore-noGender.json" />
     <EmbeddedResource Include="TestFiles\Normative\SearchParameter-AppointmentStatus.json" />
     <EmbeddedResource Include="TestFiles\Normative\SearchParameter-Patient-foo.json" />
     <EmbeddedResource Include="TestFiles\Normative\SearchParameter-SpecimenStatus.json" />
+    <EmbeddedResource Include="TestFiles\Normative\sql_8623_script.sql" />
     <EmbeddedResource Include="TestFiles\Normative\TokenOverflowChargeItem.json" />
     <EmbeddedResource Include="TestFiles\Normative\TokenOverflowPatient.json" />
     <EmbeddedResource Include="TestFiles\Normative\TokenOverflowRiskAssessment.json" />
@@ -214,6 +216,7 @@
     <EmbeddedResource Include="TestFiles\Stu3\Immunization.json" />
     <EmbeddedResource Include="TestFiles\Stu3\InvalidObservation.json" />
     <EmbeddedResource Include="TestFiles\Stu3\Location-example-hq.json" />
+    <EmbeddedResource Include="TestFiles\Stu3\MemberMatch.json" />
     <EmbeddedResource Include="TestFiles\Stu3\Observation-For-Patient-f001.json" />
     <EmbeddedResource Include="TestFiles\Stu3\ObservationWith1MinuteApgarScore.json" />
     <EmbeddedResource Include="TestFiles\Stu3\ObservationWith20MinuteApgarScore.json" />

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/MemberMatch.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/MemberMatch.json
@@ -1,0 +1,174 @@
+{
+    "resourceType": "Parameters",
+    "id": "member-match-in",
+    "parameter": [
+        {
+            "name": "MemberPatient",
+            "resource": {
+                "resourceType": "Patient",
+                "id": "1",
+                "identifier": [
+                    {
+                        "type": {
+                            "coding": [
+                                {
+                                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                                    "code": "MB"
+                                }
+                            ]
+                        },
+                        "system": "http://example.org/old-payer/identifiers/member",
+                        "value": "55678",
+                        "assigner": {
+                            "display": "Old Payer"
+                        }
+                    }
+                ],
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "Person",
+                        "given": [
+                            "Patricia",
+                            "Ann"
+                        ]
+                    }
+                ],
+                "gender": "female",
+                "birthDate": "1974-12-25"
+            }
+        },
+        {
+            "name": "OldCoverage",
+            "resource": {
+                "resourceType": "Coverage",
+                "id": "9876B1",
+                "contained": [
+                    {
+                        "resourceType": "Organization",
+                        "id": "payer",
+                        "identifier": [
+                            {
+                                "system": "http://hl7.org/fhir/sid/us-npi",
+                                "value": "9876543210"
+                            }
+                        ],
+                        "active": true,
+                        "name": "Old Health Plan",
+                        "endpoint": [
+                            {
+                                "reference": "http://example.org/old-payer/fhir"
+                            }
+                        ]
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "http://example.org/old-payer",
+                        "value": "DH10001235"
+                    }
+                ],
+                "status": "draft",
+                "beneficiary": {
+                    "reference": "Patient/1"
+                },
+                "period": {
+                    "start": "2011-05-23",
+                    "end": "2012-05-23"
+                },
+                "payor": [
+                    {
+                        "reference": "#payer"
+                    }
+                ],
+                "class": [
+                    {
+                        "type": {
+                            "coding": [
+                                {
+                                    "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+                                    "code": "group"
+                                }
+                            ]
+                        },
+                        "value": "CB135"
+                    },
+                    {
+                        "type": {
+                            "coding": [
+                                {
+                                    "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+                                    "code": "plan"
+                                }
+                            ]
+                        },
+                        "value": "B37FC"
+                    },
+                    {
+                        "type": {
+                            "coding": [
+                                {
+                                    "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+                                    "code": "subplan"
+                                }
+                            ]
+                        },
+                        "value": "P7"
+                    },
+                    {
+                        "type": {
+                            "coding": [
+                                {
+                                    "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+                                    "code": "class"
+                                }
+                            ]
+                        },
+                        "value": "SILVER"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "NewCoverage",
+            "resource": {
+                "resourceType": "Coverage",
+                "id": "AA87654",
+                "contained": [
+                    {
+                        "resourceType": "Organization",
+                        "id": "payer",
+                        "identifier": [
+                            {
+                                "system": "http://hl7.org/fhir/sid/us-npi",
+                                "value": "0123456789"
+                            }
+                        ],
+                        "active": true,
+                        "name": "New Health Plan",
+                        "endpoint": [
+                            {
+                                "reference": "http://example.org/new-payer/fhir"
+                            }
+                        ]
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "http://example.org/new-payer/identifiers/coverage",
+                        "value": "234567"
+                    }
+                ],
+                "status": "active",
+                "beneficiary": {
+                    "reference": "Patient/1"
+                },
+                "payor": [
+                    {
+                        "reference": "#payer"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/sql_8623_script.sql
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/sql_8623_script.sql
@@ -1,0 +1,400 @@
+      DECLARE @p0 SmallInt = 1418;
+      DECLARE @p1 VarChar(256) = '1';
+      DECLARE @p2 SmallInt = 103;
+      DECLARE @p3 SmallInt = 1016;
+      DECLARE @p4 NVarChar(256) = N'Patricia';
+      DECLARE @p5 NVarChar(256) = N'Ann';
+      DECLARE @p6 NVarChar(256) = N'Person';
+      DECLARE @p7 SmallInt = 696;
+      DECLARE @p8 SmallInt = 694;
+      DECLARE @p9 SmallInt = 1013;
+      DECLARE @p10 NVarChar(256) = N'http://example.org/old-payer/identifiers/member';
+      DECLARE @p11 VarChar(256) = '55678';
+      DECLARE @p12 SmallInt = 1419;
+      DECLARE @p13 NVarChar(256) = N'(http://example.org/old-payer/identifiers/member';
+      DECLARE @p14 VarChar(256) = '55678) ';
+      DECLARE @p15 NVarChar(256) = N' (Person)%';
+      DECLARE @p16 SmallInt = 690;
+      DECLARE @p17 DateTime2 = '1974-12-25T00:00:00.0000000Z';
+      DECLARE @p18 DateTime2 = '1974-12-25T23:59:59.9999999Z';
+      DECLARE @p19 SmallInt = 1011;
+      DECLARE @p20 Int = 9;
+      DECLARE @p21 VarChar(256) = 'false';
+      DECLARE @p22 SmallInt = 692;
+      DECLARE @p23 SmallInt = 693;
+      DECLARE @p24 Int = 12;
+      DECLARE @p25 VarChar(256) = 'female';
+      DECLARE @p26 SmallInt = 336;
+      DECLARE @p27 SmallInt = 31;
+      DECLARE @p28 SmallInt = 338;
+      DECLARE @p29 NVarChar(256) = N'CB135';
+      DECLARE @p30 NVarChar(256) = N'B37FC';
+      DECLARE @p31 NVarChar(256) = N'P7';
+      DECLARE @p32 NVarChar(256) = N'SILVER';
+      DECLARE @p33 SmallInt = 337;
+      DECLARE @p34 NVarChar(256) = N'http://terminology.hl7.org/CodeSystem/coverage-class';
+      DECLARE @p35 VarChar(256) = 'group';
+      DECLARE @p36 VarChar(256) = 'plan';
+      DECLARE @p37 VarChar(256) = 'subplan';
+      DECLARE @p38 VarChar(256) = 'class';
+      DECLARE @p39 VarChar(256) = '9876B1';
+      DECLARE @p40 SmallInt = 356;
+      DECLARE @p41 NVarChar(256) = N'http://example.org/old-payer';
+      DECLARE @p42 VarChar(256) = 'DH10001235';
+      DECLARE @p43 SmallInt = 360;
+      DECLARE @p44 NVarChar(256) = N'http://hl7.org/fhir/fm-status';
+      DECLARE @p45 VarChar(256) = 'draft';
+      DECLARE @p46 Int = 3;
+
+      SET STATISTICS IO ON;
+      SET STATISTICS TIME ON;
+
+      WITH cte0 AS
+      (
+          SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1
+          FROM dbo.TokenSearchParam
+          WHERE IsHistory = 0
+              AND SearchParamId = @p0
+              AND Code = @p1
+              AND ResourceTypeId = @p2
+
+      ),
+      cte1 AS
+      (
+          SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1
+          FROM dbo.StringSearchParam
+          WHERE IsHistory = 0
+              AND EXISTS(SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)
+              AND SearchParamId = @p3
+              AND Text = @p4 AND Text = @p4 COLLATE Latin1_General_100_CS_AS
+              AND ResourceTypeId = @p2
+
+      ),
+      cte2 AS
+      (
+          SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1
+          FROM dbo.StringSearchParam
+          WHERE IsHistory = 0
+              AND EXISTS(SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)
+              AND SearchParamId = @p3
+              AND Text = @p5 AND Text = @p5 COLLATE Latin1_General_100_CS_AS
+              AND ResourceTypeId = @p2
+
+      ),
+      cte3 AS
+      (
+          SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1
+          FROM dbo.StringSearchParam
+          WHERE IsHistory = 0
+              AND EXISTS(SELECT * FROM cte2 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)
+              AND SearchParamId = @p3
+              AND Text = @p6 AND Text = @p6 COLLATE Latin1_General_100_CS_AS
+              AND ResourceTypeId = @p2
+
+      ),
+      cte4 AS
+      (
+          SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1
+          FROM dbo.StringSearchParam
+          WHERE IsHistory = 0
+              AND EXISTS(SELECT * FROM cte3 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)
+              AND SearchParamId = @p7
+              AND Text = @p4 AND Text = @p4 COLLATE Latin1_General_100_CS_AS
+              AND ResourceTypeId = @p2
+
+      ),
+      cte5 AS
+      (
+          SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1
+          FROM dbo.StringSearchParam
+          WHERE IsHistory = 0
+              AND EXISTS(SELECT * FROM cte4 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)
+              AND SearchParamId = @p7
+              AND Text = @p5 AND Text = @p5 COLLATE Latin1_General_100_CS_AS
+              AND ResourceTypeId = @p2
+
+      ),
+      cte6 AS
+      (
+          SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1
+          FROM dbo.StringSearchParam
+          WHERE IsHistory = 0
+              AND EXISTS(SELECT * FROM cte5 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)
+              AND SearchParamId = @p7
+              AND Text = @p6 AND Text = @p6 COLLATE Latin1_General_100_CS_AS
+              AND ResourceTypeId = @p2
+
+      ),
+      cte7 AS
+      (
+          SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1
+          FROM dbo.StringSearchParam
+          WHERE IsHistory = 0
+              AND EXISTS(SELECT * FROM cte6 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)
+              AND SearchParamId = @p8
+              AND Text = @p4 AND Text = @p4 COLLATE Latin1_General_100_CS_AS
+              AND ResourceTypeId = @p2
+
+      ),
+      cte8 AS
+      (
+          SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1
+          FROM dbo.StringSearchParam
+          WHERE IsHistory = 0
+              AND EXISTS(SELECT * FROM cte7 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)
+              AND SearchParamId = @p8
+              AND Text = @p5 AND Text = @p5 COLLATE Latin1_General_100_CS_AS
+              AND ResourceTypeId = @p2
+
+      ),
+      cte9 AS
+      (
+          SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1
+          FROM dbo.TokenSearchParam
+          WHERE IsHistory = 0
+              AND EXISTS(SELECT * FROM cte8 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)
+              AND SearchParamId = @p9
+              AND SystemId IN (SELECT SystemId FROM dbo.System WHERE Value = @p10)
+              AND Code = @p11
+
+              AND ResourceTypeId = @p2
+
+      ),
+      cte10 AS
+      (
+          SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1
+          FROM dbo.TokenStringCompositeSearchParam
+          WHERE IsHistory = 0
+              AND EXISTS(SELECT * FROM cte9 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)
+              AND SearchParamId = @p12
+              AND SystemId1 IN (SELECT SystemId FROM dbo.System WHERE Value = @p13)
+              AND Code1 = @p14
+              AND Text2 LIKE @p15
+
+              AND ResourceTypeId = @p2
+
+      ),
+      cte11 AS
+      (
+          SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1
+          FROM dbo.DateTimeSearchParam
+          WHERE IsHistory = 0
+              AND EXISTS(SELECT * FROM cte10 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)
+              AND SearchParamId = @p16
+              AND StartDateTime >= @p17
+              AND StartDateTime <= @p18
+              AND EndDateTime <= @p18
+
+              AND ResourceTypeId = @p2
+
+      ),
+      cte12 AS
+      (
+          SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1
+          FROM dbo.TokenSearchParam
+          WHERE IsHistory = 0
+              AND EXISTS(SELECT * FROM cte11 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)
+              AND SearchParamId = @p19
+              AND SystemId = @p20
+              AND Code = @p21
+
+              AND ResourceTypeId = @p2
+
+      ),
+      cte13 AS
+      (
+          SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1
+          FROM dbo.StringSearchParam
+          WHERE IsHistory = 0
+              AND EXISTS(SELECT * FROM cte12 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)
+              AND SearchParamId = @p22
+              AND Text = @p6 AND Text = @p6 COLLATE Latin1_General_100_CS_AS
+              AND ResourceTypeId = @p2
+
+      ),
+      cte14 AS
+      (
+          SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1
+          FROM dbo.TokenSearchParam
+          WHERE IsHistory = 0
+              AND EXISTS(SELECT * FROM cte13 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)
+              AND SearchParamId = @p23
+              AND SystemId = @p24
+              AND Code = @p25
+
+              AND ResourceTypeId = @p2
+
+      ),
+      cte15 AS
+      (
+          SELECT refSource.ResourceTypeId AS T2, refSource.ResourceSurrogateId AS Sid2, refTarget.ResourceTypeId AS T1, refTarget.ResourceSurrogateId AS Sid1
+          FROM dbo.ReferenceSearchParam refSource
+          INNER JOIN dbo.Resource refTarget
+          ON refSource.ReferenceResourceTypeId = refTarget.ResourceTypeId
+              AND refSource.ReferenceResourceId = refTarget.ResourceId
+          WHERE refSource.SearchParamId = @p26
+              AND refTarget.IsHistory = 0
+              AND refSource.IsHistory = 0
+              AND refSource.ResourceTypeId IN (@p27)
+              AND refSource.ReferenceResourceTypeId IN (@p2)
+              AND EXISTS(SELECT * FROM cte14 WHERE refTarget.ResourceTypeId = T1 AND refTarget.ResourceSurrogateId = Sid1)
+              AND refTarget.ResourceTypeId = @p2
+      ),
+      cte16 AS
+      (
+          SELECT T1, Sid1, ResourceTypeId AS T2,
+          ResourceSurrogateId AS Sid2
+          FROM dbo.StringSearchParam
+          INNER JOIN cte15
+          ON ResourceTypeId = T2
+              AND ResourceSurrogateId = Sid2
+          WHERE IsHistory = 0
+              AND SearchParamId = @p28
+              AND Text = @p29 AND Text = @p29 COLLATE Latin1_General_100_CS_AS
+      ),
+      cte17 AS
+      (
+          SELECT T1, Sid1, ResourceTypeId AS T2,
+          ResourceSurrogateId AS Sid2
+          FROM dbo.StringSearchParam
+          INNER JOIN cte16
+          ON ResourceTypeId = T2
+              AND ResourceSurrogateId = Sid2
+          WHERE IsHistory = 0
+              AND SearchParamId = @p28
+              AND Text = @p30 AND Text = @p30 COLLATE Latin1_General_100_CS_AS
+      ),
+      cte18 AS
+      (
+          SELECT T1, Sid1, ResourceTypeId AS T2,
+          ResourceSurrogateId AS Sid2
+          FROM dbo.StringSearchParam
+          INNER JOIN cte17
+          ON ResourceTypeId = T2
+              AND ResourceSurrogateId = Sid2
+          WHERE IsHistory = 0
+              AND SearchParamId = @p28
+              AND Text = @p31 AND Text = @p31 COLLATE Latin1_General_100_CS_AS
+      ),
+      cte19 AS
+      (
+          SELECT T1, Sid1, ResourceTypeId AS T2,
+          ResourceSurrogateId AS Sid2
+          FROM dbo.StringSearchParam
+          INNER JOIN cte18
+          ON ResourceTypeId = T2
+              AND ResourceSurrogateId = Sid2
+          WHERE IsHistory = 0
+              AND SearchParamId = @p28
+              AND Text = @p32 AND Text = @p32 COLLATE Latin1_General_100_CS_AS
+      ),
+      cte20 AS
+      (
+          SELECT T1, Sid1, ResourceTypeId AS T2,
+          ResourceSurrogateId AS Sid2
+          FROM dbo.TokenSearchParam
+          INNER JOIN cte19
+          ON ResourceTypeId = T2
+              AND ResourceSurrogateId = Sid2
+          WHERE IsHistory = 0
+              AND SearchParamId = @p33
+              AND SystemId IN (SELECT SystemId FROM dbo.System WHERE Value = @p34)
+              AND Code = @p35
+
+      ),
+      cte21 AS
+      (
+          SELECT T1, Sid1, ResourceTypeId AS T2,
+          ResourceSurrogateId AS Sid2
+          FROM dbo.TokenSearchParam
+          INNER JOIN cte20
+          ON ResourceTypeId = T2
+              AND ResourceSurrogateId = Sid2
+          WHERE IsHistory = 0
+              AND SearchParamId = @p33
+              AND SystemId IN (SELECT SystemId FROM dbo.System WHERE Value = @p34)
+              AND Code = @p36
+
+      ),
+      cte22 AS
+      (
+          SELECT T1, Sid1, ResourceTypeId AS T2,
+          ResourceSurrogateId AS Sid2
+          FROM dbo.TokenSearchParam
+          INNER JOIN cte21
+          ON ResourceTypeId = T2
+              AND ResourceSurrogateId = Sid2
+          WHERE IsHistory = 0
+              AND SearchParamId = @p33
+              AND SystemId IN (SELECT SystemId FROM dbo.System WHERE Value = @p34)
+              AND Code = @p37
+
+      ),
+      cte23 AS
+      (
+          SELECT T1, Sid1, ResourceTypeId AS T2,
+          ResourceSurrogateId AS Sid2
+          FROM dbo.TokenSearchParam
+          INNER JOIN cte22
+          ON ResourceTypeId = T2
+              AND ResourceSurrogateId = Sid2
+          WHERE IsHistory = 0
+              AND SearchParamId = @p33
+              AND SystemId IN (SELECT SystemId FROM dbo.System WHERE Value = @p34)
+              AND Code = @p38
+
+      ),
+      cte24 AS
+      (
+          SELECT T1, Sid1, ResourceTypeId AS T2,
+          ResourceSurrogateId AS Sid2
+          FROM dbo.TokenSearchParam
+          INNER JOIN cte23
+          ON ResourceTypeId = T2
+              AND ResourceSurrogateId = Sid2
+          WHERE IsHistory = 0
+              AND SearchParamId = @p0
+              AND Code = @p39
+      ),
+      cte25 AS
+      (
+          SELECT T1, Sid1, ResourceTypeId AS T2,
+          ResourceSurrogateId AS Sid2
+          FROM dbo.TokenSearchParam
+          INNER JOIN cte24
+          ON ResourceTypeId = T2
+              AND ResourceSurrogateId = Sid2
+          WHERE IsHistory = 0
+              AND SearchParamId = @p40
+              AND SystemId IN (SELECT SystemId FROM dbo.System WHERE Value = @p41)
+              AND Code = @p42
+
+      ),
+      cte26 AS
+      (
+          SELECT T1, Sid1, ResourceTypeId AS T2,
+          ResourceSurrogateId AS Sid2
+          FROM dbo.TokenSearchParam
+          INNER JOIN cte25
+          ON ResourceTypeId = T2
+              AND ResourceSurrogateId = Sid2
+          WHERE IsHistory = 0
+              AND SearchParamId = @p43
+              AND SystemId IN (SELECT SystemId FROM dbo.System WHERE Value = @p44)
+              AND Code = @p45
+
+      ),
+      cte27 AS
+      (
+          SELECT DISTINCT TOP (@p46) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial
+          FROM cte26
+          ORDER BY T1 ASC, Sid1 ASC
+      )
+      SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource
+      FROM dbo.Resource r
+
+      INNER JOIN cte27
+      ON r.ResourceTypeId = cte27.T1 AND
+      r.ResourceSurrogateId = cte27.Sid1
+      ORDER BY r.ResourceTypeId ASC, r.ResourceSurrogateId ASC
+      /* HASH ZgZSXBM+MzloBRd89dLWBC3ztlqMo2OIDo5Jt9leEy8= */

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Stu3/MemberMatch.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Stu3/MemberMatch.json
@@ -1,0 +1,128 @@
+{
+    "resourceType": "Parameters",
+    "id": "member-match-in",
+    "parameter": [
+        {
+            "name": "MemberPatient",
+            "resource": {
+                "resourceType": "Patient",
+                "id": "1",
+                "identifier": [
+                    {
+                        "type": {
+                            "coding": [
+                                {
+                                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                                    "code": "MB"
+                                }
+                            ]
+                        },
+                        "system": "http://example.org/old-payer/identifiers/member",
+                        "value": "55678",
+                        "assigner": {
+                            "display": "Old Payer"
+                        }
+                    }
+                ],
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "Person",
+                        "given": [
+                            "Patricia",
+                            "Ann"
+                        ]
+                    }
+                ],
+                "gender": "female",
+                "birthDate": "1974-12-25"
+            }
+        },
+        {
+            "name": "OldCoverage",
+            "resource": {
+                "resourceType": "Coverage",
+                "id": "9876B1",
+                "contained": [
+                    {
+                        "resourceType": "Organization",
+                        "id": "payer",
+                        "identifier": [
+                            {
+                                "system": "http://hl7.org/fhir/sid/us-npi",
+                                "value": "9876543210"
+                            }
+                        ],
+                        "active": true,
+                        "name": "Old Health Plan",
+                        "endpoint": [
+                            {
+                                "reference": "http://example.org/old-payer/fhir"
+                            }
+                        ]
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "http://example.org/old-payer",
+                        "value": "DH10001235"
+                    }
+                ],
+                "status": "draft",
+                "beneficiary": {
+                    "reference": "Patient/1"
+                },
+                "period": {
+                    "start": "2011-05-23",
+                    "end": "2012-05-23"
+                },
+                "payor": [
+                    {
+                        "reference": "#payer"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "NewCoverage",
+            "resource": {
+                "resourceType": "Coverage",
+                "id": "AA87654",
+                "contained": [
+                    {
+                        "resourceType": "Organization",
+                        "id": "payer",
+                        "identifier": [
+                            {
+                                "system": "http://hl7.org/fhir/sid/us-npi",
+                                "value": "0123456789"
+                            }
+                        ],
+                        "active": true,
+                        "name": "New Health Plan",
+                        "endpoint": [
+                            {
+                                "reference": "http://example.org/new-payer/fhir"
+                            }
+                        ]
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "http://example.org/new-payer/identifiers/coverage",
+                        "value": "234567"
+                    }
+                ],
+                "status": "active",
+                "beneficiary": {
+                    "reference": "Patient/1"
+                },
+                "payor": [
+                    {
+                        "reference": "#payer"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/CompartmentTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/CompartmentTests.cs
@@ -158,6 +158,26 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenAPatientCompartment_WhenSearchingForAResourceTypeUsingInclude_ThenResourcesShouldBeReturned()
+        {
+            string searchUrl = $"Patient/{Fixture.Patient.Id}/Observation?_include=Observation:performer:Practitioner&performer=Practitioner/f005";
+
+            Bundle bundle = await Client.SearchAsync(searchUrl);
+            ValidateBundle(bundle, searchUrl, Fixture.Observation);
+
+            searchUrl = $"Patient/{Fixture.Patient.Id}/Observation?_union=Observation:performer:Practitioner";
+
+            bundle = await Client.SearchAsync(searchUrl);
+            Assert.NotEmpty(bundle.Entry);
+
+            searchUrl = $"Patient/{Fixture.Patient.Id}/Observation?_includeunionall=Observation:performer:Practitioner";
+
+            bundle = await Client.SearchAsync(searchUrl);
+            Assert.NotEmpty(bundle.Entry);
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
         public async Task GivenMoreSearchResultsThanCount_WhenSearchingAPatientCompartment_ThenNextLinkShouldBePopulated()
         {
             string searchUrl = $"Patient/{Fixture.Patient.Id}/*?_count=1";

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Microsoft.Health.Fhir.Shared.Tests.Integration.projitems
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Microsoft.Health.Fhir.Shared.Tests.Integration.projitems
@@ -27,6 +27,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Smart\SmartSearchTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\FhirStorageVersioningPolicyTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SearchParameterStatusDataStoreTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlServerMemberMatchTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlServerWatchdogTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlServerSchemaUpgradeTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\CosmosDbFhirStorageTestHelper.cs" />

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerMemberMatchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerMemberMatchTests.cs
@@ -1,0 +1,62 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Data.SqlClient;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.SqlServer.Features.Storage;
+using Microsoft.Health.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
+{
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.Search)]
+    public class SqlServerMemberMatchTests : IClassFixture<SqlServerFhirStorageTestsFixture>
+    {
+        private readonly string _connectionString;
+
+        public SqlServerMemberMatchTests(SqlServerFhirStorageTestsFixture fixture)
+        {
+            _connectionString = fixture.TestConnectionString;
+        }
+
+        /// <summary>
+        /// With this test it's possible for it to succeed but if it fails then it should be
+        /// a specific error. Since this error (#8623) is failure for sql to create a query plan,
+        /// when it fails it never returns data. If it doesn't hit the error then we don't care
+        /// if it returns data.
+        /// </summary>
+        [Fact]
+        public void GivenAComplexSqlStatement_WhenExecutingItMayThrowSpecificException()
+        {
+            string sql = Samples.GetFileContents("sql_8623_script", "sql");
+            using (var connection = new SqlConnection(_connectionString))
+            {
+                connection.Open();
+
+                SqlCommand sqlCommand = connection.CreateCommand();
+                sqlCommand.CommandText = sql;
+
+                bool pass;
+
+                try
+                {
+                    int response = sqlCommand.ExecuteNonQuery();
+                    pass = response >= -1;
+                }
+                catch (SqlException ex)
+                {
+                    pass = ex.Number == SqlErrorCodes.QueryProcessorNoQueryPlan;
+                    Assert.True(ex.Number == SqlErrorCodes.QueryProcessorNoQueryPlan);
+                }
+
+                if (!pass)
+                {
+                    Assert.Fail($"{nameof(GivenAComplexSqlStatement_WhenExecutingItMayThrowSpecificException)} failed ");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Code change overview
Moved sql to an inner join from a select in the where clause; removed logging statement since it creates too much noise now and the db will prevent this from happening now; fix the log output of the sql parameters to correctly display varchar/nvarchar when it's MAX - previously it was set as -1.

## Description
The reasoning behind this change is due to the large number of ctes that were generated and consequently sql was having an issue generating the query plan. Locally I could reproduce this issue every time. Note that at no point would rerunning the failing sql succeed. The only way I could get it to succeed was either reducing the parameters or I could keep the parameters as is and simply change the join as shown in the screen shot.

My source for the sql was the following postman POST https://localhost:44348/Patient/$member-match and the body was the json located on the hl7.org site here http://hl7.org/fhir/us/davinci-hrex/2020Sep/Parameters-member-match-in.json

A simplified view of the sql change is this screen shot. However, for a full and detailed comparison please compare the 2 files attached. I am curious to know why the parameter order gets changed. 

[8623.after.txt](https://github.com/microsoft/fhir-server/files/10069298/8623.after.txt)
[8623.before.txt](https://github.com/microsoft/fhir-server/files/10069300/8623.before.txt)

![image](https://user-images.githubusercontent.com/99214729/203362646-b8411034-e19c-4a80-9892-d0c29f6bde4c.png)

## Related issues
Addresses [issue #95713](https://microsofthealth.visualstudio.com/Health/_workitems/edit/95713).

## Testing
I have run many of the search type tests successfully.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
