### PR TITLE
Throttling Configuration

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Configs/ThrottlingConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Api/Configs/ThrottlingConfiguration.cs
@@ -41,5 +41,10 @@ namespace Microsoft.Health.Fhir.Api.Configs
         /// elapses before the request is picked up, the server responds with a 429.
         /// </summary>
         public int MaxMillisecondsInQueue { get; set; }
+
+        /// <summary>
+        /// a known datastore
+        /// </summary>
+        public string DataStore { get; set; } = string.Empty;
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Features/Throttling/ThrottlingMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Throttling/ThrottlingMiddleware.cs
@@ -11,7 +11,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Abstractions.Exceptions;
@@ -42,7 +41,6 @@ namespace Microsoft.Health.Fhir.Api.Features.Throttling
         private const string ThrottledContentType = "application/json; charset=utf-8";
         private static readonly ReadOnlyMemory<byte> _throttledBody = CreateThrottledBody(Resources.TooManyConcurrentRequests);
 
-        private IConfiguration _baseConfiguration = null;
         private readonly RequestDelegate _next;
         private readonly ILogger<ThrottlingMiddleware> _logger;
         private readonly HashSet<(string method, string path)> _excludedEndpoints;
@@ -62,7 +60,6 @@ namespace Microsoft.Health.Fhir.Api.Features.Throttling
 
         public ThrottlingMiddleware(
             RequestDelegate next,
-            IConfiguration baseConfiguration,
             IOptions<ThrottlingConfiguration> throttlingConfiguration,
             IOptions<SecurityConfiguration> securityConfiguration,
             ILogger<ThrottlingMiddleware> logger)
@@ -88,11 +85,11 @@ namespace Microsoft.Health.Fhir.Api.Features.Throttling
 
             // snapshot the configuration values to reduce the number of instructions that need to execute in the lock.
             _concurrentRequestLimit = configuration.ConcurrentRequestLimit;
-            if (_baseConfiguration != null && _baseConfiguration["DataStore"].Equals(KnownDataStores.CosmosDb, StringComparison.OrdinalIgnoreCase))
+            if (throttlingConfiguration.Value.DataStore.Equals(KnownDataStores.CosmosDb, StringComparison.OrdinalIgnoreCase))
             {
                 _concurrentRequestLimit = Math.Max(_concurrentRequestLimit, (int)ThrottlingLimitDefault.Gen1);
             }
-            else if (_baseConfiguration != null && _baseConfiguration["DataStore"].Equals(KnownDataStores.SqlServer, StringComparison.OrdinalIgnoreCase))
+            else if (throttlingConfiguration.Value.DataStore.Equals(KnownDataStores.SqlServer, StringComparison.OrdinalIgnoreCase))
             {
                 _concurrentRequestLimit = Math.Max(_concurrentRequestLimit, (int)ThrottlingLimitDefault.Gen2);
             }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
@@ -64,6 +64,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             var fhirServerConfiguration = new FhirServerConfiguration();
 
+            string dataStore = configurationRoot == null ? string.Empty : configurationRoot["DataStore"];
             configurationRoot?.GetSection(FhirServerConfigurationSectionName).Bind(fhirServerConfiguration);
             configureAction?.Invoke(fhirServerConfiguration);
 
@@ -80,7 +81,13 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton(Options.Options.Create(fhirServerConfiguration.Operations.Import));
             services.AddSingleton(Options.Options.Create(fhirServerConfiguration.Audit));
             services.AddSingleton(Options.Options.Create(fhirServerConfiguration.Bundle));
-            services.AddSingleton(Options.Options.Create(fhirServerConfiguration.Throttling));
+            services.AddSingleton(provider =>
+            {
+                var throttlingOptions = Options.Options.Create(fhirServerConfiguration.Throttling);
+                throttlingOptions.Value.DataStore = dataStore;
+                return throttlingOptions;
+            });
+
             services.AddSingleton(Options.Options.Create(fhirServerConfiguration.ArtifactStore));
             services.AddSingleton(Options.Options.Create(fhirServerConfiguration.ImplementationGuides));
             services.AddTransient<IStartupFilter, FhirServerStartupFilter>();


### PR DESCRIPTION
## Description
This fixes the null exception in the ctor and also revises the tests to make use of the values for gen1 and gen2 throttling.

## Related issues
Addresses [issue #100374](https://microsofthealth.visualstudio.com/Health/_workitems/edit/100374).

## Testing
All tests in the ThrottlingMiddlewareTests have successfully passed.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
