### PR TITLE
Logging a warning for search parameters with a duplicate code scenario

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionBuilder.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionBuilder.cs
@@ -324,11 +324,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
 
             results.UnionWith(searchParametersLookup[resourceType]);
 
-            var searchParameterDictionary = new ConcurrentDictionary<string, SearchParameterInfo>(
-                results.ToDictionary(
-                r => r.Code,
-                r => r,
-                StringComparer.Ordinal));
+            var searchParameterDictionary = new ConcurrentDictionary<string, SearchParameterInfo>();
+            foreach (SearchParameterInfo searchParam in results)
+            {
+                searchParameterDictionary.TryAdd(searchParam.Code, searchParam);
+            }
 
             if (!resourceTypeDictionary.TryAdd(resourceType, searchParameterDictionary))
             {

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
@@ -64,7 +64,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
                 bundle.Entries.Select(e => e.Resource).ToList(),
                 UrlLookup,
                 TypeLookup,
-                _modelInfoProvider);
+                _modelInfoProvider,
+                _logger);
         }
 
         internal ConcurrentDictionary<string, SearchParameterInfo> UrlLookup { get; set; }
@@ -161,7 +162,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
                 searchParameters,
                 UrlLookup,
                 TypeLookup,
-                _modelInfoProvider);
+                _modelInfoProvider,
+                _logger);
 
             if (calculateHash)
             {
@@ -254,7 +256,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
                                 new List<ITypedElement>() { searchParam },
                                 UrlLookup,
                                 TypeLookup,
-                                _modelInfoProvider);
+                                _modelInfoProvider,
+                                _logger);
                         }
                         catch (SearchParameterNotSupportedException ex)
                         {

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Definition/SearchParameterDefinitionBuilderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Definition/SearchParameterDefinitionBuilderTests.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Definition;
@@ -75,7 +76,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Definition
                 $"{typeof(Definitions).Namespace}.DefinitionFiles",
                 typeof(EmbeddedResourceManager).Assembly);
 
-            SearchParameterDefinitionBuilder.Build(bundle.Entries.Select(e => e.Resource).ToList(), _uriDictionary, _resourceTypeDictionary, ModelInfoProvider.Instance);
+            SearchParameterDefinitionBuilder.Build(bundle.Entries.Select(e => e.Resource).ToList(), _uriDictionary, _resourceTypeDictionary, ModelInfoProvider.Instance, NullLogger.Instance);
 
             Assert.Equal(6, _uriDictionary.Count);
 
@@ -95,7 +96,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Definition
                 $"{typeof(Definitions).Namespace}.DefinitionFiles",
                 typeof(EmbeddedResourceManager).Assembly);
 
-            SearchParameterDefinitionBuilder.Build(bundle.Entries.Select(e => e.Resource).ToList(), _uriDictionary, _resourceTypeDictionary, ModelInfoProvider.Instance);
+            SearchParameterDefinitionBuilder.Build(bundle.Entries.Select(e => e.Resource).ToList(), _uriDictionary, _resourceTypeDictionary, ModelInfoProvider.Instance, NullLogger.Instance);
 
             Assert.Equal(
                 ModelInfoProvider.GetResourceTypeNames().Concat(new[] { "Resource", "DomainResource" }).OrderBy(x => x).ToArray(),
@@ -111,8 +112,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Definition
                 $"{typeof(Definitions).Namespace}.DefinitionFiles",
                 typeof(EmbeddedResourceManager).Assembly);
 
-            SearchParameterDefinitionBuilder.Build(bundle.Entries.Select(e => e.Resource).ToList(), _uriDictionary, _resourceTypeDictionary, ModelInfoProvider.Instance);
-
+            SearchParameterDefinitionBuilder.Build(bundle.Entries.Select(e => e.Resource).ToList(), _uriDictionary, _resourceTypeDictionary, ModelInfoProvider.Instance, NullLogger.Instance);
             IDictionary<string, SearchParameterInfo> searchParametersDictionary = _resourceTypeDictionary[ResourceType.Account.ToString()];
 
             ValidateSearchParameters(
@@ -136,7 +136,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Definition
                 $"{typeof(Definitions).Namespace}.DefinitionFiles",
                 typeof(EmbeddedResourceManager).Assembly);
 
-            SearchParameterDefinitionBuilder.Build(bundle.Entries.Select(e => e.Resource).ToList(), _uriDictionary, _resourceTypeDictionary, ModelInfoProvider.Instance);
+            SearchParameterDefinitionBuilder.Build(bundle.Entries.Select(e => e.Resource).ToList(), _uriDictionary, _resourceTypeDictionary, ModelInfoProvider.Instance, NullLogger.Instance);
 
             IDictionary<string, SearchParameterInfo> searchParametersDictionary = _resourceTypeDictionary[resourceType.ToString()];
 
@@ -156,7 +156,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Definition
                 typeof(EmbeddedResourceManager).Assembly);
 
             InvalidDefinitionException ex = Assert.Throws<InvalidDefinitionException>(
-                () => SearchParameterDefinitionBuilder.Build(bundle.Entries.Select(e => e.Resource).ToList(), _uriDictionary, _resourceTypeDictionary, ModelInfoProvider.Instance));
+                () => SearchParameterDefinitionBuilder.Build(bundle.Entries.Select(e => e.Resource).ToList(), _uriDictionary, _resourceTypeDictionary, ModelInfoProvider.Instance, NullLogger.Instance));
 
             Assert.Contains(ex.Issues, issue =>
                 issue.Severity == IssueSeverity.Fatal.ToString() &&


### PR DESCRIPTION
## Description
Below exception (with different Keys) is being logged continuously for different accounts.
System.ArgumentException: An item with the same key has already been added. Key: coverage-area
I have added code to log warning and display search parameters with duplicate code that are causing this issue.

## Related issues
Addresses [issue [98881](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Olympus/Stories/?workitem=98881)].

## Testing
Created a duplicate Code scenario in my local and confirmed no exception is thrown in case of duplicate code and a warning is logged with expected details.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
