### PR TITLE
reindex updates from feedback

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -300,9 +300,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                 _reindexJobRecord.FailureCount++;
 
                 _logger.LogError(ex, "Encountered an unhandled exception. The job failure count increased to {FailureCount}.", _reindexJobRecord.FailureCount);
-                LogReindexJobRecordErrorMessage();
-
-                await UpdateJobAsync();
 
                 if (_reindexJobRecord.FailureCount >= _reindexJobConfiguration.ConsecutiveFailuresThreshold)
                 {
@@ -313,6 +310,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     _reindexJobRecord.Status = OperationStatus.Queued;
                     await UpdateJobAsync();
                 }
+
+                LogReindexJobRecordErrorMessage();
             }
             finally
             {
@@ -552,7 +551,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                 query.Error = ex.Message;
                 query.FailureCount++;
                 _logger.LogError(ex, "Encountered an unhandled exception. The query failure count increased to {FailureCount}.", _reindexJobRecord.FailureCount);
-                LogReindexJobRecordErrorMessage();
 
                 if (query.FailureCount >= _reindexJobConfiguration.ConsecutiveFailuresThreshold)
                 {
@@ -574,6 +572,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                 }
 
                 await UpdateJobAsync();
+                LogReindexJobRecordErrorMessage();
             }
             finally
             {
@@ -618,9 +617,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                             OperationOutcomeConstants.IssueType.Incomplete,
                             userMessage));
                         _logger.LogError("{TotalCount} resource(s) of the following type(s) failed to be reindexed: '{Types}'.", totalCount, string.Join("', '", resourcesTypes));
-                        LogReindexJobRecordErrorMessage();
 
                         await MoveToFinalStatusAsync(OperationStatus.Failed);
+                        LogReindexJobRecordErrorMessage();
                     }
                     else
                     {
@@ -693,8 +692,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     var message = $"Error running reindex query for resource type {queryStatus.ResourceType}.";
                     var reindexJobException = new ReindexJobException(message, ex);
                     _logger.LogError(ex, "Error running reindex query for resource type {ResourceType}", queryStatus.ResourceType);
-                    LogReindexJobRecordErrorMessage();
                     queryStatus.Error = reindexJobException.Message + " : " + ex.Message;
+                    LogReindexJobRecordErrorMessage();
 
                     throw reindexJobException;
                 }
@@ -847,9 +846,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     error);
                 _reindexJobRecord.Error.Add(issue);
                 _logger.LogError("Reindex with id {Id}, failed. Error: {Error}", _reindexJobRecord.Id, error);
-                LogReindexJobRecordErrorMessage();
                 _logger.LogInformation("Reindex job failed to complete. id: {Id}. Status: {Status}. Progress: {Progress}", _reindexJobRecord.Id, _reindexJobRecord.Status, _reindexJobRecord.Progress);
                 await MoveToFinalStatusAsync(OperationStatus.Failed);
+                LogReindexJobRecordErrorMessage();
             }
         }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlRetry/SqlRetryService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlRetry/SqlRetryService.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.SqlServer;
 using Microsoft.Health.SqlServer.Configs;
+using Microsoft.Health.SqlServer.Features.Storage;
 
 namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 {
@@ -55,7 +56,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                     233,    // A connection was successfully established with the server, but then an error occurred during the login process. (provider: Shared Memory Provider, error: 0 - No process is on the other end of the pipe.) (Microsoft SQL Server, Error: 233)
 
                 // Additional Fhir Server errors:
-                    8623,   // The query processor ran out of internal resources and could not produce a query plan.
+                    SqlErrorCodes.QueryProcessorNoQueryPlan,   // The query processor ran out of internal resources and could not produce a query plan.
+                    SqlErrorCodes.TimeoutExpired,
             };
 
         private readonly ISqlConnectionBuilder _sqlConnectionBuilder;
@@ -185,7 +187,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                 }
                 catch (Exception ex)
                 {
-                    if (!RetryTest(ex) || ++retry >= _maxRetries)
+                    if (++retry >= _maxRetries || !RetryTest(ex))
                     {
                         throw;
                     }


### PR DESCRIPTION
## Description
cleaned logging; removed errors that may contain too much info and revised GET reindex info so that it's less noisy; added sql timeout to sqlretries and improved short circuit statement

## Related issues
Addresses [issue #100499](https://microsofthealth.visualstudio.com/Health/_workitems/edit/100499).

## Testing
Ran reindex tests.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
