### PR TITLE
Fix container issue

### DIFF
--- a/src/Microsoft.Health.Fhir.Azure/ExportDestinationClient/AzureExportDestinationClient.cs
+++ b/src/Microsoft.Health.Fhir.Azure/ExportDestinationClient/AzureExportDestinationClient.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Health.Fhir.Azure.ExportDestinationClient
             }
             else
             {
-                throw new ArgumentException($"Cannot commit none existant file {fileName}");
+                throw new ArgumentException($"Cannot commit non-existant file {fileName}");
             }
 
             _dataBuffers.Remove(fileName);

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportOrchestratorJobTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportOrchestratorJobTests.cs
@@ -5,13 +5,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Health.Core;
 using Microsoft.Health.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export;
@@ -23,7 +19,6 @@ using Microsoft.Health.JobManagement;
 using Microsoft.Health.Test.Utilities;
 using Newtonsoft.Json;
 using NSubstitute;
-using NSubstitute.Core;
 using Xunit;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
@@ -34,7 +29,6 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
     {
         private ISearchService _mockSearchService = Substitute.For<ISearchService>();
         private IQueueClient _mockQueueClient = Substitute.For<IQueueClient>();
-        private ILoggerFactory _loggerFactory = new NullLoggerFactory();
 
         [Theory]
         [InlineData(ExportJobType.Patient)]
@@ -47,7 +41,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
             SetupMockQueue(numExpectedJobs, orchestratorJobId);
 
             var orchestratorJob = GetJobInfoArray(0, orchestratorJobId, false, orchestratorJobId, isParallel: true, exportJobType: exportJobType)[0];
-            var exportOrchestratorJob = new ExportOrchestratorJob(_mockQueueClient, _mockSearchService, _loggerFactory);
+            var exportOrchestratorJob = new ExportOrchestratorJob(_mockQueueClient, _mockSearchService);
             var result = await exportOrchestratorJob.ExecuteAsync(orchestratorJob, new Progress<string>((result) => { }), CancellationToken.None);
             var jobResult = JsonConvert.DeserializeObject<ExportJobRecord>(result);
 
@@ -63,7 +57,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
             SetupMockQueue(numExpectedJobs, orchestratorJobId);
 
             var orchestratorJob = GetJobInfoArray(0, orchestratorJobId, false, orchestratorJobId, isParallel: false).First();
-            var exportOrchestratorJob = new ExportOrchestratorJob(_mockQueueClient, _mockSearchService, _loggerFactory);
+            var exportOrchestratorJob = new ExportOrchestratorJob(_mockQueueClient, _mockSearchService);
             var result = await exportOrchestratorJob.ExecuteAsync(orchestratorJob, new Progress<string>((result) => { }), CancellationToken.None);
             var jobResult = JsonConvert.DeserializeObject<ExportJobRecord>(result);
             Assert.Equal(OperationStatus.Completed, jobResult.Status);
@@ -80,7 +74,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
             SetupMockQueue(numExpectedJobsPerResourceType, orchestratorJobId);
 
             var orchestratorJob = GetJobInfoArray(0, orchestratorJobId, false, orchestratorJobId, isParallel: true).First();
-            var exportOrchestratorJob = new ExportOrchestratorJob(_mockQueueClient, _mockSearchService, _loggerFactory);
+            var exportOrchestratorJob = new ExportOrchestratorJob(_mockQueueClient, _mockSearchService);
             var result = await exportOrchestratorJob.ExecuteAsync(orchestratorJob, new Progress<string>((result) => { }), CancellationToken.None);
             var jobResult = JsonConvert.DeserializeObject<ExportJobRecord>(result);
             Assert.Equal(OperationStatus.Completed, jobResult.Status);
@@ -97,7 +91,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
             SetupMockQueue(numExpectedJobs, orchestratorJobId);
 
             var orchestratorJob = GetJobInfoArray(0, orchestratorJobId, false, orchestratorJobId, isParallel: true, typeFilter: "Patient,Observation").First();
-            var exportOrchestratorJob = new ExportOrchestratorJob(_mockQueueClient, _mockSearchService, _loggerFactory);
+            var exportOrchestratorJob = new ExportOrchestratorJob(_mockQueueClient, _mockSearchService);
             var result = await exportOrchestratorJob.ExecuteAsync(orchestratorJob, new Progress<string>((result) => { }), CancellationToken.None);
             var jobResult = JsonConvert.DeserializeObject<ExportJobRecord>(result);
             Assert.Equal(OperationStatus.Completed, jobResult.Status);

--- a/src/Microsoft.Health.Fhir.Core/Configs/ExportJobConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/ExportJobConfiguration.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Health.Fhir.Core.Configs
         /// <summary>
         /// Controls how many resources will be returned for each search query while exporting the data.
         /// </summary>
-        public uint MaximumNumberOfResourcesPerQuery { get; set; } = 5000;
+        public uint MaximumNumberOfResourcesPerQuery { get; set; } = 50000;
 
         /// <summary>
         /// Number of pages to be iterated before committing the export progress.

--- a/src/Microsoft.Health.Fhir.Core/Configs/ExportJobConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/ExportJobConfiguration.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Health.Fhir.Core.Configs
         /// <summary>
         /// Controls how many resources will be returned for each search query while exporting the data.
         /// </summary>
-        public uint MaximumNumberOfResourcesPerQuery { get; set; } = 50000;
+        public uint MaximumNumberOfResourcesPerQuery { get; set; } = 5000;
 
         /// <summary>
         /// Number of pages to be iterated before committing the export progress.

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportOrchestratorJob.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportOrchestratorJob.cs
@@ -131,7 +131,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
             }
             else
             {
-                container = groupId.ToString();
+                // Need the export- to make sure the container meets the minimum length requirements of 3 characters.
+                container = $"export-{groupId}";
             }
 
             var rec = new ExportJobRecord(

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportOrchestratorJob.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportOrchestratorJob.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
-using Microsoft.Extensions.Logging;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export.Models;
 using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Models;
@@ -25,26 +24,25 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
         private IQueueClient _queueClient;
         private ISearchService _searchService;
-        private ILogger<ExportOrchestratorJob> _logger; // TODO: Either remove or use
 
         public ExportOrchestratorJob(
             IQueueClient queueClient,
-            ISearchService searchService,
-            ILoggerFactory loggerFactory)
+            ISearchService searchService)
         {
             EnsureArg.IsNotNull(queueClient, nameof(queueClient));
             EnsureArg.IsNotNull(searchService, nameof(searchService));
-            EnsureArg.IsNotNull(loggerFactory, nameof(loggerFactory));
 
             _queueClient = queueClient;
             _searchService = searchService;
-            _logger = loggerFactory.CreateLogger<ExportOrchestratorJob>();
         }
 
         internal int NumberOfSurrogateIdRanges { get; set; } = DefaultNumberOfSurrogateIdRanges;
 
         public async Task<string> ExecuteAsync(JobInfo jobInfo, IProgress<string> progress, CancellationToken cancellationToken)
         {
+            EnsureArg.IsNotNull(jobInfo, nameof(jobInfo));
+            EnsureArg.IsNotNull(progress, nameof(progress));
+
             var record = JsonConvert.DeserializeObject<ExportJobRecord>(jobInfo.Definition);
             record.QueuedTime = jobInfo.CreateDate; // get record of truth
             var surrogateIdRangeSize = (int)record.MaximumNumberOfResourcesPerQuery;
@@ -91,7 +89,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                                 startId = range.EndId;
                             }
 
-                            var processingRecord = CreateExportRecord(record, resourceType: type, startSurrogateId: range.StartId.ToString(), endSurrogateId: range.EndId.ToString(), globalStartSurrogateId: globalStartId.ToString(), globalEndSurrogateId: globalEndId.ToString());
+                            var processingRecord = CreateExportRecord(record, jobInfo.GroupId, resourceType: type, startSurrogateId: range.StartId.ToString(), endSurrogateId: range.EndId.ToString(), globalStartSurrogateId: globalStartId.ToString(), globalEndSurrogateId: globalEndId.ToString());
                             definitions.Add(JsonConvert.SerializeObject(processingRecord));
                         }
 
@@ -108,13 +106,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
                 if (!atLeastOneWorkerJobRegistered)
                 {
-                    var processingRecord = CreateExportRecord(record);
+                    var processingRecord = CreateExportRecord(record, jobInfo.GroupId);
                     await _queueClient.EnqueueAsync((byte)QueueType.Export, new[] { JsonConvert.SerializeObject(processingRecord) }, jobInfo.GroupId, false, false, cancellationToken);
                 }
             }
             else if (groupJobs.Count == 1)
             {
-                var processingRecord = CreateExportRecord(record);
+                var processingRecord = CreateExportRecord(record, jobInfo.GroupId);
                 await _queueClient.EnqueueAsync((byte)QueueType.Export, new[] { JsonConvert.SerializeObject(processingRecord) }, jobInfo.GroupId, false, false, cancellationToken);
             }
 
@@ -122,12 +120,24 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
             return JsonConvert.SerializeObject(record);
         }
 
-        private static ExportJobRecord CreateExportRecord(ExportJobRecord record, string resourceType = null, PartialDateTime since = null, PartialDateTime till = null, string startSurrogateId = null, string endSurrogateId = null, string globalStartSurrogateId = null, string globalEndSurrogateId = null)
+        private static ExportJobRecord CreateExportRecord(ExportJobRecord record, long groupId, string resourceType = null, PartialDateTime since = null, PartialDateTime till = null, string startSurrogateId = null, string endSurrogateId = null, string globalStartSurrogateId = null, string globalEndSurrogateId = null)
         {
+            var format = $"{ExportFormatTags.ResourceName}-{ExportFormatTags.Id}";
+            var container = record.StorageAccountContainerName;
+
+            if (record.Id != record.StorageAccountContainerName)
+            {
+                format = $"{ExportFormatTags.Timestamp}-{groupId}/{format}";
+            }
+            else
+            {
+                container = groupId.ToString();
+            }
+
             var rec = new ExportJobRecord(
                         record.RequestUri,
                         record.ExportType,
-                        record.ExportFormat,
+                        format,
                         string.IsNullOrEmpty(resourceType) ? record.ResourceType : resourceType,
                         record.Filters,
                         record.Hash,
@@ -147,7 +157,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                         record.AnonymizationConfigurationFileETag,
                         record.MaximumNumberOfResourcesPerQuery,
                         record.NumberOfPagesPerCommit,
-                        record.StorageAccountContainerName,
+                        container,
                         record.IsParallel,
                         record.SchemaVersion,
                         (int)JobType.ExportProcessing,

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirOperationDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirOperationDataStore.cs
@@ -59,7 +59,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
         public async Task<ExportJobOutcome> CreateExportJobAsync(ExportJobRecord jobRecord, CancellationToken cancellationToken)
         {
             var clone = jobRecord.Clone();
-            clone.Id = string.Empty;
             clone.QueuedTime = DateTime.Parse("1900-01-01");
             var def = JsonConvert.SerializeObject(clone, _jsonSerializerSettings);
             var results = await _queueClient.EnqueueAsync((byte)QueueType.Export, new[] { def }, null, false, clone.Status == OperationStatus.Completed, cancellationToken);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Export/SqlServerExportTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Export/SqlServerExportTests.cs
@@ -9,8 +9,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export.Models;
@@ -34,7 +32,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         private readonly ISearchService _searchService;
         private readonly SqlServerFhirOperationDataStore _operationDataStore;
         private readonly SqlQueueClient _queueClient;
-        private readonly ILoggerFactory _loggerFactory = new NullLoggerFactory();
         private readonly byte _queueType = (byte)QueueType.Export;
         private const string DropTrigger = "IF object_id('tmp_JobQueueIns') IS NOT NULL DROP TRIGGER tmp_JobQueueIns";
 
@@ -54,7 +51,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             {
                 PrepareData(); // 1000 patients + 1000 observations + 1000 claims. !!! RawResource is invalid.
 
-                var coordJob = new ExportOrchestratorJob(_queueClient, _searchService, _loggerFactory);
+                var coordJob = new ExportOrchestratorJob(_queueClient, _searchService);
                 //// surrogate id range size is set via max number of resources per query on coord record
                 coordJob.NumberOfSurrogateIdRanges = 5; // 100*5=500 is 50% of 1000, so there are 2 insert transactions in JobQueue per each resource type
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/FhirOperationDataStoreExportTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/FhirOperationDataStoreExportTests.cs
@@ -80,6 +80,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations
         }
 
         [Fact]
+        [FhirStorageTestsFixtureArgumentSets(DataStore.CosmosDb)]
         public async Task GivenAMatchingExportJob_WhenReCreatingPreviouslyCreatedJob_ThenTheMatchingJobShouldBeReturned()
         {
             var jobRecord = await InsertNewExportJobRecordAsync();


### PR DESCRIPTION
## Description
When creating an export job without a container if there are multiple jobs for one resource type they will override eachothers files.

## Related issues
Addresses [issue #].

## Testing
Manual testing. Working on new unit tests.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
