### PR TITLE
Modify SQL query generator for Identifier special case

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/KnownQueryParameterNames.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/KnownQueryParameterNames.cs
@@ -89,5 +89,10 @@ namespace Microsoft.Health.Fhir.Core.Features
         public const string GlobalEndSurrogateId = "_globalEndSurrogateId";
 
         public const string IgnoreSearchParamHash = "_ignoreSearchParamHash";
+
+        /// <summary>
+        /// Frequently used SearchParameters
+        /// </summary>
+        public const string Identifier = "identifier";
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Models/KnownResourceTypes.cs
+++ b/src/Microsoft.Health.Fhir.Core/Models/KnownResourceTypes.cs
@@ -41,6 +41,8 @@ namespace Microsoft.Health.Fhir.Core.Models
 
         public const string Organization = "Organization";
 
+        public const string OrganizationAffiliation = "OrganizationAffiliation";
+
         public const string Parameters = "Parameters";
 
         public const string Practitioner = "Practitioner";

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/CustomQueriesUnitTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/CustomQueriesUnitTests.cs
@@ -1,0 +1,74 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Data;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Health.Fhir.SqlServer.Features.Search;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Test.Utilities;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search
+{
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.Search)]
+    public class CustomQueriesUnitTests
+    {
+        [Fact]
+        public void GivenCustomQueryClass_WithGivenWaitTime_QueryToDBWillOccurOnlyAfterWaitPeriod()
+        {
+            // reset the dictionary
+            CustomQueries.QueryStore.Clear();
+
+            // set wait time to 2 seconds;
+            CustomQueries.WaitTime = 1;
+
+            var connection = Substitute.For<IDbConnection>();
+            var command = Substitute.For<IDbCommand>();
+            var reader = Substitute.For<IDataReader>();
+            reader.Read().Returns(false);
+            command.ExecuteReader().Returns(reader);
+            connection.CreateCommand().Returns(command);
+
+            var logger = NullLogger<SqlServerSearchService>.Instance;
+
+            CustomQueries.CheckQueryHash(connection, "hash", logger);
+            CustomQueries.CheckQueryHash(connection, "hash", logger);
+            CustomQueries.CheckQueryHash(connection, "hash", logger);
+            Task.Delay(1100).Wait();
+
+            CustomQueries.CheckQueryHash(connection, "hash", logger);
+
+            connection.Received(2).CreateCommand();
+        }
+
+        [Fact]
+        public void GivenCustomQueryClass_WithGivenSprocName_DictionaryWillPopulateCorrectly()
+        {
+            // reset the dictionary
+            CustomQueries.QueryStore.Clear();
+
+            // set wait time to 2 seconds;
+            CustomQueries.WaitTime = 1;
+            Task.Delay(1100).Wait();
+
+            var connection = Substitute.For<IDbConnection>();
+            var command = Substitute.For<IDbCommand>();
+            var reader = Substitute.For<IDataReader>();
+            reader.Read().Returns(x => true, x => true, x => true, x => true, x => false);
+            reader.GetString(0).Returns(x => "CustomQuery_hash1", x => throw new System.Exception(), x => "badData", x => "CustomQuery_hash2");
+            command.ExecuteReader().Returns(reader);
+            connection.CreateCommand().Returns(command);
+
+            var logger = NullLogger<SqlServerSearchService>.Instance;
+
+            Assert.Null(CustomQueries.CheckQueryHash(connection, "hash2", logger));
+            Assert.Equal("CustomQuery_hash1", CustomQueries.CheckQueryHash(connection, "hash1", logger));
+            Assert.Equal("CustomQuery_hash2", CustomQueries.CheckQueryHash(connection, "hash2", logger));
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/CustomQueries.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/CustomQueries.cs
@@ -1,0 +1,55 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+using Microsoft.Health.Core;
+
+namespace Microsoft.Health.Fhir.SqlServer.Features.Search
+{
+    internal static class CustomQueries
+    {
+        private static DateTimeOffset _lastUpdatedQueryCache = DateTimeOffset.MinValue;
+        public static readonly Dictionary<string, string> QueryStore = new Dictionary<string, string>();
+
+        public static string CheckQueryHash(SqlConnection connection, string hash, ILogger<SqlServerSearchService> logger)
+        {
+            var now = Clock.UtcNow;
+            if (now > _lastUpdatedQueryCache.AddMinutes(1))
+            {
+                using (SqlCommand sqlCommand = connection.CreateCommand()) // WARNING, this code will not set sqlCommand.Transaction. Sql transactions via C#/.NET are not supported in this method.
+                {
+                    try
+                    {
+                        sqlCommand.CommandText = "SELECT ROUTINE_NAME FROM INFORMATION_SCHEMA.ROUTINES WHERE ROUTINE_TYPE = 'PROCEDURE' AND ROUTINE_NAME like 'CustomQuery_%'";
+                        using (SqlDataReader reader = sqlCommand.ExecuteReader())
+                        {
+                            if (reader.Read())
+                            {
+                                string sprocName = reader.GetString(0);
+                                var tokens = sprocName.Split('_');
+                                if (tokens.Length == 2)
+                                {
+                                    QueryStore.Add(tokens[1], sprocName);
+                                }
+                            }
+                        }
+
+                        _lastUpdatedQueryCache = now;
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogWarning("Error refreshing CustomQuery cache.  This will try again on next search execution.  Error: {ExceptionMessage}", ex.Message);
+                    }
+                }
+            }
+
+            QueryStore.TryGetValue(hash, out var storedProcName);
+            return storedProcName;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/CustomQueries.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/CustomQueries.cs
@@ -4,7 +4,6 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
 using Microsoft.Extensions.Logging;
@@ -16,7 +15,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
     {
         private static DateTimeOffset _lastUpdatedQueryCache = DateTimeOffset.MinValue;
         private static object lockObject = new object();
-        public static readonly ConcurrentDictionary<string, string> QueryStore = new ConcurrentDictionary<string, string>();
+
+        public static Dictionary<string, string> QueryStore { get; set; } = new Dictionary<string, string>();
 
         public static int WaitTime { get; set; } = 60;
 
@@ -48,11 +48,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                                     }
                                 }
 
-                                QueryStore.Clear();
-                                foreach (var item in tempQueryStore)
-                                {
-                                    QueryStore.TryAdd(item.Key, item.Value);
-                                }
+                                QueryStore = tempQueryStore;
 
                                 _lastUpdatedQueryCache = now;
                             }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/ISqlQueryHashCalculator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/ISqlQueryHashCalculator.cs
@@ -1,0 +1,17 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Fhir.SqlServer.Features.Search
+{
+    public interface ISqlQueryHashCalculator
+    {
+        /// <summary>
+        /// Given a string that represents a SQL query, this returns the calculated hash of that query.
+        /// </summary>
+        /// <param name="query">The SQL query as text</param>
+        /// <returns>A string hash value.</returns>
+        string CalculateHash(string query);
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlQueryHashCalculator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlQueryHashCalculator.cs
@@ -1,0 +1,17 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Core.Extensions;
+
+namespace Microsoft.Health.Fhir.SqlServer.Features.Search
+{
+    internal class SqlQueryHashCalculator : ISqlQueryHashCalculator
+    {
+        public string CalculateHash(string query)
+        {
+            return query.ComputeHash();
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -362,7 +362,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
 
                             // Command text contains no direct user input.
 #pragma warning disable CA2100 // Review SQL queries for security vulnerabilities
-                            sqlCommand.CommandText = stringBuilder.ToString();
+                            sqlCommand.CommandText = queryText;
 #pragma warning restore CA2100 // Review SQL queries for security vulnerabilities
                         }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -1078,14 +1078,19 @@ WHERE ResourceTypeId = @p0
         private static string RemoveParamHash(string queryText)
         {
             var lines = queryText.Split('\n');
-            if (lines[lines.Length - 2].StartsWith("/* HASH", StringComparison.OrdinalIgnoreCase))
+            for (var i = lines.Length - 1; i >= 0; i--)
             {
-                return string.Join('\n', lines.Take(lines.Length - 2));
+                if (string.IsNullOrWhiteSpace(lines[i]))
+                {
+                    continue;
+                }
+                else if (lines[i].StartsWith("/* HASH", StringComparison.OrdinalIgnoreCase))
+                {
+                    return string.Join('\n', lines.Take(i));
+                }
             }
-            else
-            {
-                return queryText;
-            }
+
+            return queryText;
         }
 
         // Class copied from src\Microsoft.Health.Fhir.SqlServer\Features\Schema\Model\VLatest.Generated.net7.0.cs .

--- a/src/Microsoft.Health.Fhir.SqlServer/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
@@ -68,6 +68,10 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AsSelf()
                 .AsImplementedInterfaces();
 
+            services.Add<SqlQueryHashCalculator>()
+                .Singleton()
+                .AsImplementedInterfaces();
+
             services.Add<SqlServerSearchService>()
                 .Scoped()
                 .AsSelf()

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Microsoft.Health.Fhir.Shared.Tests.Integration.projitems
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Microsoft.Health.Fhir.Shared.Tests.Integration.projitems
@@ -26,6 +26,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\Reindex\ReindexSearchTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\Import\SqlServerFhirDataBulkOperationTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Smart\SmartSearchTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlCustomQueryTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\FhirStorageVersioningPolicyTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SearchParameterStatusDataStoreTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlRetryServiceTests.cs" />

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Microsoft.Health.Fhir.Shared.Tests.Integration.projitems
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Microsoft.Health.Fhir.Shared.Tests.Integration.projitems
@@ -47,5 +47,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlServerSqlCompatibilityTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\QueueClientTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlServerTransactionScopeTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Persistence\TestSqlHashCalculator.cs" />
   </ItemGroup>
 </Project>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTestsFixture.cs
@@ -119,6 +119,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
         public RequestContextAccessor<IFhirRequestContext> FhirRequestContextAccessor => _fixture.GetRequiredService<RequestContextAccessor<IFhirRequestContext>>();
 
+        public TestSqlHashCalculator SqlQueryHashCalculator => _fixture.GetRequiredService<TestSqlHashCalculator>();
+
         public GetResourceHandler GetResourceHandler { get; set; }
 
         public IQueueClient QueueClient => _fixture.GetRequiredService<IQueueClient>();

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/ISqlServerFhirStorageTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/ISqlServerFhirStorageTestHelper.cs
@@ -5,6 +5,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using Microsoft.Health.SqlServer.Features.Schema;
 
 namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
@@ -33,5 +34,10 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         /// </summary>
         /// <param name="sql">SQL command text.</param>
         Task ExecuteSqlCmd(string sql);
+
+        /// <summary>
+        /// Returns a SQL connection.
+        /// </summary>
+        Task<SqlConnection> GetSqlConnectionAsync();
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlCustomQueryTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlCustomQueryTests.cs
@@ -1,0 +1,133 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
+using Microsoft.Health.Fhir.Core.Features.Search;
+using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.SqlServer.Features.Search;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
+{
+    /// <summary>
+    /// Tests which retrieve a custom stored procedure if one exists for a given
+    /// SQL query based on hash
+    /// </summary>
+    [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]
+    public class SqlCustomQueryTests : IClassFixture<FhirStorageTestsFixture>
+    {
+        private readonly FhirStorageTestsFixture _fixture;
+
+        public SqlCustomQueryTests(FhirStorageTestsFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [SkippableFact]
+        [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]
+        public async Task GivenASqlQuery_IfAStoredProcExistsWithMatchingHash_ThenStoredProcUsed()
+        {
+            Skip.If(
+                ModelInfoProvider.Instance.Version != FhirSpecification.R4B,
+                "This test is only valid for R4B");
+
+            // set the wait time to 1 second
+            CustomQueries.WaitTime = 1;
+
+            // Create a query with a known hash
+            var queryParameters = new[]
+            {
+                Tuple.Create("participating-organization.identifier", $"TAB%7C910000290"),
+                Tuple.Create(SearchParameterNames.Include, $"OrganizationAffiliation:location"),
+                Tuple.Create("participating-organization.type", $"practice"),
+            };
+
+            // Query before adding an sproc to the database
+            await _fixture.SearchService.SearchAsync(KnownResourceTypes.OrganizationAffiliation, queryParameters, CancellationToken.None);
+
+            // assert an sproc was not used
+            Assert.False(await CheckIfSprocUsed());
+
+            // add the sproc
+            AddSproc();
+
+            await Task.Delay(1100);
+
+            // Query after adding an sproc to the database
+            await _fixture.SearchService.SearchAsync(KnownResourceTypes.OrganizationAffiliation, queryParameters, CancellationToken.None);
+
+            // assert an sproc was not used
+            Assert.True(await CheckIfSprocUsed());
+        }
+
+        private async Task<bool> CheckIfSprocUsed()
+        {
+            using (SqlConnection conn = await _fixture.SqlHelper.GetSqlConnectionAsync())
+            {
+                conn.Open();
+                var cmd = conn.CreateCommand();
+                cmd.CommandText = "SELECT SCHEMA_NAME(sysobject.schema_id), OBJECT_NAME(stats.object_id),  stats.last_execution_time\r\n" +
+                    "FROM sys.dm_exec_procedure_stats stats\r\n" +
+                    "INNER JOIN sys.objects sysobject ON sysobject.object_id = stats.object_id\r\n" +
+                    "WHERE  sysobject.type = 'P'\r\n" +
+                    "and (sysobject.object_id = object_id('dbo.CustomQuery_C95055F62FB607F23A74902A21645D523475218EF4330D77F69F4CB1938A83E8') \r\n" +
+                    "OR sysobject.name = 'CustomQuery_C95055F62FB607F23A74902A21645D523475218EF4330D77F69F4CB1938A83E8')\r\n" +
+                    "ORDER BY stats.last_execution_time DESC  ";
+                var reader = cmd.ExecuteReader();
+                while (reader.Read())
+                {
+                    var text = reader.GetString(1);
+                    if (text.Contains("CustomQuery"))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private void AddSproc()
+        {
+            _fixture.SqlHelper.ExecuteSqlCmd(
+                "CREATE OR ALTER PROCEDURE [dbo].[CustomQuery_C95055F62FB607F23A74902A21645D523475218EF4330D77F69F4CB1938A83E8]\r\n" +
+                "(@p0 SmallInt, @p1 SmallInt, @p2 SmallInt, @p3 SmallInt, @p4 NVarChar(256), @p5 SmallInt, @p6 VarChar(256), @p7 Int, @p8 SmallInt, @p9 Int)\r\n" +
+                "AS\r\n" +
+                "BEGIN\r\n" +
+                "WITH cte0 AS\r\n(\r\n" +
+                "SELECT refSource.ResourceTypeId AS T1, refSource.ResourceSurrogateId AS Sid1, refTarget.ResourceTypeId AS T2, refTarget.ResourceSurrogateId AS Sid2 \r\n" +
+                "FROM dbo.ReferenceSearchParam refSource\r\n    INNER JOIN dbo.Resource refTarget\r\n    ON refSource.ReferenceResourceTypeId = refTarget.ResourceTypeId\r\n" +
+                "AND refSource.ReferenceResourceId = refTarget.ResourceId\r\n    WHERE refSource.SearchParamId = @p0\r\n        AND refTarget.IsHistory = 0\r\n" +
+                "AND refSource.IsHistory = 0\r\n        AND refSource.ResourceTypeId IN (@p1)\r\n        AND refSource.ReferenceResourceTypeId IN (@p2)\r\n" +
+                "AND refSource.ResourceTypeId = @p1\r\n),\r\ncte1 AS\r\n(\r\n    SELECT T1, Sid1, ResourceTypeId AS T2, \r\n    ResourceSurrogateId AS Sid2\r\n" +
+                "FROM dbo.TokenSearchParam\r\n    INNER JOIN cte0\r\n    ON ResourceTypeId = T2\r\n        AND ResourceSurrogateId = Sid2\r\n    WHERE IsHistory = 0\r\n" +
+                "AND SearchParamId = @p3\r\n        AND Code = @p4\r\n),\r\ncte2 AS\r\n(\r\n" +
+                "SELECT refSource.ResourceTypeId AS T1, refSource.ResourceSurrogateId AS Sid1, refTarget.ResourceTypeId AS T2, refTarget.ResourceSurrogateId AS Sid2 \r\n" +
+                "FROM dbo.ReferenceSearchParam refSource\r\n    INNER JOIN dbo.Resource refTarget\r\n    ON refSource.ReferenceResourceTypeId = refTarget.ResourceTypeId\r\n" +
+                "AND refSource.ReferenceResourceId = refTarget.ResourceId\r\n    WHERE refSource.SearchParamId = @p0\r\n        AND refTarget.IsHistory = 0\r\n" +
+                "AND refSource.IsHistory = 0\r\n        AND refSource.ResourceTypeId IN (@p1)\r\n        AND refSource.ReferenceResourceTypeId IN (@p2)\r\n " +
+                " AND EXISTS(SELECT * FROM cte1 WHERE refSource.ResourceTypeId = T1 AND refSource.ResourceSurrogateId = Sid1)\r\n        AND refSource.ResourceTypeId = @p1\r\n" +
+                "),\r\ncte3 AS\r\n(\r\n    SELECT T1, Sid1, ResourceTypeId AS T2, \r\n    ResourceSurrogateId AS Sid2\r\n    FROM dbo.TokenSearchParam\r\n    INNER JOIN cte2\r\n" +
+                "ON ResourceTypeId = T2\r\n        AND ResourceSurrogateId = Sid2\r\n    WHERE IsHistory = 0\r\n        AND SearchParamId = @p5\r\n        AND Code = @p6\r\n),\r\ncte4 AS\r\n" +
+                "(\r\n    SELECT ROW_NUMBER() OVER(ORDER BY T1 ASC, Sid1 ASC) AS Row, *\r\n    FROM\r\n    (\r\n        SELECT DISTINCT TOP (@p7) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial \r\n" +
+                "FROM cte3\r\n        ORDER BY T1 ASC, Sid1 ASC\r\n    ) t\r\n),\r\ncte5 AS\r\n(\r\n" +
+                "SELECT DISTINCT refTarget.ResourceTypeId AS T1, refTarget.ResourceSurrogateId AS Sid1, 0 AS IsMatch \r\n    FROM dbo.ReferenceSearchParam refSource\r\n" +
+                "INNER JOIN dbo.Resource refTarget\r\n    ON refSource.ReferenceResourceTypeId = refTarget.ResourceTypeId\r\n        AND refSource.ReferenceResourceId = refTarget.ResourceId\r\n" +
+                "WHERE refSource.SearchParamId = @p8\r\n        AND refTarget.IsHistory = 0\r\n        AND refSource.IsHistory = 0\r\n        AND refTarget.IsDeleted = 0\r\n" +
+                "AND refSource.ResourceTypeId IN (98)\r\n        AND EXISTS( SELECT * FROM cte4 WHERE refSource.ResourceTypeId = T1 AND refSource.ResourceSurrogateId = Sid1 AND Row < @p9)\r\n" +
+                "),\r\ncte6 AS\r\n(\r\n    SELECT DISTINCT T1, Sid1, IsMatch, 0 AS IsPartial \r\n    FROM cte5\r\n),\r\ncte7 AS\r\n(\r\n    SELECT T1, Sid1, IsMatch, IsPartial \r\n" +
+                "FROM cte4\r\n    UNION ALL\r\n    SELECT T1, Sid1, IsMatch, IsPartial\r\n    FROM cte6 WHERE NOT EXISTS (SELECT * FROM cte4 WHERE cte4.Sid1 = cte6.Sid1 AND cte4.T1 = cte6.T1)\r\n" +
+                ")\r\nSELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource\r\n" +
+                "FROM dbo.Resource r\r\n\r\nINNER JOIN cte7\r\nON r.ResourceTypeId = cte7.T1 AND \r\nr.ResourceSurrogateId = cte7.Sid1\r\n" +
+                "ORDER BY IsMatch DESC, r.ResourceTypeId ASC, r.ResourceSurrogateId ASC\r\n OPTION (OPTIMIZE FOR UNKNOWN)\r\n/* HASH yWa2X9xny4iE6Z6Qe/XNkbgqhUX+qwWjXLgRz9r7E0I= */" +
+                "END");
+        }
+    }
+}

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlCustomQueryTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlCustomQueryTests.cs
@@ -10,7 +10,9 @@ using Microsoft.Data.SqlClient;
 using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.SqlServer.Features.Search;
+using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Microsoft.Health.Test.Utilities;
 using Xunit;
 using Task = System.Threading.Tasks.Task;
 
@@ -21,6 +23,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
     /// SQL query based on hash
     /// </summary>
     [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.Search)]
     public class SqlCustomQueryTests : IClassFixture<FhirStorageTestsFixture>
     {
         private readonly FhirStorageTestsFixture _fixture;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlCustomQueryTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlCustomQueryTests.cs
@@ -86,8 +86,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                     "FROM sys.dm_exec_procedure_stats stats\r\n" +
                     "INNER JOIN sys.objects sysobject ON sysobject.object_id = stats.object_id\r\n" +
                     "WHERE  sysobject.type = 'P'\r\n" +
-                    "and (sysobject.object_id = object_id('dbo.CustomQuery_C95055F62FB607F23A74902A21645D523475218EF4330D77F69F4CB1938A83E8') \r\n" +
-                    "OR sysobject.name = 'CustomQuery_C95055F62FB607F23A74902A21645D523475218EF4330D77F69F4CB1938A83E8')\r\n" +
+                    "and (sysobject.object_id = object_id('dbo.CustomQuery_B007D1A9282416ACD224E136F2B6E65BC26867FAA5AAC6D62D7AE3E54CD376EB') \r\n" +
+                    "OR sysobject.name = 'CustomQuery_B007D1A9282416ACD224E136F2B6E65BC26867FAA5AAC6D62D7AE3E54CD376EB')\r\n" +
                     "ORDER BY stats.last_execution_time DESC  ";
                 var reader = cmd.ExecuteReader();
                 while (reader.Read())
@@ -108,7 +108,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         private void AddSproc()
         {
             _fixture.SqlHelper.ExecuteSqlCmd(
-                "CREATE OR ALTER PROCEDURE [dbo].[CustomQuery_C95055F62FB607F23A74902A21645D523475218EF4330D77F69F4CB1938A83E8]\r\n" +
+                "CREATE OR ALTER PROCEDURE [dbo].[CustomQuery_B007D1A9282416ACD224E136F2B6E65BC26867FAA5AAC6D62D7AE3E54CD376EB]\r\n" +
                 "(@p0 SmallInt, @p1 SmallInt, @p2 SmallInt, @p3 SmallInt, @p4 NVarChar(256), @p5 SmallInt, @p6 VarChar(256), @p7 Int, @p8 SmallInt, @p9 Int)\r\n" +
                 "AS\r\n" +
                 "BEGIN\r\n" +

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
@@ -290,6 +290,11 @@ END
             return new SchemaInitializer(serviceProvider, config, schemaInformation, Substitute.For<IMediator>(), NullLogger<SchemaInitializer>.Instance);
         }
 
+        public async Task<SqlConnection> GetSqlConnectionAsync()
+        {
+            return await _sqlConnectionBuilder.GetSqlConnectionAsync(cancellationToken: CancellationToken.None);
+        }
+
         protected SqlConnection GetSqlConnection(string connectionString)
         {
             var connectionBuilder = new SqlConnectionStringBuilder(connectionString);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -221,6 +221,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             var compartmentSearchRewriter = new CompartmentSearchRewriter(new Lazy<ICompartmentDefinitionManager>(() => compartmentDefinitionManager), new Lazy<ISearchParameterDefinitionManager>(() => _searchParameterDefinitionManager));
             var smartCompartmentSearchRewriter = new SmartCompartmentSearchRewriter(compartmentSearchRewriter, new Lazy<ISearchParameterDefinitionManager>(() => _searchParameterDefinitionManager));
 
+            SqlQueryHashCalculator = new TestSqlHashCalculator();
+
             _searchService = new SqlServerSearchService(
                 searchOptionsFactory,
                 _fhirDataStore,
@@ -238,6 +240,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 SchemaInformation,
                 _fhirRequestContextAccessor,
                 new CompressedRawResourceConverter(),
+                SqlQueryHashCalculator,
                 NullLogger<SqlServerSearchService>.Instance);
 
             ISearchParameterSupportResolver searchParameterSupportResolver = Substitute.For<ISearchParameterSupportResolver>();
@@ -272,6 +275,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         internal SqlServerFhirModel SqlServerFhirModel { get; }
 
         internal SchemaInformation SchemaInformation { get; }
+
+        internal ISqlQueryHashCalculator SqlQueryHashCalculator { get; }
 
         public async Task InitializeAsync()
         {
@@ -376,6 +381,11 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             if (serviceType == typeof(IQueueClient))
             {
                 return _sqlQueueClient;
+            }
+
+            if (serviceType == typeof(TestSqlHashCalculator))
+            {
+                return SqlQueryHashCalculator as TestSqlHashCalculator;
             }
 
             return null;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/TestSqlHashCalculator.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/TestSqlHashCalculator.cs
@@ -1,0 +1,25 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Core.Extensions;
+using Microsoft.Health.Fhir.SqlServer.Features.Search;
+
+namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
+{
+    public class TestSqlHashCalculator : ISqlQueryHashCalculator
+    {
+        public string MostRecentSqlQuery { get; set; }
+
+        public string MostRecentSqlHash { get; set; }
+
+        public string CalculateHash(string query)
+        {
+            MostRecentSqlQuery = query;
+            MostRecentSqlHash = query.ComputeHash();
+
+            return MostRecentSqlHash;
+        }
+    }
+}


### PR DESCRIPTION
## Description
This looks for special conditions of the query when coming to the SQL query generator.  If they are found, then it adds an OPTIMIZE clause to the end of the query to indicate to SQL to ignore the specific values passed into the query and use overall statistics of the table when generating the query plan.

## Related issues
Addresses [issue AB#101784].

## Testing
For the moment, the generated result was tested on the problem database, and the new query runs quickly.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
