### PR TITLE
Add keep last updated parameter to merge

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Import/ImportResourceLoaderTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Import/ImportResourceLoaderTests.cs
@@ -243,7 +243,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Import
                             null,
                             null,
                             "SearchParam");
-                    return new ImportResource(index, 0, 0, false, resourceWrapper);
+                    return new ImportResource(index, 0, 0, false, false, resourceWrapper);
                 });
 
             IImportErrorSerializer serializer = Substitute.For<IImportErrorSerializer>();

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportResource.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportResource.cs
@@ -9,17 +9,18 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
 {
     public class ImportResource
     {
-        public ImportResource(long index, long offset, int length, bool keepVersion, ResourceWrapper resourceWrapper)
+        public ImportResource(long index, long offset, int length, bool keepLastUpdated, bool keepVersion, ResourceWrapper resourceWrapper)
         {
             Index = index;
             Offset = offset;
             Length = length;
+            KeepLastUpdated = keepLastUpdated;
             KeepVersion = keepVersion;
             ResourceWrapper = resourceWrapper;
         }
 
         public ImportResource(ResourceWrapper resource)
-            : this(0, 0, 0, false, resource)
+            : this(0, 0, 0, false, false, resource)
         {
         }
 
@@ -28,6 +29,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
             Index = index;
             Offset = offset;
             Length = 0;
+            KeepLastUpdated = false;
             KeepVersion = false;
             ImportError = importError;
         }
@@ -46,6 +48,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
         /// Json length including EOL
         /// </summary>
         public int Length { get; set; }
+
+        /// <summary>
+        /// Flag indicating whether latUpdated was provided on input
+        /// </summary>
+        public bool KeepLastUpdated { get; set; }
 
         /// <summary>
         /// Flag indicating whether version was provided on input

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Import/ImportResourceParser.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Import/ImportResourceParser.cs
@@ -36,8 +36,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
                 resource.Meta = new Meta();
             }
 
-            bool lastUpdatedIsNull;
-            if (lastUpdatedIsNull = importMode == ImportMode.InitialLoad || resource.Meta.LastUpdated == null)
+            var lastUpdatedIsNull = importMode == ImportMode.InitialLoad || resource.Meta.LastUpdated == null;
+            if (lastUpdatedIsNull)
             {
                 resource.Meta.LastUpdated = Clock.UtcNow;
             }
@@ -52,7 +52,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
             var resourceElement = resource.ToResourceElement();
             var resourceWapper = _resourceFactory.Create(resourceElement, false, true, keepVersion);
 
-            return new ImportResource(index, offset, length, keepVersion, resourceWapper);
+            return new ImportResource(index, offset, length, !lastUpdatedIsNull, keepVersion, resourceWapper);
         }
 
         private static void CheckConditionalReferenceInResource(Resource resource)

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Operations/Import/ImportProcessingJobTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Operations/Import/ImportProcessingJobTests.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
                             null,
                             "SearchParam");
 
-                        await resourceChannel.Writer.WriteAsync(new ImportResource(0, 0, 0, false, resourceWrapper));
+                        await resourceChannel.Writer.WriteAsync(new ImportResource(0, 0, 0, false, false, resourceWrapper));
                         await resourceChannel.Writer.WriteAsync(new ImportResource(1, 0, "Error"));
                         resourceChannel.Writer.Complete();
                     });

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/SqlImporter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/SqlImporter.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
                     mergeStart = DateTime.UtcNow;
                     loaded = new List<ImportResource>();
                     conflicts = new List<ImportResource>();
-                    ImportResourcesInBufferMain(resources, loaded, conflicts, importMode, timeoutRetries, cancellationToken).Wait();
+                    ImportResourcesInBufferInternal(resources, loaded, conflicts, importMode, timeoutRetries, cancellationToken).Wait();
                     break;
                 }
                 catch (Exception e)
@@ -112,18 +112,18 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
                         || (isRetriable = e.IsRetriable()) // this should allow to deal with intermittent database errors.
                         || ((isExecutionTimeout = e.IsExecutionTimeout()) && timeoutRetries++ < 3)) // timeouts happen once in a while on highly loaded databases.
                     {
-                        _logger.LogWarning(e, $"Error on {nameof(ImportResourcesInBufferMain)} retries={{Retries}} timeoutRetries={{TimeoutRetries}}", retries, timeoutRetries);
+                        _logger.LogWarning(e, $"Error on {nameof(ImportResourcesInBufferInternal)} retries={{Retries}} timeoutRetries={{TimeoutRetries}}", retries, timeoutRetries);
                         if (isRetriable || isExecutionTimeout) // others are logged in SQL by merge stored procedure
                         {
-                            _store.TryLogEvent(nameof(ImportResourcesInBufferMain), "Warn", $"retries={retries} timeoutRetries={timeoutRetries} error={e}", mergeStart, cancellationToken).Wait();
+                            _store.TryLogEvent(nameof(ImportResourcesInBufferInternal), "Warn", $"retries={retries} timeoutRetries={timeoutRetries} error={e}", mergeStart, cancellationToken).Wait();
                         }
 
                         Task.Delay(5000, cancellationToken);
                         continue;
                     }
 
-                    _logger.LogError(e, $"Error on {nameof(ImportResourcesInBufferMain)} retries={{Retries}} timeoutRetries={{TimeoutRetries}}", retries, timeoutRetries);
-                    _store.TryLogEvent(nameof(ImportResourcesInBufferMain), "Error", $"retries={retries} timeoutRetries={timeoutRetries} error={e}", mergeStart, cancellationToken).Wait();
+                    _logger.LogError(e, $"Error on {nameof(ImportResourcesInBufferInternal)} retries={{Retries}} timeoutRetries={{TimeoutRetries}}", retries, timeoutRetries);
+                    _store.TryLogEvent(nameof(ImportResourcesInBufferInternal), "Error", $"retries={retries} timeoutRetries={timeoutRetries} error={e}", mergeStart, cancellationToken).Wait();
 
                     throw;
                 }
@@ -141,7 +141,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
             resources.Clear();
         }
 
-        private async Task ImportResourcesInBufferMain(List<ImportResource> resources, List<ImportResource> loaded, List<ImportResource> conflicts, ImportMode importMode, int timeoutRetries, CancellationToken cancellationToken)
+        private async Task ImportResourcesInBufferInternal(List<ImportResource> resources, List<ImportResource> loaded, List<ImportResource> conflicts, ImportMode importMode, int timeoutRetries, CancellationToken cancellationToken)
         {
             var goodResources = resources.Where(r => string.IsNullOrEmpty(r.ImportError)).ToList();
             if (importMode == ImportMode.InitialLoad)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                 try
                 {
                     mergeStart = DateTime.UtcNow;
-                    var results = await MergeInternalAsync(resources, false, 0, cancellationToken); // TODO: Pass correct ignore last udated value for efficiency & Pass correct retries value once we start supporting retries
+                    var results = await MergeInternalAsync(resources, false, 0, cancellationToken); // TODO: Pass correct retries value once we start supporting retries
                     return results;
                 }
                 catch (Exception e)


### PR DESCRIPTION
Adding parameter to merge to regenerate last updated without overlaps if values are not provided on input.