### PR TITLE
Convert - remove postprocess exception details from logs

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/ConvertDataEngine.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/ConvertDataEngine.cs
@@ -95,7 +95,15 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.ConvertData
                     throw new ConvertDataTimeoutException(Core.Resources.ConvertDataOperationTimeout, convertException.InnerException);
                 }
 
-                _logger.LogInformation(convertException, "Convert data failed.");
+                if (convertException is PostprocessException)
+                {
+                    _logger.LogInformation("A postprocess exception occurred", "Convert data failed.");
+                }
+                else
+                {
+                    _logger.LogInformation(convertException, "Convert data failed.");
+                }
+
                 throw new ConvertDataFailedException(string.Format(Core.Resources.ConvertDataFailed, convertException.Message), convertException);
             }
             catch (Exception ex)

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/ConvertDataEngine.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/ConvertDataEngine.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.ConvertData
 
                 if (convertException is PostprocessException)
                 {
-                    _logger.LogInformation("A postprocess exception occurred", "Convert data failed.");
+                    _logger.LogInformation($"An exception of type {convertException.GetType()} occurred during postprocessing. {convertException.StackTrace}", "Convert data failed.");
                 }
                 else
                 {

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/ConvertData/MockLogger.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/ConvertData/MockLogger.cs
@@ -6,14 +6,17 @@
 using System;
 using Microsoft.Extensions.Logging;
 
-public abstract class MockLogger<T> : ILogger<T>
+namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.ConvertData
 {
-    void ILogger.Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
-     => Log(logLevel, formatter(state, exception));
+    public abstract class MockLogger<T> : ILogger<T>
+    {
+        void ILogger.Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+         => Log(logLevel, formatter(state, exception));
 
-    public abstract void Log(LogLevel logLevel, object state, Exception exception = null);
+        public abstract void Log(LogLevel logLevel, object state, Exception exception = null);
 
-    public virtual bool IsEnabled(LogLevel logLevel) => true;
+        public virtual bool IsEnabled(LogLevel logLevel) => true;
 
-    public abstract IDisposable BeginScope<TState>(TState state);
+        public abstract IDisposable BeginScope<TState>(TState state);
+    }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/ConvertData/MockLogger.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/ConvertData/MockLogger.cs
@@ -1,0 +1,19 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.Extensions.Logging;
+
+public abstract class MockLogger<T> : ILogger<T>
+{
+    void ILogger.Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+     => Log(logLevel, formatter(state, exception));
+
+    public abstract void Log(LogLevel logLevel, object state, Exception exception = null);
+
+    public virtual bool IsEnabled(LogLevel logLevel) => true;
+
+    public abstract IDisposable BeginScope<TState>(TState state);
+}

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
@@ -16,6 +16,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Conformance\ConformanceBuilderTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Conformance\ConformanceProviderExtensionTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Conformance\GetSmartConfigurationHandlerTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\ConvertData\MockLogger.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\Everything\EverythingOperationContinuationTokenTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\Everything\EverythingOperationHandlerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\Everything\PatientEverythingServiceTests.cs" />


### PR DESCRIPTION
## Description
Previously when a convert postprocess operation failed we would log the details of the failure, which included the part of input message payload which failed to be processed. We also returned the details of the input message in the HTTP response.

Since the input message payload could contain sensitive information, we should not include this information in the logs. Now, in this PR we will no longer log the input message payload in the logs. We will only state that an error has occurred during postprocessing. We will still return the same error details (which includes the partial input message payload that errored) in the HTTP response so that the user has some insight into what caused the error.

## Related issues
Addresses 106437.

## Testing
Unit tests

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
