### PR TITLE
Revised test to confirm the not modifier

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/SystemConformanceProvider.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/SystemConformanceProvider.cs
@@ -5,10 +5,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.Metrics;
 using System.Threading;
 using System.Threading.Tasks;
-using DotLiquid;
 using EnsureThat;
 using MediatR;
 using Microsoft.Extensions.Logging;

--- a/src/Microsoft.Health.Fhir.SqlServer/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Health.Fhir.SqlServer {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
@@ -286,13 +286,18 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         {
             string query = $"subject:Patient.gender:not=female&subject:Patient._tag={Fixture.Tag}";
 
-            Bundle completeBundle = await Client.SearchAsync(ResourceType.Observation, query);
-            Assert.True(completeBundle.Entry.Count == 4);
+            Bundle notFemaleBundle = await Client.SearchAsync(ResourceType.Observation, query);
+            Assert.True(notFemaleBundle.Entry.Count == 4);
 
             query = $"subject:Patient.gender:not=male&subject:Patient._tag={Fixture.Tag}";
 
-            completeBundle = await Client.SearchAsync(ResourceType.Observation, query);
-            Assert.True(completeBundle.Entry.Count == 1);
+            Bundle notMaleBundle = await Client.SearchAsync(ResourceType.Observation, query);
+            Assert.True(notMaleBundle.Entry.Count == 1);
+
+            query = $"subject:Patient._tag={Fixture.Tag}";
+
+            Bundle allPatientBundle = await Client.SearchAsync(ResourceType.Observation, query);
+            Assert.True(allPatientBundle.Entry.Count == notMaleBundle.Entry.Count + notFemaleBundle.Entry.Count);
         }
 
         public class ClassFixture : HttpIntegrationTestFixture


### PR DESCRIPTION
## Description
This revision adds one more assertion to an existing test to make sure the not modifier is working as expected.

## Related issues
Addresses [#87254](https://microsofthealth.visualstudio.com/Health/_workitems/edit/87254) as it was a concern that occurred during that bug.

## Testing
Successfully ran the tests.

## FHIR Team Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [X] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
