### PR TITLE
Narrative HTML validation fix

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Validation/Narratives/NarrativeHtmlSanitizer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Validation/Narratives/NarrativeHtmlSanitizer.cs
@@ -180,9 +180,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation.Narratives
                 var dom = parser.ParseDocument(string.Format(HtmlTemplate, html));
 
                 // Report parsing errors
-                if (errors.Any())
+                var htmlParseErrors = errors.Where(x => RaiseErrorTypes.Contains((HtmlParseError)x.Code));
+
+                if (htmlParseErrors.Any())
                 {
-                    foreach (var error in errors.Where(x => RaiseErrorTypes.Contains((HtmlParseError)x.Code)))
+                    foreach (var error in htmlParseErrors)
                     {
                         yield return string.Format(Core.Resources.IllegalHtmlParsingError, error.Message, error.Position.Line, error.Position.Column);
                     }

--- a/src/Microsoft.Health.Fhir.Core/Features/Validation/Narratives/NarrativeHtmlSanitizer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Validation/Narratives/NarrativeHtmlSanitizer.cs
@@ -180,7 +180,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation.Narratives
                 var dom = parser.ParseDocument(string.Format(HtmlTemplate, html));
 
                 // Report parsing errors
-                var htmlParseErrors = errors.Where(x => RaiseErrorTypes.Contains((HtmlParseError)x.Code));
+                var htmlParseErrors = errors.Where(x => RaiseErrorTypes.Contains((HtmlParseError)x.Code)).ToList();
 
                 if (htmlParseErrors.Any())
                 {

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Validation/Narratives/NarrativeHtmlSanitizerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Validation/Narratives/NarrativeHtmlSanitizerTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Validation.Narratives
         }
 
         [Theory]
-        [InlineData("<div><!-- Comment ended with a dash. This error should be ignored --->><not_valid_tag>This tag should return validation error</not_valid_tag></div>")]
+        [InlineData("<div><!-- Comment ended with a dash. This error should be ignored ---><not_valid_tag>This tag should return validation error</not_valid_tag></div>")]
         public void GivenHtmlWithIgnoredAndEnforecedErrors_WhenSanitizingHtml_ThenAValidationErrorIsReturned(string val)
         {
             var results = _sanitizer.Validate(val);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Validation/Narratives/NarrativeHtmlSanitizerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Validation/Narratives/NarrativeHtmlSanitizerTests.cs
@@ -61,6 +61,15 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Validation.Narratives
             Assert.Empty(results);
         }
 
+        [Theory]
+        [InlineData("<div><!-- Comment ended with a dash. This error should be ignored --->><not_valid_tag>This tag should return validation error</not_valid_tag></div>")]
+        public void GivenHtmlWithIgnoredAndEnforecedErrors_WhenSanitizingHtml_ThenAValidationErrorIsReturned(string val)
+        {
+            var results = _sanitizer.Validate(val);
+
+            Assert.NotEmpty(results);
+        }
+
         [Fact]
         public void GivenExampleNarrativeHtml_WhenSanitizingHtml_ThenValidationIsSuccessful()
         {


### PR DESCRIPTION
## Description
Updated the NarrativeHtmlSanitizer validator to not exit when HTML parse errors are to be ignored.  It now allows the validator to continue checking for errors after ignoring a HTML parse error. 

## Related issues
Addresses #3100 

## Testing
New unit test added to NarrativeHtmlSanitizerTests to check that errors can still be raised after a ignored HTML parse error is found.

## FHIR Team Checklist
- [ ] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [ ] Tag the PR with the type of update: **Bug**, **Dependencies**, **Enhancement**, or **New-Feature**
- [ ] Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR managed service (CosmosDB or common code related to service)
- [ ] Tag the PR with **Azure Healthcare APIs** if this will release to the Azure Healthcare APIs managed service (Sql server or common code related to service)
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
