### PR TITLE
Move audit files to core project to use it in AKS work

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditHelper.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditHelper.cs
@@ -16,6 +16,7 @@ using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Core.Features.Security;
 using Microsoft.Health.Fhir.Api.Features.AnonymousOperations;
 using Microsoft.Health.Fhir.Api.Features.Routing;
+using Microsoft.Health.Fhir.Core.Features.Audit;
 using Microsoft.Health.Fhir.Core.Features.Context;
 
 namespace Microsoft.Health.Fhir.Api.Features.Audit

--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditLogger.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditLogger.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Core.Features.Audit;
 using Microsoft.Health.Fhir.Core.Configs;
+using Microsoft.Health.Fhir.Core.Features.Audit;
 
 namespace Microsoft.Health.Fhir.Api.Features.Audit
 {

--- a/src/Microsoft.Health.Fhir.Api/Modules/AuditModule.cs
+++ b/src/Microsoft.Health.Fhir.Api/Modules/AuditModule.cs
@@ -10,6 +10,7 @@ using Microsoft.Health.Api.Features.Audit;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Api.Controllers;
 using Microsoft.Health.Fhir.Api.Features.Audit;
+using Microsoft.Health.Fhir.Core.Features.Audit;
 
 namespace Microsoft.Health.Fhir.Api.Modules
 {

--- a/src/Microsoft.Health.Fhir.Core/Features/Audit/AuditLogger.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Audit/AuditLogger.cs
@@ -12,9 +12,8 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Core.Features.Audit;
 using Microsoft.Health.Fhir.Core.Configs;
-using Microsoft.Health.Fhir.Core.Features.Audit;
 
-namespace Microsoft.Health.Fhir.Api.Features.Audit
+namespace Microsoft.Health.Fhir.Core.Features.Audit
 {
     /// <summary>
     /// Provides mechanism to log the audit event using default logger.

--- a/src/Microsoft.Health.Fhir.Core/Features/Audit/IAuditLogger.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Audit/IAuditLogger.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 using System.Net;
 using Microsoft.Health.Core.Features.Audit;
 
-namespace Microsoft.Health.Fhir.Api.Features.Audit
+namespace Microsoft.Health.Fhir.Core.Features.Audit
 {
     /// <summary>
     /// Provides mechanism to log audit event.

--- a/src/Microsoft.Health.Fhir.R4.Core/Microsoft.Health.Fhir.R4.Core.csproj
+++ b/src/Microsoft.Health.Fhir.R4.Core/Microsoft.Health.Fhir.R4.Core.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="AngleSharp" />
     <PackageReference Include="Ensure.That" />
     <PackageReference Include="FluentValidation" />
-    <PackageReference Include="Hl7.Fhir.Specification.R4" PrivateAssets="build;analyzers"/>
+    <PackageReference Include="Hl7.Fhir.Specification.R4" PrivateAssets="build;analyzers" />
     <PackageReference Include="MediatR" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
     <PackageReference Include="Microsoft.Extensions.Http" />

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Audit/AuditHelperTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Audit/AuditHelperTests.cs
@@ -13,6 +13,7 @@ using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Core.Features.Security;
 using Microsoft.Health.Fhir.Api.Features.AnonymousOperations;
 using Microsoft.Health.Fhir.Api.Features.Audit;
+using Microsoft.Health.Fhir.Core.Features.Audit;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Fhir.ValueSets;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/AuditTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/AuditTestFixture.cs
@@ -4,7 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Health.Fhir.Api.Features.Audit;
+using Microsoft.Health.Fhir.Core.Features.Audit;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/StartupWithTraceAuditLogger.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/StartupWithTraceAuditLogger.cs
@@ -6,7 +6,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Health.Fhir.Api.Features.Audit;
+using Microsoft.Health.Fhir.Core.Features.Audit;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit
 {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/TraceAuditLogger.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/TraceAuditLogger.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using Microsoft.Health.Core.Features.Audit;
-using Microsoft.Health.Fhir.Api.Features.Audit;
+using Microsoft.Health.Fhir.Core.Features.Audit;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit
 {


### PR DESCRIPTION
## Description
Move IAuditLogger and AuditLogger to core project to use this interface in workspace-platform

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
