### PR TITLE
changes to support a list for ScopesClaim

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Configs/AuthorizationConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/AuthorizationConfiguration.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Health.Fhir.Core.Configs
 
         public IReadOnlyList<Role> Roles { get; internal set; } = ImmutableList<Role>.Empty;
 
-        public string ScopesClaim { get; set; } = "scp";
+        public IReadOnlyList<string> ScopesClaim { get; set; } = new List<string>() { "scp" };
 
         public string FhirUserClaim { get; set; } = "fhirUser";
 

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
@@ -51,6 +51,45 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
         }
 
         [Theory]
+        [MemberData(nameof(GetTestScopesAndRoles))]
+        public async Task GivenSmartScopesSplitAcrossClaims_WhenInvoked_ThenScopeParsedandAddedtoContext(string scopes, string claims, ICollection<ScopeRestriction> expectedScopeRestrictions)
+        {
+            var fhirRequestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
+
+            var fhirRequestContext = new DefaultFhirRequestContext();
+
+            fhirRequestContextAccessor.RequestContext.Returns(fhirRequestContext);
+
+            HttpContext httpContext = new DefaultHttpContext();
+
+            var fhirConfiguration = new FhirServerConfiguration();
+            fhirConfiguration.Security.Enabled = true;
+            var authorizationConfiguration = fhirConfiguration.Security.Authorization;
+            authorizationConfiguration.Enabled = true;
+            await LoadRoles(authorizationConfiguration);
+
+            var fhirUserClaim = new Claim(authorizationConfiguration.FhirUserClaim, "https://fhirServer/Patient/foo");
+            var rolesClaim = new Claim(authorizationConfiguration.RolesClaim, claims);
+            var rolesSmartUserClaim = new Claim(authorizationConfiguration.RolesClaim, "smartUser");
+
+            foreach (string singleClaim in authorizationConfiguration.ScopesClaim)
+            {
+                var scopesClaim = new Claim(singleClaim, scopes);
+                var claimsIdentity = new ClaimsIdentity(new List<Claim>() { scopesClaim, rolesClaim, fhirUserClaim, rolesSmartUserClaim });
+                var expectedPrincipal = new ClaimsPrincipal(claimsIdentity);
+
+                httpContext.User = expectedPrincipal;
+                fhirRequestContext.Principal = expectedPrincipal;
+
+                _authorizationService = new RoleBasedFhirAuthorizationService(authorizationConfiguration, fhirRequestContextAccessor);
+
+                await _smartClinicalScopesMiddleware.Invoke(httpContext, fhirRequestContextAccessor, Options.Create(fhirConfiguration.Security), _authorizationService);
+
+                Assert.Equal(expectedScopeRestrictions, fhirRequestContext.AccessControlContext.AllowedResourceActions);
+            }
+        }
+
+        [Theory]
         [MemberData(nameof(GetTestScopes))]
         public async Task GivenSmartScope_WhenInvoked_ThenScopeParsedandAddedtoContext(string scopes, ICollection<ScopeRestriction> expectedScopeRestrictions)
         {
@@ -228,6 +267,47 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
                 Assert.Equal("Patient", fhirRequestContext.AccessControlContext.CompartmentResourceType);
                 Assert.Equal("foo", fhirRequestContext.AccessControlContext.CompartmentId);
             }
+        }
+
+        public static IEnumerable<object[]> GetTestScopesAndRoles()
+        {
+            yield return new object[]
+            {
+                "patient/Patient.read",
+                "patient/Observation.read",
+                new List<ScopeRestriction>()
+                {
+                    new ScopeRestriction("Patient", DataActions.Read, "patient"),
+                    new ScopeRestriction("Observation", DataActions.Read, "patient"),
+                },
+            };
+            yield return new object[]
+            {
+                "patient.Patient.read",
+                "user.Observation.write",
+                new List<ScopeRestriction>()
+                {
+                    new ScopeRestriction("Patient", DataActions.Read, "patient"),
+                    new ScopeRestriction("Observation", DataActions.Read | DataActions.Write, "user"),
+                },
+            };
+            yield return new object[]
+            {
+                "patient$Patient.read",
+                "practitioner/Observation.write",
+                new List<ScopeRestriction>()
+                {
+                    new ScopeRestriction("Patient", DataActions.Read, "patient"),
+                },
+            };
+            yield return new object[]
+            {
+                "patient$Patient.rd",
+                "practitioner/Observation.wr",
+                new List<ScopeRestriction>()
+                {
+                },
+            };
         }
 
         public static IEnumerable<object[]> GetTestScopes()

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
@@ -242,6 +242,15 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
                     new ScopeRestriction("Observation", DataActions.Read, "patient"),
                 },
             };
+            yield return new object[]
+            {
+                "patient.Patient.read user.Observation.write",
+                new List<ScopeRestriction>()
+                {
+                    new ScopeRestriction("Patient", DataActions.Read, "patient"),
+                    new ScopeRestriction("Observation", DataActions.Read | DataActions.Write, "user"),
+                },
+            };
 
             yield return new object[] { "user/*.*", new List<ScopeRestriction>() { new ScopeRestriction(KnownResourceTypes.All, DataActions.Read | DataActions.Write | DataActions.Export, "user") } };
             yield return new object[] { "user/Encounter.*", new List<ScopeRestriction>() { new ScopeRestriction("Encounter", DataActions.Read | DataActions.Write | DataActions.Export, "user") } };

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -13,7 +13,7 @@
             ],
             "Authorization": {
                 "Enabled": true,
-                "ScopesClaim": "scope"
+                "ScopesClaim": [ "scope" ]
             }
         },
         "Features": {


### PR DESCRIPTION
## Description
Revised ScopesClaim from a string to a list to support the following:

For certain scenarios AAD includes clinical scopes values in the roles claim.  We should include examining that claim for scopes.  We can examine any value in the claim using the regex for clinical scopes and then include them in the collection.

For any scenario where the caller to the FHIR Api is an app, rather than a user, scenario such as bulk export, with a scope of system.read.all then  we are not interpreting the clinical scope currently.  But as bulk export has only the one scope of system.read.all and we don't currently support any other system scopes, it is not currenly a problem. If not addressed right now, we will forget and will be tough to tackle later

## Related issues
Addresses [issue #98439](https://microsofthealth.visualstudio.com/Health/_workitems/edit/98439).

## Testing
Successfully ran the SmartClinicalScopesMiddlewareTests

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
