### PR TITLE
[no not review] Allow unrecognized enums / improve validation sources

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Configs/CoreFeatureConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/CoreFeatureConfiguration.cs
@@ -48,6 +48,11 @@ namespace Microsoft.Health.Fhir.Core.Configs
         public int DefaultIncludeCountPerSearch { get; set; } = 100;
 
         /// <summary>
+        /// Configuration for loading packages in for validation.
+        /// </summary>
+        public FhirPackageConfiguration PackageConfiguration { get; set; } = new();
+
+        /// <summary>
         /// Gets or sets a value whether we need to run profile validation during resource creation.
         /// </summary>
         public bool ProfileValidationOnCreate { get; set; } = false;
@@ -70,6 +75,6 @@ namespace Microsoft.Health.Fhir.Core.Configs
         /// <summary>
         /// Gets or sets the resource versioning policy.
         /// </summary>
-        public VersioningConfiguration Versioning { get; set; } = new VersioningConfiguration();
+        public VersioningConfiguration Versioning { get; set; } = new();
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Configs/FhirPackageConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/FhirPackageConfiguration.cs
@@ -1,0 +1,27 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+
+namespace Microsoft.Health.Fhir.Core.Configs;
+
+public class FhirPackageConfiguration
+{
+    /// <summary>
+    /// True if the names of the default FHIR packages should be included automatically.
+    /// hl7.fhir.[R4] and hl7.fhir.[R4].expansions.
+    /// </summary>
+    public bool IncludeDefaultPackages { get; set; }
+
+    /// <summary>
+    /// Specify the package server if different to http://packages.fhir.org.
+    /// </summary>
+    public string PackageSource { get; set; }
+
+    /// <summary>
+    /// Names of the packages to be included for validation.
+    /// </summary>
+    public ICollection<string> PackageNames { get; } = new HashSet<string>();
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs
@@ -41,12 +41,14 @@ namespace Microsoft.Health.Fhir.Api.Modules
         {
             EnsureArg.IsNotNull(services, nameof(services));
 
-#pragma warning disable CS0618 // Type or member is obsolete
-            var jsonParser = new FhirJsonParser(new ParserSettings() { PermissiveParsing = true, TruncateDateTimeToDate = true });
-#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // TruncateDateTimeToDate is marked obsolete
+            var jsonParser = new FhirJsonParser { Settings = { PermissiveParsing = true, TruncateDateTimeToDate = true, AllowUnrecognizedEnums = true, AcceptUnknownMembers = true }};
+#pragma warning restore CS0618 // TruncateDateTimeToDate is marked obsolete
             var jsonSerializer = new FhirJsonSerializer();
 
-            var xmlParser = new FhirXmlParser();
+#pragma warning disable CS0618 // TruncateDateTimeToDate is marked obsolete
+            var xmlParser = new FhirXmlParser { Settings = { PermissiveParsing = true, TruncateDateTimeToDate = true, AllowUnrecognizedEnums = true, AcceptUnknownMembers = true }};
+#pragma warning restore CS0618 // TruncateDateTimeToDate is marked obsolete
             var xmlSerializer = new FhirXmlSerializer();
 
             services.AddSingleton(jsonParser);

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/ValidationModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/ValidationModule.cs
@@ -43,7 +43,10 @@ namespace Microsoft.Health.Fhir.Api.Modules
             services.AddSingleton<ISupportedProfilesStore>(x => x.GetRequiredService<ServerProvideProfileValidation>());
             services.AddSingleton<IProvideProfilesForValidation>(x => x.GetRequiredService<ServerProvideProfileValidation>());
 
-            services.AddSingleton<IProfileValidator, ProfileValidator>();
+            services.Add<ProfileValidator>()
+                .Singleton()
+                .AsSelf()
+                .AsImplementedInterfaces();
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Validation/ProfileValidatorTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Validation/ProfileValidatorTests.cs
@@ -1,0 +1,26 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Fhir.Core.Features.Validation;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Validation;
+
+[Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+[Trait(Traits.Category, Categories.Operations)]
+public class ProfileValidatorTests
+{
+    [Fact]
+    public void GivenAProfileValidator_WhenUsingReflectedVariables_TheyCanAllBeResolved()
+    {
+        (string Server, string CorePackageName, string ExpansionsPackageName) variables = ProfileValidator.GetFhirPackageVariables();
+
+        Assert.NotEmpty(variables.Server);
+        Assert.NotEmpty(variables.CorePackageName);
+        Assert.NotEmpty(variables.ExpansionsPackageName);
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
@@ -41,6 +41,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\TypedElementSearchIndexerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\USCoreTestHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Security\Authorization\RoleBasedFhirAuthorizationServiceTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Validation\ProfileValidatorTests.cs" />
     <Compile Include="..\Microsoft.Health.Fhir.Shared.Core.UnitTests\Features\Persistence\ResourceWrapperFactoryTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\Converters\AddressToStringSearchValueConverterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\Converters\BooleanToBooleanSearchValueConverterTests.cs" />

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Validation/ProfileValidator.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Validation/ProfileValidator.cs
@@ -4,43 +4,114 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Reflection;
+using System.Threading;
 using EnsureThat;
 using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Specification.Source;
 using Hl7.Fhir.Validation;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Models;
+using Polly;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Core.Features.Validation
 {
-    public class ProfileValidator : IProfileValidator
+    public class ProfileValidator : IProfileValidator, IHostedService
     {
-        private readonly IResourceResolver _resolver;
+        private readonly ILogger<ProfileValidator> _logger;
+        private readonly IProvideProfilesForValidation _profilesResolver;
+        private readonly Lazy<IResourceResolver> _resolver;
+        private readonly CoreFeatureConfiguration _coreConfig;
+        private readonly ValidateOperationConfiguration _options;
 
-        public ProfileValidator(IProvideProfilesForValidation profilesResolver, IOptions<ValidateOperationConfiguration> options)
+        public ProfileValidator(
+            IProvideProfilesForValidation profilesResolver,
+            IOptions<CoreFeatureConfiguration> coreFeatureConfiguration,
+            IOptions<ValidateOperationConfiguration> options,
+            ILogger<ProfileValidator> logger)
         {
-            EnsureArg.IsNotNull(profilesResolver, nameof(profilesResolver));
-            EnsureArg.IsNotNull(options?.Value, nameof(options));
+            _profilesResolver = EnsureArg.IsNotNull(profilesResolver, nameof(profilesResolver));
+            _options = EnsureArg.IsNotNull(options?.Value, nameof(options));
+            _coreConfig = EnsureArg.IsNotNull(coreFeatureConfiguration?.Value, nameof(options));
+            _logger = EnsureArg.IsNotNull(logger, nameof(logger));
 
+            _resolver = new Lazy<IResourceResolver>(
+                () => Policy.Handle<Exception>()
+                    .WaitAndRetry(5, i => TimeSpan.FromSeconds(i * 2))
+                    .Execute(Initialize),
+                LazyThreadSafetyMode.ExecutionAndPublication);
+        }
+
+        private IResourceResolver Initialize()
+        {
             try
             {
-                _resolver = new MultiResolver(new CachedResolver(ZipSource.CreateValidationSource(), options.Value.CacheDurationInSeconds), profilesResolver);
+                (string Server, string CorePackageName, string ExpansionsPackageName) packageVariables = GetFhirPackageVariables();
+
+                var packagesToInclude = new HashSet<string>();
+
+                if (_coreConfig.PackageConfiguration.IncludeDefaultPackages)
+                {
+                    packagesToInclude.Add(packageVariables.CorePackageName);
+                    packagesToInclude.Add(packageVariables.ExpansionsPackageName);
+                }
+
+                foreach (var package in _coreConfig.PackageConfiguration.PackageNames)
+                {
+                    packagesToInclude.Add(package);
+                }
+
+                FhirPackageSource validationSource;
+
+                if (!string.IsNullOrEmpty(_coreConfig.PackageConfiguration.PackageSource) &&
+                    !_coreConfig.PackageConfiguration.PackageSource.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Allow local packages
+                    var resolvedPath = Path.GetFullPath(_coreConfig.PackageConfiguration.PackageSource, Environment.CurrentDirectory);
+                    validationSource = new FhirPackageSource(_coreConfig.PackageConfiguration.PackageNames.Select(x => Path.GetFullPath(x, resolvedPath)).ToArray());
+                }
+                else
+                {
+                    // Look for packages on an npm server
+                    var server = string.IsNullOrEmpty(_coreConfig.PackageConfiguration.PackageSource) ? packageVariables.Server : _coreConfig.PackageConfiguration.PackageSource;
+                    validationSource = new FhirPackageSource(server, packagesToInclude.ToArray());
+                }
+
+                // Ensure packages are downloaded to temp folder
+                validationSource.ResolveByUri("http://hl7.org/fhir/StructureDefinition/Patient");
+
+                return new MultiResolver(new CachedResolver(validationSource, _options.CacheDurationInSeconds), _profilesResolver);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                // Something went wrong during profile loading, what should we do?
+                _logger.LogError(ex, "Error initializing profile validator");
                 throw;
             }
+        }
+
+        internal static (string Server, string CorePackageName, string ExpansionsPackageName) GetFhirPackageVariables()
+        {
+            Type type = typeof(FhirPackageSource);
+            FieldInfo serverField = type.GetField("FHIR_PACKAGE_SERVER", BindingFlags.Static | BindingFlags.NonPublic);
+            FieldInfo coreField = type.GetField("FHIR_CORE_PACKAGE_NAME", BindingFlags.Static | BindingFlags.NonPublic);
+            FieldInfo expansionsField = type.GetField("FHIR_CORE_EXPANSIONS_PACKAGE_NAME", BindingFlags.Static | BindingFlags.NonPublic);
+
+            return (serverField?.GetValue(null) as string, coreField?.GetValue(null) as string, expansionsField?.GetValue(null) as string);
         }
 
         private Validator GetValidator()
         {
             var ctx = new ValidationSettings()
             {
-                ResourceResolver = _resolver,
+                ResourceResolver = _resolver.Value,
                 GenerateSnapshot = true,
                 Trace = false,
                 ResolveExternalReferences = false,
@@ -76,6 +147,24 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
                 .ToArray();
 
             return outcomeIssues;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            Task.Run(
+                () =>
+                {
+                    IResourceResolver resolver = _resolver.Value;
+                    _logger.LogInformation($"Profile validator {resolver.GetType()} initialized");
+                },
+                cancellationToken).ConfigureAwait(false);
+
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -25,6 +25,10 @@
             "SupportsBatch": true,
             "SupportsTransaction": true,
             "IncludeTotalInBundle": "None",
+            "PackageConfiguration": {
+                "IncludeDefaultPackages": true,
+                "PackageNames": []
+            },
             "ProfileValidationOnCreate": false,
             "ProfileValidationOnUpdate": false,
             "SupportsResourceChangeCapture": false,


### PR DESCRIPTION
## Description
Experiment.

Allows validation against us core with simple configuration.
![image](https://user-images.githubusercontent.com/197221/217125838-80956071-b738-4d70-9546-fda21fb836e7.png)

Local packages example:
![image](https://user-images.githubusercontent.com/197221/217688821-d0c97888-8bf3-4e43-84b8-3023decc4dd9.png)


## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
