### PR TITLE
Add validation invalid parameter type

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/ExpressionParser.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/ExpressionParser.cs
@@ -106,6 +106,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
                 }
 
                 refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter(originalType.ToString(), searchParam.ToString());
+
+                if (refSearchParameter.Type != SearchParamType.Reference)
+                {
+                    throw new InvalidSearchOperationException(isReversed ? Core.Resources.RevIncludeIncorrectParameterType : Core.Resources.IncludeIncorrectParameterType);
+                }
             }
 
             if (wildCard)

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -602,6 +602,15 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The [_include]=[resource]:[parameter] search has an invalid search parameter, must be of type reference..
+        /// </summary>
+        internal static string IncludeIncorrectParameterType {
+            get {
+                return ResourceManager.GetString("IncludeIncorrectParameterType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The parameter {0}={1} with circular reference is executed once (a single iteration)..
         /// </summary>
         internal static string IncludeIterateCircularReferenceExecutedOnce {
@@ -618,18 +627,7 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("IncludeMissingType", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   TODO
-        /// </summary>
-        internal static string IncludeParameterTypeIsInvalid
-        {
-            get
-            {
-                return ResourceManager.GetString("IncludeMissingType", resourceCulture);
-            }
-        }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The target resource type cannot be empty..
         /// </summary>
@@ -1203,6 +1201,15 @@ namespace Microsoft.Health.Fhir.Core {
         internal static string ReverseChainMissingType {
             get {
                 return ResourceManager.GetString("ReverseChainMissingType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The [_revinclude]=[resource]:[parameter] search has an invalid search parameter, must be of type reference..
+        /// </summary>
+        internal static string RevIncludeIncorrectParameterType {
+            get {
+                return ResourceManager.GetString("RevIncludeIncorrectParameterType", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -618,7 +618,18 @@ namespace Microsoft.Health.Fhir.Core {
                 return ResourceManager.GetString("IncludeMissingType", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   TODO
+        /// </summary>
+        internal static string IncludeParameterTypeIsInvalid
+        {
+            get
+            {
+                return ResourceManager.GetString("IncludeMissingType", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to The target resource type cannot be empty..
         /// </summary>

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -236,9 +236,17 @@
     <value>The _include search is missing the type to search.</value>
     <comment>_include is a query parameter.</comment>
   </data>
+  <data name="IncludeIncorrectParameterType" xml:space="preserve">
+    <value>The [_include]=[resource]:[parameter] search has an invalid search parameter, must be of type reference.</value>
+    <comment>_include is a query parameter.</comment>
+  </data>
   <data name="RevIncludeMissingType" xml:space="preserve">
     <value>The _revinclude search is missing the type to search.</value>
     <comment>_revinclude is a query parameter.</comment>
+  </data>
+  <data name="RevIncludeIncorrectParameterType" xml:space="preserve">
+    <value>The [_revinclude]=[resource]:[parameter] search has an invalid search parameter, must be of type reference.</value>
+    <comment>_include is a query parameter.</comment>
   </data>
   <data name="RevIncludeIterateTargetTypeNotSpecified" xml:space="preserve">
     <value>The '_revinclude:iterate={0}' search parameter has multiple target types. Please specify a target type.</value>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
@@ -1004,7 +1004,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
         [Fact]
         [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer)]
-        public async Task GivenAIncludeWithInvalidParameter_WhenSearched_ShouldThrowBadRequestExceptionWithIssue()
+        public async Task GivenAIncludeWithInvalidParam_WhenSearched_ShouldThrowBadRequestExceptionWithIssue()
         {
             string query = $"_include=Patient:family";
 
@@ -1012,6 +1012,21 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             Assert.Equal(HttpStatusCode.BadRequest, fhirException.StatusCode);
 
             string[] expectedDiagnostics = { string.Format(Core.Resources.IncludeIncorrectParameterType) };
+            IssueSeverity[] expectedIssueSeverities = { IssueSeverity.Error };
+            IssueType[] expectedCodeTypes = { IssueType.Invalid };
+            ValidateOperationOutcome(expectedDiagnostics, expectedIssueSeverities, expectedCodeTypes, fhirException.OperationOutcome);
+        }
+
+        [Fact]
+        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer)]
+        public async Task GivenARevincludeWithInvalidParameter_WhenSearched_ShouldThrowBadRequestExceptionWithIssue()
+        {
+            string query = $"_revinclude=Patient:family";
+
+            using var fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await Client.SearchAsync(ResourceType.Patient, query));
+            Assert.Equal(HttpStatusCode.BadRequest, fhirException.StatusCode);
+
+            string[] expectedDiagnostics = { string.Format(Core.Resources.RevIncludeIncorrectParameterType) };
             IssueSeverity[] expectedIssueSeverities = { IssueSeverity.Error };
             IssueType[] expectedCodeTypes = { IssueType.Invalid };
             ValidateOperationOutcome(expectedDiagnostics, expectedIssueSeverities, expectedCodeTypes, fhirException.OperationOutcome);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
@@ -1009,7 +1009,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             string query = $"_include=Patient:family";
 
             using var fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await Client.SearchAsync(ResourceType.Patient, query));
-            Assert.Equal(HttpStatusCode.BadRequest, fhirException.StatusCode);
+            Assert.Equal(HttpStatusCode.Forbidden, fhirException.StatusCode);
 
             string[] expectedDiagnostics = { string.Format(Core.Resources.IncludeIncorrectParameterType) };
             IssueSeverity[] expectedIssueSeverities = { IssueSeverity.Error };
@@ -1024,7 +1024,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             string query = $"_revinclude=Patient:family";
 
             using var fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await Client.SearchAsync(ResourceType.Patient, query));
-            Assert.Equal(HttpStatusCode.BadRequest, fhirException.StatusCode);
+            Assert.Equal(HttpStatusCode.Forbidden, fhirException.StatusCode);
 
             string[] expectedDiagnostics = { string.Format(Core.Resources.RevIncludeIncorrectParameterType) };
             IssueSeverity[] expectedIssueSeverities = { IssueSeverity.Error };

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
@@ -1004,14 +1004,14 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
         [Fact]
         [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer)]
-        public async Task GivenARevInclude_WhenSearched_ShouldThrowBadRequestExceptionWithIssue()
+        public async Task GivenAIncludeWithInvalidParameter_WhenSearched_ShouldThrowBadRequestExceptionWithIssue()
         {
             string query = $"_include=Patient:family";
 
             using var fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await Client.SearchAsync(ResourceType.Patient, query));
             Assert.Equal(HttpStatusCode.BadRequest, fhirException.StatusCode);
 
-            string[] expectedDiagnostics = { string.Format(Core.Resources.RevIncludeIncorrectParameterType) };
+            string[] expectedDiagnostics = { string.Format(Core.Resources.IncludeIncorrectParameterType) };
             IssueSeverity[] expectedIssueSeverities = { IssueSeverity.Error };
             IssueType[] expectedCodeTypes = { IssueType.Invalid };
             ValidateOperationOutcome(expectedDiagnostics, expectedIssueSeverities, expectedCodeTypes, fhirException.OperationOutcome);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
@@ -1004,6 +1004,21 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
         [Fact]
         [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer)]
+        public async Task GivenARevInclude_WhenSearched_ShouldThrowBadRequestExceptionWithIssue()
+        {
+            string query = $"_include=Patient:family";
+
+            using var fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await Client.SearchAsync(ResourceType.Patient, query));
+            Assert.Equal(HttpStatusCode.BadRequest, fhirException.StatusCode);
+
+            string[] expectedDiagnostics = { string.Format(Core.Resources.RevIncludeIncorrectParameterType) };
+            IssueSeverity[] expectedIssueSeverities = { IssueSeverity.Error };
+            IssueType[] expectedCodeTypes = { IssueType.Invalid };
+            ValidateOperationOutcome(expectedDiagnostics, expectedIssueSeverities, expectedCodeTypes, fhirException.OperationOutcome);
+        }
+
+        [Fact]
+        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer)]
         public async Task GivenARevIncludeIterateSearchExpressionWithMultipleResultsSetsWithoutSpecificRevIncludeIterateTargetType_WhenSearched_ShouldThrowBadRequestExceptionWithIssue()
         {
             // Non-recursive iteration - Multiple result sets: MedicationDispense:performer;Practitioner and MedicationRequest:requester:Practitioner


### PR DESCRIPTION
## Description
* Official [documentation ](http://hl7.org/fhir/search.html#include) about `_include` and `_revinclude` options.

> [_include | _revinclude]=[resource]:[parameter]: where [resource] is the name of the source resource from which the join comes and [parameter] is the name of a search parameter which must be of type reference.

* This PR adds the validation for the parameter type, that always must be of type `reference`.

## Related issues
Addresses [issue #2003 ].

## Testing
Locally tested, must show new error
* Search Patient?_include=Patient:family

![image](https://user-images.githubusercontent.com/33185677/231610643-25c192a7-bcc7-4e7e-b3cd-b8163ecb2e33.png)


## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
