### PR TITLE
Changes of incremental import billing

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportJobMetricsNotification.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportJobMetricsNotification.cs
@@ -18,7 +18,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
             DateTimeOffset endTime,
             long? dataSize,
             long? succeededCount,
-            long? failedCount)
+            long? failedCount,
+            ImportMode importMode)
         {
             FhirOperation = AuditEventSubType.Import;
             ResourceType = null;
@@ -30,6 +31,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
             DataSize = dataSize;
             SucceededCount = succeededCount;
             FailedCount = failedCount;
+            ImportMode = importMode;
         }
 
         public string FhirOperation { get; }
@@ -49,5 +51,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
         public long? SucceededCount { get; }
 
         public long? FailedCount { get; }
+
+        public ImportMode ImportMode { get; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportOrchestratorJobResult.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportOrchestratorJobResult.cs
@@ -54,5 +54,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
         public int CreatedJobCount { get; set; } // TODO: remove in stage 3
 
         public long? TotalSizeInBytes { get; set; } // TODO: remove in stage 3
+
+        /// <summary>
+        /// Import mode.
+        /// </summary>
+        public ImportMode ImportMode { get; set; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportOrchestratorJobResult.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportOrchestratorJobResult.cs
@@ -50,14 +50,5 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
         public long SucceedImportCount { get; set; } // TODO: remove in stage 3
 
         public long FailedImportCount { get; set; } // TODO: remove in stage 3
-
-        public int CreatedJobCount { get; set; } // TODO: remove in stage 3
-
-        public long? TotalSizeInBytes { get; set; } // TODO: remove in stage 3
-
-        /// <summary>
-        /// Import mode.
-        /// </summary>
-        public ImportMode ImportMode { get; set; }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/ImportOrchestratorJob.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/ImportOrchestratorJob.cs
@@ -91,6 +91,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
             _contextAccessor.RequestContext = fhirRequestContext;
 
             currentResult.Request = inputData.RequestUri.ToString();
+            currentResult.ImportMode = inputData.ImportMode;
 
             ImportOrchestratorJobErrorResult errorResult = null;
 
@@ -273,7 +274,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
                 Clock.UtcNow,
                 currentResult.TotalBytes,
                 currentResult.SucceededResources,
-                currentResult.FailedResources);
+                currentResult.FailedResources,
+                currentResult.ImportMode);
 
             await _mediator.Publish(importJobMetricsNotification, CancellationToken.None);
         }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/ImportOrchestratorJob.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/ImportOrchestratorJob.cs
@@ -91,7 +91,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
             _contextAccessor.RequestContext = fhirRequestContext;
 
             currentResult.Request = inputData.RequestUri.ToString();
-            currentResult.ImportMode = inputData.ImportMode;
 
             ImportOrchestratorJobErrorResult errorResult = null;
 
@@ -143,7 +142,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
 
                 // Processing jobs has been cancelled by CancelImportRequestHandler
                 await WaitCancelledJobCompletedAsync(jobInfo);
-                await SendImportMetricsNotification(JobStatus.Cancelled, jobInfo, currentResult);
+                await SendImportMetricsNotification(JobStatus.Cancelled, jobInfo, currentResult, inputData.ImportMode);
             }
             catch (OperationCanceledException canceledEx)
             {
@@ -157,7 +156,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
 
                 // Processing jobs has been cancelled by CancelImportRequestHandler
                 await WaitCancelledJobCompletedAsync(jobInfo);
-                await SendImportMetricsNotification(JobStatus.Cancelled, jobInfo, currentResult);
+                await SendImportMetricsNotification(JobStatus.Cancelled, jobInfo, currentResult, inputData.ImportMode);
             }
             catch (IntegrationDataStoreException integrationDataStoreEx)
             {
@@ -169,7 +168,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
                     ErrorMessage = integrationDataStoreEx.Message,
                 };
 
-                await SendImportMetricsNotification(JobStatus.Failed, jobInfo, currentResult);
+                await SendImportMetricsNotification(JobStatus.Failed, jobInfo, currentResult, inputData.ImportMode);
             }
             catch (ImportFileEtagNotMatchException eTagEx)
             {
@@ -181,7 +180,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
                     ErrorMessage = eTagEx.Message,
                 };
 
-                await SendImportMetricsNotification(JobStatus.Failed, jobInfo, currentResult);
+                await SendImportMetricsNotification(JobStatus.Failed, jobInfo, currentResult, inputData.ImportMode);
             }
             catch (ImportProcessingException processingEx)
             {
@@ -196,7 +195,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
 
                 // Cancel other processing jobs
                 await CancelProcessingJobsAsync(jobInfo);
-                await SendImportMetricsNotification(JobStatus.Failed, jobInfo, currentResult);
+                await SendImportMetricsNotification(JobStatus.Failed, jobInfo, currentResult, inputData.ImportMode);
             }
             catch (RetriableJobException ex)
             {
@@ -217,7 +216,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
 
                 // Cancel processing jobs for critical error in orchestrator job
                 await CancelProcessingJobsAsync(jobInfo);
-                await SendImportMetricsNotification(JobStatus.Failed, jobInfo, currentResult);
+                await SendImportMetricsNotification(JobStatus.Failed, jobInfo, currentResult, inputData.ImportMode);
             }
 
             // Post-process operation cannot be cancelled.
@@ -246,7 +245,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
                 throw new JobExecutionException(errorResult.ErrorMessage, errorResult);
             }
 
-            await SendImportMetricsNotification(JobStatus.Completed, jobInfo, currentResult);
+            await SendImportMetricsNotification(JobStatus.Completed, jobInfo, currentResult, inputData.ImportMode);
             return JsonConvert.SerializeObject(currentResult);
         }
 
@@ -265,7 +264,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
             });
         }
 
-        private async Task SendImportMetricsNotification(JobStatus jobStatus, JobInfo jobInfo, ImportOrchestratorJobResult currentResult)
+        private async Task SendImportMetricsNotification(JobStatus jobStatus, JobInfo jobInfo, ImportOrchestratorJobResult currentResult, ImportMode importMode)
         {
             var importJobMetricsNotification = new ImportJobMetricsNotification(
                 jobInfo.Id.ToString(),
@@ -275,7 +274,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
                 currentResult.TotalBytes,
                 currentResult.SucceededResources,
                 currentResult.FailedResources,
-                currentResult.ImportMode);
+                importMode);
 
             await _mediator.Publish(importJobMetricsNotification, CancellationToken.None);
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTests.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Import
         }
 
         [Fact]
-        public async Task GivenIncrementalImportInvalidResource_ThenErrorLogsShouldBeOutput_FailedRCountShouldMatch()
+        public async Task GivenIncrementalImportInvalidResource__WhenImportData_ThenErrorLogsShouldBeOutputAndFailedCountShouldMatch()
         {
             _metricHandler?.ResetCount();
             string patientNdJsonResource = Samples.GetNdJson("Import-InvalidPatient");
@@ -208,6 +208,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Import
         [Trait(Traits.Category, Categories.Authorization)]
         public async Task GivenAUserWithoutImportPermissions_WhenImportData_ThenServerShouldReturnForbidden_WithNoImportNotification()
         {
+            _metricHandler?.ResetCount();
             TestFhirClient tempClient = _client.CreateClientForUser(TestUsers.ReadOnlyUser, TestApplications.NativeClient);
             string patientNdJsonResource = Samples.GetNdJson("Import-Patient");
             (Uri location, string etag) = await ImportTestHelper.UploadFileAsync(patientNdJsonResource, _fixture.CloudStorageAccount);


### PR DESCRIPTION
## Description
Changes to add billing to incremental import.
ImportJobMetricsNotification needs to be published with ImportMode information so on Health PaaS side, we will know to bill the import requests or not. This PR has changes to add ImportMode in the notification that will be handled in Handler that is on HP side.

## Related issues
Addresses [issue [103222](https://microsofthealth.visualstudio.com/Health/_workitems/edit/103222/)].

## Testing
Unit tests added

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
