### PR TITLE
fix reindex calls so that they correctly apply retry calls

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -59,7 +59,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
         private readonly ILogger<SqlServerSearchService> _logger;
         private readonly BitColumn _isMatch = new BitColumn("IsMatch");
         private readonly BitColumn _isPartial = new BitColumn("IsPartial");
-        private readonly SqlConnectionWrapperFactory _sqlConnectionWrapperFactory;
         private readonly ISqlConnectionBuilder _sqlConnectionBuilder;
         private readonly ISqlRetryService _sqlRetryService;
         private readonly SqlServerDataStoreConfiguration _sqlServerDataStoreConfiguration;
@@ -81,7 +80,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
             PartitionEliminationRewriter partitionEliminationRewriter,
             CompartmentSearchRewriter compartmentSearchRewriter,
             SmartCompartmentSearchRewriter smartCompartmentSearchRewriter,
-            SqlConnectionWrapperFactory sqlConnectionWrapperFactory,
             ISqlConnectionBuilder sqlConnectionBuilder,
             ISqlRetryService sqlRetryService,
             IOptions<SqlServerDataStoreConfiguration> sqlServerDataStoreConfiguration,
@@ -94,7 +92,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
         {
             EnsureArg.IsNotNull(sqlRootExpressionRewriter, nameof(sqlRootExpressionRewriter));
             EnsureArg.IsNotNull(chainFlatteningRewriter, nameof(chainFlatteningRewriter));
-            EnsureArg.IsNotNull(sqlConnectionWrapperFactory, nameof(sqlConnectionWrapperFactory));
             EnsureArg.IsNotNull(sqlConnectionBuilder, nameof(sqlConnectionBuilder));
             EnsureArg.IsNotNull(sqlRetryService, nameof(sqlRetryService));
             EnsureArg.IsNotNull(schemaInformation, nameof(schemaInformation));
@@ -112,7 +109,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
             _compartmentSearchRewriter = compartmentSearchRewriter;
             _smartCompartmentSearchRewriter = smartCompartmentSearchRewriter;
             _chainFlatteningRewriter = chainFlatteningRewriter;
-            _sqlConnectionWrapperFactory = sqlConnectionWrapperFactory;
             _sqlConnectionBuilder = sqlConnectionBuilder;
             _sqlRetryService = sqlRetryService;
             _queryHashCalculator = queryHashCalculator;
@@ -674,6 +670,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
             return (sqlDataReader.GetInt16(0), sqlDataReader.GetString(1));
         }
 
+        private static (long StartResourceSurrogateId, long EndResourceSurrogateId, int Count) ReaderGetSurrogateIdsAndCountForResourceType(SqlDataReader sqlDataReader)
+        {
+            return (sqlDataReader.GetInt64(0), sqlDataReader.GetInt64(1), sqlDataReader.GetInt32(2));
+        }
+
         public override async Task<IReadOnlyList<(short ResourceTypeId, string Name)>> GetUsedResourceTypes(CancellationToken cancellationToken)
         {
             using var sqlCommand = new SqlCommand("dbo.GetUsedResourceTypes") { CommandType = CommandType.StoredProcedure };
@@ -936,26 +937,18 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
             int rowCount = maxItemCount;
             SearchResult searchResult = null;
 
-            await _sqlRetryService.ExecuteSql(
-                async (cancellationToken, sqlException) =>
-                {
-                    while (true)
-                    {
-                        long tmpEndResourceSurrogateId;
-                        int tmpCount;
+            while (true)
+            {
+                long tmpEndResourceSurrogateId;
+                int tmpCount;
 
-                        using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(initialCatalog: null, cancellationToken: cancellationToken).ConfigureAwait(false);
-                        using SqlCommand sqlCommand = connection.CreateCommand();
-                        connection.RetryLogicProvider = null; // To remove this line _sqlConnectionBuilder in healthcare-shared-components must be modified.
-                        await connection.OpenAsync(cancellationToken);
-
-                        sqlCommand.CommandTimeout = Math.Max((int)_sqlServerDataStoreConfiguration.CommandTimeout.TotalSeconds, 180);
-
-                        sqlCommand.Parameters.AddWithValue("@p0", searchParamHash);
-                        sqlCommand.Parameters.AddWithValue("@p1", resourceTypeId);
-                        sqlCommand.Parameters.AddWithValue("@p2", tmpStartResourceSurrogateId);
-                        sqlCommand.Parameters.AddWithValue("@p3", rowCount);
-                        sqlCommand.CommandText = @"
+                using var sqlCommand = new SqlCommand();
+                sqlCommand.CommandTimeout = Math.Max((int)_sqlServerDataStoreConfiguration.CommandTimeout.TotalSeconds, 180);
+                sqlCommand.Parameters.AddWithValue("@p0", searchParamHash);
+                sqlCommand.Parameters.AddWithValue("@p1", resourceTypeId);
+                sqlCommand.Parameters.AddWithValue("@p2", tmpStartResourceSurrogateId);
+                sqlCommand.Parameters.AddWithValue("@p3", rowCount);
+                sqlCommand.CommandText = @"
                             ; WITH A AS (SELECT TOP (@p3) ResourceSurrogateId
                             FROM dbo.Resource
                             WHERE ResourceTypeId = @p1
@@ -968,49 +961,46 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                             )
                             SELECT ISNULL(MIN(ResourceSurrogateId), 0), ISNULL(MAX(ResourceSurrogateId), 0), COUNT(*) FROM A
                             ";
-                        LogSqlCommand(sqlCommand);
+                LogSqlCommand(sqlCommand);
 
-                        using var reader = await sqlCommand.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken);
-                        await reader.ReadAsync(cancellationToken);
-                        if (!reader.HasRows)
-                        {
-                            break;
-                        }
+                IReadOnlyList<(long StartResourceSurrogateId, long EndResourceSurrogateId, int Count)> results = await sqlCommand.ExecuteReaderAsync(_sqlRetryService, ReaderGetSurrogateIdsAndCountForResourceType, _logger, cancellationToken);
+                if (results.Count == 0)
+                {
+                    break;
+                }
 
-                        tmpStartResourceSurrogateId = reader.GetInt64(0);
-                        tmpEndResourceSurrogateId = reader.GetInt64(1);
-                        tmpCount = reader.GetInt32(2);
+                (long StartResourceSurrogateId, long EndResourceSurrogateId, int Count) singleResult = results.Single();
 
-                        totalCount += tmpCount;
-                        if (startResourceSurrogateId == 0)
-                        {
-                            startResourceSurrogateId = tmpStartResourceSurrogateId;
-                        }
+                tmpStartResourceSurrogateId = singleResult.StartResourceSurrogateId;
+                tmpEndResourceSurrogateId = singleResult.EndResourceSurrogateId;
+                tmpCount = singleResult.Count;
 
-                        if (tmpEndResourceSurrogateId > 0)
-                        {
-                            endResourceSurrogateId = tmpEndResourceSurrogateId;
-                            tmpStartResourceSurrogateId = tmpEndResourceSurrogateId;
-                        }
+                totalCount += tmpCount;
+                if (startResourceSurrogateId == 0)
+                {
+                    startResourceSurrogateId = tmpStartResourceSurrogateId;
+                }
 
-                        if (tmpCount <= 1)
-                        {
-                            break;
-                        }
-                    }
+                if (tmpEndResourceSurrogateId > 0)
+                {
+                    endResourceSurrogateId = tmpEndResourceSurrogateId;
+                    tmpStartResourceSurrogateId = tmpEndResourceSurrogateId;
+                }
 
-                    searchResult = new SearchResult(totalCount, Array.Empty<Tuple<string, string>>());
-                    searchResult.ReindexResult = new SearchResultReindex()
-                    {
-                        Count = totalCount,
-                        StartResourceSurrogateId = startResourceSurrogateId,
-                        EndResourceSurrogateId = endResourceSurrogateId,
-                        CurrentResourceSurrogateId = startResourceSurrogateId,
-                    };
+                if (tmpCount <= 1)
+                {
+                    break;
+                }
+            }
 
-                    return;
-                },
-                cancellationToken);
+            searchResult = new SearchResult(totalCount, Array.Empty<Tuple<string, string>>());
+            searchResult.ReindexResult = new SearchResultReindex()
+            {
+                Count = totalCount,
+                StartResourceSurrogateId = startResourceSurrogateId,
+                EndResourceSurrogateId = endResourceSurrogateId,
+                CurrentResourceSurrogateId = startResourceSurrogateId,
+            };
 
             return searchResult;
         }
@@ -1028,46 +1018,36 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
             long endResourceSurrogateId = 0;
 
             SearchResult searchResult = null;
-            await _sqlRetryService.ExecuteSql(
-                async (cancellationToken, sqlException) =>
-                {
-                    using SqlConnection connection = await _sqlConnectionBuilder.GetSqlConnectionAsync(initialCatalog: null, cancellationToken: cancellationToken).ConfigureAwait(false);
-                    using SqlCommand sqlCommand = connection.CreateCommand();
-                    connection.RetryLogicProvider = null; // To remove this line _sqlConnectionBuilder in healthcare-shared-components must be modified.
-                    await connection.OpenAsync(cancellationToken);
 
-                    sqlCommand.CommandTimeout = Math.Max((int)_sqlServerDataStoreConfiguration.CommandTimeout.TotalSeconds, 180);
-
-                    sqlCommand.Parameters.AddWithValue("@p0", resourceTypeId);
-                    sqlCommand.CommandText = @"
+            using var sqlCommand = new SqlCommand();
+            sqlCommand.CommandTimeout = Math.Max((int)_sqlServerDataStoreConfiguration.CommandTimeout.TotalSeconds, 180);
+            sqlCommand.Parameters.AddWithValue("@p0", resourceTypeId);
+            sqlCommand.CommandText = @"
                         SELECT ISNULL(MIN(ResourceSurrogateId), 0), ISNULL(MAX(ResourceSurrogateId), 0), COUNT(ResourceSurrogateId)
                         FROM dbo.Resource
                         WHERE ResourceTypeId = @p0
                             AND IsHistory = 0
                             AND IsDeleted = 0";
-                    LogSqlCommand(sqlCommand);
+            LogSqlCommand(sqlCommand);
 
-                    using var reader = await sqlCommand.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken);
-                    await reader.ReadAsync(cancellationToken);
-                    if (reader.HasRows)
-                    {
-                        startResourceSurrogateId = reader.GetInt64(0);
-                        endResourceSurrogateId = reader.GetInt64(1);
-                        totalCount = reader.GetInt32(2);
-                    }
+            IReadOnlyList<(long StartResourceSurrogateId, long EndResourceSurrogateId, int Count)> results = await sqlCommand.ExecuteReaderAsync(_sqlRetryService, ReaderGetSurrogateIdsAndCountForResourceType, _logger, cancellationToken);
+            if (results.Count > 0)
+            {
+                (long StartResourceSurrogateId, long EndResourceSurrogateId, int Count) singleResult = results.Single();
 
-                    searchResult = new SearchResult(totalCount, Array.Empty<Tuple<string, string>>());
-                    searchResult.ReindexResult = new SearchResultReindex()
-                    {
-                        Count = totalCount,
-                        StartResourceSurrogateId = startResourceSurrogateId,
-                        EndResourceSurrogateId = endResourceSurrogateId,
-                        CurrentResourceSurrogateId = startResourceSurrogateId,
-                    };
+                startResourceSurrogateId = singleResult.StartResourceSurrogateId;
+                endResourceSurrogateId = singleResult.EndResourceSurrogateId;
+                totalCount = singleResult.Count;
+            }
 
-                    return;
-                },
-                cancellationToken);
+            searchResult = new SearchResult(totalCount, Array.Empty<Tuple<string, string>>());
+            searchResult.ReindexResult = new SearchResultReindex()
+            {
+                Count = totalCount,
+                StartResourceSurrogateId = startResourceSurrogateId,
+                EndResourceSurrogateId = endResourceSurrogateId,
+                CurrentResourceSurrogateId = startResourceSurrogateId,
+            };
 
             return searchResult;
         }


### PR DESCRIPTION
## Description
Remove the unused sqlconnectionwrapperfactory; apply the correct sql retry to the reindex functions

## Related issues
Addresses [issue #].

## Testing
Successfully ran reindex jobs locally.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
