### PR TITLE
SQL retry on query plan failure, use INNER JOIN instead of EXISTS

### DIFF
--- a/docs/rest/ComplexSQLQueryServiceRequest.http
+++ b/docs/rest/ComplexSQLQueryServiceRequest.http
@@ -1,0 +1,129 @@
+@hostname = localhost:44348
+
+### Test rest client
+https://{{hostname}}/metadata
+
+### Get the globalAdminServicePrincipal to be able to POST test data
+# @name bearer
+POST https://{{hostname}}/connect/token
+content-type: application/x-www-form-urlencoded
+
+grant_type=client_credentials
+&client_id=globalAdminServicePrincipal
+&client_secret=globalAdminServicePrincipal
+&scope=patient/Observation.read fhirUser fhir-api user/Encounter.*
+
+### Post 1st custom search parameter
+POST https://{{hostname}}/SearchParameter
+content-type: application/json
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+{
+      "resourceType" : "SearchParameter",
+      "id" : "ServiceRequest-resultStatus",
+      "extension" : [{
+        "url" : "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+        "valueCode" : "trial-use"
+      }],
+      "url" : "http://hl7.org/fhir/SearchParameter/ServiceRequest-resultStatus",
+      "version" : "4.0.1",
+      "name" : "resultStatus",
+      "status" : "draft",
+      "experimental" : false,
+      "date" : "2019-11-01T09:29:23+11:00",
+      "publisher" : "Health Level Seven International (Orders and Observations)",
+      "contact" : [{
+        "telecom" : [{
+          "system" : "url",
+          "value" : "http://hl7.org/fhir"
+        }]
+      },
+      {
+        "telecom" : [{
+          "system" : "url",
+          "value" : "http://www.hl7.org/Special/committees/orders/index.cfm"
+        }]
+      }],
+      "description" : "resultStatus",
+      "code" : "resultStatus",
+      "base" : ["ServiceRequest"],
+      "type" : "token",
+      "expression" : "ServiceRequest.extension.where(url = 'https://cynergymro.com/service-request/result-status-extension').where(value = 1).extension.where(url = 'https://cynergymro.com/service-request/result-status-extension/result-status').value.code"
+    }
+
+### Post 2st custom search parameter
+POST https://{{hostname}}/SearchParameter
+content-type: application/json
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+{
+      "resourceType" : "SearchParameter",
+      "id" : "ServiceRequest-collectionDate",
+      "extension" : [{
+        "url" : "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+        "valueCode" : "trial-use"
+      }],
+      "url" : "http://hl7.org/fhir/SearchParameter/ServiceRequest-collectionDate",
+      "version" : "4.0.1",
+      "name" : "collectionDate",
+      "status" : "draft",
+      "experimental" : false,
+      "date" : "2019-11-01T09:29:23+11:00",
+      "publisher" : "Health Level Seven International (Orders and Observations)",
+      "contact" : [{
+        "telecom" : [{
+          "system" : "url",
+          "value" : "http://hl7.org/fhir"
+        }]
+      },
+      {
+        "telecom" : [{
+          "system" : "url",
+          "value" : "http://www.hl7.org/Special/committees/orders/index.cfm"
+        }]
+      }],
+      "description" : "collectionDate",
+      "code" : "collectionDate",
+      "base" : ["ServiceRequest"],
+      "type" : "date",
+      "expression" : "ServiceRequest.extension.where(url = 'https://cynergymro.com/service-request/collection-date-extension').value"
+    }
+
+
+###  This creates a reindex job, you can do this now, or you can skip below to see if you can search
+# using the new search parameter before it is indexed
+# @name reindex
+POST https://{{hostname}}/$reindex
+content-type: application/json
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+{
+  "resourceType": "Parameters",
+  "parameter": [
+    {
+      "name": "maximumConcurrency",
+      "valueInteger": "3"
+    },
+    {
+      "name": "targetDataStoreUsagePercentage",
+      "valueInteger": "80"
+    },
+    {
+      "name": "queryDelayIntervalInMilliseconds",
+      "valueInteger": "500"
+    },
+    {
+      "name": "maximumNumberOfResourcesPerQuery",
+      "valueInteger": "5"
+    }
+  ]
+}
+
+
+### Get REindex
+GET https://localhost:44348/_operations/reindex/b80081ac-176d-4ea1-9a1e-dc736835fff7
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+### Get complex query for customer
+GET https://{{hostname}}/ServiceRequest?_count=20&_include=ServiceRequest%3Apatient&_include=ServiceRequest%3Aspecimen&_sort=-_lastUpdated&intent=original-order&resultStatus=Closed&status=active%2Ccompleted%2Cunknown&collectionDate=gt2022-05-31T00%3A00%3A00-05%3A00&collectionDate=lt2022-05-31T23%3A59%3A59-05%3A00&subject%3APatient.address-state%3Aexact=AL%2CAS%2CAZ%2CAR%2CCA%2CCO%2CCT%2CDE%2CDC%2CFL%2CGA%2CGU%2CHI%2CID%2CIL%2CIN%2CIA%2CKS%2CKY%2CLA%2CME%2CMD%2CMA%2CMI%2CMN%2CMS%2CMO%2CMT%2CNE%2CNV%2CNH%2CNJ%2CNM%2CNY%2CNC%2CND%2CMP%2COH%2COK%2COR%2CPA%2CPR%2CRI%2CSC%2CSD%2CTN%2CTX%2CUT%2CVT%2CVI%2CVA%2CWA%2CWV%2CWI%2CWY%2CAK%2CUNKNOWN&category%3Anot=Toxicology&_total=accurate
+Authorization: Bearer {{bearer.response.body.access_token}}

--- a/src/Microsoft.Health.Fhir.Shared.Tests/Samples.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Tests/Samples.cs
@@ -191,5 +191,10 @@ namespace Microsoft.Health.Fhir.Tests.Common
         {
             return EmbeddedResourceManager.GetStringContent(EmbeddedResourceSubNamespace, fileName, "ndjson");
         }
+
+        public static string GetFileContents(string fileName, string ext)
+        {
+            return EmbeddedResourceManager.GetStringContent(EmbeddedResourceSubNamespace, fileName, ext);
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -714,7 +714,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     delimited.BeginDelimitedElement().Append(VLatest.Resource.ResourceSurrogateId, chainedExpression.Reversed ? referenceTargetResourceTableAlias : referenceSourceTableAlias).Append(" = ").Append("Sid2");
                 }
             }
-            else
+            else if (CheckAppendWithJoin(searchParamTableExpression.QueryGenerator.Table.TableName))
             {
                 AppendIntersectionWithPredecessorUsingInnerJoin(StringBuilder, searchParamTableExpression, chainedExpression.Reversed ? referenceTargetResourceTableAlias : referenceSourceTableAlias);
             }
@@ -736,6 +736,12 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     .Append(" IN (")
                     .Append(string.Join(", ", chainedExpression.TargetResourceTypes.Select(x => Parameters.AddParameter(VLatest.ReferenceSearchParam.ReferenceResourceTypeId, Model.GetResourceTypeId(x), true))))
                     .Append(")");
+
+                if (searchParamTableExpression.ChainLevel == 1 && !CheckAppendWithJoin(searchParamTableExpression.QueryGenerator.Table.TableName))
+                {
+                    // if > 1, the intersection is handled by the JOIN
+                    AppendIntersectionWithPredecessor(delimited, searchParamTableExpression, chainedExpression.Reversed ? referenceTargetResourceTableAlias : referenceSourceTableAlias);
+                }
 
                 if (chainedExpression.ExpressionOnTarget != null && !expressionOnTargetHandledBySecondJoin)
                 {

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -478,7 +478,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                 }
             }
 
-            if (searchParamTableExpression.QueryGenerator.Table == VLatest.ReferenceSearchParam.TableName)
+            if (searchParamTableExpression.QueryGenerator.Table.TableName == VLatest.ReferenceSearchParam.TableName)
             {
                 AppendIntersectionWithPredecessorUsingInnerJoin(StringBuilder, searchParamTableExpression);
             }
@@ -487,7 +487,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             {
                 AppendHistoryClause(delimited);
 
-                if (searchParamTableExpression.ChainLevel == 0 && !IsInSortMode(context) && searchParamTableExpression.QueryGenerator.Table != VLatest.ReferenceSearchParam.TableName)
+                if (searchParamTableExpression.ChainLevel == 0 && !IsInSortMode(context) && searchParamTableExpression.QueryGenerator.Table.TableName != VLatest.ReferenceSearchParam.TableName)
                 {
                     // if chainLevel > 0 or if in sort mode or if ReferenceSearchParam, the intersection is already handled in a JOIN
                     AppendIntersectionWithPredecessor(delimited, searchParamTableExpression);
@@ -1034,7 +1034,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     .Append(sortContext.SortColumnName, null).AppendLine(" as SortValue")
                     .Append("FROM ").AppendLine(searchParamTableExpression.QueryGenerator.Table);
 
-                if (searchParamTableExpression.QueryGenerator.Table == VLatest.ReferenceSearchParam.TableName)
+                if (searchParamTableExpression.QueryGenerator.Table.TableName == VLatest.ReferenceSearchParam.TableName)
                 {
                     AppendIntersectionWithPredecessorUsingInnerJoin(StringBuilder, searchParamTableExpression);
                 }
@@ -1061,7 +1061,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                         StringBuilder.Append(" OR ").Append(sortContext.SortColumnName, null).Append(" ").Append(sortOperand).Append(" ").Append(Parameters.AddParameter(sortContext.SortColumnName, sortContext.SortValue, includeInHash: false)).AppendLine(")");
                     }
 
-                    if (searchParamTableExpression.QueryGenerator.Table != VLatest.ReferenceSearchParam.TableName)
+                    if (searchParamTableExpression.QueryGenerator.Table.TableName != VLatest.ReferenceSearchParam.TableName)
                     {
                         AppendIntersectionWithPredecessor(delimited, searchParamTableExpression);
                     }
@@ -1083,7 +1083,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     .Append(sortContext.SortColumnName, null).AppendLine(" as SortValue")
                     .Append("FROM ").AppendLine(searchParamTableExpression.QueryGenerator.Table);
 
-                if (searchParamTableExpression.QueryGenerator.Table == VLatest.ReferenceSearchParam.TableName)
+                if (searchParamTableExpression.QueryGenerator.Table.TableName == VLatest.ReferenceSearchParam.TableName)
                 {
                     AppendIntersectionWithPredecessorUsingInnerJoin(StringBuilder, searchParamTableExpression);
                 }
@@ -1110,7 +1110,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                         StringBuilder.Append(" OR ").Append(sortContext.SortColumnName, null).Append(" ").Append(sortOperand).Append(" ").Append(Parameters.AddParameter(sortContext.SortColumnName, sortContext.SortValue, includeInHash: false)).AppendLine(")");
                     }
 
-                    if (searchParamTableExpression.QueryGenerator.Table != VLatest.ReferenceSearchParam.TableName)
+                    if (searchParamTableExpression.QueryGenerator.Table.TableName != VLatest.ReferenceSearchParam.TableName)
                     {
                         AppendIntersectionWithPredecessor(delimited, searchParamTableExpression);
                     }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using EnsureThat;
+using Microsoft.Data.SqlClient;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Features;
 using Microsoft.Health.Fhir.Core.Features.Search;
@@ -19,6 +20,8 @@ using Microsoft.Health.Fhir.SqlServer.Features.Storage;
 using Microsoft.Health.SqlServer;
 using Microsoft.Health.SqlServer.Features.Schema;
 using Microsoft.Health.SqlServer.Features.Schema.Model;
+using Microsoft.Health.SqlServer.Features.Storage;
+using SortOrder = Microsoft.Health.Fhir.Core.Features.Search.SortOrder;
 
 namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.QueryGenerators
 {
@@ -48,6 +51,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
         private HashSet<int> _cteToLimit = new HashSet<int>();
         private bool _hasIdentifier = false;
         private int _searchParamCount = 0;
+        private bool previousSqlQueryGeneratorFailure = false;
+        private int maxTableExpressionCountLimitForExists = 8;
 
         public SqlQueryGenerator(
             IndentedStringBuilder sb,
@@ -55,7 +60,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             ISqlServerFhirModel model,
             SqlSearchType searchType,
             SchemaInformation schemaInfo,
-            string searchParameterHash)
+            string searchParameterHash,
+            SqlException sqlException = null)
         {
             EnsureArg.IsNotNull(sb, nameof(sb));
             EnsureArg.IsNotNull(parameters, nameof(parameters));
@@ -68,6 +74,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             _searchType = searchType;
             _schemaInfo = schemaInfo;
             _searchParameterHash = searchParameterHash;
+
+            if (sqlException?.ErrorCode == SqlErrorCodes.QueryProcessorNoQueryPlan)
+            {
+                previousSqlQueryGeneratorFailure = true;
+            }
         }
 
         public IndentedStringBuilder StringBuilder { get; }
@@ -1035,7 +1046,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     .Append(sortContext.SortColumnName, null).AppendLine(" as SortValue")
                     .Append("FROM ").AppendLine(searchParamTableExpression.QueryGenerator.Table);
 
-                if (searchParamTableExpression.QueryGenerator.Table.TableName == VLatest.ReferenceSearchParam.TableName)
+                if (CheckAppendWithJoin(searchParamTableExpression.QueryGenerator.Table.TableName))
                 {
                     AppendIntersectionWithPredecessorUsingInnerJoin(StringBuilder, searchParamTableExpression);
                 }
@@ -1062,7 +1073,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                         StringBuilder.Append(" OR ").Append(sortContext.SortColumnName, null).Append(" ").Append(sortOperand).Append(" ").Append(Parameters.AddParameter(sortContext.SortColumnName, sortContext.SortValue, includeInHash: false)).AppendLine(")");
                     }
 
-                    if (searchParamTableExpression.QueryGenerator.Table.TableName != VLatest.ReferenceSearchParam.TableName)
+                    if (!CheckAppendWithJoin(searchParamTableExpression.QueryGenerator.Table.TableName))
                     {
                         AppendIntersectionWithPredecessor(delimited, searchParamTableExpression);
                     }
@@ -1084,7 +1095,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     .Append(sortContext.SortColumnName, null).AppendLine(" as SortValue")
                     .Append("FROM ").AppendLine(searchParamTableExpression.QueryGenerator.Table);
 
-                if (searchParamTableExpression.QueryGenerator.Table.TableName == VLatest.ReferenceSearchParam.TableName)
+                if (CheckAppendWithJoin(searchParamTableExpression.QueryGenerator.Table.TableName))
                 {
                     AppendIntersectionWithPredecessorUsingInnerJoin(StringBuilder, searchParamTableExpression);
                 }
@@ -1111,7 +1122,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                         StringBuilder.Append(" OR ").Append(sortContext.SortColumnName, null).Append(" ").Append(sortOperand).Append(" ").Append(Parameters.AddParameter(sortContext.SortColumnName, sortContext.SortValue, includeInHash: false)).AppendLine(")");
                     }
 
-                    if (searchParamTableExpression.QueryGenerator.Table.TableName != VLatest.ReferenceSearchParam.TableName)
+                    if (!CheckAppendWithJoin(searchParamTableExpression.QueryGenerator.Table.TableName))
                     {
                         AppendIntersectionWithPredecessor(delimited, searchParamTableExpression);
                     }
@@ -1195,6 +1206,24 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             }
 
             sb.Append(")");
+        }
+
+        private bool CheckAppendWithJoin(string tableName)
+        {
+            // if this is an inner join on the Reference Search Param table, and either:
+            // 1. the number of table expressions is greater than the limit indicating a complex query
+            // 2. the previous query generator failed to generate a query
+            // then we will use the EXISTS clause instead of the inner join
+            if (tableName == VLatest.ReferenceSearchParam.TableName &&
+                (_rootExpression.SearchParamTableExpressions.Count > maxTableExpressionCountLimitForExists ||
+                previousSqlQueryGeneratorFailure))
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
         }
 
         private void AppendIntersectionWithPredecessor(IndentedStringBuilder.DelimitedScope delimited, SearchParamTableExpression searchParamTableExpression, string tableAlias = null)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -478,7 +478,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                 }
             }
 
-            if (searchParamTableExpression.QueryGenerator.Table.TableName == VLatest.ReferenceSearchParam.TableName)
+            if (searchParamTableExpression.QueryGenerator.Table.TableName == VLatest.ReferenceSearchParam.TableName
+                && searchParamTableExpression.ChainLevel == 0 && !IsInSortMode(context))
             {
                 AppendIntersectionWithPredecessorUsingInnerJoin(StringBuilder, searchParamTableExpression);
             }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -714,7 +714,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     delimited.BeginDelimitedElement().Append(VLatest.Resource.ResourceSurrogateId, chainedExpression.Reversed ? referenceTargetResourceTableAlias : referenceSourceTableAlias).Append(" = ").Append("Sid2");
                 }
             }
-            else if (CheckAppendWithJoin(searchParamTableExpression.QueryGenerator.Table.TableName))
+
+            // since we are in chain table expression, we know the Table is the ReferenceSearchParam table
+            else if (CheckAppendWithJoin(VLatest.ReferenceSearchParam.TableName))
             {
                 AppendIntersectionWithPredecessorUsingInnerJoin(StringBuilder, searchParamTableExpression, chainedExpression.Reversed ? referenceTargetResourceTableAlias : referenceSourceTableAlias);
             }
@@ -737,7 +739,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                     .Append(string.Join(", ", chainedExpression.TargetResourceTypes.Select(x => Parameters.AddParameter(VLatest.ReferenceSearchParam.ReferenceResourceTypeId, Model.GetResourceTypeId(x), true))))
                     .Append(")");
 
-                if (searchParamTableExpression.ChainLevel == 1 && !CheckAppendWithJoin(searchParamTableExpression.QueryGenerator.Table.TableName))
+                if (searchParamTableExpression.ChainLevel == 1 && !CheckAppendWithJoin(VLatest.ReferenceSearchParam.TableName))
                 {
                     // if > 1, the intersection is handled by the JOIN
                     AppendIntersectionWithPredecessor(delimited, searchParamTableExpression, chainedExpression.Reversed ? referenceTargetResourceTableAlias : referenceSourceTableAlias);

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -579,7 +579,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
             var resourceTypeId = _model.GetResourceTypeId(resourceType);
             SearchResult searchResult = null;
             await _sqlRetryService.ExecuteSql(
-                async (cancellationToken) =>
+                async (cancellationToken, sqlException) =>
                 {
                     using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(initialCatalog: null, cancellationToken: cancellationToken).ConfigureAwait(false);
                     using SqlCommand sqlCommand = connection.CreateCommand();
@@ -664,7 +664,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
             var resourceTypeId = _model.GetResourceTypeId(resourceType);
             List<(long StartId, long EndId)> searchList = null;
             await _sqlRetryService.ExecuteSql(
-                async (cancellationToken) =>
+                async (cancellationToken, sqlException) =>
                 {
                     using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(initialCatalog: null, cancellationToken: cancellationToken).ConfigureAwait(false);
                     using SqlCommand sqlCommand = connection.CreateCommand();
@@ -702,7 +702,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
             var resourceTypes = new List<(short ResourceTypeId, string Name)>();
 
             await _sqlRetryService.ExecuteSql(
-                async (cancellationToken) =>
+                async (cancellationToken, sqlException) =>
                 {
                     using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(initialCatalog: null, cancellationToken: cancellationToken).ConfigureAwait(false);
                     using SqlCommand sqlCommand = connection.CreateCommand();
@@ -1002,7 +1002,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
             SearchResult searchResult = null;
 
             await _sqlRetryService.ExecuteSql(
-                async (cancellationToken) =>
+                async (cancellationToken, sqlException) =>
                 {
                     while (true)
                     {
@@ -1094,7 +1094,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
 
             SearchResult searchResult = null;
             await _sqlRetryService.ExecuteSql(
-                async (cancellationToken) =>
+                async (cancellationToken, sqlException) =>
                 {
                     using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(initialCatalog: null, cancellationToken: cancellationToken).ConfigureAwait(false);
                     using SqlCommand sqlCommand = connection.CreateCommand();

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -314,7 +314,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
 
             SearchResult searchResult = null;
             await _sqlRetryService.ExecuteSql(
-                async (cancellationToken) =>
+                async (cancellationToken, sqlException) =>
                 {
                     using (SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(initialCatalog: null, cancellationToken: cancellationToken).ConfigureAwait(false))
                     using (SqlCommand sqlCommand = connection.CreateCommand()) // WARNING, this code will not set sqlCommand.Transaction. Sql transactions via C#/.NET are not supported in this method.
@@ -345,7 +345,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                                 _model,
                                 searchType,
                                 _schemaInformation,
-                                currentSearchParameterHash);
+                                currentSearchParameterHash,
+                                sqlException);
 
                             expression.AcceptVisitor(queryGenerator, clonedSearchOptions);
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlRetry/ISqlRetryService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlRetry/ISqlRetryService.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 {
     public interface ISqlRetryService
     {
-        Task ExecuteSql(Func<CancellationToken, Task> action, CancellationToken cancellationToken);
+        Task ExecuteSql(Func<CancellationToken, SqlException, Task> action, CancellationToken cancellationToken);
 
         Task ExecuteSql<TLogger>(SqlCommand sqlCommand, Func<SqlCommand, CancellationToken, Task> action, ILogger<TLogger> logger, string logMessage, CancellationToken cancellationToken);
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlRetry/SqlRetryService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlRetry/SqlRetryService.cs
@@ -171,16 +171,18 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
         /// <exception>When executing this method, if exception is thrown that is not retriable or if last retry fails, then same exception is thrown by this method.</exception>
-        public async Task ExecuteSql(Func<CancellationToken, Task> action, CancellationToken cancellationToken)
+        public async Task ExecuteSql(Func<CancellationToken, SqlException, Task> action, CancellationToken cancellationToken)
         {
             EnsureArg.IsNotNull(action, nameof(action));
+
+            SqlException sqlException = null;
 
             int retry = 0;
             while (true)
             {
                 try
                 {
-                    await action(cancellationToken);
+                    await action(cancellationToken, sqlException);
                     return;
                 }
                 catch (Exception ex)
@@ -188,6 +190,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                     if (!RetryTest(ex) || ++retry >= _maxRetries)
                     {
                         throw;
+                    }
+
+                    if (ex is SqlException sqlEx)
+                    {
+                        sqlException = sqlEx;
                     }
                 }
 

--- a/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
+++ b/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
@@ -13,6 +13,11 @@
     <NoWarn>$(NoWarn);NU5104;NU5100</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <None Remove="TestFiles\Normative\MemberMatch.json" />
+    <None Remove="TestFiles\Normative\sql_8623_script.sql" />
+    <None Remove="TestFiles\Stu3\MemberMatch.json" />
+  </ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="TestFiles\Normative\LegacyRawReindexJobRecord.json" />
     <EmbeddedResource Include="DefinitionFiles\R5\SearchParameters.json" />
     <EmbeddedResource Include="DefinitionFiles\R5\SearchParametersWithInvalidBase.json" />
@@ -46,6 +51,7 @@
     <EmbeddedResource Include="TestFiles\Normative\Import-Patient.ndjson" />
     <EmbeddedResource Include="TestFiles\Normative\Import-SinglePatientTemplate.ndjson" />
     <EmbeddedResource Include="TestFiles\Normative\Medication.json" />
+    <EmbeddedResource Include="TestFiles\Normative\MemberMatch.json" />
     <EmbeddedResource Include="TestFiles\Normative\PatientWithUnknownElements.json" />
     <EmbeddedResource Include="TestFiles\Normative\Profile-Patient-uscore-noidentifier.json" />
     <EmbeddedResource Include="TestFiles\Normative\Profile-Patient-uscore-noGender.json" />
@@ -53,6 +59,7 @@
     <EmbeddedResource Include="TestFiles\Normative\SearchParameter-AppointmentStatus.json" />
     <EmbeddedResource Include="TestFiles\Normative\SearchParameter-Patient-foo.json" />
     <EmbeddedResource Include="TestFiles\Normative\SearchParameter-SpecimenStatus.json" />
+    <EmbeddedResource Include="TestFiles\Normative\sql_8623_script.sql" />
     <EmbeddedResource Include="TestFiles\Normative\TokenOverflowChargeItem.json" />
     <EmbeddedResource Include="TestFiles\Normative\TokenOverflowPatient.json" />
     <EmbeddedResource Include="TestFiles\Normative\TokenOverflowRiskAssessment.json" />
@@ -225,6 +232,7 @@
     <EmbeddedResource Include="TestFiles\Stu3\Immunization.json" />
     <EmbeddedResource Include="TestFiles\Stu3\InvalidObservation.json" />
     <EmbeddedResource Include="TestFiles\Stu3\Location-example-hq.json" />
+    <EmbeddedResource Include="TestFiles\Stu3\MemberMatch.json" />
     <EmbeddedResource Include="TestFiles\Stu3\Observation-For-Patient-f001.json" />
     <EmbeddedResource Include="TestFiles\Stu3\ObservationWith1MinuteApgarScore.json" />
     <EmbeddedResource Include="TestFiles\Stu3\ObservationWith20MinuteApgarScore.json" />

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/MemberMatch.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/MemberMatch.json
@@ -1,0 +1,174 @@
+{
+    "resourceType": "Parameters",
+    "id": "member-match-in",
+    "parameter": [
+        {
+            "name": "MemberPatient",
+            "resource": {
+                "resourceType": "Patient",
+                "id": "1",
+                "identifier": [
+                    {
+                        "type": {
+                            "coding": [
+                                {
+                                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                                    "code": "MB"
+                                }
+                            ]
+                        },
+                        "system": "http://example.org/old-payer/identifiers/member",
+                        "value": "55678",
+                        "assigner": {
+                            "display": "Old Payer"
+                        }
+                    }
+                ],
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "Person",
+                        "given": [
+                            "Patricia",
+                            "Ann"
+                        ]
+                    }
+                ],
+                "gender": "female",
+                "birthDate": "1974-12-25"
+            }
+        },
+        {
+            "name": "OldCoverage",
+            "resource": {
+                "resourceType": "Coverage",
+                "id": "9876B1",
+                "contained": [
+                    {
+                        "resourceType": "Organization",
+                        "id": "payer",
+                        "identifier": [
+                            {
+                                "system": "http://hl7.org/fhir/sid/us-npi",
+                                "value": "9876543210"
+                            }
+                        ],
+                        "active": true,
+                        "name": "Old Health Plan",
+                        "endpoint": [
+                            {
+                                "reference": "http://example.org/old-payer/fhir"
+                            }
+                        ]
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "http://example.org/old-payer",
+                        "value": "DH10001235"
+                    }
+                ],
+                "status": "draft",
+                "beneficiary": {
+                    "reference": "Patient/1"
+                },
+                "period": {
+                    "start": "2011-05-23",
+                    "end": "2012-05-23"
+                },
+                "payor": [
+                    {
+                        "reference": "#payer"
+                    }
+                ],
+                "class": [
+                    {
+                        "type": {
+                            "coding": [
+                                {
+                                    "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+                                    "code": "group"
+                                }
+                            ]
+                        },
+                        "value": "CB135"
+                    },
+                    {
+                        "type": {
+                            "coding": [
+                                {
+                                    "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+                                    "code": "plan"
+                                }
+                            ]
+                        },
+                        "value": "B37FC"
+                    },
+                    {
+                        "type": {
+                            "coding": [
+                                {
+                                    "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+                                    "code": "subplan"
+                                }
+                            ]
+                        },
+                        "value": "P7"
+                    },
+                    {
+                        "type": {
+                            "coding": [
+                                {
+                                    "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+                                    "code": "class"
+                                }
+                            ]
+                        },
+                        "value": "SILVER"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "NewCoverage",
+            "resource": {
+                "resourceType": "Coverage",
+                "id": "AA87654",
+                "contained": [
+                    {
+                        "resourceType": "Organization",
+                        "id": "payer",
+                        "identifier": [
+                            {
+                                "system": "http://hl7.org/fhir/sid/us-npi",
+                                "value": "0123456789"
+                            }
+                        ],
+                        "active": true,
+                        "name": "New Health Plan",
+                        "endpoint": [
+                            {
+                                "reference": "http://example.org/new-payer/fhir"
+                            }
+                        ]
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "http://example.org/new-payer/identifiers/coverage",
+                        "value": "234567"
+                    }
+                ],
+                "status": "active",
+                "beneficiary": {
+                    "reference": "Patient/1"
+                },
+                "payor": [
+                    {
+                        "reference": "#payer"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/sql_8623_script.sql
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/sql_8623_script.sql
@@ -1,0 +1,400 @@
+﻿DECLARE @p0 SmallInt = 1418;
+      DECLARE @p1 VarChar(256) = '1';
+      DECLARE @p2 SmallInt = 103;
+      DECLARE @p3 SmallInt = 1016;
+      DECLARE @p4 NVarChar(256) = N'Patricia';
+      DECLARE @p5 NVarChar(256) = N'Ann';
+      DECLARE @p6 NVarChar(256) = N'Person';
+      DECLARE @p7 SmallInt = 696;
+      DECLARE @p8 SmallInt = 694;
+      DECLARE @p9 SmallInt = 1013;
+      DECLARE @p10 NVarChar(256) = N'http://example.org/old-payer/identifiers/member';
+      DECLARE @p11 VarChar(256) = '55678';
+      DECLARE @p12 SmallInt = 1419;
+      DECLARE @p13 NVarChar(256) = N'(http://example.org/old-payer/identifiers/member';
+      DECLARE @p14 VarChar(256) = '55678) ';
+      DECLARE @p15 NVarChar(256) = N' (Person)%';
+      DECLARE @p16 SmallInt = 690;
+      DECLARE @p17 DateTime2 = '1974-12-25T00:00:00.0000000Z';
+      DECLARE @p18 DateTime2 = '1974-12-25T23:59:59.9999999Z';
+      DECLARE @p19 SmallInt = 1011;
+      DECLARE @p20 Int = 9;
+      DECLARE @p21 VarChar(256) = 'false';
+      DECLARE @p22 SmallInt = 692;
+      DECLARE @p23 SmallInt = 693;
+      DECLARE @p24 Int = 12;
+      DECLARE @p25 VarChar(256) = 'female';
+      DECLARE @p26 SmallInt = 336;
+      DECLARE @p27 SmallInt = 31;
+      DECLARE @p28 SmallInt = 338;
+      DECLARE @p29 NVarChar(256) = N'CB135';
+      DECLARE @p30 NVarChar(256) = N'B37FC';
+      DECLARE @p31 NVarChar(256) = N'P7';
+      DECLARE @p32 NVarChar(256) = N'SILVER';
+      DECLARE @p33 SmallInt = 337;
+      DECLARE @p34 NVarChar(256) = N'http://terminology.hl7.org/CodeSystem/coverage-class';
+      DECLARE @p35 VarChar(256) = 'group';
+      DECLARE @p36 VarChar(256) = 'plan';
+      DECLARE @p37 VarChar(256) = 'subplan';
+      DECLARE @p38 VarChar(256) = 'class';
+      DECLARE @p39 VarChar(256) = '9876B1';
+      DECLARE @p40 SmallInt = 356;
+      DECLARE @p41 NVarChar(256) = N'http://example.org/old-payer';
+      DECLARE @p42 VarChar(256) = 'DH10001235';
+      DECLARE @p43 SmallInt = 360;
+      DECLARE @p44 NVarChar(256) = N'http://hl7.org/fhir/fm-status';
+      DECLARE @p45 VarChar(256) = 'draft';
+      DECLARE @p46 Int = 3;
+
+      SET STATISTICS IO ON;
+      SET STATISTICS TIME ON;
+
+      WITH cte0 AS
+      (
+          SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1
+          FROM dbo.TokenSearchParam
+          WHERE IsHistory = 0
+              AND SearchParamId = @p0
+              AND Code = @p1
+              AND ResourceTypeId = @p2
+
+      ),
+      cte1 AS
+      (
+          SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1
+          FROM dbo.StringSearchParam
+          WHERE IsHistory = 0
+              AND EXISTS(SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)
+              AND SearchParamId = @p3
+              AND Text = @p4 AND Text = @p4 COLLATE Latin1_General_100_CS_AS
+              AND ResourceTypeId = @p2
+
+      ),
+      cte2 AS
+      (
+          SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1
+          FROM dbo.StringSearchParam
+          WHERE IsHistory = 0
+              AND EXISTS(SELECT * FROM cte1 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)
+              AND SearchParamId = @p3
+              AND Text = @p5 AND Text = @p5 COLLATE Latin1_General_100_CS_AS
+              AND ResourceTypeId = @p2
+
+      ),
+      cte3 AS
+      (
+          SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1
+          FROM dbo.StringSearchParam
+          WHERE IsHistory = 0
+              AND EXISTS(SELECT * FROM cte2 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)
+              AND SearchParamId = @p3
+              AND Text = @p6 AND Text = @p6 COLLATE Latin1_General_100_CS_AS
+              AND ResourceTypeId = @p2
+
+      ),
+      cte4 AS
+      (
+          SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1
+          FROM dbo.StringSearchParam
+          WHERE IsHistory = 0
+              AND EXISTS(SELECT * FROM cte3 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)
+              AND SearchParamId = @p7
+              AND Text = @p4 AND Text = @p4 COLLATE Latin1_General_100_CS_AS
+              AND ResourceTypeId = @p2
+
+      ),
+      cte5 AS
+      (
+          SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1
+          FROM dbo.StringSearchParam
+          WHERE IsHistory = 0
+              AND EXISTS(SELECT * FROM cte4 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)
+              AND SearchParamId = @p7
+              AND Text = @p5 AND Text = @p5 COLLATE Latin1_General_100_CS_AS
+              AND ResourceTypeId = @p2
+
+      ),
+      cte6 AS
+      (
+          SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1
+          FROM dbo.StringSearchParam
+          WHERE IsHistory = 0
+              AND EXISTS(SELECT * FROM cte5 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)
+              AND SearchParamId = @p7
+              AND Text = @p6 AND Text = @p6 COLLATE Latin1_General_100_CS_AS
+              AND ResourceTypeId = @p2
+
+      ),
+      cte7 AS
+      (
+          SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1
+          FROM dbo.StringSearchParam
+          WHERE IsHistory = 0
+              AND EXISTS(SELECT * FROM cte6 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)
+              AND SearchParamId = @p8
+              AND Text = @p4 AND Text = @p4 COLLATE Latin1_General_100_CS_AS
+              AND ResourceTypeId = @p2
+
+      ),
+      cte8 AS
+      (
+          SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1
+          FROM dbo.StringSearchParam
+          WHERE IsHistory = 0
+              AND EXISTS(SELECT * FROM cte7 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)
+              AND SearchParamId = @p8
+              AND Text = @p5 AND Text = @p5 COLLATE Latin1_General_100_CS_AS
+              AND ResourceTypeId = @p2
+
+      ),
+      cte9 AS
+      (
+          SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1
+          FROM dbo.TokenSearchParam
+          WHERE IsHistory = 0
+              AND EXISTS(SELECT * FROM cte8 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)
+              AND SearchParamId = @p9
+              AND SystemId IN (SELECT SystemId FROM dbo.System WHERE Value = @p10)
+              AND Code = @p11
+
+              AND ResourceTypeId = @p2
+
+      ),
+      cte10 AS
+      (
+          SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1
+          FROM dbo.TokenStringCompositeSearchParam
+          WHERE IsHistory = 0
+              AND EXISTS(SELECT * FROM cte9 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)
+              AND SearchParamId = @p12
+              AND SystemId1 IN (SELECT SystemId FROM dbo.System WHERE Value = @p13)
+              AND Code1 = @p14
+              AND Text2 LIKE @p15
+
+              AND ResourceTypeId = @p2
+
+      ),
+      cte11 AS
+      (
+          SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1
+          FROM dbo.DateTimeSearchParam
+          WHERE IsHistory = 0
+              AND EXISTS(SELECT * FROM cte10 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)
+              AND SearchParamId = @p16
+              AND StartDateTime >= @p17
+              AND StartDateTime <= @p18
+              AND EndDateTime <= @p18
+
+              AND ResourceTypeId = @p2
+
+      ),
+      cte12 AS
+      (
+          SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1
+          FROM dbo.TokenSearchParam
+          WHERE IsHistory = 0
+              AND EXISTS(SELECT * FROM cte11 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)
+              AND SearchParamId = @p19
+              AND SystemId = @p20
+              AND Code = @p21
+
+              AND ResourceTypeId = @p2
+
+      ),
+      cte13 AS
+      (
+          SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1
+          FROM dbo.StringSearchParam
+          WHERE IsHistory = 0
+              AND EXISTS(SELECT * FROM cte12 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)
+              AND SearchParamId = @p22
+              AND Text = @p6 AND Text = @p6 COLLATE Latin1_General_100_CS_AS
+              AND ResourceTypeId = @p2
+
+      ),
+      cte14 AS
+      (
+          SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1
+          FROM dbo.TokenSearchParam
+          WHERE IsHistory = 0
+              AND EXISTS(SELECT * FROM cte13 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)
+              AND SearchParamId = @p23
+              AND SystemId = @p24
+              AND Code = @p25
+
+              AND ResourceTypeId = @p2
+
+      ),
+      cte15 AS
+      (
+          SELECT refSource.ResourceTypeId AS T2, refSource.ResourceSurrogateId AS Sid2, refTarget.ResourceTypeId AS T1, refTarget.ResourceSurrogateId AS Sid1
+          FROM dbo.ReferenceSearchParam refSource
+          INNER JOIN dbo.Resource refTarget
+          ON refSource.ReferenceResourceTypeId = refTarget.ResourceTypeId
+              AND refSource.ReferenceResourceId = refTarget.ResourceId
+          WHERE refSource.SearchParamId = @p26
+              AND refTarget.IsHistory = 0
+              AND refSource.IsHistory = 0
+              AND refSource.ResourceTypeId IN (@p27)
+              AND refSource.ReferenceResourceTypeId IN (@p2)
+              AND EXISTS(SELECT * FROM cte14 WHERE refTarget.ResourceTypeId = T1 AND refTarget.ResourceSurrogateId = Sid1)
+              AND refTarget.ResourceTypeId = @p2
+      ),
+      cte16 AS
+      (
+          SELECT T1, Sid1, ResourceTypeId AS T2,
+          ResourceSurrogateId AS Sid2
+          FROM dbo.StringSearchParam
+          INNER JOIN cte15
+          ON ResourceTypeId = T2
+              AND ResourceSurrogateId = Sid2
+          WHERE IsHistory = 0
+              AND SearchParamId = @p28
+              AND Text = @p29 AND Text = @p29 COLLATE Latin1_General_100_CS_AS
+      ),
+      cte17 AS
+      (
+          SELECT T1, Sid1, ResourceTypeId AS T2,
+          ResourceSurrogateId AS Sid2
+          FROM dbo.StringSearchParam
+          INNER JOIN cte16
+          ON ResourceTypeId = T2
+              AND ResourceSurrogateId = Sid2
+          WHERE IsHistory = 0
+              AND SearchParamId = @p28
+              AND Text = @p30 AND Text = @p30 COLLATE Latin1_General_100_CS_AS
+      ),
+      cte18 AS
+      (
+          SELECT T1, Sid1, ResourceTypeId AS T2,
+          ResourceSurrogateId AS Sid2
+          FROM dbo.StringSearchParam
+          INNER JOIN cte17
+          ON ResourceTypeId = T2
+              AND ResourceSurrogateId = Sid2
+          WHERE IsHistory = 0
+              AND SearchParamId = @p28
+              AND Text = @p31 AND Text = @p31 COLLATE Latin1_General_100_CS_AS
+      ),
+      cte19 AS
+      (
+          SELECT T1, Sid1, ResourceTypeId AS T2,
+          ResourceSurrogateId AS Sid2
+          FROM dbo.StringSearchParam
+          INNER JOIN cte18
+          ON ResourceTypeId = T2
+              AND ResourceSurrogateId = Sid2
+          WHERE IsHistory = 0
+              AND SearchParamId = @p28
+              AND Text = @p32 AND Text = @p32 COLLATE Latin1_General_100_CS_AS
+      ),
+      cte20 AS
+      (
+          SELECT T1, Sid1, ResourceTypeId AS T2,
+          ResourceSurrogateId AS Sid2
+          FROM dbo.TokenSearchParam
+          INNER JOIN cte19
+          ON ResourceTypeId = T2
+              AND ResourceSurrogateId = Sid2
+          WHERE IsHistory = 0
+              AND SearchParamId = @p33
+              AND SystemId IN (SELECT SystemId FROM dbo.System WHERE Value = @p34)
+              AND Code = @p35
+
+      ),
+      cte21 AS
+      (
+          SELECT T1, Sid1, ResourceTypeId AS T2,
+          ResourceSurrogateId AS Sid2
+          FROM dbo.TokenSearchParam
+          INNER JOIN cte20
+          ON ResourceTypeId = T2
+              AND ResourceSurrogateId = Sid2
+          WHERE IsHistory = 0
+              AND SearchParamId = @p33
+              AND SystemId IN (SELECT SystemId FROM dbo.System WHERE Value = @p34)
+              AND Code = @p36
+
+      ),
+      cte22 AS
+      (
+          SELECT T1, Sid1, ResourceTypeId AS T2,
+          ResourceSurrogateId AS Sid2
+          FROM dbo.TokenSearchParam
+          INNER JOIN cte21
+          ON ResourceTypeId = T2
+              AND ResourceSurrogateId = Sid2
+          WHERE IsHistory = 0
+              AND SearchParamId = @p33
+              AND SystemId IN (SELECT SystemId FROM dbo.System WHERE Value = @p34)
+              AND Code = @p37
+
+      ),
+      cte23 AS
+      (
+          SELECT T1, Sid1, ResourceTypeId AS T2,
+          ResourceSurrogateId AS Sid2
+          FROM dbo.TokenSearchParam
+          INNER JOIN cte22
+          ON ResourceTypeId = T2
+              AND ResourceSurrogateId = Sid2
+          WHERE IsHistory = 0
+              AND SearchParamId = @p33
+              AND SystemId IN (SELECT SystemId FROM dbo.System WHERE Value = @p34)
+              AND Code = @p38
+
+      ),
+      cte24 AS
+      (
+          SELECT T1, Sid1, ResourceTypeId AS T2,
+          ResourceSurrogateId AS Sid2
+          FROM dbo.TokenSearchParam
+          INNER JOIN cte23
+          ON ResourceTypeId = T2
+              AND ResourceSurrogateId = Sid2
+          WHERE IsHistory = 0
+              AND SearchParamId = @p0
+              AND Code = @p39
+      ),
+      cte25 AS
+      (
+          SELECT T1, Sid1, ResourceTypeId AS T2,
+          ResourceSurrogateId AS Sid2
+          FROM dbo.TokenSearchParam
+          INNER JOIN cte24
+          ON ResourceTypeId = T2
+              AND ResourceSurrogateId = Sid2
+          WHERE IsHistory = 0
+              AND SearchParamId = @p40
+              AND SystemId IN (SELECT SystemId FROM dbo.System WHERE Value = @p41)
+              AND Code = @p42
+
+      ),
+      cte26 AS
+      (
+          SELECT T1, Sid1, ResourceTypeId AS T2,
+          ResourceSurrogateId AS Sid2
+          FROM dbo.TokenSearchParam
+          INNER JOIN cte25
+          ON ResourceTypeId = T2
+              AND ResourceSurrogateId = Sid2
+          WHERE IsHistory = 0
+              AND SearchParamId = @p43
+              AND SystemId IN (SELECT SystemId FROM dbo.System WHERE Value = @p44)
+              AND Code = @p45
+
+      ),
+      cte27 AS
+      (
+          SELECT DISTINCT TOP (@p46) T1, Sid1, 1 AS IsMatch, 0 AS IsPartial
+          FROM cte26
+          ORDER BY T1 ASC, Sid1 ASC
+      )
+      SELECT DISTINCT r.ResourceTypeId, r.ResourceId, r.Version, r.IsDeleted, r.ResourceSurrogateId, r.RequestMethod, CAST(IsMatch AS bit) AS IsMatch, CAST(IsPartial AS bit) AS IsPartial, r.IsRawResourceMetaSet, r.SearchParamHash, r.RawResource
+      FROM dbo.Resource r
+
+      INNER JOIN cte27
+      ON r.ResourceTypeId = cte27.T1 AND
+      r.ResourceSurrogateId = cte27.Sid1
+      ORDER BY r.ResourceTypeId ASC, r.ResourceSurrogateId ASC
+      /* HASH ZgZSXBM+MzloBRd89dLWBC3ztlqMo2OIDo5Jt9leEy8= */

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Stu3/MemberMatch.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Stu3/MemberMatch.json
@@ -1,0 +1,128 @@
+{
+    "resourceType": "Parameters",
+    "id": "member-match-in",
+    "parameter": [
+        {
+            "name": "MemberPatient",
+            "resource": {
+                "resourceType": "Patient",
+                "id": "1",
+                "identifier": [
+                    {
+                        "type": {
+                            "coding": [
+                                {
+                                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                                    "code": "MB"
+                                }
+                            ]
+                        },
+                        "system": "http://example.org/old-payer/identifiers/member",
+                        "value": "55678",
+                        "assigner": {
+                            "display": "Old Payer"
+                        }
+                    }
+                ],
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "Person",
+                        "given": [
+                            "Patricia",
+                            "Ann"
+                        ]
+                    }
+                ],
+                "gender": "female",
+                "birthDate": "1974-12-25"
+            }
+        },
+        {
+            "name": "OldCoverage",
+            "resource": {
+                "resourceType": "Coverage",
+                "id": "9876B1",
+                "contained": [
+                    {
+                        "resourceType": "Organization",
+                        "id": "payer",
+                        "identifier": [
+                            {
+                                "system": "http://hl7.org/fhir/sid/us-npi",
+                                "value": "9876543210"
+                            }
+                        ],
+                        "active": true,
+                        "name": "Old Health Plan",
+                        "endpoint": [
+                            {
+                                "reference": "http://example.org/old-payer/fhir"
+                            }
+                        ]
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "http://example.org/old-payer",
+                        "value": "DH10001235"
+                    }
+                ],
+                "status": "draft",
+                "beneficiary": {
+                    "reference": "Patient/1"
+                },
+                "period": {
+                    "start": "2011-05-23",
+                    "end": "2012-05-23"
+                },
+                "payor": [
+                    {
+                        "reference": "#payer"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "NewCoverage",
+            "resource": {
+                "resourceType": "Coverage",
+                "id": "AA87654",
+                "contained": [
+                    {
+                        "resourceType": "Organization",
+                        "id": "payer",
+                        "identifier": [
+                            {
+                                "system": "http://hl7.org/fhir/sid/us-npi",
+                                "value": "0123456789"
+                            }
+                        ],
+                        "active": true,
+                        "name": "New Health Plan",
+                        "endpoint": [
+                            {
+                                "reference": "http://example.org/new-payer/fhir"
+                            }
+                        ]
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "http://example.org/new-payer/identifiers/coverage",
+                        "value": "234567"
+                    }
+                ],
+                "status": "active",
+                "beneficiary": {
+                    "reference": "Patient/1"
+                },
+                "payor": [
+                    {
+                        "reference": "#payer"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/StringSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/StringSearchTests.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Net;
+using System.Threading;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Client;
 using Microsoft.Health.Fhir.Core.Extensions;
@@ -23,6 +24,31 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         public StringSearchTests(StringSearchTestFixture fixture)
             : base(fixture)
         {
+        }
+
+        /// <summary>
+        /// This can have two successful outcomes. We're not looking for results to come back but
+        /// rather a 422 or 200 result. If we get one of those then that indicates the
+        /// generated sql for a membermatch has been correctly handled by sql. Prior to the
+        /// revision, we would get a 8623 error that sql can't create a sql query plan.
+        /// This membermatch json will create up to 24 CTEs.
+        /// </summary>
+        [Fact]
+        [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
+        public async void GivenAComplexSqlStatement_FromMemberMatch_SucceedsWhenExecuted()
+        {
+            HttpStatusCode httpStatusCode = HttpStatusCode.OK;
+            string body = Samples.GetJson("MemberMatch");
+            try
+            {
+                await Client.PostAsync("Patient/$member-match", body, CancellationToken.None);
+            }
+            catch (Microsoft.Health.Fhir.Client.FhirClientException ex)
+            {
+                httpStatusCode = ex.StatusCode;
+            }
+
+            Assert.True(httpStatusCode == System.Net.HttpStatusCode.UnprocessableEntity || httpStatusCode == System.Net.HttpStatusCode.OK);
         }
 
         [Fact]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Microsoft.Health.Fhir.Shared.Tests.Integration.projitems
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Microsoft.Health.Fhir.Shared.Tests.Integration.projitems
@@ -27,6 +27,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\FhirStorageVersioningPolicyTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SearchParameterStatusDataStoreTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlRetryServiceTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlServerMemberMatchTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlServerSetMergeTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlServerWatchdogTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlServerSchemaUpgradeTests.cs" />

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerMemberMatchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerMemberMatchTests.cs
@@ -1,0 +1,62 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Data.SqlClient;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.SqlServer.Features.Storage;
+using Microsoft.Health.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
+{
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.Search)]
+    public class SqlServerMemberMatchTests : IClassFixture<SqlServerFhirStorageTestsFixture>
+    {
+        private readonly string _connectionString;
+
+        public SqlServerMemberMatchTests(SqlServerFhirStorageTestsFixture fixture)
+        {
+            _connectionString = fixture.TestConnectionString;
+        }
+
+        /// <summary>
+        /// With this test it's possible for it to succeed but if it fails then it should be
+        /// a specific error. Since this error (#8623) is failure for sql to create a query plan,
+        /// when it fails it never returns data. If it doesn't hit the error then we don't care
+        /// if it returns data.
+        /// </summary>
+        [Fact]
+        public void GivenAComplexSqlStatement_WhenExecutingItMayThrowSpecificException()
+        {
+            string sql = Samples.GetFileContents("sql_8623_script", "sql");
+            using (var connection = new SqlConnection(_connectionString))
+            {
+                connection.Open();
+
+                SqlCommand sqlCommand = connection.CreateCommand();
+                sqlCommand.CommandText = sql;
+
+                bool pass;
+
+                try
+                {
+                    int response = sqlCommand.ExecuteNonQuery();
+                    pass = response >= -1;
+                }
+                catch (SqlException ex)
+                {
+                    pass = ex.Number == SqlErrorCodes.QueryProcessorNoQueryPlan;
+                    Assert.True(ex.Number == SqlErrorCodes.QueryProcessorNoQueryPlan);
+                }
+
+                if (!pass)
+                {
+                    Assert.Fail($"{nameof(GivenAComplexSqlStatement_WhenExecutingItMayThrowSpecificException)} failed ");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
At times with complex FHIR queries, the resulting SQL query is very complex and SQL server can timeout attempting to generate the query plan. We use an EXISTS clause to link References to the target type, but it reduces the burden on SQL server if we use an INNER JOIN.

This change alters the SQL query generator to use an INNER JOIN for ReferenceSearchParams.

## Related issues
Addresses [issue AB#95713].

## Testing
Manual testing with include .htpp file.  Also added automated testing via member match.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
