### PR TITLE
Add scope parameter to inferno.http

### DIFF
--- a/docs/rest/Inferno/Inferno.http
+++ b/docs/rest/Inferno/Inferno.http
@@ -30,6 +30,7 @@ grant_type=client_credentials
 # &resource={{fhirurl}}
 # &client_id={{clientid}}
 # &client_secret={{clientsecret}}
+# &scope=fhir-api
 
 # ### Capture access token from getToken request
 


### PR DESCRIPTION
## Description
Add scope parameter to the POST call getting the bearer token in `inferno.http` (file to load Inferno test data to FHIR server). Request errors out with 401 Unauthorized without this parameter.

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
