### PR TITLE
Fix use of null-conditional operator and await statements

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/BundleFactoryTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/BundleFactoryTests.cs
@@ -116,10 +116,13 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
                 var raw = actualEntry as RawBundleEntryComponent;
 
+                Assert.NotNull(raw);
+                Assert.NotNull(raw.ResourceElement);
+
                 using (var ms = new MemoryStream())
                 using (var sr = new StreamReader(ms))
                 {
-                    await raw?.ResourceElement?.SerializeToStreamAsUtf8Json(ms);
+                    await raw.ResourceElement.SerializeToStreamAsUtf8Json(ms);
                     ms.Seek(0, SeekOrigin.Begin);
                     var resourceData = await sr.ReadToEndAsync();
                     Assert.NotNull(resourceData);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/ChangeFeed/SqlServerFhirResourceChangeCaptureDisabledTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/ChangeFeed/SqlServerFhirResourceChangeCaptureDisabledTests.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.ChangeFeed
             }
             finally
             {
-                await fhirStorageTestsFixture?.DisposeAsync();
+                await fhirStorageTestsFixture.DisposeAsync();
             }
         }
     }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/ChangeFeed/SqlServerFhirResourceChangeCaptureFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/ChangeFeed/SqlServerFhirResourceChangeCaptureFixture.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.ChangeFeed
 
         public async Task DisposeAsync()
         {
-            await _storageFixture?.DisposeAsync();
+            await (_storageFixture?.DisposeAsync() ?? Task.CompletedTask);
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             finally
             {
                 await (testHelper1?.DeleteDatabase(snapshotDatabaseName) ?? Task.CompletedTask);
-                await (testHelper2?.DeleteDatabase(snapshotDatabaseName) ?? Task.CompletedTask);
+                await (testHelper2?.DeleteDatabase(diffDatabaseName) ?? Task.CompletedTask);
             }
         }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
@@ -76,8 +76,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             }
             finally
             {
-                await testHelper1?.DeleteDatabase(snapshotDatabaseName);
-                await testHelper2?.DeleteDatabase(diffDatabaseName);
+                await (testHelper1?.DeleteDatabase(snapshotDatabaseName) ?? Task.CompletedTask);
+                await (testHelper2?.DeleteDatabase(snapshotDatabaseName) ?? Task.CompletedTask);
             }
         }
 


### PR DESCRIPTION
## Description
After a review of our code base for the use of null-conditional operator and await statements this PR addresses those findings.

## Related issues
Addresses [issue #97622](https://microsofthealth.visualstudio.com/Health/_workitems/edit/97622).

## Testing
Ran all affected tests.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
