### PR TITLE
[Do not review] Reindex updates

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/JobRecordProperties.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations
 
         public const string AnonymizationConfigurationFileETag = "anonymizationConfigurationFileHash";
 
-        public const string ContinuationToken = "continuationToken";
+        public const string ResourceReindexProgressByResource = "resourceReindexProgressByResource";
 
         public const string GroupId = "groupId";
 
@@ -134,8 +134,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations
         public const string TargetSearchParameterTypes = "targetSearchParameterTypes";
 
         public const string SearchParameterResourceTypes = "searchParameterResourceTypes";
-
-        public const string CreatedChild = "createdChild";
 
         public const string Till = "till";
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobQueryStatus.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobQueryStatus.cs
@@ -14,21 +14,17 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
     /// </summary>
     public class ReindexJobQueryStatus
     {
-        public ReindexJobQueryStatus(string resourceType, string continuationToken)
+        public ReindexJobQueryStatus(string resourceType)
         {
             EnsureArg.IsNotNullOrWhiteSpace(resourceType, nameof(resourceType));
 
             ResourceType = resourceType;
-            ContinuationToken = continuationToken;
         }
 
         [JsonConstructor]
         protected ReindexJobQueryStatus()
         {
         }
-
-        [JsonProperty(JobRecordProperties.ContinuationToken)]
-        public string ContinuationToken { get; set; }
 
         /// <summary>
         /// The point at which to start a query
@@ -50,8 +46,5 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
 
         [JsonProperty(JobRecordProperties.ResourceType)]
         public string ResourceType { get; private set; }
-
-        [JsonProperty(JobRecordProperties.CreatedChild)]
-        public bool CreatedChild { get; set; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobRecord.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobRecord.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
         public long Count { get; set; }
 
         [JsonProperty(JobRecordProperties.Progress)]
-        public int Progress { get; set; }
+        public long Progress { get; set; }
 
         [JsonProperty(JobRecordProperties.ResourceTypeSearchParameterHashMap)]
         public IReadOnlyDictionary<string, string> ResourceTypeSearchParameterHashMap { get; private set; }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchResult.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchResult.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             EnsureArg.IsNotNull(unsupportedSearchParameters, nameof(unsupportedSearchParameters));
 
             Results = results;
+            TotalCount = results.Count();
             UnsupportedSearchParameters = unsupportedSearchParameters;
             ContinuationToken = continuationToken;
             SortOrder = sortOrder;

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchResultReindex.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchResultReindex.cs
@@ -25,6 +25,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
         public long Count { get; set; }
 
         /// <summary>
+        /// The count of items that have been reindexed
+        /// </summary>
+        public long CountReindexed { get; set; }
+
+        /// <summary>
         /// Used as a pointer to the Start surrogateId param when searching resources by a range of Start/End resource surrogateIds
         /// </summary>
         public long CurrentResourceSurrogateId { get; set; }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Extensions/ReindexJobRecordExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Extensions/ReindexJobRecordExtensions.cs
@@ -64,19 +64,26 @@ namespace Microsoft.Health.Fhir.Core.Extensions
             parametersResource.Add(JobRecordProperties.LastModified, new FhirDateTime(job.LastModified));
 
             decimal progress = 0;
+            decimal rounded = 0;
             if (job.Count > 0 && job.Progress > 0)
             {
                 progress = (decimal)job.Progress / job.Count * 100;
+                rounded = Math.Round(progress, 1);
             }
             else
             {
                 progress = 0;
             }
 
+            if (rounded == 100.0M && job.Count != job.Progress)
+            {
+                rounded = 99.9M;
+            }
+
             parametersResource.Add(JobRecordProperties.QueuedTime, new FhirDateTime(job.QueuedTime));
             parametersResource.Add(JobRecordProperties.TotalResourcesToReindex, new FhirDecimal(job.Count));
             parametersResource.Add(JobRecordProperties.ResourcesSuccessfullyReindexed, new FhirDecimal(job.Progress));
-            parametersResource.Add(JobRecordProperties.Progress, new FhirDecimal(Math.Round(progress, 1)));
+            parametersResource.Add(JobRecordProperties.Progress, new FhirDecimal(rounded));
             parametersResource.Add(JobRecordProperties.Status, new FhirString(job.Status.ToString()));
             parametersResource.Add(JobRecordProperties.MaximumConcurrency, new FhirDecimal(job.MaximumConcurrency));
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -15,6 +15,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
+using Hl7.Fhir.Utility;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -368,7 +369,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
 #pragma warning restore CA2100 // Review SQL queries for security vulnerabilities
                         }
 
-                        LogSqlCommand(new SqlCommandWrapper(sqlCommand)); // TODO: when SqlCommandWrapper is fully depreciated everywhere, modify LogSqlCommand to accept sqlCommand.
+                        LogSqlCommand(new SqlCommandWrapper(sqlCommand)); // TODO: when SqlCommandWrapper is fully deprecated everywhere, modify LogSqlCommand to accept sqlCommand.
 
                         using (var reader = await sqlCommand.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken))
                         {
@@ -556,6 +557,17 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
             command.Parameters.AddWithValue("@GlobalEndId", globalEndId);
         }
 
+        private static void PopulateSqlCommandFromQueryHints(SqlCommand command, short resourceTypeId, long startId, long endId, long? globalStartId, long? globalEndId)
+        {
+            command.CommandType = CommandType.StoredProcedure;
+            command.CommandText = "dbo.GetResourcesByTypeAndSurrogateIdRange";
+            command.Parameters.AddWithValue("@ResourceTypeId", resourceTypeId);
+            command.Parameters.AddWithValue("@StartId", startId);
+            command.Parameters.AddWithValue("@EndId", endId);
+            command.Parameters.AddWithValue("@GlobalStartId", globalStartId);
+            command.Parameters.AddWithValue("@GlobalEndId", globalEndId);
+        }
+
         /// <summary>
         /// Searches for resources by their type and surrogate id and optionally a searchParamHash and will return resources
         /// </summary>
@@ -570,16 +582,20 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
         public async Task<SearchResult> SearchBySurrogateIdRange(string resourceType, long startId, long endId, long? windowStartId, long? windowEndId, CancellationToken cancellationToken, string searchParamHashFilter = null)
         {
             var resourceTypeId = _model.GetResourceTypeId(resourceType);
-            try
-            {
-                using SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken, true);
-                using SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand();
-
-                VLatest.GetResourcesByTypeAndSurrogateIdRange.PopulateCommand(sqlCommandWrapper, resourceTypeId, startId, endId, windowStartId, windowEndId);
-                LogSqlCommand(sqlCommandWrapper);
-                try
+            SearchResult searchResult = null;
+            await _sqlRetryService.ExecuteSql(
+                async (cancellationToken) =>
                 {
-                    using SqlDataReader reader = await sqlCommandWrapper.ExecuteReaderAsync(cancellationToken);
+                    using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(initialCatalog: null, cancellationToken: cancellationToken).ConfigureAwait(false);
+                    using SqlCommand sqlCommand = connection.CreateCommand();
+                    connection.RetryLogicProvider = null; // To remove this line _sqlConnectionBuilder in healthcare-shared-components must be modified.
+                    await connection.OpenAsync(cancellationToken);
+
+                    sqlCommand.CommandTimeout = GetReindexCommandTimeout();
+                    PopulateSqlCommandFromQueryHints(sqlCommand, resourceTypeId, startId, endId, windowStartId, windowEndId);
+                    LogSqlCommand(new SqlCommandWrapper(sqlCommand)); // TODO: when SqlCommandWrapper is fully deprecated everywhere, modify LogSqlCommand to accept sqlCommand.
+
+                    using SqlDataReader reader = await sqlCommand.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken);
 
                     var resources = new List<SearchResultEntry>();
                     while (await reader.ReadAsync(cancellationToken))
@@ -605,7 +621,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                         }
 
                         string rawResource;
-                        using (rawResourceStream)
+                        await using (rawResourceStream)
                         {
                             rawResource = _compressedRawResourceConverter.ReadCompressedRawResource(rawResourceStream);
                         }
@@ -633,20 +649,14 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                             isMatch ? SearchEntryMode.Match : SearchEntryMode.Include));
                     }
 
-                    return new SearchResult(resources, null, null, new List<Tuple<string, string>>());
-                }
-                catch (SqlException)
-                {
-                    throw;
-                }
-            }
-            catch (Exception)
-            {
-                throw;
-            }
+                    searchResult = new SearchResult(resources, null, null, new List<Tuple<string, string>>());
+                    return;
+                },
+                cancellationToken);
+            return searchResult;
         }
 
-        private static (long StartId, long EndId) ReaderToSurogateIdRange(SqlDataReader sqlDataReader)
+        private static (long StartId, long EndId) ReaderToSurrogateIdRange(SqlDataReader sqlDataReader)
         {
             return (sqlDataReader.GetInt64(1), sqlDataReader.GetInt64(2));
         }
@@ -656,15 +666,29 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
             // TODO: this code will not set capacity for the result list!
 
             var resourceTypeId = _model.GetResourceTypeId(resourceType);
-            using SqlCommand sqlCommand = new SqlCommand();
-            sqlCommand.CommandTimeout = 1200; // Should be >> average execution time which for 100K resources is ~3 minutes.
-            GetResourceSurrogateIdRanges.PopulateCommand(sqlCommand, resourceTypeId, startId, endId, rangeSize, numberOfRanges, up);
-            return await _sqlRetryService.ExecuteSqlDataReader(
-                sqlCommand,
-                ReaderToSurogateIdRange,
-                _logger,
-                "GetSurrogateIdRanges failed.",
+            List<(long StartId, long EndId)> searchList = null;
+            await _sqlRetryService.ExecuteSql(
+                async (cancellationToken) =>
+                {
+                    using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(initialCatalog: null, cancellationToken: cancellationToken).ConfigureAwait(false);
+                    using SqlCommand sqlCommand = connection.CreateCommand();
+                    connection.RetryLogicProvider = null; // To remove this line _sqlConnectionBuilder in healthcare-shared-components must be modified.
+                    await connection.OpenAsync(cancellationToken);
+
+                    sqlCommand.CommandTimeout = GetReindexCommandTimeout();
+                    GetResourceSurrogateIdRanges.PopulateCommand(sqlCommand, resourceTypeId, startId, endId, rangeSize, numberOfRanges, up);
+                    LogSqlCommand(new SqlCommandWrapper(sqlCommand)); // TODO: when SqlCommandWrapper is fully deprecated everywhere, modify LogSqlCommand to accept sqlCommand.
+
+                    searchList = await _sqlRetryService.ExecuteSqlDataReader(
+                       sqlCommand,
+                       ReaderToSurrogateIdRange,
+                       _logger,
+                       $"{nameof(GetSurrogateIdRanges)} failed.",
+                       cancellationToken);
+                    return;
+                },
                 cancellationToken);
+            return searchList;
         }
 
         public override long GetSurrogateId(DateTime dateTime)
@@ -672,17 +696,36 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
             return ResourceSurrogateIdHelper.LastUpdatedToResourceSurrogateId(dateTime);
         }
 
+        private static (short ResourceTypeId, string Name) ReaderGetUsedResourceTypes(SqlDataReader sqlDataReader)
+        {
+            return (sqlDataReader.GetInt16(0), sqlDataReader.GetString(1));
+        }
+
         public override async Task<IReadOnlyList<(short ResourceTypeId, string Name)>> GetUsedResourceTypes(CancellationToken cancellationToken)
         {
             var resourceTypes = new List<(short ResourceTypeId, string Name)>();
-            using SqlConnectionWrapper sqlConnectionWrapper = await _sqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(cancellationToken, true);
-            using SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand();
-            VLatest.GetUsedResourceTypes.PopulateCommand(sqlCommandWrapper);
-            using SqlDataReader reader = await sqlCommandWrapper.ExecuteReaderAsync(cancellationToken);
-            while (await reader.ReadAsync(cancellationToken))
-            {
-                resourceTypes.Add((reader.GetInt16(0), reader.GetString(1)));
-            }
+
+            await _sqlRetryService.ExecuteSql(
+                async (cancellationToken) =>
+                {
+                    using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(initialCatalog: null, cancellationToken: cancellationToken).ConfigureAwait(false);
+                    using SqlCommand sqlCommand = connection.CreateCommand();
+                    connection.RetryLogicProvider = null; // To remove this line _sqlConnectionBuilder in healthcare-shared-components must be modified.
+                    await connection.OpenAsync(cancellationToken);
+
+                    sqlCommand.CommandTimeout = GetReindexCommandTimeout();
+                    sqlCommand.CommandText = "dbo.GetUsedResourceTypes";
+                    LogSqlCommand(new SqlCommandWrapper(sqlCommand)); // TODO: when SqlCommandWrapper is fully deprecated everywhere, modify LogSqlCommand to accept sqlCommand.
+
+                    resourceTypes = await _sqlRetryService.ExecuteSqlDataReader(
+                       sqlCommand,
+                       ReaderGetUsedResourceTypes,
+                       _logger,
+                       $"{nameof(GetUsedResourceTypes)} failed.",
+                       cancellationToken);
+                    return;
+                },
+                cancellationToken);
 
             return resourceTypes;
         }
@@ -865,6 +908,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
 
                 sb.AppendLine();
                 sb.AppendLine(sqlCommandWrapper.CommandText);
+
+                // this just assures that the call to this fn has occurred after the text is set
+                Debug.Assert(sqlCommandWrapper.CommandText.Length > 0);
             }
             else
             {
@@ -1063,6 +1109,11 @@ WHERE ResourceTypeId = @p0
             };
 
             return searchResult;
+        }
+
+        private int GetReindexCommandTimeout()
+        {
+            return Math.Max((int)_sqlServerDataStoreConfiguration.CommandTimeout.TotalSeconds, 1200);
         }
 
         private static string GetForceReindexResourceType(SearchOptions searchOptions)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/FhirOperationDataStoreReindexTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/FhirOperationDataStoreReindexTests.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Health.Fhir.Shared.Tests.Integration.Features.Operations
             ReindexJobRecord jobRecord = await InsertNewReindexJobRecordAsync(jobRecord => jobRecord.Status = OperationStatus.Completed);
             ReindexJobWrapper job = await _operationDataStore.GetReindexJobByIdAsync(jobRecord.Id, default);
 
-            var reindexJobQueryStatus = new ReindexJobQueryStatus(resourceType, null)
+            var reindexJobQueryStatus = new ReindexJobQueryStatus(resourceType)
             {
                 Error = queryListError,
                 FailureCount = new ReindexJobConfiguration().ConsecutiveFailuresThreshold,

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -45,7 +45,6 @@ using Microsoft.Health.Test.Utilities;
 using Newtonsoft.Json;
 using NSubstitute;
 using Xunit;
-using Xunit.Abstractions;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
@@ -835,11 +834,13 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                 {
                     // Fail-fast.
                     // If the expected status is 'Completed', and the job failed or if it was canceled, then stop the test quickly.
-                    Assert.Fail($"Fail-fast. {GetReindexJobWrapperContent(reindexJobWrapper)}");
+                    Assert.Fail($"Fail-fast. Number of attempts: {MaxNumberOfAttempts}. Time elapsed: {stopwatch.Elapsed}. JobWrapper Details: {GetReindexJobWrapperContent(reindexJobWrapper)}");
                 }
             }
 
-            Assert.True(operationStatus == reindexJobWrapper.JobRecord.Status, GetReindexJobWrapperContent(reindexJobWrapper));
+            Assert.True(
+                operationStatus == reindexJobWrapper.JobRecord.Status,
+                $" Number of attempts: {MaxNumberOfAttempts}. Time elapsed: {stopwatch.Elapsed}. JobWrapper Details: {GetReindexJobWrapperContent(reindexJobWrapper)}");
 
             return reindexJobWrapper;
         }


### PR DESCRIPTION
## Description
Changes made:

Added better commenting where necessary.

ReindexJobQueryStatus.cs: Removed unused ContinuationToken and CreatedChild fields.

JobRecordProperties.cs: Removed labels used for ContinuationToken and CreatedChild fields. Added new field for ResourceReindexProgressByResource used in GET $reindex/id.

ReindexJobRecordExtensions.cs: Added new output for GET $reindex/id so that it will give details per resource of the number of completed reindexed resources. Output will be similar to this. 
{
  "name": "resourceReindexProgressByResource",
  "valueString": "DiagnosticReport (CountReindexed of Count): 4 of 4\r\nDevice (CountReindexed of Count): 600 of 719\r\nPractitioner (CountReindexed of Count): 3 of 3"
}

SearchResultReindex.cs: Added new property CountReindexed that holds the number of reindexed resources that have been completed. This will help when not only doing an investigation but also this field is surfaced during a GET $reindex/id so the customer can see the the progress. Of course this is mostly valuable when doing more than one resource.

SearchResult.cs: Revised ctor to set the TotalCount. For some reason we never auto set this field when passing in a set of results.

ReindexJobTask.cs: Fixed initial setting of job queries to include the StartResourceSurrogateId for clarity in reviewing a saved RawJobRecord json file. Removed unused ContinuationToken and CreatedChild code references. Added code to set the CountReindexed (new field above) for clarity on job progress.

SqlServerSearchService.cs: Revised all reindex functions so that they make use of the SqlRetryService class

FhirOperationDataStoreReindexTests.cs: revised based on continuation token removal.

ReindexJobTaskTests.cs: Updated tests based on changes made.

## Related issues
Addresses reindex issues found after reindexing the large db.

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
