### PR TITLE
95084: Added more Practitioner Read tests for Smart

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Models/KnownResourceTypes.cs
+++ b/src/Microsoft.Health.Fhir.Core/Models/KnownResourceTypes.cs
@@ -61,6 +61,8 @@ namespace Microsoft.Health.Fhir.Core.Models
 
         public const string QuestionnaireResponse = "QuestionnaireResponse";
 
+        public const string CareTeam = "CareTeam";
+
         public const string All = "all";
     }
 }

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/R4/SmartCommon.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/R4/SmartCommon.json
@@ -684,7 +684,7 @@
 				]
 			  },
 			  "subject": {
-				"reference": "Patient/smart-practitioner-A",
+				"reference": "Patient/smart-patient-A",
 				"display": "P. van de Heuvel"
 			  },
 			  "performedPeriod": {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchTests.cs
@@ -535,6 +535,89 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
         }
 
         [SkippableFact]
+        public async Task GivenFhirUserClaimPractitioner_WhenCareTeamIsRequested_OnlyCareTeamResourcesInTheSameCompartmentReturned()
+        {
+            Skip.If(
+                ModelInfoProvider.Instance.Version != FhirSpecification.R4 &&
+                ModelInfoProvider.Instance.Version != FhirSpecification.R4B,
+                "This test is only valid for R4 and R4B");
+
+            var query = new List<Tuple<string, string>>();
+
+            var scopeRestriction = new ScopeRestriction(KnownResourceTypes.CareTeam, Core.Features.Security.DataActions.Read, "user");
+
+            ConfigureFhirRequestContext(_contextAccessor, new List<ScopeRestriction>() { scopeRestriction });
+            _contextAccessor.RequestContext.AccessControlContext.CompartmentId = "smart-practitioner-A";
+            _contextAccessor.RequestContext.AccessControlContext.CompartmentResourceType = "Practitioner";
+
+            var results = await _searchService.Value.SearchAsync("CareTeam", query, CancellationToken.None);
+
+            Assert.Collection(
+                            results.Results,
+                            r => Assert.True(r.Resource.ResourceId == "smart-careteam-1"));
+        }
+
+        [SkippableFact]
+        public async Task GivenFhirUserClaimPractitioner_WhenAllResourcesRequested_ResourcesInTheSameComparementAndUniversalResourcesAlsoReturned()
+        {
+            Skip.If(
+                ModelInfoProvider.Instance.Version != FhirSpecification.R4 &&
+                ModelInfoProvider.Instance.Version != FhirSpecification.R4B,
+                "This test is only valid for R4 and R4B");
+
+            var query = new List<Tuple<string, string>>();
+            query.Add(new Tuple<string, string>("_count", "100"));
+
+            var scopeRestriction = new ScopeRestriction(KnownResourceTypes.All, Core.Features.Security.DataActions.Read, "user");
+
+            ConfigureFhirRequestContext(_contextAccessor, new List<ScopeRestriction>() { scopeRestriction });
+            _contextAccessor.RequestContext.AccessControlContext.CompartmentId = "smart-practitioner-A";
+            _contextAccessor.RequestContext.AccessControlContext.CompartmentResourceType = "Practitioner";
+
+            var results = await _searchService.Value.SearchAsync(null, query, CancellationToken.None);
+
+            Assert.Contains(results.Results, r => r.Resource.ResourceTypeName == KnownResourceTypes.Observation);
+            Assert.Contains(results.Results, r => r.Resource.ResourceTypeName == KnownResourceTypes.Patient);
+            Assert.Contains(results.Results, r => r.Resource.ResourceTypeName == KnownResourceTypes.CareTeam);
+            /* As per g10 standards, Resources Organization, Medication, Location and Practitioner are returned from outside of compartment.
+            */
+            Assert.Contains(results.Results, r => r.Resource.ResourceTypeName == KnownResourceTypes.Organization);
+            Assert.Contains(results.Results, r => r.Resource.ResourceTypeName == KnownResourceTypes.Medication);
+            Assert.Contains(results.Results, r => r.Resource.ResourceTypeName == KnownResourceTypes.Location);
+            Assert.Contains(results.Results, r => r.Resource.ResourceTypeName == KnownResourceTypes.Practitioner);
+
+            Assert.Contains(
+                           results.Results,
+                           r => r.Resource.ResourceId == "smart-careteam-1");
+
+            Assert.Contains(
+                           results.Results,
+                           r => r.Resource.ResourceId == "smart-organization-A1");
+
+            Assert.Contains(
+                           results.Results,
+                           r => r.Resource.ResourceId == "smart-patient-B");
+
+            Assert.Contains(
+                           results.Results,
+                           r => r.Resource.ResourceId == "smart-practitioner-A");
+
+            Assert.Contains(
+                           results.Results,
+                           r => r.Resource.ResourceId == "smart-practitioner-B");
+
+            /*This is true because we are returning universal Organization resources even when they are not part of compartment of requested Practioner.*/
+            Assert.Contains(
+                           results.Results,
+                           r => r.Resource.ResourceId == "smart-organization-B1");
+
+            /*This is true because smart-patient-C doesnt belong to the same compartment requested and not part of universal resources that should be returned.*/
+            Assert.DoesNotContain(
+                           results.Results,
+                           r => r.Resource.ResourceId == "smart-patient-C");
+        }
+
+        [SkippableFact]
         public async Task GivenFhirUserClaimPatient_WhenAllResourcesRequested_UniversalResourcesAlsoReturned()
         {
             Skip.If(


### PR DESCRIPTION
## Description
Added integration tests for Practitioner Compartment Search (Read)

## Related issues
Addresses [issue #[95084](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Olympus/Stories/?workitem=95084)].

## Testing
Ran integration tests locally.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
