### PR TITLE
fix duplicate key error when getting params and body content

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Routing/SearchPostReroutingMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Routing/SearchPostReroutingMiddleware.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
                         request.Query = mergedPairs;
                     }
 
+                    request.ContentType = null;
                     request.Form = null;
                     request.Path = request.Path.Value.Substring(0, request.Path.Value.Length - KnownRoutes.Search.Length);
                     request.Method = "GET";

--- a/src/Microsoft.Health.Fhir.Shared.Client/FhirClient.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Client/FhirClient.cs
@@ -336,9 +336,9 @@ namespace Microsoft.Health.Fhir.Client
             return await CreateResponseAsync<Bundle>(response);
         }
 
-        public async Task<FhirResponse<Bundle>> SearchPostAsync(string resourceType, CancellationToken cancellationToken = default, params (string key, string value)[] body)
+        public async Task<FhirResponse<Bundle>> SearchPostAsync(string resourceType, string query, CancellationToken cancellationToken = default, params (string key, string value)[] body)
         {
-            using var message = new HttpRequestMessage(HttpMethod.Post, $"{(string.IsNullOrEmpty(resourceType) ? null : $"{resourceType}/")}_search")
+            using var message = new HttpRequestMessage(HttpMethod.Post, $"{(string.IsNullOrEmpty(resourceType) ? null : $"{resourceType}/")}_search?{query}")
             {
                 Content = new FormUrlEncodedContent(body.ToDictionary(p => p.key, p => p.value)),
             };

--- a/src/Microsoft.Health.Fhir.Shared.Client/IFhirClient.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Client/IFhirClient.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Health.Fhir.Client
 
         Task<FhirResponse<Bundle>> SearchAsync(string url, Tuple<string, string> customHeader, CancellationToken cancellationToken = default);
 
-        Task<FhirResponse<Bundle>> SearchPostAsync(string resourceType, CancellationToken cancellationToken = default, params (string key, string value)[] body);
+        Task<FhirResponse<Bundle>> SearchPostAsync(string resourceType, string query, CancellationToken cancellationToken = default, params (string key, string value)[] body);
 
         Task<FhirResponse<T>> UpdateAsync<T>(string uri, T resource, string ifMatchHeaderETag = null, string provenanceHeader = null, CancellationToken cancellationToken = default)
             where T : Resource;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/AuditTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/AuditTests.cs
@@ -263,7 +263,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit
         public async Task GivenAServer_WhenSearchedByResourceTypeUsingPost_ThenAuditLogEntriesShouldBeCreated()
         {
             await ExecuteAndValidate(
-                () => _client.SearchPostAsync("Observation", default, ("_tag", "123")),
+                () => _client.SearchPostAsync("Observation", null, default, ("_tag", "123")),
                 "search-type",
                 ResourceType.Observation,
                 _ => "Observation/_search",
@@ -287,7 +287,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit
         public async Task GivenAServer_WhenSearchedUsingPost_ThenAuditLogEntriesShouldBeCreated()
         {
             await ExecuteAndValidate(
-                () => _client.SearchPostAsync(null, default, ("_tag", "123")),
+                () => _client.SearchPostAsync(null, null, default, ("_tag", "123")),
                 "search-system",
                 null,
                 _ => "_search",

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -196,7 +196,150 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 sb.Append('a');
             }
 
-            await Client.SearchPostAsync("Patient", default, ("name", sb.ToString()));
+            await Client.SearchPostAsync("Patient", null, default, ("name", sb.ToString()));
+        }
+
+        /// <summary>
+        /// This test is based on the details of user story #101268
+        /// </summary>
+        /// <returns>task</returns>
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenResource_WhenPostSearchingWithBodyContent_ThenResourceMatchingShouldBeReturned()
+        {
+            AdministrativeGender gender = AdministrativeGender.Female;
+            string resourceType = KnownResourceTypes.Patient;
+            string systemIdentifier = "http://example.com/fhir/post_search_bug";
+            string value1 = "id_value_1";
+            string value2 = "id_value_2";
+            string birthDate = "2001-02-03";
+            bool active = true;
+
+            string qry_active = $"active={active.ToString().ToLower()}";
+            string qry_birthDate = $"birthdate={birthDate}";
+            string qry_gender = $"gender={gender.ToString().ToLower()}";
+            string bodyContentSystemIdentifier1 = $"{systemIdentifier}|{value1}";
+            string bodyContentSystemIdentifier2 = $"{systemIdentifier}|{value2}";
+            string qry_sysIdentifierValue1 = $"identifier={bodyContentSystemIdentifier1}";
+            string qry_sysIdentifierValue2 = $"identifier={bodyContentSystemIdentifier2}";
+
+            Patient patient = GetPatient(systemIdentifier, value1, value2, birthDate, active, gender);
+
+            try
+            {
+                using (FhirResponse<Patient> response = await Client.CreateAsync(patient))
+                {
+                    patient.VersionId = response.Resource.VersionId;
+                    patient.Id = response.Resource.Id;
+                }
+
+                // From the user story:
+                // POST /Patient/_search?active=true&gender=female&birthdate=2001-02-03&identifier=http://example.com/fhir/post_search_bug|id_value_1
+                // body content:
+                // identifier=http://example.com/fhir/post_search_bug|id_value_2
+                Bundle bundle = await Client.SearchPostAsync(
+                    resourceType,
+                    $"{qry_active}&{qry_gender}&{qry_birthDate}&{qry_sysIdentifierValue1}&{qry_birthDate}&{qry_sysIdentifierValue2}",
+                    default,
+                    ("identifier", bodyContentSystemIdentifier2));
+                Assert.Contains(bundle.Entry, x => x.Resource.Id == patient.Id);
+
+                // From the user story
+                // GET /Patient?active=true&gender=female&birthdate=2001-02-03&identifier=http://example.com/fhir/post_search_bug|id_value_1&identifier=http://example.com/fhir/post_search_bug|id_value_2
+                bundle = await Client.SearchAsync($"{resourceType}?{qry_active}&{qry_gender}&{qry_birthDate}&{qry_sysIdentifierValue1}&{qry_sysIdentifierValue2}");
+                Assert.Contains(bundle.Entry, x => x.Resource.Id == patient.Id);
+
+                // POST /Patient/_search
+                // no query params, just body content
+                // active=true&gender=female&birthdate=2001-02-03&identifier=http://example.com/fhir/post_search_bug|id_value_1
+                bundle = await Client.SearchPostAsync(
+                    resourceType,
+                    string.Empty,
+                    default,
+                    ("active", $"{active.ToString().ToLower()}"),
+                    ("gender", $"{gender.ToString().ToLower()}"),
+                    ("birthdate", $"{birthDate}"),
+                    ("identifier", $"{bodyContentSystemIdentifier1}"));
+                Assert.Contains(bundle.Entry, x => x.Resource.Id == patient.Id);
+            }
+            finally
+            {
+                await Client.HardDeleteAsync(patient);
+            }
+        }
+
+        private static Patient GetPatient(string systemIdentifier, string identifierValue1, string identifierValue2, string birthDate, bool active, AdministrativeGender gender)
+        {
+            return new Patient
+            {
+                Identifier = new List<Identifier>
+                {
+                    new Identifier()
+                    {
+                        System = systemIdentifier,
+                        Value = identifierValue1,
+                    },
+                    new Identifier()
+                    {
+                        System = systemIdentifier,
+                        Value = identifierValue2,
+                    },
+                },
+                Active = active,
+                BirthDate = birthDate,
+                Gender = gender,
+            };
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenSearchQueryWithDuplicateKeyValues_TheCorrectedLinkUrlShouldBeReturned()
+        {
+            AdministrativeGender gender = AdministrativeGender.Female;
+            string resourceType = KnownResourceTypes.Patient;
+            string systemIdentifier = "http://example.com/fhir/post_search_bug";
+            string value1 = "id_value_1";
+            string value2 = "id_value_2";
+            string birthDate = "2001-02-03";
+            bool active = true;
+
+            string qry_active = $"active={active.ToString().ToLower()}";
+            string qry_birthDate = $"birthdate={birthDate}";
+            string qry_gender = $"gender={gender.ToString().ToLower()}";
+            string bodyContentSystemIdentifier1 = $"{systemIdentifier}|{value1}";
+            string bodyContentSystemIdentifier2 = $"{systemIdentifier}|{value2}";
+            string qry_sysIdentifierValue1 = $"identifier={bodyContentSystemIdentifier1}";
+            string qry_sysIdentifierValue2 = $"identifier={bodyContentSystemIdentifier2}";
+
+            string queryStringValid = $"{qry_active}&{qry_gender}&{qry_birthDate}&{qry_sysIdentifierValue1}&{qry_birthDate}&{qry_sysIdentifierValue2}";
+            string queryStringInvalid = $"{qry_active}&{qry_gender}&{qry_birthDate}&{queryStringValid}";
+
+            Patient patient = GetPatient(systemIdentifier, value1, value2, birthDate, active, gender);
+
+            try
+            {
+                using (FhirResponse<Patient> response = await Client.CreateAsync(patient))
+                {
+                    patient.VersionId = response.Resource.VersionId;
+                    patient.Id = response.Resource.Id;
+                }
+
+                Bundle bundle = await Client.SearchPostAsync(resourceType, $"{queryStringInvalid}", default);
+                ValidateQueryStringInLinkUrl(System.Web.HttpUtility.UrlDecode(bundle.Link[0].Url), queryStringValid);
+            }
+            finally
+            {
+                await Client.HardDeleteAsync(patient);
+            }
+        }
+
+        private static void ValidateQueryStringInLinkUrl(string linkUrl, string queryString)
+        {
+            string[] nameValuePairs = queryString.Split("&", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            foreach (var nvp in nameValuePairs)
+            {
+                Assert.Contains(nvp, linkUrl);
+            }
         }
 
         [Fact]
@@ -212,21 +355,21 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
             await ExecuteAndValidateBundle($"?_type=Patient&_tag={tag}", patients);
 
-            Bundle bundle = await Client.SearchPostAsync(null, default, ("_type", "Patient"), ("_tag", tag));
+            Bundle bundle = await Client.SearchPostAsync(null, null, default, ("_type", "Patient"), ("_tag", tag));
             ValidateBundle(bundle, $"?_type=Patient&_tag={tag}", patients);
 
             bundle = await Client.SearchAsync("?_type=Observation,Patient");
             Assert.True(bundle.Entry.Count > patients.Length);
-            bundle = await Client.SearchPostAsync(null, default, ("_type", "Patient,Observation"));
+            bundle = await Client.SearchPostAsync(null, null, default, ("_type", "Patient,Observation"));
             Assert.True(bundle.Entry.Count > patients.Length);
 
             await ExecuteAndValidateBundle($"?_type=Observation,Patient&_id={observation.Id}", observation);
 
-            bundle = await Client.SearchPostAsync(null, default, ("_type", "Patient,Observation"), ("_id", observation.Id));
+            bundle = await Client.SearchPostAsync(null, null, default, ("_type", "Patient,Observation"), ("_id", observation.Id));
             ValidateBundle(bundle, $"?_type=Patient,Observation&_id={observation.Id}", observation);
 
             await ExecuteAndValidateBundle($"?_type=Observation,Patient&_id={organization.Id}");
-            bundle = await Client.SearchPostAsync(null, default, ("_type", "Patient,Observation"), ("_id", organization.Id));
+            bundle = await Client.SearchPostAsync(null, null, default, ("_type", "Patient,Observation"), ("_id", organization.Id));
             ValidateBundle(bundle, $"?_type=Patient,Observation&_id={organization.Id}");
         }
 
@@ -311,12 +454,12 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             outcome = GetAndValidateOperationOutcome(bundle);
             ValidateOperationOutcome(expectedDiagnosticsMultipleWrongTypes, expectedIssueSeverities, expectedCodeTypes, outcome);
 
-            bundle = await Client.SearchPostAsync(null, default, ("_type", "Patient1"));
+            bundle = await Client.SearchPostAsync(null, null, default, ("_type", "Patient1"));
             Assert.Contains("_type=Patient1", bundle.Link[0].Url);
             outcome = GetAndValidateOperationOutcome(bundle);
             ValidateOperationOutcome(expectedDiagnosticsOneWrongType, expectedIssueSeverities, expectedCodeTypes, outcome);
 
-            bundle = await Client.SearchPostAsync(null, default, ("_type", "Patient1,Patient2"));
+            bundle = await Client.SearchPostAsync(null, null, default, ("_type", "Patient1,Patient2"));
             Assert.Contains("_type=Patient1,Patient2", bundle.Link[0].Url);
             outcome = GetAndValidateOperationOutcome(bundle);
             ValidateOperationOutcome(expectedDiagnosticsMultipleWrongTypes, expectedIssueSeverities, expectedCodeTypes, outcome);
@@ -347,7 +490,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             ValidateBundle(bundle, patients.AsEnumerable<Resource>().Append(outcome).ToArray());
             ValidateOperationOutcome(expectedDiagnostics, expectedIssueSeverities, expectedCodeTypes, outcome);
 
-            bundle = await Client.SearchPostAsync(null, default, ("_type", "Patient1,Patient"), ("_tag", tag));
+            bundle = await Client.SearchPostAsync(null, null, default, ("_type", "Patient1,Patient"), ("_tag", tag));
             Assert.Contains("_type=Patient1,Patient", bundle.Link[0].Url);
             outcome = GetAndValidateOperationOutcome(bundle);
             ValidateBundle(bundle, patients.AsEnumerable<Resource>().Append(outcome).ToArray());
@@ -368,17 +511,17 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
             var query = $"?_type=Patient,Practitioner&family={matchingPatient.Name[0].Family}&_tag={tag}";
             await ExecuteAndValidateBundle(query, matchingPatient, matchingPractitioner);
-            Bundle bundle = await Client.SearchPostAsync(null, default, ("_type", "Patient,Practitioner"), ("family", matchingPatient.Name[0].Family), ("_tag", tag));
+            Bundle bundle = await Client.SearchPostAsync(null, null, default, ("_type", "Patient,Practitioner"), ("family", matchingPatient.Name[0].Family), ("_tag", tag));
             ValidateBundle(bundle, query, matchingPatient, matchingPractitioner);
 
             query = $"?_type=Patient,Practitioner&family={nonMatchingPatient.Name[0].Family}&_tag={tag}";
             await ExecuteAndValidateBundle(query, nonMatchingPatient);
-            bundle = await Client.SearchPostAsync(null, default, ("_type", "Patient,Practitioner"), ("family", nonMatchingPatient.Name[0].Family), ("_tag", tag));
+            bundle = await Client.SearchPostAsync(null, null, default, ("_type", "Patient,Practitioner"), ("family", nonMatchingPatient.Name[0].Family), ("_tag", tag));
             ValidateBundle(bundle, query, nonMatchingPatient);
 
             query = $"?_type=Patient,Practitioner&family={nonMatchingPractitioner.Name[0].Family}&_tag={tag}";
             await ExecuteAndValidateBundle(query, nonMatchingPractitioner);
-            bundle = await Client.SearchPostAsync(null, default, ("_type", "Patient,Practitioner"), ("family", nonMatchingPractitioner.Name[0].Family), ("_tag", tag));
+            bundle = await Client.SearchPostAsync(null, null, default, ("_type", "Patient,Practitioner"), ("family", nonMatchingPractitioner.Name[0].Family), ("_tag", tag));
             ValidateBundle(bundle, query, nonMatchingPractitioner);
         }
 
@@ -498,7 +641,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             // Create the resources
             Patient[] patients = await Client.CreateResourcesAsync<Patient>(4, tag);
             var pageSize = 2;
-            Bundle bundle = await Client.SearchPostAsync(null, default, ("_type", "Patient"), ("_count", pageSize.ToString()), ("_tag", tag));
+            Bundle bundle = await Client.SearchPostAsync(null, null, default, ("_type", "Patient"), ("_count", pageSize.ToString()), ("_tag", tag));
 
             var expectedFirstBundle = patients.Length > pageSize ? patients.ToList().GetRange(0, pageSize).ToArray() : patients;
             ValidateBundle(bundle, $"?_type=Patient&_count={pageSize}&_tag={tag}", expectedFirstBundle);
@@ -908,7 +1051,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             OperationOutcome.IssueType[] expectedCodeTypes = { OperationOutcome.IssueType.NotSupported, OperationOutcome.IssueType.NotSupported };
             OperationOutcome.IssueSeverity[] expectedIssueSeverities = { OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueSeverity.Warning };
 
-            Bundle bundle = await Client.SearchPostAsync("Patient", default, ("entry:[{", string.Empty), ("Ramen", "Spicy"));
+            Bundle bundle = await Client.SearchPostAsync("Patient", null, default, ("entry:[{", string.Empty), ("Ramen", "Spicy"));
             OperationOutcome outcome = GetAndValidateOperationOutcome(bundle);
             ValidateOperationOutcome(expectedDiagnostics, expectedIssueSeverities, expectedCodeTypes, outcome);
         }
@@ -1059,8 +1202,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             {
                 string.Format(Core.Resources.SearchParameterNotSupported, "_text", "Patient"),
             };
-            OperationOutcome.IssueType[] expectedCodeTypes = { OperationOutcome.IssueType.NotSupported};
-            OperationOutcome.IssueSeverity[] expectedIssueSeverities = { OperationOutcome.IssueSeverity.Warning};
+            OperationOutcome.IssueType[] expectedCodeTypes = { OperationOutcome.IssueType.NotSupported };
+            OperationOutcome.IssueSeverity[] expectedIssueSeverities = { OperationOutcome.IssueSeverity.Warning };
 
             Bundle bundle = await Client.SearchAsync("Patient?_text=mobile", Tuple.Create(KnownHeaders.Prefer, "handling=lenient"));
             OperationOutcome outcome = GetAndValidateOperationOutcome(bundle);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [Fact]
         public async Task GivenAnIncludeSearchExpression_WhenSearchedWithPost_ThenCorrectBundleShouldBeReturned()
         {
-            Bundle bundle = await Client.SearchPostAsync(ResourceType.Location.ToString(), default, ("_include", "Location:organization:Organization"), ("_tag", Fixture.Tag));
+            Bundle bundle = await Client.SearchPostAsync(ResourceType.Location.ToString(), null, default, ("_include", "Location:organization:Organization"), ("_tag", Fixture.Tag));
 
             ValidateBundle(
                 bundle,
@@ -335,7 +335,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         [Fact]
         public async Task GivenARevIncludeSearchExpression_WhenSearchedWithPost_ThenCorrectBundleShouldBeReturned()
         {
-            Bundle bundle = await Client.SearchPostAsync(ResourceType.Organization.ToString(), default, ("_revinclude", "Location:organization"), ("_tag", Fixture.Tag));
+            Bundle bundle = await Client.SearchPostAsync(ResourceType.Organization.ToString(), null, default, ("_revinclude", "Location:organization"), ("_tag", Fixture.Tag));
 
             ValidateBundle(
                 bundle,


### PR DESCRIPTION
## Description
This change addresses an issue that was discovered while working on user story [101268](https://microsofthealth.visualstudio.com/Health/_workitems/edit/101268) 
While testing using our .http files it was discovered that a key already exists exception was occurring when trying to repro the issues in the user story. The issue addresses specifically a POST to an endpoint like this where we have duplicated what is in the querystring to what gets put in the body content.

POST <resourcetype>/_search?name=Jon
Content-Type: application/x-www-form-urlencoded
Authorization: Bearer <token>

name=Jon


## Related issues
Addresses [issue #101268](https://microsofthealth.visualstudio.com/Health/_workitems/edit/101268).

## Testing
Added some tests to validate the duplicated querystring name/values getting set as unique name/values. Also ran the BasicSearchTests

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
