### PR TITLE
Allow config for HostingBackgroundSevice Job Queues

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/BackgroundJobService/HostingBackgroundService.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/BackgroundJobService/HostingBackgroundService.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
@@ -12,7 +13,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Configs;
-using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.JobManagement;
 
 namespace Microsoft.Health.Fhir.Api.Features.BackgroundJobService
@@ -23,19 +23,23 @@ namespace Microsoft.Health.Fhir.Api.Features.BackgroundJobService
     public class HostingBackgroundService : BackgroundService
     {
         private readonly Func<IScoped<JobHosting>> _jobHostingFactory;
+        private readonly OperationsConfiguration _operationsConfiguration;
         private readonly TaskHostingConfiguration _hostingConfiguration;
         private readonly ILogger<HostingBackgroundService> _logger;
 
         public HostingBackgroundService(
             Func<IScoped<JobHosting>> jobHostingFactory,
             IOptions<TaskHostingConfiguration> hostingConfiguration,
+            IOptions<OperationsConfiguration> operationsConfiguration,
             ILogger<HostingBackgroundService> logger)
         {
             EnsureArg.IsNotNull(jobHostingFactory, nameof(jobHostingFactory));
             EnsureArg.IsNotNull(hostingConfiguration?.Value, nameof(hostingConfiguration));
+            EnsureArg.IsNotNull(operationsConfiguration?.Value, nameof(operationsConfiguration));
             EnsureArg.IsNotNull(logger, nameof(logger));
 
             _jobHostingFactory = jobHostingFactory;
+            _operationsConfiguration = operationsConfiguration.Value;
             _hostingConfiguration = hostingConfiguration.Value;
             _logger = logger;
         }
@@ -57,11 +61,13 @@ namespace Microsoft.Health.Fhir.Api.Features.BackgroundJobService
                 }
 
                 using var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
-                var jobQueues = new[]
+                var jobQueues = new List<Task>();
+
+                foreach (var operation in _operationsConfiguration.HostingBackgroundServiceQueues)
                 {
-                    jobHostingValue.ExecuteAsync((byte)QueueType.Import, Environment.MachineName, cancellationTokenSource, true),
-                    jobHostingValue.ExecuteAsync((byte)QueueType.Export, Environment.MachineName, cancellationTokenSource),
-                };
+                    jobQueues.Add(jobHostingValue.ExecuteAsync((byte)operation.Queue, Environment.MachineName, cancellationTokenSource, operation.EnableHeartbeats));
+                }
+
                 await Task.WhenAll(jobQueues);
             }
             catch (Exception ex)

--- a/src/Microsoft.Health.Fhir.Api/Features/BackgroundJobService/HostingBackgroundService.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/BackgroundJobService/HostingBackgroundService.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Health.Fhir.Api.Features.BackgroundJobService
 
                 foreach (var operation in _operationsConfiguration.HostingBackgroundServiceQueues)
                 {
-                    jobQueues.Add(jobHostingValue.ExecuteAsync((byte)operation.Queue, Environment.MachineName, cancellationTokenSource, operation.EnableHeartbeats));
+                    jobQueues.Add(jobHostingValue.ExecuteAsync((byte)operation.Queue, Environment.MachineName, cancellationTokenSource, operation.UpdateProgressOnHeartbeat));
                 }
 
                 await Task.WhenAll(jobQueues);

--- a/src/Microsoft.Health.Fhir.Core/Configs/HostingBackgroundServiceQueueItem.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/HostingBackgroundServiceQueueItem.cs
@@ -11,5 +11,5 @@ public class HostingBackgroundServiceQueueItem
 {
     public QueueType Queue { get; set; }
 
-    public bool EnableHeartbeats { get; set; }
+    public bool UpdateProgressOnHeartbeat { get; set; }
 }

--- a/src/Microsoft.Health.Fhir.Core/Configs/HostingBackgroundServiceQueueItem.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/HostingBackgroundServiceQueueItem.cs
@@ -1,0 +1,15 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Fhir.Core.Features.Operations;
+
+namespace Microsoft.Health.Fhir.Core.Configs;
+
+public class HostingBackgroundServiceQueueItem
+{
+    public QueueType Queue { get; set; }
+
+    public bool EnableHeartbeats { get; set; }
+}

--- a/src/Microsoft.Health.Fhir.Core/Configs/OperationsConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/OperationsConfiguration.cs
@@ -3,10 +3,14 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
+
 namespace Microsoft.Health.Fhir.Core.Configs
 {
     public class OperationsConfiguration
     {
+        public IList<HostingBackgroundServiceQueueItem> HostingBackgroundServiceQueues { get; } = new List<HostingBackgroundServiceQueueItem>();
+
         public ExportJobConfiguration Export { get; set; } = new ExportJobConfiguration();
 
         public ReindexJobConfiguration Reindex { get; set; } = new ReindexJobConfiguration();

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -45,6 +45,9 @@
             "AllowCredentials": false
         },
         "Operations": {
+            "HostingBackgroundServiceQueues":
+                [{ "Queue": "Import", "EnableHeartbeats": true },
+                 { "Queue": "Export", "EnableHeartbeats": false }],
             "Export": {
                 "Enabled": true,
                 "StorageAccountConnection": null,

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -46,8 +46,8 @@
         },
         "Operations": {
             "HostingBackgroundServiceQueues":
-                [{ "Queue": "Import", "EnableHeartbeats": true },
-                 { "Queue": "Export", "EnableHeartbeats": false }],
+                [{ "Queue": "Import", "UpdateProgressOnHeartbeat": true },
+                 { "Queue": "Export", "UpdateProgressOnHeartbeat": false }],
             "Export": {
                 "Enabled": true,
                 "StorageAccountConnection": null,


### PR DESCRIPTION
Allow config for the jobs that are run as part of HostingBackgroundSevice. This allows the HostingBackgroundSevice to always be registered, but configured with the queues it should monitor/run.

## Description
Describe the changes in this PR.

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
