### PR TITLE
Adding a support for telemetry via Azure Monitor OpenTelemetry

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,6 +29,7 @@
     <PackageVersion Include="AngleSharp" Version="1.0.3" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.2.2" />
     <PackageVersion Include="Azure.Identity" Version="1.9.0" />
+    <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.0.0-beta.4" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.16.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
     <PackageVersion Include="Ensure.That" Version="10.1.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -119,5 +119,6 @@
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.assert" Version="2.4.2" />
     <PackageVersion Include="System.Drawing.Common" Version="7.0.0" />
+    <PackageVersion Include="Moq" Version="4.18.1" />
   </ItemGroup>
 </Project>

--- a/Microsoft.Health.Fhir.sln
+++ b/Microsoft.Health.Fhir.sln
@@ -180,6 +180,16 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Fhir.R4B.A
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IndexRebuilder", "tools\IndexRebuilder\IndexRebuilder.csproj", "{F4DE2945-80C5-48FE-B58A-4AD1264C9FEA}"
 EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Microsoft.Health.Fhir.Shared.Web.UnitTests", "src\Microsoft.Health.Fhir.Shared.Web.UnitTests\Microsoft.Health.Fhir.Shared.Web.UnitTests.shproj", "{73BC4365-2BFB-41C7-B0B1-610059F967AC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Health.Fhir.R4.Web.UnitTests", "src\Microsoft.Health.Fhir.R4.Web.UnitTests\Microsoft.Health.Fhir.R4.Web.UnitTests.csproj", "{C834E05D-79CA-4983-8599-28AC098F755A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Health.Fhir.R4B.Web.UnitTests", "src\Microsoft.Health.Fhir.R4B.Web.UnitTests\Microsoft.Health.Fhir.R4B.Web.UnitTests.csproj", "{6F000A06-6307-46FF-83FA-DD9FD2FD2AA5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Health.Fhir.R5.Web.UnitTests", "src\Microsoft.Health.Fhir.R5.Web.UnitTests\Microsoft.Health.Fhir.R5.Web.UnitTests.csproj", "{62E8CD81-91A9-4872-BC6E-9EBBED8D50FD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Health.Fhir.Stu3.Web.UnitTests", "src\Microsoft.Health.Fhir.Stu3.Web.UnitTests\Microsoft.Health.Fhir.Stu3.Web.UnitTests.csproj", "{8F4858B3-A3CF-4130-B3B2-954CBA9FE780}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -414,6 +424,22 @@ Global
 		{F4DE2945-80C5-48FE-B58A-4AD1264C9FEA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F4DE2945-80C5-48FE-B58A-4AD1264C9FEA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F4DE2945-80C5-48FE-B58A-4AD1264C9FEA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C834E05D-79CA-4983-8599-28AC098F755A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C834E05D-79CA-4983-8599-28AC098F755A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C834E05D-79CA-4983-8599-28AC098F755A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C834E05D-79CA-4983-8599-28AC098F755A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6F000A06-6307-46FF-83FA-DD9FD2FD2AA5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6F000A06-6307-46FF-83FA-DD9FD2FD2AA5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6F000A06-6307-46FF-83FA-DD9FD2FD2AA5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6F000A06-6307-46FF-83FA-DD9FD2FD2AA5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{62E8CD81-91A9-4872-BC6E-9EBBED8D50FD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{62E8CD81-91A9-4872-BC6E-9EBBED8D50FD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{62E8CD81-91A9-4872-BC6E-9EBBED8D50FD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{62E8CD81-91A9-4872-BC6E-9EBBED8D50FD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8F4858B3-A3CF-4130-B3B2-954CBA9FE780}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8F4858B3-A3CF-4130-B3B2-954CBA9FE780}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8F4858B3-A3CF-4130-B3B2-954CBA9FE780}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8F4858B3-A3CF-4130-B3B2-954CBA9FE780}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -496,6 +522,11 @@ Global
 		{5E456FD7-E5A5-41F4-A0D3-7215585AEB7A} = {FCD51BAF-BFE5-476F-B562-C9AB36AA9839}
 		{A5DED132-32B1-4804-95F5-EBC6092EC8AE} = {85F39C13-BC62-49A0-9C06-3BBA724D35ED}
 		{D6C90E8C-50AF-45D8-B2D3-1B9B07E65F3E} = {1295CCC3-73FB-4376-AE95-F6F31A37B152}
+		{73BC4365-2BFB-41C7-B0B1-610059F967AC} = {323F60C6-936A-4C5B-AF6A-F27E93AA7B05}
+		{C834E05D-79CA-4983-8599-28AC098F755A} = {323F60C6-936A-4C5B-AF6A-F27E93AA7B05}
+		{6F000A06-6307-46FF-83FA-DD9FD2FD2AA5} = {323F60C6-936A-4C5B-AF6A-F27E93AA7B05}
+		{62E8CD81-91A9-4872-BC6E-9EBBED8D50FD} = {323F60C6-936A-4C5B-AF6A-F27E93AA7B05}
+		{8F4858B3-A3CF-4130-B3B2-954CBA9FE780} = {323F60C6-936A-4C5B-AF6A-F27E93AA7B05}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E370FB31-CF95-47D1-B1E1-863A77973FF8}
@@ -526,8 +557,11 @@ Global
 		test\Microsoft.Health.Fhir.Shared.Tests.Integration\Microsoft.Health.Fhir.Shared.Tests.Integration.projitems*{5e456fd7-e5a5-41f4-a0d3-7215585aeb7a}*SharedItemsImports = 5
 		src\Microsoft.Health.Fhir.Shared.Tests\Microsoft.Health.Fhir.Shared.Tests.projitems*{61443024-e60b-4e61-9851-b8d57a8886dc}*SharedItemsImports = 5
 		test\Microsoft.Health.Fhir.Shared.Tests.Integration\Microsoft.Health.Fhir.Shared.Tests.Integration.projitems*{61443024-e60b-4e61-9851-b8d57a8886dc}*SharedItemsImports = 5
+		src\Microsoft.Health.Fhir.Shared.Web.UnitTests\Microsoft.Health.Fhir.Shared.Web.UnitTests.projitems*{62e8cd81-91a9-4872-bc6e-9ebbed8d50fd}*SharedItemsImports = 5
+		src\Microsoft.Health.Fhir.Shared.Web.UnitTests\Microsoft.Health.Fhir.Shared.Web.UnitTests.projitems*{6f000a06-6307-46ff-83fa-dd9fd2fd2aa5}*SharedItemsImports = 5
 		src\Microsoft.Health.Fhir.Shared.Api.UnitTests\Microsoft.Health.Fhir.Shared.Api.UnitTests.projitems*{734cac7f-d979-4639-8067-a0875c0691f2}*SharedItemsImports = 5
 		src\Microsoft.Health.Fhir.Shared.Tests\Microsoft.Health.Fhir.Shared.Tests.projitems*{734cac7f-d979-4639-8067-a0875c0691f2}*SharedItemsImports = 5
+		src\Microsoft.Health.Fhir.Shared.Web.UnitTests\Microsoft.Health.Fhir.Shared.Web.UnitTests.projitems*{73bc4365-2bfb-41c7-b0b1-610059f967ac}*SharedItemsImports = 13
 		src\Microsoft.Health.Fhir.Shared.Client\Microsoft.Health.Fhir.Shared.Client.projitems*{743ea25c-a6f5-4b41-bc56-69d9a89386a3}*SharedItemsImports = 5
 		src\Microsoft.Health.Fhir.Shared.Tests\Microsoft.Health.Fhir.Shared.Tests.projitems*{7f2b9209-2c50-42ed-961b-a09cc8a26a07}*SharedItemsImports = 5
 		test\Microsoft.Health.Fhir.Shared.Tests.Crucible\Microsoft.Health.Fhir.Shared.Tests.Crucible.projitems*{7f2b9209-2c50-42ed-961b-a09cc8a26a07}*SharedItemsImports = 5
@@ -539,6 +573,7 @@ Global
 		src\Microsoft.Health.Fhir.Shared.Web\Microsoft.Health.Fhir.Shared.Web.projitems*{8b173ba3-2018-4bb7-b32a-d4a9fc7984eb}*SharedItemsImports = 5
 		src\Microsoft.Health.Fhir.Shared.Api.UnitTests\Microsoft.Health.Fhir.Shared.Api.UnitTests.projitems*{8c3a5e1a-3ba8-4f50-a0ba-99a149edbee6}*SharedItemsImports = 5
 		src\Microsoft.Health.Fhir.Shared.Tests\Microsoft.Health.Fhir.Shared.Tests.projitems*{8c3a5e1a-3ba8-4f50-a0ba-99a149edbee6}*SharedItemsImports = 5
+		src\Microsoft.Health.Fhir.Shared.Web.UnitTests\Microsoft.Health.Fhir.Shared.Web.UnitTests.projitems*{8f4858b3-a3cf-4130-b3b2-954cba9fe780}*SharedItemsImports = 5
 		src\Microsoft.Health.Fhir.Shared.Web\Microsoft.Health.Fhir.Shared.Web.projitems*{934ca8bb-b0a7-4187-bf4d-c937fbba1777}*SharedItemsImports = 13
 		src\Microsoft.Health.Fhir.Shared.Client\Microsoft.Health.Fhir.Shared.Client.projitems*{9cc529d4-8384-41cf-9bda-6f3ef8117891}*SharedItemsImports = 5
 		src\Microsoft.Health.Fhir.Shared.Core\Microsoft.Health.Fhir.Shared.Core.projitems*{a0320ae9-3f87-44a3-8263-5af7e00085d4}*SharedItemsImports = 5
@@ -556,6 +591,7 @@ Global
 		src\Microsoft.Health.Fhir.Shared.Web\Microsoft.Health.Fhir.Shared.Web.projitems*{c5294685-ae6b-434c-9e31-90b3893027de}*SharedItemsImports = 5
 		src\Microsoft.Health.Fhir.Shared.Client\Microsoft.Health.Fhir.Shared.Client.projitems*{c65993f8-e77b-4f7a-be49-5cae9dca3162}*SharedItemsImports = 5
 		src\Microsoft.Health.Fhir.Shared.Core\Microsoft.Health.Fhir.Shared.Core.projitems*{c6759c03-6060-44d7-b44d-0bd89908b741}*SharedItemsImports = 5
+		src\Microsoft.Health.Fhir.Shared.Web.UnitTests\Microsoft.Health.Fhir.Shared.Web.UnitTests.projitems*{c834e05d-79ca-4983-8599-28ac098f755a}*SharedItemsImports = 5
 		src\Microsoft.Health.Fhir.Shared.Api\Microsoft.Health.Fhir.Shared.Api.projitems*{d3d42fb0-72d6-4a67-ac58-9ca1274dbfe1}*SharedItemsImports = 5
 		src\Microsoft.Health.Fhir.Shared.Api\Microsoft.Health.Fhir.Shared.Api.projitems*{d5ecb95c-a199-4690-9ba9-4ef7e8126d81}*SharedItemsImports = 5
 		src\Microsoft.Health.Fhir.Shared.Api.UnitTests\Microsoft.Health.Fhir.Shared.Api.UnitTests.projitems*{d6c90e8c-50af-45d8-b2d3-1b9b07e65f3e}*SharedItemsImports = 5

--- a/src/Microsoft.Health.Fhir.R4.Web.UnitTests/Microsoft.Health.Fhir.R4.Web.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.R4.Web.UnitTests/Microsoft.Health.Fhir.R4.Web.UnitTests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>Microsoft.Health.Fhir.Web.UnitTests</RootNamespace>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Health.Test.Utilities" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Health.Fhir.R4.Web\Microsoft.Health.Fhir.R4.Web.csproj" />
+    <ProjectReference Include="..\Microsoft.Health.Fhir.Tests.Common\Microsoft.Health.Fhir.Tests.Common.csproj" />
+  </ItemGroup>
+  <Import Project="..\Microsoft.Health.Fhir.Shared.Web.UnitTests\Microsoft.Health.Fhir.Shared.Web.UnitTests.projitems" Label="Shared" />
+</Project>

--- a/src/Microsoft.Health.Fhir.R4.Web/Microsoft.Health.Fhir.R4.Web.csproj
+++ b/src/Microsoft.Health.Fhir.R4.Web/Microsoft.Health.Fhir.R4.Web.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" />
     <PackageReference Include="IdentityServer4" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />

--- a/src/Microsoft.Health.Fhir.R4B.Web.UnitTests/Microsoft.Health.Fhir.R4B.Web.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.R4B.Web.UnitTests/Microsoft.Health.Fhir.R4B.Web.UnitTests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>Microsoft.Health.Fhir.Web.UnitTests</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Health.Fhir.R4B.Web\Microsoft.Health.Fhir.R4B.Web.csproj" />
+    <ProjectReference Include="..\Microsoft.Health.Fhir.Tests.Common\Microsoft.Health.Fhir.Tests.Common.csproj" />
+  </ItemGroup>
+  <Import Project="..\Microsoft.Health.Fhir.Shared.Web.UnitTests\Microsoft.Health.Fhir.Shared.Web.UnitTests.projitems" Label="Shared" />
+</Project>

--- a/src/Microsoft.Health.Fhir.R4B.Web/Microsoft.Health.Fhir.R4B.Web.csproj
+++ b/src/Microsoft.Health.Fhir.R4B.Web/Microsoft.Health.Fhir.R4B.Web.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" />
     <PackageReference Include="IdentityServer4" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />

--- a/src/Microsoft.Health.Fhir.R5.Web.UnitTests/Microsoft.Health.Fhir.R5.Web.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.R5.Web.UnitTests/Microsoft.Health.Fhir.R5.Web.UnitTests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>Microsoft.Health.Fhir.Web.UnitTests</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Health.Fhir.R5.Web\Microsoft.Health.Fhir.R5.Web.csproj" />
+    <ProjectReference Include="..\Microsoft.Health.Fhir.Tests.Common\Microsoft.Health.Fhir.Tests.Common.csproj" />
+  </ItemGroup>
+  <Import Project="..\Microsoft.Health.Fhir.Shared.Web.UnitTests\Microsoft.Health.Fhir.Shared.Web.UnitTests.projitems" Label="Shared" />
+</Project>

--- a/src/Microsoft.Health.Fhir.R5.Web/Microsoft.Health.Fhir.R5.Web.csproj
+++ b/src/Microsoft.Health.Fhir.R5.Web/Microsoft.Health.Fhir.R5.Web.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" />
     <PackageReference Include="IdentityServer4" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />

--- a/src/Microsoft.Health.Fhir.Shared.Web.UnitTests/Microsoft.Health.Fhir.Shared.Web.UnitTests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Web.UnitTests/Microsoft.Health.Fhir.Shared.Web.UnitTests.projitems
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects Condition="'$(MSBuildVersion)' == '' Or '$(MSBuildVersion)' &lt; '16.0'">$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>73bc4365-2bfb-41c7-b0b1-610059f967ac</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>Microsoft.Health.Fhir.Shared.Web.UnitTests</Import_RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)StartupTests.cs" />
+  </ItemGroup>
+</Project>

--- a/src/Microsoft.Health.Fhir.Shared.Web.UnitTests/Microsoft.Health.Fhir.Shared.Web.UnitTests.shproj
+++ b/src/Microsoft.Health.Fhir.Shared.Web.UnitTests/Microsoft.Health.Fhir.Shared.Web.UnitTests.shproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>73bc4365-2bfb-41c7-b0b1-610059f967ac</ProjectGuid>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <PropertyGroup />
+  <Import Project="Microsoft.Health.Fhir.Shared.Web.UnitTests.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+</Project>

--- a/src/Microsoft.Health.Fhir.Shared.Web.UnitTests/StartupTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web.UnitTests/StartupTests.cs
@@ -1,0 +1,88 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.ApplicationInsights;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Fhir.Web;
+using Microsoft.Health.Test.Utilities;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Shared.Web.UnitTests
+{
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.SmartOnFhir)]
+    public class StartupTests
+    {
+        private const string ApplicationInsightsConfigurationName = "ApplicationInsights:InstrumentationKey";
+        private const string AzureMonitorConfigurationName = "AzureMonitor:ConnectionString";
+        private const string AddApplicationInsightsTelemetryMethodName = "AddApplicationInsightsTelemetry";
+        private const string AddAzureMonitorOpenTelemetryMethodName = "AddAzureMonitorOpenTelemetry";
+
+        [Fact]
+        public void GivenAppSettings_WhenApplicationInsightsOnAndOpenTelemetryOff_ThenApplicationInsightsShouldBeEnabled()
+        {
+            string instrumentationKey = Guid.NewGuid().ToString();
+            Mock<IConfiguration> configuration = new Mock<IConfiguration>();
+            configuration.Setup(x => x[ApplicationInsightsConfigurationName]).Returns(instrumentationKey);
+            configuration.Setup(x => x[AzureMonitorConfigurationName]).Returns((string)null);
+
+            IList<ServiceDescriptor> serviceDescriptors = new List<ServiceDescriptor>();
+            Mock<IServiceCollection> services = new Mock<IServiceCollection>();
+            services.Setup(x => x.Count).Returns(serviceDescriptors.Count);
+            services.Setup(x => x[It.IsAny<int>()]).Returns((int i) => serviceDescriptors[i]);
+            services.Setup(x => x.Add(It.IsAny<ServiceDescriptor>())).Callback<ServiceDescriptor>((ServiceDescriptor descriptor) => serviceDescriptors.Add(descriptor));
+
+            Startup startup = new Startup(configuration.Object);
+            var addAppInsightsTelemetryMethod = startup.GetType().GetMethod(AddApplicationInsightsTelemetryMethodName, BindingFlags.NonPublic | BindingFlags.Instance);
+            addAppInsightsTelemetryMethod.Invoke(startup, new object[] { services.Object });
+            Assert.Contains(serviceDescriptors, descriptor => descriptor.ImplementationType == typeof(ApplicationInsightsLoggerProvider));
+            Assert.Contains(serviceDescriptors, descriptor => descriptor.ImplementationType == typeof(CloudRoleNameTelemetryInitializer));
+            Assert.Contains(serviceDescriptors, descriptor => descriptor.ImplementationType == typeof(UserAgentHeaderTelemetryInitializer));
+
+            serviceDescriptors.Clear();
+            var addOpenTelemetryMethod = startup.GetType().GetMethod(AddAzureMonitorOpenTelemetryMethodName, BindingFlags.NonPublic | BindingFlags.Instance);
+            addOpenTelemetryMethod.Invoke(startup, new object[] { services.Object });
+            Assert.Empty(serviceDescriptors);
+        }
+
+        [Fact]
+        public void GivenAppSettings_WhenApplicationInsightsOnAndOpenTelemetryOn_ThenOpenTelemetryShouldBeEnabled()
+        {
+            string instrumentationKey = Guid.NewGuid().ToString();
+            string connectionString = $"InstrumentationKey={Guid.NewGuid()};IngestionEndpoint=https://local.in.applicationinsights.azure.com/;LiveEndpoint=https://local.livediagnostics.monitor.azure.com/";
+            Mock<IConfiguration> configuration = new Mock<IConfiguration>();
+            configuration.Setup(x => x[ApplicationInsightsConfigurationName]).Returns(instrumentationKey);
+            configuration.Setup(x => x[AzureMonitorConfigurationName]).Returns(connectionString);
+
+            IList<ServiceDescriptor> serviceDescriptors = new List<ServiceDescriptor>();
+            Mock<IServiceCollection> services = new Mock<IServiceCollection>();
+            services.Setup(x => x.Count).Returns(serviceDescriptors.Count);
+            services.Setup(x => x[It.IsAny<int>()]).Returns((int i) => serviceDescriptors[i]);
+            services.Setup(x => x.Add(It.IsAny<ServiceDescriptor>())).Callback<ServiceDescriptor>((ServiceDescriptor descriptor) => serviceDescriptors.Add(descriptor));
+
+            Startup startup = new Startup(configuration.Object);
+            var addAppInsightsTelemetryMethod = startup.GetType().GetMethod(AddApplicationInsightsTelemetryMethodName, BindingFlags.NonPublic | BindingFlags.Instance);
+            addAppInsightsTelemetryMethod.Invoke(startup, new object[] { services.Object });
+            Assert.Empty(serviceDescriptors);
+
+            serviceDescriptors.Clear();
+            var addOpenTelemetryMethod = startup.GetType().GetMethod(AddAzureMonitorOpenTelemetryMethodName, BindingFlags.NonPublic | BindingFlags.Instance);
+            addOpenTelemetryMethod.Invoke(startup, new object[] { services.Object });
+            Assert.NotEmpty(serviceDescriptors.Where(descriptor =>
+                descriptor.ImplementationType != null ? descriptor.ImplementationType.FullName.Contains("OpenTelemetry", StringComparison.OrdinalIgnoreCase) : false));
+            Assert.Empty(serviceDescriptors.Where(descriptor =>
+                descriptor.ImplementationType == typeof(ApplicationInsightsLoggerProvider)
+                || descriptor.ImplementationType == typeof(CloudRoleNameTelemetryInitializer)
+                || descriptor.ImplementationType == typeof(UserAgentHeaderTelemetryInitializer)));
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
@@ -118,6 +118,7 @@ namespace Microsoft.Health.Fhir.Web
             }
 
             AddApplicationInsightsTelemetry(services);
+            AddAzureMonitorOpenTelemetry(services);
         }
 
         private void AddTaskHostingService(IServiceCollection services)
@@ -183,7 +184,7 @@ namespace Microsoft.Health.Fhir.Web
         {
             string instrumentationKey = Configuration["ApplicationInsights:InstrumentationKey"];
 
-            if (!string.IsNullOrWhiteSpace(instrumentationKey))
+            if (!string.IsNullOrWhiteSpace(instrumentationKey) && string.IsNullOrWhiteSpace(Configuration["AzureMonitor:ConnectionString"]))
             {
                 services.AddHttpContextAccessor();
                 services.AddApplicationInsightsTelemetry(instrumentationKey);
@@ -211,15 +212,14 @@ namespace Microsoft.Health.Fhir.Web
         }
 
         /// <summary>
-        /// Adds ApplicationInsights for telemetry and logging.
+        /// Adds AzureMonitorOpenTelemetry for telemetry and logging.
         /// </summary>
         private void AddAzureMonitorOpenTelemetry(IServiceCollection services)
         {
-            string instrumentationKey = Configuration["ApplicationInsights:InstrumentationKey"];
+            string connectionString = Configuration["AzureMonitor:ConnectionString"];
 
-            if (!string.IsNullOrWhiteSpace(instrumentationKey))
+            if (!string.IsNullOrWhiteSpace(connectionString))
             {
-                var connectionString = "InstrumentationKey=47be7b75-0baa-40a2-8bb8-4f67dfe658e1;IngestionEndpoint=https://westus2-2.in.applicationinsights.azure.com/;LiveEndpoint=https://westus2.livediagnostics.monitor.azure.com/";
                 services.AddOpenTelemetry()
                     .UseAzureMonitor(options => options.ConnectionString = connectionString)
                     .ConfigureResource(resourceBuilder =>

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -46,9 +46,16 @@
             "AllowCredentials": false
         },
         "Operations": {
-            "HostingBackgroundServiceQueues":
-                [{ "Queue": "Import", "UpdateProgressOnHeartbeat": true },
-                 { "Queue": "Export", "UpdateProgressOnHeartbeat": false }],
+            "HostingBackgroundServiceQueues": [
+                {
+                    "Queue": "Import",
+                    "UpdateProgressOnHeartbeat": true
+                },
+                {
+                    "Queue": "Export",
+                    "UpdateProgressOnHeartbeat": false
+                }
+            ],
             "Export": {
                 "Enabled": true,
                 "StorageAccountConnection": null,
@@ -186,7 +193,7 @@
         "MaxRunningTaskCount": 1
     },
     "ApplicationInsights": {
-        "InstrumentationKey": "47be7b75-0baa-40a2-8bb8-4f67dfe658e1"
+        "InstrumentationKey": ""
     },
     "PrometheusMetrics": {
         "enabled": false,
@@ -195,5 +202,8 @@
         "dotnetRuntimeMetrics": true,
         "httpMetrics": true,
         "systemMetrics": true
+    },
+    "AzureMonitor": {
+        "ConnectionString": ""
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -186,7 +186,7 @@
         "MaxRunningTaskCount": 1
     },
     "ApplicationInsights": {
-        "InstrumentationKey": ""
+        "InstrumentationKey": "47be7b75-0baa-40a2-8bb8-4f67dfe658e1"
     },
     "PrometheusMetrics": {
         "enabled": false,

--- a/src/Microsoft.Health.Fhir.Stu3.Web.UnitTests/Microsoft.Health.Fhir.Stu3.Web.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.Stu3.Web.UnitTests/Microsoft.Health.Fhir.Stu3.Web.UnitTests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AssemblyName>Microsoft.Health.Fhir.Web.UnitTests</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Health.Fhir.Stu3.Web\Microsoft.Health.Fhir.Stu3.Web.csproj" />
+    <ProjectReference Include="..\Microsoft.Health.Fhir.Tests.Common\Microsoft.Health.Fhir.Tests.Common.csproj" />
+  </ItemGroup>
+  <Import Project="..\Microsoft.Health.Fhir.Shared.Web.UnitTests\Microsoft.Health.Fhir.Shared.Web.UnitTests.projitems" Label="Shared" />
+</Project>

--- a/src/Microsoft.Health.Fhir.Stu3.Web/Microsoft.Health.Fhir.Stu3.Web.csproj
+++ b/src/Microsoft.Health.Fhir.Stu3.Web/Microsoft.Health.Fhir.Stu3.Web.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" />
     <PackageReference Include="IdentityServer4" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />


### PR DESCRIPTION
## Description
Add a support for emitting telemetry to an Application Insights resource via Azure Monitor OpenTelemetry package.

## Related issues
Addresses [issue #[101952](https://microsofthealth.visualstudio.com/Health/_workitems/edit/101952)].

## Testing
Locally tested running some E2E test with my test Application Insights resource. (Trying to add some UTs but having some issues. Will update the PR with UTs.)

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
