### PR TITLE
Fail group jobs on generic exception

### DIFF
--- a/src/Microsoft.Health.TaskManagement/JobHosting.cs
+++ b/src/Microsoft.Health.TaskManagement/JobHosting.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Health.JobManagement
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Job {JobId} failed.", jobInfo.Id);
+                _logger.LogError(ex, "Job {JobId} failed with generic exception.", jobInfo.Id);
 
                 object error = new { message = ex.Message, stackTrace = ex.StackTrace };
                 jobInfo.Result = JsonConvert.SerializeObject(error);
@@ -169,7 +169,7 @@ namespace Microsoft.Health.JobManagement
 
                 try
                 {
-                    await _queueClient.CompleteJobAsync(jobInfo, false, CancellationToken.None);
+                    await _queueClient.CompleteJobAsync(jobInfo, true, CancellationToken.None);
                 }
                 catch (Exception completeEx)
                 {


### PR DESCRIPTION
## Description
Job hosting should cancel jobs in a group if one fails in an unrecoverable way. This change cancels jobs in a group if one fails with a generic exception.

## Related issues
Addresses [Bug 98695](https://microsofthealth.visualstudio.com/Health/_workitems/edit/98695): Export does not run fail fast logic

## Testing
New unit test was added. Manual testing was done.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
