### PR TITLE
default throttling values for both cosmosdb and sqlserver

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Throttling/ThrottlingMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Throttling/ThrottlingMiddleware.cs
@@ -88,17 +88,14 @@ namespace Microsoft.Health.Fhir.Api.Features.Throttling
             }
 
             // snapshot the configuration values to reduce the number of instructions that need to execute in the lock.
+            _concurrentRequestLimit = configuration.ConcurrentRequestLimit;
             if (_baseConfiguration["DataStore"].Equals(KnownDataStores.CosmosDb, StringComparison.OrdinalIgnoreCase))
             {
-                _concurrentRequestLimit = Math.Max(configuration.ConcurrentRequestLimit, (int)ThrottlingLimitDefault.Gen1);
+                _concurrentRequestLimit = Math.Max(_concurrentRequestLimit, (int)ThrottlingLimitDefault.Gen1);
             }
             else if (_baseConfiguration["DataStore"].Equals(KnownDataStores.SqlServer, StringComparison.OrdinalIgnoreCase))
             {
-                _concurrentRequestLimit = Math.Max(configuration.ConcurrentRequestLimit, (int)ThrottlingLimitDefault.Gen2);
-            }
-            else
-            {
-                _concurrentRequestLimit = configuration.ConcurrentRequestLimit;
+                _concurrentRequestLimit = Math.Max(_concurrentRequestLimit, (int)ThrottlingLimitDefault.Gen2);
             }
 
             _maxMillisecondsInQueue = configuration.MaxMillisecondsInQueue;

--- a/src/Microsoft.Health.Fhir.Api/Features/Throttling/ThrottlingMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Throttling/ThrottlingMiddleware.cs
@@ -90,11 +90,11 @@ namespace Microsoft.Health.Fhir.Api.Features.Throttling
             // snapshot the configuration values to reduce the number of instructions that need to execute in the lock.
             if (_baseConfiguration["DataStore"].Equals(KnownDataStores.CosmosDb, StringComparison.OrdinalIgnoreCase))
             {
-                _concurrentRequestLimit = configuration.ConcurrentRequestLimit == 0 ? (int)ThrottlingLimitDefault.Gen1 : Math.Max(configuration.ConcurrentRequestLimit, (int)ThrottlingLimitDefault.Gen1);
+                _concurrentRequestLimit = Math.Max(configuration.ConcurrentRequestLimit, (int)ThrottlingLimitDefault.Gen1);
             }
             else if (_baseConfiguration["DataStore"].Equals(KnownDataStores.SqlServer, StringComparison.OrdinalIgnoreCase))
             {
-                _concurrentRequestLimit = configuration.ConcurrentRequestLimit == 0 ? (int)ThrottlingLimitDefault.Gen2 : Math.Max(configuration.ConcurrentRequestLimit, (int)ThrottlingLimitDefault.Gen2);
+                _concurrentRequestLimit = Math.Max(configuration.ConcurrentRequestLimit, (int)ThrottlingLimitDefault.Gen2);
             }
             else
             {

--- a/src/Microsoft.Health.Fhir.Core/Features/KnownDataStores.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/KnownDataStores.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-namespace Microsoft.Health.Fhir.Web
+namespace Microsoft.Health.Fhir.Core.Features
 {
     public static class KnownDataStores
     {

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/ThrottlingLimitDefault.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/ThrottlingLimitDefault.cs
@@ -1,0 +1,13 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Fhir.Core.Features.Operations
+{
+    public enum ThrottlingLimitDefault
+    {
+        Gen1 = 15,
+        Gen2 = 75,
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Throttling/ThrottlingMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Throttling/ThrottlingMiddlewareTests.cs
@@ -17,6 +17,7 @@ using Hl7.Fhir.Serialization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -84,6 +85,7 @@ namespace Microsoft.Health.Fhir.Shared.Api.UnitTests.Features.Throttling
                             x.Response.StatusCode = StatusCodes.Status408RequestTimeout;
                         }
                     },
+                    Substitute.For<IConfiguration>(),
                     Options.Create(_throttlingConfiguration),
                     Options.Create(new SecurityConfiguration { Enabled = _securityEnabled }),
                     NullLogger<ThrottlingMiddleware>.Instance));
@@ -234,6 +236,7 @@ namespace Microsoft.Health.Fhir.Shared.Api.UnitTests.Features.Throttling
         {
             var throttlingMiddleware = new ThrottlingMiddleware(
                 context => throw new RequestRateExceededException(TimeSpan.FromSeconds(1)),
+                Substitute.For<IConfiguration>(),
                 Options.Create(_throttlingConfiguration),
                 Options.Create(new SecurityConfiguration()),
                 NullLogger<ThrottlingMiddleware>.Instance);
@@ -250,6 +253,7 @@ namespace Microsoft.Health.Fhir.Shared.Api.UnitTests.Features.Throttling
         {
             var throttlingMiddleware = new ThrottlingMiddleware(
                 context => throw new RequestRateExceededException(TimeSpan.FromSeconds(1)),
+                Substitute.For<IConfiguration>(),
                 Options.Create(_throttlingConfiguration),
                 Options.Create(new SecurityConfiguration()),
                 NullLogger<ThrottlingMiddleware>.Instance);

--- a/src/Microsoft.Health.Fhir.Shared.Web/Microsoft.Health.Fhir.Shared.Web.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Web/Microsoft.Health.Fhir.Shared.Web.projitems
@@ -14,7 +14,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)DevelopmentIdentityProviderConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DevelopmentIdentityProviderRegistrationExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DevelopmentIdentityProviderUserConfiguration.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)KnownDataStores.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Program.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PrometheusMetricsConfig.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PrometheusMetricsApplicationBuilderExtensions.cs" />

--- a/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
@@ -20,7 +19,6 @@ using Microsoft.Health.Fhir.Azure;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export;
-using Microsoft.Health.Fhir.Core.Features.Operations.Import;
 using Microsoft.Health.Fhir.Shared.Web;
 using Microsoft.Health.JobManagement;
 using Microsoft.Health.SqlServer.Configs;


### PR DESCRIPTION
## Description
This allows a default value for the throttling middleware for both cosmosdb and sqlserver to be set.

## Related issues
Addresses [issue #100374](https://microsofthealth.visualstudio.com/Health/_workitems/edit/100374).

## Testing
Successfully ran all tests in ThrottlingMiddlewareTests.cs

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
