### PR TITLE
Enhancing test to exit early when assertion is true

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Operations/Reindex/ReindexJobCosmosThrottleControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Operations/Reindex/ReindexJobCosmosThrottleControllerTests.cs
@@ -65,6 +65,11 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Operations.Reindex
                 currentThrottling = throttleController.GetThrottleBasedDelay();
                 totalThrottling += currentThrottling;
 
+                if (totalThrottling > 0)
+                {
+                    break;
+                }
+
                 _output.WriteLine($"Current throttle based delay is: {currentThrottling}");
                 _fhirRequestContextAccessor.RequestContext.ResponseHeaders.Add(CosmosDbHeaders.RequestCharge, "100.0");
                 throttleController.UpdateDatastoreUsage();


### PR DESCRIPTION
## Description
Based on the change in #3064 this change makes a small improvement such that it exits the test once its assertion is true.

## Related issues
Addresses [#98543](https://microsofthealth.visualstudio.com/Health/_workitems/edit/98543).

## Testing
Ran the associated test.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
