### PR TITLE
Fix startup exception

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/BackgroundJobService/JobFactory.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/BackgroundJobService/JobFactory.cs
@@ -7,16 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using EnsureThat;
-using MediatR;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using Microsoft.Health.Core.Features.Context;
-using Microsoft.Health.Fhir.Core.Configs;
-using Microsoft.Health.Fhir.Core.Features.Context;
-using Microsoft.Health.Fhir.Core.Features.Operations;
-using Microsoft.Health.Fhir.Core.Features.Operations.Export;
-using Microsoft.Health.Fhir.Core.Features.Operations.Import;
-using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.JobManagement;
 
 namespace Microsoft.Health.Fhir.Api.Features.BackgroundJobService
@@ -26,60 +16,11 @@ namespace Microsoft.Health.Fhir.Api.Features.BackgroundJobService
     /// </summary>
     public class JobFactory : IJobFactory
     {
-        private readonly IImportResourceLoader _importResourceLoader;
-        private readonly IResourceBulkImporter _resourceBulkImporter;
-        private readonly IImportErrorStoreFactory _importErrorStoreFactory;
-        private readonly IImportOrchestratorJobDataStoreOperation _importOrchestratorTaskDataStoreOperation;
-        private readonly IIntegrationDataStoreClient _integrationDataStoreClient;
-        private readonly IQueueClient _queueClient;
-        private readonly RequestContextAccessor<IFhirRequestContext> _contextAccessor;
-        private readonly IMediator _mediator;
-        private readonly OperationsConfiguration _operationsConfiguration;
-        private readonly Func<IExportJobTask> _exportJobTaskFactory;
-        private readonly ISearchService _searchService;
-        private readonly ILoggerFactory _loggerFactory;
         private readonly Dictionary<int, Func<IJob>> _jobFactoryLookup;
 
-        public JobFactory(
-            IImportResourceLoader importResourceLoader,
-            IResourceBulkImporter resourceBulkImporter,
-            IImportErrorStoreFactory importErrorStoreFactory,
-            IImportOrchestratorJobDataStoreOperation importOrchestratorTaskDataStoreOperation,
-            IQueueClient queueClient,
-            IIntegrationDataStoreClient integrationDataStoreClient,
-            RequestContextAccessor<IFhirRequestContext> contextAccessor,
-            IOptions<OperationsConfiguration> operationsConfig,
-            IMediator mediator,
-            Func<IExportJobTask> exportJobTaskFactory,
-            ISearchService searchService,
-            IEnumerable<Func<IJob>> jobFactories,
-            ILoggerFactory loggerFactory)
+        public JobFactory(IEnumerable<Func<IJob>> jobFactories)
         {
-            EnsureArg.IsNotNull(importResourceLoader, nameof(importResourceLoader));
-            EnsureArg.IsNotNull(resourceBulkImporter, nameof(resourceBulkImporter));
-            EnsureArg.IsNotNull(importErrorStoreFactory, nameof(importErrorStoreFactory));
-            EnsureArg.IsNotNull(importOrchestratorTaskDataStoreOperation, nameof(importOrchestratorTaskDataStoreOperation));
-            EnsureArg.IsNotNull(queueClient, nameof(queueClient));
-            EnsureArg.IsNotNull(integrationDataStoreClient, nameof(integrationDataStoreClient));
-            EnsureArg.IsNotNull(contextAccessor, nameof(contextAccessor));
-            EnsureArg.IsNotNull(mediator, nameof(mediator));
-            EnsureArg.IsNotNull(exportJobTaskFactory, nameof(exportJobTaskFactory));
-            EnsureArg.IsNotNull(searchService, nameof(searchService));
             EnsureArg.IsNotNull(jobFactories, nameof(jobFactories));
-            EnsureArg.IsNotNull(loggerFactory, nameof(loggerFactory));
-
-            _importResourceLoader = importResourceLoader;
-            _resourceBulkImporter = resourceBulkImporter;
-            _importErrorStoreFactory = importErrorStoreFactory;
-            _importOrchestratorTaskDataStoreOperation = importOrchestratorTaskDataStoreOperation;
-            _integrationDataStoreClient = integrationDataStoreClient;
-            _queueClient = queueClient;
-            _contextAccessor = contextAccessor;
-            _mediator = mediator;
-            _operationsConfiguration = operationsConfig.Value;
-            _exportJobTaskFactory = exportJobTaskFactory;
-            _searchService = searchService;
-            _loggerFactory = loggerFactory;
 
             _jobFactoryLookup = new Dictionary<int, Func<IJob>>();
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
     /// <summary>
     /// Provides mechanism to access search parameter definition.
     /// </summary>
-    public class SearchParameterDefinitionManager : ISearchParameterDefinitionManager, IHostedService, INotificationHandler<SearchParametersUpdatedNotification>, INotificationHandler<StorageInitializedNotification>
+    public class SearchParameterDefinitionManager : ISearchParameterDefinitionManager, INotificationHandler<SearchParametersUpdatedNotification>, INotificationHandler<StorageInitializedNotification>
     {
         private readonly IModelInfoProvider _modelInfoProvider;
         private readonly IMediator _mediator;
@@ -57,6 +57,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             UrlLookup = new ConcurrentDictionary<string, SearchParameterInfo>();
             _searchServiceFactory = searchServiceFactory;
             _logger = logger;
+
+            var bundle = SearchParameterDefinitionBuilder.ReadEmbeddedSearchParameters("search-parameters.json", _modelInfoProvider);
+
+            SearchParameterDefinitionBuilder.Build(
+                bundle.Entries.Select(e => e.Resource).ToList(),
+                UrlLookup,
+                TypeLookup,
+                _modelInfoProvider);
         }
 
         internal ConcurrentDictionary<string, SearchParameterInfo> UrlLookup { get; set; }
@@ -70,21 +78,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         {
             get { return new ReadOnlyDictionary<string, string>(_resourceTypeSearchParameterHashMap.ToDictionary(kvp => kvp.Key, kvp => kvp.Value)); }
         }
-
-        public Task StartAsync(CancellationToken cancellationToken)
-        {
-            var bundle = SearchParameterDefinitionBuilder.ReadEmbeddedSearchParameters("search-parameters.json", _modelInfoProvider);
-
-            SearchParameterDefinitionBuilder.Build(
-                bundle.Entries.Select(e => e.Resource).ToList(),
-                UrlLookup,
-                TypeLookup,
-                _modelInfoProvider);
-
-            return Task.CompletedTask;
-        }
-
-        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
         public async Task EnsureInitializedAsync(CancellationToken cancellationToken)
         {

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/SearchModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/SearchModule.cs
@@ -63,7 +63,6 @@ namespace Microsoft.Health.Fhir.Api.Modules
                 .Singleton()
                 .AsSelf()
                 .AsService<ISearchParameterDefinitionManager>()
-                .AsService<IHostedService>()
                 .AsService<INotificationHandler<SearchParametersUpdatedNotification>>()
                 .AsService<INotificationHandler<StorageInitializedNotification>>();
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
@@ -65,8 +65,6 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             _fhirRequestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
             _fhirRequestContextAccessor.RequestContext.Returns(_fhirRequestContext);
 
-            _searchParameterDefinitionManager.StartAsync(CancellationToken.None);
-
             _manager = new SearchParameterStatusManager(
                 _searchParameterStatusDataStore,
                 _searchParameterDefinitionManager,

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterFixtureData.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterFixtureData.cs
@@ -81,7 +81,6 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         {
             var searchService = Substitute.For<ISearchService>();
             var definitionManager = new SearchParameterDefinitionManager(modelInfoProvider, mediator, () => searchService.CreateMockScope(), NullLogger<SearchParameterDefinitionManager>.Instance);
-            await definitionManager.StartAsync(CancellationToken.None);
             await definitionManager.EnsureInitializedAsync(CancellationToken.None);
 
             var statusRegistry = new FilebasedSearchParameterStatusDataStore(

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/IncludeRewriterTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/IncludeRewriterTests.cs
@@ -1653,7 +1653,6 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
             {
                 if (!isInitialized)
                 {
-                    await ((SearchParameterDefinitionManager)SearchParameterDefinitionManager).StartAsync(CancellationToken.None);
                     await ((SearchParameterDefinitionManager)SearchParameterDefinitionManager).EnsureInitializedAsync(CancellationToken.None);
                     isInitialized = true;
                 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -953,7 +953,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
             var mediator = new Mediator(type => services.GetService(type));
 
             _searchParameterDefinitionManager2 = new SearchParameterDefinitionManager(ModelInfoProvider.Instance, mediator, () => _searchService, NullLogger<SearchParameterDefinitionManager>.Instance);
-            await _searchParameterDefinitionManager2.StartAsync(CancellationToken.None);
             await _searchParameterDefinitionManager2.EnsureInitializedAsync(CancellationToken.None);
             _supportedSearchParameterDefinitionManager2 = new SupportedSearchParameterDefinitionManager(_searchParameterDefinitionManager2);
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
@@ -97,7 +97,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             _fhirRequestContextAccessor.RequestContext.RouteName.Returns("routeName");
 
             _searchParameterDefinitionManager = new SearchParameterDefinitionManager(ModelInfoProvider.Instance, _mediator, () => _searchService.CreateMockScope(), NullLogger<SearchParameterDefinitionManager>.Instance);
-            await _searchParameterDefinitionManager.StartAsync(CancellationToken.None);
 
             _supportedSearchParameterDefinitionManager = new SupportedSearchParameterDefinitionManager(_searchParameterDefinitionManager);
             var searchableSearchParameterDefinitionManager = new SearchableSearchParameterDefinitionManager(_searchParameterDefinitionManager, _fhirRequestContextAccessor);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -114,8 +114,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
             _searchParameterDefinitionManager = new SearchParameterDefinitionManager(ModelInfoProvider.Instance, _mediator, () => _searchService.CreateMockScope(), NullLogger<SearchParameterDefinitionManager>.Instance);
 
-            _searchParameterDefinitionManager.StartAsync(CancellationToken.None);
-
             _filebasedSearchParameterStatusDataStore = new FilebasedSearchParameterStatusDataStore(_searchParameterDefinitionManager, ModelInfoProvider.Instance);
 
             var securityConfiguration = new SecurityConfiguration { PrincipalClaims = { "oid" } };


### PR DESCRIPTION
## Description
PaaS startup was failing when TaskHosting was enabled because the SearchParamerterDefinitionManager hadn't been fully initialized. This PR makes the SearchParameterDefinitionMangaer initialize in its constructor and removes the requirement from the JobFactory.

## Related issues
Build exception in PaaS

## Testing
Existing unit and E2E tests as well as manual testing to check for regression.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
