### PR TITLE
Bulk delete enhancements

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/BulkDelete/BulkDeleteProcessingJob.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/BulkDelete/BulkDeleteProcessingJob.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.BulkDelete
                     method: "BulkDelete",
                     uriString: definition.Url,
                     baseUriString: definition.BaseUrl,
-                    correlationId: jobInfo.Id.ToString(),
+                    correlationId: jobInfo.Id.ToString() + '-' + jobInfo.GroupId.ToString(),
                     requestHeaders: new Dictionary<string, StringValues>(),
                     responseHeaders: new Dictionary<string, StringValues>())
                 {

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/ResourceHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/ResourceHandlerTests.cs
@@ -18,6 +18,7 @@ using Microsoft.Health.Core.Internal;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Core.Features.Audit;
 using Microsoft.Health.Fhir.Core.Features.Conformance;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
@@ -108,7 +109,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Resources
             var referenceResolver = new ResourceReferenceResolver(_searchService, new TestQueryStringParser());
             _resourceIdProvider = new ResourceIdProvider();
 
-            var deleter = new DeletionService(_resourceWrapperFactory, lazyConformanceProvider, _fhirDataStore, _searchService, _resourceIdProvider);
+            var auditLogger = Substitute.For<IAuditLogger>();
+
+            var deleter = new DeletionService(_resourceWrapperFactory, lazyConformanceProvider, _fhirDataStore, _searchService, _resourceIdProvider, new FhirRequestContextAccessor(), auditLogger);
 
             collection.Add(x => _mediator).Singleton().AsSelf();
             collection.Add(x => new CreateResourceHandler(_fhirDataStore, lazyConformanceProvider, _resourceWrapperFactory, _resourceIdProvider, referenceResolver, _authorizationService)).Singleton().AsSelf().AsImplementedInterfaces();

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeletionService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeletionService.cs
@@ -104,7 +104,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
         {
             EnsureArg.IsNotNull(request, nameof(request));
 
-            (IReadOnlyCollection<SearchResultEntry> matchedResults, string ct) = await _searchService.ConditionalSearchAsync(request.ResourceType, request.ConditionalParameters, cancellationToken, request.MaxDeleteCount);
+            var searchCount = 1000;
+
+            (IReadOnlyCollection<SearchResultEntry> matchedResults, string ct) = await _searchService.ConditionalSearchAsync(request.ResourceType, request.ConditionalParameters, cancellationToken, request.DeleteAll ? searchCount : request.MaxDeleteCount);
 
             var itemsDeleted = new HashSet<string>();
 
@@ -178,7 +180,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
                             request.ResourceType,
                             request.ConditionalParameters,
                             cancellationToken,
-                            request.DeleteAll ? null : request.MaxDeleteCount - itemsDeleted.Count,
+                            request.DeleteAll ? searchCount : request.MaxDeleteCount - itemsDeleted.Count,
                             ct);
                     }
                     else

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/JobInfoExtensions.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/JobInfoExtensions.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             DateTime createDate = sqlDataReader.Read(jobQueueTable.CreateDate, 8);
             object startDateObj = sqlDataReader.GetValue(9);
             DateTime? startDate = startDateObj is DBNull ? null : (DateTime)startDateObj;
-            object endDateObj = sqlDataReader.GetValue(9);
+            object endDateObj = sqlDataReader.GetValue(10);
             DateTime? endDate = endDateObj is DBNull ? null : (DateTime)endDateObj;
             DateTime heartbeatDate = sqlDataReader.Read(jobQueueTable.HeartbeatDate, 11);
             bool cancelRequested = sqlDataReader.Read(jobQueueTable.CancelRequested, 12);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTestsFixture.cs
@@ -21,6 +21,7 @@ using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Fhir.Api.Features.Bundle;
 using Microsoft.Health.Fhir.Api.Features.Routing;
 using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Core.Features.Audit;
 using Microsoft.Health.Fhir.Core.Features.Conformance;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Definition;
@@ -182,7 +183,9 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
             GetResourceHandler = new GetResourceHandler(DataStore, new Lazy<IConformanceProvider>(() => ConformanceProvider), resourceWrapperFactory, _resourceIdProvider, _dataResourceFilter, DisabledFhirAuthorizationService.Instance, FhirRequestContextAccessor, SearchService);
 
-            var deleter = new DeletionService(resourceWrapperFactory, new Lazy<IConformanceProvider>(() => ConformanceProvider), DataStore, SearchService, _resourceIdProvider);
+            var auditLogger = Substitute.For<IAuditLogger>();
+
+            var deleter = new DeletionService(resourceWrapperFactory, new Lazy<IConformanceProvider>(() => ConformanceProvider), DataStore, SearchService, _resourceIdProvider, new FhirRequestContextAccessor(), auditLogger);
 
             var collection = new ServiceCollection();
 


### PR DESCRIPTION
## Description
Adds audit logging to delete operations
Improves bulk delete performance

## Related issues
Addresses [User Story 104736](https://microsofthealth.visualstudio.com/Health/_workitems/edit/104736): [Needs to be done prior to GA] Audit event logs need to be populated with delete information

## Testing

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
