### PR TITLE
[Service Setup] [Fix] Add new tryparse logic to validate configurations in JSON format

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Binders/DictionaryExpansionConfigurationProvider.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Binders/DictionaryExpansionConfigurationProvider.cs
@@ -93,12 +93,11 @@ public class DictionaryExpansionConfigurationProvider : ConfigurationProvider
         try
         {
             dictionary = JsonConvert.DeserializeObject<Dictionary<string, string>>(value);
+            return true;
         }
         catch (JsonReaderException)
         {
             return false;
         }
-
-        return true;
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Features/Binders/DictionaryExpansionConfigurationProvider.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Binders/DictionaryExpansionConfigurationProvider.cs
@@ -53,29 +53,14 @@ public class DictionaryExpansionConfigurationProvider : ConfigurationProvider
         Data = data;
     }
 
-    private void EnumerateKeys(IEnumerable<string> keys, Dictionary<string, string> data, string path = null)
-    {
-        foreach (string keyName in keys.Distinct())
-        {
-            var keyPath = path != null ? $"{path}:{keyName}" : keyName;
-
-            _configurationProvider.TryGet(keyPath, out string environmentVariableValue);
-
-            if (!string.IsNullOrEmpty(environmentVariableValue)
-                && TryParseDictionaryJson(environmentVariableValue, out Dictionary<string, string> asDictionary))
-            {
-                foreach (KeyValuePair<string, string> kvp in asDictionary!)
-                {
-                    data.Add($"{keyPath}:{kvp.Key}", kvp.Value);
-                }
-            }
-
-            IEnumerable<string> innerKeys = _configurationProvider.GetChildKeys(Array.Empty<string>(), keyPath);
-            EnumerateKeys(innerKeys, data, keyPath);
-        }
-    }
-
-    private static bool TryParseDictionaryJson(string value, out Dictionary<string, string> dictionary)
+    /// <summary>
+    /// Try to parse a JSON string value into a Dictionary.
+    /// </summary>
+    /// <param name="value">JSON string value to be parsed.</param>
+    /// <param name="dictionary">Resultant dictionary if the value is able to be parsed.</param>
+    /// <returns>True if the JSON string value is able to be parsed to a Dictionary.</returns>
+    /// <remarks>Public method for testing purposes.</remarks>
+    public static bool TryParseDictionaryJson(string value, out Dictionary<string, string> dictionary)
     {
         dictionary = null;
 
@@ -98,6 +83,28 @@ public class DictionaryExpansionConfigurationProvider : ConfigurationProvider
         catch (JsonReaderException)
         {
             return false;
+        }
+    }
+
+    private void EnumerateKeys(IEnumerable<string> keys, Dictionary<string, string> data, string path = null)
+    {
+        foreach (string keyName in keys.Distinct())
+        {
+            var keyPath = path != null ? $"{path}:{keyName}" : keyName;
+
+            _configurationProvider.TryGet(keyPath, out string environmentVariableValue);
+
+            if (!string.IsNullOrEmpty(environmentVariableValue)
+                && TryParseDictionaryJson(environmentVariableValue, out Dictionary<string, string> asDictionary))
+            {
+                foreach (KeyValuePair<string, string> kvp in asDictionary!)
+                {
+                    data.Add($"{keyPath}:{kvp.Key}", kvp.Value);
+                }
+            }
+
+            IEnumerable<string> innerKeys = _configurationProvider.GetChildKeys(Array.Empty<string>(), keyPath);
+            EnumerateKeys(innerKeys, data, keyPath);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Features/Binders/DictionaryExpansionConfigurationProvider.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Binders/DictionaryExpansionConfigurationProvider.cs
@@ -70,7 +70,7 @@ public class DictionaryExpansionConfigurationProvider : ConfigurationProvider
         }
 
         value = value.Trim();
-        if (!value.Trim().StartsWith("{", StringComparison.Ordinal) || !value.Trim().EndsWith("}", StringComparison.Ordinal))
+        if (!value.StartsWith("{", StringComparison.Ordinal) || !value.EndsWith("}", StringComparison.Ordinal))
         {
             return false;
         }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Binders/DictionaryExpansionConfigurationProviderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Binders/DictionaryExpansionConfigurationProviderTests.cs
@@ -138,10 +138,16 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Binders
 
         [Theory]
         [InlineData("")]
+        [InlineData("{}")]
+        [InlineData("{ {")]
+        [InlineData("{ { } }")]
+        [InlineData(" {} ")]
+        [InlineData(" { } ")]
         [InlineData("{foo}")]
         [InlineData(" { foo } ")]
         [InlineData("{ 'foo' }")]
         [InlineData("{ \"foo\" }")]
+        [InlineData("{070741cc-f9e9-516d-9f32-f3a4cca9614d}")]
         public void GivenAnInvalidJsonConfiguration_WhenInitialized_ThenKeepValuesAsTheyAre(string value)
         {
             MockConfigurationProvider mockProvider = new MockConfigurationProvider(

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Binders/DictionaryExpansionConfigurationProviderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Binders/DictionaryExpansionConfigurationProviderTests.cs
@@ -136,6 +136,27 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Binders
             Assert.Equal(variablesInJsonFormat, numberOfJsonVariablesInMockProvider);
         }
 
+        [Theory]
+        [InlineData("")]
+        [InlineData("{foo}")]
+        [InlineData(" { foo } ")]
+        [InlineData("{ 'foo' }")]
+        [InlineData("{ \"foo\" }")]
+        public void GivenAnInvalidJsonConfiguration_WhenInitialized_ThenKeepValuesAsTheyAre(string value)
+        {
+            MockConfigurationProvider mockProvider = new MockConfigurationProvider(
+                new Dictionary<string, string>()
+                {
+                    { "key", value},
+                });
+
+            DictionaryExpansionConfigurationProvider configurationProvider = new DictionaryExpansionConfigurationProvider(mockProvider);
+
+            configurationProvider.Load();
+
+            Assert.Empty(configurationProvider.GetChildKeys(Array.Empty<string>(), null));
+        }
+
         private static bool HasJsonStructure(string value) => value.Trim().StartsWith("{", StringComparison.Ordinal);
 
         public sealed class MockConfigurationProvider : ConfigurationProvider

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Binders/DictionaryExpansionConfigurationProviderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Binders/DictionaryExpansionConfigurationProviderTests.cs
@@ -12,7 +12,6 @@ using Microsoft.Extensions.Configuration.EnvironmentVariables;
 using Microsoft.Health.Fhir.Api.Features.Binders;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Test.Utilities;
-using Newtonsoft.Json;
 using Xunit;
 
 namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Binders
@@ -69,9 +68,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Binders
                 string value = (string)entry.Value;
                 environmentVariablesAsDictionary.Add(key, value);
 
-                if (HasJsonStructure(value))
+                if (DictionaryExpansionConfigurationProvider.TryParseDictionaryJson(value, out Dictionary<string, string> asDictionary))
                 {
-                    Dictionary<string, string> asDictionary = JsonConvert.DeserializeObject<Dictionary<string, string>>(value);
                     variablesInJsonFormat += asDictionary.Count;
                 }
             }
@@ -116,9 +114,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Binders
                 string value = (string)entry.Value;
                 environmentVariablesAsDictionary.Add(key, value);
 
-                if (HasJsonStructure(value))
+                if (DictionaryExpansionConfigurationProvider.TryParseDictionaryJson(value, out Dictionary<string, string> asDictionary))
                 {
-                    Dictionary<string, string> asDictionary = JsonConvert.DeserializeObject<Dictionary<string, string>>(value);
                     variablesInJsonFormat += asDictionary.Count;
                 }
             }
@@ -162,8 +159,6 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Binders
 
             Assert.Empty(configurationProvider.GetChildKeys(Array.Empty<string>(), null));
         }
-
-        private static bool HasJsonStructure(string value) => value.Trim().StartsWith("{", StringComparison.Ordinal);
 
         public sealed class MockConfigurationProvider : ConfigurationProvider
         {


### PR DESCRIPTION
## Description
Adding a new tryparse logic to validate environment variable with JSON values and, when applicable, load them as dictionaries. 

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
