### PR TITLE
97938 Controller method parameter name mismatch

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Filters/ValidateParametersResourceAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Filters/ValidateParametersResourceAttribute.cs
@@ -21,7 +21,13 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
         {
             EnsureArg.IsNotNull(context, nameof(context));
 
-            context.ActionArguments.TryGetValue("inputParams", out var inputResource);
+            object inputResource = null;
+            context.ActionArguments?.TryGetValue("inputParams", out inputResource);
+            if (inputResource == null)
+            {
+                throw new InvalidProgramException("Controller method does not contain parameter named 'inputParams'");
+            }
+
             if (inputResource is not Parameters)
             {
                 throw new RequestNotValidException(string.Format(Resources.UnsupportedResourceType, inputResource.GetType().ToString()));

--- a/src/Microsoft.Health.Fhir.Api/Features/Filters/ValidateParametersResourceAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Filters/ValidateParametersResourceAttribute.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
             context.ActionArguments?.TryGetValue("inputParams", out inputResource);
             if (inputResource == null)
             {
-                throw new InvalidProgramException("Controller method does not contain parameter named 'inputParams'");
+                throw new MissingMethodException("Controller method does not contain parameter named 'inputParams'");
             }
 
             if (inputResource is not Parameters)


### PR DESCRIPTION
## Description
Checks for null references. If controller method parameter is not named exactly "inputParams" then there will be a mismatch between parameter name used as a key in the dictionary and "inputParams" string in the filter method. In this case value will not be found in the dictionary and null will be returned instead of the object, therefore causing null reference. This makes sure that null reference is not thrown and instead, a more user-friendly exception with a proper message is thrown. Affects all controllers/methods that have ValidateParametersResourceAttribute attribute (right now MemberMatchController and ReindexControlleer).

## Related issues
Addresses [97938].

## Testing
Manually created test cases. Only way this could happen is if somehow asp.net mvc lib does not initialize the dictionary object (unlikely bug in that lib) or if there's a mismatch between parameter name and string "inputParams". So, renamed the parameter in the controller method, recompiled, triggered call in postman, reproduced bug and then verified that fix would prevent null reference exception even if parameter was mistakenly incorrectly named.

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [X] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ X] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
