### PR TITLE
Handle pretty parameter for single resource

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Extensions/RawResourceElementExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Extensions/RawResourceElementExtensions.cs
@@ -36,11 +36,18 @@ namespace Microsoft.Health.Fhir.Core.Extensions
         {
             EnsureArg.IsNotNull(rawResource, nameof(rawResource));
 
+            if (rawResource.RawResource.IsMetaSet && !pretty)
+            {
+                await using var sw = new StreamWriter(outputStream, leaveOpen: true);
+                await sw.WriteAsync(rawResource.RawResource.Data);
+                return;
+            }
+
             var jsonDocument = JsonDocument.Parse(rawResource.RawResource.Data);
 
-            await using Utf8JsonWriter writer = new Utf8JsonWriter(outputStream, pretty ? _indentedWriterOptions : _writerOptions);
+            await using var writer = new Utf8JsonWriter(outputStream, pretty ? _indentedWriterOptions : _writerOptions);
 
-            if (rawResource.RawResource.IsMetaSet)
+            if (rawResource.RawResource.IsMetaSet && pretty)
             {
                 jsonDocument.WriteTo(writer);
                 return;

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Formatters/FhirJsonOutputFormatter.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Formatters/FhirJsonOutputFormatter.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Formatters
                 }
                 else
                 {
-                    await (context.Object as RawResourceElement).SerializeToStreamAsUtf8Json(context.HttpContext.Response.Body);
+                    await (context.Object as RawResourceElement).SerializeToStreamAsUtf8Json(context.HttpContext.Response.Body, pretty);
                     return;
                 }
             }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/BundleFactoryTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/BundleFactoryTests.cs
@@ -79,8 +79,10 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             Assert.Equal(_selfUrl.OriginalString, actual.Scalar<string>("Bundle.link.where(relation='self').url"));
         }
 
-        [Fact]
-        public void GivenASearchResult_WhenCreateSearchBundle_ThenCorrectBundleShouldBeReturned()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void GivenASearchResult_WhenCreateSearchBundle_ThenCorrectBundleShouldBeReturned(bool pretty)
         {
             _urlResolver.ResolveResourceWrapperUrl(Arg.Any<ResourceWrapper>()).Returns(x => new Uri(string.Format(_resourceUrlFormat, x.ArgAt<ResourceWrapper>(0).ResourceId)));
             _urlResolver.ResolveRouteUrl(_unsupportedSearchParameters).Returns(_selfUrl);
@@ -122,7 +124,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
                 using (var ms = new MemoryStream())
                 using (var sr = new StreamReader(ms))
                 {
-                    await raw.ResourceElement.SerializeToStreamAsUtf8Json(ms);
+                    await raw.ResourceElement.SerializeToStreamAsUtf8Json(ms, pretty);
                     ms.Seek(0, SeekOrigin.Begin);
                     var resourceData = await sr.ReadToEndAsync();
                     Assert.NotNull(resourceData);


### PR DESCRIPTION
## Description
Handled the use of the pretty parameter for read operation.

## Related issues
Addresses [issue #3010].

## Testing
Tested using Postman, unit tests and automated tests (awaiting pipeline to be green).

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
