### PR TITLE
Fix InvalidOperationException thrown as RetriableJobException

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/SqlImportOperation.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/SqlImportOperation.cs
@@ -159,8 +159,12 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             catch (Exception ex)
             {
                 _logger.LogInformation(ex, "BulkCopyDataAsync failed.");
+                if (ex.IsRetriable())
+                {
+                    throw new RetriableJobException(ex.Message, ex);
+                }
 
-                throw new RetriableJobException(ex.Message, ex);
+                throw;
             }
         }
 

--- a/src/Microsoft.Health.TaskManagement.UnitTests/JobHostingTests.cs
+++ b/src/Microsoft.Health.TaskManagement.UnitTests/JobHostingTests.cs
@@ -253,6 +253,42 @@ namespace Microsoft.Health.JobManagement.UnitTests
         }
 
         [Fact]
+        public async Task GivenJobWithInvalidOperationException_WhenJobHostingStart_ThenJobFail()
+        {
+            int executeCount0 = 0;
+            TestJobFactory factory = new TestJobFactory(t =>
+            {
+                return new TestJob(
+                    (progress, token) =>
+                    {
+                        Interlocked.Increment(ref executeCount0);
+                        if (executeCount0 <= 1)
+                        {
+                            throw new InvalidOperationException("test");
+                        }
+
+                        return Task.FromResult(t.Result);
+                    });
+            });
+
+            TestQueueClient queueClient = new TestQueueClient();
+            JobInfo job1 = (await queueClient.EnqueueAsync(0, new string[] { "task1" }, null, false, false, CancellationToken.None)).First();
+
+            JobHosting jobHosting = new JobHosting(queueClient, factory, _logger);
+            jobHosting.PollingFrequencyInSeconds = 0;
+            jobHosting.MaxRunningJobCount = 1;
+            jobHosting.JobHeartbeatTimeoutThresholdInSeconds = 1;
+
+            CancellationTokenSource tokenSource = new CancellationTokenSource();
+
+            tokenSource.CancelAfter(TimeSpan.FromSeconds(2));
+            await jobHosting.ExecuteAsync(0, "test", tokenSource);
+
+            Assert.Equal(JobStatus.Failed, job1.Status);
+            Assert.Equal(1, executeCount0);
+        }
+
+        [Fact]
         public async Task GivenJobRunning_WhenCancel_ThenJobShouldBeCancelled()
         {
             AutoResetEvent autoResetEvent = new AutoResetEvent(false);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Import/SqlServerFhirDataBulkOperationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Import/SqlServerFhirDataBulkOperationTests.cs
@@ -179,10 +179,14 @@ namespace Microsoft.Health.Fhir.Shared.Tests.Integration.Features.Operations.Imp
         public async Task GivenBatchInValidResources_WhenBulkCopy_ThenExceptionShouldBeThrow()
         {
             long startSurrogateId = ResourceSurrogateIdHelper.LastUpdatedToResourceSurrogateId(DateTime.Now);
-            int count = 1001;
+            short typeId = _fixture.SqlServerFhirModel.GetResourceTypeId("Patient");
+            int count = 1;
 
-            DataTable inputTable = TestBulkDataProvider.GenerateInValidUriSearchParamsTable(count, startSurrogateId, 0);
+            DataTable inputTable = TestBulkDataProvider.GenerateInValidUriSearchParamsTable(count, startSurrogateId, typeId);
             await Assert.ThrowsAnyAsync<Exception>(async () => await _sqlServerFhirDataBulkOperation.BulkCopyDataAsync(inputTable, CancellationToken.None));
+
+            inputTable = TestBulkDataProvider.GenerateInvalidDataTokenQuantityCompositeSearchParamsTable(count, startSurrogateId, typeId);
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await _sqlServerFhirDataBulkOperation.BulkCopyDataAsync(inputTable, CancellationToken.None));
         }
 
         [Fact]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Import/TestBulkDataProvider.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Import/TestBulkDataProvider.cs
@@ -152,6 +152,20 @@ namespace Microsoft.Health.Fhir.Shared.Tests.Integration.Features.Operations.Imp
             return result;
         }
 
+        public static DataTable GenerateInvalidDataTokenQuantityCompositeSearchParamsTable(int count, long startSurrogatedId, short resoureType)
+        {
+            TokenQuantityCompositeSearchParamsTableBulkCopyDataGenerator generator = new TokenQuantityCompositeSearchParamsTableBulkCopyDataGenerator();
+
+            DataTable result = generator.GenerateDataTable();
+
+            for (int i = 0; i < count; ++i)
+            {
+                TokenQuantityCompositeSearchParamsTableBulkCopyDataGenerator.FillDataTable(result, resoureType, startSurrogatedId + i, new BulkTokenQuantityCompositeSearchParamTableTypeV2Row(0, 0, 0, string.Empty, null, 0, 0, 20180221235900, 0, 0));
+            }
+
+            return result;
+        }
+
         public static DataTable GenerateTokenSearchParamsTable(int count, long startSurrogatedId, short resoureType, string resourceId = null)
         {
             TokenSearchParamsTableBulkCopyDataGenerator generator = new TokenSearchParamsTableBulkCopyDataGenerator();


### PR DESCRIPTION
## Description
This update fixes all exceptions that are thrown at the BulkCopyDataAsync function so that it checks if the exception is retriable before throwing a RetriableJobException. This check for ex.IsRetriable() was already done in most the functions in the SqlImportOperation class but was missed for this function.

## Related issues
Addresses [issue #102026](https://microsofthealth.visualstudio.com/Health/_workitems/edit/102026).

## Testing
Revised tests and created new tests

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
