### PR TITLE
Convert Refactor for Missing External MI Case

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/ConvertDataEngine.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/ConvertDataEngine.cs
@@ -23,22 +23,22 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.ConvertData
 {
     public class ConvertDataEngine : IConvertDataEngine
     {
-        private readonly IConvertDataTemplateProvider _convertDataTemplateProvider;
+        private readonly ITemplateProviderFactory _templateProviderFactory;
         private readonly ConvertDataConfiguration _convertDataConfiguration;
         private readonly ILogger<ConvertDataEngine> _logger;
 
         private readonly Dictionary<DataType, IFhirConverter> _converterMap = new Dictionary<DataType, IFhirConverter>();
 
         public ConvertDataEngine(
-            IConvertDataTemplateProvider convertDataTemplateProvider,
+            ITemplateProviderFactory templateProviderFactory,
             IOptions<ConvertDataConfiguration> convertDataConfiguration,
             ILogger<ConvertDataEngine> logger)
         {
-            EnsureArg.IsNotNull(convertDataTemplateProvider, nameof(convertDataTemplateProvider));
+            EnsureArg.IsNotNull(templateProviderFactory, nameof(templateProviderFactory));
             EnsureArg.IsNotNull(convertDataConfiguration, nameof(convertDataConfiguration));
             EnsureArg.IsNotNull(logger, nameof(logger));
 
-            _convertDataTemplateProvider = convertDataTemplateProvider;
+            _templateProviderFactory = templateProviderFactory;
             _convertDataConfiguration = convertDataConfiguration.Value;
             _logger = logger;
 
@@ -47,7 +47,18 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.ConvertData
 
         public async Task<ConvertDataResponse> Process(ConvertDataRequest convertRequest, CancellationToken cancellationToken)
         {
-            var templateCollection = await _convertDataTemplateProvider.GetTemplateCollectionAsync(convertRequest, cancellationToken);
+            IConvertDataTemplateProvider convertDataTemplateProvider;
+
+            if (convertRequest.IsDefaultTemplateReference)
+            {
+                convertDataTemplateProvider = _templateProviderFactory.GetDefaultTemplateProvider();
+            }
+            else
+            {
+                convertDataTemplateProvider = _templateProviderFactory.GetContainerRegistryTemplateProvider();
+            }
+
+            List<Dictionary<string, DotLiquid.Template>> templateCollection = await convertDataTemplateProvider.GetTemplateCollectionAsync(convertRequest, cancellationToken);
 
             ITemplateProvider templateProvider = new TemplateProvider(templateCollection);
             if (templateProvider == null)

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/DefaultTemplateProvider.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/DefaultTemplateProvider.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IdentityModel.Tokens.Jwt;
 using System.Threading;
 using System.Threading.Tasks;
 using DotLiquid;
@@ -21,26 +20,23 @@ using Microsoft.Health.Fhir.TemplateManagement.Exceptions;
 
 namespace Microsoft.Health.Fhir.Core.Features.Operations.ConvertData
 {
-    public class ContainerRegistryTemplateProvider : IConvertDataTemplateProvider, IDisposable
+    public class DefaultTemplateProvider : IConvertDataTemplateProvider, IDisposable
     {
         private bool _disposed = false;
-        private readonly IContainerRegistryTokenProvider _containerRegistryTokenProvider;
+        private readonly ILogger _logger;
+        private readonly MemoryCache _cache;
         private readonly ITemplateCollectionProviderFactory _templateCollectionProviderFactory;
         private readonly ConvertDataConfiguration _convertDataConfig;
-        private readonly MemoryCache _cache;
-        private readonly ILogger<ContainerRegistryTemplateProvider> _logger;
 
-        public ContainerRegistryTemplateProvider(
-            IContainerRegistryTokenProvider containerRegistryTokenProvider,
+        public DefaultTemplateProvider(
             IOptions<ConvertDataConfiguration> convertDataConfig,
-            ILogger<ContainerRegistryTemplateProvider> logger)
+            ILogger<IConvertDataTemplateProvider> logger)
         {
-            EnsureArg.IsNotNull(containerRegistryTokenProvider, nameof(containerRegistryTokenProvider));
             EnsureArg.IsNotNull(convertDataConfig, nameof(convertDataConfig));
             EnsureArg.IsNotNull(logger, nameof(logger));
 
-            _containerRegistryTokenProvider = containerRegistryTokenProvider;
             _convertDataConfig = convertDataConfig.Value;
+
             _logger = logger;
 
             // Initialize cache and template collection provider factory
@@ -52,42 +48,21 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.ConvertData
         }
 
         /// <summary>
-        /// Fetch template collection from container registry following a custom template convert request.
+        /// Fetch template collection from built-in archive following a default template convert request.
         /// </summary>
         /// <param name="request">The convert data request which contains template reference.</param>
         /// <param name="cancellationToken">Cancellation token to cancel the fetch operation.</param>
         /// <returns>Template collection.</returns>
         public async Task<List<Dictionary<string, Template>>> GetTemplateCollectionAsync(ConvertDataRequest request, CancellationToken cancellationToken)
         {
-            _logger.LogInformation("Using a custom template collection for data conversion.");
+            var accessToken = string.Empty;
 
-            async Task<string> TokenEntryFactory(ICacheEntry entry)
-            {
-                var token = await _containerRegistryTokenProvider.GetTokenAsync(request.RegistryServer, cancellationToken);
-                entry.Size = token.Length;
-                entry.AbsoluteExpiration = GetTokenAbsoluteExpiration(token);
-                return token;
-            }
-
-            var accessToken = await _cache.GetOrCreateAsync(GetCacheKey(request.RegistryServer), TokenEntryFactory);
+            _logger.LogInformation("Using the default template collection for data conversion.");
 
             try
             {
                 var provider = _templateCollectionProviderFactory.CreateTemplateCollectionProvider(request.TemplateCollectionReference, accessToken);
                 return await provider.GetTemplateCollectionAsync(cancellationToken);
-            }
-            catch (ContainerRegistryAuthenticationException authEx)
-            {
-                // Remove token from cache when authentication failed.
-                _cache.Remove(GetCacheKey(request.RegistryServer));
-
-                _logger.LogWarning(authEx, "Failed to access container registry.");
-                throw new ContainerRegistryNotAuthorizedException(string.Format(Core.Resources.ContainerRegistryNotAuthorized, request.RegistryServer), authEx);
-            }
-            catch (ImageFetchException fetchEx)
-            {
-                _logger.LogWarning(fetchEx, "Failed to fetch template image.");
-                throw new FetchTemplateCollectionFailedException(string.Format(Core.Resources.FetchTemplateCollectionFailed, fetchEx.Message), fetchEx);
             }
             catch (TemplateManagementException templateEx)
             {
@@ -99,33 +74,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.ConvertData
                 _logger.LogError(unhandledEx, "Unhandled exception: failed to get template collection.");
                 throw new FetchTemplateCollectionFailedException(string.Format(Core.Resources.FetchTemplateCollectionFailed, unhandledEx.Message), unhandledEx);
             }
-        }
-
-        /// <summary>
-        /// Try to parse exp claim from the acr JWT token. Return 30 minutes as default expiration.
-        /// </summary>
-        /// <param name="accessToken">JWT token with "Bearer" prefix.</param>
-        /// <returns>Expiration DateTimeOffset.</returns>
-        private static DateTimeOffset GetTokenAbsoluteExpiration(string accessToken)
-        {
-            var defaultExpiration = DateTimeOffset.Now.AddMinutes(30);
-
-            if (accessToken.StartsWith("bearer ", StringComparison.OrdinalIgnoreCase))
-            {
-                var jwtTokenText = accessToken.Substring(7);
-                var handler = new JwtSecurityTokenHandler();
-                var jwtToken = handler.ReadToken(jwtTokenText) as JwtSecurityToken;
-
-                // Add 5 minutes buffer in case of last minute expirations.
-                return new DateTimeOffset(jwtToken.ValidTo).AddMinutes(-5);
-            }
-
-            return defaultExpiration;
-        }
-
-        private static string GetCacheKey(string registryServer)
-        {
-            return $"registry_{registryServer}";
         }
 
         public void Dispose()

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/FhirServerBuilderConvertDataRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/FhirServerBuilderConvertDataRegistrationExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             EnsureArg.IsNotNull(fhirServerBuilder, nameof(fhirServerBuilder));
 
-            fhirServerBuilder.AddConvertDataTemplateProvider()
+            fhirServerBuilder.AddConvertDataTemplateProviders()
                 .AddConvertDataEngine();
 
             return fhirServerBuilder;
@@ -29,9 +29,11 @@ namespace Microsoft.Extensions.DependencyInjection
             return fhirServerBuilder;
         }
 
-        private static IFhirServerBuilder AddConvertDataTemplateProvider(this IFhirServerBuilder fhirServerBuilder)
+        private static IFhirServerBuilder AddConvertDataTemplateProviders(this IFhirServerBuilder fhirServerBuilder)
         {
-            fhirServerBuilder.Services.AddSingleton<IConvertDataTemplateProvider, ContainerRegistryTemplateProvider>();
+            fhirServerBuilder.Services.AddSingleton<DefaultTemplateProvider>();
+            fhirServerBuilder.Services.AddSingleton<ContainerRegistryTemplateProvider>();
+            fhirServerBuilder.Services.AddSingleton<ITemplateProviderFactory, TemplateProviderFactory>();
 
             return fhirServerBuilder;
         }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/ITemplateProviderFactory.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/ITemplateProviderFactory.cs
@@ -1,0 +1,14 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Fhir.Core.Features.Operations.ConvertData
+{
+    public interface ITemplateProviderFactory
+    {
+        public IConvertDataTemplateProvider GetContainerRegistryTemplateProvider();
+
+        public IConvertDataTemplateProvider GetDefaultTemplateProvider();
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/TemplateProviderFactory.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/TemplateProviderFactory.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.ConvertData
 {
     public class TemplateProviderFactory : ITemplateProviderFactory
     {
-        private IServiceProvider _sp;
+        private readonly IServiceProvider _sp;
 
         public TemplateProviderFactory(IServiceProvider sp)
         {

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/TemplateProviderFactory.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/TemplateProviderFactory.cs
@@ -1,0 +1,31 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using EnsureThat;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Health.Fhir.Core.Features.Operations.ConvertData
+{
+    public class TemplateProviderFactory : ITemplateProviderFactory
+    {
+        private IServiceProvider _sp;
+
+        public TemplateProviderFactory(IServiceProvider sp)
+        {
+            _sp = EnsureArg.IsNotNull(sp, nameof(sp));
+        }
+
+        public IConvertDataTemplateProvider GetContainerRegistryTemplateProvider()
+        {
+            return _sp.GetRequiredService<ContainerRegistryTemplateProvider>();
+        }
+
+        public IConvertDataTemplateProvider GetDefaultTemplateProvider()
+        {
+            return _sp.GetRequiredService<DefaultTemplateProvider>();
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/ConvertData/ContainerRegistryTemplateProviderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/ConvertData/ContainerRegistryTemplateProviderTests.cs
@@ -38,19 +38,23 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Conver
             }
         }
 
-        [Fact]
-        public async Task GivenAnInvalidToken_WhenFetchingCustomTemplates_ExceptionShouldBeThrown()
-        {
-            var containerRegistryTemplateProvider = GetDefaultTemplateProvider();
-            var templateReference = "test.azurecr.io/templates:latest";
-
-            await Assert.ThrowsAsync<ContainerRegistryNotAuthorizedException>(() => containerRegistryTemplateProvider.GetTemplateCollectionAsync(GetRequestWithTemplateReference(templateReference), CancellationToken.None));
-        }
-
         private IConvertDataTemplateProvider GetDefaultTemplateProvider()
         {
+            var convertDataConfig = new ConvertDataConfiguration
+            {
+                Enabled = true,
+                OperationTimeout = TimeSpan.FromSeconds(1),
+            };
+            convertDataConfig.ContainerRegistryServers.Add("test.azurecr.io");
+
+            var config = Options.Create(convertDataConfig);
+            return new DefaultTemplateProvider(config, new NullLogger<DefaultTemplateProvider>());
+        }
+
+        private IConvertDataTemplateProvider GetCustomTemplateProvider()
+        {
             IContainerRegistryTokenProvider tokenProvider = Substitute.For<IContainerRegistryTokenProvider>();
-            tokenProvider.GetTokenAsync(default, default).ReturnsForAnyArgs("Bearer faketoken");
+            tokenProvider.GetTokenAsync(default, default).ReturnsForAnyArgs("Faketoken");
 
             var convertDataConfig = new ConvertDataConfiguration
             {
@@ -68,4 +72,3 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Conver
             return new ConvertDataRequest(Samples.SampleHl7v2Message, DataType.Hl7v2, templateReference.Split('/')[0], true, templateReference, "ADT_A01");
         }
     }
-}

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/ConvertData/ContainerRegistryTemplateProviderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/ConvertData/ContainerRegistryTemplateProviderTests.cs
@@ -72,3 +72,4 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Conver
             return new ConvertDataRequest(Samples.SampleHl7v2Message, DataType.Hl7v2, templateReference.Split('/')[0], true, templateReference, "ADT_A01");
         }
     }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/ConvertData/ConvertDataRequestHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/ConvertData/ConvertDataRequestHandlerTests.cs
@@ -116,13 +116,12 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Conver
 
             IOptions<ConvertDataConfiguration> convertDataConfiguration = Options.Create(convertDataConfig);
 
-            IContainerRegistryTokenProvider tokenProvider = Substitute.For<IContainerRegistryTokenProvider>();
-            tokenProvider.GetTokenAsync(Arg.Any<string>(), default).ReturnsForAnyArgs(string.Empty);
-
-            ContainerRegistryTemplateProvider templateProvider = new ContainerRegistryTemplateProvider(tokenProvider, convertDataConfiguration, new NullLogger<ContainerRegistryTemplateProvider>());
+            DefaultTemplateProvider templateProvider = new DefaultTemplateProvider(convertDataConfiguration, new NullLogger<DefaultTemplateProvider>());
+            ITemplateProviderFactory templateProviderFactory = Substitute.For<ITemplateProviderFactory>();
+            templateProviderFactory.GetDefaultTemplateProvider().Returns(templateProvider);
 
             var convertDataEngine = new ConvertDataEngine(
-                templateProvider,
+                templateProviderFactory,
                 convertDataConfiguration,
                 new NullLogger<ConvertDataEngine>());
 


### PR DESCRIPTION
## Description
This PR addresses the issue of a user being unable to make a default template call unless they have the permissions/access token necessary for a custom template request configured. Default templates are currently stored in the code base, so no external permissions/tokens should be required to access these templates. This PR enables the use case for convert using default templates without external permissions/tokens configured by separating out the logic and dependency chains for custom and default template convert requests.

## Related issues
Addresses [issue #102114](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Aegean/Stories/?workitem=102114).

## Testing
Unit tests were updated to align with the two use cases achieved by the updated logic. A FHIR server was also run locally and the control flow was verified for both a default and custom template request.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
