### PR TITLE
Changes group not found exception to an info log

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportJobTaskTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportJobTaskTests.cs
@@ -2198,7 +2198,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
             {
                 var ex = exception as ResourceNotFoundException;
 
-                if (logLevel == LogLevel.Information && ex?.ResourceKey?.ResourceType?.Equals(KnownResourceTypes.Group, StringComparison.OrdinalIgnoreCase) == true)
+                if (logLevel == LogLevel.Information && ex?.ResourceKey?.ResourceType == KnownResourceTypes.Group)
                 {
                     ResourceKeyList.Add(ex?.ResourceKey);
                 }

--- a/src/Microsoft.Health.Fhir.Core/Exceptions/ResourceNotFoundException.cs
+++ b/src/Microsoft.Health.Fhir.Core/Exceptions/ResourceNotFoundException.cs
@@ -4,24 +4,25 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Diagnostics;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Core.Exceptions
 {
     public class ResourceNotFoundException : FhirException
     {
-        public ResourceNotFoundException(string message, bool groupNotFound = false)
+        public ResourceNotFoundException(string message, ResourceKey resourceKey = null)
             : base(message)
         {
             Debug.Assert(!string.IsNullOrEmpty(message), "Exception message should not be empty");
 
-            GroupNotFound = groupNotFound;
+            ResourceKey = resourceKey;
             Issues.Add(new OperationOutcomeIssue(
-                    GroupNotFound ? OperationOutcomeConstants.IssueSeverity.Information : OperationOutcomeConstants.IssueSeverity.Error,
+                    ResourceKey.ResourceType == "Group" ? OperationOutcomeConstants.IssueSeverity.Information : OperationOutcomeConstants.IssueSeverity.Error,
                     OperationOutcomeConstants.IssueType.NotFound,
                     message));
         }
 
-        public bool GroupNotFound { get; init; } // Special case for group not found, will be turned into info log in the action filter.
+        public ResourceKey ResourceKey { get; init; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Exceptions/ResourceNotFoundException.cs
+++ b/src/Microsoft.Health.Fhir.Core/Exceptions/ResourceNotFoundException.cs
@@ -10,15 +10,18 @@ namespace Microsoft.Health.Fhir.Core.Exceptions
 {
     public class ResourceNotFoundException : FhirException
     {
-        public ResourceNotFoundException(string message)
+        public ResourceNotFoundException(string message, bool groupNotFound = false)
             : base(message)
         {
             Debug.Assert(!string.IsNullOrEmpty(message), "Exception message should not be empty");
 
+            GroupNotFound = groupNotFound;
             Issues.Add(new OperationOutcomeIssue(
-                    OperationOutcomeConstants.IssueSeverity.Error,
+                    GroupNotFound ? OperationOutcomeConstants.IssueSeverity.Information : OperationOutcomeConstants.IssueSeverity.Error,
                     OperationOutcomeConstants.IssueType.NotFound,
                     message));
         }
+
+        public bool GroupNotFound { get; init; } // Special case for group not found, will be turned into info log in the action filter.
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Exceptions/ResourceNotFoundException.cs
+++ b/src/Microsoft.Health.Fhir.Core/Exceptions/ResourceNotFoundException.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Health.Fhir.Core.Exceptions
 
             ResourceKey = resourceKey;
             Issues.Add(new OperationOutcomeIssue(
-                    ResourceKey.ResourceType == "Group" ? OperationOutcomeConstants.IssueSeverity.Information : OperationOutcomeConstants.IssueSeverity.Error,
+                    OperationOutcomeConstants.IssueSeverity.Error,
                     OperationOutcomeConstants.IssueType.NotFound,
                     message));
         }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -213,7 +213,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
             }
             catch (ResourceNotFoundException rnfe)
             {
-                if (rnfe.ResourceKey.ResourceType == KnownResourceTypes.Group)
+                if (rnfe.ResourceKey?.ResourceType == KnownResourceTypes.Group)
                 {
                     _logger.LogInformation(rnfe, "Can't find specified resource. The job will be marked as failed.");
                 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -213,7 +213,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
             }
             catch (ResourceNotFoundException rnfe)
             {
-                if (rnfe.ResourceKey.ResourceType == "Group")
+                if (rnfe.ResourceKey.ResourceType == KnownResourceTypes.Group)
                 {
                     _logger.LogInformation(rnfe, "Can't find specified resource. The job will be marked as failed.");
                 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -213,7 +213,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
             }
             catch (ResourceNotFoundException rnfe)
             {
-                if (rnfe.GroupNotFound)
+                if (rnfe.ResourceKey.ResourceType == "Group")
                 {
                     _logger.LogInformation(rnfe, "Can't find specified resource. The job will be marked as failed.");
                 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -213,7 +213,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
             }
             catch (ResourceNotFoundException rnfe)
             {
-                _logger.LogError(rnfe, "Can't find specified resource. The job will be marked as failed.");
+                if (rnfe.GroupNotFound)
+                {
+                    _logger.LogInformation(rnfe, "Can't find specified resource. The job will be marked as failed.");
+                }
+                else
+                {
+                    _logger.LogError(rnfe, "Can't find specified resource. The job will be marked as failed.");
+                }
 
                 _exportJobRecord.FailureDetails = new JobFailureDetails(rnfe.Message, HttpStatusCode.BadRequest);
                 await CompleteJobAsync(OperationStatus.Failed, cancellationToken);

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
@@ -87,17 +87,6 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
 
                         break;
                     case ResourceNotFoundException _:
-                        operationOutcomeResult.StatusCode = HttpStatusCode.NotFound;
-                        if (((ResourceNotFoundException)fhirException).GroupNotFound)
-                        {
-                            // Special case, if group not found then just log info.
-                            context.Result = operationOutcomeResult;
-                            context.ExceptionHandled = true;
-                            _logger.LogInformation($"{operationOutcomeResult.StatusCode} error returned. {fhirException.Message}");
-                            return;
-                        }
-
-                        break;
                     case JobNotFoundException _:
                         operationOutcomeResult.StatusCode = HttpStatusCode.NotFound;
                         break;

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
@@ -87,6 +87,17 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
 
                         break;
                     case ResourceNotFoundException _:
+                        operationOutcomeResult.StatusCode = HttpStatusCode.NotFound;
+                        if (((ResourceNotFoundException)fhirException).GroupNotFound)
+                        {
+                            // Special case, if group not found then just log info.
+                            context.Result = operationOutcomeResult;
+                            context.ExceptionHandled = true;
+                            _logger.LogInformation($"{operationOutcomeResult.StatusCode} error returned. {fhirException.Message}");
+                            return;
+                        }
+
+                        break;
                     case JobNotFoundException _:
                         operationOutcomeResult.StatusCode = HttpStatusCode.NotFound;
                         break;

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Export/GroupMemberExtractor.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Export/GroupMemberExtractor.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
             if (groupResource == null)
             {
-                throw new ResourceNotFoundException($"Group {groupId} was not found.", true);
+                throw new ResourceNotFoundException($"Group {groupId} was not found.", new ResourceKey("Group", groupId));
             }
 
             var group = _resourceDeserializer.Deserialize(groupResource);

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Export/GroupMemberExtractor.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Export/GroupMemberExtractor.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
             if (groupResource == null)
             {
-                throw new ResourceNotFoundException($"Group {groupId} was not found.", new ResourceKey("Group", groupId));
+                throw new ResourceNotFoundException($"Group {groupId} was not found.", new ResourceKey(KnownResourceTypes.Group, groupId));
             }
 
             var group = _resourceDeserializer.Deserialize(groupResource);

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Export/GroupMemberExtractor.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Export/GroupMemberExtractor.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
             if (groupResource == null)
             {
-                throw new ResourceNotFoundException($"Group {groupId} was not found.");
+                throw new ResourceNotFoundException($"Group {groupId} was not found.", true);
             }
 
             var group = _resourceDeserializer.Deserialize(groupResource);


### PR DESCRIPTION
## Description
During exports, if nonexistent group is used then exception is logged as info instead of error.

## Related issues
Internal 97939.

## Testing
Unit test was built to verify logging is done as Info.

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [X] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [X] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
