### PR TITLE
Change to Fhir Exception name and add more logging

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Client/FhirClient.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Client/FhirClient.cs
@@ -616,6 +616,9 @@ namespace Microsoft.Health.Fhir.Client
             {
                 await response.Content.LoadIntoBufferAsync();
 
+                using var message = new HttpRequestMessage(HttpMethod.Get, "health/check");
+                using HttpResponseMessage healthCheck = await HttpClient.SendAsync(message, CancellationToken.None);
+
                 FhirResponse<OperationOutcome> operationOutcome;
                 try
                 {
@@ -624,10 +627,10 @@ namespace Microsoft.Health.Fhir.Client
                 catch (Exception)
                 {
                     // The response could not be read as an OperationOutcome. Throw a generic HTTP error.
-                    throw new HttpRequestException($"Status code: {response.StatusCode}; reason phrase: '{response.ReasonPhrase}'; body: '{await response.Content.ReadAsStringAsync()}'");
+                    throw new HttpRequestException($"Status code: {response.StatusCode}; reason phrase: '{response.ReasonPhrase}'; body: '{await response.Content.ReadAsStringAsync()}'; health check: '{healthCheck.StatusCode}'");
                 }
 
-                throw new FhirException(operationOutcome);
+                throw new FhirClientException(operationOutcome, healthCheck.StatusCode);
             }
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Client/FhirClientException.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Client/FhirClientException.cs
@@ -13,7 +13,7 @@ using Hl7.Fhir.Model;
 
 namespace Microsoft.Health.Fhir.Client
 {
-    public class FhirClientException: Exception, IDisposable
+    public class FhirClientException : Exception, IDisposable
     {
         public FhirClientException(FhirResponse<OperationOutcome> response, HttpStatusCode healthCheck)
         {

--- a/src/Microsoft.Health.Fhir.Shared.Client/FhirClientException.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Client/FhirClientException.cs
@@ -13,11 +13,12 @@ using Hl7.Fhir.Model;
 
 namespace Microsoft.Health.Fhir.Client
 {
-    public class FhirException : Exception, IDisposable
+    public class FhirClientException: Exception, IDisposable
     {
-        public FhirException(FhirResponse<OperationOutcome> response)
+        public FhirClientException(FhirResponse<OperationOutcome> response, HttpStatusCode healthCheck)
         {
             Response = response;
+            HealthCheckResult = healthCheck;
         }
 
         public HttpStatusCode StatusCode => Response.StatusCode;
@@ -29,6 +30,8 @@ namespace Microsoft.Health.Fhir.Client
         public HttpContent Content => Response.Content;
 
         public OperationOutcome OperationOutcome => Response.Resource;
+
+        public HttpStatusCode HealthCheckResult { get; private set; }
 
         public override string Message => FormatMessage();
 
@@ -66,7 +69,10 @@ namespace Microsoft.Health.Fhir.Client
             message.Append("Url: (").Append(Response.Response.RequestMessage?.Method.Method ?? "NO_HTTP_METHOD_AVAILABLE").Append(") ").AppendLine(Response.Response.RequestMessage?.RequestUri.ToString() ?? "NO_URI_AVAILABLE");
             message.Append("Response code: ").Append(Response.Response.StatusCode.ToString()).Append('(').Append((int)Response.Response.StatusCode).AppendLine(")");
             message.Append("Reason phrase: ").AppendLine(Response.Response.ReasonPhrase ?? "NO_REASON_PHRASE");
+            message.Append("Content: ").AppendLine(Response.Content?.ToString() ?? "NO_CONTENT");
+            message.Append("Request: ").AppendLine(Response.Response.RequestMessage.Content?.ToString() ?? "NO_REQUEST");
             message.Append("Timestamp: ").AppendLine(DateTime.UtcNow.ToString("o"));
+            message.Append("Health Check Result: ").Append(HealthCheckResult.ToString()).Append('(').Append((int)HealthCheckResult).AppendLine(")");
             message.AppendLine("==============================================");
 
             return message.ToString();

--- a/src/Microsoft.Health.Fhir.Shared.Client/Microsoft.Health.Fhir.Shared.Client.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Client/Microsoft.Health.Fhir.Shared.Client.projitems
@@ -11,7 +11,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)FhirClient.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FhirClientExtensions.cs" />
-    <Compile Include="..\Microsoft.Health.Fhir.Shared.Client\FhirClientException.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)FhirClientException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FhirResponse.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FhirResponse{T}.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IFhirClient.cs" />

--- a/src/Microsoft.Health.Fhir.Shared.Client/Microsoft.Health.Fhir.Shared.Client.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Client/Microsoft.Health.Fhir.Shared.Client.projitems
@@ -11,7 +11,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)FhirClient.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FhirClientExtensions.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)FhirException.cs" />
+    <Compile Include="..\Microsoft.Health.Fhir.Shared.Client\FhirClientException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FhirResponse.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FhirResponse{T}.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IFhirClient.cs" />

--- a/test/Microsoft.Health.Fhir.R4.Tests.E2E/Rest/VersionSpecificTests.cs
+++ b/test/Microsoft.Health.Fhir.R4.Tests.E2E/Rest/VersionSpecificTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         public async Task GivenAnObservation_WithInvalidDecimalSpecification_ThenBadRequestShouldBeReturned()
         {
             var resource = Samples.GetJsonSample<Observation>("ObservationWithInvalidDecimalSpecification");
-            using FhirException exception = await Assert.ThrowsAsync<FhirException>(() => _client.CreateAsync(resource));
+            using FhirClientException exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.CreateAsync(resource));
             Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
         }
 
@@ -70,7 +70,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Fact]
         public async Task GivenAResourceThatWasRenamed_WhenSearched_ThenExceptionShouldBeThrown()
         {
-            using FhirException exception = await Assert.ThrowsAsync<FhirException>(() => _client.SearchAsync("Sequence"));
+            using FhirClientException exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.SearchAsync("Sequence"));
 
             Assert.Equal(HttpStatusCode.NotFound, exception.StatusCode);
         }

--- a/test/Microsoft.Health.Fhir.R4B.Tests.E2E/Rest/VersionSpecificTests.cs
+++ b/test/Microsoft.Health.Fhir.R4B.Tests.E2E/Rest/VersionSpecificTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         public async Task GivenAnObservation_WithInvalidDecimalSpecification_ThenBadRequestShouldBeReturned()
         {
             var resource = Samples.GetJsonSample<Observation>("ObservationWithInvalidDecimalSpecification");
-            using FhirException exception = await Assert.ThrowsAsync<FhirException>(() => _client.CreateAsync(resource));
+            using FhirClientException exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.CreateAsync(resource));
             Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
         }
 
@@ -70,7 +70,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Fact]
         public async Task GivenAResourceThatWasRenamed_WhenSearched_ThenExceptionShouldBeThrown()
         {
-            using FhirException exception = await Assert.ThrowsAsync<FhirException>(() => _client.SearchAsync("Sequence"));
+            using FhirClientException exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.SearchAsync("Sequence"));
 
             Assert.Equal(HttpStatusCode.NotFound, exception.StatusCode);
         }

--- a/test/Microsoft.Health.Fhir.R5.Tests.E2E/Rest/VersionSpecificTests.cs
+++ b/test/Microsoft.Health.Fhir.R5.Tests.E2E/Rest/VersionSpecificTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         public async Task GivenAnObservation_WithInvalidDecimalSpecification_ThenBadRequestShouldBeReturned()
         {
             var resource = Samples.GetJsonSample<Observation>("ObservationWithInvalidDecimalSpecification");
-            using FhirException exception = await Assert.ThrowsAsync<FhirException>(() => _client.CreateAsync(resource));
+            using FhirClientException exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.CreateAsync(resource));
             Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
         }
 
@@ -70,7 +70,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Fact]
         public async Task GivenAResourceThatWasRenamed_WhenSearched_ThenExceptionShouldBeThrown()
         {
-            using FhirException exception = await Assert.ThrowsAsync<FhirException>(() => _client.SearchAsync("Sequence"));
+            using FhirClientException exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.SearchAsync("Sequence"));
 
             Assert.Equal(HttpStatusCode.NotFound, exception.StatusCode);
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/AnonymizedExportTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/AnonymizedExportTests.cs
@@ -350,7 +350,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             (string fileName, string _) = await UploadConfigurationAsync(RedactResourceIdAnonymizationConfiguration);
 
             string containerName = string.Empty;
-            await Assert.ThrowsAsync<FhirException>(() => _testFhirClient.AnonymizedExportAsync(fileName, dateTime, containerName));
+            await Assert.ThrowsAsync<FhirClientException>(() => _testFhirClient.AnonymizedExportAsync(fileName, dateTime, containerName));
         }
 
         private async Task<(string name, string eTag)> UploadConfigurationAsync(string configurationContent, string blobName = null)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/AuditTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/AuditTests.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit
                     {
                         await _client.ReadAsync<Patient>(ResourceType.Patient, resourceId);
                     }
-                    catch (FhirException ex)
+                    catch (FhirClientException ex)
                     {
                         result = ex.Response;
                         ex.Dispose();
@@ -556,7 +556,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit
             await ExecuteAndValidateBundle(
               async () =>
               {
-                  using var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await _client.PostBundleAsync(requestBundle.ToPoco<Bundle>()));
+                  using var fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await _client.PostBundleAsync(requestBundle.ToPoco<Bundle>()));
 
                   return fhirException.Response;
               },
@@ -615,7 +615,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit
             // Create a new client with no token supplied.
             var client = createClient();
 
-            using FhirResponse<OperationOutcome> response = (await Assert.ThrowsAsync<FhirException>(() => client.ReadAsync<Patient>(url))).Response;
+            using FhirResponse<OperationOutcome> response = (await Assert.ThrowsAsync<FhirClientException>(() => client.ReadAsync<Patient>(url))).Response;
 
             string correlationId = response.Headers.GetValues(RequestIdHeaderName).FirstOrDefault();
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BasicAuthTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BasicAuthTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         public async Task GivenAUserWithNoCreatePermissions_WhenCreatingAResource_TheServerShouldReturnForbidden()
         {
             TestFhirClient tempClient = _client.CreateClientForUser(TestUsers.ReadOnlyUser, TestApplications.NativeClient);
-            FhirException fhirException = await Assert.ThrowsAsync<FhirException>(async () => await tempClient.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>()));
+            FhirClientException fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await tempClient.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>()));
             Assert.StartsWith(ForbiddenMessage, fhirException.Message);
             Assert.Equal(HttpStatusCode.Forbidden, fhirException.StatusCode);
         }
@@ -66,7 +66,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Observation createdResource = await tempClient.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>());
 
             tempClient = _client.CreateClientForUser(TestUsers.ReadOnlyUser, TestApplications.NativeClient);
-            FhirException fhirException = await Assert.ThrowsAsync<FhirException>(async () => await tempClient.UpdateAsync(createdResource));
+            FhirClientException fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await tempClient.UpdateAsync(createdResource));
             Assert.StartsWith(ForbiddenMessage, fhirException.Message);
             Assert.Equal(HttpStatusCode.Forbidden, fhirException.StatusCode);
         }
@@ -78,7 +78,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             TestFhirClient tempClient = _client.CreateClientForUser(TestUsers.ReadWriteUser, TestApplications.NativeClient);
             Observation createdResource = await tempClient.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>());
 
-            FhirException fhirException = await Assert.ThrowsAsync<FhirException>(async () => await tempClient.HardDeleteAsync(createdResource));
+            FhirClientException fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await tempClient.HardDeleteAsync(createdResource));
             Assert.StartsWith(ForbiddenMessage, fhirException.Message);
             Assert.Equal(HttpStatusCode.Forbidden, fhirException.StatusCode);
         }
@@ -100,9 +100,9 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             // Getting the resource should result in NotFound.
             await ExecuteAndValidateNotFoundStatus(() => tempClient.ReadAsync<Observation>(ResourceType.Observation, createdResource.Id));
 
-            async Task<FhirException> ExecuteAndValidateNotFoundStatus(Func<Task> action)
+            async Task<FhirClientException> ExecuteAndValidateNotFoundStatus(Func<Task> action)
             {
-                using FhirException exception = await Assert.ThrowsAsync<FhirException>(action);
+                using FhirClientException exception = await Assert.ThrowsAsync<FhirClientException>(action);
                 Assert.Equal(HttpStatusCode.NotFound, exception.StatusCode);
                 return exception;
             }
@@ -140,7 +140,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         {
             TestFhirClient tempClient = _client.CreateClientForClientApplication(TestApplications.InvalidClient);
 
-            FhirException fhirException = await Assert.ThrowsAsync<FhirException>(async () => await tempClient.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>()));
+            FhirClientException fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await tempClient.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>()));
             Assert.StartsWith(UnauthorizedMessage, fhirException.Message);
             Assert.Equal(HttpStatusCode.Unauthorized, fhirException.StatusCode);
 
@@ -168,7 +168,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         public async Task GivenAClientWithInvalidAuthToken_WhenCreatingAResource_TheServerShouldReturnUnauthorized()
         {
             TestFhirClient tempClient = _client.CreateClientForClientApplication(TestApplications.InvalidClient).Clone();
-            FhirException fhirException = await Assert.ThrowsAsync<FhirException>(async () => await tempClient.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>()));
+            FhirClientException fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await tempClient.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>()));
             Assert.StartsWith(UnauthorizedMessage, fhirException.Message);
             Assert.Equal(HttpStatusCode.Unauthorized, fhirException.StatusCode);
         }
@@ -178,7 +178,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         public async Task GivenAClientWithWrongAudience_WhenCreatingAResource_TheServerShouldReturnUnauthorized()
         {
             TestFhirClient tempClient = _client.CreateClientForClientApplication(TestApplications.WrongAudienceClient);
-            FhirException fhirException = await Assert.ThrowsAsync<FhirException>(async () => await tempClient.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>()));
+            FhirClientException fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await tempClient.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>()));
             Assert.StartsWith(UnauthorizedMessage, fhirException.Message);
             Assert.Equal(HttpStatusCode.Unauthorized, fhirException.StatusCode);
         }
@@ -206,7 +206,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         {
             TestFhirClient tempClient = _client.CreateClientForUser(TestUsers.ReadOnlyUser, TestApplications.NativeClient);
 
-            FhirException fhirException = await Assert.ThrowsAsync<FhirException>(async () => await tempClient.ExportAsync());
+            FhirClientException fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await tempClient.ExportAsync());
             Assert.StartsWith(ForbiddenMessage, fhirException.Message);
             Assert.Equal(HttpStatusCode.Forbidden, fhirException.StatusCode);
         }
@@ -230,7 +230,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             TestFhirClient tempClient = _client.CreateClientForUser(TestUsers.ReadOnlyUser, TestApplications.NativeClient);
 
             var parameters = Samples.GetDefaultConvertDataParameter().ToPoco<Parameters>();
-            FhirException fhirException = await Assert.ThrowsAsync<FhirException>(async () => await tempClient.ConvertDataAsync(parameters));
+            FhirClientException fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await tempClient.ConvertDataAsync(parameters));
             Assert.Equal(ForbiddenMessage, fhirException.Message);
             Assert.Equal(HttpStatusCode.Forbidden, fhirException.StatusCode);
         }
@@ -253,7 +253,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         {
             TestFhirClient tempClient = _client.CreateClientForUser(TestUsers.ReadWriteUser, TestApplications.NativeClient);
             var resource = Samples.GetJsonSample("ValueSet").ToPoco<ValueSet>();
-            FhirException fhirException = await Assert.ThrowsAsync<FhirException>(async () => await tempClient.CreateAsync<ValueSet>(resource));
+            FhirClientException fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await tempClient.CreateAsync<ValueSet>(resource));
             Assert.StartsWith(ForbiddenMessage, fhirException.Message);
             Assert.Equal(HttpStatusCode.Forbidden, fhirException.StatusCode);
         }
@@ -264,7 +264,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         {
             TestFhirClient tempClient = _client.CreateClientForUser(TestUsers.ReadWriteUser, TestApplications.NativeClient);
             var resource = Samples.GetJsonSample("ValueSet").ToPoco<ValueSet>();
-            var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await tempClient.UpdateAsync<ValueSet>(resource));
+            var fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await tempClient.UpdateAsync<ValueSet>(resource));
 
             Assert.StartsWith(ForbiddenMessage, fhirException.Message);
             Assert.Equal(HttpStatusCode.Forbidden, fhirException.StatusCode);
@@ -276,7 +276,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         {
             TestFhirClient tempClient = _client.CreateClientForUser(TestUsers.ReadWriteUser, TestApplications.NativeClient);
             var resource = Samples.GetJsonSample("ValueSet").ToPoco<ValueSet>();
-            var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await tempClient.CreateAsync<ValueSet>(resource, "identifier=boo"));
+            var fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await tempClient.CreateAsync<ValueSet>(resource, "identifier=boo"));
 
             Assert.StartsWith(ForbiddenMessage, fhirException.Message);
             Assert.Equal(HttpStatusCode.Forbidden, fhirException.StatusCode);
@@ -289,7 +289,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             TestFhirClient tempClient = _client.CreateClientForUser(TestUsers.ReadWriteUser, TestApplications.NativeClient);
             var resource = Samples.GetJsonSample("ValueSet").ToPoco<ValueSet>();
             var weakETag = "W/\"identifier=boo\"";
-            var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await tempClient.UpdateAsync<ValueSet>(resource, weakETag));
+            var fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await tempClient.UpdateAsync<ValueSet>(resource, weakETag));
 
             Assert.StartsWith(ForbiddenMessage, fhirException.Message);
             Assert.Equal(HttpStatusCode.Forbidden, fhirException.StatusCode);
@@ -301,7 +301,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         {
             TestFhirClient tempClient = _client.CreateClientForUser(TestUsers.ReadWriteUser, TestApplications.NativeClient);
             var resource = Samples.GetJsonSample("ValueSet").ToPoco<ValueSet>();
-            var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await tempClient.DeleteAsync<ValueSet>(resource));
+            var fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await tempClient.DeleteAsync<ValueSet>(resource));
 
             Assert.StartsWith(ForbiddenMessage, fhirException.Message);
             Assert.Equal(HttpStatusCode.Forbidden, fhirException.StatusCode);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BatchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BatchTests.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenANonBundleResource_WhenSubmittingABatch_ThenBadRequestIsReturned()
         {
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(() => _client.PostBundleAsync(Samples.GetDefaultObservation().ToPoco<Observation>()));
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(() => _client.PostBundleAsync(Samples.GetDefaultObservation().ToPoco<Observation>()));
 
             Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
         }
@@ -155,7 +155,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenBundleTypeIsMissing_WhenSubmittingABundle_ThenMethodNotAllowedExceptionIsReturned()
         {
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(() => _client.PostBundleAsync(Samples.GetJsonSample("Bundle-TypeMissing").ToPoco<Bundle>()));
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(() => _client.PostBundleAsync(Samples.GetJsonSample("Bundle-TypeMissing").ToPoco<Bundle>()));
             ValidateOperationOutcome(ex.StatusCode.ToString(), ex.OperationOutcome, "MethodNotAllowed", "Bundle type is not present. Possible values are: transaction or batch", IssueType.Forbidden);
         }
 
@@ -274,7 +274,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             if (profileValidation)
             {
-                using FhirException ex = await Assert.ThrowsAsync<FhirException>(() => _client.PostBundleWithValidationHeaderAsync(bundle, profileValidation));
+                using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(() => _client.PostBundleWithValidationHeaderAsync(bundle, profileValidation));
                 Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
             }
             else

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/CompartmentTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/CompartmentTests.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         {
             string searchUrl = $"Patient/{Fixture.Patient.Id}/foo";
 
-            FhirException exception = await Assert.ThrowsAsync<FhirException>(async () => await Client.SearchAsync(searchUrl));
+            FhirClientException exception = await Assert.ThrowsAsync<FhirClientException>(async () => await Client.SearchAsync(searchUrl));
             Assert.Equal(HttpStatusCode.NotFound, exception.Response.StatusCode);
         }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalCreateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalCreateTests.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         {
             var observation = Samples.GetDefaultObservation().ToPoco<Observation>();
             observation.Id = null;
-            var exception = await Assert.ThrowsAsync<FhirException>(() => _client.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>(), $"identifier={Guid.NewGuid().ToString()}", "Jibberish"));
+            var exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>(), $"identifier={Guid.NewGuid().ToString()}", "Jibberish"));
             Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
         }
 
@@ -121,7 +121,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             var observation2 = Samples.GetDefaultObservation().ToPoco<Observation>();
             observation2.Id = Guid.NewGuid().ToString();
 
-            var exception = await Assert.ThrowsAsync<FhirException>(() => _client.CreateAsync(
+            var exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.CreateAsync(
                 observation2,
                 $"identifier={identifier}"));
 
@@ -132,7 +132,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenAResource_WhenCreatingConditionallyWithEmptyIfNoneHeader_TheServerShouldFail()
         {
-            var exception = await Assert.ThrowsAsync<FhirException>(() => _client.CreateAsync(
+            var exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.CreateAsync(
                 Samples.GetDefaultObservation().ToPoco<Observation>(),
                 "&"));
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalDeleteTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalDeleteTests.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             await CreateWithIdentifier(identifier);
             await ValidateResults(identifier, 2);
 
-            await Assert.ThrowsAsync<FhirException>(() => _client.DeleteAsync($"{_resourceType}?identifier={identifier}", CancellationToken.None));
+            await Assert.ThrowsAsync<FhirClientException>(() => _client.DeleteAsync($"{_resourceType}?identifier={identifier}", CancellationToken.None));
         }
 
         [InlineData(-1)]
@@ -88,7 +88,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         public async Task GivenMultipleMatchingResources_WhenDeletingConditionallyWithOutOfRanceCount_TheServerShouldReturnError(int deleteCount)
         {
             var identifier = Guid.NewGuid().ToString();
-            await Assert.ThrowsAsync<FhirException>(() => _client.DeleteAsync($"{_resourceType}?identifier={identifier}&_count={deleteCount}", CancellationToken.None));
+            await Assert.ThrowsAsync<FhirClientException>(() => _client.DeleteAsync($"{_resourceType}?identifier={identifier}&_count={deleteCount}", CancellationToken.None));
         }
 
         [InlineData(true)]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalPatchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalPatchTests.cs
@@ -43,9 +43,9 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenConditionWithNoExistingResources_WhenPatching_TheServerShouldReturnNoFound()
         {
-            var exceptionJson = await Assert.ThrowsAsync<FhirException>(() =>
+            var exceptionJson = await Assert.ThrowsAsync<FhirClientException>(() =>
                 _client.ConditionalJsonPatchAsync<Patient>("Patient", $"identifier={Guid.NewGuid()}", _patchDocumentJson));
-            var exceptionFhir = await Assert.ThrowsAsync<FhirException>(() =>
+            var exceptionFhir = await Assert.ThrowsAsync<FhirClientException>(() =>
                 _client.ConditionalFhirPatchAsync<Patient>("Patient", $"identifier={Guid.NewGuid()}", _fhirPatchRequest));
 
             Assert.Equal(HttpStatusCode.NotFound, exceptionJson.Response.StatusCode);
@@ -56,9 +56,9 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenNoCondition_WhenPatching_ThenAnErrorShouldBeReturned()
         {
-            var exceptionJson = await Assert.ThrowsAsync<FhirException>(() =>
+            var exceptionJson = await Assert.ThrowsAsync<FhirClientException>(() =>
                 _client.ConditionalJsonPatchAsync<Patient>("Patient", string.Empty, _patchDocumentJson));
-            var exceptionFhir = await Assert.ThrowsAsync<FhirException>(() =>
+            var exceptionFhir = await Assert.ThrowsAsync<FhirClientException>(() =>
                 _client.ConditionalFhirPatchAsync<Patient>("Patient", string.Empty, _fhirPatchRequest));
 
             Assert.Equal(HttpStatusCode.PreconditionFailed, exceptionJson.Response.StatusCode);
@@ -124,7 +124,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             var observation2 = Samples.GetDefaultObservation().ToPoco<Observation>();
             observation2.Id = null;
 
-            var exception = await Assert.ThrowsAsync<FhirException>(() => _client.ConditionalJsonPatchAsync<Patient>(
+            var exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.ConditionalJsonPatchAsync<Patient>(
                 "Patient",
                 $"identifier={identifier}",
                 _patchDocumentJson));
@@ -149,7 +149,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             var observation2 = Samples.GetDefaultObservation().ToPoco<Observation>();
             observation2.Id = null;
 
-            var exception = await Assert.ThrowsAsync<FhirException>(() => _client.ConditionalFhirPatchAsync<Patient>(
+            var exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.ConditionalFhirPatchAsync<Patient>(
                 "Patient",
                 $"identifier={identifier}",
                 _fhirPatchRequest));
@@ -221,12 +221,12 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             response.Resource.BirthDate = "2020-01-01";
             using FhirResponse<Patient> secondVersion = await _client.UpdateAsync(response.Resource);
 
-            var exceptionJson = await Assert.ThrowsAsync<FhirException>(() => _client.ConditionalJsonPatchAsync<Patient>(
+            var exceptionJson = await Assert.ThrowsAsync<FhirClientException>(() => _client.ConditionalJsonPatchAsync<Patient>(
                 "Patient",
                 $"identifier={identifier}",
                 _patchDocumentJson,
                 "3"));
-            var exceptionFhir = await Assert.ThrowsAsync<FhirException>(() => _client.ConditionalFhirPatchAsync<Patient>(
+            var exceptionFhir = await Assert.ThrowsAsync<FhirClientException>(() => _client.ConditionalFhirPatchAsync<Patient>(
                 "Patient",
                 $"identifier={identifier}",
                 _fhirPatchRequest,

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalUpdateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalUpdateTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         {
             var observation = Samples.GetDefaultObservation().ToPoco<Observation>();
 
-            var exception = await Assert.ThrowsAsync<FhirException>(() => _client.ConditionalUpdateAsync(
+            var exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.ConditionalUpdateAsync(
                 observation,
                 string.Empty));
 
@@ -92,7 +92,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             var observation = Samples.GetDefaultObservation().ToPoco<Observation>();
 
             var weakETag = "W/\"Jibberish\"";
-            var exception = await Assert.ThrowsAsync<FhirException>(() => _client.ConditionalUpdateAsync(
+            var exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.ConditionalUpdateAsync(
                 observation,
                 null,
                 weakETag));
@@ -189,7 +189,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             var observation2 = Samples.GetDefaultObservation().ToPoco<Observation>();
             observation2.Id = Guid.NewGuid().ToString();
 
-            var exception = await Assert.ThrowsAsync<FhirException>(() => _client.ConditionalUpdateAsync(
+            var exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.ConditionalUpdateAsync(
                 observation2,
                 $"identifier={identifier}"));
 
@@ -214,7 +214,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             var observation2 = Samples.GetDefaultObservation().ToPoco<Observation>();
             observation2.Id = null;
 
-            var exception = await Assert.ThrowsAsync<FhirException>(() => _client.ConditionalUpdateAsync(
+            var exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.ConditionalUpdateAsync(
                 observation2,
                 $"identifier={identifier}"));
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/CreateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/CreateTests.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenAResourceAndMalformedProvenanceHeader_WhenPostingToHttp_TheServerShouldRespondSuccessfully()
         {
-            var exception = await Assert.ThrowsAsync<FhirException>(() => _client.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>(), provenanceHeader: "Jibberish"));
+            var exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>(), provenanceHeader: "Jibberish"));
             Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
         }
 
@@ -98,7 +98,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             poco.Text.Div = $"<div>{largeStringBuilder.ToString()}</div>";
 
-            var exception = await Assert.ThrowsAsync<FhirException>(() => _client.CreateAsync(poco));
+            var exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.CreateAsync(poco));
             Assert.Equal(HttpStatusCode.RequestEntityTooLarge, exception.StatusCode);
         }
 
@@ -152,7 +152,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenAnUnsupportedResourceType_WhenPostingToHttp_TheServerShouldRespondWithANotFoundResponse()
         {
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(() => _client.CreateAsync("NotObservation", Samples.GetDefaultObservation().ToPoco<Observation>()));
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(() => _client.CreateAsync("NotObservation", Samples.GetDefaultObservation().ToPoco<Observation>()));
 
             Assert.Equal(HttpStatusCode.NotFound, ex.StatusCode);
         }
@@ -181,7 +181,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         public async Task GivenAnInvalidResource_WhenPostingToHttp_TheServerShouldRespondWithBadRequestResponse()
         {
             // An empty observation is invalid because it is missing fields that have a minimum cardinality of 1
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(() => _client.CreateAsync(new Observation()));
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(() => _client.CreateAsync(new Observation()));
 
             Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
         }
@@ -193,7 +193,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Observation observation = Samples.GetDefaultObservation().ToPoco<Observation>();
             observation.Effective = new FhirDateTime("2021-10-13+02:00");
 
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(() => _client.CreateAsync(observation));
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(() => _client.CreateAsync(observation));
             Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
             Assert.Contains("format", ex.Message);
         }
@@ -231,7 +231,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
                 .UpdateId("' SELECT name FROM syscolumns WHERE id = (SELECT id FROM sysobjects WHERE name = tablename')--")
                 .ToPoco<Observation>();
 
-            var exception = await Assert.ThrowsAsync<FhirException>(async () => await _client.UpdateAsync(observation));
+            var exception = await Assert.ThrowsAsync<FhirClientException>(async () => await _client.UpdateAsync(observation));
 
             Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
         }
@@ -271,7 +271,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             // Xml can't even serialize these broken fragments
             if (_client.Format != ResourceFormat.Xml)
             {
-                var exception = await Assert.ThrowsAsync<FhirException>(() => _client.CreateAsync(observation));
+                var exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.CreateAsync(observation));
                 Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
             }
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/DeleteTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/DeleteTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             await _client.DeleteAsync(response.Resource);
 
             // Subsequent read on the resource should return Gone.
-            using FhirException ex = await ExecuteAndValidateGoneStatus(() => _client.ReadAsync<Observation>(ResourceType.Observation, resourceId));
+            using FhirClientException ex = await ExecuteAndValidateGoneStatus(() => _client.ReadAsync<Observation>(ResourceType.Observation, resourceId));
 
             string eTag = ex.Headers.ETag.ToString();
 
@@ -61,9 +61,9 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             // Subsequent read on the deleted version should return Gone.
             await ExecuteAndValidateGoneStatus(() => _client.VReadAsync<Observation>(ResourceType.Observation, resourceId, deleteVersionId));
 
-            async Task<FhirException> ExecuteAndValidateGoneStatus(Func<Task> action)
+            async Task<FhirClientException> ExecuteAndValidateGoneStatus(Func<Task> action)
             {
-                using FhirException exception = await Assert.ThrowsAsync<FhirException>(action);
+                using FhirClientException exception = await Assert.ThrowsAsync<FhirClientException>(action);
 
                 Assert.Equal(HttpStatusCode.Gone, exception.StatusCode);
 
@@ -119,7 +119,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             async Task ExecuteAndValidateNotFoundStatus(Func<Task> action)
             {
-                using FhirException exception = await Assert.ThrowsAsync<FhirException>(action);
+                using FhirClientException exception = await Assert.ThrowsAsync<FhirClientException>(action);
 
                 Assert.Equal(HttpStatusCode.NotFound, exception.StatusCode);
             }
@@ -192,7 +192,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
         private async Task GivenExecuteAndValidateNotFoundStatus(Func<Task> action)
         {
-            FhirException exception = null;
+            FhirClientException exception = null;
 
             do
             {
@@ -202,7 +202,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
                     await Task.Delay(500);
                 }
 
-                exception = await Assert.ThrowsAsync<FhirException>(action);
+                exception = await Assert.ThrowsAsync<FhirClientException>(action);
             }
             while (exception.StatusCode == (HttpStatusCode)429);
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTests.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         {
             string searchUrl = "Observation/bar/$everything";
 
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.SearchAsync(searchUrl));
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(() => Client.SearchAsync(searchUrl));
 
             Assert.Equal(HttpStatusCode.NotFound, ex.StatusCode);
         }
@@ -133,7 +133,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         {
             string searchUrl = $"Patient/{Fixture.Patient.Id}/$everything?ct={continuationToken}";
 
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.SearchAsync(searchUrl));
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(() => Client.SearchAsync(searchUrl));
 
             Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
         }
@@ -309,7 +309,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         {
             string searchUrl = $"Patient/{Fixture.PatientWithReplacedByLink.Id}/$everything";
 
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.SearchAsync(searchUrl, Tuple.Create(KnownHeaders.Prefer, "handling=strict")));
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(() => Client.SearchAsync(searchUrl, Tuple.Create(KnownHeaders.Prefer, "handling=strict")));
 
             // Confirm header location contains url for the correct request
             string id = Fixture.PatientReferencedByReplacedByLink.Id;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ExceptionTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ExceptionTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
                 return;
             }
 
-            using var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await _client.ReadAsync<OperationOutcome>("?throw=internal"));
+            using var fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await _client.ReadAsync<OperationOutcome>("?throw=internal"));
 
             Assert.Equal(HttpStatusCode.InternalServerError, fhirException.StatusCode);
 
@@ -68,7 +68,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
                 return;
             }
 
-            using var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await _client.ReadAsync<OperationOutcome>("?throw=middleware"));
+            using var fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await _client.ReadAsync<OperationOutcome>("?throw=middleware"));
 
             Assert.Equal(HttpStatusCode.InternalServerError, fhirException.StatusCode);
 
@@ -87,7 +87,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenAnUnknownRoute_WhenPostingToHttp_TheServerShouldReturnAnOperationOutcome()
         {
-            using var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await _client.ReadAsync<OperationOutcome>("unknownRoute"));
+            using var fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await _client.ReadAsync<OperationOutcome>("unknownRoute"));
 
             Assert.Equal(HttpStatusCode.NotFound, fhirException.StatusCode);
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/FhirPathPatchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/FhirPathPatchTests.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.Equal(AdministrativeGender.Male, response.Resource.Gender);
             Assert.NotNull(response.Resource.Address);
 
-            var exception = await Assert.ThrowsAsync<FhirException>(() => _client.FhirPatchAsync(response.Resource, patchRequest));
+            var exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.FhirPatchAsync(response.Resource, patchRequest));
 
             Assert.Equal(HttpStatusCode.BadRequest, exception.Response.StatusCode);
             var responseObject = exception.Response.ToT();
@@ -160,7 +160,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             var patchRequest = new Parameters().AddAddPatchParameter("Patient", "dummyProperty", new FhirString("dummy"));
 
-            var exception = await Assert.ThrowsAsync<FhirException>(() => _client.FhirPatchAsync(
+            var exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.FhirPatchAsync(
                 response.Resource,
                 patchRequest));
 
@@ -186,7 +186,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             var poco = Samples.GetDefaultPatient().ToPoco<Patient>();
             FhirResponse<Patient> response = await _client.CreateAsync(poco);
 
-            var exception = await Assert.ThrowsAsync<FhirException>(() => _client.FhirPatchAsync(
+            var exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.FhirPatchAsync(
                 response.Resource,
                 patchRequest));
 
@@ -213,7 +213,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             var patchRequest = new Parameters().AddReplacePatchParameter(patchPath, patchValue)
 ;
-            var exception = await Assert.ThrowsAsync<FhirException>(() => _client.FhirPatchAsync(
+            var exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.FhirPatchAsync(
                 response.Resource,
                 patchRequest));
 
@@ -233,7 +233,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             var patchRequest = new Parameters().AddAddPatchParameter("Patient", "deceased", new FhirDateTime("2015-02-14T13:42:00+10:00"));
 
-            var exception = await Assert.ThrowsAsync<FhirException>(() => _client.FhirPatchAsync(
+            var exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.FhirPatchAsync(
                 poco,
                 patchRequest));
 
@@ -250,7 +250,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             var patchRequest = new Parameters().AddAddPatchParameter("Patient", "deceased", new FhirDateTime("2015-02-14T13:42:00+10:00"));
 
-            var exception = await Assert.ThrowsAsync<FhirException>(() => _client.FhirPatchAsync(
+            var exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.FhirPatchAsync(
                 response.Resource,
                 patchRequest));
 
@@ -287,7 +287,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             var patchRequest = new Parameters().AddAddPatchParameter("Patient", "deceased", new FhirDateTime("2015-02-14T13:42:00+10:00"));
 
-            var exception = await Assert.ThrowsAsync<FhirException>(() => _client.FhirPatchAsync(
+            var exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.FhirPatchAsync(
                 response.Resource,
                 patchRequest,
                 "5"));
@@ -330,7 +330,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
                 new Parameters.ParameterComponent { Name = "value", Value = versionSpecificResourceReference },
             });
 
-            var exception = await Assert.ThrowsAsync<FhirException>(() => _client.FhirPatchAsync(
+            var exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.FhirPatchAsync(
                 response.Resource,
                 patchRequest));
 
@@ -437,13 +437,13 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             var patchRequest = new Parameters().AddAddPatchParameter("ActivityDefinition", "approvalDate", new FhirDateTime(dateTimeString));
 
             // DateTime without offset
-            await Assert.ThrowsAsync<FhirException>(() => _client.FhirPatchAsync(response.Resource, patchRequest));
+            await Assert.ThrowsAsync<FhirClientException>(() => _client.FhirPatchAsync(response.Resource, patchRequest));
 
             string dateTimeOffsetString = "2022-05-02T14:00:00+02:00";
             patchRequest = new Parameters().AddAddPatchParameter("ActivityDefinition", "approvalDate", new FhirDateTime(dateTimeOffsetString));
 
             // DateTime with offset
-            await Assert.ThrowsAsync<FhirException>(() => _client.FhirPatchAsync(response.Resource, patchRequest));
+            await Assert.ThrowsAsync<FhirClientException>(() => _client.FhirPatchAsync(response.Resource, patchRequest));
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HistoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HistoryTests.cs
@@ -399,7 +399,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         {
             var before = DateTime.UtcNow.AddSeconds(300);
             var beforeUriString = HttpUtility.UrlEncode(before.ToString("o"));
-            var ex = await Assert.ThrowsAsync<FhirException>(() => _client.SearchAsync("_history?_before=" + beforeUriString));
+            var ex = await Assert.ThrowsAsync<FhirClientException>(() => _client.SearchAsync("_history?_before=" + beforeUriString));
 
             Assert.Contains("Parameter _before cannot a be a value in the future", ex.Message);
         }
@@ -407,7 +407,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Fact]
         public async Task GivenAnInvalidSortValue_WhenGettingSystemHistory_AnErrorIsReturned()
         {
-            var ex = await Assert.ThrowsAsync<FhirException>(() => _client.SearchAsync("_history?_sort=_id"));
+            var ex = await Assert.ThrowsAsync<FhirClientException>(() => _client.SearchAsync("_history?_sort=_id"));
 
             Assert.Contains("Sorting by the '_id' parameter is not supported.", ex.Message);
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTestHelper.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Import
                     Uri checkLocation = await testFhirClient.ImportAsync(request.ToParameters());
                     return checkLocation;
                 }
-                catch (FhirException fhirException)
+                catch (FhirClientException fhirException)
                 {
                     if (!HttpStatusCode.Conflict.Equals(fhirException.StatusCode))
                     {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTests.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Import
 
             request.Mode = ImportConstants.InitialLoadMode;
             request.Force = true;
-            FhirException fhirException = await Assert.ThrowsAsync<FhirException>(async () => await tempClient.ImportAsync(request.ToParameters(), CancellationToken.None));
+            FhirClientException fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await tempClient.ImportAsync(request.ToParameters(), CancellationToken.None));
             Assert.StartsWith(ForbiddenMessage, fhirException.Message);
             Assert.Equal(HttpStatusCode.Forbidden, fhirException.StatusCode);
         }
@@ -183,7 +183,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Import
             request.Mode = ImportConstants.InitialLoadMode;
             request.Force = true;
             Uri checkLocation = await ImportTestHelper.CreateImportTaskAsync(_client, request);
-            FhirException fhirException = await Assert.ThrowsAsync<FhirException>(async () => await _client.ImportAsync(request.ToParameters(), CancellationToken.None));
+            FhirClientException fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await _client.ImportAsync(request.ToParameters(), CancellationToken.None));
             Assert.Equal(HttpStatusCode.Conflict, fhirException.StatusCode);
 
             HttpResponseMessage response;
@@ -471,7 +471,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Import
                 await Task.Delay(TimeSpan.FromSeconds(3));
             }
 
-            FhirException fhirException = await Assert.ThrowsAsync<FhirException>(async () => await _client.CheckImportAsync(checkLocation));
+            FhirClientException fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await _client.CheckImportAsync(checkLocation));
             Assert.Equal(HttpStatusCode.BadRequest, fhirException.StatusCode);
         }
 
@@ -496,7 +496,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Import
 
             Uri checkLocation = await ImportTestHelper.CreateImportTaskAsync(_client, request);
 
-            FhirException fhirException = await Assert.ThrowsAsync<FhirException>(
+            FhirClientException fhirException = await Assert.ThrowsAsync<FhirClientException>(
                 async () =>
                 {
                     HttpResponseMessage response;
@@ -546,7 +546,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Import
 
             Uri checkLocation = await ImportTestHelper.CreateImportTaskAsync(_client, request);
 
-            FhirException fhirException = await Assert.ThrowsAsync<FhirException>(
+            FhirClientException fhirException = await Assert.ThrowsAsync<FhirClientException>(
                 async () =>
                 {
                     HttpResponseMessage response;
@@ -592,7 +592,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Import
                 },
             };
 
-            FhirException fhirException = await Assert.ThrowsAsync<FhirException>(
+            FhirClientException fhirException = await Assert.ThrowsAsync<FhirClientException>(
                 async () => await ImportTestHelper.CreateImportTaskAsync(_client, request));
 
             Assert.Equal(HttpStatusCode.BadRequest, fhirException.StatusCode);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/JsonPatchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/JsonPatchTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             FhirResponse<Patient> response = await _client.CreateAsync(poco);
             Assert.Equal(AdministrativeGender.Male, response.Resource.Gender);
             Assert.NotNull(response.Resource.Address);
-            var exception = await Assert.ThrowsAsync<FhirException>(() => _client.JsonPatchAsync(response.Resource, patch));
+            var exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.JsonPatchAsync(response.Resource, patch));
             Assert.Equal(HttpStatusCode.BadRequest, exception.Response.StatusCode);
         }
 
@@ -108,7 +108,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             string patchDocument = "[{\"op\":\"add\",\"path\":\"/dummyProperty\",\"value\":\"dummy\"}]";
 
-            var exception = await Assert.ThrowsAsync<FhirException>(() => _client.JsonPatchAsync(
+            var exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.JsonPatchAsync(
                 response.Resource,
                 patchDocument));
 
@@ -132,7 +132,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             string patchDocument =
                 "[{\"op\":\"replace\",\"path\":\"" + propertyName + "\",\"value\":\"" + value + "\"}]";
 
-            var exception = await Assert.ThrowsAsync<FhirException>(() => _client.JsonPatchAsync(
+            var exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.JsonPatchAsync(
                 response.Resource,
                 patchDocument));
 
@@ -152,7 +152,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             string patchDocument =
                 "[{\"op\":\"replace\",\"path\":\"" + propertyName + "\",\"value\":\"" + value + "\"}]";
 
-            var exception = await Assert.ThrowsAsync<FhirException>(() => _client.JsonPatchAsync(
+            var exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.JsonPatchAsync(
                 response.Resource,
                 patchDocument));
 
@@ -169,7 +169,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             string patchDocument =
                 "[{\"op\":\"add\",\"path\":\"/deceasedDateTime\",\"value\":\"2015-02-14T13:42:00+10:00\"}]";
 
-            var exception = await Assert.ThrowsAsync<FhirException>(() => _client.JsonPatchAsync(
+            var exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.JsonPatchAsync(
                 poco,
                 patchDocument));
 
@@ -187,7 +187,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             string patchDocument =
                 "[{\"op\":\"add\",\"path\":\"/deceasedDateTime\",\"value\":\"2015-02-14T13:42:00+10:00\"}]";
 
-            var exception = await Assert.ThrowsAsync<FhirException>(() => _client.JsonPatchAsync(
+            var exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.JsonPatchAsync(
                 response.Resource,
                 patchDocument));
 
@@ -205,7 +205,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             string patchDocument =
                 "[{\"op\":\"add\",\"path\":\"/deceasedDateTime\",\"value\":\"2015-02-14T13:42:00+10:00\"}]";
 
-            var exception = await Assert.ThrowsAsync<FhirException>(() => _client.JsonPatchAsync(
+            var exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.JsonPatchAsync(
                 response.Resource,
                 patchDocument,
                 "5"));
@@ -242,7 +242,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             string patchDocument =
                 "[{\"op\":\"add\",\"path\":\"/deceasedDateTime\",\"value\":\"2015-02-14T13:42:00+10:00\"}]";
 
-            var exception = await Assert.ThrowsAsync<FhirException>(() => _client.JsonPatchAsync(
+            var exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.JsonPatchAsync(
                 response.Resource,
                 patchDocument));
 
@@ -297,7 +297,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             string patchDocument =
                 "[{\"op\":\"test\",\"path\":\"/deceasedBoolean\",\"value\": true}, {\"op\":\"replace\",\"path\":\"/deceasedBoolean\",\"value\":\"false\"}]";
 
-            var exception = await Assert.ThrowsAsync<FhirException>(() => _client.JsonPatchAsync(
+            var exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.JsonPatchAsync(
                 response.Resource,
                 patchDocument));
 
@@ -380,14 +380,14 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
                 "[{\"op\":\"add\",\"path\":\"/approvalDate\",\"value\":\"" + dateTimeString + "\"}]";
 
             // DateTime without offset
-            await Assert.ThrowsAsync<FhirException>(() => _client.JsonPatchAsync(response.Resource, patchDocument));
+            await Assert.ThrowsAsync<FhirClientException>(() => _client.JsonPatchAsync(response.Resource, patchDocument));
 
             string dateTimeOffsetString = "2022-05-02T14:00:00+02:00";
             patchDocument =
                 "[{\"op\":\"add\",\"path\":\"/approvalDate\",\"value\":\"" + dateTimeOffsetString + "\"}]";
 
             // DateTime with offset
-            await Assert.ThrowsAsync<FhirException>(() => _client.JsonPatchAsync(response.Resource, patchDocument));
+            await Assert.ThrowsAsync<FhirClientException>(() => _client.JsonPatchAsync(response.Resource, patchDocument));
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/MemberMatchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/MemberMatchTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             _fixture.SetPatient(searchPatient, city, name, birthDate: date);
             var searchCoverage = new Coverage();
             _fixture.SetCoverage(searchCoverage, searchPatient, type, subPlan);
-            var ex = await Assert.ThrowsAsync<FhirException>(async () => await _client.MemberMatch(searchPatient, searchCoverage));
+            var ex = await Assert.ThrowsAsync<FhirClientException>(async () => await _client.MemberMatch(searchPatient, searchCoverage));
             Assert.Equal(HttpStatusCode.UnprocessableEntity, ex.StatusCode);
             Assert.Equal(Core.Resources.MemberMatchMultipleMatchesFound, ex.OperationOutcome.Issue.First().Diagnostics);
         }
@@ -76,7 +76,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             _fixture.SetPatient(searchPatient, city, name, birthDate: date);
             var searchCoverage = new Coverage();
             _fixture.SetCoverage(searchCoverage, searchPatient, type, subPlan);
-            var ex = await Assert.ThrowsAsync<FhirException>(async () => await _client.MemberMatch(searchPatient, searchCoverage));
+            var ex = await Assert.ThrowsAsync<FhirClientException>(async () => await _client.MemberMatch(searchPatient, searchCoverage));
             Assert.Equal(HttpStatusCode.UnprocessableEntity, ex.StatusCode);
             Assert.Equal(Core.Resources.MemberMatchNoMatchFound, ex.OperationOutcome.Issue.First().Diagnostics);
         }
@@ -85,7 +85,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         public async Task GivenNonParametersRequestBody_WhenMemberMatchSent_ThenBadRequest()
         {
             string body = Samples.GetJson("PatientWithMinimalData");
-            var ex = await Assert.ThrowsAsync<FhirException>(async () => await _client.PostAsync("Patient/$member-match", body));
+            var ex = await Assert.ThrowsAsync<FhirClientException>(async () => await _client.PostAsync("Patient/$member-match", body));
             Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
         }
     }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/MetadataTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/MetadataTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenInvalidFormatParameter_WhenGettingMetadata_TheServerShouldReturnNotAcceptable()
         {
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(async () => await _client.ReadAsync<CapabilityStatement>("metadata?_format=blah"));
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(async () => await _client.ReadAsync<CapabilityStatement>("metadata?_format=blah"));
             Assert.Equal(HttpStatusCode.NotAcceptable, ex.StatusCode);
         }
 
@@ -47,7 +47,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenInvalidPrettyParameter_WhenGettingMetadata_TheServerShouldReturnBadRequest(string value)
         {
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(async () => await _client.ReadAsync<CapabilityStatement>($"metadata?_pretty={value}"));
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(async () => await _client.ReadAsync<CapabilityStatement>($"metadata?_pretty={value}"));
             Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
         }
 
@@ -57,7 +57,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenInvalidSummaryParameter_WhenGettingMetadata_TheServerShouldReturnBadRequest(string value)
         {
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(async () => await _client.ReadAsync<CapabilityStatement>($"metadata?_summary={value}"));
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(async () => await _client.ReadAsync<CapabilityStatement>($"metadata?_summary={value}"));
             Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
         }
 
@@ -67,7 +67,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenInvalidElementsParameter_WhenGettingMetadata_TheServerShouldReturnBadRequest(string value)
         {
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(async () => await _client.ReadAsync<CapabilityStatement>($"metadata?_elements={value}"));
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(async () => await _client.ReadAsync<CapabilityStatement>($"metadata?_elements={value}"));
             Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
         }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ObservationResolveReferenceTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ObservationResolveReferenceTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             observation.Subject.Reference = $"Patient?identifier={uniqueIdentifier}";
 
-            var exception = await Assert.ThrowsAsync<FhirException>(() => _client.CreateAsync(observation));
+            var exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.CreateAsync(observation));
             var issue = exception.Response.Resource.Issue.First();
             Assert.Equal(HttpStatusCode.BadRequest, exception.Response.StatusCode);
             Assert.Equal(IssueSeverity.Error, issue.Severity.Value);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ReadTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ReadTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenANonExistantId_WhenGettingAResource_TheServerShouldReturnANotFoundStatus()
         {
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(
                 () => _client.ReadAsync<Observation>(ResourceType.Observation, Guid.NewGuid().ToString()));
 
             Assert.Equal(System.Net.HttpStatusCode.NotFound, ex.StatusCode);
@@ -67,7 +67,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             await _client.DeleteAsync(createdResource);
 
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(
                 () => _client.ReadAsync<Observation>(ResourceType.Observation, createdResource.Id));
 
             Assert.Equal(System.Net.HttpStatusCode.Gone, ex.StatusCode);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -325,7 +325,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenEmptyTypeOfResource_WhenSearching_ThenBadRequestShouldBeReturned()
         {
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.SearchAsync($"?_type="));
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(() => Client.SearchAsync($"?_type="));
 
             Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
         }
@@ -385,7 +385,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenVariousTypesOfResources_WhenSearchingAcrossAllResourceTypesUsingNonCommonSearchParameter_ThenExceptionShouldBeThrown()
         {
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.SearchAsync($"?_type=Encounter,Procedure&subject=Patient/123"));
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(() => Client.SearchAsync($"?_type=Encounter,Procedure&subject=Patient/123"));
 
             Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
         }
@@ -570,7 +570,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenResources_WhenSearchedWithIncorrectFormatParams_ThenExceptionShouldBeThrown(string key, string val)
         {
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.SearchAsync($"Patient?{key}={val}"));
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(() => Client.SearchAsync($"Patient?{key}={val}"));
 
             Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
         }
@@ -611,7 +611,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenListOfResources_WhenSearchedWithElementsAndSummaryNotSetToFalse_ThenExceptionShouldBeThrown(string elementsValues, string summaryValue)
         {
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.SearchAsync($"Patient?_elements={elementsValues}&_summary={summaryValue}"));
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(() => Client.SearchAsync($"Patient?_elements={elementsValues}&_summary={summaryValue}"));
 
             const HttpStatusCode expectedStatusCode = HttpStatusCode.BadRequest;
             Assert.Equal(expectedStatusCode, ex.StatusCode);
@@ -792,7 +792,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
             var totalType = TotalType.Estimate.ToString();
 
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.SearchAsync($"Patient?_total={totalType}"));
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(() => Client.SearchAsync($"Patient?_total={totalType}"));
 
             var expectedStatusCode = HttpStatusCode.Forbidden;
             Assert.Equal(expectedStatusCode, ex.StatusCode);
@@ -809,7 +809,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenListOfResources_WhenSearchedWithInvalidTotalType_ThenExceptionShouldBeThrown(string key, string val)
         {
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.SearchAsync($"Patient?{key}={val}"));
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(() => Client.SearchAsync($"Patient?{key}={val}"));
 
             var expectedStatusCode = HttpStatusCode.BadRequest;
             Assert.Equal(expectedStatusCode, ex.StatusCode);
@@ -931,7 +931,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [Fact]
         public async Task GivenASearchRequestWithInvalidParametersAndStrictHandling_WhenHandled_ReturnsBadRequest()
         {
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(() =>
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(() =>
                 Client.SearchAsync("Patient?Cookie=Chip&Ramen=Spicy", Tuple.Create(KnownHeaders.Prefer, "handling=strict")));
             Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
         }
@@ -954,7 +954,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [Fact]
         public async Task GivenASearchRequestWithInvalidHandling_WhenHandled_ReturnsBadRequest()
         {
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(() =>
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(() =>
                 Client.SearchAsync("Patient?Cookie=Chip&Ramen=Spicy", Tuple.Create(KnownHeaders.Prefer, "handling=foo")));
             Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
         }
@@ -1078,7 +1078,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [Fact]
         public async Task GivenASearchRequestWithParameterTextAndStrictHandling_WhenHandled_ReturnsBadRequest()
         {
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(() =>
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(() =>
                 Client.SearchAsync("Patient?_text=mobile", Tuple.Create(KnownHeaders.Prefer, "handling=strict")));
             Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
@@ -277,7 +277,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 await Task.WhenAll(batch.Select(_ => Client.CreateAsync(resource)));
             }
 
-            await Assert.ThrowsAsync<FhirException>(async () => await Client.SearchAsync(ResourceType.Observation, query));
+            await Assert.ThrowsAsync<FhirClientException>(async () => await Client.SearchAsync(ResourceType.Observation, query));
         }
 
         public class ClassFixture : HttpIntegrationTestFixture

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
                 Assert.True(success);
             }
-            catch (FhirException ex) when (ex.StatusCode == HttpStatusCode.BadRequest && ex.Message.Contains("not enabled"))
+            catch (FhirClientException ex) when (ex.StatusCode == HttpStatusCode.BadRequest && ex.Message.Contains("not enabled"))
             {
                 _output.WriteLine($"Skipping because reindex is disabled.");
                 return;
@@ -205,7 +205,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
                 Assert.True(success);
             }
-            catch (FhirException ex) when (ex.StatusCode == HttpStatusCode.BadRequest && ex.Message.Contains("not enabled"))
+            catch (FhirClientException ex) when (ex.StatusCode == HttpStatusCode.BadRequest && ex.Message.Contains("not enabled"))
             {
                 _output.WriteLine($"Skipping because reindex is disabled.");
                 return;
@@ -240,7 +240,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             {
                 await Client.PostAsync("SearchParameter", searchParam);
             }
-            catch (FhirException ex)
+            catch (FhirClientException ex)
             {
                 Assert.Contains(ex.OperationOutcome.Issue, i => i.Diagnostics.Contains(errorMessage));
             }
@@ -333,7 +333,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
                 Assert.True(success);
             }
-            catch (FhirException ex) when (ex.StatusCode == HttpStatusCode.BadRequest && ex.Message.Contains("not enabled"))
+            catch (FhirClientException ex) when (ex.StatusCode == HttpStatusCode.BadRequest && ex.Message.Contains("not enabled"))
             {
                 _output.WriteLine($"Skipping because reindex is disabled.");
                 return;
@@ -443,7 +443,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
                 Assert.True(success, $"There are bundle validation failures. {retryCount} attempts reached. Check test logs.");
             }
-            catch (FhirException ex) when (ex.StatusCode == HttpStatusCode.BadRequest && ex.Message.Contains("not enabled"))
+            catch (FhirClientException ex) when (ex.StatusCode == HttpStatusCode.BadRequest && ex.Message.Contains("not enabled"))
             {
                 _output.WriteLine($"Skipping because reindex is disabled.");
                 return;
@@ -472,7 +472,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         public async Task GivenNonParametersRequestBody_WhenReindexSent_ThenBadRequest()
         {
             string body = Samples.GetJson("PatientWithMinimalData");
-            FhirException ex = await Assert.ThrowsAsync<FhirException>(async () => await Client.PostAsync("$reindex", body));
+            FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(async () => await Client.PostAsync("$reindex", body));
             Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
         }
 
@@ -532,7 +532,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                     catch (Exception exp)
                     {
                         _output.WriteLine($"Attempt {retryCount} of {MaxRetryCount}: CustomSearchParameter test experienced issue attempted to clean up SearchParameter {searchParam.Url}.  The exception is {exp}");
-                        if (exp is FhirException fhirException && fhirException.OperationOutcome?.Issue != null)
+                        if (exp is FhirClientException fhirException && fhirException.OperationOutcome?.Issue != null)
                         {
                             foreach (OperationOutcome.IssueComponent issueComponent in fhirException.OperationOutcome.Issue)
                             {
@@ -547,7 +547,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 while (!success && retryCount < MaxRetryCount);
 
                 Assert.True(success);
-                FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.ReadAsync<SearchParameter>(ResourceType.SearchParameter, searchParam.Id));
+                FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(() => Client.ReadAsync<SearchParameter>(ResourceType.SearchParameter, searchParam.Id));
                 Assert.Contains("Gone", ex.Message);
             }
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/DateSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/DateSearchTests.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [InlineData("!")]
         public async Task GivenAnInvalidDateTimeSearchParam_WhenSearched_ThenExceptionShouldBeThrown(string queryValue)
         {
-            using var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await Client.SearchAsync(ResourceType.Patient, $"birthdate={queryValue}"));
+            using var fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await Client.SearchAsync(ResourceType.Patient, $"birthdate={queryValue}"));
 
             Assert.Equal(HttpStatusCode.BadRequest, fhirException.StatusCode);
         }
@@ -172,7 +172,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [InlineData("1973-02-28T01:01:09.999999999999999999")]
         public async Task GivenAnOutOfRangeDateTimeSearchParam_WhenSearched_ThenExceptionShouldBeThrown(string queryValue)
         {
-            using var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await Client.SearchAsync(ResourceType.Patient, $"birthdate={queryValue}"));
+            using var fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await Client.SearchAsync(ResourceType.Patient, $"birthdate={queryValue}"));
 
             Assert.Equal(HttpStatusCode.BadRequest, fhirException.StatusCode);
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
@@ -1177,7 +1177,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             // Non-recursive iteration - Multiple result sets: MedicationDispense:performer;Practitioner and MedicationRequest:requester:Practitioner
             string query = $"_include=MedicationDispense:performer:Practitioner&_include=MedicationDispense:prescription&_include:iterate=MedicationRequest:requester:Practitioner&_revinclude:iterate=Patient:general-practitioner&_tag={Fixture.Tag}";
 
-            using var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await Client.SearchAsync(ResourceType.MedicationDispense, query));
+            using var fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await Client.SearchAsync(ResourceType.MedicationDispense, query));
             Assert.Equal(HttpStatusCode.BadRequest, fhirException.StatusCode);
 
             string[] expectedDiagnostics = { string.Format(Core.Resources.RevIncludeIterateTargetTypeNotSpecified, "Patient:general-practitioner") };
@@ -1364,7 +1364,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         {
             string query = $"{include}=Observation:subject:NotAResourceType";
 
-            using var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await Client.SearchAsync(ResourceType.Patient, query));
+            using var fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await Client.SearchAsync(ResourceType.Patient, query));
             Assert.Equal(HttpStatusCode.BadRequest, fhirException.StatusCode);
 
             string[] expectedDiagnostics = { string.Format(Core.Resources.ResourceNotSupported, "NotAResourceType") };
@@ -1383,7 +1383,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         {
             string query = $"{include}=Observation:subject:{target}";
 
-            using var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await Client.SearchAsync(ResourceType.Patient, query));
+            using var fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await Client.SearchAsync(ResourceType.Patient, query));
             Assert.Equal(HttpStatusCode.BadRequest, fhirException.StatusCode);
 
             string[] expectedDiagnostics = { string.Format(Core.Resources.IncludeRevIncludeInvalidTargetResourceType) };

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SearchTestsBase.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SearchTestsBase.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             HttpStatusCode expectedStatusCode,
             OperationOutcome expectedOperationOutcome)
         {
-            FhirException ex = await Assert.ThrowsAsync<FhirException>(() => Client.SearchAsync(searchUrl, customHeader));
+            FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(() => Client.SearchAsync(searchUrl, customHeader));
             Assert.Equal(expectedStatusCode, ex.StatusCode);
             ex.OperationOutcome.Id = null;
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/StringSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/StringSearchTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             {
                 await Client.PostAsync("Patient/$member-match", body, CancellationToken.None);
             }
-            catch (Microsoft.Health.Fhir.Client.FhirException ex)
+            catch (Microsoft.Health.Fhir.Client.FhirClientException ex)
             {
                 httpStatusCode = ex.StatusCode;
             }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TransactionTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TransactionTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenAProperBundle_WhenSubmittingATransactionForCosmosDbDataStore_ThenNotSupportedIsReturned()
         {
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(() => _client.PostBundleAsync(Samples.GetDefaultTransaction().ToPoco<Bundle>()));
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(() => _client.PostBundleAsync(Samples.GetDefaultTransaction().ToPoco<Bundle>()));
             Assert.Equal(HttpStatusCode.MethodNotAllowed, ex.StatusCode);
         }
 
@@ -92,7 +92,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         {
             var requestBundle = Samples.GetJsonSample("Bundle-TransactionWithInvalidProcessingRoutes");
 
-            using var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await _client.PostBundleAsync(requestBundle.ToPoco<Bundle>()));
+            using var fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await _client.PostBundleAsync(requestBundle.ToPoco<Bundle>()));
             Assert.Equal(HttpStatusCode.BadRequest, fhirException.StatusCode);
 
             string[] expectedDiagnostics = { "Requested operation 'Patient?identifier=123456' is not supported using DELETE." };
@@ -110,7 +110,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             var getIdGuid = Guid.NewGuid().ToString();
             requestBundle.Entry[1].Request.Url = requestBundle.Entry[1].Request.Url + getIdGuid;
 
-            using var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await _client.PostBundleAsync(requestBundle));
+            using var fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await _client.PostBundleAsync(requestBundle));
             Assert.Equal(HttpStatusCode.NotFound, fhirException.StatusCode);
 
             string[] expectedDiagnostics = { "Transaction failed on 'GET' for the requested url '/" + requestBundle.Entry[1].Request.Url + "'.", "Resource type 'Patient' with id '12345" + getIdGuid + "' couldn't be found." };
@@ -138,7 +138,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             var parser = new Hl7.Fhir.Serialization.FhirJsonParser();
             var bundle = parser.Parse<Bundle>(bundleAsString);
 
-            using var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await _client.PostBundleAsync(bundle));
+            using var fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await _client.PostBundleAsync(bundle));
             Assert.Equal(HttpStatusCode.BadRequest, fhirException.StatusCode);
 
             string[] expectedDiagnostics = { $"Bundle contains multiple entries that refers to the same resource 'Patient?identifier=http:/example.org/fhir/ids|{id}'." };
@@ -154,7 +154,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             TestFhirClient tempClient = _client.CreateClientForClientApplication(TestApplications.WrongAudienceClient);
             var requestBundle = Samples.GetJsonSample("Bundle-TransactionWithValidBundleEntry");
 
-            using var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await tempClient.PostBundleAsync(requestBundle.ToPoco<Bundle>()));
+            using var fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await tempClient.PostBundleAsync(requestBundle.ToPoco<Bundle>()));
             Assert.Equal(HttpStatusCode.Unauthorized, fhirException.StatusCode);
 
             string[] expectedDiagnostics = { "Authentication failed." };
@@ -175,7 +175,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             var parser = new Hl7.Fhir.Serialization.FhirJsonParser();
             var requestBundle = parser.Parse<Bundle>(bundleAsString);
 
-            using var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await tempClient.PostBundleAsync(requestBundle));
+            using var fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await tempClient.PostBundleAsync(requestBundle));
             Assert.Equal(HttpStatusCode.Forbidden, fhirException.StatusCode);
 
             string[] expectedDiagnostics = { "Transaction failed on 'POST' for the requested url '/Patient'.", "Authorization failed." };
@@ -214,7 +214,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
                 },
             };
 
-            using var fhirException = await Assert.ThrowsAsync<FhirException>(async () => await _client.PostBundleAsync(bundle));
+            using var fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await _client.PostBundleAsync(bundle));
 
             Assert.Equal(HttpStatusCode.BadRequest, fhirException.StatusCode);
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/UpdateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/UpdateTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         {
             Observation createdResource = await _client.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>());
 
-            var exception = await Assert.ThrowsAsync<FhirException>(() => _client.UpdateAsync(
+            var exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.UpdateAsync(
                 createdResource,
                 null,
                 "Jibberish"));
@@ -77,7 +77,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         {
             var observation = Samples.GetDefaultObservation().ToPoco<Observation>();
             observation.Id = null;
-            var exception = await Assert.ThrowsAsync<FhirException>(() => _client.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>(), $"identifier={Guid.NewGuid().ToString()}", "Jibberish"));
+            var exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>(), $"identifier={Guid.NewGuid().ToString()}", "Jibberish"));
             Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
         }
 
@@ -137,7 +137,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         {
             Observation createdResource = await _client.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>());
 
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(
                 () => _client.UpdateAsync($"Observation/{Guid.NewGuid()}", createdResource));
 
             Assert.Equal(System.Net.HttpStatusCode.BadRequest, ex.StatusCode);
@@ -149,7 +149,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         {
             var resourceToCreate = Samples.GetDefaultObservation().ToPoco<Observation>();
 
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(
                 () => _client.UpdateAsync($"Observation/{Guid.NewGuid()}", resourceToCreate));
 
             Assert.Equal(System.Net.HttpStatusCode.BadRequest, ex.StatusCode);
@@ -181,7 +181,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         {
             Observation createdResource = await _client.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>());
 
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(() => _client.UpdateAsync(createdResource, invalidETag));
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(() => _client.UpdateAsync(createdResource, invalidETag));
 
             Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
         }
@@ -198,7 +198,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             // Try to update the resource with some content change
             UpdateObservation(createdResource);
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(() => _client.UpdateAsync(createdResource, weakETag));
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(() => _client.UpdateAsync(createdResource, weakETag));
 #if Stu3
             Assert.Equal(HttpStatusCode.Conflict, ex.StatusCode);
 #else

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/VReadTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/VReadTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenANonExistingIdAndVersionId_WhenGettingAResource_TheServerShouldReturnANotFoundStatus()
         {
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(
                 () => _client.VReadAsync<Observation>(ResourceType.Observation, Guid.NewGuid().ToString(), Guid.NewGuid().ToString()));
 
             Assert.Equal(System.Net.HttpStatusCode.NotFound, ex.StatusCode);
@@ -67,7 +67,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         {
             Observation createdResource = await _client.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>());
 
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(
                 () => _client.VReadAsync<Observation>(ResourceType.Observation, createdResource.Id, Guid.NewGuid().ToString()));
 
             Assert.Equal(System.Net.HttpStatusCode.NotFound, ex.StatusCode);
@@ -83,7 +83,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             var deletedVersion = WeakETag.FromWeakETag(deleteResponse.Headers.ETag.ToString()).VersionId;
 
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(
                 () => _client.VReadAsync<Observation>(ResourceType.Observation, createdResource.Id, deletedVersion));
 
             Assert.Equal(System.Net.HttpStatusCode.Gone, ex.StatusCode);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ValidateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ValidateTests.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Fact]
         public async void GivenUnpresentIdRequest_WhenValidateIt_ThenAnErrorShouldBeReturned()
         {
-            var exception = await Assert.ThrowsAsync<FhirException>(async () =>
+            var exception = await Assert.ThrowsAsync<FhirClientException>(async () =>
             await _client.ValidateByIdAsync(ResourceType.Patient, "-1", "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"));
 
             Assert.Equal(HttpStatusCode.NotFound, exception.Response.StatusCode);
@@ -201,7 +201,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             var patient = Samples.GetJson("Patient");
             var profile = "abc";
 
-            var exception = await Assert.ThrowsAsync<FhirException>(async () => await _client.ValidateAsync("Patient/$validate", patient, profile));
+            var exception = await Assert.ThrowsAsync<FhirClientException>(async () => await _client.ValidateAsync("Patient/$validate", patient, profile));
             Assert.Equal(HttpStatusCode.BadRequest, exception.Response.StatusCode);
 
             Parameters parameters = new Parameters();
@@ -210,7 +210,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             var parser = new FhirJsonParser();
             parameters.Parameter.Add(new Parameters.ParameterComponent() { Name = "resource", Resource = Samples.GetDefaultPatient().ToPoco<Patient>() });
 
-            exception = await Assert.ThrowsAsync<FhirException>(async () => await _client.ValidateAsync("Patient/$validate", parameters.ToJson()));
+            exception = await Assert.ThrowsAsync<FhirClientException>(async () => await _client.ValidateAsync("Patient/$validate", parameters.ToJson()));
 
             Assert.Equal(HttpStatusCode.BadRequest, exception.Response.StatusCode);
         }

--- a/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/Rest/VersionSpecificTests.cs
+++ b/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/Rest/VersionSpecificTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         public async Task GivenAnObservation_WithInvalidDecimalSpecification_ThenBadRequestShouldBeReturned()
         {
             var resource = Samples.GetJsonSample<Observation>("ObservationWithInvalidDecimalSpecification");
-            using FhirException exception = await Assert.ThrowsAsync<FhirException>(() => _client.CreateAsync(resource));
+            using FhirClientException exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.CreateAsync(resource));
             Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
         }
     }


### PR DESCRIPTION
## Description
Renames one of the FHIR Exceptions to FHIR Client Exception
Adds more logging to failed FHIR calls.

## Related issues
Help debug in platform

## Testing
Existing unit and e2e tests

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
