### PR TITLE
Fix: Do not allow Duplicated Search Parameters

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
@@ -176,6 +176,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         [ConditionalConstraint]
         [Route(KnownRoutes.ResourceType)]
         [AuditEventType(AuditEventSubType.ConditionalCreate)]
+        [ServiceFilter(typeof(SearchParameterFilterAttribute))]
         public async Task<IActionResult> ConditionalCreate([FromBody] Resource resource)
         {
             StringValues conditionalCreateHeader = HttpContext.Request.Headers[KnownHeaders.IfNoneExist];
@@ -228,6 +229,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         [HttpPut]
         [Route(KnownRoutes.ResourceType)]
         [AuditEventType(AuditEventSubType.ConditionalUpdate)]
+        [ServiceFilter(typeof(SearchParameterFilterAttribute))]
         public async Task<IActionResult> ConditionalUpdate([FromBody] Resource resource)
         {
             IReadOnlyList<Tuple<string, string>> conditionalParameters = GetQueriesForSearch();

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
@@ -210,6 +210,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         [ValidateResourceIdFilter]
         [Route(KnownRoutes.ResourceTypeById)]
         [AuditEventType(AuditEventSubType.Update)]
+        [ServiceFilter(typeof(SearchParameterFilterAttribute))]
         public async Task<IActionResult> Update([FromBody] Resource resource, [ModelBinder(typeof(WeakETagBinder))] WeakETag ifMatchHeader)
         {
             Guid? bundleOperationId = GetBundleOperationId();

--- a/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
+++ b/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
@@ -85,6 +85,7 @@
     <EmbeddedResource Include="TestFiles\Normative\SearchParameterUnsupportedType.json" />
     <EmbeddedResource Include="TestFiles\Normative\SearchParameterExpressionWrongProperty.json" />
     <EmbeddedResource Include="TestFiles\Normative\SearchParameterBadSyntax.json" />
+    <EmbeddedResource Include="TestFiles\Normative\SearchParameterDuplicated.json" />
     <EmbeddedResource Include="TestFiles\Normative\SearchParameterMissingExpression.json" />
     <EmbeddedResource Include="TestFiles\Normative\SearchParameterMissingBase.json" />
     <EmbeddedResource Include="TestFiles\Normative\Specimen.json" />

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/SearchParameterDuplicated.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/SearchParameterDuplicated.json
@@ -1,11 +1,10 @@
 {
     "resourceType": "SearchParameter",
-    "id": "58c1c284-d770-448d-a6cc-a74998b51408",
     "meta": {
         "versionId": "3",
         "lastUpdated": "2023-04-04T19:31:09.483+00:00"
     },
-    "url": "http://fhir.medlix.org/SearchParameter/observation-code",
+    "url": "http://fhir.medlix.org/SearchParameter/observation-code-test",
     "version": "1.0.0",
     "name": "code",
     "status": "active",

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/SearchParameterDuplicated.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/SearchParameterDuplicated.json
@@ -1,0 +1,19 @@
+{
+    "resourceType": "SearchParameter",
+    "id": "58c1c284-d770-448d-a6cc-a74998b51408",
+    "meta": {
+        "versionId": "3",
+        "lastUpdated": "2023-04-04T19:31:09.483+00:00"
+    },
+    "url": "http://fhir.medlix.org/SearchParameter/observation-code",
+    "version": "1.0.0",
+    "name": "code",
+    "status": "active",
+    "description": "Observation filtering based on code",
+    "code": "code",
+    "base": [
+        "Observation"
+    ],
+    "type": "token",
+    "expression": "Observation.code.coding.where(system = 'http://loinc.org/' or system = 'http://loinc.org').code"
+}

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalCreateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalCreateTests.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
-        public async Task GivenAResource_WhenCreatingConditionallyANewSearchParameterResource_TheServerShouldValidateTheNewResourceSuccessfully()
+        public async Task GivenAResource_WhenCreatingConditionallyANewDuplicatedSearchParameterResource_TheServerShouldFail()
         {
             var id = Guid.NewGuid();
             var resourceToCreate = Samples.GetJsonSample<SearchParameter>("SearchParameterDuplicated");

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalCreateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalCreateTests.cs
@@ -145,15 +145,15 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenAResource_WhenCreatingConditionallyANewDuplicatedSearchParameterResource_TheServerShouldFail()
         {
-            var id = Guid.NewGuid();
             var resourceToCreate = Samples.GetJsonSample<SearchParameter>("SearchParameterDuplicated");
-            resourceToCreate.Id = id.ToString();
+            resourceToCreate.Id = null;
 
             using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(() => _client.CreateAsync(
                 resourceToCreate,
-                $"SearchParameter/id={id}"));
+                $"identifier={Guid.NewGuid().ToString()}"));
 
             Assert.Equal(System.Net.HttpStatusCode.BadRequest, ex.StatusCode);
+            Assert.Contains("A search parameter with the same code value 'code' already exists for base type 'Observation'", ex.Message);
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalCreateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalCreateTests.cs
@@ -140,5 +140,20 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.Single(exception.OperationOutcome.Issue);
             Assert.True(exception.Response.Resource.Issue[0].Diagnostics.Equals(string.Format(Core.Resources.ConditionalOperationNotSelectiveEnough, "Observation")));
         }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenAResource_WhenCreatingConditionallyANewSearchParameterResource_TheServerShouldValidateTheNewResourceSuccessfully()
+        {
+            var id = Guid.NewGuid();
+            var resourceToCreate = Samples.GetJsonSample<SearchParameter>("SearchParameterDuplicated");
+            resourceToCreate.Id = id.ToString();
+
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(() => _client.ConditionalUpdateAsync(
+                resourceToCreate,
+                $"SearchParameter/id={id}"));
+
+            Assert.Equal(System.Net.HttpStatusCode.BadRequest, ex.StatusCode);
+        }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalCreateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalCreateTests.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             var resourceToCreate = Samples.GetJsonSample<SearchParameter>("SearchParameterDuplicated");
             resourceToCreate.Id = id.ToString();
 
-            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(() => _client.ConditionalUpdateAsync(
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(() => _client.CreateAsync(
                 resourceToCreate,
                 $"SearchParameter/id={id}"));
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalUpdateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalUpdateTests.cs
@@ -243,7 +243,11 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
                 resourceToCreate,
                 $"SearchParameter/id={id}"));
 
+            var operationOutcome = ex.OperationOutcome;
             Assert.Equal(System.Net.HttpStatusCode.BadRequest, ex.StatusCode);
+            Assert.NotNull(operationOutcome.Id);
+            Assert.NotEmpty(operationOutcome.Issue);
+            Assert.Contains("A search parameter with the same code value 'code' already exists for base type 'Observation'", operationOutcome.Issue[1].Diagnostics);
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalUpdateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalUpdateTests.cs
@@ -233,7 +233,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
-        public async Task GivenAResource_WhenUpsertingConditionallyANewSearchParameterResource_TheServerShouldValidateTheNewResourceSuccessfully()
+        public async Task GivenAResource_WhenUpsertingConditionallyANewDuplicatedSearchParameterResource_TheServerShouldFail()
         {
             var id = Guid.NewGuid();
             var resourceToCreate = Samples.GetJsonSample<SearchParameter>("SearchParameterDuplicated");

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalUpdateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalUpdateTests.cs
@@ -230,5 +230,20 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             Assert.Equal(HttpStatusCode.PreconditionFailed, exception.Response.StatusCode);
         }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenAResource_WhenUpsertingConditionallyANewSearchParameterResource_TheServerShouldValidateTheNewResourceSuccessfully()
+        {
+            var id = Guid.NewGuid();
+            var resourceToCreate = Samples.GetJsonSample<SearchParameter>("SearchParameterDuplicated");
+            resourceToCreate.Id = id.ToString();
+
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(() => _client.ConditionalUpdateAsync(
+                resourceToCreate,
+                $"SearchParameter/id={id}"));
+
+            Assert.Equal(System.Net.HttpStatusCode.BadRequest, ex.StatusCode);
+        }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/UpdateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/UpdateTests.cs
@@ -263,7 +263,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
-        public async Task GivenTheResource_WhenUpdatingANewSearchParameterResource_TheServerShouldValidateTheNewResourceSuccessfully()
+        public async Task GivenTheResource_WhenUpdatingANewDuplicatedSearchParameterResource_TheServerShouldFail()
         {
             var id = Guid.NewGuid();
             var resourceToCreate = Samples.GetJsonSample<SearchParameter>("SearchParameterDuplicated");

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/UpdateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/UpdateTests.cs
@@ -265,10 +265,12 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenTheResource_WhenUpdatingANewSearchParameterResource_TheServerShouldValidateTheNewResourceSuccessfully()
         {
+            var id = Guid.NewGuid();
             var resourceToCreate = Samples.GetJsonSample<SearchParameter>("SearchParameterDuplicated");
+            resourceToCreate.Id = id.ToString();
 
             using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(
-                () => _client.UpdateAsync($"SearchParameter/{Guid.NewGuid()}", resourceToCreate));
+                () => _client.UpdateAsync($"SearchParameter/{id}", resourceToCreate));
 
             Assert.Equal(System.Net.HttpStatusCode.BadRequest, ex.StatusCode);
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/UpdateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/UpdateTests.cs
@@ -272,7 +272,12 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(
                 () => _client.UpdateAsync($"SearchParameter/{id}", resourceToCreate));
 
+            var operationOutcome = ex.OperationOutcome;
+
             Assert.Equal(System.Net.HttpStatusCode.BadRequest, ex.StatusCode);
+            Assert.NotNull(operationOutcome.Id);
+            Assert.NotEmpty(operationOutcome.Issue);
+            Assert.Contains("A search parameter with the same code value 'code' already exists for base type 'Observation'", operationOutcome.Issue[1].Diagnostics);
         }
 
         private static void ValidateUpdateResponse(Observation oldResource, FhirResponse<Observation> newResponse, bool same, HttpStatusCode expectedStatusCode)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/UpdateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/UpdateTests.cs
@@ -261,6 +261,18 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.Contains(updateResponseAfterMetaUpdated.Resource.Meta.Tag, t => t.Code == "TestCode2");
         }
 
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenTheResource_WhenUpdatingANewSearchParameterResource_TheServerShouldValidateTheNewResourceSuccessfully()
+        {
+            var resourceToCreate = Samples.GetJsonSample<SearchParameter>("SearchParameterDuplicated");
+
+            using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(
+                () => _client.UpdateAsync($"SearchParameter/{Guid.NewGuid()}", resourceToCreate));
+
+            Assert.Equal(System.Net.HttpStatusCode.BadRequest, ex.StatusCode);
+        }
+
         private static void ValidateUpdateResponse(Observation oldResource, FhirResponse<Observation> newResponse, bool same, HttpStatusCode expectedStatusCode)
         {
             Assert.Equal(expectedStatusCode, newResponse.StatusCode);


### PR DESCRIPTION
## Context
- Code and base should not be used more than once when creating a new search parameter
- Url should not be repited
 
## Description
- FHIR server shouldn't allow duplicated Search Parameters.

## Related issues
Addresses [issue #].

## Testing
- Added E2E tests

## Manual Testing
- Download the [DuplicatedSearchParameterTest.http](https://gist.github.com/abiisnn/f8bb2305468ccaeebd867b426a47c257) file.
- Set break points in the following lines of the [FhirController](https://github.com/microsoft/fhir-server/blob/main/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs) file.
   - [181](https://github.com/microsoft/fhir-server/blob/1d76a6469775d7b2f7aeaf509e2b36e000b7acda/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs#L181)
   - [215](https://github.com/microsoft/fhir-server/blob/1d76a6469775d7b2f7aeaf509e2b36e000b7acda/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs#L215)
   - [232](https://github.com/microsoft/fhir-server/blob/1d76a6469775d7b2f7aeaf509e2b36e000b7acda/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs#L232)
- Send each request and make sure it reaches the respective line, *ie* when you send the Update request, it should reach the breakpoint in line 215.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
