### PR TITLE
Clone AccessControlContext for Bundle operations

### DIFF
--- a/docs/rest/SMARTScopesExample.http
+++ b/docs/rest/SMARTScopesExample.http
@@ -254,3 +254,32 @@ content-type: application/json
 Authorization: Bearer {{bearer.response.body.access_token}}
 
 < ./Data/BundleTransaction.json
+
+
+### Testing Transaction bundle for Smart user with Write only access
+# @name bearer
+POST https://{{hostname}}/connect/token
+content-type: application/x-www-form-urlencoded
+
+grant_type=client_credentials
+&client_id=smart-patient-A
+&client_secret=smart-patient-A
+&scope=patient/Observation.*
+
+### Test a Bundle with GET request inside, should not return only patient data
+POST https://{{hostname}}
+content-type: application/json
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+{
+  'type': 'batch',
+  'resourceType': 'Bundle',
+  'entry': [
+    {
+      'request': {
+        'method': 'GET',
+        'url': '/Observation'
+      }
+    }
+  ]
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
@@ -653,6 +653,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                     controllerName?.ToString(),
                     actionName?.ToString()),
                 ExecutingBatchOrTransaction = true,
+                AccessControlContext = _originalFhirRequestContext.AccessControlContext.Clone() as AccessControlContext,
             };
             foreach (var scopeRestriction in _originalFhirRequestContext.AccessControlContext.AllowedResourceActions)
             {


### PR DESCRIPTION
## Description
There was an issue with applying SMART restrictions in Bundle processing in that we didn't clone the access control context for the requests in a bundle.  This makes sure that the SMART context is applied to all the requests.

## Related issues
Addresses [issue AB#[102910](https://dev.azure.com/microsofthealth/Health/_workitems/edit/102910)].

## Testing
Manual test was added to the .http file for SMART

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
