### PR TITLE
HostingBackgroundService should wait for StorageInitialized

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/BackgroundJobService/JobFactory.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/BackgroundJobService/JobFactory.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using EnsureThat;
+using Microsoft.Extensions.Logging;
 using Microsoft.Health.JobManagement;
 
 namespace Microsoft.Health.Fhir.Api.Features.BackgroundJobService
@@ -18,7 +19,7 @@ namespace Microsoft.Health.Fhir.Api.Features.BackgroundJobService
     {
         private readonly Dictionary<int, Func<IJob>> _jobFactoryLookup;
 
-        public JobFactory(IEnumerable<Func<IJob>> jobFactories)
+        public JobFactory(IEnumerable<Func<IJob>> jobFactories, ILogger<JobFactory> logger)
         {
             EnsureArg.IsNotNull(jobFactories, nameof(jobFactories));
 
@@ -26,14 +27,22 @@ namespace Microsoft.Health.Fhir.Api.Features.BackgroundJobService
 
             foreach (Func<IJob> jobFunc in jobFactories)
             {
-                var instance = jobFunc.Invoke();
-                if (instance.GetType().GetCustomAttribute(typeof(JobTypeIdAttribute), false) is JobTypeIdAttribute jobTypeAttr)
+                try
                 {
-                    _jobFactoryLookup.Add(jobTypeAttr.JobTypeId, jobFunc);
+                    IJob instance = jobFunc.Invoke();
+                    if (instance.GetType().GetCustomAttribute(typeof(JobTypeIdAttribute), false) is JobTypeIdAttribute jobTypeAttr)
+                    {
+                        _jobFactoryLookup.Add(jobTypeAttr.JobTypeId, jobFunc);
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException($"Job type {instance.GetType().Name} does not have {nameof(JobTypeIdAttribute)}.");
+                    }
                 }
-                else
+                catch (Exception ex)
                 {
-                    throw new InvalidOperationException($"Job type {instance.GetType().Name} does not have {nameof(JobTypeIdAttribute)}.");
+                    logger.LogError(ex, "Failed to create job factory.");
+                    throw;
                 }
             }
         }

--- a/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using MediatR;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
@@ -18,7 +19,9 @@ using Microsoft.Health.Fhir.Api.Features.BackgroundJobService;
 using Microsoft.Health.Fhir.Api.Modules;
 using Microsoft.Health.Fhir.Azure;
 using Microsoft.Health.Fhir.Core.Configs;
+using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features;
+using Microsoft.Health.Fhir.Core.Messages.Storage;
 using Microsoft.Health.Fhir.Core.Registration;
 using Microsoft.Health.Fhir.Shared.Web;
 using Microsoft.Health.Fhir.SqlServer.Features.Storage;
@@ -119,7 +122,12 @@ namespace Microsoft.Health.Fhir.Web
                 .AsSelf();
             services.AddFactory<IScoped<JobHosting>>();
 
-            services.AddHostedService<HostingBackgroundService>();
+            services.RemoveServiceTypeExact<HostingBackgroundService, INotificationHandler<StorageInitializedNotification>>()
+                .Add<HostingBackgroundService>()
+                .Singleton()
+                .AsSelf()
+                .AsImplementedInterfaces();
+
             services.Add<JobFactory>()
                 .Scoped()
                 .AsSelf()


### PR DESCRIPTION
## Description
HostingBackgroundService should wait for StorageInitializedNotification, jobs that require QueueClient (all) or any data access should respect this. This allows all job tasks to inherit this behavior.

@PTaladay, @LTA-Thinking 

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
