### PR TITLE
[Patient $everything] Adding validation to continuation tokens

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/EverythingControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/EverythingControllerTests.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
 {
     [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
     [Trait(Traits.Category, Categories.Search)]
+    [Trait(Traits.Category, Categories.PatientEverything)]
     public class EverythingControllerTests
     {
         private readonly EverythingController _everythingController;

--- a/src/Microsoft.Health.Fhir.Shared.Client/FhirClientException.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Client/FhirClientException.cs
@@ -76,16 +76,28 @@ namespace Microsoft.Health.Fhir.Client
                 message.Append(": ").Append(diagnostic);
             }
 
+            string contentResponse = "NO_CONTENT";
+            if (Response.Content != null)
+            {
+                contentResponse = Response.Content.ReadAsStringAsync().Result;
+            }
+
+            string contentRequest = "NO_REQUEST";
+            if (Response.Response.RequestMessage.Content != null)
+            {
+                contentRequest = Response.Response.RequestMessage.Content.ReadAsStringAsync().Result;
+            }
+
             message.Append(" (").Append(operationId).AppendLine(")");
 
             message.AppendLine("==============================================");
             message.Append("Url: (").Append(Response.Response.RequestMessage?.Method.Method ?? "NO_HTTP_METHOD_AVAILABLE").Append(") ").AppendLine(Response.Response.RequestMessage?.RequestUri.ToString() ?? "NO_URI_AVAILABLE");
             message.Append("Response code: ").Append(Response.Response.StatusCode.ToString()).Append('(').Append((int)Response.Response.StatusCode).AppendLine(")");
             message.Append("Reason phrase: ").AppendLine(Response.Response.ReasonPhrase ?? "NO_REASON_PHRASE");
-            message.Append("Content: ").AppendLine(Response.Content?.ToString() ?? "NO_CONTENT");
-            message.Append("Request: ").AppendLine(Response.Response.RequestMessage.Content?.ToString() ?? "NO_REQUEST");
             message.Append("Timestamp: ").AppendLine(DateTime.UtcNow.ToString("o"));
             message.Append("Health Check Result: ").Append(HealthCheckResult.ToString()).Append('(').Append((int)HealthCheckResult).AppendLine(")");
+            message.Append("Content: ").AppendLine(contentResponse);
+            message.Append("Request: ").AppendLine(contentRequest);
             message.AppendLine("==============================================");
 
             return message.ToString();

--- a/src/Microsoft.Health.Fhir.Shared.Client/FhirClientException.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Client/FhirClientException.cs
@@ -76,16 +76,30 @@ namespace Microsoft.Health.Fhir.Client
                 message.Append(": ").Append(diagnostic);
             }
 
-            string contentResponse = "NO_CONTENT";
-            if (Response.Content != null)
+            string responseInfo = "NO_RESPONSEINFO";
+            try
             {
-                contentResponse = Response.Content.ReadAsStringAsync().Result;
+                if (Response.Content != null)
+                {
+                    responseInfo = Response.Content.ReadAsStringAsync().Result;
+                }
+            }
+            catch (ObjectDisposedException)
+            {
+                responseInfo = "RESPONSEINFO_ALREADY_DISPOSED";
             }
 
-            string contentRequest = "NO_REQUEST";
-            if (Response.Response.RequestMessage.Content != null)
+            string requestInfo = "NO_REQUESTINFO";
+            try
             {
-                contentRequest = Response.Response.RequestMessage.Content.ReadAsStringAsync().Result;
+                if (Response.Response.RequestMessage.Content != null)
+                {
+                    requestInfo = Response.Response.RequestMessage.Content.ReadAsStringAsync().Result;
+                }
+            }
+            catch (ObjectDisposedException)
+            {
+                requestInfo = "REQUESTINFO_ALREADY_DISPOSED";
             }
 
             message.Append(" (").Append(operationId).AppendLine(")");
@@ -96,8 +110,8 @@ namespace Microsoft.Health.Fhir.Client
             message.Append("Reason phrase: ").AppendLine(Response.Response.ReasonPhrase ?? "NO_REASON_PHRASE");
             message.Append("Timestamp: ").AppendLine(DateTime.UtcNow.ToString("o"));
             message.Append("Health Check Result: ").Append(HealthCheckResult.ToString()).Append('(').Append((int)HealthCheckResult).AppendLine(")");
-            message.Append("Content: ").AppendLine(contentResponse);
-            message.Append("Request: ").AppendLine(contentRequest);
+            message.Append("Response Info: ").AppendLine(responseInfo);
+            message.Append("Request Info: ").AppendLine(requestInfo);
             message.AppendLine("==============================================");
 
             return message.ToString();

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/EverythingOperationContinuationTokenTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/EverythingOperationContinuationTokenTests.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Everything
 {
     [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
     [Trait(Traits.Category, Categories.Search)]
+    [Trait(Traits.Category, Categories.PatientEverything)]
     public class EverythingOperationContinuationTokenTests
     {
         [Fact]

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/PatientEverythingServiceTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Everything/PatientEverythingServiceTests.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Everything
 {
     [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
     [Trait(Traits.Category, Categories.Search)]
+    [Trait(Traits.Category, Categories.PatientEverything)]
     public class PatientEverythingServiceTests
     {
         private readonly IModelInfoProvider _modelInfoProvider = Substitute.For<IModelInfoProvider>();

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
                 case 0:
                     searchResult = await SearchIncludes(resourceId, parentPatientId, since, types, token, cancellationToken);
 
-                    if (!searchResult.Results.Any())
+                    if (!searchResult.Results.Any() && string.IsNullOrEmpty(searchResult.ContinuationToken))
                     {
                         phase = 1;
                         goto case 1;
@@ -144,7 +144,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
                     }
 
                     searchResult = await SearchCompartmentWithDate(resourceId, start, end, since, types, encodedInternalContinuationToken, cancellationToken);
-                    if (!searchResult.Results.Any())
+                    if (!searchResult.Results.Any() && string.IsNullOrEmpty(searchResult.ContinuationToken))
                     {
                         phase = 2;
                         goto case 2;
@@ -162,7 +162,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
                     // Previous versions of FHIR should still query for "Devices" explicitly.
                     if (_modelInfoProvider.Version < FhirSpecification.R5)
                     {
-                        if (!searchResult.Results.Any())
+                        if (!searchResult.Results.Any() && string.IsNullOrEmpty(searchResult.ContinuationToken))
                         {
                             phase = 3;
                             goto case 3;

--- a/src/Microsoft.Health.Fhir.Tests.Common/Categories.cs
+++ b/src/Microsoft.Health.Fhir.Tests.Common/Categories.cs
@@ -21,6 +21,11 @@ namespace Microsoft.Health.Fhir.Tests.Common
 
         public const string ConditionalOperations = nameof(ConditionalOperations);
 
+        /// <summary>
+        /// Set of tests validating FHIR domain related logic.
+        /// </summary>
+        public const string Conformance = nameof(Conformance);
+
         public const string ConvertData = nameof(ConvertData);
 
         public const string Cors = nameof(Cors);
@@ -39,11 +44,6 @@ namespace Microsoft.Health.Fhir.Tests.Common
         /// Set of tests validating data source functionalities (like, SQL, Cosmos, Storage Accounts).
         /// </summary>
         public const string DataSourceValidation = nameof(DataSourceValidation);
-
-        /// <summary>
-        /// Set of tests validating FHIR domain related logic.
-        /// </summary>
-        public const string Conformance = nameof(Conformance);
 
         public const string DomainLogicValidation = nameof(DomainLogicValidation);
 
@@ -64,6 +64,8 @@ namespace Microsoft.Health.Fhir.Tests.Common
         public const string Operations = nameof(Operations);
 
         public const string Patch = nameof(Patch);
+
+        public const string PatientEverything = nameof(PatientEverything);
 
         public const string Schema = nameof(Schema);
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/EverythingOperationTests.cs
@@ -23,7 +23,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
     [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
     [Trait(Traits.Category, Categories.Search)]
-    [Trait(Traits.Category, Categories.CompartmentSearch)]
+    [Trait(Traits.Category, Categories.PatientEverything)]
+    [Trait(Traits.Category, Categories.CompartmentSearch)] // Patient $everything calls Compartment Search internally.
     [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.All)]
     public class EverythingOperationTests : SearchTestsBase<EverythingOperationTestFixture>
     {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SearchTestsBase.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SearchTestsBase.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 allResourcesReturned.AddRange(fhirBundleResponse.Resource.Entry.Select(e => e.Resource));
                 queryUrl = fhirBundleResponse.Resource.NextLink?.ToString();
             }
-            while (queryUrl != null);
+            while (!string.IsNullOrWhiteSpace(queryUrl));
 
             if (numberOfResourcesIsGreaterThanExpected)
             {


### PR DESCRIPTION
Adding validation to continuation tokens, to include any possible additional page with results.

## Description
For a Gen1 FHIR account, in the case results are split into more than one partition, it's possible that the first page can be blank, while the second page has results. To ensure that Patient $everything includes the results from the second page. I'm adding a validation that checks for not ignoring the Continuation Token returned in those casea. 

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
