### PR TITLE
force reindex option by passing in a list of SearchParams

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Reindex/ReindexHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Reindex/ReindexHandlerTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         {
             var request = new GetReindexRequest("id");
 
-            var jobRecord = new ReindexJobRecord(_resourceTypeSearchParameterHashMap, new List<string>(), 1);
+            var jobRecord = CreateJobRecord();
             var jobWrapper = new ReindexJobWrapper(jobRecord, WeakETag.FromVersionId("id"));
             _fhirOperationDataStore.GetReindexJobByIdAsync("id", Arg.Any<CancellationToken>()).Returns(jobWrapper);
 
@@ -59,7 +59,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         {
             var request = new GetReindexRequest("id");
 
-            var jobRecord = new ReindexJobRecord(_resourceTypeSearchParameterHashMap, new List<string>(), 1);
+            var jobRecord = CreateJobRecord();
             var jobWrapper = new ReindexJobWrapper(jobRecord, WeakETag.FromVersionId("id"));
             _fhirOperationDataStore.GetReindexJobByIdAsync("id", Arg.Any<CancellationToken>()).Returns(jobWrapper);
 
@@ -76,7 +76,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         {
             var request = new GetReindexRequest("id");
 
-            var jobRecord = new ReindexJobRecord(_resourceTypeSearchParameterHashMap, new List<string>(), 1);
+            var jobRecord = CreateJobRecord();
             var jobWrapper = new ReindexJobWrapper(jobRecord, WeakETag.FromVersionId("id"));
             _fhirOperationDataStore.GetReindexJobByIdAsync("id", Arg.Any<CancellationToken>()).Throws(new JobNotFoundException("not found"));
 
@@ -90,7 +90,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         {
             var request = new GetReindexRequest("id");
 
-            var jobRecord = new ReindexJobRecord(_resourceTypeSearchParameterHashMap, new List<string>(), 1);
+            var jobRecord = CreateJobRecord();
             var jobWrapper = new ReindexJobWrapper(jobRecord, WeakETag.FromVersionId("id"));
             _fhirOperationDataStore.GetReindexJobByIdAsync("id", CancellationToken.None).Throws(new Exception(null, new RequestRateExceededException(TimeSpan.FromMilliseconds(100))));
 
@@ -105,7 +105,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         {
             var request = new CancelReindexRequest("id");
 
-            var jobRecord = new ReindexJobRecord(_resourceTypeSearchParameterHashMap, new List<string>(), 1);
+            var jobRecord = CreateJobRecord();
             var jobWrapper = new ReindexJobWrapper(jobRecord, WeakETag.FromVersionId("id"));
             _fhirOperationDataStore.GetReindexJobByIdAsync("id", Arg.Any<CancellationToken>()).Returns(jobWrapper);
 
@@ -122,10 +122,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         {
             var request = new CancelReindexRequest("id");
 
-            var jobRecord = new ReindexJobRecord(_resourceTypeSearchParameterHashMap, new List<string>(), 1)
-            {
-                Status = OperationStatus.Completed,
-            };
+            var jobRecord = CreateJobRecord(OperationStatus.Completed);
 
             var jobWrapper = new ReindexJobWrapper(jobRecord, WeakETag.FromVersionId("id"));
             _fhirOperationDataStore.GetReindexJobByIdAsync("id", Arg.Any<CancellationToken>()).Returns(jobWrapper);
@@ -140,10 +137,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         {
             var request = new CancelReindexRequest("id");
 
-            var jobRecord = new ReindexJobRecord(_resourceTypeSearchParameterHashMap, new List<string>(), 1)
-            {
-                Status = OperationStatus.Running,
-            };
+            var jobRecord = CreateJobRecord(OperationStatus.Running);
 
             var jobWrapper = new ReindexJobWrapper(jobRecord, WeakETag.FromVersionId("id"));
             _fhirOperationDataStore.GetReindexJobByIdAsync("id", Arg.Any<CancellationToken>()).Returns(jobWrapper);
@@ -154,6 +148,14 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
             var result = await handler.Handle(request, CancellationToken.None);
 
             Assert.Equal(OperationStatus.Canceled, result.Job.JobRecord.Status);
+        }
+
+        private ReindexJobRecord CreateJobRecord(OperationStatus status = OperationStatus.Queued)
+        {
+            return new ReindexJobRecord(_resourceTypeSearchParameterHashMap, new List<string>(), new List<string>(), new List<string>(), 1)
+            {
+                Status = status,
+            };
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Reindex/ReindexJobWorkerTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Reindex/ReindexJobWorkerTests.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         {
             Dictionary<string, string> searchParameterHashMap = new Dictionary<string, string>();
             searchParameterHashMap.Add("patient", "hash1");
-            return new ReindexJobWrapper(new ReindexJobRecord(searchParameterHashMap, new List<string>(), 5), WeakETag.FromVersionId("0"));
+            return new ReindexJobWrapper(new ReindexJobRecord(searchParameterHashMap, new List<string>(), new List<string>(), new List<string>(), 5), WeakETag.FromVersionId("0"));
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
@@ -13,7 +13,6 @@ using System.Threading.Tasks;
 using EnsureThat;
 using Hl7.Fhir.ElementModel;
 using MediatR;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Exceptions;

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
@@ -127,6 +127,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations
 
         public const string TargetResourceTypes = "targetResourceTypes";
 
+        public const string TargetSearchParameterTypes = "targetSearchParameterTypes";
+
+        public const string SearchParameterResourceTypes = "searchParameterResourceTypes";
+
         public const string CreatedChild = "createdChild";
 
         public const string Till = "till";

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/CreateReindexRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/CreateReindexRequestHandler.cs
@@ -90,10 +90,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                         throw new RequestNotValidException(Core.Resources.SearchParameterByDefinitionUriNotSupported, searchParameterUrl);
                     }
 
-                    if (searchParameterInfo != null)
-                    {
-                        searchParameterResourceTypes.UnionWith(searchParameterInfo.BaseResourceTypes);
-                    }
+                    searchParameterResourceTypes.UnionWith(searchParameterInfo.BaseResourceTypes);
                 }
 
                 hashMap = new Dictionary<string, string>();
@@ -123,12 +120,5 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
 
             return new CreateReindexResponse(outcome);
         }
-
-        /*
-        private SearchParameterInfo GetSearchParameterInfo(object paramInfo)
-        {
-            return null;
-        }
-        */
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobRecord.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobRecord.cs
@@ -31,13 +31,17 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
         public ReindexJobRecord(
             IReadOnlyDictionary<string, string> searchParametersHash,
             IReadOnlyCollection<string> targetResourceTypes,
+            IReadOnlyCollection<string> targetSearchParameterTypes,
+            IReadOnlyCollection<string> searchParameterResourceTypes,
             ushort maxiumumConcurrency = 1,
             uint maxResourcesPerQuery = 100,
             int queryDelayIntervalInMilliseconds = 500,
             ushort? targetDataStoreUsagePercentage = null)
         {
-            EnsureArg.IsNotNull(searchParametersHash, nameof(searchParametersHash));
-            EnsureArg.IsNotNull(targetResourceTypes, nameof(targetResourceTypes));
+            ResourceTypeSearchParameterHashMap = EnsureArg.IsNotNull(searchParametersHash, nameof(searchParametersHash));
+            TargetResourceTypes = EnsureArg.IsNotNull(targetResourceTypes, nameof(targetResourceTypes));
+            TargetSearchParameterTypes = EnsureArg.IsNotNull(targetSearchParameterTypes, nameof(targetSearchParameterTypes));
+            SearchParameterResourceTypes = EnsureArg.IsNotNull(searchParameterResourceTypes, nameof(searchParameterResourceTypes));
 
             // Default values
             SchemaVersion = 1;
@@ -46,8 +50,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
 
             QueuedTime = Clock.UtcNow;
             LastModified = Clock.UtcNow;
-
-            ResourceTypeSearchParameterHashMap = searchParametersHash;
 
             // check for MaximumConcurrency boundary
             if (maxiumumConcurrency < MinMaximumConcurrency || maxiumumConcurrency > MaxMaximumConcurrency)
@@ -94,8 +96,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
             {
                 ModelInfoProvider.EnsureValidResourceType(type, nameof(type));
             }
-
-            TargetResourceTypes = targetResourceTypes;
         }
 
         [JsonConstructor]
@@ -167,6 +167,18 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
         [JsonProperty(JobRecordProperties.TargetResourceTypes)]
         public IReadOnlyCollection<string> TargetResourceTypes { get; private set; } = new List<string>();
 
+        /// <summary>
+        /// A user can supply a list of search params to force a reindex job even though the status is Enabled
+        /// </summary>
+        [JsonProperty(JobRecordProperties.TargetSearchParameterTypes)]
+        public IReadOnlyCollection<string> TargetSearchParameterTypes { get; private set; } = new List<string>();
+
+        /// <summary>
+        /// This will be the base resource types from the <see cref="TargetSearchParameterTypes"/>
+        /// </summary>
+        [JsonProperty(JobRecordProperties.SearchParameterResourceTypes)]
+        public IReadOnlyCollection<string> SearchParameterResourceTypes { get; private set; } = new List<string>();
+
         [JsonIgnore]
         public string ResourceList
         {
@@ -183,6 +195,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
         public string TargetResourceTypeList
         {
             get { return string.Join(",", TargetResourceTypes); }
+        }
+
+        [JsonIgnore]
+        public string TargetSearchParameterTypeList
+        {
+            get { return string.Join(",", TargetSearchParameterTypes); }
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -207,6 +207,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     }
                 }
             }
+            else if (_reindexJobRecord.SearchParameterResourceTypes.Any())
+            {
+                resourceList.UnionWith(_reindexJobRecord.SearchParameterResourceTypes);
+            }
             else
             {
                 notYetIndexedParams.AddRange(possibleNotYetIndexedParams);
@@ -221,7 +225,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             }
 
             // if there are not any parameters which are supported but not yet indexed, then we have nothing to do
-            if (!notYetIndexedParams.Any())
+            if (!notYetIndexedParams.Any() && resourceList.Count == 0)
             {
                 _reindexJobRecord.Error.Add(new OperationOutcomeIssue(
                     OperationOutcomeConstants.IssueSeverity.Information,
@@ -325,7 +329,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                 {
                     // grab the next query from the list which is labeled as queued and run it
                     var query = _reindexJobRecord.QueryList.Keys.Where(q => q.Status == OperationStatus.Queued).OrderBy(q => q.LastModified).FirstOrDefault();
-                    CancellationTokenSource queryTokensSource = new CancellationTokenSource();
+                    using CancellationTokenSource queryTokensSource = new CancellationTokenSource();
                     queryCancellationTokens.TryAdd(query, queryTokensSource);
 
                     // We don't await ProcessQuery, so query status can or can not be changed inside immediately

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
@@ -16,7 +16,6 @@ using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Search.Parameters;
 using Microsoft.Health.Fhir.Core.Messages.Search;
 using Microsoft.Health.Fhir.Core.Models;
-using static System.Net.WebRequestMethods;
 
 namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
 {

--- a/src/Microsoft.Health.Fhir.Core/Messages/Reindex/CreateReindexRequest.cs
+++ b/src/Microsoft.Health.Fhir.Core/Messages/Reindex/CreateReindexRequest.cs
@@ -14,7 +14,6 @@ namespace Microsoft.Health.Fhir.Core.Messages.Reindex
         public CreateReindexRequest(
             IReadOnlyCollection<string> targetResourceTypes,
             IReadOnlyCollection<string> targetSearchParameterTypes,
-            IReadOnlyCollection<string> searchParameterResourceTypes,
             ushort? maximumConcurrency = null,
             uint? maximumResourcesPerQuery = null,
             int? queryDelayIntervalInMilliseconds = null,
@@ -26,14 +25,11 @@ namespace Microsoft.Health.Fhir.Core.Messages.Reindex
             TargetDataStoreUsagePercentage = targetDataStoreUsagePercentage;
             TargetResourceTypes = EnsureArg.IsNotNull(targetResourceTypes, nameof(targetResourceTypes));
             TargetSearchParameterTypes = EnsureArg.IsNotNull(targetSearchParameterTypes, nameof(targetSearchParameterTypes));
-            SearchParameterResourceTypes = EnsureArg.IsNotNull(searchParameterResourceTypes, nameof(searchParameterResourceTypes));
         }
 
         public IReadOnlyCollection<string> TargetResourceTypes { get; }
 
         public IReadOnlyCollection<string> TargetSearchParameterTypes { get; }
-
-        public IReadOnlyCollection<string> SearchParameterResourceTypes { get; }
 
         public ushort? MaximumConcurrency { get; }
 

--- a/src/Microsoft.Health.Fhir.Core/Messages/Reindex/CreateReindexRequest.cs
+++ b/src/Microsoft.Health.Fhir.Core/Messages/Reindex/CreateReindexRequest.cs
@@ -13,21 +13,27 @@ namespace Microsoft.Health.Fhir.Core.Messages.Reindex
     {
         public CreateReindexRequest(
             IReadOnlyCollection<string> targetResourceTypes,
+            IReadOnlyCollection<string> targetSearchParameterTypes,
+            IReadOnlyCollection<string> searchParameterResourceTypes,
             ushort? maximumConcurrency = null,
             uint? maximumResourcesPerQuery = null,
             int? queryDelayIntervalInMilliseconds = null,
             ushort? targetDataStoreUsagePercentage = null)
         {
-            EnsureArg.IsNotNull(targetResourceTypes, nameof(targetResourceTypes));
-
             MaximumConcurrency = maximumConcurrency;
             MaximumResourcesPerQuery = maximumResourcesPerQuery;
             QueryDelayIntervalInMilliseconds = queryDelayIntervalInMilliseconds;
             TargetDataStoreUsagePercentage = targetDataStoreUsagePercentage;
-            TargetResourceTypes = targetResourceTypes;
+            TargetResourceTypes = EnsureArg.IsNotNull(targetResourceTypes, nameof(targetResourceTypes));
+            TargetSearchParameterTypes = EnsureArg.IsNotNull(targetSearchParameterTypes, nameof(targetSearchParameterTypes));
+            SearchParameterResourceTypes = EnsureArg.IsNotNull(searchParameterResourceTypes, nameof(searchParameterResourceTypes));
         }
 
         public IReadOnlyCollection<string> TargetResourceTypes { get; }
+
+        public IReadOnlyCollection<string> TargetSearchParameterTypes { get; }
+
+        public IReadOnlyCollection<string> SearchParameterResourceTypes { get; }
 
         public ushort? MaximumConcurrency { get; }
 

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -1088,6 +1088,15 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Reindex targets are mutually exclusive. Please only use one at a time..
+        /// </summary>
+        internal static string ReindexMultipleTargetsNotSupported {
+            get {
+                return ResourceManager.GetString("ReindexMultipleTargetsNotSupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The requested action is not allowed..
         /// </summary>
         internal static string RequestedActionNotAllowed {

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -703,4 +703,7 @@
     <value>Status code is missing for the resource '{0}/{1}'.</value>
     <comment>The resource does not contain the expected status code following US Core requirements. {0} is the resource type of a FHIR resource. {1} is the ID of a FHIR resource.</comment>
   </data>
+  <data name="ReindexMultipleTargetsNotSupported" xml:space="preserve">
+    <value>Reindex targets are mutually exclusive. Please only use one at a time.</value>
+  </data>
 </root>

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Operations/Reindex/ReindexJobCosmosThrottleControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Operations/Reindex/ReindexJobCosmosThrottleControllerTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Operations.Reindex
         public async Task GivenATargetRUConsumption_WhenConsumedRUsIsTooHigh_QueryDelayIsIncreased()
         {
             var throttleController = new ReindexJobCosmosThrottleController(_fhirRequestContextAccessor, new NullLogger<ReindexJobCosmosThrottleController>());
-            var reindexJob = new ReindexJobRecord(new Dictionary<string, string>(), new List<string>(), targetDataStoreUsagePercentage: 80);
+            var reindexJob = new ReindexJobRecord(new Dictionary<string, string>(), new List<string>(), new List<string>(), new List<string>(), targetDataStoreUsagePercentage: 80);
             reindexJob.QueryDelayIntervalInMilliseconds = 50;
             throttleController.Initialize(reindexJob, 1000);
 
@@ -85,7 +85,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Operations.Reindex
         public async Task GivenATargetRUConsumption_WhenConsumedRUsDecreases_QueryDelayIsDecreased()
         {
             var throttleController = new ReindexJobCosmosThrottleController(_fhirRequestContextAccessor, new NullLogger<ReindexJobCosmosThrottleController>());
-            var reindexJob = new ReindexJobRecord(new Dictionary<string, string>(), new List<string>(), targetDataStoreUsagePercentage: 80);
+            var reindexJob = new ReindexJobRecord(new Dictionary<string, string>(), new List<string>(), new List<string>(), new List<string>(), targetDataStoreUsagePercentage: 80);
             reindexJob.QueryDelayIntervalInMilliseconds = 50;
             throttleController.Initialize(reindexJob, 1000);
 
@@ -121,7 +121,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Operations.Reindex
             var throttleController = new ReindexJobCosmosThrottleController(_fhirRequestContextAccessor, new NullLogger<ReindexJobCosmosThrottleController>());
             Assert.Equal(0, throttleController.GetThrottleBasedDelay());
 
-            var reindexJob = new ReindexJobRecord(new Dictionary<string, string>(), new List<string>(), targetDataStoreUsagePercentage: null);
+            var reindexJob = new ReindexJobRecord(new Dictionary<string, string>(), new List<string>(), new List<string>(), new List<string>(), targetDataStoreUsagePercentage: null);
             reindexJob.QueryDelayIntervalInMilliseconds = 50;
             throttleController.Initialize(reindexJob, null);
             Assert.Equal(0, throttleController.GetThrottleBasedDelay());
@@ -131,7 +131,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Operations.Reindex
         public void GivenBatchSizeCostAboveTarget_WhenGetBatchSizeCalled_ReducedBatchSizeReturned()
         {
             var throttleController = new ReindexJobCosmosThrottleController(_fhirRequestContextAccessor, new NullLogger<ReindexJobCosmosThrottleController>());
-            var reindexJob = new ReindexJobRecord(new Dictionary<string, string>(), new List<string>(), targetDataStoreUsagePercentage: 80);
+            var reindexJob = new ReindexJobRecord(new Dictionary<string, string>(), new List<string>(), new List<string>(), new List<string>(), targetDataStoreUsagePercentage: 80);
             reindexJob.QueryDelayIntervalInMilliseconds = 50;
             throttleController.Initialize(reindexJob, 1000);
 

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ReindexControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ReindexControllerTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -12,14 +13,17 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Api.Controllers;
 using Microsoft.Health.Fhir.Api.Features.ActionResults;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Exceptions;
+using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Routing;
+using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Messages.Reindex;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Tests.Common;
@@ -140,12 +144,15 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
                 _mediator,
                 optionsOperationConfiguration,
                 _urlResolver,
-                NullLogger<ReindexController>.Instance);
+                NullLogger<ReindexController>.Instance,
+                Substitute.For<Func<IScoped<ISearchService>>>(),
+                Substitute.For<IModelInfoProvider>(),
+                NullLogger<SearchParameterDefinitionManager>.Instance);
         }
 
         private static CreateReindexResponse GetCreateReindexResponse()
         {
-            var jobRecord = new ReindexJobRecord(_searchParameterHashMap, new List<string>(), 5);
+            var jobRecord = new ReindexJobRecord(_searchParameterHashMap, new List<string>(), new List<string>(), new List<string>(), 5);
             var jobWrapper = new ReindexJobWrapper(
                 jobRecord,
                 WeakETag.FromVersionId("33a64df551425fcc55e4d42a148795d9f25f89d4"));
@@ -154,7 +161,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
 
         private static GetReindexResponse GetReindexJobResponse()
         {
-            var jobRecord = new ReindexJobRecord(_searchParameterHashMap, new List<string>(), 5);
+            var jobRecord = new ReindexJobRecord(_searchParameterHashMap, new List<string>(), new List<string>(), new List<string>(), 5);
             var jobWrapper = new ReindexJobWrapper(
                 jobRecord,
                 WeakETag.FromVersionId("33a64df551425fcc55e4d42a148795d9f25f89d4"));
@@ -167,7 +174,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
             parametersResource.Parameter = new List<Parameters.ParameterComponent>();
 
             parametersResource.Parameter.Add(new Parameters.ParameterComponent()
-                { Name = JobRecordProperties.MaximumConcurrency, Value = new FhirDecimal(maxConcurrency ?? _reindexJobConfig.DefaultMaximumThreadsPerReindexJob) });
+            { Name = JobRecordProperties.MaximumConcurrency, Value = new FhirDecimal(maxConcurrency ?? _reindexJobConfig.DefaultMaximumThreadsPerReindexJob) });
 
             return parametersResource;
         }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ReindexControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ReindexControllerTests.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -13,17 +12,14 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
-using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Api.Controllers;
 using Microsoft.Health.Fhir.Api.Features.ActionResults;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Exceptions;
-using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Routing;
-using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Messages.Reindex;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Tests.Common;
@@ -144,10 +140,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
                 _mediator,
                 optionsOperationConfiguration,
                 _urlResolver,
-                NullLogger<ReindexController>.Instance,
-                Substitute.For<Func<IScoped<ISearchService>>>(),
-                Substitute.For<IModelInfoProvider>(),
-                NullLogger<SearchParameterDefinitionManager>.Instance);
+                NullLogger<ReindexController>.Instance);
         }
 
         private static CreateReindexResponse GetCreateReindexResponse()

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ReindexController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ReindexController.cs
@@ -15,6 +15,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Api.Features.Audit;
+using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Api.Features.ActionResults;
 using Microsoft.Health.Fhir.Api.Features.Filters;
 using Microsoft.Health.Fhir.Api.Features.Headers;
@@ -22,8 +23,10 @@ using Microsoft.Health.Fhir.Api.Features.Routing;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Routing;
+using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Messages.Reindex;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.ValueSets;
@@ -39,12 +42,18 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         private readonly ILogger<ReindexController> _logger;
         private static Dictionary<string, HashSet<string>> _supportedParams = InitSupportedParams();
         private readonly IUrlResolver _urlResolver;
+        private readonly Func<IScoped<ISearchService>> _searchService;
+        private readonly IModelInfoProvider _modelInfoProvider;
+        private readonly ILogger<SearchParameterDefinitionManager> _searchLogger;
 
         public ReindexController(
             IMediator mediator,
             IOptions<OperationsConfiguration> operationsConfig,
             IUrlResolver urlResolver,
-            ILogger<ReindexController> logger)
+            ILogger<ReindexController> logger,
+            Func<IScoped<ISearchService>> searchService,
+            IModelInfoProvider modelInfoProvider,
+            ILogger<SearchParameterDefinitionManager> searchLogger)
         {
             EnsureArg.IsNotNull(mediator, nameof(mediator));
             EnsureArg.IsNotNull(operationsConfig?.Value?.Reindex, nameof(operationsConfig));
@@ -55,6 +64,9 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             _config = operationsConfig.Value.Reindex;
             _urlResolver = urlResolver;
             _logger = logger;
+            _searchService = searchService;
+            _modelInfoProvider = modelInfoProvider;
+            _searchLogger = searchLogger;
         }
 
         [HttpPost]
@@ -73,6 +85,9 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             int? queryDelay = ReadNumericParameter(inputParams, JobRecordProperties.QueryDelayIntervalInMilliseconds);
             ushort? targetDataStoreResourcePercentage = (ushort?)ReadNumericParameter(inputParams, JobRecordProperties.TargetDataStoreUsagePercentage);
             string targetResourceTypes = ReadStringParameter(inputParams, JobRecordProperties.TargetResourceTypes);
+            string targetSearchParamTypes = ReadStringParameter(inputParams, JobRecordProperties.TargetSearchParameterTypes);
+
+            SearchParameterDefinitionManager searchParameterDefinitionManager = new SearchParameterDefinitionManager(_modelInfoProvider, _mediator, _searchService, _searchLogger);
 
             ResourceElement response = await _mediator.CreateReindexJobAsync(
                 maximumConcurrency,
@@ -80,6 +95,8 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                 queryDelay,
                 targetDataStoreResourcePercentage,
                 targetResourceTypes,
+                targetSearchParamTypes,
+                searchParameterDefinitionManager,
                 HttpContext.RequestAborted);
 
             var result = FhirResult.Create(response, HttpStatusCode.Created)
@@ -222,6 +239,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                 JobRecordProperties.MaximumNumberOfResourcesPerQuery,
                 JobRecordProperties.TargetDataStoreUsagePercentage,
                 JobRecordProperties.TargetResourceTypes,
+                JobRecordProperties.TargetSearchParameterTypes,
             };
 
             var patchParams = new HashSet<string>()

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexJobTaskTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexJobTaskTests.cs
@@ -393,7 +393,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                 paramHashMap = new Dictionary<string, string>() { { "Patient", "patientHash" } };
             }
 
-            return new ReindexJobRecord(paramHashMap, new List<string>(), maxiumumConcurrency: 1, maxResourcePerQuery);
+            return new ReindexJobRecord(paramHashMap, new List<string>(), new List<string>(), new List<string>(), maxiumumConcurrency: 1, maxResourcePerQuery);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Extensions/ReindexJobRecordExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Extensions/ReindexJobRecordExtensions.cs
@@ -80,6 +80,11 @@ namespace Microsoft.Health.Fhir.Core.Extensions
                 parametersResource.Add(JobRecordProperties.TargetResourceTypes, new FhirString(job.TargetResourceTypeList));
             }
 
+            if (!string.IsNullOrEmpty(job.TargetSearchParameterTypeList))
+            {
+                parametersResource.Add(JobRecordProperties.TargetSearchParameterTypes, new FhirString(job.TargetSearchParameterTypeList));
+            }
+
             if (!string.IsNullOrEmpty(job.TargetDataStoreUsagePercentage.ToString()))
             {
                 parametersResource.Add(JobRecordProperties.TargetDataStoreUsagePercentage, new FhirDecimal(job.TargetDataStoreUsagePercentage));

--- a/src/Microsoft.Health.Fhir.Shared.Core/Extensions/ReindexMediatorExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Extensions/ReindexMediatorExtensions.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 using EnsureThat;
 using MediatR;
 using Microsoft.Health.Fhir.Core.Exceptions;
-using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Messages.Reindex;
 using Microsoft.Health.Fhir.Core.Models;
 
@@ -27,11 +26,9 @@ namespace Microsoft.Health.Fhir.Core.Extensions
             ushort? targetDataStoreResourcePercentage,
             string targetResourceTypesString,
             string targetSearchParamTypesString,
-            SearchParameterDefinitionManager searchParameterDefinitionManager,
             CancellationToken cancellationToken)
         {
             EnsureArg.IsNotNull(mediator, nameof(mediator));
-            EnsureArg.IsNotNull(searchParameterDefinitionManager, nameof(searchParameterDefinitionManager));
 
             var targetResourceTypes = new List<string>();
 
@@ -48,17 +45,10 @@ namespace Microsoft.Health.Fhir.Core.Extensions
             }
 
             var targetSearchParamTypes = new List<string>();
-            var searchParameterResourceTypes = new HashSet<string>();
 
             if (!string.IsNullOrEmpty(targetSearchParamTypesString))
             {
                 targetSearchParamTypes.AddRange(targetSearchParamTypesString.Split(",").Select(s => s.Trim()));
-                foreach (var resourceType in targetSearchParamTypes)
-                {
-                    // this will force validate the search param exists and is valid
-                    var searchParameterInfo = searchParameterDefinitionManager.GetSearchParameter(resourceType);
-                    searchParameterResourceTypes.UnionWith(searchParameterInfo.BaseResourceTypes);
-                }
             }
 
             if (targetResourceTypes.Count > 0 && targetSearchParamTypes.Count > 0)
@@ -66,7 +56,7 @@ namespace Microsoft.Health.Fhir.Core.Extensions
                 throw new RequestNotValidException(Resources.ReindexMultipleTargetsNotSupported);
             }
 
-            var request = new CreateReindexRequest(targetResourceTypes, targetSearchParamTypes, searchParameterResourceTypes, maximumConcurrency, maxResourcesPerQuery, queryDelay, targetDataStoreResourcePercentage);
+            var request = new CreateReindexRequest(targetResourceTypes, targetSearchParamTypes, maximumConcurrency, maxResourcesPerQuery, queryDelay, targetDataStoreResourcePercentage);
 
             CreateReindexResponse response = await mediator.Send(request, cancellationToken);
             return response.Job.ToParametersResourceElement();

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/FhirOperationDataStoreReindexTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/FhirOperationDataStoreReindexTests.cs
@@ -312,7 +312,7 @@ namespace Microsoft.Health.Fhir.Shared.Tests.Integration.Features.Operations
         {
             Dictionary<string, string> searchParamHashMap = new Dictionary<string, string>();
             searchParamHashMap.Add("Patient", "searchParamHash");
-            var jobRecord = new ReindexJobRecord(searchParamHashMap, new List<string>(), maxiumumConcurrency: 1);
+            var jobRecord = new ReindexJobRecord(searchParamHashMap, new List<string>(), new List<string>(), new List<string>(), maxiumumConcurrency: 1);
 
             jobRecordCustomizer?.Invoke(jobRecord);
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
         [Fact]
         public async Task GivenLessThanMaximumRunningJobs_WhenCreatingAReindexJob_ThenNewJobShouldBeCreated()
         {
-            var request = new CreateReindexRequest(new List<string>(), new List<string>(), new List<string>());
+            var request = new CreateReindexRequest(new List<string>(), new List<string>());
             CreateReindexResponse response = await _createReindexRequestHandler.Handle(request, CancellationToken.None);
 
             Assert.NotNull(response);
@@ -187,23 +187,23 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                 switch (jobRecordProperty)
                 {
                     case JobRecordProperties.MaximumConcurrency:
-                        request = new CreateReindexRequest(new List<string>(), new List<string>(), new List<string>(), (ushort?)value);
+                        request = new CreateReindexRequest(new List<string>(), new List<string>(), (ushort?)value);
                         errorMessage = string.Format(Fhir.Core.Resources.InvalidReIndexParameterValue, jobRecordProperty, ReindexJobRecord.MinMaximumConcurrency, ReindexJobRecord.MaxMaximumConcurrency);
                         break;
                     case JobRecordProperties.MaximumNumberOfResourcesPerQuery:
-                        request = new CreateReindexRequest(new List<string>(), new List<string>(), new List<string>(), null, (uint?)value);
+                        request = new CreateReindexRequest(new List<string>(), new List<string>(), null, (uint?)value);
                         errorMessage = string.Format(Fhir.Core.Resources.InvalidReIndexParameterValue, jobRecordProperty, ReindexJobRecord.MinMaximumNumberOfResourcesPerQuery, ReindexJobRecord.MaxMaximumNumberOfResourcesPerQuery);
                         break;
                     case JobRecordProperties.QueryDelayIntervalInMilliseconds:
-                        request = new CreateReindexRequest(new List<string>(), new List<string>(), new List<string>(), null, null, value);
+                        request = new CreateReindexRequest(new List<string>(), new List<string>(), null, null, value);
                         errorMessage = string.Format(Fhir.Core.Resources.InvalidReIndexParameterValue, jobRecordProperty, ReindexJobRecord.MinQueryDelayIntervalInMilliseconds, ReindexJobRecord.MaxQueryDelayIntervalInMilliseconds);
                         break;
                     case JobRecordProperties.TargetDataStoreUsagePercentage:
-                        request = new CreateReindexRequest(new List<string>(), new List<string>(), new List<string>(), null, null, null, (ushort?)value);
+                        request = new CreateReindexRequest(new List<string>(), new List<string>(), null, null, null, (ushort?)value);
                         errorMessage = string.Format(Fhir.Core.Resources.InvalidReIndexParameterValue, jobRecordProperty, ReindexJobRecord.MinTargetDataStoreUsagePercentage, ReindexJobRecord.MaxTargetDataStoreUsagePercentage);
                         break;
                     default:
-                        request = new CreateReindexRequest(new List<string>() { jobRecordProperty }, new List<string>(), new List<string>());
+                        request = new CreateReindexRequest(new List<string>(), new List<string>());
                         errorMessage = $"Resource type 'Foo' is not supported. (Parameter 'type')";
                         break;
                 }
@@ -237,19 +237,19 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
             switch (jobRecordProperty)
             {
                 case JobRecordProperties.MaximumConcurrency:
-                    request = new CreateReindexRequest(new List<string>(), new List<string>(), new List<string>(), (ushort?)value);
+                    request = new CreateReindexRequest(new List<string>(), new List<string>(), (ushort?)value);
                     break;
                 case JobRecordProperties.MaximumNumberOfResourcesPerQuery:
-                    request = new CreateReindexRequest(new List<string>(), new List<string>(), new List<string>(), null, (uint?)value);
+                    request = new CreateReindexRequest(new List<string>(), new List<string>(), null, (uint?)value);
                     break;
                 case JobRecordProperties.QueryDelayIntervalInMilliseconds:
-                    request = new CreateReindexRequest(new List<string>(), new List<string>(), new List<string>(), null, null, value);
+                    request = new CreateReindexRequest(new List<string>(), new List<string>(), null, null, value);
                     break;
                 case JobRecordProperties.TargetDataStoreUsagePercentage:
-                    request = new CreateReindexRequest(new List<string>(), new List<string>(), new List<string>(), null, null, null, (ushort?)value);
+                    request = new CreateReindexRequest(new List<string>(), new List<string>(), null, null, null, (ushort?)value);
                     break;
                 default:
-                    request = new CreateReindexRequest(new List<string>() { jobRecordProperty }, new List<string>(), new List<string>());
+                    request = new CreateReindexRequest(new List<string>(), new List<string>());
                     break;
             }
 
@@ -281,12 +281,11 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
 
             SearchIndexEntry si = sample1.Wrapper.SearchIndices.FirstOrDefault();
             var targetSearchParameterTypes = new List<string>() { si.SearchParameter.Url.OriginalString };
-            var searchParameterResourceTypes = new List<string>() { "Patient" };
 
             var queryParams = new List<Tuple<string, string>> { new(searchParamCode, sampleName1) };
             SearchResult searchResults = await _searchService.Value.SearchAsync("Patient", queryParams, CancellationToken.None);
 
-            var request = new CreateReindexRequest(new List<string>(), targetSearchParameterTypes, searchParameterResourceTypes);
+            var request = new CreateReindexRequest(new List<string>(), targetSearchParameterTypes);
             CreateReindexResponse response = await SetUpForReindexing(request);
             using var cancellationTokenSource = new CancellationTokenSource();
 
@@ -313,7 +312,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
         [Fact]
         public async Task GivenAlreadyRunningJob_WhenCreatingAReindexJob_ThenJobConflictExceptionThrown()
         {
-            var request = new CreateReindexRequest(new List<string>(), new List<string>(), new List<string>());
+            var request = new CreateReindexRequest(new List<string>(), new List<string>());
 
             CreateReindexResponse response = await _createReindexRequestHandler.Handle(request, CancellationToken.None);
 
@@ -326,7 +325,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
         [Fact]
         public async Task GivenNoSupportedSearchParameters_WhenRunningReindexJob_ThenJobIsCanceled()
         {
-            var request = new CreateReindexRequest(new List<string>(), new List<string>(), new List<string>());
+            var request = new CreateReindexRequest(new List<string>(), new List<string>());
             CreateReindexResponse response = await SetUpForReindexing(request);
 
             using var cancellationTokenSource = new CancellationTokenSource();
@@ -347,7 +346,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
             var searchParam = _supportedSearchParameterDefinitionManager.GetSearchParameter("http://hl7.org/fhir/SearchParameter/Measure-name");
             searchParam.IsSearchable = false;
 
-            var request = new CreateReindexRequest(new List<string>(), new List<string>(), new List<string>());
+            var request = new CreateReindexRequest(new List<string>(), new List<string>());
             CreateReindexResponse response = await SetUpForReindexing(request);
 
             using var cancellationTokenSource = new CancellationTokenSource();
@@ -475,7 +474,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
             // Confirm that "foo" is dropped from the query string and all patients are returned
             Assert.Equal(4, searchResults.Results.Count());
 
-            var createReindexRequest = new CreateReindexRequest(new List<string>(), new List<string>(), new List<string>(), 1, 1, 500);
+            var createReindexRequest = new CreateReindexRequest(new List<string>(), new List<string>(), 1, 1, 500);
             CreateReindexResponse response = await SetUpForReindexing(createReindexRequest);
 
             using var cancellationTokenSource = new CancellationTokenSource();
@@ -845,7 +844,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
         {
             if (request == null)
             {
-                request = new CreateReindexRequest(new List<string>(), new List<string>(), new List<string>());
+                request = new CreateReindexRequest(new List<string>(), new List<string>());
             }
 
             CreateReindexResponse response = await _createReindexRequestHandler.Handle(request, CancellationToken.None);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
         [Fact]
         public async Task GivenLessThanMaximumRunningJobs_WhenCreatingAReindexJob_ThenNewJobShouldBeCreated()
         {
-            var request = new CreateReindexRequest(new List<string>());
+            var request = new CreateReindexRequest(new List<string>(), new List<string>(), new List<string>());
             CreateReindexResponse response = await _createReindexRequestHandler.Handle(request, CancellationToken.None);
 
             Assert.NotNull(response);
@@ -187,23 +187,23 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                 switch (jobRecordProperty)
                 {
                     case JobRecordProperties.MaximumConcurrency:
-                        request = new CreateReindexRequest(new List<string>(), (ushort?)value);
+                        request = new CreateReindexRequest(new List<string>(), new List<string>(), new List<string>(), (ushort?)value);
                         errorMessage = string.Format(Fhir.Core.Resources.InvalidReIndexParameterValue, jobRecordProperty, ReindexJobRecord.MinMaximumConcurrency, ReindexJobRecord.MaxMaximumConcurrency);
                         break;
                     case JobRecordProperties.MaximumNumberOfResourcesPerQuery:
-                        request = new CreateReindexRequest(new List<string>(), null, (uint?)value);
+                        request = new CreateReindexRequest(new List<string>(), new List<string>(), new List<string>(), null, (uint?)value);
                         errorMessage = string.Format(Fhir.Core.Resources.InvalidReIndexParameterValue, jobRecordProperty, ReindexJobRecord.MinMaximumNumberOfResourcesPerQuery, ReindexJobRecord.MaxMaximumNumberOfResourcesPerQuery);
                         break;
                     case JobRecordProperties.QueryDelayIntervalInMilliseconds:
-                        request = new CreateReindexRequest(new List<string>(), null, null, value);
+                        request = new CreateReindexRequest(new List<string>(), new List<string>(), new List<string>(), null, null, value);
                         errorMessage = string.Format(Fhir.Core.Resources.InvalidReIndexParameterValue, jobRecordProperty, ReindexJobRecord.MinQueryDelayIntervalInMilliseconds, ReindexJobRecord.MaxQueryDelayIntervalInMilliseconds);
                         break;
                     case JobRecordProperties.TargetDataStoreUsagePercentage:
-                        request = new CreateReindexRequest(new List<string>(), null, null, null, (ushort?)value);
+                        request = new CreateReindexRequest(new List<string>(), new List<string>(), new List<string>(), null, null, null, (ushort?)value);
                         errorMessage = string.Format(Fhir.Core.Resources.InvalidReIndexParameterValue, jobRecordProperty, ReindexJobRecord.MinTargetDataStoreUsagePercentage, ReindexJobRecord.MaxTargetDataStoreUsagePercentage);
                         break;
                     default:
-                        request = new CreateReindexRequest(new List<string>() { jobRecordProperty });
+                        request = new CreateReindexRequest(new List<string>() { jobRecordProperty }, new List<string>(), new List<string>());
                         errorMessage = $"Resource type 'Foo' is not supported. (Parameter 'type')";
                         break;
                 }
@@ -237,19 +237,19 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
             switch (jobRecordProperty)
             {
                 case JobRecordProperties.MaximumConcurrency:
-                    request = new CreateReindexRequest(new List<string>(), (ushort?)value);
+                    request = new CreateReindexRequest(new List<string>(), new List<string>(), new List<string>(), (ushort?)value);
                     break;
                 case JobRecordProperties.MaximumNumberOfResourcesPerQuery:
-                    request = new CreateReindexRequest(new List<string>(), null, (uint?)value);
+                    request = new CreateReindexRequest(new List<string>(), new List<string>(), new List<string>(), null, (uint?)value);
                     break;
                 case JobRecordProperties.QueryDelayIntervalInMilliseconds:
-                    request = new CreateReindexRequest(new List<string>(), null, null, value);
+                    request = new CreateReindexRequest(new List<string>(), new List<string>(), new List<string>(), null, null, value);
                     break;
                 case JobRecordProperties.TargetDataStoreUsagePercentage:
-                    request = new CreateReindexRequest(new List<string>(), null, null, null, (ushort?)value);
+                    request = new CreateReindexRequest(new List<string>(), new List<string>(), new List<string>(), null, null, null, (ushort?)value);
                     break;
                 default:
-                    request = new CreateReindexRequest(new List<string>() { jobRecordProperty });
+                    request = new CreateReindexRequest(new List<string>() { jobRecordProperty }, new List<string>(), new List<string>());
                     break;
             }
 
@@ -259,9 +259,61 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
         }
 
         [Fact]
+        public async Task GivenSearchParametersToReindex_ThenReindexJobShouldComplete()
+        {
+            var randomName = Guid.NewGuid().ToString().ComputeHash().Substring(0, 14).ToLower();
+            string searchParamName = randomName;
+            string searchParamCode = randomName + "Code";
+            SearchParameter searchParam = await CreateSearchParam(searchParamName, SearchParamType.String, ResourceType.Patient, "Patient.name", searchParamCode);
+
+            string sampleName1 = randomName + "searchIndicesPatient1";
+            string sampleName2 = randomName + "searchIndicesPatient2";
+
+            string sampleId1 = Guid.NewGuid().ToString();
+            string sampleId2 = Guid.NewGuid().ToString();
+
+            // Set up the values that the search index extraction should return during reindexing
+            var searchValues = new List<(string, ISearchValue)> { (sampleId1, new StringSearchValue(sampleName1)), (sampleId2, new StringSearchValue(sampleName2)) };
+            MockSearchIndexExtraction(searchValues, searchParam);
+
+            UpsertOutcome sample1 = await CreatePatientResource(sampleName1, sampleId1);
+            UpsertOutcome sample2 = await CreatePatientResource(sampleName2, sampleId2);
+
+            SearchIndexEntry si = sample1.Wrapper.SearchIndices.FirstOrDefault();
+            var targetSearchParameterTypes = new List<string>() { si.SearchParameter.Url.OriginalString };
+            var searchParameterResourceTypes = new List<string>() { "Patient" };
+
+            var queryParams = new List<Tuple<string, string>> { new(searchParamCode, sampleName1) };
+            SearchResult searchResults = await _searchService.Value.SearchAsync("Patient", queryParams, CancellationToken.None);
+
+            var request = new CreateReindexRequest(new List<string>(), targetSearchParameterTypes, searchParameterResourceTypes);
+            CreateReindexResponse response = await SetUpForReindexing(request);
+            using var cancellationTokenSource = new CancellationTokenSource();
+
+            try
+            {
+                var reindexJobWorker = await PerformReindexingOperation(response, OperationStatus.Completed, cancellationTokenSource);
+
+                Assert.True(reindexJobWorker.JobRecord.ResourceCounts.Count > 0);
+                Assert.True(reindexJobWorker.JobRecord.Progress > 0);
+                Assert.Contains(reindexJobWorker.JobRecord.ResourceList, "Patient");
+            }
+            finally
+            {
+                cancellationTokenSource.Cancel();
+
+                _searchParameterDefinitionManager.DeleteSearchParameter(searchParam.ToTypedElement());
+                await _testHelper.DeleteSearchParameterStatusAsync(searchParam.Url, CancellationToken.None);
+
+                await _fixture.DataStore.HardDeleteAsync(sample1.Wrapper.ToResourceKey(), false, CancellationToken.None);
+                await _fixture.DataStore.HardDeleteAsync(sample2.Wrapper.ToResourceKey(), false, CancellationToken.None);
+            }
+        }
+
+        [Fact]
         public async Task GivenAlreadyRunningJob_WhenCreatingAReindexJob_ThenJobConflictExceptionThrown()
         {
-            var request = new CreateReindexRequest(new List<string>());
+            var request = new CreateReindexRequest(new List<string>(), new List<string>(), new List<string>());
 
             CreateReindexResponse response = await _createReindexRequestHandler.Handle(request, CancellationToken.None);
 
@@ -274,21 +326,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
         [Fact]
         public async Task GivenNoSupportedSearchParameters_WhenRunningReindexJob_ThenJobIsCanceled()
         {
-            var request = new CreateReindexRequest(new List<string>());
-
-            CreateReindexResponse response = await _createReindexRequestHandler.Handle(request, CancellationToken.None);
-
-            Assert.NotNull(response);
-            Assert.False(string.IsNullOrWhiteSpace(response.Job.JobRecord.Id));
-
-            _reindexJobWorker = new ReindexJobWorker(
-                () => _scopedOperationDataStore,
-                Options.Create(_jobConfiguration),
-                InitializeReindexJobTask,
-                _searchParameterOperations,
-                NullLogger<ReindexJobWorker>.Instance);
-
-            await _reindexJobWorker.Handle(new SearchParametersInitializedNotification(), CancellationToken.None);
+            var request = new CreateReindexRequest(new List<string>(), new List<string>(), new List<string>());
+            CreateReindexResponse response = await SetUpForReindexing(request);
 
             using var cancellationTokenSource = new CancellationTokenSource();
 
@@ -307,21 +346,9 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
         {
             var searchParam = _supportedSearchParameterDefinitionManager.GetSearchParameter("http://hl7.org/fhir/SearchParameter/Measure-name");
             searchParam.IsSearchable = false;
-            var request = new CreateReindexRequest(new List<string>());
 
-            CreateReindexResponse response = await _createReindexRequestHandler.Handle(request, CancellationToken.None);
-
-            Assert.NotNull(response);
-            Assert.False(string.IsNullOrWhiteSpace(response.Job.JobRecord.Id));
-
-            _reindexJobWorker = new ReindexJobWorker(
-                () => _scopedOperationDataStore,
-                Options.Create(_jobConfiguration),
-                InitializeReindexJobTask,
-                _searchParameterOperations,
-                NullLogger<ReindexJobWorker>.Instance);
-
-            await _reindexJobWorker.Handle(new SearchParametersInitializedNotification(), CancellationToken.None);
+            var request = new CreateReindexRequest(new List<string>(), new List<string>(), new List<string>());
+            CreateReindexResponse response = await SetUpForReindexing(request);
 
             using var cancellationTokenSource = new CancellationTokenSource();
 
@@ -448,7 +475,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
             // Confirm that "foo" is dropped from the query string and all patients are returned
             Assert.Equal(4, searchResults.Results.Count());
 
-            var createReindexRequest = new CreateReindexRequest(new List<string>(), 1, 1, 500);
+            var createReindexRequest = new CreateReindexRequest(new List<string>(), new List<string>(), new List<string>(), 1, 1, 500);
             CreateReindexResponse response = await SetUpForReindexing(createReindexRequest);
 
             using var cancellationTokenSource = new CancellationTokenSource();
@@ -818,7 +845,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
         {
             if (request == null)
             {
-                request = new CreateReindexRequest(new List<string>());
+                request = new CreateReindexRequest(new List<string>(), new List<string>(), new List<string>());
             }
 
             CreateReindexResponse response = await _createReindexRequestHandler.Handle(request, CancellationToken.None);


### PR DESCRIPTION
## Description
This change allows a $reindex job to be forced by passing in a list of search parameter types when you POST a reindex job.
Example body for a POST would be like the following. Notice that "targetResourceTypes" is commented out in this sample as it is mutually exclusive with "targetSearchParameterTypes". So for this sample, we're going to force a reindex job to run based on the 2 SearchParameter URIs set for that valueString.

```json
{
  "resourceType": "Parameters",
  "parameter": [
    {
      "name": "maximumConcurrency",
      "valueInteger": "1"
    },
    {
      "name": "targetDataStoreUsagePercentage",
      "valueInteger": "100"
    },
    {
      "name": "queryDelayIntervalInMilliseconds",
      "valueInteger": "500"
    },
    {
      "name": "maximumNumberOfResourcesPerQuery",
      "valueInteger": "200"
    },/*
    {
      "name": "targetResourceTypes",
      "valueString": ""
    },*/
    {
      "name": "targetSearchParameterTypes",
      "valueString": "http://hl7.org/fhir/SearchParameter/Observation-device,http://hl7.org/fhir/SearchParameter/Account-status"
    }
  ]
}
```

## Related issues
Addresses [issue #100038](https://microsofthealth.visualstudio.com/Health/_workitems/edit/100038).

## Testing
Created a new reindex test and confirmed that all other reindex tests pass when running locally.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
