### PR TITLE
Allow local export defaults when debugging

### DIFF
--- a/src/Microsoft.Health.Fhir.R4.Web/Properties/launchSettings.json
+++ b/src/Microsoft.Health.Fhir.R4.Web/Properties/launchSettings.json
@@ -14,6 +14,7 @@
             "environmentVariables": {
                 "TestAuthEnvironment:FilePath": "..//..//testauthenvironment.json",
                 "DataStore": "CosmosDb",
+                "FhirServer:Operations:Export:StorageAccountConnection": "UseDevelopmentStorage=true",
                 "ASPNETCORE_ENVIRONMENT": "development"
             },
             "applicationUrl": "https://localhost:44348/"
@@ -29,6 +30,7 @@
                 "DataStore": "SqlServer",
                 "TaskHosting:Enabled": "true",
                 "TaskHosting:MaxRunningTaskCount": "2",
+                "FhirServer:Operations:Export:StorageAccountConnection": "UseDevelopmentStorage=true",
                 "FhirServer:Operations:IntegrationDataStore:StorageAccountConnection": "UseDevelopmentStorage=true",
                 "FhirServer:Operations:Import:Enabled": "true",
                 "ASPNETCORE_ENVIRONMENT": "development"

--- a/src/Microsoft.Health.Fhir.R4B.Web/Properties/launchSettings.json
+++ b/src/Microsoft.Health.Fhir.R4B.Web/Properties/launchSettings.json
@@ -14,6 +14,7 @@
             "environmentVariables": {
                 "TestAuthEnvironment:FilePath": "..//..//testauthenvironment.json",
                 "DataStore": "CosmosDb",
+                "FhirServer:Operations:Export:StorageAccountConnection": "UseDevelopmentStorage=true",
                 "ASPNETCORE_ENVIRONMENT": "development"
             },
             "applicationUrl": "https://localhost:44348/"
@@ -29,6 +30,7 @@
                 "DataStore": "SqlServer",
                 "TaskHosting:Enabled": "true",
                 "TaskHosting:MaxRunningTaskCount": "2",
+                "FhirServer:Operations:Export:StorageAccountConnection": "UseDevelopmentStorage=true",
                 "FhirServer:Operations:IntegrationDataStore:StorageAccountConnection": "UseDevelopmentStorage=true",
                 "FhirServer:Operations:Import:Enabled": "true",
                 "ASPNETCORE_ENVIRONMENT": "development"

--- a/src/Microsoft.Health.Fhir.R5.Web/Properties/launchSettings.json
+++ b/src/Microsoft.Health.Fhir.R5.Web/Properties/launchSettings.json
@@ -14,6 +14,7 @@
             "environmentVariables": {
                 "TestAuthEnvironment:FilePath": "..//..//testauthenvironment.json",
                 "DataStore": "CosmosDb",
+                "FhirServer:Operations:Export:StorageAccountConnection": "UseDevelopmentStorage=true",
                 "ASPNETCORE_ENVIRONMENT": "development"
             },
             "applicationUrl": "https://localhost:44348/"
@@ -29,6 +30,7 @@
                 "DataStore": "SqlServer",
                 "TaskHosting:Enabled": "true",
                 "TaskHosting:MaxRunningTaskCount": "2",
+                "FhirServer:Operations:Export:StorageAccountConnection": "UseDevelopmentStorage=true",
                 "FhirServer:Operations:IntegrationDataStore:StorageAccountConnection": "UseDevelopmentStorage=true",
                 "FhirServer:Operations:Import:Enabled": "true",
                 "ASPNETCORE_ENVIRONMENT": "development"

--- a/src/Microsoft.Health.Fhir.Stu3.Web/Properties/launchSettings.json
+++ b/src/Microsoft.Health.Fhir.Stu3.Web/Properties/launchSettings.json
@@ -14,6 +14,7 @@
             "environmentVariables": {
                 "TestAuthEnvironment:FilePath": "..//..//testauthenvironment.json",
                 "DataStore": "CosmosDb",
+                "FhirServer:Operations:Export:StorageAccountConnection": "UseDevelopmentStorage=true",
                 "ASPNETCORE_ENVIRONMENT": "development"
             },
             "applicationUrl": "https://localhost:44348/"
@@ -29,6 +30,7 @@
                 "DataStore": "SqlServer",
                 "TaskHosting:Enabled": "true",
                 "TaskHosting:MaxRunningTaskCount": "2",
+                "FhirServer:Operations:Export:StorageAccountConnection": "UseDevelopmentStorage=true",
                 "FhirServer:Operations:IntegrationDataStore:StorageAccountConnection": "UseDevelopmentStorage=true",
                 "FhirServer:Operations:Import:Enabled": "true",
                 "ASPNETCORE_ENVIRONMENT": "development"


### PR DESCRIPTION
## Description
Adds local emulator connection string when debugging locally.

## Testing
Run Azurite
Hit F5
You can export locally without changing anything else now!

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
