### PR TITLE
Periodic dequeue of jobs with timed out heartbeats.

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Queues/CosmosQueueClient.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Queues/CosmosQueueClient.cs
@@ -260,7 +260,7 @@ public class CosmosQueueClient : IQueueClient
     }
 
     /// <inheritdoc />
-    public async Task<JobInfo> DequeueAsync(byte queueType, string worker, int heartbeatTimeoutSec, CancellationToken cancellationToken, long? jobId = null)
+    public async Task<JobInfo> DequeueAsync(byte queueType, string worker, int heartbeatTimeoutSec, CancellationToken cancellationToken, long? jobId = null, bool checkTimeoutJobsOnly = false)
     {
         return await _retryPolicy.ExecuteAsync(async () =>
         {

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlQueueClient.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlQueueClient.cs
@@ -137,12 +137,13 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             return dequeuedJobs;
         }
 
-        public async Task<JobInfo> DequeueAsync(byte queueType, string worker, int heartbeatTimeoutSec, CancellationToken cancellationToken, long? jobId = null)
+        public async Task<JobInfo> DequeueAsync(byte queueType, string worker, int heartbeatTimeoutSec, CancellationToken cancellationToken, long? jobId = null, bool checkTimeoutJobsOnly = false)
         {
             using var sqlCommand = new SqlCommand() { CommandText = "dbo.DequeueJob", CommandType = CommandType.StoredProcedure };
             sqlCommand.Parameters.AddWithValue("@QueueType", queueType);
             sqlCommand.Parameters.AddWithValue("@Worker", worker);
             sqlCommand.Parameters.AddWithValue("@HeartbeatTimeoutSec", heartbeatTimeoutSec);
+            sqlCommand.Parameters.AddWithValue("@CheckTimeoutJobs", checkTimeoutJobsOnly);
             if (jobId.HasValue)
             {
                 sqlCommand.Parameters.AddWithValue("@InputJobId", jobId.Value);

--- a/src/Microsoft.Health.TaskManagement.UnitTests/TestQueueClient.cs
+++ b/src/Microsoft.Health.TaskManagement.UnitTests/TestQueueClient.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Health.JobManagement.UnitTests
             return dequeuedJobs;
         }
 
-        public Task<JobInfo> DequeueAsync(byte queueType, string worker, int heartbeatTimeoutSec, CancellationToken cancellationToken, long? jobId = null)
+        public Task<JobInfo> DequeueAsync(byte queueType, string worker, int heartbeatTimeoutSec, CancellationToken cancellationToken, long? jobId = null, bool checkTimeoutJobsOnly = false)
         {
             DequeueFaultAction?.Invoke();
             JobInfo job = null;

--- a/src/Microsoft.Health.TaskManagement/IQueueClient.cs
+++ b/src/Microsoft.Health.TaskManagement/IQueueClient.cs
@@ -46,7 +46,8 @@ namespace Microsoft.Health.JobManagement
         /// <param name="heartbeatTimeoutSec">Heartbeat timeout for retry</param>
         /// <param name="cancellationToken">Cancellation Token</param>
         /// <param name="jobId">Requested job id for dequeue</param>
-        public Task<JobInfo> DequeueAsync(byte queueType, string worker, int heartbeatTimeoutSec, CancellationToken cancellationToken, long? jobId = null);
+        /// <param name="checkTimeoutJobsOnly">Forces to check only jobs that timed out heartbeats</param>
+        public Task<JobInfo> DequeueAsync(byte queueType, string worker, int heartbeatTimeoutSec, CancellationToken cancellationToken, long? jobId = null, bool checkTimeoutJobsOnly = false);
 
         /// <summary>
         /// Get job by id

--- a/src/Microsoft.Health.TaskManagement/JobHosting.cs
+++ b/src/Microsoft.Health.TaskManagement/JobHosting.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Health.JobManagement
             }
             else
             {
-                _checkTimeoutJobsStopwatches.TryAdd(key, new Stopwatch());
+                _checkTimeoutJobsStopwatches.TryAdd(key, Stopwatch.StartNew());
             }
 
             return false;


### PR DESCRIPTION
Currently these jobs are dequeued at the end of processing. This causes accumulation of timeout/abandoned jobs, which becomes significant for large $import/$export (>100K jobs). Not nice. 