### PR TITLE
Attempting to fix issue with delete group

### DIFF
--- a/build/jobs/cleanup.yml
+++ b/build/jobs/cleanup.yml
@@ -11,7 +11,14 @@ jobs:
       azureSubscription: $(ConnectedServiceName)
       azurePowerShellVersion: latestVersion
       ScriptType: InlineScript
-      Inline: 'Get-AzResourceGroup -Name $(ResourceGroupName) | Remove-AzResourceGroup -Verbose -Force'
+      Inline: 'Get-AzResourceGroup -Name $(ResourceGroupName) -ErrorVariable notPresent -ErrorAction SilentlyContinue |
+              if ($notPresent) {
+                Write-Host "Resource group $(ResourceGroupName) not found"
+              } else {
+                Write-Host "Deleting resource group $(ResourceGroupName)"
+                Remove-AzResourceGroup -Name $(ResourceGroupName) -Force -Verbose
+              }'
+      
 
 - template: ./cleanup-aad.yml
 

--- a/build/jobs/cleanup.yml
+++ b/build/jobs/cleanup.yml
@@ -11,13 +11,14 @@ jobs:
       azureSubscription: $(ConnectedServiceName)
       azurePowerShellVersion: latestVersion
       ScriptType: InlineScript
-      Inline: 'Get-AzResourceGroup -Name $(ResourceGroupName) -ErrorVariable notPresent -ErrorAction SilentlyContinue |
-              if ($notPresent) {
-                Write-Host "Resource group $(ResourceGroupName) not found"
-              } else {
-                Write-Host "Deleting resource group $(ResourceGroupName)"
-                Remove-AzResourceGroup -Name $(ResourceGroupName) -Force -Verbose
-              }'
+      Inline: |
+        Get-AzResourceGroup -Name $(ResourceGroupName) -ErrorVariable notPresent -ErrorAction SilentlyContinue 
+        if ($notPresent) {
+          Write-Host "Resource group $(ResourceGroupName) not found"
+        } else {
+          Write-Host "Deleting resource group $(ResourceGroupName)"
+          Remove-AzResourceGroup -Name $(ResourceGroupName) -Force -Verbose
+        }
       
 
 - template: ./cleanup-aad.yml


### PR DESCRIPTION
## Description
Describe the changes in this PR.

## Related issues
Addresses [issue #].

## Testing
Ran PR build. Once completed I ran the last job again to validate that it still passes when resource group is gone. 
![image](https://user-images.githubusercontent.com/5921981/234468584-aa23bd07-42cf-4f8d-b7f2-f601c963ebb2.png)


## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
