### PR TITLE
fix for kvp where the value is a guid and not json

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Binders/DictionaryExpansionConfigurationProvider.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Binders/DictionaryExpansionConfigurationProvider.cs
@@ -61,18 +61,37 @@ public class DictionaryExpansionConfigurationProvider : ConfigurationProvider
 
             _configurationProvider.TryGet(keyPath, out string environmentVariableValue);
 
-            if (!string.IsNullOrEmpty(environmentVariableValue) && environmentVariableValue.Trim().StartsWith("{", StringComparison.Ordinal) == true)
+            if (!string.IsNullOrEmpty(environmentVariableValue))
             {
-                Dictionary<string, string> asDictionary = JsonConvert.DeserializeObject<Dictionary<string, string>>(environmentVariableValue);
-
-                foreach (KeyValuePair<string, string> kvp in asDictionary!)
+                Dictionary<string, string> asDictionary = HasJsonStructure(environmentVariableValue);
+                if (asDictionary?.Count > 0)
                 {
-                    data.Add($"{keyPath}:{kvp.Key}", kvp.Value);
+                    foreach (KeyValuePair<string, string> kvp in asDictionary!)
+                    {
+                        data.Add($"{keyPath}:{kvp.Key}", kvp.Value);
+                    }
                 }
             }
 
             IEnumerable<string> innerKeys = _configurationProvider.GetChildKeys(Array.Empty<string>(), keyPath);
             EnumerateKeys(innerKeys, data, keyPath);
         }
+    }
+
+    private static Dictionary<string, string> HasJsonStructure(string value)
+    {
+        try
+        {
+            if (value.Trim().StartsWith("{", StringComparison.Ordinal))
+            {
+                return JsonConvert.DeserializeObject<Dictionary<string, string>>(value);
+            }
+        }
+        catch (Newtonsoft.Json.JsonReaderException)
+        {
+            return default;
+        }
+
+        return default;
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Binders/DictionaryExpansionConfigurationProviderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Binders/DictionaryExpansionConfigurationProviderTests.cs
@@ -69,9 +69,9 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Binders
                 string value = (string)entry.Value;
                 environmentVariablesAsDictionary.Add(key, value);
 
-                if (HasJsonStructure(value))
+                Dictionary<string, string> asDictionary = HasJsonStructure(value);
+                if (asDictionary?.Count > 0)
                 {
-                    Dictionary<string, string> asDictionary = JsonConvert.DeserializeObject<Dictionary<string, string>>(value);
                     variablesInJsonFormat += asDictionary.Count;
                 }
             }
@@ -100,6 +100,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Binders
                 var customVariables = new Dictionary<string, string>()
                 {
                     { "FhirServer:CoreFeatures:Versioning:ResourceTypeOverrides", "{ \"account\": \"no-version\", \"visionprescription\": \"versioned\", \"activitydefinition\": \"versioned-update\" }" },
+                    { "NotValidJson", "{4EDD8C98-B197-450C-B63C-217CB9AE2C09}"},
                 };
                 e = customVariables.GetEnumerator();
             }
@@ -116,9 +117,9 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Binders
                 string value = (string)entry.Value;
                 environmentVariablesAsDictionary.Add(key, value);
 
-                if (HasJsonStructure(value))
+                Dictionary<string, string> asDictionary = HasJsonStructure(value);
+                if (asDictionary?.Count > 0)
                 {
-                    Dictionary<string, string> asDictionary = JsonConvert.DeserializeObject<Dictionary<string, string>>(value);
                     variablesInJsonFormat += asDictionary.Count;
                 }
             }
@@ -136,7 +137,22 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Binders
             Assert.Equal(variablesInJsonFormat, numberOfJsonVariablesInMockProvider);
         }
 
-        private static bool HasJsonStructure(string value) => value.Trim().StartsWith("{", StringComparison.Ordinal);
+        private static Dictionary<string, string> HasJsonStructure(string value)
+        {
+            try
+            {
+                if (value.Trim().StartsWith("{", StringComparison.Ordinal))
+                {
+                    return JsonConvert.DeserializeObject<Dictionary<string, string>>(value);
+                }
+            }
+            catch (Newtonsoft.Json.JsonReaderException)
+            {
+                return default;
+            }
+
+            return default;
+        }
 
         public sealed class MockConfigurationProvider : ConfigurationProvider
         {


### PR DESCRIPTION
## Description
This fixes an issue that assumes the value will be JSON if it starts with "{". In my example it was not valid JSON but did start with the curly brace. This fix will handle that.

## Related issues
Addresses [issue #].

## Testing
Created a new test for this specific issue and ran the existing tests.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
