### PR TITLE
SqlExActionProcessor should pass through the innerexception

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Exceptions/LoginFailedForUserException.cs
+++ b/src/Microsoft.Health.Fhir.Core/Exceptions/LoginFailedForUserException.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Diagnostics;
 using Microsoft.Health.Fhir.Core.Models;
 
@@ -10,8 +11,8 @@ namespace Microsoft.Health.Fhir.Core.Exceptions
 {
     public class LoginFailedForUserException : FhirException
     {
-        public LoginFailedForUserException(string message)
-            : base(message)
+        public LoginFailedForUserException(string message, Exception innerException = null)
+            : base(message, innerException)
         {
             Debug.Assert(!string.IsNullOrEmpty(message), "Exception message should not be empty");
 

--- a/src/Microsoft.Health.Fhir.Core/Exceptions/MethodNotAllowedException.cs
+++ b/src/Microsoft.Health.Fhir.Core/Exceptions/MethodNotAllowedException.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Diagnostics;
 using Microsoft.Health.Fhir.Core.Models;
 
@@ -10,8 +11,8 @@ namespace Microsoft.Health.Fhir.Core.Exceptions
 {
     public class MethodNotAllowedException : FhirException
     {
-        public MethodNotAllowedException(string message)
-            : base(message)
+        public MethodNotAllowedException(string message, Exception innerException = null)
+            : base(message, innerException)
         {
             Debug.Assert(!string.IsNullOrEmpty(message), "Exception message should not be empty");
 

--- a/src/Microsoft.Health.Fhir.Core/Exceptions/RequestTimeoutException.cs
+++ b/src/Microsoft.Health.Fhir.Core/Exceptions/RequestTimeoutException.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Diagnostics;
 using Microsoft.Health.Fhir.Core.Models;
 
@@ -10,8 +11,8 @@ namespace Microsoft.Health.Fhir.Core.Exceptions
 {
     public class RequestTimeoutException : FhirException
     {
-        public RequestTimeoutException(string message)
-            : base(message)
+        public RequestTimeoutException(string message, Exception innerException = null)
+            : base(message, innerException)
         {
             Debug.Assert(!string.IsNullOrEmpty(message), "Exception message should not be empty");
 

--- a/src/Microsoft.Health.Fhir.Core/Exceptions/ResourceSqlException.cs
+++ b/src/Microsoft.Health.Fhir.Core/Exceptions/ResourceSqlException.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Diagnostics;
 using Microsoft.Health.Fhir.Core.Models;
 
@@ -10,8 +11,8 @@ namespace Microsoft.Health.Fhir.Core.Exceptions
 {
     public class ResourceSqlException : FhirException
     {
-        public ResourceSqlException(string message)
-            : base(message)
+        public ResourceSqlException(string message, Exception innerException = null)
+            : base(message, innerException)
         {
             Debug.Assert(!string.IsNullOrEmpty(message), "Exception message should not be empty");
 

--- a/src/Microsoft.Health.Fhir.Core/Exceptions/ResourceSqlTruncateException.cs
+++ b/src/Microsoft.Health.Fhir.Core/Exceptions/ResourceSqlTruncateException.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Diagnostics;
 using Microsoft.Health.Fhir.Core.Models;
 
@@ -10,8 +11,8 @@ namespace Microsoft.Health.Fhir.Core.Exceptions
 {
     public class ResourceSqlTruncateException : FhirException
     {
-        public ResourceSqlTruncateException(string message)
-            : base(message)
+        public ResourceSqlTruncateException(string message, Exception innerException = null)
+            : base(message, innerException)
         {
             Debug.Assert(!string.IsNullOrEmpty(message), "Exception message should not be empty");
 

--- a/src/Microsoft.Health.Fhir.Core/Exceptions/SqlQueryPlanException.cs
+++ b/src/Microsoft.Health.Fhir.Core/Exceptions/SqlQueryPlanException.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Diagnostics;
 using Microsoft.Health.Fhir.Core.Models;
 
@@ -10,8 +11,8 @@ namespace Microsoft.Health.Fhir.Core.Exceptions
 {
     public class SqlQueryPlanException : FhirException
     {
-        public SqlQueryPlanException(string message)
-            : base(message)
+        public SqlQueryPlanException(string message, Exception innerException)
+            : base(message, innerException)
         {
             Debug.Assert(!string.IsNullOrEmpty(message), "Exception message should not be empty");
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlExceptionActionProcessor.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlExceptionActionProcessor.cs
@@ -7,8 +7,10 @@ using System;
 using System.Data.SqlTypes;
 using System.Threading;
 using System.Threading.Tasks;
+using EnsureThat;
 using MediatR.Pipeline;
 using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.SqlServer.Features.Storage;
 
@@ -17,36 +19,46 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
     public class SqlExceptionActionProcessor<TRequest, TException> : IRequestExceptionAction<TRequest, TException>
         where TException : Exception
     {
+        private readonly ILogger<SqlExceptionActionProcessor<TRequest, TException>> _logger;
         private const int LoginFailedForUser = 18456;
+
+        public SqlExceptionActionProcessor(ILogger<SqlExceptionActionProcessor<TRequest, TException>> logger)
+        {
+            _logger = EnsureArg.IsNotNull(logger, nameof(logger));
+        }
 
         public Task Execute(TRequest request, TException exception, CancellationToken cancellationToken)
         {
             if (exception is SqlException sqlException)
             {
+                _logger.LogError(exception, $"A {nameof(SqlException)} occurred while executing request");
+
                 if (sqlException.Number == SqlErrorCodes.TimeoutExpired)
                 {
-                    throw new RequestTimeoutException(Resources.ExecutionTimeoutExpired);
+                    throw new RequestTimeoutException(Resources.ExecutionTimeoutExpired, exception);
                 }
                 else if (sqlException.Number == SqlErrorCodes.MethodNotAllowed)
                 {
-                    throw new MethodNotAllowedException(Core.Resources.ResourceCreationNotAllowed);
+                    throw new MethodNotAllowedException(Core.Resources.ResourceCreationNotAllowed, exception);
                 }
                 else if (sqlException.Number == SqlErrorCodes.QueryProcessorNoQueryPlan)
                 {
-                    throw new SqlQueryPlanException(Core.Resources.SqlQueryProcessorRanOutOfInternalResourcesException);
+                    throw new SqlQueryPlanException(Core.Resources.SqlQueryProcessorRanOutOfInternalResourcesException, exception);
                 }
                 else if (sqlException.Number == LoginFailedForUser)
                 {
-                    throw new LoginFailedForUserException(Core.Resources.InternalServerError);
+                    throw new LoginFailedForUserException(Core.Resources.InternalServerError, exception);
                 }
                 else
                 {
-                    throw new ResourceSqlException(Core.Resources.InternalServerError);
+                    throw new ResourceSqlException(Core.Resources.InternalServerError, exception);
                 }
             }
             else if (exception is SqlTruncateException sqlTruncateException)
             {
-                throw new ResourceSqlTruncateException(sqlTruncateException.Message);
+                _logger.LogError(exception, $"A {nameof(ResourceSqlTruncateException)} occurred while executing request");
+
+                throw new ResourceSqlTruncateException(sqlTruncateException.Message, exception);
             }
 
             return Task.CompletedTask;


### PR DESCRIPTION
## Description
SqlExceptionActionProcessor can generically handle any SQL Exception that bubble up from executing a handler, however, by not logging or passing through the inner exception we're not capturing the details.

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
