### PR TITLE
Add system scopes to test IDP

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Web/DevelopmentIdentityProviderRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web/DevelopmentIdentityProviderRegistrationExtensions.cs
@@ -171,8 +171,10 @@ namespace Microsoft.Health.Fhir.Web
 
             scopes.Add(new ApiScope("patient/*.*"));
             scopes.Add(new ApiScope("user/*.*"));
+            scopes.Add(new ApiScope("system/*.*"));
             scopes.Add(new ApiScope("patient/*.read"));
             scopes.Add(new ApiScope("user/*.write"));
+            scopes.Add(new ApiScope("user/*.read"));
 
             foreach (var resourceType in resourceTypes)
             {
@@ -182,6 +184,8 @@ namespace Microsoft.Health.Fhir.Web
                 scopes.Add(new ApiScope($"user/{resourceType}.read"));
                 scopes.Add(new ApiScope($"patient/{resourceType}.write"));
                 scopes.Add(new ApiScope($"user/{resourceType}.write"));
+                scopes.Add(new ApiScope($"system/{resourceType}.write"));
+                scopes.Add(new ApiScope($"system/{resourceType}.read"));
             }
 
             return scopes;

--- a/src/Microsoft.Health.Fhir.Shared.Web/DevelopmentIdentityProviderRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web/DevelopmentIdentityProviderRegistrationExtensions.cs
@@ -172,6 +172,7 @@ namespace Microsoft.Health.Fhir.Web
             scopes.Add(new ApiScope("patient/*.*"));
             scopes.Add(new ApiScope("user/*.*"));
             scopes.Add(new ApiScope("system/*.*"));
+            scopes.Add(new ApiScope("system/*.read"));
             scopes.Add(new ApiScope("patient/*.read"));
             scopes.Add(new ApiScope("user/*.write"));
             scopes.Add(new ApiScope("user/*.read"));


### PR DESCRIPTION
## Description
A small change to add system scopes to the test IDP.

## Related issues
Addresses [issue AB#104427].

## Testing
By adding these scopes, manual testing is possible.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
