### PR TITLE
Add metadata to health check

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Configs/ExportJobConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/ExportJobConfiguration.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Health.Fhir.Core.Configs
         /// <summary>
         /// Controls how many resources will be returned for each search query while exporting the data.
         /// </summary>
-        public uint MaximumNumberOfResourcesPerQuery { get; set; } = 50000;
+        public uint MaximumNumberOfResourcesPerQuery { get; set; } = 10;
 
         /// <summary>
         /// Number of pages to be iterated before committing the export progress.

--- a/src/Microsoft.Health.Fhir.Core/Configs/ExportJobConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/ExportJobConfiguration.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Health.Fhir.Core.Configs
         /// <summary>
         /// Controls how many resources will be returned for each search query while exporting the data.
         /// </summary>
-        public uint MaximumNumberOfResourcesPerQuery { get; set; } = 10;
+        public uint MaximumNumberOfResourcesPerQuery { get; set; } = 50000;
 
         /// <summary>
         /// Number of pages to be iterated before committing the export progress.

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/ConformanceHealthCheck.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/ConformanceHealthCheck.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
                 }
                 else
                 {
-                    _logger.LogWarning("Capability statement was null.");
+                    _logger.LogError("Capability statement was null.");
 
                     return HealthCheckResult.Unhealthy("Failed to retrieve the capability statement.");
                 }
@@ -58,13 +58,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
                     return HealthCheckResult.Healthy("Successfully retrieved the capability statement.");
                 }
 
-                _logger.LogWarning(ex, "Failed to retrieve the capability statement.");
+                _logger.LogError(ex, "Failed to retrieve the capability statement.");
 
                 return HealthCheckResult.Unhealthy("Failed to retrieve the capability statement.");
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Failed to retrieve the capability statement.");
+                _logger.LogError(ex, "Failed to retrieve the capability statement.");
 
                 return HealthCheckResult.Unhealthy("Failed to retrieve the capability statement.");
             }

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/ConformanceHealthCheck.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/ConformanceHealthCheck.cs
@@ -1,0 +1,61 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EnsureThat;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Health.Fhir.Core.Features.Conformance
+{
+    public class ConformanceHealthCheck : IHealthCheck
+    {
+        private readonly IConformanceProvider _systemConformanceProvider;
+        private readonly ILogger<ConformanceHealthCheck> _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CosmosHealthCheck"/> class.
+        /// </summary>
+        /// <param name="systemConformanceProvider">The provider for the capability statement/</param>
+        /// <param name="logger">The logger.</param>
+        public ConformanceHealthCheck(
+            IConformanceProvider systemConformanceProvider,
+            ILogger<ConformanceHealthCheck> logger)
+        {
+            EnsureArg.IsNotNull(systemConformanceProvider, nameof(systemConformanceProvider));
+            EnsureArg.IsNotNull(logger, nameof(logger));
+
+            _systemConformanceProvider = systemConformanceProvider;
+            _logger = logger;
+        }
+
+        public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var metadata = await _systemConformanceProvider.GetMetadata(cancellationToken);
+
+                if (metadata != null)
+                {
+                    return HealthCheckResult.Healthy("Successfully retrieved the capability statement.");
+                }
+                else
+                {
+                    _logger.LogWarning("Capability statement was null.");
+
+                    return HealthCheckResult.Unhealthy("Failed to retrieve the capability statement.");
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to retrieve the capability statement.");
+
+                return HealthCheckResult.Unhealthy("Failed to retrieve the capability statement.");
+            }
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/ConformanceHealthCheck.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/ConformanceHealthCheck.cs
@@ -50,6 +50,18 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
                     return HealthCheckResult.Unhealthy("Failed to retrieve the capability statement.");
                 }
             }
+            catch (ArgumentNullException ex)
+            {
+                if (ex.StackTrace.Contains("UrlHelperFactory", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    // If the metadata document hasn't been initialized yet before health check is called the Url Helper factory will not have an action context from this call. The system is still healthy.
+                    return HealthCheckResult.Healthy("Successfully retrieved the capability statement.");
+                }
+
+                _logger.LogWarning(ex, "Failed to retrieve the capability statement.");
+
+                return HealthCheckResult.Unhealthy("Failed to retrieve the capability statement.");
+            }
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "Failed to retrieve the capability statement.");

--- a/src/Microsoft.Health.Fhir.Core/Microsoft.Health.Fhir.Core.csproj
+++ b/src/Microsoft.Health.Fhir.Core/Microsoft.Health.Fhir.Core.csproj
@@ -42,6 +42,7 @@
     <PackageReference Include="MediatR" />
     <PackageReference Include="Microsoft.AspNetCore.JsonPatch" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Logging" />

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs
@@ -131,6 +131,9 @@ namespace Microsoft.Health.Fhir.Api.Modules
                 .AsSelf()
                 .AsImplementedInterfaces();
 
+            services.AddHealthChecks()
+                .AddCheck<ConformanceHealthCheck>(name: "MetadataHealthCheck");
+
             services.TypesInSameAssembly(KnownAssemblies.All)
                 .AssignableTo<IProvideCapability>()
                 .Transient()


### PR DESCRIPTION
## Description
Adds a check to make sure the metadata document is available to the health check. Since the capabilities statement (aka metadata) is required by most endpoints if it is not available the service should be marked as unhealthy.

## Related issues
Addresses [issue #].

## Testing
Manual.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
