### PR TITLE
Adds auth to the tool so blends can be uploaded to servers with auth

### DIFF
--- a/tools/FHIRDataSynth/Program.cs
+++ b/tools/FHIRDataSynth/Program.cs
@@ -86,8 +86,8 @@ namespace FHIRDataSynth
                     Console.WriteLine("example:");
                     Console.WriteLine(" FHIRDataSynth.exe verifyfile ..\\out-dir 1 ..\\tr.json");
                     Console.WriteLine();
-                    Console.WriteLine("To import blend to server:");
-                    Console.WriteLine(" FHIRDataSynth.exe 'import' ServerUrl ResourceGroupCount InputStrorageUrl import-blob-container importResultFileName InputConnectionString");
+                    Console.WriteLine("To import blend to server. If server uses authentication use optional BearerAuthenticationToken parameter:");
+                    Console.WriteLine(" FHIRDataSynth.exe 'import' ServerUrl ResourceGroupCount InputStrorageUrl import-blob-container importResultFileName InputConnectionString [BearerAuthenticationToken]");
                     Console.WriteLine("example:");
                     Console.WriteLine(" FHIRDataSynth.exe import http://svr.azurewebsites.net 4 https://syntheadatastore.blob.core.windows.net out-container ..\\importresult.json \"Storage Account Connection String\"");
                     Console.WriteLine();
@@ -287,7 +287,7 @@ namespace FHIRDataSynth
                             break;
                         case importCommand:
                             {
-                                if (args.Length != 7)
+                                if (args.Length != 7 && args.Length != 8)
                                 {
                                     throw new FHIRDataSynthException("Invalid number of input parameters.");
                                 }
@@ -298,20 +298,32 @@ namespace FHIRDataSynth
                                 string inputBlobContainerName = args[4];
                                 string importResultFileName = args[5];
                                 string inputConnectionString = args[6];
-                                ServerImport.Import(serverUrl, resourceGroupCount, inputUrl, inputBlobContainerName, importResultFileName, inputConnectionString).Wait();
+                                string bearerToken = null;
+                                if (args.Length == 8)
+                                {
+                                    bearerToken = args[7];
+                                }
+
+                                ServerImport.Import(serverUrl, resourceGroupCount, inputUrl, inputBlobContainerName, importResultFileName, inputConnectionString, bearerToken).Wait();
                                 ret = 0;
                             }
 
                             break;
                         case isFinishedCommand:
                             {
-                                if (args.Length != 2)
+                                if (args.Length != 2 && args.Length != 3)
                                 {
                                     throw new FHIRDataSynthException("Invalid number of input parameters.");
                                 }
 
                                 string importResultFileName = args[1];
-                                Task<bool> t = ServerImport.IsImportFinished(importResultFileName);
+                                string bearerToken = null;
+                                if (args.Length == 3)
+                                {
+                                    bearerToken = args[2];
+                                }
+
+                                Task<bool> t = ServerImport.IsImportFinished(importResultFileName, bearerToken);
                                 t.Wait();
                                 if (t.Result)
                                 {


### PR DESCRIPTION
## Description
Adds authentication to the tool so resource blends can be uploaded to servers that use authentication.

## Related issues

## Testing
Manually, tool is not part of the pipeline testing process and has no unit test.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
