### PR TITLE
Remove Basic Auth from Redeploy Ci Pipeline

### DIFF
--- a/build/ci-deploy.yml
+++ b/build/ci-deploy.yml
@@ -1,7 +1,7 @@
 # DESCRIPTION: 	
-# Deploys the CI environment in case the persistant resources are deleted or broken.
+# Deploys the CI environment in case the persistent resources are deleted or broken.
 # This pipeline is only needed if CI is broken. It can be months between runs.
-# As CI is a persistant environment this pipeline should not be run unless needed.
+# As CI is a persistent environment this pipeline should not be run unless needed.
 
 name: $(SourceBranchName)-$(Date:yyyyMMdd)$(Rev:-r)
 trigger: none

--- a/build/ci-variables.yml
+++ b/build/ci-variables.yml
@@ -1,7 +1,7 @@
 variables:
     ResourceGroupRegion: 'southcentralus'
     # Due to deleting a keyvault with purge protection we must use a name other than msh-fhir-ci for 90 days after 5/20/2021.
-    resourceGroupRoot: 'msh-fhir-ci2'
+    resourceGroupRoot: 'msh-fhir-ci3'
     appServicePlanName: '$(resourceGroupRoot)-linux'
     DeploymentEnvironmentName: '$(resourceGroupRoot)'
     ResourceGroupName: '$(resourceGroupRoot)'

--- a/build/ci-variables.yml
+++ b/build/ci-variables.yml
@@ -1,7 +1,7 @@
 variables:
     ResourceGroupRegion: 'southcentralus'
     # Due to deleting a keyvault with purge protection we must use a name other than msh-fhir-ci for 90 days after 5/20/2021.
-    resourceGroupRoot: 'msh-fhir-ci3'
+    resourceGroupRoot: 'msh-fhir-ci2'
     appServicePlanName: '$(resourceGroupRoot)-linux'
     DeploymentEnvironmentName: '$(resourceGroupRoot)'
     ResourceGroupName: '$(resourceGroupRoot)'

--- a/build/jobs/cleanup-resourcegroup-aad.yml
+++ b/build/jobs/cleanup-resourcegroup-aad.yml
@@ -11,6 +11,13 @@ jobs:
       azureSubscription: $(ConnectedServiceName)
       azurePowerShellVersion: latestVersion
       ScriptType: InlineScript
-      Inline: 'Get-AzResourceGroup -Name $(ResourceGroupName) | Remove-AzResourceGroup -Verbose -Force'
+      Inline: |
+        Get-AzResourceGroup -Name $(ResourceGroupName) -ErrorVariable notPresent -ErrorAction SilentlyContinue 
+        if ($notPresent) {
+          Write-Host "Resource group $(ResourceGroupName) not found"
+        } else {
+          Write-Host "Deleting resource group $(ResourceGroupName)"
+          Remove-AzResourceGroup -Name $(ResourceGroupName) -Force -Verbose
+        }
 
 - template: ./cleanup-aad.yml

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -329,8 +329,7 @@
                             "value": "true"
                         }
                     ],
-                    "scmType": "None",
-                    "ftpsState": "Disabled"
+                    "scmType": "None"
                 }
                 },
                 "serverFarmId": "[resourceId(variables('appServicePlanResourceGroup'), 'Microsoft.Web/serverfarms/', variables('appServicePlanName'))]",

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -370,9 +370,7 @@
                     "apiVersion": "2020-12-01",
                     "name": "scm",
                     "type": "Microsoft.Web/sites/slots/basicPublishingCredentialsPolicies",
-                    "dependsOn": [
-                        "[variables('appServiceResourceId')]"
-                    ],
+                    "kind": "string",
                     "properties": {
                         "allow": false
                     }

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -369,7 +369,7 @@
                 {
                     "type": "Microsoft.Web/sites/basicPublishingCredentialsPolicies",
                     "apiVersion": "2022-09-01",
-                    "name": "[concat(parameters('serviceName'), '/scm')]",
+                    "name": "[concat(variables('serviceName'), '/scm')]",
                     "location": "South Central US",
                     "dependsOn": [
                         "Microsoft.Web/sites"

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -365,21 +365,20 @@
                         "alwaysOn": true,
                         "healthCheckPath": "/health/check"
                     }
+                },
+                {
+                    "apiVersion": "2020-12-01",
+                    "name": "scm",
+                    "type": "basicPublishingCredentialsPolicies",
+                    "kind": "string",
+                    "dependsOn":[
+                        "[variables('serviceName')]"
+                    ],
+                    "properties": {
+                        "allow": false
+                    }
                 }
             ]
-        },
-        {
-            "apiVersion": "2020-12-01",
-            "name": "[concat(parameters('serviceName'), '/scm')]",
-            "location": "[resourceGroup().location]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Web/sites', parameters('serviceName'))]"
-            ],
-            "type": "Microsoft.Web/sites/slots/basicPublishingCredentialsPolicies",
-            "kind": "string",
-            "properties": {
-                "allow": false
-            }
         },
         {
             "apiVersion": "2015-05-01",

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -328,11 +328,13 @@
                             "name": "WEBSITES_ENABLE_APP_SERVICE_STORAGE",
                             "value": "true"
                         }
-                    ]
+                    ],
+                    "generalSettings": {
+                        "basicAuthEnabled": false
+                    }
                 },
                 "serverFarmId": "[resourceId(variables('appServicePlanResourceGroup'), 'Microsoft.Web/serverfarms/', variables('appServicePlanName'))]",
-                "clientAffinityEnabled": false,
-                "basicAuthEnabled": false,
+                "clientAffinityEnabled": false
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]"

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -329,9 +329,9 @@
                             "value": "true"
                         }
                     ],
-                    "generalSettings": {
-                        "basicAuthEnabled": false
-                    }
+                    "scmType": "None",
+                    "ftpsState": "Disabled"
+                }
                 },
                 "serverFarmId": "[resourceId(variables('appServicePlanResourceGroup'), 'Microsoft.Web/serverfarms/', variables('appServicePlanName'))]",
                 "clientAffinityEnabled": false

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -377,6 +377,18 @@
                     "properties": {
                         "allow": false
                     }
+                },
+                                {
+                    "apiVersion": "2020-12-01",
+                    "name": "ftp",
+                    "type": "basicPublishingCredentialsPolicies",
+                    "kind": "string",
+                    "dependsOn":[
+                        "[variables('serviceName')]"
+                    ],
+                    "properties": {
+                        "allow": false
+                    }
                 }
             ]
         },

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -329,8 +329,8 @@
                             "value": "true"
                         }
                     ],
-                    "scmType": "None"
-                }
+                    "scmType": "None",
+                    "ftpsState": "Disabled"
                 },
                 "serverFarmId": "[resourceId(variables('appServicePlanResourceGroup'), 'Microsoft.Web/serverfarms/', variables('appServicePlanName'))]",
                 "clientAffinityEnabled": false

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -365,17 +365,21 @@
                         "alwaysOn": true,
                         "healthCheckPath": "/health/check"
                     }
-                },
-                {
-                    "apiVersion": "2020-12-01",
-                    "name": "scm",
-                    "type": "Microsoft.Web/sites/slots/basicPublishingCredentialsPolicies",
-                    "kind": "string",
-                    "properties": {
-                        "allow": false
-                    }
                 }
             ]
+        },
+        {
+            "apiVersion": "2020-12-01",
+            "name": "[concat(parameters('serviceName'), '/scm')]",
+            "location": "[resourceGroup().location]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('serviceName'))]"
+            ],
+            "type": "Microsoft.Web/sites/slots/basicPublishingCredentialsPolicies",
+            "kind": "string",
+            "properties": {
+                "allow": false
+            }
         },
         {
             "apiVersion": "2015-05-01",

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -367,10 +367,12 @@
                     }
                 },
                 {
-                    "type": "Microsoft.Web/sites/slots/basicPublishingCredentialsPolicies",
                     "apiVersion": "2020-12-01",
                     "name": "scm",
-                    "kind": "string",
+                    "type": "Microsoft.Web/sites/slots/basicPublishingCredentialsPolicies",
+                    "dependsOn": [
+                        "[variables('appServiceResourceId')]"
+                    ],
                     "properties": {
                         "allow": false
                     }

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -371,6 +371,7 @@
                     "name": "scm",
                     "type": "basicPublishingCredentialsPolicies",
                     "kind": "string",
+                    "location": "[resourceGroup().location]",
                     "dependsOn":[
                         "[variables('serviceName')]"
                     ],
@@ -383,6 +384,7 @@
                     "name": "ftp",
                     "type": "basicPublishingCredentialsPolicies",
                     "kind": "string",
+                    "location": "[resourceGroup().location]",
                     "dependsOn":[
                         "[variables('serviceName')]"
                     ],

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -367,12 +367,10 @@
                     }
                 },
                 {
-                    "type": "basicPublishingCredentialsPolicies",
-                    "apiVersion": "2022-09-01",
-                    "name": "[concat(variables('serviceName'), '/scm')]",
-                    "dependsOn": [
-                        "Microsoft.Web/sites"
-                    ],
+                    "type": "Microsoft.Web/sites/slots/basicPublishingCredentialsPolicies",
+                    "apiVersion": "2020-12-01",
+                    "name": "scm",
+                    "kind": "string",
                     "properties": {
                         "allow": false
                     }

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -367,10 +367,9 @@
                     }
                 },
                 {
-                    "type": "Microsoft.Web/sites/basicPublishingCredentialsPolicies",
+                    "type": "basicPublishingCredentialsPolicies",
                     "apiVersion": "2022-09-01",
                     "name": "[concat(variables('serviceName'), '/scm')]",
-                    "location": "South Central US",
                     "dependsOn": [
                         "Microsoft.Web/sites"
                     ],

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -365,6 +365,18 @@
                         "alwaysOn": true,
                         "healthCheckPath": "/health/check"
                     }
+                },
+                {
+                    "type": "Microsoft.Web/sites/basicPublishingCredentialsPolicies",
+                    "apiVersion": "2022-09-01",
+                    "name": "[concat(parameters('serviceName'), '/scm')]",
+                    "location": "South Central US",
+                    "dependsOn": [
+                        "Microsoft.Web/sites"
+                    ],
+                    "properties": {
+                        "allow": false
+                    }
                 }
             ]
         },

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -331,7 +331,8 @@
                     ]
                 },
                 "serverFarmId": "[resourceId(variables('appServicePlanResourceGroup'), 'Microsoft.Web/serverfarms/', variables('appServicePlanName'))]",
-                "clientAffinityEnabled": false
+                "clientAffinityEnabled": false,
+                "basicAuthEnabled": false,
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]"


### PR DESCRIPTION
## Description
Disabled Basic Auth when using the CI Deploy pipeline so we don't run a security risk. 

## Related issues
Addresses [issue #].

## Testing
Redployed using script update and verified that Basic Auth was disabled.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
