### PR TITLE
Reverting PR3228 for hot fix

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/ExpressionParser.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/ExpressionParser.cs
@@ -106,11 +106,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
                 }
 
                 refSearchParameter = _searchParameterDefinitionManager.GetSearchParameter(originalType.ToString(), searchParam.ToString());
-
-                if (refSearchParameter.Type != SearchParamType.Reference)
-                {
-                    throw new InvalidSearchOperationException(isReversed ? Core.Resources.RevIncludeIncorrectParameterType : Core.Resources.IncludeIncorrectParameterType);
-                }
             }
 
             if (wildCard)

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -602,15 +602,6 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The [_include]=[resource]:[parameter] search has an invalid search parameter, must be of type reference..
-        /// </summary>
-        internal static string IncludeIncorrectParameterType {
-            get {
-                return ResourceManager.GetString("IncludeIncorrectParameterType", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The parameter {0}={1} with circular reference is executed once (a single iteration)..
         /// </summary>
         internal static string IncludeIterateCircularReferenceExecutedOnce {
@@ -1210,15 +1201,6 @@ namespace Microsoft.Health.Fhir.Core {
         internal static string ReverseChainMissingType {
             get {
                 return ResourceManager.GetString("ReverseChainMissingType", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The [_revinclude]=[resource]:[parameter] search has an invalid search parameter, must be of type reference..
-        /// </summary>
-        internal static string RevIncludeIncorrectParameterType {
-            get {
-                return ResourceManager.GetString("RevIncludeIncorrectParameterType", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -236,17 +236,9 @@
     <value>The _include search is missing the type to search.</value>
     <comment>_include is a query parameter.</comment>
   </data>
-  <data name="IncludeIncorrectParameterType" xml:space="preserve">
-    <value>The [_include]=[resource]:[parameter] search has an invalid search parameter, must be of type reference.</value>
-    <comment>_include is a query parameter.</comment>
-  </data>
   <data name="RevIncludeMissingType" xml:space="preserve">
     <value>The _revinclude search is missing the type to search.</value>
     <comment>_revinclude is a query parameter.</comment>
-  </data>
-  <data name="RevIncludeIncorrectParameterType" xml:space="preserve">
-    <value>The [_revinclude]=[resource]:[parameter] search has an invalid search parameter, must be of type reference.</value>
-    <comment>_include is a query parameter.</comment>
   </data>
   <data name="RevIncludeIterateTargetTypeNotSpecified" xml:space="preserve">
     <value>The '_revinclude:iterate={0}' search parameter has multiple target types. Please specify a target type.</value>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludeSearchTests.cs
@@ -1004,36 +1004,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
         [Fact]
         [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer)]
-        public async Task GivenAIncludeWithInvalidParam_WhenSearched_ShouldThrowBadRequestExceptionWithIssue()
-        {
-            string query = $"_include=Patient:family";
-
-            using var fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await Client.SearchAsync(ResourceType.Patient, query));
-            Assert.Equal(HttpStatusCode.Forbidden, fhirException.StatusCode);
-
-            string[] expectedDiagnostics = { string.Format(Core.Resources.IncludeIncorrectParameterType) };
-            IssueSeverity[] expectedIssueSeverities = { IssueSeverity.Error };
-            IssueType[] expectedCodeTypes = { IssueType.Invalid };
-            ValidateOperationOutcome(expectedDiagnostics, expectedIssueSeverities, expectedCodeTypes, fhirException.OperationOutcome);
-        }
-
-        [Fact]
-        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer)]
-        public async Task GivenARevincludeWithInvalidParameter_WhenSearched_ShouldThrowBadRequestExceptionWithIssue()
-        {
-            string query = $"_revinclude=Patient:family";
-
-            using var fhirException = await Assert.ThrowsAsync<FhirClientException>(async () => await Client.SearchAsync(ResourceType.Patient, query));
-            Assert.Equal(HttpStatusCode.Forbidden, fhirException.StatusCode);
-
-            string[] expectedDiagnostics = { string.Format(Core.Resources.RevIncludeIncorrectParameterType) };
-            IssueSeverity[] expectedIssueSeverities = { IssueSeverity.Error };
-            IssueType[] expectedCodeTypes = { IssueType.Invalid };
-            ValidateOperationOutcome(expectedDiagnostics, expectedIssueSeverities, expectedCodeTypes, fhirException.OperationOutcome);
-        }
-
-        [Fact]
-        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer)]
         public async Task GivenARevIncludeIterateSearchExpressionWithMultipleResultsSetsWithoutSpecificRevIncludeIterateTargetType_WhenSearched_ShouldThrowBadRequestExceptionWithIssue()
         {
             // Non-recursive iteration - Multiple result sets: MedicationDispense:performer;Practitioner and MedicationRequest:requester:Practitioner


### PR DESCRIPTION
## Description
Reverting PR3228 for hot fix

## Related issues
Addresses [issue #].

## Testing
[Describe how this change was tested.]
https://localhost:44348/ServiceRequest?_count=1000&_include=ServiceRequest:patient&_include=ServiceRequest:specimen&_include:iterate=DocumentReference:author&_include=ServiceRequest:category is not throwing error now

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
