### PR TITLE
Move SQL log

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -425,14 +425,16 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                     }
                     catch (SqlException e)
                     {
-                        _logger.LogError(e, $"Error from SQL database on {nameof(UpsertAsync)}");
-
                         switch (e.Number)
                         {
                             case SqlErrorCodes.Conflict:
                                 // someone else beat us to it, re-read and try comparing again - Compared resource was updated
+                                _logger.LogInformation($"Conflict on {nameof(UpsertAsync)}. Trying again.");
                                 continue;
                             default:
+                                // Exceptions should only be logged as errors if they cannot be handled.
+                                // Exceptions that still allow the call to succeed should be informational to avoid cluttering logs.
+                                _logger.LogError(e, $"Error from SQL database on {nameof(UpsertAsync)}");
                                 throw;
                         }
                     }


### PR DESCRIPTION
## Description
Moves a logging statement to avoid logging errors that don't fail a call.

## Related issues
Addresses excess exceptions in our logs.

## Testing

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
