### PR TITLE
fix for a string getting identified as secrets by Guardian

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/AadSmartOnFhirProxyControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/AadSmartOnFhirProxyControllerTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 using System.Reflection;
+using System.Text;
 using System.Threading.Tasks;
 using System.Web;
 using Microsoft.AspNetCore.Mvc;
@@ -174,8 +175,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
         [InlineData("authorization_code", "clientId", null, null, null)]
         [InlineData("authorization_code", "clientId", "clientSecret", null, null)]
         [InlineData("authorization_code", "clientId", "clientSecret", "InvalidCode", null)]
-
-        // [InlineData("authorization_code", "clientId", "clientSecret", "xxxxxxxxxxxxxxxxxxxxxxxx", null)] // xxxxxxxxxxxxxxxxxxxxxxxx is { "code" : "foo" } base 64 encoded
+        [MemberData(nameof(GetInvalidQueryParamsData))]
         public async Task GivenInvalidQueryParams_WhenTokenRequestAction_ThenBadRequestExceptionThrown(
             string grantType, string clientId, string clientSecret, string compoundCode, string redirectUriString)
         {
@@ -194,6 +194,12 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
             };
 
             await Assert.ThrowsAsync<AadSmartOnFhirProxyBadRequestException>(() => _controller.Token(grantType, compoundCode, redirectUri, clientId, clientSecret));
+        }
+
+        public static IEnumerable<object[]> GetInvalidQueryParamsData()
+        {
+            var encoded = Convert.ToBase64String(Encoding.UTF8.GetBytes("{ \"code\" : \"foo\" }"));
+            yield return new object[] { "authorization_code", "clientId", "clientSecret", encoded, null };
         }
 
         [Theory]

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/AadSmartOnFhirProxyControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/AadSmartOnFhirProxyControllerTests.cs
@@ -159,14 +159,22 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
         }
 
         [Theory]
-        [InlineData("Zm9v", null, null, null)] // Zm9v is "foo" base64 encoded
-        [InlineData("aHR0cDovL3Rlc3QudXJs", null, null, null)] // aHR0cDovL3Rlc3QudXJs is "http://test.url" base64 encoded
-        [InlineData("aHR0cDovL3Rlc3QudXJs", "code", null, null)]
-        [InlineData("aHR0cDovL3Rlc3QudXJs", "code", "state", null)]
+        [MemberData(nameof(GetParamsDataForGivenInvalidQueryParams_WhenCallbackRequestAction_ThenBadRequestExceptionThrown))]
         public void GivenInvalidQueryParams_WhenCallbackRequestAction_ThenBadRequestExceptionThrown(
             string redirectUrl, string code, string state, string sessionState)
         {
-                Assert.Throws<AadSmartOnFhirProxyBadRequestException>(() => _controller.Callback(redirectUrl, code, state, sessionState, null, null));
+            Assert.Throws<AadSmartOnFhirProxyBadRequestException>(() => _controller.Callback(redirectUrl, code, state, sessionState, null, null));
+        }
+
+        public static IEnumerable<object[]> GetParamsDataForGivenInvalidQueryParams_WhenCallbackRequestAction_ThenBadRequestExceptionThrown()
+        {
+            var foo = Convert.ToBase64String(Encoding.UTF8.GetBytes("foo"));
+            var testUrl = Convert.ToBase64String(Encoding.UTF8.GetBytes("http://test.url"));
+
+            yield return new object[] { foo, null, null, null };
+            yield return new object[] { testUrl, null, null, null };
+            yield return new object[] { testUrl, "code", null, null };
+            yield return new object[] { testUrl, "code", "state", null };
         }
 
         [Theory]
@@ -175,7 +183,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
         [InlineData("authorization_code", "clientId", null, null, null)]
         [InlineData("authorization_code", "clientId", "clientSecret", null, null)]
         [InlineData("authorization_code", "clientId", "clientSecret", "InvalidCode", null)]
-        [MemberData(nameof(GetInvalidQueryParamsData))]
+        [MemberData(nameof(GetParamsDataForGivenInvalidQueryParams_WhenTokenRequestAction_ThenBadRequestExceptionThrown))]
         public async Task GivenInvalidQueryParams_WhenTokenRequestAction_ThenBadRequestExceptionThrown(
             string grantType, string clientId, string clientSecret, string compoundCode, string redirectUriString)
         {
@@ -196,7 +204,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
             await Assert.ThrowsAsync<AadSmartOnFhirProxyBadRequestException>(() => _controller.Token(grantType, compoundCode, redirectUri, clientId, clientSecret));
         }
 
-        public static IEnumerable<object[]> GetInvalidQueryParamsData()
+        public static IEnumerable<object[]> GetParamsDataForGivenInvalidQueryParams_WhenTokenRequestAction_ThenBadRequestExceptionThrown()
         {
             var encoded = Convert.ToBase64String(Encoding.UTF8.GetBytes("{ \"code\" : \"foo\" }"));
             yield return new object[] { "authorization_code", "clientId", "clientSecret", encoded, null };

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/AadSmartOnFhirProxyControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/AadSmartOnFhirProxyControllerTests.cs
@@ -159,14 +159,14 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
         }
 
         [Theory]
-        [MemberData(nameof(GetParamsDataForGivenInvalidQueryParams_WhenCallbackRequestAction_ThenBadRequestExceptionThrown))]
+        [MemberData(nameof(GetMultipleInvalidParams))]
         public void GivenInvalidQueryParams_WhenCallbackRequestAction_ThenBadRequestExceptionThrown(
             string redirectUrl, string code, string state, string sessionState)
         {
             Assert.Throws<AadSmartOnFhirProxyBadRequestException>(() => _controller.Callback(redirectUrl, code, state, sessionState, null, null));
         }
 
-        public static IEnumerable<object[]> GetParamsDataForGivenInvalidQueryParams_WhenCallbackRequestAction_ThenBadRequestExceptionThrown()
+        public static IEnumerable<object[]> GetMultipleInvalidParams()
         {
             var foo = Convert.ToBase64String(Encoding.UTF8.GetBytes("foo"));
             var testUrl = Convert.ToBase64String(Encoding.UTF8.GetBytes("http://test.url"));
@@ -183,7 +183,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
         [InlineData("authorization_code", "clientId", null, null, null)]
         [InlineData("authorization_code", "clientId", "clientSecret", null, null)]
         [InlineData("authorization_code", "clientId", "clientSecret", "InvalidCode", null)]
-        [MemberData(nameof(GetParamsDataForGivenInvalidQueryParams_WhenTokenRequestAction_ThenBadRequestExceptionThrown))]
+        [MemberData(nameof(GetInvalidParams))]
         public async Task GivenInvalidQueryParams_WhenTokenRequestAction_ThenBadRequestExceptionThrown(
             string grantType, string clientId, string clientSecret, string compoundCode, string redirectUriString)
         {
@@ -204,7 +204,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
             await Assert.ThrowsAsync<AadSmartOnFhirProxyBadRequestException>(() => _controller.Token(grantType, compoundCode, redirectUri, clientId, clientSecret));
         }
 
-        public static IEnumerable<object[]> GetParamsDataForGivenInvalidQueryParams_WhenTokenRequestAction_ThenBadRequestExceptionThrown()
+        public static IEnumerable<object[]> GetInvalidParams()
         {
             var encoded = Convert.ToBase64String(Encoding.UTF8.GetBytes("{ \"code\" : \"foo\" }"));
             yield return new object[] { "authorization_code", "clientId", "clientSecret", encoded, null };

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/AadSmartOnFhirProxyControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/AadSmartOnFhirProxyControllerTests.cs
@@ -159,14 +159,14 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
         }
 
         [Theory]
-        [MemberData(nameof(GetMultipleInvalidParams))]
+        [MemberData(nameof(GetParamsDataForGivenInvalidQueryParams_RedirectUrlCodeStateSession))]
         public void GivenInvalidQueryParams_WhenCallbackRequestAction_ThenBadRequestExceptionThrown(
             string redirectUrl, string code, string state, string sessionState)
         {
             Assert.Throws<AadSmartOnFhirProxyBadRequestException>(() => _controller.Callback(redirectUrl, code, state, sessionState, null, null));
         }
 
-        public static IEnumerable<object[]> GetMultipleInvalidParams()
+        public static IEnumerable<object[]> GetParamsDataForGivenInvalidQueryParams_RedirectUrlCodeStateSession()
         {
             var foo = Convert.ToBase64String(Encoding.UTF8.GetBytes("foo"));
             var testUrl = Convert.ToBase64String(Encoding.UTF8.GetBytes("http://test.url"));
@@ -183,7 +183,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
         [InlineData("authorization_code", "clientId", null, null, null)]
         [InlineData("authorization_code", "clientId", "clientSecret", null, null)]
         [InlineData("authorization_code", "clientId", "clientSecret", "InvalidCode", null)]
-        [MemberData(nameof(GetInvalidParams))]
+        [MemberData(nameof(GetParamsDataForGivenInvalidQueryParams_TokenCompoundCode))]
         public async Task GivenInvalidQueryParams_WhenTokenRequestAction_ThenBadRequestExceptionThrown(
             string grantType, string clientId, string clientSecret, string compoundCode, string redirectUriString)
         {
@@ -204,7 +204,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
             await Assert.ThrowsAsync<AadSmartOnFhirProxyBadRequestException>(() => _controller.Token(grantType, compoundCode, redirectUri, clientId, clientSecret));
         }
 
-        public static IEnumerable<object[]> GetInvalidParams()
+        public static IEnumerable<object[]> GetParamsDataForGivenInvalidQueryParams_TokenCompoundCode()
         {
             var encoded = Convert.ToBase64String(Encoding.UTF8.GetBytes("{ \"code\" : \"foo\" }"));
             yield return new object[] { "authorization_code", "clientId", "clientSecret", encoded, null };


### PR DESCRIPTION
## Description
Guardian identified a hardcoded base64 encoded string as a secret. This change will use the decoded version as the hardcoded string and send in the base64 version of it instead.

## Related issues
Addresses [issue #].

## Testing
Locally ran the tests that were revised. Although this isn't the same as what Guardian does.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
