### PR TITLE
Refactor for IConvertDataTemplateProviders

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/ContainerRegistryTemplateProvider.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/ContainerRegistryTemplateProvider.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.ConvertData
         public ContainerRegistryTemplateProvider(
             IContainerRegistryTokenProvider containerRegistryTokenProvider,
             IOptions<ConvertDataConfiguration> convertDataConfig,
-            ILogger<ContainerRegistryTemplateProvider> logger)
+            ILogger<IConvertDataTemplateProvider> logger)
             : base(convertDataConfig, logger)
         {
             EnsureArg.IsNotNull(containerRegistryTokenProvider, nameof(containerRegistryTokenProvider));

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/ContainerRegistryTemplateProvider.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/ContainerRegistryTemplateProvider.cs
@@ -14,41 +14,23 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Core.Configs;
-using Microsoft.Health.Fhir.Core.Features.Operations.ConvertData.Models;
 using Microsoft.Health.Fhir.Core.Messages.ConvertData;
-using Microsoft.Health.Fhir.TemplateManagement;
-using Microsoft.Health.Fhir.TemplateManagement.Exceptions;
 
 namespace Microsoft.Health.Fhir.Core.Features.Operations.ConvertData
 {
-    public class ContainerRegistryTemplateProvider : IConvertDataTemplateProvider, IDisposable
+    public class ContainerRegistryTemplateProvider : DefaultTemplateProvider, IConvertDataTemplateProvider
     {
-        private bool _disposed = false;
         private readonly IContainerRegistryTokenProvider _containerRegistryTokenProvider;
-        private readonly ITemplateCollectionProviderFactory _templateCollectionProviderFactory;
-        private readonly ConvertDataConfiguration _convertDataConfig;
-        private readonly MemoryCache _cache;
-        private readonly ILogger<ContainerRegistryTemplateProvider> _logger;
 
         public ContainerRegistryTemplateProvider(
             IContainerRegistryTokenProvider containerRegistryTokenProvider,
             IOptions<ConvertDataConfiguration> convertDataConfig,
             ILogger<ContainerRegistryTemplateProvider> logger)
+            : base(convertDataConfig, logger)
         {
             EnsureArg.IsNotNull(containerRegistryTokenProvider, nameof(containerRegistryTokenProvider));
-            EnsureArg.IsNotNull(convertDataConfig, nameof(convertDataConfig));
-            EnsureArg.IsNotNull(logger, nameof(logger));
 
             _containerRegistryTokenProvider = containerRegistryTokenProvider;
-            _convertDataConfig = convertDataConfig.Value;
-            _logger = logger;
-
-            // Initialize cache and template collection provider factory
-            _cache = new MemoryCache(new MemoryCacheOptions
-            {
-                SizeLimit = _convertDataConfig.CacheSizeLimit,
-            });
-            _templateCollectionProviderFactory = new TemplateCollectionProviderFactory(_cache, Options.Create(_convertDataConfig.TemplateCollectionOptions));
         }
 
         /// <summary>
@@ -57,14 +39,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.ConvertData
         /// <param name="request">The convert data request which contains template reference.</param>
         /// <param name="cancellationToken">Cancellation token to cancel the fetch operation.</param>
         /// <returns>Template collection.</returns>
-        public async Task<List<Dictionary<string, Template>>> GetTemplateCollectionAsync(ConvertDataRequest request, CancellationToken cancellationToken)
+        public override async Task<List<Dictionary<string, Template>>> GetTemplateCollectionAsync(ConvertDataRequest request, CancellationToken cancellationToken)
         {
             // We have embedded a default template collection in the templatemanagement package.
             // If the template collection is the default reference, we don't need to retrieve token.
             var accessToken = string.Empty;
             if (!request.IsDefaultTemplateReference)
             {
-                _logger.LogInformation("Using a custom template collection for data conversion.");
+                Logger.LogInformation("Using a custom template collection for data conversion.");
 
                 async Task<string> TokenEntryFactory(ICacheEntry entry)
                 {
@@ -74,41 +56,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.ConvertData
                     return token;
                 }
 
-                accessToken = await _cache.GetOrCreateAsync(GetCacheKey(request.RegistryServer), TokenEntryFactory);
+                accessToken = await Cache.GetOrCreateAsync(GetCacheKey(request.RegistryServer), TokenEntryFactory);
             }
             else
             {
-                _logger.LogInformation("Using the default template collection for data conversion.");
+                Logger.LogInformation("Using the default template collection for data conversion.");
             }
 
-            try
-            {
-                var provider = _templateCollectionProviderFactory.CreateTemplateCollectionProvider(request.TemplateCollectionReference, accessToken);
-                return await provider.GetTemplateCollectionAsync(cancellationToken);
-            }
-            catch (ContainerRegistryAuthenticationException authEx)
-            {
-                // Remove token from cache when authentication failed.
-                _cache.Remove(GetCacheKey(request.RegistryServer));
-
-                _logger.LogWarning(authEx, "Failed to access container registry.");
-                throw new ContainerRegistryNotAuthorizedException(string.Format(Core.Resources.ContainerRegistryNotAuthorized, request.RegistryServer), authEx);
-            }
-            catch (ImageFetchException fetchEx)
-            {
-                _logger.LogWarning(fetchEx, "Failed to fetch template image.");
-                throw new FetchTemplateCollectionFailedException(string.Format(Core.Resources.FetchTemplateCollectionFailed, fetchEx.Message), fetchEx);
-            }
-            catch (TemplateManagementException templateEx)
-            {
-                _logger.LogWarning(templateEx, "Template collection is invalid.");
-                throw new TemplateCollectionErrorException(string.Format(Core.Resources.FetchTemplateCollectionFailed, templateEx.Message), templateEx);
-            }
-            catch (Exception unhandledEx)
-            {
-                _logger.LogError(unhandledEx, "Unhandled exception: failed to get template collection.");
-                throw new FetchTemplateCollectionFailedException(string.Format(Core.Resources.FetchTemplateCollectionFailed, unhandledEx.Message), unhandledEx);
-            }
+            return await GetTemplatesFromRequestAsync(request, accessToken, cancellationToken);
         }
 
         /// <summary>
@@ -130,32 +85,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.ConvertData
             }
 
             return defaultExpiration;
-        }
-
-        private static string GetCacheKey(string registryServer)
-        {
-            return $"registry_{registryServer}";
-        }
-
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (_disposed)
-            {
-                return;
-            }
-
-            if (disposing)
-            {
-                _cache?.Dispose();
-            }
-
-            _disposed = true;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/DefaultTemplateProvider.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/DefaultTemplateProvider.cs
@@ -1,11 +1,14 @@
-﻿using System;
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
 using System.Collections.Generic;
-using System.IdentityModel.Tokens.Jwt;
 using System.Threading;
 using System.Threading.Tasks;
 using DotLiquid;
 using EnsureThat;
-using Microsoft.Azure.ContainerRegistry.Models;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -25,7 +28,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.ConvertData
 
         public DefaultTemplateProvider(
             IOptions<ConvertDataConfiguration> convertDataConfig,
-            ILogger<ContainerRegistryTemplateProvider> logger)
+            ILogger<IConvertDataTemplateProvider> logger)
         {
             EnsureArg.IsNotNull(convertDataConfig, nameof(convertDataConfig));
             EnsureArg.IsNotNull(logger, nameof(logger));
@@ -44,7 +47,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.ConvertData
 
         protected MemoryCache Cache { get; }
 
-        protected ILogger<ContainerRegistryTemplateProvider> Logger { get; }
+        protected ILogger<IConvertDataTemplateProvider> Logger { get; }
 
         /// <summary>
         /// Fetch template collection from container registry or built-in archive.

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/DefaultTemplateProvider.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/DefaultTemplateProvider.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Threading;
+using System.Threading.Tasks;
+using DotLiquid;
+using EnsureThat;
+using Microsoft.Azure.ContainerRegistry.Models;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Fhir.Core.Configs;
+using Microsoft.Health.Fhir.Core.Features.Operations.ConvertData.Models;
+using Microsoft.Health.Fhir.Core.Messages.ConvertData;
+using Microsoft.Health.Fhir.TemplateManagement;
+using Microsoft.Health.Fhir.TemplateManagement.Exceptions;
+
+namespace Microsoft.Health.Fhir.Core.Features.Operations.ConvertData
+{
+    public class DefaultTemplateProvider : IConvertDataTemplateProvider, IDisposable
+    {
+        private bool _disposed = false;
+        private readonly ITemplateCollectionProviderFactory _templateCollectionProviderFactory;
+        private readonly ConvertDataConfiguration _convertDataConfig;
+
+        public DefaultTemplateProvider(
+            IOptions<ConvertDataConfiguration> convertDataConfig,
+            ILogger<ContainerRegistryTemplateProvider> logger)
+        {
+            EnsureArg.IsNotNull(convertDataConfig, nameof(convertDataConfig));
+            EnsureArg.IsNotNull(logger, nameof(logger));
+
+            _convertDataConfig = convertDataConfig.Value;
+
+            Logger = logger;
+
+            // Initialize cache and template collection provider factory
+            Cache = new MemoryCache(new MemoryCacheOptions
+            {
+                SizeLimit = _convertDataConfig.CacheSizeLimit,
+            });
+            _templateCollectionProviderFactory = new TemplateCollectionProviderFactory(Cache, Options.Create(_convertDataConfig.TemplateCollectionOptions));
+        }
+
+        protected MemoryCache Cache { get; }
+
+        protected ILogger<ContainerRegistryTemplateProvider> Logger { get; }
+
+        /// <summary>
+        /// Fetch template collection from container registry or built-in archive.
+        /// </summary>
+        /// <param name="request">The convert data request which contains template reference.</param>
+        /// <param name="cancellationToken">Cancellation token to cancel the fetch operation.</param>
+        /// <returns>Template collection.</returns>
+        public virtual async Task<List<Dictionary<string, Template>>> GetTemplateCollectionAsync(ConvertDataRequest request, CancellationToken cancellationToken)
+        {
+            // We have embedded a default template collection in the templatemanagement package.
+            // If the template collection is the default reference, we don't need to retrieve token.
+            var accessToken = string.Empty;
+            if (!request.IsDefaultTemplateReference)
+            {
+                throw new ContainerRegistryAuthenticationException("External Managed Identity not configured.");
+            }
+            else
+            {
+                Logger.LogInformation("Using the default template collection for data conversion.");
+            }
+
+            return await GetTemplatesFromRequestAsync(request, accessToken, cancellationToken);
+        }
+
+        /// <summary>
+        /// Fetch template collection from container registry or built-in archive given a request and an access token.
+        /// </summary>
+        /// <param name="request">The convert data request which contains template reference.</param>
+        /// <param name="accessToken">The token used to access a container registry. Can be empty for a default template request.</param>
+        /// <param name="cancellationToken">Cancellation token to cancel the fetch operation.</param>
+        /// <returns>Template collection.</returns>
+        protected async Task<List<Dictionary<string, Template>>> GetTemplatesFromRequestAsync(ConvertDataRequest request, string accessToken, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var provider = _templateCollectionProviderFactory.CreateTemplateCollectionProvider(request.TemplateCollectionReference, accessToken);
+                return await provider.GetTemplateCollectionAsync(cancellationToken);
+            }
+            catch (ContainerRegistryAuthenticationException authEx)
+            {
+                // Remove token from cache when authentication failed.
+                Cache.Remove(GetCacheKey(request.RegistryServer));
+
+                Logger.LogWarning(authEx, "Failed to access container registry.");
+                throw new ContainerRegistryNotAuthorizedException(string.Format(Core.Resources.ContainerRegistryNotAuthorized, request.RegistryServer), authEx);
+            }
+            catch (ImageFetchException fetchEx)
+            {
+                Logger.LogWarning(fetchEx, "Failed to fetch template image.");
+                throw new FetchTemplateCollectionFailedException(string.Format(Core.Resources.FetchTemplateCollectionFailed, fetchEx.Message), fetchEx);
+            }
+            catch (TemplateManagementException templateEx)
+            {
+                Logger.LogWarning(templateEx, "Template collection is invalid.");
+                throw new TemplateCollectionErrorException(string.Format(Core.Resources.FetchTemplateCollectionFailed, templateEx.Message), templateEx);
+            }
+            catch (Exception unhandledEx)
+            {
+                Logger.LogError(unhandledEx, "Unhandled exception: failed to get template collection.");
+                throw new FetchTemplateCollectionFailedException(string.Format(Core.Resources.FetchTemplateCollectionFailed, unhandledEx.Message), unhandledEx);
+            }
+        }
+
+        protected virtual string SetToken(ConvertDataRequest request, CancellationToken cancellationToken)
+        {
+            // We have embedded a default template collection in the templatemanagement package.
+            // If the template collection is the default reference, we don't need to retrieve token.
+            var accessToken = string.Empty;
+            if (!request.IsDefaultTemplateReference)
+            {
+                throw new ContainerRegistryAuthenticationException("External Managed Identity not configured.");
+            }
+            else
+            {
+                Logger.LogInformation("Using the default template collection for data conversion.");
+            }
+
+            return accessToken;
+        }
+
+        protected static string GetCacheKey(string registryServer)
+        {
+            return $"registry_{registryServer}";
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                Cache?.Dispose();
+            }
+
+            _disposed = true;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/FhirServerBuilderConvertDataRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/FhirServerBuilderConvertDataRegistrationExtensions.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Extensions.DependencyInjection
         private static IFhirServerBuilder AddConvertDataTemplateProvider(this IFhirServerBuilder fhirServerBuilder)
         {
             fhirServerBuilder.Services.AddSingleton<IConvertDataTemplateProvider, ContainerRegistryTemplateProvider>();
+            fhirServerBuilder.Services.AddSingleton<IConvertDataTemplateProvider, DefaultTemplateProvider>();
 
             return fhirServerBuilder;
         }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/ConvertData/DefaultTemplateProviderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/ConvertData/DefaultTemplateProviderTests.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
@@ -13,6 +13,7 @@ using Microsoft.Health.Fhir.Core.Features.Operations.ConvertData;
 using Microsoft.Health.Fhir.Core.Features.Operations.ConvertData.Models;
 using Microsoft.Health.Fhir.Core.Messages.ConvertData;
 using Microsoft.Health.Fhir.Liquid.Converter.Models;
+using Microsoft.Health.Fhir.TemplateManagement.Exceptions;
 using Microsoft.Health.Fhir.TemplateManagement.Models;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Test.Utilities;
@@ -23,31 +24,31 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Conver
 {
     [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
     [Trait(Traits.Category, Categories.Operations)]
-    public class ContainerRegistryTemplateProviderTests
+    public class DefaultTemplateProviderTests
     {
         [Fact]
-        public async Task GivenDefaultTemplateReference_ForAcrTemplateProvider_WhenFetchingTemplates_DefaultTemplateCollectionShouldReturn()
+        public async Task GivenDefaultTemplateReference_WhenFetchingTemplatesInDefaultProvider_DefaultTemplateCollectionShouldReturn()
         {
-            var containerRegistryTemplateProvider = GetContainerRegistryTemplateProvider();
+            var containerRegistryTemplateProvider = GetDefaultTemplateProvider();
             foreach (var templateInfo in DefaultTemplateInfo.DefaultTemplateMap.Values)
             {
                 var templateReference = templateInfo.ImageReference;
-                var templateCollection = await containerRegistryTemplateProvider.GetTemplateCollectionAsync(GetRequestWithTemplateReference(templateReference), CancellationToken.None);
+                var templateCollection = await containerRegistryTemplateProvider.GetTemplateCollectionAsync(GetRequestWithDefaultTemplateReference(templateReference), CancellationToken.None);
 
                 Assert.NotEmpty(templateCollection);
             }
         }
 
         [Fact]
-        public async Task GivenAnInvalidToken_WhenFetchingCustomTemplates_ExceptionShouldBeThrown()
+        public async Task GivenCustomTemplateReference_ForDefaultTemplateProvider_WhenFetchingCustomTemplates_ExceptionShouldBeThrown()
         {
-            var containerRegistryTemplateProvider = GetContainerRegistryTemplateProvider();
+            var containerRegistryTemplateProvider = GetDefaultTemplateProvider();
             var templateReference = "test.azurecr.io/templates:latest";
 
-            await Assert.ThrowsAsync<ContainerRegistryNotAuthorizedException>(() => containerRegistryTemplateProvider.GetTemplateCollectionAsync(GetRequestWithTemplateReference(templateReference), CancellationToken.None));
+            await Assert.ThrowsAsync<ContainerRegistryAuthenticationException>(() => containerRegistryTemplateProvider.GetTemplateCollectionAsync(GetRequestWithCustomTemplateReference(templateReference), CancellationToken.None));
         }
 
-        private IConvertDataTemplateProvider GetContainerRegistryTemplateProvider()
+        private IConvertDataTemplateProvider GetDefaultTemplateProvider()
         {
             IContainerRegistryTokenProvider tokenProvider = Substitute.For<IContainerRegistryTokenProvider>();
             tokenProvider.GetTokenAsync(default, default).ReturnsForAnyArgs("Bearer faketoken");
@@ -60,12 +61,17 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Conver
             convertDataConfig.ContainerRegistryServers.Add("test.azurecr.io");
 
             var config = Options.Create(convertDataConfig);
-            return new ContainerRegistryTemplateProvider(tokenProvider, config, new NullLogger<ContainerRegistryTemplateProvider>());
+            return new DefaultTemplateProvider(config, new NullLogger<DefaultTemplateProvider>());
         }
 
-        private ConvertDataRequest GetRequestWithTemplateReference(string templateReference)
+        private ConvertDataRequest GetRequestWithDefaultTemplateReference(string templateReference)
         {
             return new ConvertDataRequest(Samples.SampleHl7v2Message, DataType.Hl7v2, templateReference.Split('/')[0], true, templateReference, "ADT_A01");
+        }
+
+        private ConvertDataRequest GetRequestWithCustomTemplateReference(string templateReference)
+        {
+            return new ConvertDataRequest(Samples.SampleHl7v2Message, DataType.Hl7v2, templateReference.Split('/')[0], false, templateReference, "ADT_A01");
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
@@ -15,6 +15,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Conformance\ConformanceBuilderTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Conformance\ConformanceProviderExtensionTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Conformance\GetSmartConfigurationHandlerTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)features\operations\convertdata\DefaultTemplateProviderTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\Everything\EverythingOperationContinuationTokenTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\Everything\EverythingOperationHandlerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\Everything\PatientEverythingServiceTests.cs" />


### PR DESCRIPTION
Separated logic for default template use case and custom template use case into a DefaultTemplateProvider and a CustomTemplateProvider, which inherits from the DefaultTemplateProvider.