### PR TITLE
Set portReuseMode to PrivatePortPool

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/FhirCosmosClientInitializer.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/FhirCosmosClientInitializer.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
             IEnumerable<RequestHandler> requestHandlers = _requestHandlerFactory.Invoke();
 
             var builder = new CosmosClientBuilder(host, key)
-                .WithConnectionModeDirect(enableTcpConnectionEndpointRediscovery: true)
+                .WithConnectionModeDirect(enableTcpConnectionEndpointRediscovery: true, portReuseMode: PortReuseMode.PrivatePortPool)
                 .WithCustomSerializer(new FhirCosmosSerializer(_logger))
                 .WithThrottlingRetryOptions(TimeSpan.FromSeconds(configuration.RetryOptions.MaxWaitTimeInSeconds), configuration.RetryOptions.MaxNumberOfRetries)
                 .AddCustomHandlers(requestHandlers.ToArray());


### PR DESCRIPTION
## Description
We are seeing below error in some busy regions. 
`Error: Only one usage of each socket address (protocol/network address/port) is normally permitted.`

The error is seen on `Microsoft.Health.Fhir.CosmosDb.Features.Storage.CosmosClientExtensions.TryGetContainerAsync(Database cosmosClient, String collectionId)`  

As per the [guidelines](https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/cosmos-db/nosql/performance-tips.md) updating [ConnectionPolicy.PortReuseMode](https://github.com/MicrosoftDocs/azure-docs/blob/main/dotnet/api/microsoft.azure.documents.client.connectionpolicy.portreusemode) to `PrivatePortPool `

`ReuseUnicastPort and PrivatePortPool are not mutually exclusive.  When PrivatePortPool is enabled, the client first tries to reuse a port it already has. It falls back to allocating a new port if the initial attempts failed. If this fails, too, the client then falls back to ReuseUnicastPort.`

ReuseUnicastPort - Windows Server 2016 and newer: Uses the SO_REUSE_UNICASTPORT option if the operating system has automatic client port reuse enabled. Older versions of Windows, Linux, other: Uses default socket options.

PrivatePortPool - Windows: Tracks client ports used by the Cosmos DB client and reuses them. Ports are reused at DocumentClient scope. Linux: Uses default socket options.

Some useful [docs](https://stackoverflow.com/questions/44548444/how-does-servicepointmanager-reuseport-and-so-reuse-unicastport-alleviate-epheme)

## Related issues
Addresses [AB99011](https://microsofthealth.visualstudio.com/Health/_workitems/edit/99011)

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
