### PR TITLE
Adds CosmosQueueClient

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Queues/CosmosQueueClient.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Queues/CosmosQueueClient.cs
@@ -1,0 +1,527 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using EnsureThat;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Health.Core;
+using Microsoft.Health.Core.Extensions;
+using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Health.Fhir.CosmosDb.Features.Queries;
+using Microsoft.Health.JobManagement;
+using Polly;
+
+namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Queues;
+
+public class CosmosQueueClient : IQueueClient
+{
+    private readonly Func<IScoped<Container>> _containerFactory;
+    private readonly ICosmosQueryFactory _queryFactory;
+    private readonly ICosmosDbDistributedLockFactory _distributedLockFactory;
+    private static readonly AsyncPolicy _retryPolicy = Policy
+        .Handle<RetriableJobException>()
+        .WaitAndRetryAsync(3, _ => TimeSpan.FromMilliseconds(GenerateRandomNumber()));
+
+    public CosmosQueueClient(
+        Func<IScoped<Container>> containerFactory,
+        ICosmosQueryFactory queryFactory,
+        ICosmosDbDistributedLockFactory distributedLockFactory)
+    {
+        _containerFactory = EnsureArg.IsNotNull(containerFactory, nameof(containerFactory));
+        _queryFactory = EnsureArg.IsNotNull(queryFactory, nameof(queryFactory));
+        _distributedLockFactory = EnsureArg.IsNotNull(distributedLockFactory, nameof(distributedLockFactory));
+    }
+
+    public bool IsInitialized() => true;
+
+    public async Task<IReadOnlyList<JobInfo>> EnqueueAsync(
+        byte queueType,
+        string[] definitions,
+        long? groupId,
+        bool forceOneActiveJobGroup,
+        bool isCompleted,
+        CancellationToken cancellationToken)
+    {
+        EnsureArg.IsNotNull(definitions, nameof(definitions));
+
+        var id = GetLongId();
+        var jobInfos = new List<JobInfo>();
+
+        var definitionHashes = definitions.Select(d => $"'{d.ComputeHash()}'").ToList();
+
+        using IScoped<Container> container = _containerFactory.Invoke();
+
+        QueryDefinition existingJobsSpec = new QueryDefinition(@$"SELECT VALUE c FROM root c
+             JOIN d in c.definitions
+             WHERE c.queueType = @queueType 
+              AND (c.groupId = @groupId OR @groupId = null)
+              AND ARRAY_CONTAINS([0, 1], d.status)
+              AND ARRAY_CONTAINS([{string.Join(",", definitionHashes)}], d.definitionHash)")
+            .WithParameter("@queueType", queueType)
+            .WithParameter("@groupId", groupId);
+
+        FeedResponse<JobGroupWrapper> existingJobs = await ExecuteQueryAsync(existingJobsSpec, 100, cancellationToken);
+
+        if (existingJobs.Count > 0)
+        {
+            IEnumerable<JobInfo> existingJobInfos =
+                existingJobs.Resource
+                    .SelectMany(x => x.ToJobInfo(x.Definitions.Where(y => definitions.Contains(y.Definition))));
+
+            jobInfos.AddRange(existingJobInfos);
+        }
+
+        var newDefinitions = definitions.Except(jobInfos.Select(x => x.Definition)).ToArray();
+
+        if (forceOneActiveJobGroup)
+        {
+            await using ICosmosDbDistributedLock distributedLock = _distributedLockFactory.Create(container.Value, "__jobQueue:" + queueType);
+
+            if (await distributedLock.TryAcquireLock())
+            {
+                QueryDefinition sqlQuerySpec = new QueryDefinition(@"SELECT VALUE count(1) FROM root c JOIN d in c.definitions
+         WHERE c.queueType = @queueType 
+           AND ARRAY_CONTAINS([0, 1], d.status)").WithParameter("@queueType", queueType);
+
+                var query = _queryFactory.Create<int>(
+                    container.Value,
+                    new CosmosQueryContext(
+                        sqlQuerySpec,
+                        new QueryRequestOptions { PartitionKey = new PartitionKey(JobGroupWrapper.JobInfoPartitionKey) }));
+
+                FeedResponse<int> itemResponse = await query.ExecuteNextAsync(cancellationToken);
+
+                if (itemResponse.Resource.FirstOrDefault() > 0)
+                {
+                    throw new JobConflictException("Failed to enqueue job.");
+                }
+
+                jobInfos.AddRange(await CreateNewJob(id, queueType, newDefinitions, groupId, isCompleted, cancellationToken));
+            }
+        }
+        else
+        {
+            jobInfos.AddRange(await CreateNewJob(id, queueType, newDefinitions, groupId, isCompleted, cancellationToken));
+        }
+
+        return jobInfos;
+    }
+
+    private async Task<IReadOnlyList<JobInfo>> CreateNewJob(long id, byte queueType, string[] definitions, long? groupId, bool isCompleted, CancellationToken cancellationToken)
+    {
+        var jobInfo = new JobGroupWrapper
+        {
+            Id = id.ToString(),
+            QueueType = queueType,
+            GroupId = groupId ?? id,
+            CreateDate = Clock.UtcNow,
+            TimeToLive = (int)TimeSpan.FromDays(30).TotalSeconds,
+        };
+
+        var jobId = id;
+
+        foreach (var item in definitions)
+        {
+            var definitionInfo = new JobDefinitionWrapper
+            {
+                JobId = jobId++,
+                Status = isCompleted ? (byte)JobStatus.Completed : (byte)JobStatus.Created,
+                Definition = item,
+                DefinitionHash = item.ComputeHash(),
+            };
+
+            jobInfo.Definitions.Add(definitionInfo);
+        }
+
+        using IScoped<Container> container = _containerFactory.Invoke();
+        ItemResponse<JobGroupWrapper> result = await container.Value.CreateItemAsync(jobInfo, new PartitionKey(JobGroupWrapper.JobInfoPartitionKey), cancellationToken: cancellationToken);
+
+        return result.Resource.ToJobInfo().ToList();
+    }
+
+    public async Task<IReadOnlyCollection<JobInfo>> DequeueJobsAsync(
+        byte queueType,
+        int numberOfJobsToDequeue,
+        string worker,
+        int heartbeatTimeoutSec,
+        CancellationToken cancellationToken)
+    {
+        QueryDefinition sqlQuerySpec = new QueryDefinition(@"SELECT VALUE c FROM root c
+           JOIN d in c.definitions
+           WHERE c.queueType = @queueType 
+           AND (d.status = 0 OR
+               (d.status = 1 AND d.heartbeatDateTime < @heartbeatDateTimeout))
+           ORDER BY c.priority ASC")
+            .WithParameter("@queueType", queueType)
+            .WithParameter("@heartbeatDateTimeout", Clock.UtcNow.AddSeconds(-heartbeatTimeoutSec));
+
+        return await _retryPolicy.ExecuteAsync(async () =>
+            {
+                FeedResponse<JobGroupWrapper> response = await ExecuteQueryAsync(sqlQuerySpec, 1, cancellationToken);
+
+                JobGroupWrapper item = response.FirstOrDefault();
+                if (item != null)
+                {
+                    return await DequeueItemsInternalAsync(item, numberOfJobsToDequeue, worker, heartbeatTimeoutSec, cancellationToken);
+                }
+
+                return Array.Empty<JobInfo>();
+            });
+    }
+
+    private async Task<IReadOnlyCollection<JobInfo>> DequeueItemsInternalAsync(JobGroupWrapper item, int numberOfJobsToDequeue, string worker, int heartbeatTimeoutSec, CancellationToken cancellationToken, long? jobId = null)
+    {
+        var scan = item.Definitions
+            .Where(x => x.JobId == jobId
+                 || (jobId == null &&
+                     (x.Status == (byte)JobStatus.Created
+                     || (x.Status == (byte)JobStatus.Running && x.HeartbeatDateTime < Clock.UtcNow.AddSeconds(-heartbeatTimeoutSec)))))
+            .OrderBy(x => x.Status)
+            .ToList();
+
+        if (scan.Count == 0)
+        {
+            return Array.Empty<JobInfo>();
+        }
+
+        var toReturn = new List<JobDefinitionWrapper>();
+        foreach (JobDefinitionWrapper job in scan.Take(numberOfJobsToDequeue))
+        {
+            if (!string.IsNullOrEmpty(job.Worker))
+            {
+                job.Info = $"Prev worker: {job.Worker}. ";
+            }
+
+            if (job.DequeueCount > 10)
+            {
+                if (job.Status == (byte)JobStatus.Running)
+                {
+                    job.CancelRequested = true;
+                }
+
+                job.Status = (byte)JobStatus.Failed;
+                job.Info += "Dequeue count exceeded.";
+            }
+            else
+            {
+                job.Status = (byte)JobStatus.Running;
+                job.HeartbeatDateTime = Clock.UtcNow;
+                job.Worker = worker;
+                job.DequeueCount += 1;
+                job.StartDate ??= Clock.UtcNow;
+                job.Version = GenerateVersion();
+
+                toReturn.Add(job);
+            }
+        }
+
+        await SaveJobGroupAsync(item, cancellationToken);
+
+        return item.ToJobInfo(toReturn).ToList();
+    }
+
+    public async Task<JobInfo> DequeueAsync(byte queueType, string worker, int heartbeatTimeoutSec, CancellationToken cancellationToken, long? jobId = null)
+    {
+        if (jobId == null)
+        {
+            var job = await DequeueJobsAsync(queueType, 1, worker, heartbeatTimeoutSec, cancellationToken);
+            return job?.FirstOrDefault();
+        }
+
+        var jobs = await GetJobsByIdsInternalAsync(queueType, new[] { jobId.Value }, false, cancellationToken);
+        if (jobs.Count == 1)
+        {
+            var job = await DequeueItemsInternalAsync(jobs[0].JobGroup, 1, worker, heartbeatTimeoutSec, cancellationToken);
+        }
+
+        throw new JobNotExistException("Job not found.");
+    }
+
+    public async Task<JobInfo> GetJobByIdAsync(byte queueType, long jobId, bool returnDefinition, CancellationToken cancellationToken)
+    {
+        IReadOnlyList<JobInfo> job = await GetJobsByIdsAsync(queueType, new[] { jobId }, returnDefinition, cancellationToken);
+
+        if (job.Count == 1)
+        {
+            return job[0];
+        }
+
+        if (job.Count > 1)
+        {
+            throw new InvalidOperationException("More than one job found.");
+        }
+
+        return null;
+    }
+
+    public async Task<IReadOnlyList<JobInfo>> GetJobsByIdsAsync(byte queueType, long[] jobIds, bool returnDefinition, CancellationToken cancellationToken)
+    {
+        var jobs = await GetJobsByIdsInternalAsync(queueType, jobIds, returnDefinition, cancellationToken);
+
+        var infos = new List<JobInfo>();
+        foreach ((JobGroupWrapper JobGroup, IReadOnlyList<JobDefinitionWrapper> MatchingJob) item in jobs)
+        {
+            infos.AddRange(item.JobGroup.ToJobInfo(item.MatchingJob));
+        }
+
+        return infos;
+    }
+
+    public async Task<IReadOnlyList<JobInfo>> GetJobByGroupIdAsync(byte queueType, long groupId, bool returnDefinition, CancellationToken cancellationToken)
+    {
+        JobGroupWrapper job = await GetGroupInternalAsync(queueType, groupId, cancellationToken);
+
+        if (job != null)
+        {
+            return job.ToJobInfo(job.Definitions).ToList();
+        }
+
+        return null;
+    }
+
+    public async Task<bool> PutJobHeartbeatAsync(JobInfo jobInfo, CancellationToken cancellationToken)
+    {
+        return await _retryPolicy.ExecuteAsync(async () =>
+        {
+            var jobs = await GetJobsByIdsInternalAsync(jobInfo.QueueType, new[] { jobInfo.Id }, false, cancellationToken);
+
+            var job = jobs.Single();
+            JobDefinitionWrapper item = job.MatchingJob.Single();
+
+            if (item.Version != jobInfo.Version)
+            {
+                throw new JobConflictException("Job version mismatch.");
+            }
+
+            if (item.Status == (byte)JobStatus.Running)
+            {
+                item.HeartbeatDateTime = Clock.UtcNow;
+
+                if (jobInfo.Data.HasValue)
+                {
+                    item.Data = jobInfo.Data;
+                }
+
+                if (!string.IsNullOrEmpty(jobInfo.Result))
+                {
+                    item.Result = jobInfo.Result;
+                }
+
+                await SaveJobGroupAsync(job.JobGroup, cancellationToken);
+            }
+
+            return item.CancelRequested;
+        });
+    }
+
+    public async Task CancelJobByGroupIdAsync(byte queueType, long groupId, CancellationToken cancellationToken)
+    {
+        JobGroupWrapper job = await GetGroupInternalAsync(queueType, groupId, cancellationToken);
+        if (job != null)
+        {
+            foreach (JobDefinitionWrapper item in job.Definitions)
+            {
+                if (item.Status == (byte)JobStatus.Running)
+                {
+                    item.CancelRequested = true;
+                }
+                else if (item.Status == (byte)JobStatus.Created)
+                {
+                    item.Status = (byte)JobStatus.Cancelled;
+                }
+            }
+
+            await SaveJobGroupAsync(job, cancellationToken);
+        }
+    }
+
+    public async Task CancelJobByIdAsync(byte queueType, long jobId, CancellationToken cancellationToken)
+    {
+        var jobs = await GetJobsByIdsInternalAsync(queueType, new[] { jobId }, false, cancellationToken);
+
+        if (jobs.Count == 1)
+        {
+            (JobGroupWrapper JobGroup, IReadOnlyList<JobDefinitionWrapper> MatchingJob) job = jobs[0];
+            JobDefinitionWrapper item = job.MatchingJob[0];
+
+            if (item != null)
+            {
+                CancelJobDefinition(item);
+
+                await SaveJobGroupAsync(job.JobGroup, cancellationToken);
+            }
+        }
+    }
+
+    public async Task CompleteJobAsync(JobInfo jobInfo, bool requestCancellationOnFailure, CancellationToken cancellationToken)
+    {
+        var jobs = await GetJobsByIdsInternalAsync(jobInfo.QueueType, new[] { jobInfo.Id }, false, cancellationToken);
+
+        (JobGroupWrapper JobGroup, IReadOnlyList<JobDefinitionWrapper> MatchingJob) definitionTuple = jobs.Single();
+        JobDefinitionWrapper item = definitionTuple.MatchingJob.Single();
+
+        if (item != null)
+        {
+            if (jobInfo.Status == JobStatus.Failed)
+            {
+                if (requestCancellationOnFailure)
+                {
+                    foreach (JobDefinitionWrapper jobDefinition in definitionTuple.JobGroup.Definitions)
+                    {
+                        CancelJobDefinition(jobDefinition);
+                    }
+                }
+
+                item.Status = (byte)JobStatus.Failed;
+            }
+            else if (item.CancelRequested)
+            {
+                item.Status = (byte)JobStatus.Cancelled;
+            }
+            else
+            {
+                item.Status = (byte?)jobInfo.Status ?? (byte?)JobStatus.Completed;
+            }
+
+            item.EndDate = Clock.UtcNow;
+            item.Result = jobInfo.Result;
+
+            await SaveJobGroupAsync(definitionTuple.JobGroup, cancellationToken);
+        }
+    }
+
+    private async Task<JobGroupWrapper> GetGroupInternalAsync(
+        byte queueType,
+        long groupId,
+        CancellationToken cancellationToken)
+    {
+            QueryDefinition sqlQuerySpec = new QueryDefinition(@"SELECT VALUE c FROM root c
+           WHERE c.groupId = @groupId and c.queueType = @queueType")
+                .WithParameter("@groupId", groupId)
+                .WithParameter("@queueType", queueType);
+
+            FeedResponse<JobGroupWrapper> response = await ExecuteQueryAsync(sqlQuerySpec, 1, cancellationToken);
+
+            return response.FirstOrDefault();
+    }
+
+    private async Task<IReadOnlyList<(JobGroupWrapper JobGroup, IReadOnlyList<JobDefinitionWrapper> MatchingJob)>> GetJobsByIdsInternalAsync(byte queueType, long[] jobIds, bool returnDefinition, CancellationToken cancellationToken)
+    {
+        QueryDefinition sqlQuerySpec = new QueryDefinition(@$"SELECT VALUE c FROM root c JOIN d in c.definitions
+           WHERE c.queueType = @queueType 
+           AND ARRAY_CONTAINS([{string.Join(",", jobIds)}], d.jobId)")
+            .WithParameter("@queueType", queueType);
+
+        FeedResponse<JobGroupWrapper> response = await ExecuteQueryAsync(sqlQuerySpec, jobIds.Length, cancellationToken);
+
+        var infos = new List<(JobGroupWrapper JobGroup, IReadOnlyList<JobDefinitionWrapper> MatchingJob)>();
+
+        foreach (JobGroupWrapper item in response)
+        {
+            var scan = item.Definitions
+                .Where(x => jobIds.Contains(x.JobId))
+                .ToList();
+
+            infos.Add((item, scan));
+        }
+
+        return infos;
+    }
+
+    private static void CancelJobDefinition(JobDefinitionWrapper item)
+    {
+        switch (item.Status)
+        {
+            case (byte)JobStatus.Running:
+                item.CancelRequested = true;
+                break;
+            case (byte)JobStatus.Created:
+                item.Status = (byte)JobStatus.Cancelled;
+                item.EndDate = Clock.UtcNow;
+                break;
+        }
+    }
+
+    private async Task<FeedResponse<JobGroupWrapper>> ExecuteQueryAsync(QueryDefinition sqlQuerySpec, int itemCount, CancellationToken cancellationToken)
+    {
+        using IScoped<Container> container = _containerFactory.Invoke();
+
+        ICosmosQuery<JobGroupWrapper> query = _queryFactory.Create<JobGroupWrapper>(
+            container.Value,
+            new CosmosQueryContext(
+                sqlQuerySpec,
+                new QueryRequestOptions { PartitionKey = new PartitionKey(JobGroupWrapper.JobInfoPartitionKey), MaxItemCount = itemCount }));
+
+        FeedResponse<JobGroupWrapper> response = await query.ExecuteNextAsync(cancellationToken);
+        return response;
+    }
+
+    private async Task SaveJobGroupAsync(JobGroupWrapper definition, CancellationToken cancellationToken)
+    {
+        using IScoped<Container> container = _containerFactory.Invoke();
+
+        try
+        {
+            await container.Value.UpsertItemAsync(
+                definition,
+                new PartitionKey(JobGroupWrapper.JobInfoPartitionKey),
+                new ItemRequestOptions { IfMatchEtag = definition.ETag },
+                cancellationToken: cancellationToken);
+        }
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.PreconditionFailed)
+        {
+            throw new RetriableJobException("Job precondition failed.", ex);
+        }
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.TooManyRequests)
+        {
+            throw new RetriableJobException("Service too busy.", ex);
+        }
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.RequestEntityTooLarge)
+        {
+            throw new JobExecutionException("Job data too large.", ex);
+        }
+    }
+
+    private static long GetLongId()
+    {
+        return IdHelper.DateToId(Clock.UtcNow.DateTime) + GenerateRandomNumber();
+    }
+
+    /// <summary>
+    /// To generate a random number between 100 and 999,
+    /// the method uses the formula (randomValue / UInt16.MaxValue) * 899 + 100.
+    /// This takes the percentage of the maximum UInt16 value that the generated value represents,
+    /// multiplies it by 899 (the difference between 999 and 100),
+    /// and adds 100 to shift the range to between 100 and 999.
+    /// </summary>
+    private static int GenerateRandomNumber()
+    {
+        using var rng = RandomNumberGenerator.Create();
+        var bytes = new byte[2];
+        rng.GetBytes(bytes);
+
+        var value = BitConverter.ToUInt16(bytes, 0);
+        var percentage = (double)value / ushort.MaxValue;
+
+        var randomNumber = (int)Math.Round(percentage * 899) + 100;
+        return randomNumber;
+    }
+
+    /// <summary>
+    /// Returns a version number based on the current time.
+    /// Similar to SQL "datediff_big(millisecond,'0001-01-01',getUTCdate())"
+    /// </summary>
+    private static long GenerateVersion()
+    {
+        TimeSpan diff = DateTime.UtcNow - new DateTime(1, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        return (long)diff.TotalMilliseconds;
+    }
+}

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Queues/IdHelper.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Queues/IdHelper.cs
@@ -1,0 +1,33 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using EnsureThat;
+using Microsoft.Health.Core.Extensions;
+
+namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Queues;
+
+internal static class IdHelper
+{
+    private const int ShiftFactor = 3;
+
+    internal static readonly DateTime MaxDateTime = new DateTime(long.MaxValue >> ShiftFactor, DateTimeKind.Utc).TruncateToMillisecond().AddTicks(-1);
+
+    public static long DateToId(DateTime dateTime)
+    {
+        EnsureArg.IsLte(dateTime, MaxDateTime, nameof(dateTime));
+        long id = dateTime.TruncateToMillisecond().Ticks << ShiftFactor;
+
+        Debug.Assert(id >= 0, "The ID should not have become negative");
+        return id;
+    }
+
+    public static DateTime IdToDate(long resourceSurrogateId)
+    {
+        var dateTime = new DateTime(resourceSurrogateId >> ShiftFactor, DateTimeKind.Utc);
+        return dateTime.TruncateToMillisecond();
+    }
+}

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Queues/JobDefinitionWrapper.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Queues/JobDefinitionWrapper.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Queues;
 public class JobDefinitionWrapper
 {
     [JsonProperty("jobId")]
-    public long JobId { get; set; }
+    public string JobId { get; set; }
 
     [JsonProperty("status")]
     public byte? Status { get; set; }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Queues/JobDefinitionWrapper.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Queues/JobDefinitionWrapper.cs
@@ -1,0 +1,54 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Newtonsoft.Json;
+
+namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Queues;
+
+public class JobDefinitionWrapper
+{
+    [JsonProperty("jobId")]
+    public long JobId { get; set; }
+
+    [JsonProperty("status")]
+    public byte? Status { get; set; }
+
+    [JsonProperty("worker")]
+    public string Worker { get; set; }
+
+    [JsonProperty("definition")]
+    public string Definition { get; set; }
+
+    [JsonProperty("definitionHash")]
+    public string DefinitionHash { get; set; }
+
+    [JsonProperty("result")]
+    public string Result { get; set; }
+
+    [JsonProperty("data")]
+    public long? Data { get; set; }
+
+    [JsonProperty("startDate")]
+    public DateTimeOffset? StartDate { get; set; }
+
+    [JsonProperty("endDate")]
+    public DateTimeOffset? EndDate { get; set; }
+
+    [JsonProperty("heartbeatDateTime")]
+    public DateTimeOffset HeartbeatDateTime { get; set; }
+
+    [JsonProperty("cancelRequested")]
+    public bool CancelRequested { get; set; }
+
+    [JsonProperty("info")]
+    public string Info { get; set; }
+
+    [JsonProperty("dequeueCount")]
+    public int DequeueCount { get; set; }
+
+    [JsonProperty("version")]
+    public long Version { get; set; }
+}

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Queues/JobGroupWrapper.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Queues/JobGroupWrapper.cs
@@ -1,0 +1,36 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Queues;
+
+public class JobGroupWrapper : SystemData
+{
+    public const string JobInfoPartitionKey = "__jobs__";
+
+    [JsonProperty("groupId")]
+    public long GroupId { get; set; }
+
+    [JsonProperty(KnownDocumentProperties.PartitionKey)]
+    public string PartitionKey { get; } = JobInfoPartitionKey;
+
+    [JsonProperty("queueType")]
+    public byte QueueType { get; set; }
+
+    [JsonProperty("priority")]
+    public long Priority { get; set; }
+
+    [JsonProperty("definitions")]
+    public IList<JobDefinitionWrapper> Definitions { get; } = new List<JobDefinitionWrapper>();
+
+    [JsonProperty("createDate")]
+    public DateTimeOffset CreateDate { get; set; }
+
+    [JsonProperty("ttl")]
+    public long TimeToLive { get; set; }
+}

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Queues/JobGroupWrapper.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Queues/JobGroupWrapper.cs
@@ -14,7 +14,7 @@ public class JobGroupWrapper : SystemData
     public const string JobInfoPartitionKey = "__jobs__";
 
     [JsonProperty("groupId")]
-    public long GroupId { get; set; }
+    public string GroupId { get; set; }
 
     [JsonProperty(KnownDocumentProperties.PartitionKey)]
     public string PartitionKey { get; } = JobInfoPartitionKey;
@@ -23,7 +23,7 @@ public class JobGroupWrapper : SystemData
     public byte QueueType { get; set; }
 
     [JsonProperty("priority")]
-    public long Priority { get; set; }
+    public int Priority { get; set; }
 
     [JsonProperty("definitions")]
     public IList<JobDefinitionWrapper> Definitions { get; } = new List<JobDefinitionWrapper>();

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Queues/JobInfoExtensions.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Queues/JobInfoExtensions.cs
@@ -20,10 +20,10 @@ public static class JobInfoExtensions
     {
         return items.Select(jobInfoWrapperItem => new JobInfo
         {
-            Id = jobInfoWrapperItem.JobId,
+            Id = long.Parse(jobInfoWrapperItem.JobId),
             QueueType = jobGroupWrapper.QueueType,
             Status = jobInfoWrapperItem.Status.HasValue ? (JobStatus?)jobInfoWrapperItem.Status.Value : null,
-            GroupId = jobGroupWrapper.GroupId,
+            GroupId = long.Parse(jobGroupWrapper.GroupId),
             Definition = jobInfoWrapperItem.Definition,
             Result = jobInfoWrapperItem.Result,
             Data = jobInfoWrapperItem.Data,

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Queues/JobInfoExtensions.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Queues/JobInfoExtensions.cs
@@ -1,0 +1,39 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Health.JobManagement;
+
+namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Queues;
+
+public static class JobInfoExtensions
+{
+    public static IEnumerable<JobInfo> ToJobInfo(this JobGroupWrapper jobGroupWrapper)
+    {
+        return jobGroupWrapper.ToJobInfo(jobGroupWrapper.Definitions);
+    }
+
+    public static IEnumerable<JobInfo> ToJobInfo(this JobGroupWrapper jobGroupWrapper, IEnumerable<JobDefinitionWrapper> items)
+    {
+        return items.Select(jobInfoWrapperItem => new JobInfo
+        {
+            Id = jobInfoWrapperItem.JobId,
+            QueueType = jobGroupWrapper.QueueType,
+            Status = jobInfoWrapperItem.Status.HasValue ? (JobStatus?)jobInfoWrapperItem.Status.Value : null,
+            GroupId = jobGroupWrapper.GroupId,
+            Definition = jobInfoWrapperItem.Definition,
+            Result = jobInfoWrapperItem.Result,
+            Data = jobInfoWrapperItem.Data,
+            CancelRequested = jobInfoWrapperItem.CancelRequested,
+            Priority = jobGroupWrapper.Priority,
+            CreateDate = jobGroupWrapper.CreateDate.UtcDateTime,
+            StartDate = jobInfoWrapperItem.StartDate?.UtcDateTime,
+            EndDate = jobInfoWrapperItem.EndDate?.UtcDateTime,
+            HeartbeatDateTime = jobInfoWrapperItem.HeartbeatDateTime.UtcDateTime,
+            Version = jobInfoWrapperItem.Version,
+        });
+    }
+}

--- a/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
@@ -17,7 +17,6 @@ using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
 using Microsoft.Health.Fhir.Core.Features.Search.Registry;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Core.Registration;
-using Microsoft.Health.Fhir.CosmosDb;
 using Microsoft.Health.Fhir.CosmosDb.Configs;
 using Microsoft.Health.Fhir.CosmosDb.Features.Health;
 using Microsoft.Health.Fhir.CosmosDb.Features.Operations;
@@ -27,9 +26,12 @@ using Microsoft.Health.Fhir.CosmosDb.Features.Search;
 using Microsoft.Health.Fhir.CosmosDb.Features.Search.Queries;
 using Microsoft.Health.Fhir.CosmosDb.Features.Storage;
 using Microsoft.Health.Fhir.CosmosDb.Features.Storage.Operations;
+using Microsoft.Health.Fhir.CosmosDb.Features.Storage.Queues;
 using Microsoft.Health.Fhir.CosmosDb.Features.Storage.Registry;
 using Microsoft.Health.Fhir.CosmosDb.Features.Storage.StoredProcedures;
 using Microsoft.Health.Fhir.CosmosDb.Features.Storage.Versioning;
+using Microsoft.Health.JobManagement;
+using Constants = Microsoft.Health.Fhir.CosmosDb.Constants;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -230,6 +232,12 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Add<SmartCompartmentSearchRewriter>()
                 .Singleton()
                 .AsSelf();
+
+            services.Add<CosmosQueueClient>()
+                .Scoped()
+                .AsSelf()
+                .AsImplementedInterfaces()
+                .AsFactory<IScoped<IQueueClient>>();
 
             return fhirServerBuilder;
         }

--- a/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
@@ -18,6 +19,7 @@ using Microsoft.Health.Fhir.Api.Features.BackgroundJobService;
 using Microsoft.Health.Fhir.Azure;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features;
+using Microsoft.Health.Fhir.Core.Features.Operations.Export;
 using Microsoft.Health.Fhir.Core.Features.Operations.Import;
 using Microsoft.Health.JobManagement;
 using Microsoft.Health.SqlServer.Configs;
@@ -116,8 +118,9 @@ namespace Microsoft.Health.Fhir.Web
                 .AsImplementedInterfaces();
             services.Configure<TaskHostingConfiguration>(options => Configuration.GetSection("TaskHosting").Bind(options));
 
-            IEnumerable<TypeRegistrationBuilder> jobs = services.TypesInSameAssemblyAs<ImportOrchestratorJob>()
+            IEnumerable<TypeRegistrationBuilder> jobs = services.TypesInSameAssemblyAs<ExportOrchestratorJob>()
                 .AssignableTo<IJob>()
+                .Where(t => t.Type.Name.Contains("Import", StringComparison.Ordinal) == false)
                 .Transient()
                 .AsSelf();
 

--- a/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
@@ -120,7 +120,6 @@ namespace Microsoft.Health.Fhir.Web
 
             IEnumerable<TypeRegistrationBuilder> jobs = services.TypesInSameAssemblyAs<ExportOrchestratorJob>()
                 .AssignableTo<IJob>()
-                .Where(t => t.Type.Name.Contains("Import", StringComparison.Ordinal) == false)
                 .Transient()
                 .AsSelf();
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
@@ -253,17 +253,6 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.AddHostedService<WatchdogsBackgroundService>();
 
-            IEnumerable<TypeRegistrationBuilder> jobs = services.TypesInSameAssemblyAs<ImportOrchestratorJob>()
-                .AssignableTo<IJob>()
-                .Where(t => t.Type.Name.Contains("Import", StringComparison.Ordinal))
-                .Transient()
-                .AsSelf();
-
-            foreach (TypeRegistrationBuilder job in jobs)
-            {
-                job.AsDelegate<Func<IJob>>();
-            }
-
             return fhirServerBuilder;
         }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
@@ -4,16 +4,12 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using EnsureThat;
 using MediatR;
 using MediatR.Pipeline;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Extensions;
-using Microsoft.Health.Fhir.Core.Features.Operations.Export;
-using Microsoft.Health.Fhir.Core.Features.Operations.Import;
 using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
 using Microsoft.Health.Fhir.Core.Features.Search.Registry;
 using Microsoft.Health.Fhir.Core.Messages.Storage;
@@ -28,7 +24,6 @@ using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors;
 using Microsoft.Health.Fhir.SqlServer.Features.Storage;
 using Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry;
 using Microsoft.Health.Fhir.SqlServer.Features.Watchdogs;
-using Microsoft.Health.JobManagement;
 using Microsoft.Health.SqlServer.Api.Registration;
 using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Features.Client;

--- a/src/Microsoft.Health.Fhir.SqlServer/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using EnsureThat;
 using MediatR;
@@ -11,6 +12,8 @@ using MediatR.Pipeline;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Core.Features.Operations.Export;
+using Microsoft.Health.Fhir.Core.Features.Operations.Import;
 using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
 using Microsoft.Health.Fhir.Core.Features.Search.Registry;
 using Microsoft.Health.Fhir.Core.Messages.Storage;
@@ -25,6 +28,7 @@ using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors;
 using Microsoft.Health.Fhir.SqlServer.Features.Storage;
 using Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry;
 using Microsoft.Health.Fhir.SqlServer.Features.Watchdogs;
+using Microsoft.Health.JobManagement;
 using Microsoft.Health.SqlServer.Api.Registration;
 using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Features.Client;
@@ -248,6 +252,17 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AsService<INotificationHandler<StorageInitializedNotification>>();
 
             services.AddHostedService<WatchdogsBackgroundService>();
+
+            IEnumerable<TypeRegistrationBuilder> jobs = services.TypesInSameAssemblyAs<ImportOrchestratorJob>()
+                .AssignableTo<IJob>()
+                .Where(t => t.Type.Name.Contains("Import", StringComparison.Ordinal))
+                .Transient()
+                .AsSelf();
+
+            foreach (TypeRegistrationBuilder job in jobs)
+            {
+                job.AsDelegate<Func<IJob>>();
+            }
 
             return fhirServerBuilder;
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Microsoft.Health.Fhir.Shared.Tests.Integration.projitems
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Microsoft.Health.Fhir.Shared.Tests.Integration.projitems
@@ -43,7 +43,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlServerFhirStorageTestHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlServerFhirStorageTestsFixture.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlServerSqlCompatibilityTests.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlQueueClientTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Persistence\QueueClientTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlServerTransactionScopeTests.cs" />
   </ItemGroup>
 </Project>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTestsFixture.cs
@@ -45,6 +45,7 @@ using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.Common.Mocks;
+using Microsoft.Health.JobManagement;
 using Microsoft.Health.SqlServer.Features.Schema;
 using NSubstitute;
 using Xunit;
@@ -119,6 +120,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         public RequestContextAccessor<IFhirRequestContext> FhirRequestContextAccessor => _fixture.GetRequiredService<RequestContextAccessor<IFhirRequestContext>>();
 
         public GetResourceHandler GetResourceHandler { get; set; }
+
+        public IQueueClient QueueClient => _fixture.GetRequiredService<IQueueClient>();
 
         public void Dispose()
         {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -35,6 +35,7 @@ using Microsoft.Health.Fhir.SqlServer.Features.Search;
 using Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors;
 using Microsoft.Health.Fhir.SqlServer.Features.Storage;
 using Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry;
+using Microsoft.Health.JobManagement;
 using Microsoft.Health.JobManagement.UnitTests;
 using Microsoft.Health.SqlServer;
 using Microsoft.Health.SqlServer.Configs;
@@ -68,6 +69,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         private readonly SearchParameterStatusManager _searchParameterStatusManager;
         private readonly IMediator _mediator = Substitute.For<IMediator>();
         private readonly RequestContextAccessor<IFhirRequestContext> _fhirRequestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
+        private readonly SqlQueueClient _sqlQueueClient;
 
         public SqlServerFhirStorageTestsFixture()
             : this(SchemaVersionConstants.Max, $"FHIRINTEGRATIONTEST_{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}_{BigInteger.Abs(new BigInteger(Guid.NewGuid().ToByteArray()))}")
@@ -239,6 +241,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 NullLogger<SearchParameterStatusManager>.Instance);
 
             _testHelper = new SqlServerFhirStorageTestHelper(initialConnectionString, MasterDatabaseName, sqlServerFhirModel, SqlConnectionBuilder, queueClient);
+
+            _sqlQueueClient = new SqlQueueClient(SqlConnectionWrapperFactory, SchemaInformation, NullLogger<SqlQueueClient>.Instance);
         }
 
         public string TestConnectionString { get; }
@@ -353,6 +357,11 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             if (serviceType == typeof(RequestContextAccessor<IFhirRequestContext>))
             {
                 return _fhirRequestContextAccessor;
+            }
+
+            if (serviceType == typeof(IQueueClient))
+            {
+                return _sqlQueueClient;
             }
 
             return null;


### PR DESCRIPTION
## Description
Adds CosmosQueueClient class. This PR is benign in that I doesn't change any behavior, it just adds this provider for Cosmos.

![image](https://user-images.githubusercontent.com/197221/220229846-374cb856-c4a4-4206-b740-5337fb874bef.png)

**Next steps:** After this Export in Cosmos and SQL can share more common code paths: https://github.com/microsoft/fhir-server/compare/personal/bkowitz/cosmos-queueclient...personal/bkowitz/cosmos-queueclient-export2

## Testing
Refactors and uses existing QueueClientTests

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
