### PR TITLE
Removed Status for Search Params in Capability Statement

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
@@ -8,11 +8,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using EnsureThat;
 using Hl7.Fhir.ElementModel;
-using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Core.Configs;
@@ -39,29 +36,25 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
         private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager;
         private readonly CoreFeatureConfiguration _configuration;
         private readonly ISupportedProfilesStore _supportedProfiles;
-        private readonly SearchParameterStatusManager _searchParameterStatusManager;
 
         private CapabilityStatementBuilder(
             ListedCapabilityStatement statement,
             IModelInfoProvider modelInfoProvider,
             ISearchParameterDefinitionManager searchParameterDefinitionManager,
             IOptions<CoreFeatureConfiguration> configuration,
-            ISupportedProfilesStore supportedProfiles,
-            SearchParameterStatusManager searchParameterStatusManager)
+            ISupportedProfilesStore supportedProfiles)
         {
             EnsureArg.IsNotNull(statement, nameof(statement));
             EnsureArg.IsNotNull(modelInfoProvider, nameof(modelInfoProvider));
             EnsureArg.IsNotNull(searchParameterDefinitionManager, nameof(searchParameterDefinitionManager));
             EnsureArg.IsNotNull(configuration, nameof(configuration));
             EnsureArg.IsNotNull(supportedProfiles, nameof(supportedProfiles));
-            EnsureArg.IsNotNull(searchParameterStatusManager, nameof(searchParameterStatusManager));
 
             _statement = statement;
             _modelInfoProvider = modelInfoProvider;
             _searchParameterDefinitionManager = searchParameterDefinitionManager;
             _configuration = configuration.Value;
             _supportedProfiles = supportedProfiles;
-            _searchParameterStatusManager = searchParameterStatusManager;
         }
 
         public static ICapabilityStatementBuilder Create(
@@ -100,7 +93,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
             statement.Date = ProductVersionInfo.CreationTime.ToString("O");
             statement.Url = urlResolver.ResolveMetadataUrl(false);
 
-            return new CapabilityStatementBuilder(statement, modelInfoProvider, searchParameterDefinitionManager, configuration, supportedProfiles, searchParameterStatusManager);
+            return new CapabilityStatementBuilder(statement, modelInfoProvider, searchParameterDefinitionManager, configuration, supportedProfiles);
         }
 
         public ICapabilityStatementBuilder Apply(Action<ListedCapabilityStatement> action)
@@ -184,13 +177,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
             return this;
         }
 
-        private async Task<ICapabilityStatementBuilder> SyncSearchParamsAsync(string resourceType, CancellationToken cancellationToken)
+        private ICapabilityStatementBuilder SyncSearchParamsAsync(string resourceType)
         {
             EnsureArg.IsNotNullOrEmpty(resourceType, nameof(resourceType));
             EnsureArg.IsTrue(_modelInfoProvider.IsKnownResource(resourceType), nameof(resourceType), x => GenerateTypeErrorMessage(x, resourceType));
 
             List<SearchParameterInfo> searchParams = _searchParameterDefinitionManager.GetSearchParameters(resourceType).ToList();
-            var searchParamStatuses = await _searchParameterStatusManager.GetAllSearchParameterStatus(cancellationToken);
 
             if (searchParams.Any())
             {
@@ -338,10 +330,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
             return this;
         }
 
-        public async Task<ICapabilityStatementBuilder> SyncSearchParametersAsync(CancellationToken cancellationToken)
+        public ICapabilityStatementBuilder SyncSearchParametersAsync()
         {
-            EnsureArg.IsNotNull(_searchParameterStatusManager, nameof(_searchParameterStatusManager));
-
             foreach (string resource in _modelInfoProvider.GetResourceTypeNames())
             {
                 ApplyToResource(resource, c => c.SearchRevInclude.Clear());
@@ -355,7 +345,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
                     continue;
                 }
 
-                await SyncSearchParamsAsync(resource, cancellationToken);
+                SyncSearchParamsAsync(resource);
             }
 
             return this;

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
@@ -211,8 +211,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
                             continue;
                         }
 
-                        string status = string.Format("Current status of search parameter is {0}. ", searchParamStatuses.SingleOrDefault(x => x.Uri == searchParam.Definition)?.Status.ToString());
-                        searchParam.Documentation = status = status + searchParam.Documentation;
                         c.SearchParam.Add(searchParam);
                     }
                 });

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/ICapabilityStatementBuilder.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/ICapabilityStatementBuilder.cs
@@ -47,8 +47,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
         /// <summary>
         /// Updates capability statement to latest supported search paramaters by checkin in memory storage for search parameters.
         /// </summary>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        Task<ICapabilityStatementBuilder> SyncSearchParametersAsync(CancellationToken cancellationToken);
+        ICapabilityStatementBuilder SyncSearchParametersAsync();
 
         /// <summary>
         /// Updates capability statement to lastest supported profiles by pulling them from database.

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/SystemConformanceProvider.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/SystemConformanceProvider.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
                 if (_builder != null)
                 {
                     // Update search params;
-                    await _builder.SyncSearchParametersAsync(CancellationToken.None);
+                    _builder.SyncSearchParametersAsync();
 
                     // Update supported profiles;
                     _builder.SyncProfiles();
@@ -246,7 +246,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
                 {
                     case RebuildPart.SearchParameter:
                         // Update search params;
-                        await _builder.SyncSearchParametersAsync(cancellationToken);
+                        _builder.SyncSearchParametersAsync();
                         break;
 
                     case RebuildPart.Profiles:

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -693,9 +693,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
             try
             {
                 watch = Stopwatch.StartNew();
-                var builderTask = Task.Run(() => builder.SyncSearchParametersAsync(CancellationToken.None));
-                builderTask.Wait();
-                builder = builderTask.Result;
+                builder = builder.SyncSearchParametersAsync();
                 _logger.LogInformation("CosmosFhirDataStore. 'Search Parameters' built. Elapsed: {ElapsedTime}. Memory: {MemoryInUse}.", watch.Elapsed, GC.GetTotalMemory(forceFullCollection: false));
             }
             catch (Exception e)

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Conformance/ConformanceBuilderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Conformance/ConformanceBuilderTests.cs
@@ -186,14 +186,14 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Conformance
         }
 
         [Fact]
-        public async System.Threading.Tasks.Task GivenAConformanceBuilder_WhenSyncSearchParameters_ThenDocumentationIsAdded()
+        public void GivenAConformanceBuilder_WhenSyncSearchParameters_ThenDocumentationIsAdded()
         {
             string description = "Logical id of this artifact";
 
             _searchParameterDefinitionManager.GetSearchParameters("Account")
                 .Returns(new[] { new SearchParameterInfo("_id", "_id", SearchParamType.Token, description: description), });
 
-            await _builder.SyncSearchParametersAsync(CancellationToken.None);
+            _builder.SyncSearchParametersAsync();
 
             ITypedElement statement = _builder.Build();
 
@@ -243,12 +243,12 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Conformance
         }
 
         [Fact]
-        public async void GivenAConformanceBuilder_WhenAddingResourceSearchParamAndSync_ThenTypeSearchParamIsNotAddedUnderResource()
+        public void GivenAConformanceBuilder_WhenAddingResourceSearchParamAndSync_ThenTypeSearchParamIsNotAddedUnderResource()
         {
             _searchParameterDefinitionManager.GetSearchParameters("Account")
                .Returns(new[] { new SearchParameterInfo("_type", "_type", SearchParamType.Token, description: "description"), });
 
-            await _builder.SyncSearchParametersAsync(CancellationToken.None);
+            _builder.SyncSearchParametersAsync();
 
             ITypedElement statement = _builder.Build();
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -679,10 +679,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
         {
             EnsureArg.IsNotNull(builder, nameof(builder));
 
-            var task = Task.Run(() => builder.PopulateDefaultResourceInteractions()
-                .SyncSearchParametersAsync(CancellationToken.None));
-            task.Wait();
-            builder.AddGlobalSearchParameters()
+            builder.PopulateDefaultResourceInteractions()
+                .SyncSearchParametersAsync()
+                .AddGlobalSearchParameters()
                 .SyncProfiles();
 
             if (_coreFeatures.SupportsBatch)


### PR DESCRIPTION
## Description
The change to use Documentation field to host search parameter status was redundant since it always is "Enabled". Removing this as it isn't needed.

## Related issues
Addresses [issue AB#104442].

## Testing
Ran Capability statement Unit Tests, and manually validated that the field no longer displays the status.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
