### PR TITLE
Added additional event types for milestones in validate-prs.yml

### DIFF
--- a/.github/workflows/validate-prs.yml
+++ b/.github/workflows/validate-prs.yml
@@ -11,6 +11,8 @@ on:
       - reopened
       - synchronize
       - edited
+      - milestoned
+      - demilestoned
 
 env:
   LABELS: ${{ join( github.event.pull_request.labels.*.name, ' ' ) }}


### PR DESCRIPTION
## Description
Updating of milestone was not triggering the metadata check to validate that it had been updated appropriately. 

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
