### PR TITLE
Adds more retries in CosmosQueueClient

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/QueueClientTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/QueueClientTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
     [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
     [Trait(Traits.Category, Categories.DataSourceValidation)]
-    [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]
+    [FhirStorageTestsFixtureArgumentSets(DataStore.All)]
     public class QueueClientTests : IClassFixture<FhirStorageTestsFixture>
     {
         private readonly ITestOutputHelper _testOutputHelper;
@@ -156,7 +156,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 new CancellationTokenSource());
             await Task.Delay(TimeSpan.FromSeconds(1));
             JobInfo jobInfo2 = await _queueClient.DequeueAsync(queueType, "test-worker", 0, CancellationToken.None);
-            Assert.Equal(jobInfo1.Result, jobInfo2.Result);
+
+            Assert.Equal(jobInfo1.Result, jobInfo2?.Result);
         }
 
         [Fact]


### PR DESCRIPTION
## Description
Adds more retries in CosmosQueueClient to improve behavior in Integration tests

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
