### PR TITLE
SearchParameter $status failing when called

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Routing/KnownRoutes.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Routing/KnownRoutes.cs
@@ -81,6 +81,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
         public const string SearchParameters = "SearchParameter/";
         public const string Status = "$status";
         public const string SearchParametersStatusQuery = SearchParameters + Status;
+        public const string SearchParametersStatusQueryDefintion = OperationDefinition + "/" + OperationsConstants.SearchParameterStatus;
         public const string SearchParametersStatusById = SearchParameters + IdRouteSegment + "/" + Status;
         public const string SearchParametersStatusPostQuery = SearchParametersStatusQuery + "/" + Search;
     }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/OperationDefinitionController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/OperationDefinitionController.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         }
 
         [HttpGet]
-        [Route(KnownRoutes.SearchParametersStatusQuery, Name = RouteNames.SearchParameterStatusOperationDefinition)]
+        [Route(KnownRoutes.SearchParametersStatusQueryDefintion, Name = RouteNames.SearchParameterStatusOperationDefinition)]
         [AllowAnonymous]
         public async Task<IActionResult> SearchParameterStatusOperationDefintion()
         {


### PR DESCRIPTION
## Description
Found a bug that got introduced after adding in the status operation to the cacpability statement. It was using the same route as the GET method for the SearchParameter controller.

## Related issues
Addresses [issue #].

## Testing
Ran through search parameter GET operation and the metadata endpoint to verify they returned correctly. 

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
