### PR TITLE
Add intermediate export stage

### DIFF
--- a/src/Microsoft.Health.TaskManagement.UnitTests/TestQueueClient.cs
+++ b/src/Microsoft.Health.TaskManagement.UnitTests/TestQueueClient.cs
@@ -197,7 +197,11 @@ namespace Microsoft.Health.JobManagement.UnitTests
                 }
 
                 job.HeartbeatDateTime = DateTime.Now;
-                job.Result = jobInfo.Result;
+
+                if (jobInfo.Result != null)
+                {
+                    job.Result = jobInfo.Result;
+                }
 
                 cancel = job.CancelRequested;
             }

--- a/src/Microsoft.Health.TaskManagement/Constants.cs
+++ b/src/Microsoft.Health.TaskManagement/Constants.cs
@@ -16,5 +16,7 @@ namespace Microsoft.Health.JobManagement
         public const int DefaultJobHeartbeatTimeoutThresholdInSeconds = 300;
 
         public const int DefaultJobHeartbeatIntervalInSeconds = 30;
+
+        public const int DefaultJobHeavyHeartbeatIntervalInSeconds = 300;
     }
 }

--- a/src/Microsoft.Health.TaskManagement/Constants.cs
+++ b/src/Microsoft.Health.TaskManagement/Constants.cs
@@ -17,6 +17,6 @@ namespace Microsoft.Health.JobManagement
 
         public const int DefaultJobHeartbeatIntervalInSeconds = 30;
 
-        public const int DefaultJobHeavyHeartbeatIntervalInSeconds = 300;
+        public const int DefaultJobHeavyHeartbeatIntervalInSeconds = 600;
     }
 }

--- a/src/Microsoft.Health.TaskManagement/JobHosting.cs
+++ b/src/Microsoft.Health.TaskManagement/JobHosting.cs
@@ -117,7 +117,10 @@ namespace Microsoft.Health.JobManagement
                     jobCancellationToken.Cancel();
                 }
 
-                var progress = new Progress<string>((result) => { jobInfo.Result = result; });
+                var progress = new Progress<string>((result) =>
+                {
+                    jobInfo.Result = result;
+                });
 
                 var runningJob = useHeavyHeartbeats
                                ? ExecuteJobWithHeavyHeartbeatsAsync(
@@ -200,6 +203,7 @@ namespace Microsoft.Health.JobManagement
         public static async Task<string> ExecuteJobWithHeartbeatsAsync(IQueueClient queueClient, JobInfo jobInfo, Func<CancellationTokenSource, Task<string>> action, TimeSpan heartbeatPeriod, TimeSpan heavyHeartbeatPeriod, CancellationTokenSource cancellationTokenSource)
         {
             EnsureArg.IsNotNull(queueClient, nameof(queueClient));
+            EnsureArg.IsNotNull(jobInfo, nameof(jobInfo));
             EnsureArg.IsNotNull(action, nameof(action));
 
             var heavyHeartbeatInterval = heavyHeartbeatPeriod / heartbeatPeriod;


### PR DESCRIPTION
## Description
When a long running export job is run there is no intermediate states recorded. This means that if the job is stopped and restarted it has to start from the beginning. This PR adds saving of intermediate stages to long running jobs by having the heartbeat record results every 10 minutes.

## Related issues
Addresses [Bug 99078](https://microsofthealth.visualstudio.com/Health/_workitems/edit/99078): Single threaded export does not save intermediate states

## Testing
Manual testing and new unit test.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
