### PR TITLE
Fix int overflow on offset calculation

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/ImportOrchestratorJob.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/ImportOrchestratorJob.cs
@@ -295,7 +295,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
                 for (var stream = 0; stream < numberOfStreams; stream++)
                 {
                     var newInput = input.Clone();
-                    newInput.Offset = stream * BytesToRead;
+                    newInput.Offset = (long)stream * BytesToRead; // make sure that arithmetic on long is used
                     newInput.BytesToRead = BytesToRead;
                     lock (inputs)
                     {


### PR DESCRIPTION
This affects $import with input files over 2GB in size.