### PR TITLE
Ensure $convert template providers read from cache

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/ContainerRegistryTemplateProvider.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/ContainerRegistryTemplateProvider.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.ConvertData
         private readonly ITemplateCollectionProviderFactory _templateCollectionProviderFactory;
         private readonly ConvertDataConfiguration _convertDataConfig;
         private readonly MemoryCache _cache;
-        private MemoryCache _templateProviderCache;
-        private SemaphoreSlim _templateProviderFactorySemaphore;
+        private readonly MemoryCache _templateProviderCache;
+        private readonly SemaphoreSlim _templateProviderFactorySemaphore;
         private readonly ILogger<ContainerRegistryTemplateProvider> _logger;
 
         public ContainerRegistryTemplateProvider(

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/ContainerRegistryTemplateProvider.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/ContainerRegistryTemplateProvider.cs
@@ -84,14 +84,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.ConvertData
                    If template provider is not in cache, then limit the number of threads that can create new providers to 1, and then create a new provider.
                    This is to limit the amount of providers created in a multi-threaded scenario, so that we do not have multiple providers pulling the same image from the ACR.
                 */
-                ITemplateCollectionProvider provider = _templateProviderCache.Get(request.TemplateCollectionReference) as TemplateCollectionProvider;
+                ITemplateCollectionProvider provider = _templateProviderCache.Get(request.TemplateCollectionReference) as ITemplateCollectionProvider;
 
                 if (provider == null)
                 {
                     await _templateProviderFactorySemaphore.WaitAsync(cancellationToken);
                     try
                     {
-                        provider = _templateProviderCache.Get(request.TemplateCollectionReference) as TemplateCollectionProvider;
+                        provider = _templateProviderCache.Get(request.TemplateCollectionReference) as ITemplateCollectionProvider;
                         if (provider == null)
                         {
                             provider = _templateCollectionProviderFactory.CreateTemplateCollectionProvider(request.TemplateCollectionReference, accessToken);


### PR DESCRIPTION
## Description
When receiving many $convert-data requests concurrently it is possible for many template providers to be created. Each template provider has a cache where the contents of the template are cached. In the case where the templates have not yet been cached or the cache has expired, and when receiving many requests at once, it is possible for each template provider to request template data from the ACR which results in a lot of pulls from the ACR. To address this, we will be caching the template provider and limiting the number of threads that can create a new template provider to 1. This ensures that at most only one provider will be created and will read from the ACR. All other requests will read from the cache.

## Related issues
Addresses work item#104027.

## Testing
Before change: 
Created a console app that sends 1000 concurrent $convert-data requests.
The application code was observed to pull the same image from ACR many times and was eventually blocked from reading from ACR. Many $convert-data requests fail with HTTP 500 errors when unable to pull from ACR

After change:
Send 1000 $convert-data requests
The application code reads from ACR once and all $convert-data requests are fulfilled.

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
