### PR TITLE
User Agent header value is not logging in Platform

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Web/UserAgentHeaderTelemetryInitializer.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web/UserAgentHeaderTelemetryInitializer.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Globalization;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
@@ -26,7 +27,8 @@ namespace Microsoft.Health.Fhir.Shared.Web
             {
                 if (_httpContextAccessor.HttpContext.Request.Headers.TryGetValue(HeaderNames.UserAgent, out var userAgent))
                 {
-                    requestTelemetry.Properties.Add(HeaderNames.UserAgent, userAgent);
+                    string propertyName = HeaderNames.UserAgent.Replace('-', '_').ToLower(CultureInfo.InvariantCulture);
+                    requestTelemetry.Properties.Add(propertyName, userAgent);
                 }
             }
         }


### PR DESCRIPTION
## Description
User Agent value shows up in OSS, but not logging to Geneva. This appears to be due to the fact that the '-' can cause issues with Kusto and Geneva. I've updated the property name to minimize issues.

## Related issues
Addresses [issue AB#102620].

## Testing
Ran through OSS to verify the value still logs. 

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
