### PR TITLE
[Livesite] Handled nested SecurityTokenException

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Context/FhirAuthenticationExceptionHandlerMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Context/FhirAuthenticationExceptionHandlerMiddleware.cs
@@ -34,15 +34,28 @@ namespace Microsoft.Health.Fhir.Api.Features.Context
             }
             catch (Exception ex)
             {
-                if (ex.InnerException is SecurityTokenException)
-                {
-                    ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
-                }
-                else
-                {
-                    ExceptionDispatchInfo.Capture(ex).Throw();
-                }
+                ThrowIfSecurityTokenException(ex);
+
+                ExceptionDispatchInfo.Capture(ex).Throw();
             }
+        }
+
+        private static bool ThrowIfSecurityTokenException(Exception ex)
+        {
+            // Before checking if the current exception inherits from SecurityTokenException,
+            // check if the inner exception is a SecurityTokenException.
+            // That way, the most nested exception is raised.
+            if (ex.InnerException != null)
+            {
+                ThrowIfSecurityTokenException(ex.InnerException);
+            }
+
+            if (ex is SecurityTokenException)
+            {
+                ExceptionDispatchInfo.Capture(ex).Throw();
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
## Description
Describe the changes in this PR.

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
