### PR TITLE
Removed Pending Delete Status for Search Parameter Status

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -187,8 +187,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
         private async Task<bool> TryPopulateNewJobFields(CancellationToken cancellationToken)
         {
             // Build query based on new search params
-            // Find search parameters not in a final state such as supported, pendingDelete, pendingDisable.
-            List<SearchParameterStatus> validStatus = new List<SearchParameterStatus>() { SearchParameterStatus.Supported, SearchParameterStatus.PendingDelete, SearchParameterStatus.PendingDisable };
+            // Find search parameters not in a final state such as supported and pendingDisable.
+            List<SearchParameterStatus> validStatus = new List<SearchParameterStatus>() { SearchParameterStatus.Supported, SearchParameterStatus.PendingDisable };
             var searchParamStatusCollection = await _searchParameterStatusManager.GetAllSearchParameterStatus(cancellationToken);
             var possibleNotYetIndexedParams = _searchParameterDefinitionManager.AllSearchParameters.Where(sp => validStatus.Contains(searchParamStatusCollection.First(p => p.Uri == sp.Url).Status) || sp.IsSearchable == false || sp.SortStatus == SortParameterStatus.Supported);
             var notYetIndexedParams = new List<SearchParameterInfo>();
@@ -818,11 +818,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     {
                         _logger.LogInformation("Reindex job updating the status of the fully indexed search, id: {Id}, parameter: '{ParamUri}' to Disabled.", _reindexJobRecord.Id, searchParam);
                         await _searchParameterStatusManager.UpdateSearchParameterStatusAsync(new List<string>() { searchParamInfo.Url.ToString() }, SearchParameterStatus.Disabled, cancellationToken);
-                    }
-                    else if (spStatus == Search.Registry.SearchParameterStatus.PendingDelete)
-                    {
-                        _logger.LogInformation("Reindex job updating the status of the fully indexed search, id: {Id}, parameter: '{ParamUri}' to Deleted.", _reindexJobRecord.Id, searchParam);
-                        await _searchParameterStatusManager.UpdateSearchParameterStatusAsync(new List<string>() { searchParamInfo.Url.ToString() }, SearchParameterStatus.Deleted, cancellationToken);
                     }
                     else if (spStatus == SearchParameterStatus.Supported || spStatus == SearchParameterStatus.Enabled)
                     {

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatus.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatus.cs
@@ -11,8 +11,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
         Supported = 2,
         Enabled = 3,
         Deleted = 4,
-        PendingDelete = 5,
-        PendingDisable = 6,
-        Unsupported = 7,
+        PendingDisable = 5,
+        Unsupported = 6,
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
         internal async Task DeleteSearchParameterStatusAsync(string url, CancellationToken cancellationToken)
         {
             var searchParamUris = new List<string>() { url };
-            await UpdateSearchParameterStatusAsync(searchParamUris, SearchParameterStatus.PendingDelete, cancellationToken);
+            await UpdateSearchParameterStatusAsync(searchParamUris, SearchParameterStatus.Deleted, cancellationToken);
         }
 
         internal async Task<IReadOnlyCollection<ResourceSearchParameterStatus>> GetSearchParameterStatusUpdates(CancellationToken cancellationToken)

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/SearchParameterController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/SearchParameterController.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         [ValidateSearchParameterStateRequestAtrribute]
         public async Task<IActionResult> GetSearchParametersStatus(CancellationToken cancellationToken)
         {
-            CheckIfSearchParameterStatusIsEnabledOrADHS();
+            CheckIfSearchParameterStatusIsEnabledOrAHDS();
 
             SearchParameterStateRequest request = new SearchParameterStateRequest(GetQueriesForSearch());
             SearchParameterStateResponse result = await _mediator.Send(request, cancellationToken);
@@ -81,7 +81,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         [AuditEventType(AuditEventSubType.SearchParameterStatus)]
         public async Task<IActionResult> PostSearchParametersStatus(CancellationToken cancellationToken)
         {
-            CheckIfSearchParameterStatusIsEnabledOrADHS();
+            CheckIfSearchParameterStatusIsEnabledOrAHDS();
 
             SearchParameterStateRequest request = new SearchParameterStateRequest(GetQueriesForSearch());
             SearchParameterStateResponse result = await _mediator.Send(request, cancellationToken);
@@ -100,7 +100,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         [AuditEventType(AuditEventSubType.SearchParameterStatus)]
         public async Task<IActionResult> UpdateSearchParametersStatus([FromBody] Parameters inputParams, CancellationToken cancellationToken)
         {
-            CheckIfSearchParameterStatusIsEnabledOrADHS();
+            CheckIfSearchParameterStatusIsEnabledOrAHDS();
             SearchParameterStateUpdateRequest updateRequest = ParseUpdateRequestBody(inputParams);
             SearchParameterStateUpdateResponse result = await _mediator.Send(updateRequest, cancellationToken);
 
@@ -110,7 +110,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         /// <summary>
         /// Provide appropriate response if Search Parameter Status feature is not enabled
         /// </summary>
-        private void CheckIfSearchParameterStatusIsEnabledOrADHS()
+        private void CheckIfSearchParameterStatusIsEnabledOrAHDS()
         {
             if (!_coreFeaturesConfig.SupportsSelectableSearchParameters || !_isSelectSearchParameterSupported)
             {

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/SearchParameterState/SearchParameterStateHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/SearchParameterState/SearchParameterStateHandlerTests.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Search
                     },
                     new ResourceSearchParameterStatus
                     {
-                        Status = SearchParameterStatus.PendingDelete,
+                        Status = SearchParameterStatus.Deleted,
                         Uri = new Uri(ResourceQuery),
                     },
                     new ResourceSearchParameterStatus
@@ -186,7 +186,7 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Search
             Parameters result = response.SearchParameters.ToPoco<Parameters>();
             Assert.Equal(8, result.Parameter.Count);
             Assert.True(result.Parameter.Where(p => p.Part.Where(pt => pt.Name == SearchParameterStateProperties.Url && pt.Value.ToString() == ResourceId).Any() && p.Part.Where(pt => pt.Name == SearchParameterStateProperties.Status && pt.Value.ToString() == SearchParameterStatus.Enabled.ToString()).Any()).Any());
-            Assert.True(result.Parameter.Where(p => p.Part.Where(pt => pt.Name == SearchParameterStateProperties.Url && pt.Value.ToString() == ResourceQuery).Any() && p.Part.Where(pt => pt.Name == SearchParameterStateProperties.Status && pt.Value.ToString() == SearchParameterStatus.PendingDelete.ToString()).Any()).Any());
+            Assert.True(result.Parameter.Where(p => p.Part.Where(pt => pt.Name == SearchParameterStateProperties.Url && pt.Value.ToString() == ResourceQuery).Any() && p.Part.Where(pt => pt.Name == SearchParameterStateProperties.Status && pt.Value.ToString() == SearchParameterStatus.Deleted.ToString()).Any()).Any());
             Assert.True(result.Parameter.Where(p => p.Part.Where(pt => pt.Name == SearchParameterStateProperties.Url && pt.Value.ToString() == ResourceLastUpdated).Any() && p.Part.Where(pt => pt.Name == SearchParameterStateProperties.Status && pt.Value.ToString() == SearchParameterStatus.PendingDisable.ToString()).Any()).Any());
             Assert.True(result.Parameter.Where(p => p.Part.Where(pt => pt.Name == SearchParameterStateProperties.Url && pt.Value.ToString() == ResourceProfile).Any() && p.Part.Where(pt => pt.Name == SearchParameterStateProperties.Status && pt.Value.ToString() == SearchParameterStatus.Disabled.ToString()).Any()).Any());
             Assert.True(result.Parameter.Where(p => p.Part.Where(pt => pt.Name == SearchParameterStateProperties.Url && pt.Value.ToString() == ResourceSecurity).Any() && p.Part.Where(pt => pt.Name == SearchParameterStateProperties.Status && pt.Value.ToString() == SearchParameterStatus.Supported.ToString()).Any()).Any());
@@ -244,7 +244,7 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Search
             Parameters result = response.SearchParameters.ToPoco<Parameters>();
             Assert.Equal(6, result.Parameter.Count);
             Assert.True(result.Parameter.Where(p => p.Part.Where(pt => pt.Name == SearchParameterStateProperties.Url && pt.Value.ToString() == ResourceId).Any() && p.Part.Where(pt => pt.Name == SearchParameterStateProperties.Status && pt.Value.ToString() == SearchParameterStatus.Enabled.ToString()).Any()).Any());
-            Assert.True(result.Parameter.Where(p => p.Part.Where(pt => pt.Name == SearchParameterStateProperties.Url && pt.Value.ToString() == ResourceQuery).Any() && p.Part.Where(pt => pt.Name == SearchParameterStateProperties.Status && pt.Value.ToString() == SearchParameterStatus.PendingDelete.ToString()).Any()).Any());
+            Assert.True(result.Parameter.Where(p => p.Part.Where(pt => pt.Name == SearchParameterStateProperties.Url && pt.Value.ToString() == ResourceQuery).Any() && p.Part.Where(pt => pt.Name == SearchParameterStateProperties.Status && pt.Value.ToString() == SearchParameterStatus.Deleted.ToString()).Any()).Any());
             Assert.True(result.Parameter.Where(p => p.Part.Where(pt => pt.Name == SearchParameterStateProperties.Url && pt.Value.ToString() == ResourceLastUpdated).Any() && p.Part.Where(pt => pt.Name == SearchParameterStateProperties.Status && pt.Value.ToString() == SearchParameterStatus.PendingDisable.ToString()).Any()).Any());
             Assert.True(result.Parameter.Where(p => p.Part.Where(pt => pt.Name == SearchParameterStateProperties.Url && pt.Value.ToString() == ResourceProfile).Any() && p.Part.Where(pt => pt.Name == SearchParameterStateProperties.Status && pt.Value.ToString() == SearchParameterStatus.Disabled.ToString()).Any()).Any());
             Assert.True(result.Parameter.Where(p => p.Part.Where(pt => pt.Name == SearchParameterStateProperties.Url && pt.Value.ToString() == ResourceSecurity).Any() && p.Part.Where(pt => pt.Name == SearchParameterStateProperties.Status && pt.Value.ToString() == SearchParameterStatus.Supported.ToString()).Any()).Any());

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/SearchParameterState/SearchParameterStateUpdateHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/SearchParameterState/SearchParameterStateUpdateHandlerTests.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Search
                     },
                     new ResourceSearchParameterStatus
                     {
-                        Status = SearchParameterStatus.PendingDelete,
+                        Status = SearchParameterStatus.Deleted,
                         Uri = new Uri(ResourceQuery),
                     },
                     new ResourceSearchParameterStatus


### PR DESCRIPTION
## Description
In the case of search parameters being deleted, they used the DeleteSearchParameterBehavior and then call the DeleteResourcehandler which removes it from the data store. There is nothing for reindex to do in this case.

## Testing
Ran through several reindexes to verify this is the case.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
