### PR TITLE
[Health Check] Limit of 30 seconds + retry

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Health/CosmosHealthCheckTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Health/CosmosHealthCheckTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Health
         }
 
         [Fact]
-        public async Task GivenCosmosDb_WhenCosmosOperationCanceledExceptionIsOnceThrown_ThenUnhealthyStateShouldBeReturned()
+        public async Task GivenCosmosDb_WhenCosmosOperationCanceledExceptionIsOnceThrown_ThenHealthyStateShouldBeReturned()
         {
             // This test simulates that the first call to Health Check results in an OperationCanceledException.
             // The first attempt should fail, but the next ones should pass.

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Health/CosmosHealthCheck.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Health/CosmosHealthCheck.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Health
                     else if (attempt >= maxNumberAttempts)
                     {
                         _logger.LogWarning(coce, "Failed to connect to the data store. There were {NumberOfAttempts} attempts to connect to the data store, but they suffered a '{ExceptionType}'.", attempt, nameof(CosmosOperationCanceledException));
-                        return HealthCheckResult.Unhealthy("Failed to connect to the data store. CosmosOperationCanceledException.");
+                        return HealthCheckResult.Unhealthy("Failed to connect to the data store. Operation canceled.");
                     }
                     else
                     {


### PR DESCRIPTION
Limiting Gen1 Health Check to a 30 seconds operation, and allowing this operation to be retried in case of CosmosOperationCanceledException. 

## Related issues
- Health Check taking more than 30 seconds to execute. 

## Testing
This change was tested locally. Multiple concurrent requests were executed to test the ability to handle multiple health check validations at the same time. 

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
