### PR TITLE
SearchParameterStatusManager should update datetime after DB write

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
@@ -227,12 +227,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
                 }
             }
 
+            _searchParameterStatusDataStore.SyncStatuses(updatedSearchParameterStatus);
+
             if (updatedSearchParameterStatus.Any())
             {
                 _latestSearchParams = updatedSearchParameterStatus.Select(p => p.LastUpdated).Max();
             }
-
-            _searchParameterStatusDataStore.SyncStatuses(updatedSearchParameterStatus);
 
             await _mediator.Publish(new SearchParametersUpdatedNotification(updated), cancellationToken);
         }


### PR DESCRIPTION
## Description
We had a customer issue where the FHIR service would not load the latest SearchParameter status.  Looking into the logs there were some transient network issues which prevented writing/reading from the database temporarily.

Looking into the code, we were updating the last successfull read/write of the search parameter status before sync'ing to the DB.  In the event of a database failure, the in memory datetime would be out of sync with the database.  This is a small PR to write the DB first.  In the event of a failure, the status will be sync'd on the next attempt.

## Related issues
Addresses [issue AB#101603].

## Testing
Reran existing test suite.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
