### PR TITLE
Combined logging to remove number of log statements for SMART

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Security.Claims;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using EnsureThat;
@@ -53,9 +54,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
 
             var authorizationConfiguration = securityConfigurationOptions.Value.Authorization;
 
-            _logger.LogInformation("Principal exists {Principal}", fhirRequestContextAccessor.RequestContext.Principal != null);
-            _logger.LogInformation("securityConfigurationOptions Value Enabled {SecutiryConfigurationOption}", securityConfigurationOptions.Value.Enabled);
-            _logger.LogInformation("Authorization configuration enabled {AuthorizationConfiguration} ", authorizationConfiguration.Enabled);
+            // _logger.LogInformation("Principal exists {Principal}", fhirRequestContextAccessor.RequestContext.Principal != null);
+            // _logger.LogInformation("securityConfigurationOptions Value Enabled {SecutiryConfigurationOption}", securityConfigurationOptions.Value.Enabled);
+            // _logger.LogInformation("Authorization configuration enabled {AuthorizationConfiguration} ", authorizationConfiguration.Enabled);
 
             if (fhirRequestContextAccessor.RequestContext.Principal != null
                 && securityConfigurationOptions.Value.Enabled
@@ -67,6 +68,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
                 var dataActions = await authorizationService.CheckAccess(DataActions.Smart, context.RequestAborted);
 
                 _logger.LogInformation("Smart Data Action is present {Smart}", dataActions.HasFlag(DataActions.Smart));
+
+                var scopeRestrictions = new StringBuilder();
+                scopeRestrictions.Append("Resource(s) allowed and permitted data actions on it are : ");
 
                 // Only read and apply SMART clinical scopes if the user has the Smart Data action
                 if (dataActions.HasFlag(DataActions.Smart))
@@ -111,8 +115,14 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
                                 }
 
                                 fhirRequestContext.AccessControlContext.AllowedResourceActions.Add(new ScopeRestriction(resource, permittedDataActions, id));
+                                scopeRestrictions.Append(" ( ");
+                                scopeRestrictions.Append(resource);
+                                scopeRestrictions.Append(" - ");
+                                scopeRestrictions.Append(permittedDataActions);
+                                scopeRestrictions.Append(" ) ");
+                                scopeRestrictions.Append(" \n ");
 
-                                _logger.LogInformation("Resource and permitted data actions {Resource} {PermittedDataActions} ", resource, permittedDataActions);
+                                // _logger.LogInformation("Resource and permitted data actions {Resource} {PermittedDataActions} ", resource, permittedDataActions);
 
                                 if (string.Equals("system", id, StringComparison.OrdinalIgnoreCase))
                                 {
@@ -122,6 +132,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
                         }
                     }
 
+                    _logger.LogInformation("Scope restrictions allowed are {ScopeRestriction}", scopeRestrictions);
                     _logger.LogInformation("FhirUserClaim is present {FhirUserClaim}", includeFhirUserClaim);
 
                     if (includeFhirUserClaim)


### PR DESCRIPTION
## Description
Describe the changes in this PR.

## Related issues
Addresses [issue # [97780](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Olympus/Stories/?workitem=97780)].

## Testing
Ran unit tests and looked into log statements. Below are some sample log statements with different scope permissions.

- Resource(s) allowed and permitted data actions on it are :  ( all - Read, Write, Export )  
- Resource(s) allowed and permitted data actions on it are :  ( Encounter - Read, Write, Export )  
- Resource(s) allowed and permitted data actions on it are :  ( Patient - Read, Write, Export )  
- Resource(s) allowed and permitted data actions on it are : 
- Resource(s) allowed and permitted data actions on it are :  ( Patient - Read )  
-   ( Observation - Read )  
-   ( Encounter - Read, Write, Export )  

 

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
