### PR TITLE
[Hotfix] Null reference fix and new logs

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/SystemConformanceProvider.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/SystemConformanceProvider.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
@@ -25,21 +26,27 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
     public sealed class SystemConformanceProvider
         : ConformanceProviderBase, IConfiguredConformanceProvider, INotificationHandler<RebuildCapabilityStatement>, IAsyncDisposable
     {
+#pragma warning disable CA2213 // Disposable fields should be disposed // SystemConformanceProvider is a Singleton class.
+        private readonly SemaphoreSlim _defaultCapabilitySemaphore = new SemaphoreSlim(1, 1);
+        private readonly SemaphoreSlim _metadataSemaphore = new SemaphoreSlim(1, 1);
+#pragma warning restore CA2213 // Disposable fields should be disposed // SystemConformanceProvider is a Singleton class.
+
+        private readonly TimeSpan _backgroundLoopLoggingInterval = TimeSpan.FromMinutes(10);
         private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
         private readonly int _rebuildDelay = 240; // 4 hours in minutes
         private readonly IModelInfoProvider _modelInfoProvider;
         private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager;
         private readonly Func<IScoped<IEnumerable<IProvideCapability>>> _capabilityProviders;
-        private ResourceElement _listedCapabilityStatement;
-        private ResourceElement _metadata;
-        private ICapabilityStatementBuilder _builder;
-        private Task _rebuilder;
-        private static SemaphoreSlim _defaultCapabilitySemaphore = new SemaphoreSlim(1, 1);
-        private static SemaphoreSlim _metadataSemaphore = new SemaphoreSlim(1, 1);
         private readonly List<Action<ListedCapabilityStatement>> _configurationUpdates = new List<Action<ListedCapabilityStatement>>();
         private readonly IOptions<CoreFeatureConfiguration> _configuration;
         private readonly ISupportedProfilesStore _supportedProfiles;
         private readonly ILogger _logger;
+
+        private ResourceElement _listedCapabilityStatement;
+        private ResourceElement _metadata;
+        private ICapabilityStatementBuilder _builder;
+        private Task _rebuilder;
+        private bool _disposed;
 
         public SystemConformanceProvider(
             IModelInfoProvider modelInfoProvider,
@@ -62,12 +69,20 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
             _configuration = configuration;
             _supportedProfiles = supportedProfiles;
             _logger = logger;
+            _disposed = false;
         }
 
         public override async Task<ResourceElement> GetCapabilityStatementOnStartup(CancellationToken cancellationToken = default(CancellationToken))
         {
+            if (_disposed)
+            {
+                _logger.LogError("SystemConformanceProvider is already disposed.");
+            }
+
             if (_listedCapabilityStatement == null)
             {
+                _logger.LogInformation("SystemConformanceProvider: Initializing new Capability Statement.");
+
                 await _defaultCapabilitySemaphore.WaitAsync(cancellationToken);
 
                 try
@@ -78,9 +93,24 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
 
                         using (IScoped<IEnumerable<IProvideCapability>> providerFactory = _capabilityProviders())
                         {
-                            foreach (IProvideCapability provider in providerFactory.Value)
+                            IEnumerable<IProvideCapability> providers = providerFactory.Value;
+                            foreach (IProvideCapability provider in providers)
                             {
-                                provider.Build(_builder);
+                                Stopwatch watch = Stopwatch.StartNew();
+                                try
+                                {
+                                    _logger.LogInformation("SystemConformanceProvider: Building Capability Statement. Provider '{ProviderName}'.", provider.ToString());
+                                    provider.Build(_builder);
+                                }
+                                catch (Exception e)
+                                {
+                                    _logger.LogError(e, "SystemConformanceProvider: Failed running '{ProviderName}' when building a new CapabilityStatement.", provider.ToString());
+                                    throw;
+                                }
+                                finally
+                                {
+                                    _logger.LogInformation("SystemConformanceProvider: Building Capability Statement. Provider '{ProviderName}' completed. Elapsed time {ElapsedTime}.", provider.ToString(), watch.Elapsed);
+                                }
                             }
                         }
 
@@ -108,13 +138,26 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
         {
             while (!_cancellationTokenSource.IsCancellationRequested)
             {
+                Stopwatch sw = Stopwatch.StartNew();
                 for (int i = 0; i < _rebuildDelay; i++)
                 {
                     await Task.Delay(TimeSpan.FromMinutes(1));
 
+                    if (_disposed)
+                    {
+                        _logger.LogError("SystemConformanceProvider is already disposed. SystemConformanceProvider's BackgroudLoop is completed.");
+                    }
+
                     if (_cancellationTokenSource.IsCancellationRequested)
                     {
+                        _logger.LogInformation("SystemConformanceProvider's BackgroudLoop is canceled.");
                         return;
+                    }
+
+                    if (sw.Elapsed >= _backgroundLoopLoggingInterval)
+                    {
+                        _logger.LogInformation("SystemConformanceProvider's BackgroudLoop is active and running.");
+                        sw.Restart();
                     }
                 }
 
@@ -153,6 +196,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
 
         public async ValueTask DisposeAsync()
         {
+            _logger.LogInformation("SystemConformanceProvider: DisposeAsync invoked.");
+
             if (!_cancellationTokenSource.IsCancellationRequested)
             {
                 _cancellationTokenSource.Cancel();
@@ -165,14 +210,22 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
 
             _cancellationTokenSource.Dispose();
             _rebuilder = null;
-            _defaultCapabilitySemaphore?.Dispose();
-            _defaultCapabilitySemaphore = null;
-            _metadataSemaphore?.Dispose();
-            _metadataSemaphore = null;
+
+            // Stopped disposing '_defaultCapabilitySemaphore' to validate a null reference in prod.
+            // Stopped disposing '_metadataSemaphore' to validate a null reference in prod.
+
+            _disposed = true;
+
+            _logger.LogInformation("SystemConformanceProvider: DisposeAsync completed.");
         }
 
         public async Task Handle(RebuildCapabilityStatement notification, CancellationToken cancellationToken)
         {
+            if (_disposed)
+            {
+                _logger.LogError("SystemConformanceProvider is already disposed.");
+            }
+
             EnsureArg.IsNotNull(notification, nameof(notification));
 
             _logger.LogInformation("SystemConformanceProvider: Rebuild capability statement notification handled");
@@ -206,6 +259,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
 
         public override async Task<ResourceElement> GetMetadata(CancellationToken cancellationToken = default)
         {
+            if (_disposed)
+            {
+                _logger.LogError("SystemConformanceProvider is already disposed.");
+            }
+
             // There is a chance that the BackgroundLoop handler sets _metadata to null between when it is checked and returned, so the value is stored in a local variable.
             ResourceElement metadata;
             if ((metadata = _metadata) != null)

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -630,14 +631,69 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
         {
             EnsureArg.IsNotNull(builder, nameof(builder));
 
-            builder.PopulateDefaultResourceInteractions()
-                .SyncSearchParameters()
-                .AddGlobalSearchParameters()
-                .SyncProfiles();
+            _logger.LogInformation("CosmosFhirDataStore. Building Capability Statement.");
+
+            Stopwatch watch = Stopwatch.StartNew();
+            try
+            {
+                builder = builder.PopulateDefaultResourceInteractions();
+                _logger.LogInformation("CosmosFhirDataStore. 'Default Resource Interactions' built. Elapsed: {ElapsedTime}. Memory: {MemoryInUse}.", watch.Elapsed, GC.GetTotalMemory(forceFullCollection: false));
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "CosmosFhirDataStore. 'Default Resource Interactions' failed. Elapsed: {ElapsedTime}. Memory: {MemoryInUse}.", watch.Elapsed, GC.GetTotalMemory(forceFullCollection: false));
+                throw;
+            }
+
+            try
+            {
+                watch = Stopwatch.StartNew();
+                builder = builder.SyncSearchParameters();
+                _logger.LogInformation("CosmosFhirDataStore. 'Search Parameters' built. Elapsed: {ElapsedTime}. Memory: {MemoryInUse}.", watch.Elapsed, GC.GetTotalMemory(forceFullCollection: false));
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "CosmosFhirDataStore. 'Search Parameters' failed. Elapsed: {ElapsedTime}. Memory: {MemoryInUse}.", watch.Elapsed, GC.GetTotalMemory(forceFullCollection: false));
+                throw;
+            }
+
+            try
+            {
+                watch = Stopwatch.StartNew();
+                builder = builder.AddGlobalSearchParameters();
+                _logger.LogInformation("CosmosFhirDataStore. 'Global Search Parameters' built. Elapsed: {ElapsedTime}. Memory: {MemoryInUse}.", watch.Elapsed, GC.GetTotalMemory(forceFullCollection: false));
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "CosmosFhirDataStore. 'Global Search Parameters' failed. Elapsed: {ElapsedTime}. Memory: {MemoryInUse}.", watch.Elapsed, GC.GetTotalMemory(forceFullCollection: false));
+                throw;
+            }
+
+            try
+            {
+                watch = Stopwatch.StartNew();
+                builder = builder.SyncProfiles();
+                _logger.LogInformation("CosmosFhirDataStore. 'Sync Profiles' built. Elapsed: {ElapsedTime}. Memory: {MemoryInUse}.", watch.Elapsed, GC.GetTotalMemory(forceFullCollection: false));
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "CosmosFhirDataStore. 'Sync Profiles' failed. Elapsed: {ElapsedTime}. Memory: {MemoryInUse}.", watch.Elapsed, GC.GetTotalMemory(forceFullCollection: false));
+                throw;
+            }
 
             if (_coreFeatures.SupportsBatch)
             {
-                builder.AddGlobalInteraction(SystemRestfulInteraction.Batch);
+                try
+                {
+                    watch = Stopwatch.StartNew();
+                    builder.AddGlobalInteraction(SystemRestfulInteraction.Batch);
+                    _logger.LogInformation("CosmosFhirDataStore. 'Global Interaction' built. Elapsed: {ElapsedTime}. Memory: {MemoryInUse}.", watch.Elapsed, GC.GetTotalMemory(forceFullCollection: false));
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError(e, "CosmosFhirDataStore. 'Global Interaction' failed. Elapsed: {ElapsedTime}. Memory: {MemoryInUse}.", watch.Elapsed, GC.GetTotalMemory(forceFullCollection: false));
+                    throw;
+                }
             }
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Security/SecurityProvider.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Security/SecurityProvider.cs
@@ -51,17 +51,25 @@ namespace Microsoft.Health.Fhir.Api.Features.Security
         {
             if (_securityConfiguration.Enabled)
             {
-                builder.Apply(statement =>
+                try
                 {
-                    if (_securityConfiguration.EnableAadSmartOnFhirProxy)
+                    builder.Apply(statement =>
                     {
-                        AddProxyOAuthSecurityService(statement, RouteNames.AadSmartOnFhirProxyAuthorize, RouteNames.AadSmartOnFhirProxyToken);
-                    }
-                    else
-                    {
-                        AddOAuthSecurityService(statement);
-                    }
-                });
+                        if (_securityConfiguration.EnableAadSmartOnFhirProxy)
+                        {
+                            AddProxyOAuthSecurityService(statement, RouteNames.AadSmartOnFhirProxyAuthorize, RouteNames.AadSmartOnFhirProxyToken);
+                        }
+                        else
+                        {
+                            AddOAuthSecurityService(statement);
+                        }
+                    });
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError(e, "SecurityProvider failed creating a new Capability Statement.");
+                    throw;
+                }
             }
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/OperationsModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/OperationsModule.cs
@@ -71,10 +71,6 @@ namespace Microsoft.Health.Fhir.Api.Modules
 
             services.AddSingleton<IReindexUtilities, ReindexUtilities>();
 
-            services.Add<OperationsCapabilityProvider>()
-                .Transient()
-                .AsService<IProvideCapability>();
-
             services.AddSingleton<IPatientEverythingService, PatientEverythingService>();
 
             services.Add<ImportResourceLoader>()


### PR DESCRIPTION
- Setting semaphores to be readonly attributes.
- Adding memory logs to CosmosFhirDataStore.
- Adding more logs.
- Removing additional Capability Provider declaration.

## Description
Describe the changes in this PR.

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [x] **Update the title** of the PR to be succinct and less than 65 characters
- [x] **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- [x] Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- [x] Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
