### PR TITLE
cleanup the retry logic

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -581,23 +581,18 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
         public async Task<SearchResult> SearchBySurrogateIdRange(string resourceType, long startId, long endId, long? windowStartId, long? windowEndId, CancellationToken cancellationToken, string searchParamHashFilter = null)
         {
             var resourceTypeId = _model.GetResourceTypeId(resourceType);
-            SearchResult searchResult = null;
+            using var sqlCommand = new SqlCommand();
+            sqlCommand.CommandTimeout = GetReindexCommandTimeout();
+            PopulateSqlCommandFromQueryHints(sqlCommand, resourceTypeId, startId, endId, windowStartId, windowEndId);
+            LogSqlCommand(sqlCommand);
+            List<SearchResultEntry> resources = null;
             await _sqlRetryService.ExecuteSql(
-                async (cancellationToken, sqlException) =>
+                sqlCommand,
+                async (cmd, cancel) =>
                 {
-                    using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(initialCatalog: null, cancellationToken: cancellationToken).ConfigureAwait(false);
-                    using SqlCommand sqlCommand = connection.CreateCommand();
-                    connection.RetryLogicProvider = null; // To remove this line _sqlConnectionBuilder in healthcare-shared-components must be modified.
-                    await connection.OpenAsync(cancellationToken);
-
-                    sqlCommand.CommandTimeout = GetReindexCommandTimeout();
-                    PopulateSqlCommandFromQueryHints(sqlCommand, resourceTypeId, startId, endId, windowStartId, windowEndId);
-                    LogSqlCommand(sqlCommand);
-
-                    using SqlDataReader reader = await sqlCommand.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken);
-
-                    var resources = new List<SearchResultEntry>();
-                    while (await reader.ReadAsync(cancellationToken))
+                    using SqlDataReader reader = await cmd.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancel);
+                    resources = new List<SearchResultEntry>();
+                    while (await reader.ReadAsync(cancel))
                     {
                         ReadWrapper(
                             reader,
@@ -651,12 +646,12 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                             isMatch ? SearchEntryMode.Match : SearchEntryMode.Include));
                     }
 
-                    searchResult = new SearchResult(resources, null, null, new List<Tuple<string, string>>());
-                    searchResult.TotalCount = resources.Count;
                     return;
                 },
+                _logger,
+                null,
                 cancellationToken);
-            return searchResult;
+            return new SearchResult(resources, null, null, new List<Tuple<string, string>>()) { TotalCount = resources.Count };
         }
 
         private static (long StartId, long EndId) ReaderToSurrogateIdRange(SqlDataReader sqlDataReader)
@@ -666,8 +661,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
 
         public override async Task<IReadOnlyList<(long StartId, long EndId)>> GetSurrogateIdRanges(string resourceType, long startId, long endId, int rangeSize, int numberOfRanges, bool up, CancellationToken cancellationToken)
         {
-            // TODO: this code will not set capacity for the result list!
-
             var resourceTypeId = _model.GetResourceTypeId(resourceType);
             List<(long StartId, long EndId)> searchList = null;
             await _sqlRetryService.ExecuteSql(


### PR DESCRIPTION
## Description
Fix the retry logic so that it correctly applies the retry logic

## Related issues
Addresses [issue #].

## Testing
Ran this against my local reindex job

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
