### PR TITLE
Add permission-user to capabilities in /.well-known

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/GetSmartConfigurationHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/GetSmartConfigurationHandler.cs
@@ -51,6 +51,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
                         "sso-openid-connect",
                         "permission-offline",
                         "permission-patient",
+                        "permission-user",
                     };
 
                     return new GetSmartConfigurationResponse(authorizationEndpoint, tokenEndpoint, capabilities);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Conformance/GetSmartConfigurationHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Conformance/GetSmartConfigurationHandlerTests.cs
@@ -62,6 +62,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Conformance
                         "sso-openid-connect",
                         "permission-offline",
                         "permission-patient",
+                        "permission-user",
                     });
         }
 


### PR DESCRIPTION
## Description
Details in the description and comments section of [this user story](https://microsofthealth.visualstudio.com/Health/_workitems/edit/97910).

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
