### PR TITLE
Fix resource version issue

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/DataGenerator/ResourceTableBulkCopyDataGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/DataGenerator/ResourceTableBulkCopyDataGenerator.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import.DataGenerat
 
             FillColumn(newRow, VLatest.Resource.ResourceTypeId.Metadata.Name, resourceTypeId);
             FillColumn(newRow, VLatest.Resource.ResourceId.Metadata.Name, resourceId);
-            FillColumn(newRow, VLatest.Resource.Version.Metadata.Name, 1);
+            FillColumn(newRow, VLatest.Resource.Version.Metadata.Name, 0);
             FillColumn(newRow, VLatest.Resource.IsHistory.Metadata.Name, false);
             FillColumn(newRow, VLatest.Resource.ResourceSurrogateId.Metadata.Name, resourceSurrogateId);
             FillColumn(newRow, VLatest.Resource.IsDeleted.Metadata.Name, false);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTestHelper.cs
@@ -71,6 +71,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Import
 
             foreach (Resource resultResource in result.Entry.Select(e => e.Resource))
             {
+                Assert.Equal("1", resultResource.VersionId);
                 Assert.Contains(resources, expectedResource => expectedResource.Id.Equals(resultResource.Id));
             }
         }


### PR DESCRIPTION
## Description
Fix resource version issue from 1 => 0

## Related issues
Addresses [issue #].

## Testing
Add E2E tests

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [x] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [x] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
