### PR TITLE
Audit logs for incremental import

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditHelper.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditHelper.cs
@@ -127,7 +127,8 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
                     callerClaims: claimsExtractor.Extract(),
                     customHeaders: _auditHeaderReader.Read(httpContext),
                     operationType: sanitizedOperationType,
-                    callerAgent: DefaultCallerAgent);
+                    callerAgent: DefaultCallerAgent,
+                    additionalProperties: null);
             }
         }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Audit/AuditLogger.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Audit/AuditLogger.cs
@@ -35,7 +35,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Audit
             "Claims: {Claims}" + Environment.NewLine +
             "CustomHeaders: {CustomHeaders}" + Environment.NewLine +
             "OperationType: {OperationType}" + Environment.NewLine +
-            "CallerAgent: {CallerAgent}" + Environment.NewLine;
+            "CallerAgent: {CallerAgent}" + Environment.NewLine +
+            "AdditionalProperties: {AdditionalProperties}" + Environment.NewLine;
 
         private readonly SecurityConfiguration _securityConfiguration;
         private readonly ILogger<IAuditLogger> _logger;
@@ -63,10 +64,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Audit
             IReadOnlyCollection<KeyValuePair<string, string>> callerClaims,
             IReadOnlyDictionary<string, string> customHeaders = null,
             string operationType = null,
-            string callerAgent = null)
+            string callerAgent = null,
+            IReadOnlyDictionary<string, string> additionalProperties = null)
         {
             string claimsInString = null;
             string customerHeadersInString = null;
+            string additionalPropertiesInString = null;
 
             if (callerClaims != null)
             {
@@ -76,6 +79,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Audit
             if (customHeaders != null)
             {
                 customerHeadersInString = string.Join(";", customHeaders.Select(header => $"{header.Key}={header.Value}"));
+            }
+
+            if (additionalProperties != null)
+            {
+                additionalPropertiesInString = string.Join(";", additionalProperties.Select(props => $"{props.Key}={props.Value}"));
             }
 
             _logger.LogInformation(
@@ -94,7 +102,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Audit
                 claimsInString,
                 customerHeadersInString,
                 operationType,
-                callerAgent);
+                callerAgent,
+                additionalPropertiesInString);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Audit/IAuditLogger.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Audit/IAuditLogger.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Audit
         /// <param name="customHeaders">Headers added by the caller with data to be added to the audit logs.</param>
         /// <param name="operationType">The operation type.</param>
         /// <param name="callerAgent">The caller agent.</param>
+        /// <param name="additionalProperties">To add additional properties to logs.</param>
         void LogAudit(
             AuditAction auditAction,
             string operation,
@@ -40,6 +41,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Audit
             IReadOnlyCollection<KeyValuePair<string, string>> callerClaims,
             IReadOnlyDictionary<string, string> customHeaders = null,
             string operationType = null,
-            string callerAgent = null);
+            string callerAgent = null,
+            IReadOnlyDictionary<string, string> additionalProperties = null);
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Operations/Import/ImportOrchestratorJobTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Operations/Import/ImportOrchestratorJobTests.cs
@@ -13,8 +13,10 @@ using MediatR;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Microsoft.Health.Core.Features.Audit;
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Configs;
+using Microsoft.Health.Fhir.Core.Features.Audit;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Operations.Import;
@@ -70,14 +72,17 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
             await VerifyJobStatusChangedAsync(100, JobStatus.Failed, 14, 14);
         }
 
-        [Fact]
-        public async Task GivenAnOrchestratorJobAndWrongEtag_WhenOrchestratorJobStart_ThenJobShouldFailedWithDetails()
+        [InlineData(ImportMode.InitialLoad)]
+        [InlineData(ImportMode.IncrementalLoad)]
+        [Theory]
+        public async Task GivenAnOrchestratorJobAndWrongEtag_WhenOrchestratorJobStart_ThenJobShouldFailedWithDetails(ImportMode importMode)
         {
             IImportOrchestratorJobDataStoreOperation fhirDataBulkImportOperation = Substitute.For<IImportOrchestratorJobDataStoreOperation>();
             RequestContextAccessor<IFhirRequestContext> contextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
             ILoggerFactory loggerFactory = new NullLoggerFactory();
             IIntegrationDataStoreClient integrationDataStoreClient = Substitute.For<IIntegrationDataStoreClient>();
             ImportOrchestratorJobDefinition importOrchestratorInputData = new ImportOrchestratorJobDefinition();
+            IAuditLogger auditLogger = Substitute.For<IAuditLogger>();
 
             IMediator mediator = Substitute.For<IMediator>();
 
@@ -88,6 +93,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
             importOrchestratorInputData.InputFormat = "ndjson";
             importOrchestratorInputData.InputSource = new Uri("http://dummy");
             importOrchestratorInputData.RequestUri = new Uri("http://dummy");
+            importOrchestratorInputData.ImportMode = importMode;
 
             integrationDataStoreClient.GetPropertiesAsync(Arg.Any<Uri>(), Arg.Any<CancellationToken>())
                 .Returns(callInfo =>
@@ -107,7 +113,8 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
                 integrationDataStoreClient,
                 testQueueClient,
                 Options.Create(new ImportTaskConfiguration()),
-                loggerFactory);
+                loggerFactory,
+                auditLogger);
 
             JobExecutionException jobExecutionException = await Assert.ThrowsAsync<JobExecutionException>(async () => await orchestratorJob.ExecuteAsync(orchestratorJobInfo, new Progress<string>(), CancellationToken.None));
             ImportOrchestratorJobErrorResult resultDetails = (ImportOrchestratorJobErrorResult)jobExecutionException.Error;
@@ -124,10 +131,50 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
                     notification.SucceededCount == 0 &&
                     notification.FailedCount == 0),
                 Arg.Any<CancellationToken>());
+
+            if (importMode == ImportMode.IncrementalLoad)
+            {
+                var incrementalImportProperties = new Dictionary<string, string>();
+                incrementalImportProperties["JobId"] = orchestratorJobInfo.Id.ToString();
+                incrementalImportProperties["SucceededResources"] = "0";
+                incrementalImportProperties["FailedResources"] = "0";
+
+                auditLogger.Received(1);
+                auditLogger.Received().LogAudit(
+                    auditAction: Arg.Any<AuditAction>(),
+                    operation: Arg.Any<string>(),
+                    resourceType: Arg.Any<string>(),
+                    requestUri: Arg.Any<Uri>(),
+                    statusCode: Arg.Any<HttpStatusCode?>(),
+                    correlationId: Arg.Any<string>(),
+                    callerIpAddress: Arg.Any<string>(),
+                    callerClaims: Arg.Any<IReadOnlyCollection<KeyValuePair<string, string>>>(),
+                    customHeaders: Arg.Any<IReadOnlyDictionary<string, string>>(),
+                    operationType: Arg.Any<string>(),
+                    callerAgent: Arg.Any<string>(),
+                    additionalProperties: Arg.Is<IReadOnlyDictionary<string, string>>(dict =>
+                                        dict.ContainsKey("JobId") && dict["JobId"].Equals(orchestratorJobInfo.Id.ToString()) &&
+                                        dict.ContainsKey("SucceededResources") && dict["SucceededResources"].Equals("0") &&
+                                        dict.ContainsKey("FailedResources") && dict["FailedResources"].Equals("0")));
+            }
+            else if (importMode == ImportMode.InitialLoad)
+            {
+                auditLogger.DidNotReceiveWithAnyArgs().LogAudit(
+                               auditAction: default,
+                               operation: default,
+                               resourceType: default,
+                               requestUri: default,
+                               statusCode: default,
+                               correlationId: default,
+                               callerIpAddress: default,
+                               callerClaims: default);
+            }
         }
 
-        [Fact]
-        public async Task GivenAnOrchestratorJob_WhenIntegrationExceptionThrow_ThenJobShouldFailedWithDetails()
+        [InlineData(ImportMode.InitialLoad)]
+        [InlineData(ImportMode.IncrementalLoad)]
+        [Theory]
+        public async Task GivenAnOrchestratorJob_WhenIntegrationExceptionThrow_ThenJobShouldFailedWithDetails(ImportMode importMode)
         {
             IImportOrchestratorJobDataStoreOperation fhirDataBulkImportOperation = Substitute.For<IImportOrchestratorJobDataStoreOperation>();
             RequestContextAccessor<IFhirRequestContext> contextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
@@ -135,6 +182,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
             IIntegrationDataStoreClient integrationDataStoreClient = Substitute.For<IIntegrationDataStoreClient>();
             ImportOrchestratorJobDefinition importOrchestratorJobInputData = new ImportOrchestratorJobDefinition();
             IMediator mediator = Substitute.For<IMediator>();
+            IAuditLogger auditLogger = Substitute.For<IAuditLogger>();
 
             importOrchestratorJobInputData.BaseUri = new Uri("http://dummy");
             var inputs = new List<InputResource>();
@@ -143,6 +191,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
             importOrchestratorJobInputData.InputFormat = "ndjson";
             importOrchestratorJobInputData.InputSource = new Uri("http://dummy");
             importOrchestratorJobInputData.RequestUri = new Uri("http://dummy");
+            importOrchestratorJobInputData.ImportMode = importMode;
 
             integrationDataStoreClient.GetPropertiesAsync(Arg.Any<Uri>(), Arg.Any<CancellationToken>())
                 .Returns<Task<Dictionary<string, object>>>(_ =>
@@ -159,7 +208,8 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
                 integrationDataStoreClient,
                 testQueueClient,
                 Options.Create(new ImportTaskConfiguration()),
-                loggerFactory);
+                loggerFactory,
+                auditLogger);
 
             JobExecutionException jobExecutionException = await Assert.ThrowsAsync<JobExecutionException>(async () => await orchestratorJob.ExecuteAsync(orchestratorJobInfo, new Progress<string>(), CancellationToken.None));
             ImportOrchestratorJobErrorResult resultDetails = (ImportOrchestratorJobErrorResult)jobExecutionException.Error;
@@ -176,10 +226,50 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
                     notification.SucceededCount == 0 &&
                     notification.FailedCount == 0),
                 Arg.Any<CancellationToken>());
+
+            if (importMode == ImportMode.IncrementalLoad)
+            {
+                var incrementalImportProperties = new Dictionary<string, string>();
+                incrementalImportProperties["JobId"] = orchestratorJobInfo.Id.ToString();
+                incrementalImportProperties["SucceededResources"] = "0";
+                incrementalImportProperties["FailedResources"] = "0";
+
+                auditLogger.Received(1);
+                auditLogger.Received().LogAudit(
+                    auditAction: Arg.Any<AuditAction>(),
+                    operation: Arg.Any<string>(),
+                    resourceType: Arg.Any<string>(),
+                    requestUri: Arg.Any<Uri>(),
+                    statusCode: Arg.Any<HttpStatusCode?>(),
+                    correlationId: Arg.Any<string>(),
+                    callerIpAddress: Arg.Any<string>(),
+                    callerClaims: Arg.Any<IReadOnlyCollection<KeyValuePair<string, string>>>(),
+                    customHeaders: Arg.Any<IReadOnlyDictionary<string, string>>(),
+                    operationType: Arg.Any<string>(),
+                    callerAgent: Arg.Any<string>(),
+                    additionalProperties: Arg.Is<IReadOnlyDictionary<string, string>>(dict =>
+                                        dict.ContainsKey("JobId") && dict["JobId"].Equals(orchestratorJobInfo.Id.ToString()) &&
+                                        dict.ContainsKey("SucceededResources") && dict["SucceededResources"].Equals("0") &&
+                                        dict.ContainsKey("FailedResources") && dict["FailedResources"].Equals("0")));
+            }
+            else if (importMode == ImportMode.InitialLoad)
+            {
+                auditLogger.DidNotReceiveWithAnyArgs().LogAudit(
+                               auditAction: default,
+                               operation: default,
+                               resourceType: default,
+                               requestUri: default,
+                               statusCode: default,
+                               correlationId: default,
+                               callerIpAddress: default,
+                               callerClaims: default);
+            }
         }
 
-        [Fact]
-        public async Task GivenAnOrchestratorJob_WhenFailedAtPreprocessStep_ThenJobExecutionExceptionShouldBeThrowAndContextUpdated()
+        [InlineData(ImportMode.InitialLoad)]
+        [InlineData(ImportMode.IncrementalLoad)]
+        [Theory]
+        public async Task GivenAnOrchestratorJob_WhenFailedAtPreprocessStep_ThenJobExecutionExceptionShouldBeThrowAndContextUpdated(ImportMode importMode)
         {
             IImportOrchestratorJobDataStoreOperation fhirDataBulkImportOperation = Substitute.For<IImportOrchestratorJobDataStoreOperation>();
             RequestContextAccessor<IFhirRequestContext> contextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
@@ -188,6 +278,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
             IMediator mediator = Substitute.For<IMediator>();
             ImportOrchestratorJobDefinition importOrchestratorJobInputData = new ImportOrchestratorJobDefinition();
             List<(long begin, long end)> surrogatedIdRanges = new List<(long begin, long end)>();
+            IAuditLogger auditLogger = Substitute.For<IAuditLogger>();
 
             importOrchestratorJobInputData.BaseUri = new Uri("http://dummy");
             var inputs = new List<InputResource>();
@@ -197,6 +288,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
             importOrchestratorJobInputData.InputFormat = "ndjson";
             importOrchestratorJobInputData.InputSource = new Uri("http://dummy");
             importOrchestratorJobInputData.RequestUri = new Uri("http://dummy");
+            importOrchestratorJobInputData.ImportMode = importMode;
 
             integrationDataStoreClient.GetPropertiesAsync(Arg.Any<Uri>(), Arg.Any<CancellationToken>())
                 .Returns(callInfo =>
@@ -223,7 +315,8 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
                 integrationDataStoreClient,
                 testQueueClient,
                 Options.Create(new ImportTaskConfiguration()),
-                loggerFactory);
+                loggerFactory,
+                auditLogger);
             orchestratorJob.PollingPeriodSec = 0;
 
             var jobExecutionException = await Assert.ThrowsAnyAsync<JobExecutionException>(() => orchestratorJob.ExecuteAsync(orchestratorJobInfo, new Progress<string>(), CancellationToken.None));
@@ -241,10 +334,50 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
                     notification.SucceededCount == 0 &&
                     notification.FailedCount == 0),
                 Arg.Any<CancellationToken>());
+
+            if (importMode == ImportMode.IncrementalLoad)
+            {
+                var incrementalImportProperties = new Dictionary<string, string>();
+                incrementalImportProperties["JobId"] = orchestratorJobInfo.Id.ToString();
+                incrementalImportProperties["SucceededResources"] = "0";
+                incrementalImportProperties["FailedResources"] = "0";
+
+                auditLogger.Received(1);
+                auditLogger.Received().LogAudit(
+                    auditAction: Arg.Any<AuditAction>(),
+                    operation: Arg.Any<string>(),
+                    resourceType: Arg.Any<string>(),
+                    requestUri: Arg.Any<Uri>(),
+                    statusCode: Arg.Any<HttpStatusCode?>(),
+                    correlationId: Arg.Any<string>(),
+                    callerIpAddress: Arg.Any<string>(),
+                    callerClaims: Arg.Any<IReadOnlyCollection<KeyValuePair<string, string>>>(),
+                    customHeaders: Arg.Any<IReadOnlyDictionary<string, string>>(),
+                    operationType: Arg.Any<string>(),
+                    callerAgent: Arg.Any<string>(),
+                    additionalProperties: Arg.Is<IReadOnlyDictionary<string, string>>(dict =>
+                                        dict.ContainsKey("JobId") && dict["JobId"].Equals(orchestratorJobInfo.Id.ToString()) &&
+                                        dict.ContainsKey("SucceededResources") && dict["SucceededResources"].Equals("0") &&
+                                        dict.ContainsKey("FailedResources") && dict["FailedResources"].Equals("0")));
+            }
+            else if (importMode == ImportMode.InitialLoad)
+            {
+                auditLogger.DidNotReceiveWithAnyArgs().LogAudit(
+                               auditAction: default,
+                               operation: default,
+                               resourceType: default,
+                               requestUri: default,
+                               statusCode: default,
+                               correlationId: default,
+                               callerIpAddress: default,
+                               callerClaims: default);
+            }
         }
 
-        [Fact]
-        public async Task GivenAnOrchestratorJob_WhenRetriableExceptionThrow_ThenJobExecutionShuldFailedWithRetriableException()
+        [InlineData(ImportMode.InitialLoad)]
+        [InlineData(ImportMode.IncrementalLoad)]
+        [Theory]
+        public async Task GivenAnOrchestratorJob_WhenRetriableExceptionThrow_ThenJobExecutionShuldFailedWithRetriableException(ImportMode importMode)
         {
             IImportOrchestratorJobDataStoreOperation fhirDataBulkImportOperation = Substitute.For<IImportOrchestratorJobDataStoreOperation>();
             RequestContextAccessor<IFhirRequestContext> contextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
@@ -253,6 +386,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
             IMediator mediator = Substitute.For<IMediator>();
             ImportOrchestratorJobDefinition importOrchestratorInputData = new ImportOrchestratorJobDefinition();
             List<(long begin, long end)> surrogatedIdRanges = new List<(long begin, long end)>();
+            IAuditLogger auditLogger = Substitute.For<IAuditLogger>();
 
             importOrchestratorInputData.BaseUri = new Uri("http://dummy");
             var inputs = new List<InputResource>();
@@ -262,6 +396,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
             importOrchestratorInputData.InputFormat = "ndjson";
             importOrchestratorInputData.InputSource = new Uri("http://dummy");
             importOrchestratorInputData.RequestUri = new Uri("http://dummy");
+            importOrchestratorInputData.ImportMode = importMode;
 
             integrationDataStoreClient.GetPropertiesAsync(Arg.Any<Uri>(), Arg.Any<CancellationToken>())
                 .Returns(callInfo =>
@@ -288,7 +423,8 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
                 integrationDataStoreClient,
                 testQueueClient,
                 Options.Create(new ImportTaskConfiguration()),
-                loggerFactory);
+                loggerFactory,
+                auditLogger);
             orchestratorJob.PollingPeriodSec = 0;
 
             await Assert.ThrowsAnyAsync<RetriableJobException>(() => orchestratorJob.ExecuteAsync(orchestratorJobInfo, new Progress<string>(), CancellationToken.None));
@@ -296,10 +432,22 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
             _ = mediator.DidNotReceive().Publish(
                 Arg.Any<ImportJobMetricsNotification>(),
                 Arg.Any<CancellationToken>());
+
+            auditLogger.DidNotReceiveWithAnyArgs().LogAudit(
+                        auditAction: default,
+                        operation: default,
+                        resourceType: default,
+                        requestUri: default,
+                        statusCode: default,
+                        correlationId: default,
+                        callerIpAddress: default,
+                        callerClaims: default);
         }
 
-        [Fact]
-        public async Task GivenAnOrchestratorJob_WhenLastSubJobFailed_ThenImportProcessingExceptionShouldBeThrowAndWaitForOtherSubJobsCancelledAndCompleted()
+        [InlineData(ImportMode.InitialLoad)]
+        [InlineData(ImportMode.IncrementalLoad)]
+        [Theory]
+        public async Task GivenAnOrchestratorJob_WhenLastSubJobFailed_ThenImportProcessingExceptionShouldBeThrowAndWaitForOtherSubJobsCancelledAndCompleted(ImportMode importMode)
         {
             IImportOrchestratorJobDataStoreOperation fhirDataBulkImportOperation = Substitute.For<IImportOrchestratorJobDataStoreOperation>();
             RequestContextAccessor<IFhirRequestContext> contextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
@@ -309,6 +457,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
             ImportOrchestratorJobDefinition importOrchestratorInputData = new ImportOrchestratorJobDefinition();
             ImportOrchestratorJobResult importOrchestratorJobResult = new ImportOrchestratorJobResult();
             TestQueueClient testQueueClient = new TestQueueClient();
+            IAuditLogger auditLogger = Substitute.For<IAuditLogger>();
             bool getJobByGroupIdCalledTime = false;
 
             testQueueClient.GetJobByIdFunc = (queueClient, id, _) =>
@@ -349,6 +498,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
             importOrchestratorInputData.InputFormat = "ndjson";
             importOrchestratorInputData.InputSource = new Uri("http://dummy");
             importOrchestratorInputData.RequestUri = new Uri("http://dummy");
+            importOrchestratorInputData.ImportMode = importMode;
             JobInfo orchestratorJobInfo = (await testQueueClient.EnqueueAsync(0, new string[] { JsonConvert.SerializeObject(importOrchestratorInputData) }, 1, false, false, CancellationToken.None)).First();
 
             integrationDataStoreClient.GetPropertiesAsync(Arg.Any<Uri>(), Arg.Any<CancellationToken>())
@@ -367,7 +517,8 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
                 integrationDataStoreClient,
                 testQueueClient,
                 Options.Create(new ImportTaskConfiguration()),
-                loggerFactory);
+                loggerFactory,
+                auditLogger);
             orchestratorJob.PollingPeriodSec = 0;
             var jobExecutionException = await Assert.ThrowsAnyAsync<JobExecutionException>(() => orchestratorJob.ExecuteAsync(orchestratorJobInfo, new Progress<string>(), CancellationToken.None));
 
@@ -382,10 +533,45 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
                    notification.Status == JobStatus.Failed.ToString() &&
                    notification.CreateTime == orchestratorJobInfo.CreateDate),
                Arg.Any<CancellationToken>());
+
+            if (importMode == ImportMode.IncrementalLoad)
+            {
+                auditLogger.Received(1);
+                auditLogger.Received().LogAudit(
+                    auditAction: Arg.Any<AuditAction>(),
+                    operation: Arg.Any<string>(),
+                    resourceType: Arg.Any<string>(),
+                    requestUri: Arg.Any<Uri>(),
+                    statusCode: Arg.Any<HttpStatusCode?>(),
+                    correlationId: Arg.Any<string>(),
+                    callerIpAddress: Arg.Any<string>(),
+                    callerClaims: Arg.Any<IReadOnlyCollection<KeyValuePair<string, string>>>(),
+                    customHeaders: Arg.Any<IReadOnlyDictionary<string, string>>(),
+                    operationType: Arg.Any<string>(),
+                    callerAgent: Arg.Any<string>(),
+                    additionalProperties: Arg.Is<IReadOnlyDictionary<string, string>>(dict =>
+                                        dict.ContainsKey("JobId") && dict["JobId"].Equals(orchestratorJobInfo.Id.ToString()) &&
+                                        dict.ContainsKey("SucceededResources") && dict["SucceededResources"].Equals("0") &&
+                                        dict.ContainsKey("FailedResources") && dict["FailedResources"].Equals("0")));
+            }
+            else if (importMode == ImportMode.InitialLoad)
+            {
+                auditLogger.DidNotReceiveWithAnyArgs().LogAudit(
+                               auditAction: default,
+                               operation: default,
+                               resourceType: default,
+                               requestUri: default,
+                               statusCode: default,
+                               correlationId: default,
+                               callerIpAddress: default,
+                               callerClaims: default);
+            }
         }
 
-        [Fact]
-        public async Task GivenAnOrchestratorJob_WhenSubJobFailedAndOthersRunning_ThenImportProcessingExceptionShouldBeThrowAndContextUpdated()
+        [InlineData(ImportMode.InitialLoad)]
+        [InlineData(ImportMode.IncrementalLoad)]
+        [Theory]
+        public async Task GivenAnOrchestratorJob_WhenSubJobFailedAndOthersRunning_ThenImportProcessingExceptionShouldBeThrowAndContextUpdated(ImportMode importMode)
         {
             IImportOrchestratorJobDataStoreOperation fhirDataBulkImportOperation = Substitute.For<IImportOrchestratorJobDataStoreOperation>();
             RequestContextAccessor<IFhirRequestContext> contextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
@@ -394,6 +580,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
             IMediator mediator = Substitute.For<IMediator>();
             ImportOrchestratorJobDefinition importOrchestratorInputData = new ImportOrchestratorJobDefinition();
             TestQueueClient testQueueClient = new TestQueueClient();
+            IAuditLogger auditLogger = Substitute.For<IAuditLogger>();
             bool getJobByGroupIdCalledTime = false;
             testQueueClient.GetJobByIdFunc = (queueClient, id, _) =>
             {
@@ -446,6 +633,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
             importOrchestratorInputData.InputFormat = "ndjson";
             importOrchestratorInputData.InputSource = new Uri("http://dummy");
             importOrchestratorInputData.RequestUri = new Uri("http://dummy");
+            importOrchestratorInputData.ImportMode = importMode;
             JobInfo orchestratorJobInfo = (await testQueueClient.EnqueueAsync(0, new string[] { JsonConvert.SerializeObject(importOrchestratorInputData) }, 1, false, false, CancellationToken.None)).First();
 
             integrationDataStoreClient.GetPropertiesAsync(Arg.Any<Uri>(), Arg.Any<CancellationToken>())
@@ -464,7 +652,8 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
                 integrationDataStoreClient,
                 testQueueClient,
                 Options.Create(new ImportTaskConfiguration()),
-                loggerFactory);
+                loggerFactory,
+                auditLogger);
             orchestratorJob.PollingPeriodSec = 0;
 
             var jobExecutionException = await Assert.ThrowsAnyAsync<JobExecutionException>(() => orchestratorJob.ExecuteAsync(orchestratorJobInfo, new Progress<string>(), CancellationToken.None));
@@ -480,10 +669,45 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
                     notification.SucceededCount == 0 &&
                     notification.FailedCount == 0),
                 Arg.Any<CancellationToken>());
+
+            if (importMode == ImportMode.IncrementalLoad)
+            {
+                auditLogger.Received(1);
+                auditLogger.Received().LogAudit(
+                    auditAction: Arg.Any<AuditAction>(),
+                    operation: Arg.Any<string>(),
+                    resourceType: Arg.Any<string>(),
+                    requestUri: Arg.Any<Uri>(),
+                    statusCode: Arg.Any<HttpStatusCode?>(),
+                    correlationId: Arg.Any<string>(),
+                    callerIpAddress: Arg.Any<string>(),
+                    callerClaims: Arg.Any<IReadOnlyCollection<KeyValuePair<string, string>>>(),
+                    customHeaders: Arg.Any<IReadOnlyDictionary<string, string>>(),
+                    operationType: Arg.Any<string>(),
+                    callerAgent: Arg.Any<string>(),
+                    additionalProperties: Arg.Is<IReadOnlyDictionary<string, string>>(dict =>
+                                        dict.ContainsKey("JobId") && dict["JobId"].Equals(orchestratorJobInfo.Id.ToString()) &&
+                                        dict.ContainsKey("SucceededResources") && dict["SucceededResources"].Equals("0") &&
+                                        dict.ContainsKey("FailedResources") && dict["FailedResources"].Equals("0")));
+            }
+            else if (importMode == ImportMode.InitialLoad)
+            {
+                auditLogger.DidNotReceiveWithAnyArgs().LogAudit(
+                               auditAction: default,
+                               operation: default,
+                               resourceType: default,
+                               requestUri: default,
+                               statusCode: default,
+                               correlationId: default,
+                               callerIpAddress: default,
+                               callerClaims: default);
+            }
         }
 
-        [Fact]
-        public async Task GivenAnOrchestratorJob_WhneSubJobCancelledAfterThreeCalls_ThenOperationCanceledExceptionShouldBeThrowAndContextUpdate()
+        [InlineData(ImportMode.InitialLoad)]
+        [InlineData(ImportMode.IncrementalLoad)]
+        [Theory]
+        public async Task GivenAnOrchestratorJob_WhneSubJobCancelledAfterThreeCalls_ThenOperationCanceledExceptionShouldBeThrowAndContextUpdate(ImportMode importMode)
         {
             IImportOrchestratorJobDataStoreOperation fhirDataBulkImportOperation = Substitute.For<IImportOrchestratorJobDataStoreOperation>();
             RequestContextAccessor<IFhirRequestContext> contextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
@@ -492,6 +716,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
             IMediator mediator = Substitute.For<IMediator>();
             ImportOrchestratorJobDefinition importOrchestratorJobInputData = new ImportOrchestratorJobDefinition();
             TestQueueClient testQueueClient = new TestQueueClient();
+            IAuditLogger auditLogger = Substitute.For<IAuditLogger>();
             int callTime = 0;
             testQueueClient.GetJobByIdFunc = (queueClient, id, _) =>
             {
@@ -513,6 +738,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
             importOrchestratorJobInputData.InputFormat = "ndjson";
             importOrchestratorJobInputData.InputSource = new Uri("http://dummy");
             importOrchestratorJobInputData.RequestUri = new Uri("http://dummy");
+            importOrchestratorJobInputData.ImportMode = importMode;
 
             integrationDataStoreClient.GetPropertiesAsync(Arg.Any<Uri>(), Arg.Any<CancellationToken>())
                 .Returns(callInfo =>
@@ -531,7 +757,8 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
                 integrationDataStoreClient,
                 testQueueClient,
                 Options.Create(new ImportTaskConfiguration()),
-                loggerFactory);
+                loggerFactory,
+                auditLogger);
             orchestratorJob.PollingPeriodSec = 0;
 
             var jobExecutionException = await Assert.ThrowsAnyAsync<JobExecutionException>(() => orchestratorJob.ExecuteAsync(orchestratorJobInfo, new Progress<string>(), CancellationToken.None));
@@ -547,10 +774,45 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
                     notification.SucceededCount == 0 &&
                     notification.FailedCount == 0),
                 Arg.Any<CancellationToken>());
+
+            if (importMode == ImportMode.IncrementalLoad)
+            {
+                auditLogger.Received(1);
+                auditLogger.Received().LogAudit(
+                    auditAction: Arg.Any<AuditAction>(),
+                    operation: Arg.Any<string>(),
+                    resourceType: Arg.Any<string>(),
+                    requestUri: Arg.Any<Uri>(),
+                    statusCode: Arg.Any<HttpStatusCode?>(),
+                    correlationId: Arg.Any<string>(),
+                    callerIpAddress: Arg.Any<string>(),
+                    callerClaims: Arg.Any<IReadOnlyCollection<KeyValuePair<string, string>>>(),
+                    customHeaders: Arg.Any<IReadOnlyDictionary<string, string>>(),
+                    operationType: Arg.Any<string>(),
+                    callerAgent: Arg.Any<string>(),
+                    additionalProperties: Arg.Is<IReadOnlyDictionary<string, string>>(dict =>
+                                        dict.ContainsKey("JobId") && dict["JobId"].Equals(orchestratorJobInfo.Id.ToString()) &&
+                                        dict.ContainsKey("SucceededResources") && dict["SucceededResources"].Equals("0") &&
+                                        dict.ContainsKey("FailedResources") && dict["FailedResources"].Equals("0")));
+            }
+            else if (importMode == ImportMode.InitialLoad)
+            {
+                auditLogger.DidNotReceiveWithAnyArgs().LogAudit(
+                               auditAction: default,
+                               operation: default,
+                               resourceType: default,
+                               requestUri: default,
+                               statusCode: default,
+                               correlationId: default,
+                               callerIpAddress: default,
+                               callerClaims: default);
+            }
         }
 
-        [Fact]
-        public async Task GivenAnOrchestratorJob_WhenSubJobFailedAfterThreeCalls_ThenImportProcessingExceptionShouldBeThrowAndContextUpdated()
+        [InlineData(ImportMode.InitialLoad)]
+        [InlineData(ImportMode.IncrementalLoad)]
+        [Theory]
+        public async Task GivenAnOrchestratorJob_WhenSubJobFailedAfterThreeCalls_ThenImportProcessingExceptionShouldBeThrowAndContextUpdated(ImportMode importMode)
         {
             IImportOrchestratorJobDataStoreOperation fhirDataBulkImportOperation = Substitute.For<IImportOrchestratorJobDataStoreOperation>();
             RequestContextAccessor<IFhirRequestContext> contextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
@@ -559,6 +821,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
             IMediator mediator = Substitute.For<IMediator>();
             ImportOrchestratorJobDefinition importOrchestratorJobInputData = new ImportOrchestratorJobDefinition();
             TestQueueClient testQueueClient = new TestQueueClient();
+            IAuditLogger auditLogger = Substitute.For<IAuditLogger>();
             int callTime = 0;
             testQueueClient.GetJobByIdFunc = (queueClient, id, _) =>
             {
@@ -580,6 +843,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
             importOrchestratorJobInputData.InputFormat = "ndjson";
             importOrchestratorJobInputData.InputSource = new Uri("http://dummy");
             importOrchestratorJobInputData.RequestUri = new Uri("http://dummy");
+            importOrchestratorJobInputData.ImportMode = importMode;
 
             integrationDataStoreClient.GetPropertiesAsync(Arg.Any<Uri>(), Arg.Any<CancellationToken>())
                 .Returns(callInfo =>
@@ -598,7 +862,8 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
                 integrationDataStoreClient,
                 testQueueClient,
                 Options.Create(new ImportTaskConfiguration()),
-                loggerFactory);
+                loggerFactory,
+                auditLogger);
             orchestratorJob.PollingPeriodSec = 0;
 
             var jobExecutionException = await Assert.ThrowsAnyAsync<JobExecutionException>(() => orchestratorJob.ExecuteAsync(orchestratorJobInfo, new Progress<string>(), CancellationToken.None));
@@ -615,10 +880,45 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
                     notification.SucceededCount == 0 &&
                     notification.FailedCount == 0),
                 Arg.Any<CancellationToken>());
+
+            if (importMode == ImportMode.IncrementalLoad)
+            {
+                auditLogger.Received(1);
+                auditLogger.Received().LogAudit(
+                    auditAction: Arg.Any<AuditAction>(),
+                    operation: Arg.Any<string>(),
+                    resourceType: Arg.Any<string>(),
+                    requestUri: Arg.Any<Uri>(),
+                    statusCode: Arg.Any<HttpStatusCode?>(),
+                    correlationId: Arg.Any<string>(),
+                    callerIpAddress: Arg.Any<string>(),
+                    callerClaims: Arg.Any<IReadOnlyCollection<KeyValuePair<string, string>>>(),
+                    customHeaders: Arg.Any<IReadOnlyDictionary<string, string>>(),
+                    operationType: Arg.Any<string>(),
+                    callerAgent: Arg.Any<string>(),
+                    additionalProperties: Arg.Is<IReadOnlyDictionary<string, string>>(dict =>
+                                        dict.ContainsKey("JobId") && dict["JobId"].Equals(orchestratorJobInfo.Id.ToString()) &&
+                                        dict.ContainsKey("SucceededResources") && dict["SucceededResources"].Equals("0") &&
+                                        dict.ContainsKey("FailedResources") && dict["FailedResources"].Equals("0")));
+            }
+            else if (importMode == ImportMode.InitialLoad)
+            {
+                auditLogger.DidNotReceiveWithAnyArgs().LogAudit(
+                               auditAction: default,
+                               operation: default,
+                               resourceType: default,
+                               requestUri: default,
+                               statusCode: default,
+                               correlationId: default,
+                               callerIpAddress: default,
+                               callerClaims: default);
+            }
         }
 
-        [Fact]
-        public async Task GivenAnOrchestratorJob_WhenSubJobCancelled_ThenOperationCancelledExceptionShouldBeThrowAndContextUpdated()
+        [InlineData(ImportMode.InitialLoad)]
+        [InlineData(ImportMode.IncrementalLoad)]
+        [Theory]
+        public async Task GivenAnOrchestratorJob_WhenSubJobCancelled_ThenOperationCancelledExceptionShouldBeThrowAndContextUpdated(ImportMode importMode)
         {
             IImportOrchestratorJobDataStoreOperation fhirDataBulkImportOperation = Substitute.For<IImportOrchestratorJobDataStoreOperation>();
             RequestContextAccessor<IFhirRequestContext> contextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
@@ -627,6 +927,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
             IMediator mediator = Substitute.For<IMediator>();
             ImportOrchestratorJobDefinition importOrchestratorInputData = new ImportOrchestratorJobDefinition();
             TestQueueClient testQueueClient = new TestQueueClient();
+            IAuditLogger auditLogger = Substitute.For<IAuditLogger>();
             testQueueClient.GetJobByIdFunc = (queueClient, id, _) =>
             {
                 JobInfo jobInfo = new JobInfo()
@@ -647,6 +948,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
             importOrchestratorInputData.InputFormat = "ndjson";
             importOrchestratorInputData.InputSource = new Uri("http://dummy");
             importOrchestratorInputData.RequestUri = new Uri("http://dummy");
+            importOrchestratorInputData.ImportMode = importMode;
 
             integrationDataStoreClient.GetPropertiesAsync(Arg.Any<Uri>(), Arg.Any<CancellationToken>())
                 .Returns(callInfo =>
@@ -666,7 +968,8 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
                 integrationDataStoreClient,
                 testQueueClient,
                 Options.Create(new ImportTaskConfiguration()),
-                loggerFactory);
+                loggerFactory,
+                auditLogger);
             orchestratorJob.PollingPeriodSec = 0;
 
             var jobExecutionException = await Assert.ThrowsAnyAsync<JobExecutionException>(() => orchestratorJob.ExecuteAsync(orchestratorJobInfo, new Progress<string>(), CancellationToken.None));
@@ -682,10 +985,45 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
                     notification.SucceededCount == 0 &&
                     notification.FailedCount == 0),
                 Arg.Any<CancellationToken>());
+
+            if (importMode == ImportMode.IncrementalLoad)
+            {
+                auditLogger.Received(1);
+                auditLogger.Received().LogAudit(
+                    auditAction: Arg.Any<AuditAction>(),
+                    operation: Arg.Any<string>(),
+                    resourceType: Arg.Any<string>(),
+                    requestUri: Arg.Any<Uri>(),
+                    statusCode: Arg.Any<HttpStatusCode?>(),
+                    correlationId: Arg.Any<string>(),
+                    callerIpAddress: Arg.Any<string>(),
+                    callerClaims: Arg.Any<IReadOnlyCollection<KeyValuePair<string, string>>>(),
+                    customHeaders: Arg.Any<IReadOnlyDictionary<string, string>>(),
+                    operationType: Arg.Any<string>(),
+                    callerAgent: Arg.Any<string>(),
+                    additionalProperties: Arg.Is<IReadOnlyDictionary<string, string>>(dict =>
+                                        dict.ContainsKey("JobId") && dict["JobId"].Equals(orchestratorJobInfo.Id.ToString()) &&
+                                        dict.ContainsKey("SucceededResources") && dict["SucceededResources"].Equals("0") &&
+                                        dict.ContainsKey("FailedResources") && dict["FailedResources"].Equals("0")));
+            }
+            else if (importMode == ImportMode.InitialLoad)
+            {
+                auditLogger.DidNotReceiveWithAnyArgs().LogAudit(
+                               auditAction: default,
+                               operation: default,
+                               resourceType: default,
+                               requestUri: default,
+                               statusCode: default,
+                               correlationId: default,
+                               callerIpAddress: default,
+                               callerClaims: default);
+            }
         }
 
-        [Fact]
-        public async Task GivenAnOrchestratorJob_WhenSubJobFailed_ThenImportProcessingExceptionShouldBeThrowAndContextUpdated()
+        [InlineData(ImportMode.InitialLoad)]
+        [InlineData(ImportMode.IncrementalLoad)]
+        [Theory]
+        public async Task GivenAnOrchestratorJob_WhenSubJobFailed_ThenImportProcessingExceptionShouldBeThrowAndContextUpdated(ImportMode importMode)
         {
             IImportOrchestratorJobDataStoreOperation fhirDataBulkImportOperation = Substitute.For<IImportOrchestratorJobDataStoreOperation>();
             RequestContextAccessor<IFhirRequestContext> contextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
@@ -694,6 +1032,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
             IMediator mediator = Substitute.For<IMediator>();
             ImportOrchestratorJobDefinition importOrchestratorInputData = new ImportOrchestratorJobDefinition();
             TestQueueClient testQueueClient = new TestQueueClient();
+            IAuditLogger auditLogger = Substitute.For<IAuditLogger>();
             testQueueClient.GetJobByIdFunc = (queueClient, id, _) =>
             {
                 JobInfo jobInfo = new JobInfo()
@@ -714,6 +1053,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
             importOrchestratorInputData.InputFormat = "ndjson";
             importOrchestratorInputData.InputSource = new Uri("http://dummy");
             importOrchestratorInputData.RequestUri = new Uri("http://dummy");
+            importOrchestratorInputData.ImportMode = importMode;
 
             integrationDataStoreClient.GetPropertiesAsync(Arg.Any<Uri>(), Arg.Any<CancellationToken>())
                 .Returns(callInfo =>
@@ -733,7 +1073,8 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
                 integrationDataStoreClient,
                 testQueueClient,
                 Options.Create(new Core.Configs.ImportTaskConfiguration()),
-                loggerFactory);
+                loggerFactory,
+                auditLogger);
             orchestratorJob.PollingPeriodSec = 0;
 
             var jobExecutionException = await Assert.ThrowsAnyAsync<JobExecutionException>(() => orchestratorJob.ExecuteAsync(orchestratorJobInfo, new Progress<string>(), CancellationToken.None));
@@ -752,10 +1093,45 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
                     notification.SucceededCount == 0 &&
                     notification.FailedCount == 0),
                 Arg.Any<CancellationToken>());
+
+            if (importMode == ImportMode.IncrementalLoad)
+            {
+                auditLogger.Received(1);
+                auditLogger.Received().LogAudit(
+                    auditAction: Arg.Any<AuditAction>(),
+                    operation: Arg.Any<string>(),
+                    resourceType: Arg.Any<string>(),
+                    requestUri: Arg.Any<Uri>(),
+                    statusCode: Arg.Any<HttpStatusCode?>(),
+                    correlationId: Arg.Any<string>(),
+                    callerIpAddress: Arg.Any<string>(),
+                    callerClaims: Arg.Any<IReadOnlyCollection<KeyValuePair<string, string>>>(),
+                    customHeaders: Arg.Any<IReadOnlyDictionary<string, string>>(),
+                    operationType: Arg.Any<string>(),
+                    callerAgent: Arg.Any<string>(),
+                    additionalProperties: Arg.Is<IReadOnlyDictionary<string, string>>(dict =>
+                                        dict.ContainsKey("JobId") && dict["JobId"].Equals(orchestratorJobInfo.Id.ToString()) &&
+                                        dict.ContainsKey("SucceededResources") && dict["SucceededResources"].Equals("0") &&
+                                        dict.ContainsKey("FailedResources") && dict["FailedResources"].Equals("0")));
+            }
+            else if (importMode == ImportMode.InitialLoad)
+            {
+                auditLogger.DidNotReceiveWithAnyArgs().LogAudit(
+                               auditAction: default,
+                               operation: default,
+                               resourceType: default,
+                               requestUri: default,
+                               statusCode: default,
+                               correlationId: default,
+                               callerIpAddress: default,
+                               callerClaims: default);
+            }
         }
 
-        [Fact]
-        public async Task GivenAnOrchestratorJob_WhenFailedAtPostProcessStep_ThenRetrableExceptionShouldBeThrowAndContextUpdated()
+        [InlineData(ImportMode.InitialLoad)]
+        [InlineData(ImportMode.IncrementalLoad)]
+        [Theory]
+        public async Task GivenAnOrchestratorJob_WhenFailedAtPostProcessStep_ThenRetrableExceptionShouldBeThrowAndContextUpdated(ImportMode importMode)
         {
             IImportOrchestratorJobDataStoreOperation fhirDataBulkImportOperation = Substitute.For<IImportOrchestratorJobDataStoreOperation>();
             RequestContextAccessor<IFhirRequestContext> contextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
@@ -764,6 +1140,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
             IMediator mediator = Substitute.For<IMediator>();
             ImportOrchestratorJobDefinition importOrchestratorJobInputData = new ImportOrchestratorJobDefinition();
             TestQueueClient testQueueClient = new TestQueueClient();
+            IAuditLogger auditLogger = Substitute.For<IAuditLogger>();
             testQueueClient.GetJobByIdFunc = (testQueueClient, id, _) =>
             {
                 JobInfo jobInfo = testQueueClient.JobInfos.First(t => t.Id == id);
@@ -797,6 +1174,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
             importOrchestratorJobInputData.InputFormat = "ndjson";
             importOrchestratorJobInputData.InputSource = new Uri("http://dummy");
             importOrchestratorJobInputData.RequestUri = new Uri("http://dummy");
+            importOrchestratorJobInputData.ImportMode = importMode;
 
             integrationDataStoreClient.GetPropertiesAsync(Arg.Any<Uri>(), Arg.Any<CancellationToken>())
                 .Returns(callInfo =>
@@ -822,7 +1200,8 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
                 integrationDataStoreClient,
                 testQueueClient,
                 Options.Create(new Core.Configs.ImportTaskConfiguration()),
-                loggerFactory);
+                loggerFactory,
+                auditLogger);
             orchestratorJob.PollingPeriodSec = 0;
 
             await Assert.ThrowsAnyAsync<RetriableJobException>(() => orchestratorJob.ExecuteAsync(orchestratorJobInfo, new Progress<string>(), CancellationToken.None));
@@ -830,6 +1209,16 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
             _ = mediator.DidNotReceive().Publish(
                 Arg.Any<ImportJobMetricsNotification>(),
                 Arg.Any<CancellationToken>());
+
+            auditLogger.DidNotReceiveWithAnyArgs().LogAudit(
+                               auditAction: default,
+                               operation: default,
+                               resourceType: default,
+                               requestUri: default,
+                               statusCode: default,
+                               correlationId: default,
+                               callerIpAddress: default,
+                               callerClaims: default);
         }
 
         [Fact]
@@ -843,6 +1232,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
             ImportOrchestratorJobDefinition importOrchestratorJobInputData = new ImportOrchestratorJobDefinition();
             List<(long begin, long end)> surrogatedIdRanges = new List<(long begin, long end)>();
             TestQueueClient testQueueClient = new TestQueueClient();
+            IAuditLogger auditLogger = Substitute.For<IAuditLogger>();
             testQueueClient.GetJobByIdFunc = (testQueueClient, id, cancellationToken) =>
             {
                 JobInfo jobInfo = testQueueClient.JobInfos.First(t => t.Id == id);
@@ -888,7 +1278,8 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
                 integrationDataStoreClient,
                 testQueueClient,
                 Options.Create(new Core.Configs.ImportTaskConfiguration()),
-                loggerFactory);
+                loggerFactory,
+                auditLogger);
             orchestratorJob.PollingPeriodSec = 0;
 
             CancellationTokenSource cancellationToken = new CancellationTokenSource();
@@ -909,6 +1300,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
             ImportOrchestratorJobResult importOrchestratorJobResult = new ImportOrchestratorJobResult();
 
             TestQueueClient testQueueClient = new TestQueueClient();
+            IAuditLogger auditLogger = Substitute.For<IAuditLogger>();
             testQueueClient.GetJobByIdFunc = (testQueueClient, id, _) =>
             {
                 JobInfo jobInfo = testQueueClient.JobInfos.First(t => t.Id == id);
@@ -1010,7 +1402,8 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
                 integrationDataStoreClient,
                 testQueueClient,
                 Options.Create(new ImportTaskConfiguration()),
-                loggerFactory);
+                loggerFactory,
+                auditLogger);
             orchestratorJob.PollingPeriodSec = 0;
             var jobExecutionException = await Assert.ThrowsAnyAsync<JobExecutionException>(() => orchestratorJob.ExecuteAsync(orchestratorJobInfo, new Progress<string>(), CancellationToken.None));
             ImportOrchestratorJobErrorResult resultDetails = (ImportOrchestratorJobErrorResult)jobExecutionException.Error;
@@ -1037,6 +1430,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
             ImportOrchestratorJobResult importOrchestratorJobResult = new ImportOrchestratorJobResult();
 
             TestQueueClient testQueueClient = new TestQueueClient();
+            IAuditLogger auditLogger = Substitute.For<IAuditLogger>();
             testQueueClient.GetJobByIdFunc = (testQueueClient, id, _) =>
             {
                 JobInfo jobInfo = testQueueClient.JobInfos.First(t => t.Id == id);
@@ -1138,7 +1532,8 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Import
                 integrationDataStoreClient,
                 testQueueClient,
                 Options.Create(new Core.Configs.ImportTaskConfiguration()),
-                loggerFactory)
+                loggerFactory,
+                auditLogger)
             {
                 PollingPeriodSec = 0,
             };

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/ImportOrchestratorJob.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/ImportOrchestratorJob.cs
@@ -296,7 +296,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
                 operationType: string.Empty,
                 callerAgent: DefaultCallerAgent,
                 additionalProperties: incrementalImportProperties);
-                _logger.LogInformation("After logging Audit logs for incremental import");
+                _logger.LogInformation("Audit logs for incremental import are added");
             }
 
             var importJobMetricsNotification = new ImportJobMetricsNotification(

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/ImportOrchestratorJob.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/ImportOrchestratorJob.cs
@@ -12,13 +12,16 @@ using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
+using Hl7.Fhir.Rest;
 using MediatR;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Health.Core;
+using Microsoft.Health.Core.Features.Audit;
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Configs;
+using Microsoft.Health.Fhir.Core.Features.Audit;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Operations.Import;
@@ -41,6 +44,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
         private ImportTaskConfiguration _importConfiguration;
         private ILogger<ImportOrchestratorJob> _logger;
         private IIntegrationDataStoreClient _integrationDataStoreClient;
+        private readonly IAuditLogger _auditLogger;
+        internal const string DefaultCallerAgent = "Microsoft.Health.Fhir.Server";
 
         public ImportOrchestratorJob(
             IMediator mediator,
@@ -49,7 +54,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
             IIntegrationDataStoreClient integrationDataStoreClient,
             IQueueClient queueClient,
             IOptions<ImportTaskConfiguration> importConfiguration,
-            ILoggerFactory loggerFactory)
+            ILoggerFactory loggerFactory,
+            IAuditLogger auditLogger)
         {
             EnsureArg.IsNotNull(mediator, nameof(mediator));
             EnsureArg.IsNotNull(contextAccessor, nameof(contextAccessor));
@@ -58,6 +64,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
             EnsureArg.IsNotNull(queueClient, nameof(queueClient));
             EnsureArg.IsNotNull(importConfiguration?.Value, nameof(importConfiguration));
             EnsureArg.IsNotNull(loggerFactory, nameof(loggerFactory));
+            EnsureArg.IsNotNull(auditLogger, nameof(auditLogger));
 
             _mediator = mediator;
             _contextAccessor = contextAccessor;
@@ -66,6 +73,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
             _queueClient = queueClient;
             _importConfiguration = importConfiguration.Value;
             _logger = loggerFactory.CreateLogger<ImportOrchestratorJob>();
+            _auditLogger = auditLogger;
 
             PollingPeriodSec = _importConfiguration.PollingFrequencyInSeconds;
         }
@@ -142,7 +150,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
 
                 // Processing jobs has been cancelled by CancelImportRequestHandler
                 await WaitCancelledJobCompletedAsync(jobInfo);
-                await SendImportMetricsNotification(JobStatus.Cancelled, jobInfo, currentResult, inputData.ImportMode);
+                await SendImportMetricsNotification(JobStatus.Cancelled, jobInfo, currentResult, inputData.ImportMode, fhirRequestContext);
             }
             catch (OperationCanceledException canceledEx)
             {
@@ -156,7 +164,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
 
                 // Processing jobs has been cancelled by CancelImportRequestHandler
                 await WaitCancelledJobCompletedAsync(jobInfo);
-                await SendImportMetricsNotification(JobStatus.Cancelled, jobInfo, currentResult, inputData.ImportMode);
+                await SendImportMetricsNotification(JobStatus.Cancelled, jobInfo, currentResult, inputData.ImportMode, fhirRequestContext);
             }
             catch (IntegrationDataStoreException integrationDataStoreEx)
             {
@@ -168,7 +176,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
                     ErrorMessage = integrationDataStoreEx.Message,
                 };
 
-                await SendImportMetricsNotification(JobStatus.Failed, jobInfo, currentResult, inputData.ImportMode);
+                await SendImportMetricsNotification(JobStatus.Failed, jobInfo, currentResult, inputData.ImportMode, fhirRequestContext);
             }
             catch (ImportFileEtagNotMatchException eTagEx)
             {
@@ -180,7 +188,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
                     ErrorMessage = eTagEx.Message,
                 };
 
-                await SendImportMetricsNotification(JobStatus.Failed, jobInfo, currentResult, inputData.ImportMode);
+                await SendImportMetricsNotification(JobStatus.Failed, jobInfo, currentResult, inputData.ImportMode, fhirRequestContext);
             }
             catch (ImportProcessingException processingEx)
             {
@@ -195,7 +203,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
 
                 // Cancel other processing jobs
                 await CancelProcessingJobsAsync(jobInfo);
-                await SendImportMetricsNotification(JobStatus.Failed, jobInfo, currentResult, inputData.ImportMode);
+                await SendImportMetricsNotification(JobStatus.Failed, jobInfo, currentResult, inputData.ImportMode, fhirRequestContext);
             }
             catch (RetriableJobException ex)
             {
@@ -216,7 +224,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
 
                 // Cancel processing jobs for critical error in orchestrator job
                 await CancelProcessingJobsAsync(jobInfo);
-                await SendImportMetricsNotification(JobStatus.Failed, jobInfo, currentResult, inputData.ImportMode);
+                await SendImportMetricsNotification(JobStatus.Failed, jobInfo, currentResult, inputData.ImportMode, fhirRequestContext);
             }
 
             // Post-process operation cannot be cancelled.
@@ -245,7 +253,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
                 throw new JobExecutionException(errorResult.ErrorMessage, errorResult);
             }
 
-            await SendImportMetricsNotification(JobStatus.Completed, jobInfo, currentResult, inputData.ImportMode);
+            await SendImportMetricsNotification(JobStatus.Completed, jobInfo, currentResult, inputData.ImportMode, fhirRequestContext);
             return JsonConvert.SerializeObject(currentResult);
         }
 
@@ -264,9 +272,33 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
             });
         }
 
-        private async Task SendImportMetricsNotification(JobStatus jobStatus, JobInfo jobInfo, ImportOrchestratorJobResult currentResult, ImportMode importMode)
+        private async Task SendImportMetricsNotification(JobStatus jobStatus, JobInfo jobInfo, ImportOrchestratorJobResult currentResult, ImportMode importMode, FhirRequestContext fhirRequestContext)
         {
             _logger.LogInformation("SucceededResources {SucceededResources} and FailedResources {FailedResources} in Import", currentResult.SucceededResources, currentResult.FailedResources);
+
+            if (importMode == ImportMode.IncrementalLoad)
+            {
+                var incrementalImportProperties = new Dictionary<string, string>();
+                incrementalImportProperties["JobId"] = jobInfo.Id.ToString();
+                incrementalImportProperties["SucceededResources"] = currentResult.SucceededResources.ToString();
+                incrementalImportProperties["FailedResources"] = currentResult.FailedResources.ToString();
+
+                _auditLogger.LogAudit(
+                AuditAction.Executed,
+                operation: ImportMode.IncrementalLoad.ToString(),
+                resourceType: string.Empty,
+                requestUri: fhirRequestContext.Uri,
+                statusCode: HttpStatusCode.Accepted,
+                correlationId: fhirRequestContext.CorrelationId,
+                callerIpAddress: string.Empty,
+                callerClaims: null,
+                customHeaders: null,
+                operationType: string.Empty,
+                callerAgent: DefaultCallerAgent,
+                additionalProperties: incrementalImportProperties);
+                _logger.LogInformation("After logging Audit logs for incremental import");
+            }
+
             var importJobMetricsNotification = new ImportJobMetricsNotification(
                 jobInfo.Id.ToString(),
                 jobStatus.ToString(),

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/TraceAuditLogger.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/TraceAuditLogger.cs
@@ -28,7 +28,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit
             IReadOnlyCollection<KeyValuePair<string, string>> callerClaims,
             IReadOnlyDictionary<string, string> customHeaders,
             string operationType,
-            string callerAgent)
+            string callerAgent,
+            IReadOnlyDictionary<string, string> additionalProperties)
         {
             _auditEntries.Add(new AuditEntry(
                 auditAction,


### PR DESCRIPTION
## Description
Modified IAuditLogger interface to support additionalProperties dictionary values.
For incremental import, I am sending job Id, succeeded count and failed count.
additionalProperties can be used in future for sending other information into audit logs as well.

## Related issues
Addresses [issue # [103223](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Olympus/Stories/?workitem=103223)].

## Testing
Tested by manually running both initial and incremental load.
Created test cases.


## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
