### PR TITLE
Only Allow AHDS for Selectable SearchParameters

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Registration/AzureApiForFhirRuntimeConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Registration/AzureApiForFhirRuntimeConfiguration.cs
@@ -1,0 +1,12 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Fhir.Core.Registration
+{
+    public class AzureApiForFhirRuntimeConfiguration : IFhirRuntimeConfiguration
+    {
+        public bool IsSelectiveSearchParameterSupported => false;
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Registration/AzureHealthDataServicesRuntimeConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Registration/AzureHealthDataServicesRuntimeConfiguration.cs
@@ -1,0 +1,12 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Fhir.Core.Registration
+{
+    public class AzureHealthDataServicesRuntimeConfiguration : IFhirRuntimeConfiguration
+    {
+        public bool IsSelectiveSearchParameterSupported => true;
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Registration/IFhirRuntimeConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Registration/IFhirRuntimeConfiguration.cs
@@ -1,0 +1,12 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Fhir.Core.Registration
+{
+    public interface IFhirRuntimeConfiguration
+    {
+        bool IsSelectiveSearchParameterSupported { get; }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/SearchParameterController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/SearchParameterController.cs
@@ -13,18 +13,17 @@ using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Api.Features.Audit;
-using Microsoft.Health.Fhir.Api.Configs;
 using Microsoft.Health.Fhir.Api.Extensions;
 using Microsoft.Health.Fhir.Api.Features.ActionResults;
 using Microsoft.Health.Fhir.Api.Features.Filters;
 using Microsoft.Health.Fhir.Api.Features.Routing;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Exceptions;
-using Microsoft.Health.Fhir.Core.Features;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Operations.SearchParameterState;
 using Microsoft.Health.Fhir.Core.Features.Search.Registry;
 using Microsoft.Health.Fhir.Core.Messages.SearchParameterState;
+using Microsoft.Health.Fhir.Core.Registration;
 using Microsoft.Health.Fhir.ValueSets;
 
 namespace Microsoft.Health.Fhir.Api.Controllers
@@ -37,19 +36,19 @@ namespace Microsoft.Health.Fhir.Api.Controllers
     {
         private readonly IMediator _mediator;
         private readonly CoreFeatureConfiguration _coreFeaturesConfig;
-        private bool _isAzureApiForFhir = false;
+        private bool _isSelectSearchParameterSupported;
 
-        public SearchParameterController(IMediator mediator, IOptions<CoreFeatureConfiguration> coreFeatures, IOptions<ThrottlingConfiguration> throttlingConfig)
+        public SearchParameterController(IMediator mediator, IOptions<CoreFeatureConfiguration> coreFeatures, IFhirRuntimeConfiguration fhirConfig)
         {
             EnsureArg.IsNotNull(mediator, nameof(mediator));
             EnsureArg.IsNotNull(coreFeatures?.Value, nameof(coreFeatures));
-            EnsureArg.IsNotNull(throttlingConfig?.Value, nameof(throttlingConfig));
+            EnsureArg.IsNotNull(fhirConfig, nameof(fhirConfig));
 
             _mediator = mediator;
             _coreFeaturesConfig = coreFeatures.Value;
 
             // Used to prevent Azure Api for Fhir from using this controller.
-            _isAzureApiForFhir = throttlingConfig.Value.DataStore.Equals(KnownDataStores.CosmosDb, StringComparison.OrdinalIgnoreCase);
+            _isSelectSearchParameterSupported = fhirConfig.IsSelectiveSearchParameterSupported;
         }
 
         /// <summary>
@@ -113,7 +112,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         /// </summary>
         private void CheckIfSearchParameterStatusIsEnabledOrADHS()
         {
-            if (!_coreFeaturesConfig.SupportsSelectableSearchParameters || _isAzureApiForFhir)
+            if (!_coreFeaturesConfig.SupportsSelectableSearchParameters || !_isSelectSearchParameterSupported)
             {
                 throw new RequestNotValidException(string.Format(Resources.OperationNotEnabled, OperationsConstants.SearchParameterStatus));
             }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/SearchParameterController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/SearchParameterController.cs
@@ -13,12 +13,14 @@ using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Api.Features.Audit;
+using Microsoft.Health.Fhir.Api.Configs;
 using Microsoft.Health.Fhir.Api.Extensions;
 using Microsoft.Health.Fhir.Api.Features.ActionResults;
 using Microsoft.Health.Fhir.Api.Features.Filters;
 using Microsoft.Health.Fhir.Api.Features.Routing;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Exceptions;
+using Microsoft.Health.Fhir.Core.Features;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Operations.SearchParameterState;
 using Microsoft.Health.Fhir.Core.Features.Search.Registry;
@@ -35,14 +37,19 @@ namespace Microsoft.Health.Fhir.Api.Controllers
     {
         private readonly IMediator _mediator;
         private readonly CoreFeatureConfiguration _coreFeaturesConfig;
+        private bool _isAzureApiForFhir = false;
 
-        public SearchParameterController(IMediator mediator, IOptions<CoreFeatureConfiguration> coreFeatures)
+        public SearchParameterController(IMediator mediator, IOptions<CoreFeatureConfiguration> coreFeatures, IOptions<ThrottlingConfiguration> throttlingConfig)
         {
             EnsureArg.IsNotNull(mediator, nameof(mediator));
             EnsureArg.IsNotNull(coreFeatures?.Value, nameof(coreFeatures));
+            EnsureArg.IsNotNull(throttlingConfig?.Value, nameof(throttlingConfig));
 
             _mediator = mediator;
             _coreFeaturesConfig = coreFeatures.Value;
+
+            // Used to prevent Azure Api for Fhir from using this controller.
+            _isAzureApiForFhir = throttlingConfig.Value.DataStore.Equals(KnownDataStores.CosmosDb, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -56,7 +63,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         [ValidateSearchParameterStateRequestAtrribute]
         public async Task<IActionResult> GetSearchParametersStatus(CancellationToken cancellationToken)
         {
-            CheckIfSearchParameterStatusIsEnabledAndRespond();
+            CheckIfSearchParameterStatusIsEnabledOrADHS();
 
             SearchParameterStateRequest request = new SearchParameterStateRequest(GetQueriesForSearch());
             SearchParameterStateResponse result = await _mediator.Send(request, cancellationToken);
@@ -75,7 +82,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         [AuditEventType(AuditEventSubType.SearchParameterStatus)]
         public async Task<IActionResult> PostSearchParametersStatus(CancellationToken cancellationToken)
         {
-            CheckIfSearchParameterStatusIsEnabledAndRespond();
+            CheckIfSearchParameterStatusIsEnabledOrADHS();
 
             SearchParameterStateRequest request = new SearchParameterStateRequest(GetQueriesForSearch());
             SearchParameterStateResponse result = await _mediator.Send(request, cancellationToken);
@@ -94,7 +101,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         [AuditEventType(AuditEventSubType.SearchParameterStatus)]
         public async Task<IActionResult> UpdateSearchParametersStatus([FromBody] Parameters inputParams, CancellationToken cancellationToken)
         {
-            CheckIfSearchParameterStatusIsEnabledAndRespond();
+            CheckIfSearchParameterStatusIsEnabledOrADHS();
             SearchParameterStateUpdateRequest updateRequest = ParseUpdateRequestBody(inputParams);
             SearchParameterStateUpdateResponse result = await _mediator.Send(updateRequest, cancellationToken);
 
@@ -104,9 +111,9 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         /// <summary>
         /// Provide appropriate response if Search Parameter Status feature is not enabled
         /// </summary>
-        private void CheckIfSearchParameterStatusIsEnabledAndRespond()
+        private void CheckIfSearchParameterStatusIsEnabledOrADHS()
         {
-            if (!_coreFeaturesConfig.SupportsSelectableSearchParameters)
+            if (!_coreFeaturesConfig.SupportsSelectableSearchParameters || _isAzureApiForFhir)
             {
                 throw new RequestNotValidException(string.Format(Resources.OperationNotEnabled, OperationsConstants.SearchParameterStatus));
             }

--- a/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
@@ -19,6 +19,7 @@ using Microsoft.Health.Fhir.Azure;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features;
 using Microsoft.Health.Fhir.Core.Features.Operations.Export;
+using Microsoft.Health.Fhir.Core.Registration;
 using Microsoft.Health.Fhir.Shared.Web;
 using Microsoft.Health.Fhir.SqlServer.Features.Storage;
 using Microsoft.Health.JobManagement;
@@ -58,10 +59,12 @@ namespace Microsoft.Health.Fhir.Web
             string dataStore = Configuration["DataStore"];
             if (dataStore.Equals(KnownDataStores.CosmosDb, StringComparison.OrdinalIgnoreCase))
             {
+                fhirServerBuilder.Services.Add<AzureApiForFhirRuntimeConfiguration>().Singleton().AsImplementedInterfaces();
                 fhirServerBuilder.AddCosmosDb();
             }
             else if (dataStore.Equals(KnownDataStores.SqlServer, StringComparison.OrdinalIgnoreCase))
             {
+                fhirServerBuilder.Services.Add<AzureHealthDataServicesRuntimeConfiguration>().Singleton().AsImplementedInterfaces();
                 fhirServerBuilder.AddSqlServer(config =>
                 {
                     Configuration?.GetSection(SqlServerDataStoreConfiguration.SectionName).Bind(config);


### PR DESCRIPTION
## Description
Added in a runtime configuration for Azure Api for FHIR and Azure Health Data Services that share a common interface. This explicitly sets whether selectable search parameters can be used. Configuration is passed through DI.

## Related issues
Addresses [issue AB#103193].

## Testing
Added unit test and manually ran tests to verify as well.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
