### PR TITLE
Add pipeline to cleanup PR environments

### DIFF
--- a/build/cleanup-pr-environments.yml
+++ b/build/cleanup-pr-environments.yml
@@ -24,9 +24,19 @@ stages:
         azurePowerShellVersion: latestVersion
         ScriptType: InlineScript
         Inline: |
-          $excludeList = ${env:Exclude}.Split(',').Trim()
+          Write-Host "Starting"
+
+          Write-Host ${env:Exclude}
+          try {
+            $excludeList = ${env:Exclude}.Split(',').Trim()
+          }
+          catch {
+          }
+
+          Write-Host "Getting resource groups"
           $resourceGroups = Get-AzResourceGroup -Name "$(resourceGroupRoot)*" -Location "$(ResourceGroupRegion)" | Where ResourceGroupName -NotIn $excludeList 
 
+          Write-Host "Finding cutoff time"
           $cutoffTime = Get-Date
           If (${env:DeleteRecent} -ne $true)
           {
@@ -35,6 +45,7 @@ stages:
 
           ForEach ($group in $resourceGroups)
           {
+            Write-Host "Deleting $($group.ResourceGroupName)"
             $deploymentTimes = Get-AzResourceGroupDeployment -ResourceGroupName $group.ResourceGroupName | Select Timestamp | Where Timestamp -lt $cutoffTime
             If ($deploymentTimes.Count -gt 0)
             {

--- a/build/cleanup-pr-environments.yml
+++ b/build/cleanup-pr-environments.yml
@@ -1,0 +1,29 @@
+# DESCRIPTION: 	
+# Removes resource groups used in PRs.
+# THIS WILL DELETE ALL PR RESOURCE GROUPS, EVEN THOSE CURRENTLY RUNNING.
+# Check that no PRs are currently running and no one needs any of the resource groups before running.
+# The Exclude variable can be used to preserve specific resource groups. It is a comma seperated list of the full resource group names.
+
+variables:
+- template: build-variables.yml
+- template: pr-variables.yml
+
+stages:
+- stage: CleanupRGs
+  displayName: 'Cleanup Resource Groups'
+  jobs:
+  - job: DeleteResourceGroup
+    displayName: 'Delete resource group'
+    pool:
+      name: '$(SharedLinuxPool)'
+      vmImage: '$(LinuxVmImage)'
+    steps:
+    - task: AzurePowerShell@4
+      displayName: 'Delete resource group'
+      inputs:
+        azureSubscription: $(ConnectedServiceName)
+        azurePowerShellVersion: latestVersion
+        ScriptType: InlineScript
+        Inline: |
+          $excludeList = $(Exclude).Split(',').Trim()
+          Get-AzResourceGroup -Name "$(resourceGroupRoot)*" -Location "$(ResourceGroupRegion)" | Where ResourceGroupName -NotIn $excludeList | Remove-AzResourceGroup -Verbose -Force

--- a/build/cleanup-pr-environments.yml
+++ b/build/cleanup-pr-environments.yml
@@ -2,7 +2,7 @@
 # Removes resource groups used in PRs.
 # THIS WILL DELETE ALL PR RESOURCE GROUPS, EVEN THOSE CURRENTLY RUNNING.
 # Check that no PRs are currently running and no one needs any of the resource groups before running.
-# The Exclude variable can be used to preserve specific resource groups. It is a comma seperated list of the full resource group names.
+# The Exclude variable can be used to preserve specific resource groups. It is a comma seperated list of the full resource group names. 
 
 variables:
 - template: build-variables.yml
@@ -25,5 +25,5 @@ stages:
         azurePowerShellVersion: latestVersion
         ScriptType: InlineScript
         Inline: |
-          $excludeList = $(Exclude).Split(',').Trim()
+          $excludeList = ${env:Exclude}.Split(',').Trim()
           Get-AzResourceGroup -Name "$(resourceGroupRoot)*" -Location "$(ResourceGroupRegion)" | Where ResourceGroupName -NotIn $excludeList | Remove-AzResourceGroup -Verbose -Force

--- a/build/cleanup-pr-environments.yml
+++ b/build/cleanup-pr-environments.yml
@@ -26,4 +26,19 @@ stages:
         ScriptType: InlineScript
         Inline: |
           $excludeList = ${env:Exclude}.Split(',').Trim()
-          Get-AzResourceGroup -Name "$(resourceGroupRoot)*" -Location "$(ResourceGroupRegion)" | Where ResourceGroupName -NotIn $excludeList | Remove-AzResourceGroup -Verbose -Force
+          $resourceGroups = Get-AzResourceGroup -Name "$(resourceGroupRoot)*" -Location "$(ResourceGroupRegion)" | Where ResourceGroupName -NotIn $excludeList 
+
+          $cutoffTime = Get-Date
+          If (${env:DeleteRecent} -ne $true)
+          {
+            $cutoffTime = $cutoffTime.AddDays(-7)
+          }
+
+          ForEach ($group in $resourceGroups)
+          {
+            $deploymentTimes = Get-AzResourceGroupDeployment -ResourceGroupName $group.ResourceGroupName | Select Timestamp | Where Timestamp -lt $cutoffTime
+            If ($deploymentTimes.Count -gt 0)
+            {
+              Remove-AzResourceGroup -Name $group.ResourceGroupName -Verbose -Force
+            }
+          }

--- a/build/cleanup-pr-environments.yml
+++ b/build/cleanup-pr-environments.yml
@@ -1,8 +1,7 @@
 # DESCRIPTION: 	
 # Removes resource groups used in PRs.
-# THIS WILL DELETE ALL PR RESOURCE GROUPS, EVEN THOSE CURRENTLY RUNNING.
-# Check that no PRs are currently running and no one needs any of the resource groups before running.
 # The Exclude variable can be used to preserve specific resource groups. It is a comma seperated list of the full resource group names. 
+# The DeleteRecent variable can be used to delete recent runs. Otherwise only resource groups with no deployments in the last week will be deleted.
 
 variables:
 - template: build-variables.yml


### PR DESCRIPTION
## Description
Adds a new pipeline that deletes all PR environments to free up resources.

## Related issues
Addresses our reoccurring issue of running out of quota for resources in our PR subscription.

## Testing
Manually ran pipeline.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip
