### PR TITLE
Revised OperationOutcome message when identifier missing

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Extensions/SearchServiceExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Extensions/SearchServiceExtensions.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Health.Fhir.Core.Exceptions;
@@ -34,6 +33,11 @@ namespace Microsoft.Health.Fhir.Core.Extensions
         /// "If-Exists" headers on the API. Additional logic is used to filter parameters that don't restrict
         /// results, and also ensure that the query meets criteria requirements
         /// </summary>
+        /// <param name="searchService">searchService</param>
+        /// <param name="instanceType">The instanceType to search</param>
+        /// <param name="conditionalParameters">ConditionalParameters</param>
+        /// <param name="cancellationToken">a CancellationToken</param>
+        /// <returns>Search collection</returns>
         public static async Task<IReadOnlyCollection<SearchResultEntry>> ConditionalSearchAsync(this ISearchService searchService, string instanceType, IReadOnlyList<Tuple<string, string>> conditionalParameters, CancellationToken cancellationToken)
         {
             // Most "Conditional" logic needs only 0, 1 or >1, so here we can limit to "2"
@@ -46,6 +50,14 @@ namespace Microsoft.Health.Fhir.Core.Extensions
         /// "If-Exists" headers on the API. Additional logic is used to filter parameters that don't restrict
         /// results, and also ensure that the query meets criteria requirements
         /// </summary>
+        /// <param name="searchService">searchService</param>
+        /// <param name="instanceType">The instanceType to search</param>
+        /// <param name="conditionalParameters">ConditionalParameters</param>
+        /// <param name="count">the search Count</param>
+        /// <param name="cancellationToken">a CancellationToken</param>
+        /// <param name="continuationToken">a optional ContinuationToken</param>
+        /// <returns>Search collection and a continuationToken</returns>
+        /// <exception cref="PreconditionFailedException">Returns this exception when all passed in params match the search result unusedParams</exception>
         internal static async Task<(IReadOnlyCollection<SearchResultEntry> results, string continuationToken)> ConditionalSearchAsync(
             this ISearchService searchService,
             string instanceType,
@@ -74,7 +86,7 @@ namespace Microsoft.Health.Fhir.Core.Extensions
             int? totalUnusedParameters = results?.UnsupportedSearchParameters.Count;
             if (totalUnusedParameters == userProvidedParameterCount)
             {
-                throw new PreconditionFailedException(Core.Resources.ConditionalOperationNotSelectiveEnough);
+                throw new PreconditionFailedException(string.Format(CultureInfo.InvariantCulture, Core.Resources.ConditionalOperationNotSelectiveEnough, instanceType));
             }
 
             SearchResultEntry[] matchedResults = results?.Results.Where(x => x.SearchEntryMode == ValueSets.SearchEntryMode.Match).ToArray();

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -250,6 +250,15 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The id field for {0} is required when using a PUT operation..
+        /// </summary>
+        internal static string ConditionalOperationMissingParameters {
+            get {
+                return ResourceManager.GetString("ConditionalOperationMissingParameters", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Operation was not attempted because search criteria was not selective enough..
         /// </summary>
         internal static string ConditionalOperationNotSelectiveEnough {
@@ -1574,7 +1583,7 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Error deserializing resource &apos;{0}&apos; for validation: {1}.
+        ///   Looks up a localized string similar to Error deserializing resource &apos;{0}/{1}&apos; for validation: {2}.
         /// </summary>
         internal static string USCoreDeserializationError {
             get {

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -250,16 +250,7 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The id field for {0} is required when using a PUT operation..
-        /// </summary>
-        internal static string ConditionalOperationMissingParameters {
-            get {
-                return ResourceManager.GetString("ConditionalOperationMissingParameters", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Operation was not attempted because search criteria was not selective enough..
+        ///   Looks up a localized string similar to Conditional operation on {0} was not attempted because search criteria was not selective enough..
         /// </summary>
         internal static string ConditionalOperationNotSelectiveEnough {
             get {

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -169,7 +169,8 @@
     <value>The composite separator cannot be found.</value>
   </data>
   <data name="ConditionalOperationNotSelectiveEnough" xml:space="preserve">
-    <value>Operation was not attempted because search criteria was not selective enough.</value>
+    <value>Conditional operation on {0} was not attempted because search criteria was not selective enough.</value>
+    <comment>{0} should be a ResourceType</comment>
   </data>
   <data name="ConditionalUpdateMismatchedIds" xml:space="preserve">
     <value>Found result with Id '{0}', which did not match the provided Id '{1}'.</value>
@@ -698,9 +699,5 @@
   <data name="USCoreMissingDataRequirement" xml:space="preserve">
     <value>Status code is missing for the resource '{0}/{1}'.</value>
     <comment>The resource does not contain the expected status code following US Core requirements. {0} is the resource type of a FHIR resource. {1} is the ID of a FHIR resource.</comment>
-  </data>
-  <data name="ConditionalOperationMissingParameters" xml:space="preserve">
-    <value>The id field for {0} is required when using a PUT operation.</value>
-    <comment>{0} should be a ResourceType</comment>
   </data>
 </root>

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -687,7 +687,7 @@
   <data name="FhirUserClaimIsNotAValidResource" xml:space="preserve">
     <value>Provided fhirUser claim {0} is not a valid resource in this fhir server.</value>
     <comment>{0} is a url of a fhir resource.</comment>
-  </data>  
+  </data>
   <data name="InternalServerError" xml:space="preserve">
     <value>An internal error has occurred. If this problem persists, please contact Customer Support.</value>
   </data>
@@ -698,5 +698,9 @@
   <data name="USCoreMissingDataRequirement" xml:space="preserve">
     <value>Status code is missing for the resource '{0}/{1}'.</value>
     <comment>The resource does not contain the expected status code following US Core requirements. {0} is the resource type of a FHIR resource. {1} is the ID of a FHIR resource.</comment>
+  </data>
+  <data name="ConditionalOperationMissingParameters" xml:space="preserve">
+    <value>The id field for {0} is required when using a PUT operation.</value>
+    <comment>{0} should be a ResourceType</comment>
   </data>
 </root>

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/ConditionalResourceHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/ConditionalResourceHandler.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -63,7 +64,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources
             else
             {
                 // Multiple matches: The server returns a 412 Precondition Failed error indicating the client's criteria were not selective enough
-                throw new PreconditionFailedException(Core.Resources.ConditionalOperationNotSelectiveEnough);
+                throw new PreconditionFailedException(string.Format(CultureInfo.InvariantCulture, Core.Resources.ConditionalOperationNotSelectiveEnough, request.ResourceType));
             }
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Create/ConditionalCreateResourceValidator.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Create/ConditionalCreateResourceValidator.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Globalization;
 using FluentValidation;
 using Microsoft.Health.Fhir.Core.Messages.Create;
 
@@ -14,7 +15,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Create
         public ConditionalCreateResourceValidator()
         {
             RuleFor(x => x.ConditionalParameters)
-                .NotEmpty().WithMessage(Core.Resources.ConditionalOperationNotSelectiveEnough);
+                .Custom((conditionalParameters, context) =>
+                {
+                    if (conditionalParameters.Count == 0)
+                    {
+                        context.AddFailure(string.Format(CultureInfo.InvariantCulture, Core.Resources.ConditionalOperationNotSelectiveEnough, context.InstanceToValidate.ResourceType));
+                    }
+                });
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/ConditionalDeleteResourceHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/ConditionalDeleteResourceHandler.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -78,7 +79,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Delete
             else
             {
                 // Multiple matches: The server returns a 412 Precondition Failed error indicating the client's criteria were not selective enough
-                throw new PreconditionFailedException(Core.Resources.ConditionalOperationNotSelectiveEnough);
+                throw new PreconditionFailedException(string.Format(CultureInfo.InvariantCulture, Core.Resources.ConditionalOperationNotSelectiveEnough, request.ResourceType));
             }
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/ConditionalDeleteResourceValidator.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/ConditionalDeleteResourceValidator.cs
@@ -25,8 +25,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Create
                 .WithMessage(request => string.Format(CultureInfo.InvariantCulture, Core.Resources.ResourceNotSupported, request.ResourceType));
 
             RuleFor(x => x.ConditionalParameters)
-                .NotEmpty()
-                .WithMessage(Core.Resources.ConditionalOperationNotSelectiveEnough);
+                .Custom((conditionalParameters, context) =>
+                {
+                    if (conditionalParameters.Count == 0)
+                    {
+                        context.AddFailure(string.Format(CultureInfo.InvariantCulture, Core.Resources.ConditionalOperationNotSelectiveEnough, context.InstanceToValidate.ResourceType));
+                    }
+                });
 
             RuleFor(x => x.MaxDeleteCount)
                 .InclusiveBetween(1, configuration.Value.ConditionalDeleteMaxItems)

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Upsert/ConditionalUpsertResourceValidator.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Upsert/ConditionalUpsertResourceValidator.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Globalization;
 using FluentValidation;
 using Microsoft.Health.Fhir.Core.Messages.Upsert;
 
@@ -14,7 +15,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Upsert
         public ConditionalUpsertResourceValidator()
         {
             RuleFor(x => x.ConditionalParameters)
-                .NotEmpty().WithMessage(Core.Resources.ConditionalOperationNotSelectiveEnough);
+                .Custom((conditionalParameters, context) =>
+                {
+                    if (conditionalParameters.Count == 0)
+                    {
+                        context.AddFailure(string.Format(CultureInfo.InvariantCulture, Core.Resources.ConditionalOperationMissingParameters, nameof(context.InstanceToValidate.ResourceType) + " " + context.InstanceToValidate.ResourceType));
+                    }
+                });
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Upsert/ConditionalUpsertResourceValidator.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Upsert/ConditionalUpsertResourceValidator.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Upsert
                 {
                     if (conditionalParameters.Count == 0)
                     {
-                        context.AddFailure(string.Format(CultureInfo.InvariantCulture, Core.Resources.ConditionalOperationMissingParameters, nameof(context.InstanceToValidate.ResourceType) + " " + context.InstanceToValidate.ResourceType));
+                        context.AddFailure(string.Format(CultureInfo.InvariantCulture, Core.Resources.ConditionalOperationNotSelectiveEnough, context.InstanceToValidate.ResourceType));
                     }
                 });
         }

--- a/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
+++ b/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
@@ -30,6 +30,7 @@
     <EmbeddedResource Include="TestFiles\Normative\BloodPressure.json" />
     <EmbeddedResource Include="TestFiles\Normative\Bundle-FhirPatch.json" />
     <EmbeddedResource Include="TestFiles\Normative\Bundle-BinaryPatch.json" />
+    <EmbeddedResource Include="TestFiles\Normative\Bundle-MissingIdentifier.json" />
     <EmbeddedResource Include="TestFiles\Normative\Bundle-TypeMissing.json" />
     <EmbeddedResource Include="TestFiles\Normative\Coverage.json" />
     <EmbeddedResource Include="TestFiles\Normative\Import-InvalidPatient.ndjson" />

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/Bundle-MissingIdentifier.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/Bundle-MissingIdentifier.json
@@ -1,0 +1,20 @@
+﻿{
+    "resourceType": "Bundle",
+    "id": "bundle-batch",
+    "meta": {
+        "lastUpdated": "2014-08-18T01:43:30Z"
+    },
+    "type": "batch",
+    "entry": [
+        {
+            "fullUrl": "urn:uuid:",
+            "resource": {
+                "resourceType": "Location"
+            },
+            "request": {
+                "method": "PUT",
+                "url": "Location/"
+            }
+        }
+    ]
+}

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalCreateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalCreateTests.cs
@@ -32,6 +32,20 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenAnObservationWithIncompleteReference_WhenCreatingConditionally_TheServerRespondsWithCorrectMessage()
+        {
+            Observation observation = Samples.GetDefaultObservation().ToPoco<Observation>();
+            observation.Id = Guid.NewGuid().ToString();
+            observation.Subject.Reference = "Patient/";
+
+            using FhirException ex = await Assert.ThrowsAsync<FhirException>(() => _client.CreateAsync(observation.TypeName, observation, Core.Features.KnownHeaders.IfNoneExist));
+
+            Assert.Equal(HttpStatusCode.PreconditionFailed, ex.StatusCode);
+            Assert.True(ex.Response.Resource.Issue[0].Diagnostics.Equals(string.Format(Core.Resources.ConditionalOperationNotSelectiveEnough, observation.TypeName)));
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
         public async Task GivenAResource_WhenCreatingConditionallyWithNoIdAndNoExisting_TheServerShouldReturnTheResourceSuccessfully()
         {
             var observation = Samples.GetDefaultObservation().ToPoco<Observation>();

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalCreateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalCreateTests.cs
@@ -32,20 +32,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
-        public async Task GivenAnObservationWithIncompleteReference_WhenCreatingConditionally_TheServerRespondsWithCorrectMessage()
-        {
-            Observation observation = Samples.GetDefaultObservation().ToPoco<Observation>();
-            observation.Id = Guid.NewGuid().ToString();
-            observation.Subject.Reference = "Patient/";
-
-            using FhirException ex = await Assert.ThrowsAsync<FhirException>(() => _client.CreateAsync(observation.TypeName, observation, Core.Features.KnownHeaders.IfNoneExist));
-
-            Assert.Equal(HttpStatusCode.PreconditionFailed, ex.StatusCode);
-            Assert.True(ex.Response.Resource.Issue[0].Diagnostics.Equals(string.Format(Core.Resources.ConditionalOperationNotSelectiveEnough, observation.TypeName)));
-        }
-
-        [Fact]
-        [Trait(Traits.Priority, Priority.One)]
         public async Task GivenAResource_WhenCreatingConditionallyWithNoIdAndNoExisting_TheServerShouldReturnTheResourceSuccessfully()
         {
             var observation = Samples.GetDefaultObservation().ToPoco<Observation>();
@@ -152,7 +138,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             Assert.Equal(HttpStatusCode.BadRequest, exception.Response.StatusCode);
             Assert.Single(exception.OperationOutcome.Issue);
-            Assert.Equal(Core.Resources.ConditionalOperationNotSelectiveEnough, exception.OperationOutcome.Issue[0].Diagnostics);
+            Assert.True(exception.Response.Resource.Issue[0].Diagnostics.Equals(string.Format(Core.Resources.ConditionalOperationNotSelectiveEnough, "Observation")));
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalDeleteTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalDeleteTests.cs
@@ -37,6 +37,15 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             _client = fixture.TestFhirClient;
         }
 
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenAnIncompleteSearchParam_WhenDeletingConditionally_TheServerRespondsWithCorrectMessage()
+        {
+            FhirException fhirException = await Assert.ThrowsAsync<FhirException>(() => _client.DeleteAsync($"{_resourceType}?identifier=", CancellationToken.None));
+            Assert.Equal(HttpStatusCode.PreconditionFailed, fhirException.StatusCode);
+            Assert.True(fhirException.Response.Resource.Issue[0].Diagnostics.Equals(string.Format(Core.Resources.ConditionalOperationNotSelectiveEnough, _resourceType)));
+        }
+
         [InlineData(1)]
         [InlineData(100)]
         [Theory]
@@ -121,7 +130,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             await Task.WhenAll(Enumerable.Range(1, create).Select(_ => CreateWithIdentifier(identifier)));
 
-            await GetResourceCount(identifier);
+            // await GetResourceCount(identifier);
 
             FhirResponse response = await _client.DeleteAsync($"{_resourceType}?identifier={identifier}&hardDelete={hardDelete}&_count={delete}", CancellationToken.None);
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalDeleteTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalDeleteTests.cs
@@ -130,8 +130,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             await Task.WhenAll(Enumerable.Range(1, create).Select(_ => CreateWithIdentifier(identifier)));
 
-            // await GetResourceCount(identifier);
-
             FhirResponse response = await _client.DeleteAsync($"{_resourceType}?identifier={identifier}&hardDelete={hardDelete}&_count={delete}", CancellationToken.None);
 
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalPatchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalPatchTests.cs
@@ -41,6 +41,26 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenAnObservation_WhenPatchingConditionally_TheServerRespondsWithCorrectMessage()
+        {
+            Observation observation = Samples.GetDefaultObservation().ToPoco<Observation>();
+            observation.Id = Guid.NewGuid().ToString();
+            using FhirResponse<Observation> response = await _client.CreateAsync(observation);
+            Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+            Parameters observationFhirPatchRequest = new Parameters().AddReplacePatchParameter("subject.reference", new FhirString("Patient/"));
+
+            FhirException exceptionFhir = await Assert.ThrowsAsync<FhirException>(() => _client.ConditionalFhirPatchAsync<Observation>(
+                "Observation",
+                $"id={response.Resource.Id}",
+                observationFhirPatchRequest));
+
+            Assert.Equal(HttpStatusCode.PreconditionFailed, exceptionFhir.StatusCode);
+            Assert.True(exceptionFhir.Response.Resource.Issue[0].Diagnostics.Equals(string.Format(Core.Resources.ConditionalOperationNotSelectiveEnough, observation.TypeName)));
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
         public async Task GivenConditionWithNoExistingResources_WhenPatching_TheServerShouldReturnNoFound()
         {
             var exceptionJson = await Assert.ThrowsAsync<FhirException>(() =>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalUpdateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalUpdateTests.cs
@@ -32,12 +32,12 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
-        public async Task GivenAResourceTypeWithMissingId_WhenCreatingConditionally_TheServerRespondsWithCorrectMessage()
+        public async Task GivenABundledResourceTypeWithMissingId_WhenCreatingConditionally_TheServerRespondsWithCorrectMessage()
         {
             Bundle bundle = Samples.GetJsonSample("Bundle-MissingIdentifier").ToPoco<Bundle>();
             FhirException exception = await Assert.ThrowsAsync<FhirException>(() => _client.ConditionalUpdateAsync(bundle, string.Empty));
             Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
-            Assert.True(exception.Response.Resource.Issue[0].Diagnostics.Equals(string.Format(Core.Resources.ConditionalOperationMissingParameters, "ResourceType " + nameof(Bundle))));
+            Assert.True(exception.Response.Resource.Issue[0].Diagnostics.Equals(string.Format(Core.Resources.ConditionalOperationNotSelectiveEnough, bundle.TypeName)));
         }
 
         [Fact]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalUpdateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalUpdateTests.cs
@@ -32,6 +32,16 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenAResourceTypeWithMissingId_WhenCreatingConditionally_TheServerRespondsWithCorrectMessage()
+        {
+            Bundle bundle = Samples.GetJsonSample("Bundle-MissingIdentifier").ToPoco<Bundle>();
+            FhirException exception = await Assert.ThrowsAsync<FhirException>(() => _client.ConditionalUpdateAsync(bundle, string.Empty));
+            Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
+            Assert.True(exception.Response.Resource.Issue[0].Diagnostics.Equals(string.Format(Core.Resources.ConditionalOperationMissingParameters, "ResourceType " + nameof(Bundle))));
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
         public async Task GivenAResource_WhenUpsertingConditionallyWithNoIdAndNoExisting_TheServerShouldReturnTheUpdatedResourceSuccessfully()
         {
             var observation = Samples.GetDefaultObservation().ToPoco<Observation>();


### PR DESCRIPTION
## Description
This change will handle cases where a PUT operation doesn't have the identifier for the resource type included in a url field. When this issue is caught, we'll provide a more meaningful message that states what resource type is missing the identifier.

## Related issues
Addresses [issue #95161](https://microsofthealth.visualstudio.com/Health/_workitems/edit/95161).

## Testing
Created new supporting test

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
