### PR TITLE
[Fix] Limit the number of resources loaded in FHIR Model

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
@@ -252,7 +252,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                         COMMIT TRANSACTION
     
                         -- result set 5
-                        SELECT Value, SystemId from dbo.System;
+                        SELECT TOP 10000 Value, SystemId from dbo.System;
 
                         -- result set 6
                         SELECT Value, QuantityCodeId FROM dbo.QuantityCode";


### PR DESCRIPTION
## Description
Limiting the number of resources loaded from dbo.System in FHIR Model. 

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)


