### PR TITLE
Added task in Analyze.yml to cleanup VM in Build

### DIFF
--- a/build/jobs/analyze.yml
+++ b/build/jobs/analyze.yml
@@ -141,6 +141,13 @@ steps:
     GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)\build\jobs\tsaconfig.gdntsa'
     GdnPublishTsaExportedResultsPublishable: true
 
+
+- task: DeleteFiles@1
+  displayName: 'Delete files to make space'
+  inputs:
+    SourceFolder: '$(Build.SourcesDirectory)'
+    Contents: '**\*'
+
 - task: DropValidatorTask@0
   displayName: 'SBOM Validator and Publisher Task'
   inputs:


### PR DESCRIPTION
## Description
Added delete file task to free up space on the VM as it tends to run out before all tasks complete. Issue was with SBOM validator task indicating no more space before it could run. This delete task removes the build sourcesdirectory content as SBOM only deals with the artifacts from the build at that point. 

## Related issues
Addresses [issue #].

## Testing
Testing on PR build pipeline.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
