### PR TITLE
Added SearchParameter Data Action

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Security/DataActions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Security/DataActions.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Security
         ConvertData = 1 << 7,
         EditProfileDefinitions = 1 << 8, // Allows to Create/Update/Delete resources related to profile's resources.
         Import = 1 << 9,
+        SearchParameter = 1 << 10,
 
         Smart = 1 << 30, // Do not include Smart in the '*' case.  We only want smart for a user if explicitly added to the role or user
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Security/roles.schema.json
+++ b/src/Microsoft.Health.Fhir.Core/Features/Security/roles.schema.json
@@ -15,7 +15,8 @@
                 "convertData",
                 "import",
                 "editProfileDefinitions",
-                "smart"
+                "smart",
+                "searchParameter"
             ]
         }
     },

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/SearchParameterState/SearchParameterStateUpdateHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/SearchParameterState/SearchParameterStateUpdateHandlerTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Search
             _searchParameterStateUpdateHandler = new SearchParameterStateUpdateHandler(_authorizationService, _searchParameterStatusManager, _logger2);
             _cancellationToken = CancellationToken.None;
 
-            _authorizationService.CheckAccess(DataActions.Reindex, _cancellationToken).Returns(DataActions.Reindex);
+            _authorizationService.CheckAccess(DataActions.SearchParameter, _cancellationToken).Returns(DataActions.SearchParameter);
             var searchParamDefinitionStore = new List<SearchParameterInfo>
             {
                 new SearchParameterInfo(

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/SearchParameterState/SearchParameterStateUpdateHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/SearchParameterState/SearchParameterStateUpdateHandler.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.SearchParameterState
         {
             EnsureArg.IsNotNull(request, nameof(request));
 
-            if (await _authorizationService.CheckAccess(DataActions.Reindex, cancellationToken) != DataActions.Reindex)
+            if (await _authorizationService.CheckAccess(DataActions.SearchParameter, cancellationToken) != DataActions.SearchParameter)
             {
                 throw new UnauthorizedFhirActionException();
             }


### PR DESCRIPTION
## Description
Added SearchParameter Data Action. Will be used to create a new role.

## Related issues
Addresses [issue AB#103806].

## Testing
Updated existing unit tests to use new data action instead of reindex for $status operation.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
