### PR TITLE
nuget multiple feeds security analysis warning fixed

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -5,15 +5,11 @@
   </config>
   <packageSources>
     <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="Microsoft Health OSS" value="https://microsofthealthoss.pkgs.visualstudio.com/FhirServer/_packaging/Public/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
-    <packageSource key="nuget.org">
-      <package pattern="*" />
-    </packageSource>
     <packageSource key="Microsoft Health OSS">
-      <package pattern="Microsoft.Health.*" />
+      <package pattern="*" />
     </packageSource>
   </packageSourceMapping>
   <disabledPackageSources>


### PR DESCRIPTION
## Description
fhir-server pr internal checks is failing at step "Secure Supply Chain Analysis (auto-injected by policy)".
Changes are done to remove nuget.org from nuget.config file and added that as upstream in "Microsoft Health OSS" Azure artifacts feed.

## Related issues
Fixing buil failures as part of secondary

## Testing
By runnin fhir-server pr internal checks

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
