### PR TITLE
Job Factory provides Job tasks with an ambient scope

### DIFF
--- a/R4.slnf
+++ b/R4.slnf
@@ -27,6 +27,8 @@
       "src\\Microsoft.Health.Fhir.SqlServer.UnitTests\\Microsoft.Health.Fhir.SqlServer.UnitTests.csproj",
       "src\\Microsoft.Health.Fhir.SqlServer\\Microsoft.Health.Fhir.SqlServer.csproj",
       "src\\Microsoft.Health.Fhir.Tests.Common\\Microsoft.Health.Fhir.Tests.Common.csproj",
+      "src\\Microsoft.Health.TaskManagement\\Microsoft.Health.TaskManagement.csproj",
+      "src\\Microsoft.Health.TaskManagement.UnitTests\\Microsoft.Health.TaskManagement.UnitTests.csproj",
       "src\\Microsoft.Health.Fhir.ValueSets\\Microsoft.Health.Fhir.ValueSets.csproj",
       "src\\Microsoft.Health.TaskManagement.UnitTests\\Microsoft.Health.TaskManagement.UnitTests.csproj",
       "src\\Microsoft.Health.TaskManagement\\Microsoft.Health.TaskManagement.csproj",
@@ -35,7 +37,7 @@
       "test\\Microsoft.Health.Fhir.Shared.Tests.Crucible\\Microsoft.Health.Fhir.Shared.Tests.Crucible.shproj",
       "test\\Microsoft.Health.Fhir.Shared.Tests.E2E.Common\\Microsoft.Health.Fhir.Shared.Tests.E2E.Common.shproj",
       "test\\Microsoft.Health.Fhir.Shared.Tests.E2E\\Microsoft.Health.Fhir.Shared.Tests.E2E.shproj",
-      "test\\Microsoft.Health.Fhir.Shared.Tests.Integration\\Microsoft.Health.Fhir.Shared.Tests.Integration.shproj"
+      "test\\Microsoft.Health.Fhir.Shared.Tests.Integration\\Microsoft.Health.Fhir.Shared.Tests.Integration.shproj",
     ]
   }
 }

--- a/src/Microsoft.Health.Fhir.Api/Features/BackgroundJobService/HostingBackgroundService.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/BackgroundJobService/HostingBackgroundService.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Configs;
+using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Messages.Storage;
 using Microsoft.Health.JobManagement;
 
@@ -24,14 +25,14 @@ namespace Microsoft.Health.Fhir.Api.Features.BackgroundJobService
     /// </summary>
     public class HostingBackgroundService : BackgroundService, INotificationHandler<StorageInitializedNotification>
     {
-        private readonly Func<IScoped<JobHosting>> _jobHostingFactory;
+        private readonly IScopeProvider<JobHosting> _jobHostingFactory;
         private readonly OperationsConfiguration _operationsConfiguration;
         private readonly TaskHostingConfiguration _hostingConfiguration;
         private readonly ILogger<HostingBackgroundService> _logger;
         private bool _storageReady;
 
         public HostingBackgroundService(
-            Func<IScoped<JobHosting>> jobHostingFactory,
+            IScopeProvider<JobHosting> jobHostingFactory,
             IOptions<TaskHostingConfiguration> hostingConfiguration,
             IOptions<OperationsConfiguration> operationsConfiguration,
             ILogger<HostingBackgroundService> logger)
@@ -53,7 +54,7 @@ namespace Microsoft.Health.Fhir.Api.Features.BackgroundJobService
 
             try
             {
-                using IScoped<JobHosting> jobHosting = _jobHostingFactory();
+                using IScoped<JobHosting> jobHosting = _jobHostingFactory.Invoke();
                 JobHosting jobHostingValue = jobHosting.Value;
                 if (_hostingConfiguration != null)
                 {

--- a/src/Microsoft.Health.Fhir.Api/Features/BackgroundJobService/JobFactory.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/BackgroundJobService/JobFactory.cs
@@ -5,9 +5,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using EnsureThat;
 using Microsoft.Extensions.Logging;
+using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.JobManagement;
 
 namespace Microsoft.Health.Fhir.Api.Features.BackgroundJobService
@@ -17,26 +20,28 @@ namespace Microsoft.Health.Fhir.Api.Features.BackgroundJobService
     /// </summary>
     public class JobFactory : IJobFactory
     {
-        private readonly Dictionary<int, Func<IJob>> _jobFactoryLookup;
+        private readonly IScopeProvider<IEnumerable<Func<IJob>>> _jobFactories;
+        private readonly Dictionary<int, int> _jobFactoryLookup;
 
-        public JobFactory(IEnumerable<Func<IJob>> jobFactories, ILogger<JobFactory> logger)
+        public JobFactory(IScopeProvider<IEnumerable<Func<IJob>>> jobFactories, ILogger<JobFactory> logger)
         {
             EnsureArg.IsNotNull(jobFactories, nameof(jobFactories));
+            _jobFactories = jobFactories;
+            _jobFactoryLookup = new Dictionary<int, int>();
 
-            _jobFactoryLookup = new Dictionary<int, Func<IJob>>();
-
-            foreach (Func<IJob> jobFunc in jobFactories)
+            using var jobs = jobFactories.Invoke();
+            foreach (var jobFunc in jobs.Value.Select((lazy, i) => (Instance: lazy, Index: i)))
             {
                 try
                 {
-                    IJob instance = jobFunc.Invoke();
-                    if (instance.GetType().GetCustomAttribute(typeof(JobTypeIdAttribute), false) is JobTypeIdAttribute jobTypeAttr)
+                    var jobInstance = jobFunc.Instance.Invoke();
+                    if (jobInstance.GetType().GetCustomAttribute(typeof(JobTypeIdAttribute), false) is JobTypeIdAttribute jobTypeAttr)
                     {
-                        _jobFactoryLookup.Add(jobTypeAttr.JobTypeId, jobFunc);
+                        _jobFactoryLookup.Add(jobTypeAttr.JobTypeId, jobFunc.Index);
                     }
                     else
                     {
-                        throw new InvalidOperationException($"Job type {instance.GetType().Name} does not have {nameof(JobTypeIdAttribute)}.");
+                        throw new InvalidOperationException($"Job type {jobInstance.GetType().Name} does not have {nameof(JobTypeIdAttribute)}.");
                     }
                 }
                 catch (Exception ex)
@@ -47,16 +52,36 @@ namespace Microsoft.Health.Fhir.Api.Features.BackgroundJobService
             }
         }
 
-        public IJob Create(JobInfo jobInfo)
+        public IScoped<IJob> Create(JobInfo jobInfo)
         {
             EnsureArg.IsNotNull(jobInfo, nameof(jobInfo));
 
-            if (_jobFactoryLookup.TryGetValue(jobInfo.GetJobTypeId() ?? int.MinValue, out Func<IJob> jobFactory))
+            IScoped<IEnumerable<Func<IJob>>> scope = _jobFactories.Invoke();
+
+            if (_jobFactoryLookup.TryGetValue(jobInfo.GetJobTypeId() ?? int.MinValue, out var index))
             {
-                return jobFactory.Invoke();
+                return new ScopedJob(scope.Value.ElementAt(index).Invoke(), scope);
             }
 
             throw new NotSupportedException($"Unknown task definition. ID: {jobInfo?.Id ?? -1}");
+        }
+
+        private class ScopedJob : IScoped<IJob>
+        {
+            private readonly IDisposable _disposableScope;
+
+            public ScopedJob(IJob value, IDisposable disposableScope)
+            {
+                Value = EnsureArg.IsNotNull(value, nameof(value));
+                _disposableScope = EnsureArg.IsNotNull(disposableScope, nameof(disposableScope));
+            }
+
+            public IJob Value { get; }
+
+            public void Dispose()
+            {
+                _disposableScope?.Dispose();
+            }
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Features/BackgroundJobService/JobFactory.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/BackgroundJobService/JobFactory.cs
@@ -21,20 +21,22 @@ namespace Microsoft.Health.Fhir.Api.Features.BackgroundJobService
     public class JobFactory : IJobFactory
     {
         private readonly IScopeProvider<IEnumerable<Func<IJob>>> _jobFactories;
+        private readonly ILogger<JobFactory> _logger;
         private readonly Dictionary<int, int> _jobFactoryLookup;
 
         public JobFactory(IScopeProvider<IEnumerable<Func<IJob>>> jobFactories, ILogger<JobFactory> logger)
         {
             EnsureArg.IsNotNull(jobFactories, nameof(jobFactories));
             _jobFactories = jobFactories;
+            _logger = logger;
             _jobFactoryLookup = new Dictionary<int, int>();
 
-            using var jobs = jobFactories.Invoke();
-            foreach (var jobFunc in jobs.Value.Select((lazy, i) => (Instance: lazy, Index: i)))
+            using IScoped<IEnumerable<Func<IJob>>> jobs = jobFactories.Invoke();
+            foreach ((Func<IJob> Instance, int Index) jobFunc in jobs.Value.Select((lazy, i) => (Instance: lazy, Index: i)))
             {
                 try
                 {
-                    var jobInstance = jobFunc.Instance.Invoke();
+                    IJob jobInstance = jobFunc.Instance.Invoke();
                     if (jobInstance.GetType().GetCustomAttribute(typeof(JobTypeIdAttribute), false) is JobTypeIdAttribute jobTypeAttr)
                     {
                         _jobFactoryLookup.Add(jobTypeAttr.JobTypeId, jobFunc.Index);
@@ -46,7 +48,7 @@ namespace Microsoft.Health.Fhir.Api.Features.BackgroundJobService
                 }
                 catch (Exception ex)
                 {
-                    logger.LogError(ex, "Failed to create job factory.");
+                    logger.LogError(ex, "Failed to create job factory");
                     throw;
                 }
             }
@@ -56,27 +58,22 @@ namespace Microsoft.Health.Fhir.Api.Features.BackgroundJobService
         {
             EnsureArg.IsNotNull(jobInfo, nameof(jobInfo));
 
-            IScoped<IEnumerable<Func<IJob>>> scope = _jobFactories.Invoke();
-
-            if (_jobFactoryLookup.TryGetValue(jobInfo.GetJobTypeId() ?? int.MinValue, out var index))
+            if (_jobFactoryLookup.TryGetValue(jobInfo.GetJobTypeId() ?? -1, out var index))
             {
-                return new ScopedJob(scope.Value.ElementAt(index).Invoke(), scope);
+                IScoped<IEnumerable<Func<IJob>>> scope = _jobFactories.Invoke();
+                IJob instance = scope.Value.ElementAt(index).Invoke();
+                _logger.LogJobInformation(jobInfo, "Created job instance {JobInstance}", instance.GetType().Name);
+                return new ScopedJob(instance, scope);
             }
 
-            throw new NotSupportedException($"Unknown task definition. ID: {jobInfo?.Id ?? -1}");
+            throw new NotSupportedException($"Unknown task definition. ID: {jobInfo.Id}, Type: {jobInfo.GetJobTypeId()}");
         }
 
-        private class ScopedJob : IScoped<IJob>
+        private class ScopedJob(IJob value, IDisposable disposableScope) : IScoped<IJob>
         {
-            private readonly IDisposable _disposableScope;
+            private readonly IDisposable _disposableScope = EnsureArg.IsNotNull(disposableScope, nameof(disposableScope));
 
-            public ScopedJob(IJob value, IDisposable disposableScope)
-            {
-                Value = EnsureArg.IsNotNull(value, nameof(value));
-                _disposableScope = EnsureArg.IsNotNull(disposableScope, nameof(disposableScope));
-            }
-
-            public IJob Value { get; }
+            public IJob Value { get; } = EnsureArg.IsNotNull(value, nameof(value));
 
             public void Dispose()
             {

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Extensions/CreateMockedScopeExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Extensions/CreateMockedScopeExtensions.cs
@@ -5,6 +5,8 @@
 
 using System;
 using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Health.Fhir.Core.Features;
+using Microsoft.Health.Fhir.Core.Features.Operations;
 using NSubstitute;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
@@ -21,6 +23,25 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
         public static Func<IScoped<T>> CreateMockScopeFactory<T>(this T obj)
         {
             return () => obj.CreateMockScope();
+        }
+
+        public static IScopeProvider<T> CreateMockScopeProviderFromScoped<T>(this IScoped<T> obj)
+        {
+            IScopeProvider<T> provider = Substitute.For<IScopeProvider<T>>();
+            provider.Invoke().Returns(obj);
+            return provider;
+        }
+
+        public static IScopeProvider<T> CreateMockScopeProvider<T>(this T obj)
+        {
+            if (obj.GetType().IsGenericType && obj.GetType().GetGenericTypeDefinition() == typeof(IScoped<>))
+            {
+                throw new InvalidOperationException($"Unwrap {typeof(T)} or use {nameof(CreateMockScopeProviderFromScoped)}.");
+            }
+
+            return obj
+                .CreateMockScope()
+                .CreateMockScopeProviderFromScoped();
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Extensions/CreateMockedScopeExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Extensions/CreateMockedScopeExtensions.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using EnsureThat;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Features;
 using Microsoft.Health.Fhir.Core.Features.Operations;
@@ -42,6 +43,18 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Extensions
             return obj
                 .CreateMockScope()
                 .CreateMockScopeProviderFromScoped();
+        }
+
+        public static IScopeProvider<T> CreateMockScopeProvider<T>(this Func<T> obj)
+        {
+            if (obj.GetType().IsGenericType && obj.GetType().GetGenericTypeDefinition() == typeof(IScoped<>))
+            {
+                throw new InvalidOperationException($"Unwrap {typeof(T)} or use {nameof(CreateMockScopeProviderFromScoped)}.");
+            }
+
+            IScopeProvider<T> provider = Substitute.For<IScopeProvider<T>>();
+            provider.Invoke().Returns(_ => obj.Invoke().CreateMockScope());
+            return provider;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
@@ -19,6 +19,7 @@ using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Definition.BundleWrappers;
+using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
 using Microsoft.Health.Fhir.Core.Messages.CapabilityStatement;
@@ -35,14 +36,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
     {
         private readonly IModelInfoProvider _modelInfoProvider;
         private readonly IMediator _mediator;
-        private ConcurrentDictionary<string, string> _resourceTypeSearchParameterHashMap;
-        private readonly Func<IScoped<ISearchService>> _searchServiceFactory;
+        private readonly ConcurrentDictionary<string, string> _resourceTypeSearchParameterHashMap;
+        private readonly IScopeProvider<ISearchService> _searchServiceFactory;
         private readonly ILogger _logger;
 
         public SearchParameterDefinitionManager(
             IModelInfoProvider modelInfoProvider,
             IMediator mediator,
-            Func<IScoped<ISearchService>> searchServiceFactory,
+            IScopeProvider<ISearchService> searchServiceFactory,
             ILogger<SearchParameterDefinitionManager> logger)
         {
             EnsureArg.IsNotNull(modelInfoProvider, nameof(modelInfoProvider));

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/LegacyExportJobWorker.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/LegacyExportJobWorker.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
@@ -23,15 +24,19 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
     /// </summary>
     public class LegacyExportJobWorker : INotificationHandler<StorageInitializedNotification>
     {
-        private readonly Func<IScoped<ILegacyExportOperationDataStore>> _fhirOperationDataStoreFactory;
+        private readonly IScopeProvider<ILegacyExportOperationDataStore> _fhirOperationDataStoreFactory;
         private readonly ExportJobConfiguration _exportJobConfiguration;
-        private readonly Func<IExportJobTask> _exportJobTaskFactory;
+        private readonly IScopeProvider<IExportJobTask> _exportJobTaskFactory;
         private readonly ILogger _logger;
         private bool _storageReady;
 
         private const int MaximumDelayInSeconds = 3600;
 
-        public LegacyExportJobWorker(Func<IScoped<ILegacyExportOperationDataStore>> fhirOperationDataStoreFactory, IOptions<ExportJobConfiguration> exportJobConfiguration, Func<IExportJobTask> exportJobTaskFactory, ILogger<LegacyExportJobWorker> logger)
+        public LegacyExportJobWorker(
+            IScopeProvider<ILegacyExportOperationDataStore> fhirOperationDataStoreFactory,
+            IOptions<ExportJobConfiguration> exportJobConfiguration,
+            IScopeProvider<IExportJobTask> exportJobTaskFactory,
+            ILogger<LegacyExportJobWorker> logger)
         {
             EnsureArg.IsNotNull(fhirOperationDataStoreFactory, nameof(fhirOperationDataStoreFactory));
             EnsureArg.IsNotNull(exportJobConfiguration?.Value, nameof(exportJobConfiguration));
@@ -46,7 +51,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
         public async Task ExecuteAsync(CancellationToken cancellationToken)
         {
-            var runningTasks = new List<Task>();
+            var runningTasks = new List<(Task Task, IScoped<IExportJobTask> Scope)>();
             TimeSpan delayBeforeNextPoll = _exportJobConfiguration.JobPollingFrequency;
 
             while (!cancellationToken.IsCancellationRequested)
@@ -56,12 +61,16 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                     try
                     {
                         // Remove all completed tasks.
-                        runningTasks.RemoveAll(task => task.IsCompleted);
+                        foreach (var task in runningTasks.Where(task => task.Task.IsCompleted).ToList())
+                        {
+                            task.Scope.Dispose();
+                            runningTasks.Remove(task);
+                        }
 
                         // Get list of available jobs.
                         if (runningTasks.Count < _exportJobConfiguration.MaximumNumberOfConcurrentJobsAllowedPerInstance)
                         {
-                            using IScoped<ILegacyExportOperationDataStore> store = _fhirOperationDataStoreFactory();
+                            using IScoped<ILegacyExportOperationDataStore> store = _fhirOperationDataStoreFactory.Invoke();
                             ushort numberOfJobsToAcquire = (ushort)(_exportJobConfiguration.MaximumNumberOfConcurrentJobsAllowedPerInstance - runningTasks.Count);
 
                             IReadOnlyCollection<ExportJobOutcome> jobs = await store.Value.AcquireLegacyExportJobsAsync(
@@ -73,7 +82,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                             {
                                 _logger.LogTrace("Picked up job: {JobId}.", job.JobRecord.Id);
 
-                                runningTasks.Add(_exportJobTaskFactory().ExecuteAsync(job.JobRecord, job.ETag, cancellationToken));
+                                IScoped<IExportJobTask> taskScope = _exportJobTaskFactory.Invoke();
+                                runningTasks.Add((taskScope.Value.ExecuteAsync(job.JobRecord, job.ETag, cancellationToken), taskScope));
                             }
                         }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/IScopeProvider.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/IScopeProvider.cs
@@ -1,0 +1,13 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Extensions.DependencyInjection;
+
+namespace Microsoft.Health.Fhir.Core.Features.Operations;
+
+public interface IScopeProvider<T>
+{
+    IScoped<T> Invoke();
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobWorker.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobWorker.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
@@ -24,17 +25,17 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
     /// </summary>
     public class ReindexJobWorker : INotificationHandler<SearchParametersInitializedNotification>
     {
-        private readonly Func<IScoped<IFhirOperationDataStore>> _fhirOperationDataStoreFactory;
+        private readonly IScopeProvider<IFhirOperationDataStore> _fhirOperationDataStoreFactory;
         private readonly ReindexJobConfiguration _reindexJobConfiguration;
-        private readonly Func<IReindexJobTask> _reindexJobTaskFactory;
+        private readonly IScopeProvider<IReindexJobTask> _reindexJobTaskFactory;
         private readonly ISearchParameterOperations _searchParameterOperations;
         private readonly ILogger _logger;
         private bool _searchParametersInitialized = false;
 
         public ReindexJobWorker(
-            Func<IScoped<IFhirOperationDataStore>> fhirOperationDataStoreFactory,
+            IScopeProvider<IFhirOperationDataStore> fhirOperationDataStoreFactory,
             IOptions<ReindexJobConfiguration> reindexJobConfiguration,
-            Func<IReindexJobTask> reindexJobTaskFactory,
+            IScopeProvider<IReindexJobTask> reindexJobTaskFactory,
             ISearchParameterOperations searchParameterOperations,
             ILogger<ReindexJobWorker> logger)
         {
@@ -53,7 +54,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
 
         public async Task ExecuteAsync(CancellationToken cancellationToken)
         {
-            var runningTasks = new List<Task>();
+            var runningTasks = new List<(Task Task, IScoped<IReindexJobTask> Scope)>();
 
             while (!cancellationToken.IsCancellationRequested)
             {
@@ -78,26 +79,33 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     try
                     {
                         // Remove all completed tasks.
-                        runningTasks.RemoveAll(task => task.IsCompleted);
+                        // Remove all completed tasks.
+                        foreach (var task in runningTasks.Where(task => task.Task.IsCompleted).ToList())
+                        {
+                            task.Scope.Dispose();
+                            runningTasks.Remove(task);
+                        }
 
                         // Get list of available jobs.
                         if (runningTasks.Count < _reindexJobConfiguration.MaximumNumberOfConcurrentJobsAllowed)
                         {
-                            using (IScoped<IFhirOperationDataStore> store = _fhirOperationDataStoreFactory.Invoke())
+                            using IScoped<IFhirOperationDataStore> store = _fhirOperationDataStoreFactory.Invoke();
+
+                            _logger.LogTrace("Querying datastore for reindex jobs.");
+
+                            IReadOnlyCollection<ReindexJobWrapper> jobs = await store.Value.AcquireReindexJobsAsync(
+                                _reindexJobConfiguration.MaximumNumberOfConcurrentJobsAllowed,
+                                _reindexJobConfiguration.JobHeartbeatTimeoutThreshold,
+                                cancellationToken);
+
+                            foreach (ReindexJobWrapper job in jobs)
                             {
-                                _logger.LogTrace("Querying datastore for reindex jobs.");
+                                _logger.LogTrace("Picked up reindex job: {JobId}.", job.JobRecord.Id);
 
-                                IReadOnlyCollection<ReindexJobWrapper> jobs = await store.Value.AcquireReindexJobsAsync(
-                                    _reindexJobConfiguration.MaximumNumberOfConcurrentJobsAllowed,
-                                    _reindexJobConfiguration.JobHeartbeatTimeoutThreshold,
-                                    cancellationToken);
-
-                                foreach (ReindexJobWrapper job in jobs)
-                                {
-                                    _logger.LogTrace("Picked up reindex job: {JobId}.", job.JobRecord.Id);
-
-                                    runningTasks.Add(_reindexJobTaskFactory().ExecuteAsync(job.JobRecord, job.ETag, cancellationToken));
-                                }
+                                IScoped<IReindexJobTask> reindexJobScope = _reindexJobTaskFactory.Invoke();
+                                runningTasks.Add(
+                                    (reindexJobScope.Value.ExecuteAsync(job.JobRecord, job.ETag, cancellationToken),
+                                        reindexJobScope));
                             }
                         }
                     }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/ScopeProvider.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/ScopeProvider.cs
@@ -1,0 +1,33 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using EnsureThat;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Health.Extensions.DependencyInjection;
+
+namespace Microsoft.Health.Fhir.Core.Features.Operations;
+
+/// <summary>
+/// Provides a factory to resolve instances in a background task.
+/// This class should not implement IDisposable, this is to avoid being referenced by the root IoC container.
+/// </summary>
+/// <typeparam name="T">The service type to resolve.</typeparam>
+public class ScopeProvider<T> : IScopeProvider<T>
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    public ScopeProvider(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = EnsureArg.IsNotNull(serviceProvider, nameof(serviceProvider));
+    }
+
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Scope is disposed in returned class.")]
+    public IScoped<T> Invoke()
+    {
+        return new ScopedComponent<T>(_serviceProvider.CreateScope());
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/ScopedComponent.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/ScopedComponent.cs
@@ -1,0 +1,44 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using EnsureThat;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Health.Extensions.DependencyInjection;
+
+namespace Microsoft.Health.Fhir.Core.Features.Operations;
+
+internal sealed class ScopedComponent<T> : IScoped<T>
+{
+    private bool _isDisposed;
+    private IServiceScope _serviceScope;
+    private readonly T _value;
+
+    public ScopedComponent(IServiceScope serviceScope)
+    {
+        _serviceScope = EnsureArg.IsNotNull(serviceScope, nameof(serviceScope));
+        _value = _serviceScope.ServiceProvider.GetService<T>();
+    }
+
+    public T Value
+    {
+        get
+        {
+            if (_isDisposed)
+            {
+                throw new ObjectDisposedException($"Service scope for {typeof(T)} has been disposed.");
+            }
+
+            return _value;
+        }
+    }
+
+    public void Dispose()
+    {
+        _serviceScope?.Dispose();
+        _serviceScope = null;
+        _isDisposed = true;
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/ScopedComponent.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/ScopedComponent.cs
@@ -26,11 +26,14 @@ internal sealed class ScopedComponent<T> : IScoped<T>
     {
         get
         {
+#if NET8_0_OR_GREATER
+            ObjectDisposedException.ThrowIf(_isDisposed, _value);
+#else
             if (_isDisposed)
             {
                 throw new ObjectDisposedException($"Service scope for {typeof(T)} has been disposed.");
             }
-
+#endif
             return _value;
         }
     }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs
@@ -25,8 +25,10 @@ using Microsoft.Health.Fhir.Api.Features.Formatters;
 using Microsoft.Health.Fhir.Api.Features.Resources;
 using Microsoft.Health.Fhir.Api.Features.Resources.Bundle;
 using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Core.Features;
 using Microsoft.Health.Fhir.Core.Features.Conformance;
 using Microsoft.Health.Fhir.Core.Features.Context;
+using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Security;
 using Microsoft.Health.Fhir.Core.Messages.CapabilityStatement;
@@ -163,6 +165,8 @@ namespace Microsoft.Health.Fhir.Api.Modules
 
             services.AddLazy();
             services.AddScoped();
+
+            services.AddTransient(typeof(IScopeProvider<>), typeof(ScopeProvider<>));
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/SearchParameterState/SearchParameterStateHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/SearchParameterState/SearchParameterStateHandlerTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Search
 
         public SearchParameterStateHandlerTests()
         {
-            _searchParameterDefinitionManager = Substitute.For<SearchParameterDefinitionManager>(ModelInfoProvider.Instance, _mediator, () => _searchService.CreateMockScope(), NullLogger<SearchParameterDefinitionManager>.Instance);
+            _searchParameterDefinitionManager = Substitute.For<SearchParameterDefinitionManager>(ModelInfoProvider.Instance, _mediator, _searchService.CreateMockScopeProvider(), NullLogger<SearchParameterDefinitionManager>.Instance);
             _searchParameterStatusManager = new SearchParameterStatusManager(_searchParameterStatusDataStore, _searchParameterDefinitionManager, _searchParameterSupportResolver, _mediator, _logger);
             _searchParameterHandler = new SearchParameterStateHandler(_authorizationService, _searchParameterDefinitionManager, _searchParameterStatusManager);
             _cancellationToken = CancellationToken.None;

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/SearchParameterState/SearchParameterStateUpdateHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/SearchParameterState/SearchParameterStateUpdateHandlerTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Search
 
         public SearchParameterStateUpdateHandlerTests()
         {
-            _searchParameterDefinitionManager = Substitute.For<SearchParameterDefinitionManager>(ModelInfoProvider.Instance, _mediator, () => _searchService.CreateMockScope(), NullLogger<SearchParameterDefinitionManager>.Instance);
+            _searchParameterDefinitionManager = Substitute.For<SearchParameterDefinitionManager>(ModelInfoProvider.Instance, _mediator, _searchService.CreateMockScopeProvider(), NullLogger<SearchParameterDefinitionManager>.Instance);
             _searchParameterStatusManager = new SearchParameterStatusManager(_searchParameterStatusDataStore, _searchParameterDefinitionManager, _searchParameterSupportResolver, _mediator, _logger);
             _searchParameterStateUpdateHandler = new SearchParameterStateUpdateHandler(_authorizationService, _searchParameterStatusManager, _logger2, _auditLogger);
             _cancellationToken = CancellationToken.None;

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             _searchParameterSupportResolver = Substitute.For<ISearchParameterSupportResolver>();
             _mediator = Substitute.For<IMediator>();
             _searchParameterStatusDataStore = Substitute.For<ISearchParameterStatusDataStore>();
-            _searchParameterDefinitionManager = new SearchParameterDefinitionManager(ModelInfoProvider.Instance, _mediator, () => _searchService.CreateMockScope(), NullLogger<SearchParameterDefinitionManager>.Instance);
+            _searchParameterDefinitionManager = new SearchParameterDefinitionManager(ModelInfoProvider.Instance, _mediator, _searchService.CreateMockScopeProvider(), NullLogger<SearchParameterDefinitionManager>.Instance);
             _fhirRequestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
             _fhirRequestContextAccessor.RequestContext.Returns(_fhirRequestContext);
 
@@ -499,7 +499,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
                 .IsSearchParameterSupported(Arg.Is<SearchParameterInfo>(s => s.Name.StartsWith("preexisting")))
                 .Returns((true, false));
 
-            var searchParameterDefinitionManager = new SearchParameterDefinitionManager(ModelInfoProvider.Instance, _mediator, () => searchService.CreateMockScope(), NullLogger<SearchParameterDefinitionManager>.Instance);
+            var searchParameterDefinitionManager = new SearchParameterDefinitionManager(ModelInfoProvider.Instance, _mediator, searchService.CreateMockScopeProvider(), NullLogger<SearchParameterDefinitionManager>.Instance);
 
             await searchParameterDefinitionManager.EnsureInitializedAsync(CancellationToken.None);
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterFixtureData.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterFixtureData.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         public static async Task<SearchParameterDefinitionManager> CreateSearchParameterDefinitionManagerAsync(IModelInfoProvider modelInfoProvider, IMediator mediator)
         {
             var searchService = Substitute.For<ISearchService>();
-            var definitionManager = new SearchParameterDefinitionManager(modelInfoProvider, mediator, () => searchService.CreateMockScope(), NullLogger<SearchParameterDefinitionManager>.Instance);
+            var definitionManager = new SearchParameterDefinitionManager(modelInfoProvider, mediator, searchService.CreateMockScopeProvider(), NullLogger<SearchParameterDefinitionManager>.Instance);
             await definitionManager.EnsureInitializedAsync(CancellationToken.None);
 
             var statusRegistry = new FilebasedSearchParameterStatusDataStore(
@@ -100,7 +100,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         public static async Task<SearchParameterStatusManager> CreateSearchParameterStatusManagerAsync(IModelInfoProvider modelInfoProvider, IMediator mediator)
         {
             var searchService = Substitute.For<ISearchService>();
-            var definitionManager = new SearchParameterDefinitionManager(modelInfoProvider, mediator, () => searchService.CreateMockScope(), NullLogger<SearchParameterDefinitionManager>.Instance);
+            var definitionManager = new SearchParameterDefinitionManager(modelInfoProvider, mediator, searchService.CreateMockScopeProvider(), NullLogger<SearchParameterDefinitionManager>.Instance);
             await definitionManager.EnsureInitializedAsync(CancellationToken.None);
 
             var statusRegistry = new FilebasedSearchParameterStatusDataStore(

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/IncludeRewriterTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/IncludeRewriterTests.cs
@@ -1644,7 +1644,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
                     .Build();
                 var mediator = Substitute.For<IMediator>();
                 var searchService = Substitute.For<ISearchService>();
-                SearchParameterDefinitionManager = new SearchParameterDefinitionManager(modelInfoProvider, mediator, () => searchService.CreateMockScope(), NullLogger<SearchParameterDefinitionManager>.Instance);
+                SearchParameterDefinitionManager = new SearchParameterDefinitionManager(modelInfoProvider, mediator, searchService.CreateMockScopeProvider(), NullLogger<SearchParameterDefinitionManager>.Instance);
             }
 
             public ISearchParameterDefinitionManager SearchParameterDefinitionManager { get; }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerSearchParameterStatusDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerSearchParameterStatusDataStore.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Features.Definition;
+using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Features.Search.Registry;
 using Microsoft.Health.Fhir.Core.Models;
@@ -27,7 +28,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry
 {
     internal class SqlServerSearchParameterStatusDataStore : ISearchParameterStatusDataStore
     {
-        private readonly Func<IScoped<SqlConnectionWrapperFactory>> _scopedSqlConnectionWrapperFactory;
+        private readonly IScopeProvider<SqlConnectionWrapperFactory> _scopedSqlConnectionWrapperFactory;
         private readonly VLatest.UpsertSearchParamsTvpGenerator<List<ResourceSearchParameterStatus>> _updateSearchParamsTvpGenerator;
         private readonly ISearchParameterStatusDataStore _filebasedSearchParameterStatusDataStore;
         private readonly SchemaInformation _schemaInformation;
@@ -36,7 +37,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry
         private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager;
 
         public SqlServerSearchParameterStatusDataStore(
-            Func<IScoped<SqlConnectionWrapperFactory>> scopedSqlConnectionWrapperFactory,
+            IScopeProvider<SqlConnectionWrapperFactory> scopedSqlConnectionWrapperFactory,
             VLatest.UpsertSearchParamsTvpGenerator<List<ResourceSearchParameterStatus>> updateSearchParamsTvpGenerator,
             FilebasedSearchParameterStatusDataStore.Resolver filebasedRegistry,
             SchemaInformation schemaInformation,
@@ -70,7 +71,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry
                 return await _filebasedSearchParameterStatusDataStore.GetSearchParameterStatuses(cancellationToken);
             }
 
-            using (IScoped<SqlConnectionWrapperFactory> scopedSqlConnectionWrapperFactory = _scopedSqlConnectionWrapperFactory())
+            using (IScoped<SqlConnectionWrapperFactory> scopedSqlConnectionWrapperFactory = _scopedSqlConnectionWrapperFactory.Invoke())
             using (SqlConnectionWrapper sqlConnectionWrapper = await scopedSqlConnectionWrapperFactory.Value.ObtainSqlConnectionWrapperAsync(cancellationToken, true))
             using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand())
             {
@@ -163,7 +164,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry
                 }
             }
 
-            using (IScoped<SqlConnectionWrapperFactory> scopedSqlConnectionWrapperFactory = _scopedSqlConnectionWrapperFactory())
+            using (IScoped<SqlConnectionWrapperFactory> scopedSqlConnectionWrapperFactory = _scopedSqlConnectionWrapperFactory.Invoke())
             using (SqlConnectionWrapper sqlConnectionWrapper = await scopedSqlConnectionWrapperFactory.Value.ObtainSqlConnectionWrapperAsync(cancellationToken, true))
             using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand())
             {

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
@@ -19,6 +19,7 @@ using Microsoft.Health.Abstractions.Exceptions;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features.Definition;
+using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Search.Registry;
 using Microsoft.Health.Fhir.Core.Messages.Storage;
 using Microsoft.Health.Fhir.Core.Models;
@@ -45,7 +46,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
         private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager;
         private readonly ISearchParameterStatusDataStore _filebasedSearchParameterStatusDataStore;
         private readonly SecurityConfiguration _securityConfiguration;
-        private readonly Func<IScoped<SqlConnectionWrapperFactory>> _scopedSqlConnectionWrapperFactory;
+        private readonly IScopeProvider<SqlConnectionWrapperFactory> _scopedSqlConnectionWrapperFactory;
         private readonly IMediator _mediator;
         private readonly ILogger<SqlServerFhirModel> _logger;
         private Dictionary<string, short> _resourceTypeToId;
@@ -64,7 +65,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             ISearchParameterDefinitionManager searchParameterDefinitionManager,
             FilebasedSearchParameterStatusDataStore.Resolver filebasedRegistry,
             IOptions<SecurityConfiguration> securityConfiguration,
-            Func<IScoped<SqlConnectionWrapperFactory>> scopedSqlConnectionWrapperFactory,
+            IScopeProvider<SqlConnectionWrapperFactory> scopedSqlConnectionWrapperFactory,
             IMediator mediator,
             ILogger<SqlServerFhirModel> logger)
         {
@@ -193,7 +194,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                 return;
             }
 
-            using (IScoped<SqlConnectionWrapperFactory> scopedSqlConnectionWrapperFactory = _scopedSqlConnectionWrapperFactory())
+            using (IScoped<SqlConnectionWrapperFactory> scopedSqlConnectionWrapperFactory = _scopedSqlConnectionWrapperFactory.Invoke())
             using (SqlConnectionWrapper sqlConnectionWrapper = await scopedSqlConnectionWrapperFactory.Value.ObtainSqlConnectionWrapperAsync(cancellationToken, true))
             using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand())
             {
@@ -216,7 +217,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
         private async Task InitializeBase(CancellationToken cancellationToken)
         {
-            using (IScoped<SqlConnectionWrapperFactory> scopedSqlConnectionWrapperFactory = _scopedSqlConnectionWrapperFactory())
+            using (IScoped<SqlConnectionWrapperFactory> scopedSqlConnectionWrapperFactory = _scopedSqlConnectionWrapperFactory.Invoke())
             using (SqlConnectionWrapper sqlConnectionWrapper = await scopedSqlConnectionWrapperFactory.Value.ObtainSqlConnectionWrapperAsync(cancellationToken, true))
             using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand())
             {
@@ -363,7 +364,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
         private async Task InitializeSearchParameterStatuses(CancellationToken cancellationToken)
         {
-            using (IScoped<SqlConnectionWrapperFactory> scopedSqlConnectionWrapperFactory = _scopedSqlConnectionWrapperFactory())
+            using (IScoped<SqlConnectionWrapperFactory> scopedSqlConnectionWrapperFactory = _scopedSqlConnectionWrapperFactory.Invoke())
             using (SqlConnectionWrapper sqlConnectionWrapper = await scopedSqlConnectionWrapperFactory.Value.ObtainSqlConnectionWrapperAsync(cancellationToken, true))
             using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand())
             {
@@ -433,7 +434,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             // Forgive me father, I have sinned.
             // In ideal world I should make this method async, but that spirals out of control and forces changes in all RowGenerators (about 35 files)
             // and overall logic of preparing data for insert.
-            using (IScoped<SqlConnectionWrapperFactory> scopedSqlConnectionWrapperFactory = _scopedSqlConnectionWrapperFactory())
+            using (IScoped<SqlConnectionWrapperFactory> scopedSqlConnectionWrapperFactory = _scopedSqlConnectionWrapperFactory.Invoke())
             using (SqlConnectionWrapper sqlConnectionWrapper = scopedSqlConnectionWrapperFactory.Value.ObtainSqlConnectionWrapperAsync(CancellationToken.None, true).Result)
             using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand())
             {

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Watchdogs/DefragWatchdog.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Watchdogs/DefragWatchdog.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Watchdogs
 
         private async Task ChangeDatabaseSettingsAsync(bool isOn, CancellationToken cancellationToken)
         {
-            using var cmd = new SqlCommand("dbo.DefragChangeDatabaseSettings") { CommandType = CommandType.StoredProcedure};
+            await using var cmd = new SqlCommand("dbo.DefragChangeDatabaseSettings") { CommandType = CommandType.StoredProcedure};
             cmd.Parameters.AddWithValue("@IsOn", isOn);
             await cmd.ExecuteNonQueryAsync(_sqlRetryService, _logger, cancellationToken);
 
@@ -172,7 +172,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Watchdogs
 
             _logger.LogInformation("Beginning defrag on Table: {Table}, Index: {Index}, Partition: {PartitionNumber}", table, index, partitionNumber);
 
-            using var cmd = new SqlCommand("dbo.Defrag") { CommandType = CommandType.StoredProcedure, CommandTimeout = 0 }; // this is long running
+            await using var cmd = new SqlCommand("dbo.Defrag") { CommandType = CommandType.StoredProcedure, CommandTimeout = 0 }; // this is long running
             cmd.Parameters.AddWithValue("@TableName", table);
             cmd.Parameters.AddWithValue("@IndexName", index);
             cmd.Parameters.AddWithValue("@PartitionNumber", partitionNumber);
@@ -192,7 +192,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Watchdogs
 
         private async Task<int> InitDefragAsync(long groupId, CancellationToken cancellationToken)
         {
-            using var cmd = new SqlCommand("dbo.InitDefrag") { CommandType = CommandType.StoredProcedure, CommandTimeout = 0 }; // this is long running
+            await using var cmd = new SqlCommand("dbo.InitDefrag") { CommandType = CommandType.StoredProcedure, CommandTimeout = 0 }; // this is long running
             cmd.Parameters.AddWithValue("@QueueType", QueueType);
             cmd.Parameters.AddWithValue("@GroupId", groupId);
             var defragItemsParam = new SqlParameter("@DefragItems", SqlDbType.Int) { Direction = ParameterDirection.Output };
@@ -254,7 +254,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Watchdogs
 
         private async Task<(long groupId, long jobId, long version, int activeDefragItems)> GetActiveCoordinatorJobAsync(CancellationToken cancellationToken)
         {
-            using var cmd = new SqlCommand("dbo.GetActiveJobs") { CommandType = CommandType.StoredProcedure };
+            await using var cmd = new SqlCommand("dbo.GetActiveJobs") { CommandType = CommandType.StoredProcedure };
             cmd.Parameters.AddWithValue("@QueueType", QueueType);
             (long groupId, long jobId, long version) id = (-1, -1, -1);
             var activeDefragItems = 0;

--- a/src/Microsoft.Health.TaskManagement.UnitTests/TestJobFactory.cs
+++ b/src/Microsoft.Health.TaskManagement.UnitTests/TestJobFactory.cs
@@ -4,6 +4,8 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using Microsoft.Health.Extensions.DependencyInjection;
+using NSubstitute;
 
 namespace Microsoft.Health.JobManagement.UnitTests
 {
@@ -16,9 +18,11 @@ namespace Microsoft.Health.JobManagement.UnitTests
             _factoryFunc = factoryFunc;
         }
 
-        public IJob Create(JobInfo jobInfo)
+        public IScoped<IJob> Create(JobInfo jobInfo)
         {
-            return _factoryFunc(jobInfo);
+            IScoped<IJob> scope = Substitute.For<IScoped<IJob>>();
+            scope.Value.Returns(_factoryFunc(jobInfo));
+            return scope;
         }
     }
 }

--- a/src/Microsoft.Health.TaskManagement/IJobFactory.cs
+++ b/src/Microsoft.Health.TaskManagement/IJobFactory.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Microsoft.Health.Extensions.DependencyInjection;
+
 namespace Microsoft.Health.JobManagement
 {
     /// <summary>
@@ -15,6 +17,6 @@ namespace Microsoft.Health.JobManagement
         /// </summary>
         /// <param name="jobInfo">Job information payload.</param>
         /// <returns>Job for execution.</returns>
-        IJob Create(JobInfo jobInfo);
+        IScoped<IJob> Create(JobInfo jobInfo);
     }
 }

--- a/src/Microsoft.Health.TaskManagement/JobHosting.cs
+++ b/src/Microsoft.Health.TaskManagement/JobHosting.cs
@@ -135,12 +135,12 @@ namespace Microsoft.Health.JobManagement
 #endif
                 }
 
-                var runningJob = ExecuteJobWithHeartbeatsAsync(
+                Task<string> runningJob = ExecuteJobWithHeartbeatsAsync(
                                     _queueClient,
                                     jobInfo.QueueType,
                                     jobInfo.Id,
                                     jobInfo.Version,
-                                    cancellationSource => job.ExecuteAsync(jobInfo, cancellationSource.Token),
+                                    cancellationSource => job.Value.ExecuteAsync(jobInfo, cancellationSource.Token),
                                     TimeSpan.FromSeconds(JobHeartbeatIntervalInSeconds),
                                     jobCancellationToken);
 
@@ -225,6 +225,7 @@ namespace Microsoft.Health.JobManagement
 
             var jobInfo = new JobInfo { QueueType = queueType, Id = jobId, Version = version }; // not other data points
 
+            // WARNING: Avoid using 'async' lambda when delegate type returns 'void'
             await using (new Timer(async _ => await PutJobHeartbeatAsync(queueClient, jobInfo, cancellationTokenSource), null, TimeSpan.FromSeconds(RandomNumberGenerator.GetInt32(100) / 100.0 * heartbeatPeriod.TotalSeconds), heartbeatPeriod))
             {
                 return await action(cancellationTokenSource);

--- a/src/Microsoft.Health.TaskManagement/JobHosting.cs
+++ b/src/Microsoft.Health.TaskManagement/JobHosting.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Extensions.Logging;
+using Microsoft.Health.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 
 namespace Microsoft.Health.JobManagement
@@ -112,9 +113,9 @@ namespace Microsoft.Health.JobManagement
             EnsureArg.IsNotNull(jobInfo, nameof(jobInfo));
             using var jobCancellationToken = new CancellationTokenSource();
 
-            IJob job = _jobFactory.Create(jobInfo);
+            using IScoped<IJob> job = _jobFactory.Create(jobInfo);
 
-            if (job == null)
+            if (job?.Value == null)
             {
                 _logger.LogJobWarning(jobInfo, "Job {JobId}. Not supported job type.", jobInfo.Id);
                 return;

--- a/src/Microsoft.Health.TaskManagement/Microsoft.Health.TaskManagement.csproj
+++ b/src/Microsoft.Health.TaskManagement/Microsoft.Health.TaskManagement.csproj
@@ -4,6 +4,7 @@
     <PackageReference Include="Ensure.That" />
     <PackageReference Include="FluentValidation" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="System.Net.Http" />
   </ItemGroup>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -895,9 +895,9 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
             Assert.False(string.IsNullOrWhiteSpace(response.Job.JobRecord.Id));
 
             _reindexJobWorker = new ReindexJobWorker(
-                () => _scopedOperationDataStore,
+                _scopedOperationDataStore.CreateMockScopeProviderFromScoped(),
                 Options.Create(_jobConfiguration),
-                InitializeReindexJobTask,
+                InitializeReindexJobTask().CreateMockScopeProvider(),
                 _searchParameterOperations,
                 NullLogger<ReindexJobWorker>.Instance);
 
@@ -936,7 +936,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
             return searchParam;
         }
 
-        private ReindexJobTask InitializeReindexJobTask()
+        private IReindexJobTask InitializeReindexJobTask()
         {
             return new ReindexJobTask(
                 () => _scopedOperationDataStore,
@@ -1033,7 +1033,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
 
             var mediator = new Mediator(services);
 
-            _searchParameterDefinitionManager2 = new SearchParameterDefinitionManager(ModelInfoProvider.Instance, mediator, () => _searchService, NullLogger<SearchParameterDefinitionManager>.Instance);
+            _searchParameterDefinitionManager2 = new SearchParameterDefinitionManager(ModelInfoProvider.Instance, mediator, _searchService.CreateMockScopeProviderFromScoped(), NullLogger<SearchParameterDefinitionManager>.Instance);
             await _searchParameterDefinitionManager2.EnsureInitializedAsync(CancellationToken.None);
             _supportedSearchParameterDefinitionManager2 = new SupportedSearchParameterDefinitionManager(_searchParameterDefinitionManager2);
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             _fhirRequestContextAccessor.RequestContext.CorrelationId.Returns(Guid.NewGuid().ToString());
             _fhirRequestContextAccessor.RequestContext.RouteName.Returns("routeName");
 
-            _searchParameterDefinitionManager = new SearchParameterDefinitionManager(ModelInfoProvider.Instance, _mediator, () => _searchService.CreateMockScope(), NullLogger<SearchParameterDefinitionManager>.Instance);
+            _searchParameterDefinitionManager = new SearchParameterDefinitionManager(ModelInfoProvider.Instance, _mediator, CreateMockedScopeExtensions.CreateMockScopeProvider(() => _searchService), NullLogger<SearchParameterDefinitionManager>.Instance);
 
             _supportedSearchParameterDefinitionManager = new SupportedSearchParameterDefinitionManager(_searchParameterDefinitionManager);
             var searchableSearchParameterDefinitionManager = new SearchableSearchParameterDefinitionManager(_searchParameterDefinitionManager, _fhirRequestContextAccessor);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             var serviceProviderSchemaInitializer = collection.BuildServiceProvider();
             _schemaInitializer = new SchemaInitializer(serviceProviderSchemaInitializer, SqlServerDataStoreConfiguration, SchemaInformation, mediator, NullLogger<SchemaInitializer>.Instance);
 
-            _searchParameterDefinitionManager = new SearchParameterDefinitionManager(ModelInfoProvider.Instance, _mediator, () => _searchService.CreateMockScope(), NullLogger<SearchParameterDefinitionManager>.Instance);
+            _searchParameterDefinitionManager = new SearchParameterDefinitionManager(ModelInfoProvider.Instance, _mediator, CreateMockedScopeExtensions.CreateMockScopeProvider(() => _searchService), NullLogger<SearchParameterDefinitionManager>.Instance);
 
             _filebasedSearchParameterStatusDataStore = new FilebasedSearchParameterStatusDataStore(_searchParameterDefinitionManager, ModelInfoProvider.Instance);
 
@@ -135,7 +135,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 _searchParameterDefinitionManager,
                 () => _filebasedSearchParameterStatusDataStore,
                 Options.Create(securityConfiguration),
-                () => SqlConnectionWrapperFactory.CreateMockScope(),
+                SqlConnectionWrapperFactory.CreateMockScopeProvider(),
                 Substitute.For<IMediator>(),
                 NullLogger<SqlServerFhirModel>.Instance);
             SqlServerFhirModel = sqlServerFhirModel;
@@ -157,7 +157,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             _supportedSearchParameterDefinitionManager = new SupportedSearchParameterDefinitionManager(_searchParameterDefinitionManager);
 
             SqlServerSearchParameterStatusDataStore = new SqlServerSearchParameterStatusDataStore(
-                () => SqlConnectionWrapperFactory.CreateMockScope(),
+                SqlConnectionWrapperFactory.CreateMockScopeProvider(),
                 upsertSearchParamsTvpGenerator,
                 () => _filebasedSearchParameterStatusDataStore,
                 SchemaInformation,

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             var initialConnectionString = Environment.GetEnvironmentVariable("SqlServer:ConnectionString") ?? LocalConnectionString;
 
             var searchService = Substitute.For<ISearchService>();
-            ISearchParameterDefinitionManager defManager = new SearchParameterDefinitionManager(ModelInfoProvider.Instance, Substitute.For<IMediator>(), () => searchService.CreateMockScope(), NullLogger<SearchParameterDefinitionManager>.Instance);
+            ISearchParameterDefinitionManager defManager = new SearchParameterDefinitionManager(ModelInfoProvider.Instance, Substitute.For<IMediator>(), searchService.CreateMockScopeProvider(), NullLogger<SearchParameterDefinitionManager>.Instance);
             FilebasedSearchParameterStatusDataStore statusStore = new FilebasedSearchParameterStatusDataStore(defManager, ModelInfoProvider.Instance);
 
             var schemaInformation = new SchemaInformation(SchemaVersionConstants.MinForUpgrade, maxSchemaVersion);
@@ -140,7 +140,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 defManager,
                 () => statusStore,
                 Options.Create(securityConfiguration),
-                () => defaultSqlConnectionWrapperFactory.CreateMockScope(),
+                defaultSqlConnectionWrapperFactory.CreateMockScopeProvider(),
                 Substitute.For<IMediator>(),
                 NullLogger<SqlServerFhirModel>.Instance);
 


### PR DESCRIPTION
## Description
Job Factory provides Job tasks with an ambient scope.

### Problem
ASP.NET provides an ambient scope for Controllers and other components based on the lifetime of an http request. Our background jobs currently don't provide this and resolve all dependencies from the root container.
When an object implements IDisposable, the root container will track this dependency until the app exits, this reference can cause objects to build in memory and prevent proper garbage collection.

### This PR
When a jobInfo is dequeued and the corresponding IJob implementation is created, a new scope is provided for that job to run in. At the end of the run the scope is disposed, without being tracked by the root container, allowing for .NET to collect the objects that are no longer in use.

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
