### PR TITLE
Adding queryList Errors to the reindex output

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
@@ -43,6 +43,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations
 
         public const string QueryList = "queryList";
 
+        public const string QueryListErrors = "queryListErrors";
+
         public const string Page = "page";
 
         public const string Error = "error";

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -554,6 +554,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     }
 
                     query.Status = OperationStatus.Failed;
+                    _reindexJobRecord.Status = OperationStatus.Failed;
                 }
                 else
                 {

--- a/src/Microsoft.Health.Fhir.Shared.Core/Extensions/ReindexJobRecordExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Extensions/ReindexJobRecordExtensions.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using EnsureThat;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Core.Features.Operations;
@@ -36,6 +37,18 @@ namespace Microsoft.Health.Fhir.Core.Extensions
                 }
 
                 parametersResource.Parameter.Add(new Parameters.ParameterComponent() { Name = JobRecordProperties.Output, Part = outputMessages });
+            }
+
+            List<ReindexJobQueryStatus> queryErrors = job.QueryList.Keys.Where(e => !string.IsNullOrWhiteSpace(e.Error)).ToList();
+            if (queryErrors.Any())
+            {
+                var outputMessages = new HashSet<string>();
+                foreach (ReindexJobQueryStatus key in queryErrors)
+                {
+                    outputMessages.Add($"{key.ResourceType}: {key.Error}");
+                }
+
+                parametersResource.Add($"{JobRecordProperties.QueryListErrors}", new FhirString(string.Join(" ", outputMessages)));
             }
 
             if (job.StartTime.HasValue)


### PR DESCRIPTION
## Description
When the query to discover resources needing to reindexed fails, the exception details are recorded in the ReindexJobRecord queryList.Errors collection.  This collection is not serialized to a Parameters resource when querying ReindexJob status and this change addresses the issue.

This is an example output of how the error will be reported for the QueryList. Now the exception was a forced exception that I caused but you get the idea of how it will look on line 26 and 27 in the screen shot.

![image](https://user-images.githubusercontent.com/99214729/235241460-23924a0f-821e-4f84-9e05-1731666d866e.png)


## Related issues
Addresses [issue #100499](https://microsofthealth.visualstudio.com/Health/_workitems/edit/100499).

## Testing
Added a new test to validate the field is output when appropriate.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
