### PR TITLE
Updating to ci3 as ci2 won't setup sql dbs.

### DIFF
--- a/build/ci-variables.yml
+++ b/build/ci-variables.yml
@@ -1,7 +1,7 @@
 variables:
     ResourceGroupRegion: 'southcentralus'
     # Due to deleting a keyvault with purge protection we must use a name other than msh-fhir-ci for 90 days after 5/20/2021.
-    resourceGroupRoot: 'msh-fhir-ci2'
+    resourceGroupRoot: 'msh-fhir-ci3'
     appServicePlanName: '$(resourceGroupRoot)-linux'
     DeploymentEnvironmentName: '$(resourceGroupRoot)'
     ResourceGroupName: '$(resourceGroupRoot)'


### PR DESCRIPTION
## Description
Static CI pipeline had its tokens expire and needed to be recreated. Ran into issue where the SQL servers were not creating due to a logical operation needing to finish. I incremented the resource group name and created a new CI environment. Need this checked in so all other builds will point to the new location.

## Related issues
Addresses [issue #]. Fixes CI pipeline being broken.

## Testing
Ran through the pipeline and verified new resources are up.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
