### PR TITLE
Search Parameter validation failure issues logged

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Support;
 using MediatR;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.Extensions.DependencyInjection;
@@ -261,10 +262,18 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
                         catch (SearchParameterNotSupportedException ex)
                         {
                             _logger.LogWarning(ex, "Error loading search parameter {Url} from data store.", searchParam.GetStringScalar("url"));
+                            foreach (OperationOutcomeIssue issue in ex.Issues)
+                            {
+                                _logger.LogWarning(issue.Diagnostics);
+                            }
                         }
                         catch (InvalidDefinitionException ex)
                         {
                             _logger.LogWarning(ex, "Error loading search parameter {Url} from data store.", searchParam.GetStringScalar("url"));
+                            foreach (OperationOutcomeIssue issue in ex.Issues)
+                            {
+                                _logger.LogWarning(issue.Diagnostics);
+                            }
                         }
                         catch (Exception ex)
                         {


### PR DESCRIPTION
## Description
This PR is about logging the actual reason that caused Search Parameter validation failure and logs InvalidDefinitionException in Exception Telemetry for different accounts in search parameter definition builder.

Current code captures details about what is causing validation failure but not logging it. I modified code to log the cause that fails validation. 


## Related issues
Addresses [issue [# 88668](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Olympus/Stories/?workitem=88668)].

## Testing
Do not have invalid search parameters in my local or Test.
So tested it by breaking the code intentionally to confirm detailed logs are showing up.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
