### PR TITLE
Fix for Searches not Checking Search Parameter Status

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/ISupportedSearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/ISupportedSearchParameterDefinitionManager.cs
@@ -13,10 +13,5 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
     /// </summary>
     public interface ISupportedSearchParameterDefinitionManager : ISearchParameterDefinitionManager
     {
-        /// <summary>
-        /// Gets list of search parameters that are supported but not yet searchable or sortable.
-        /// </summary>
-        /// <returns>An <see cref="IEnumerable{T}"/> that contains the matching search parameters.</returns>
-        IEnumerable<SearchParameterInfo> GetSearchParametersRequiringReindexing();
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchableSearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchableSearchParameterDefinitionManager.cs
@@ -81,9 +81,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
                 return parameter;
             }
 
-            return null;
-
-            // throw new SearchParameterNotSupportedException(resourceType, code);
+            throw new SearchParameterNotSupportedException(resourceType, code);
         }
 
         public SearchParameterInfo GetSearchParameter(string definitionUri)

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchableSearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchableSearchParameterDefinitionManager.cs
@@ -81,7 +81,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
                 return parameter;
             }
 
-            throw new SearchParameterNotSupportedException(resourceType, code);
+            return null;
+
+            // throw new SearchParameterNotSupportedException(resourceType, code);
         }
 
         public SearchParameterInfo GetSearchParameter(string definitionUri)

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchableSearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchableSearchParameterDefinitionManager.cs
@@ -159,8 +159,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
 
         private bool IsEnabled(SearchParameterInfo parameter)
         {
+            if (parameter.Code == "_type")
+            {
+                return true;
+            }
+
             var searchParameterStatuses = _statusManager.GetAllSearchParameterStatus(default).ConfigureAwait(false).GetAwaiter().GetResult();
-            return searchParameterStatuses.Where(sp => sp.Uri.OriginalString.Equals(parameter.Url.OriginalString, StringComparison.OrdinalIgnoreCase)).FirstOrDefault().Status == SearchParameterStatus.Enabled;
+            return searchParameterStatuses.Where(sp => sp.Uri.OriginalString.Equals(parameter.Url.OriginalString, StringComparison.OrdinalIgnoreCase)).First().Status == SearchParameterStatus.Enabled;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SupportedSearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SupportedSearchParameterDefinitionManager.cs
@@ -72,11 +72,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             throw new SearchParameterNotSupportedException(definitionUri);
         }
 
-        public IEnumerable<SearchParameterInfo> GetSearchParametersRequiringReindexing()
-        {
-            return AllSearchParameters.Where(p => p.IsSearchable == false || p.SortStatus == SortParameterStatus.Supported);
-        }
-
         public string GetSearchParameterHashForResourceType(string resourceType)
         {
             return _inner.GetSearchParameterHashForResourceType(resourceType);

--- a/src/Microsoft.Health.Fhir.Core/Features/KnownQueryParameterNames.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/KnownQueryParameterNames.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Linq;
+
 namespace Microsoft.Health.Fhir.Core.Features
 {
     /// <summary>
@@ -98,5 +100,48 @@ namespace Microsoft.Health.Fhir.Core.Features
         public const string HardDelete = "_hardDelete";
 
         public const string PurgeHistory = "_purgeHistory";
+
+        private static readonly string[] _parameterNames =
+        {
+            At,
+            Before,
+            ContinuationToken,
+            Count,
+            Format,
+            LastUpdated,
+            Mode,
+            Pretty,
+            Profile,
+            Since,
+            Sort,
+            Summary,
+            Elements,
+            Total,
+            List,
+            Id,
+            Type,
+            Container,
+            AnonymizationConfigurationLocation,
+            AnonymizationConfigurationCollectionReference,
+            AnonymizationConfigurationFileEtag,
+            OutputFormat,
+            TypeFilter,
+            Text,
+            Till,
+            IsParallel,
+            StartSurrogateId,
+            EndSurrogateId,
+            GlobalStartSurrogateId,
+            GlobalEndSurrogateId,
+            IgnoreSearchParamHash,
+            Identifier,
+            HardDelete,
+            PurgeHistory,
+        };
+
+        public static bool IsKnownParameter(string parameterName)
+        {
+            return _parameterNames.Contains(parameterName);
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/ISearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/ISearchOptionsFactory.cs
@@ -5,13 +5,15 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.Health.Fhir.Core.Features.Search
 {
     public interface ISearchOptionsFactory
     {
-        SearchOptions Create(string resourceType, IReadOnlyList<Tuple<string, string>> queryParameters, bool isAsyncOperation = false);
+        Task<SearchOptions> Create(string resourceType, IReadOnlyList<Tuple<string, string>> queryParameters, bool isAsyncOperation = false, CancellationToken cancellationToken = default);
 
-        SearchOptions Create(string compartmentType, string compartmentId, string resourceType, IReadOnlyList<Tuple<string, string>> queryParameters, bool isAsyncOperation = false, bool useSmartCompartmentDefinition = false);
+        Task<SearchOptions> Create(string compartmentType, string compartmentId, string resourceType, IReadOnlyList<Tuple<string, string>> queryParameters, bool isAsyncOperation = false, bool useSmartCompartmentDefinition = false, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchService.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchService.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             CancellationToken cancellationToken,
             bool isAsyncOperation = false)
         {
-            SearchOptions searchOptions = _searchOptionsFactory.Create(resourceType, queryParameters, isAsyncOperation);
+            SearchOptions searchOptions = await _searchOptionsFactory.Create(resourceType, queryParameters, isAsyncOperation, cancellationToken);
 
             // Execute the actual search.
             return await SearchAsync(searchOptions, cancellationToken);
@@ -62,7 +62,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             bool isAsyncOperation = false,
             bool useSmartCompartmentDefinition = false)
         {
-            SearchOptions searchOptions = _searchOptionsFactory.Create(compartmentType, compartmentId, resourceType, queryParameters, isAsyncOperation, useSmartCompartmentDefinition);
+            SearchOptions searchOptions = await _searchOptionsFactory.Create(compartmentType, compartmentId, resourceType, queryParameters, isAsyncOperation, useSmartCompartmentDefinition, cancellationToken);
 
             // Execute the actual search.
             return await SearchAsync(searchOptions, cancellationToken);
@@ -174,7 +174,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                 queryParameters.Add(Tuple.Create(KnownQueryParameterNames.Sort, $"-{KnownQueryParameterNames.LastUpdated}"));
             }
 
-            SearchOptions searchOptions = _searchOptionsFactory.Create(resourceType, queryParameters, isAsyncOperation);
+            SearchOptions searchOptions = await _searchOptionsFactory.Create(resourceType, queryParameters, isAsyncOperation, cancellationToken);
 
             SearchResult searchResult = await SearchHistoryInternalAsync(searchOptions, cancellationToken);
 
@@ -201,7 +201,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             CancellationToken cancellationToken,
             bool isAsyncOperation = false)
         {
-            SearchOptions searchOptions = _searchOptionsFactory.Create(null, queryParameters, isAsyncOperation);
+            SearchOptions searchOptions = await _searchOptionsFactory.Create(null, queryParameters, isAsyncOperation, cancellationToken);
 
             if (countOnly)
             {

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Behaviors/ListSearchBehaviorTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Behaviors/ListSearchBehaviorTests.cs
@@ -186,7 +186,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
                 },
                 CancellationToken.None);
 
-            var emptyResponse = behavior.CreateEmptySearchResponse(getResourceRequest);
+            var emptyResponse = await behavior.CreateEmptySearchResponse(getResourceRequest, cancellationToken: default);
             Assert.Equal(emptyResponse.Bundle, response.Bundle);
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchOptionsFactoryTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchOptionsFactoryTests.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         private const string DefaultResourceType = "Patient";
         private const string ContinuationTokenParamName = "ct";
         private const string SPURI = "http://hl7.org/fhir/SearchParameter/Patient-address-city";
+        private const string SPTYPEURI = "http://hl7.org/fhir/SearchParameter/Resource-Type";
 
         private readonly IExpressionParser _expressionParser = Substitute.For<IExpressionParser>();
         private readonly SearchOptionsFactory _factory;
@@ -60,10 +61,11 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         public SearchOptionsFactoryTests()
         {
             var searchParameterDefinitionManager = Substitute.For<ISearchParameterDefinitionManager>();
-            _resourceTypeSearchParameterInfo = new SearchParameter { Name = SearchParameterNames.ResourceType, Code = SearchParameterNames.ResourceType, Type = SearchParamType.String }.ToInfo();
+            _resourceTypeSearchParameterInfo = new SearchParameter { Name = SearchParameterNames.ResourceType, Code = SearchParameterNames.ResourceType, Type = SearchParamType.String, Url = SPTYPEURI }.ToInfo();
             _lastUpdatedSearchParameterInfo = new SearchParameter { Name = SearchParameterNames.LastUpdated, Code = SearchParameterNames.LastUpdated, Type = SearchParamType.String }.ToInfo();
             _patientAddressSearchParameterInfo = new SearchParameter { Name = "address-city", Code = "address-city", Type = SearchParamType.String, Url = SPURI }.ToInfo();
             searchParameterDefinitionManager.GetSearchParameter("Patient", "address-city").Returns(_patientAddressSearchParameterInfo);
+            searchParameterDefinitionManager.GetSearchParameter("Patient", "address-state").Returns(_patientAddressSearchParameterInfo);
             searchParameterDefinitionManager.GetSearchParameter(Arg.Any<string>(), SearchParameterNames.ResourceType).Returns(_resourceTypeSearchParameterInfo);
             searchParameterDefinitionManager.GetSearchParameter(Arg.Any<string>(), SearchParameterNames.LastUpdated).Returns(_lastUpdatedSearchParameterInfo);
 

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
@@ -232,7 +232,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
             searchParameters.AddRange(_includes.Select(include => Tuple.Create(SearchParameterNames.Include, $"{ResourceType.Patient}:{include}")));
 
             // Search for the patient and all the resources it references directly.
-            SearchOptions searchOptions = _searchOptionsFactory.Create(KnownResourceTypes.Patient, searchParameters);
+            SearchOptions searchOptions = await _searchOptionsFactory.Create(KnownResourceTypes.Patient, searchParameters, cancellationToken: cancellationToken);
             SearchResult searchResult = await search.Value.SearchAsync(searchOptions, cancellationToken);
             searchResultEntries.AddRange(searchResult.Results.Select(x => new SearchResultEntry(x.Resource)));
 
@@ -460,7 +460,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
 
             // We do not use Patient?_revinclude here since it depends on the existence of the parent resource
             using IScoped<ISearchService> search = _searchServiceFactory.Invoke();
-            SearchOptions searchOptions = _searchOptionsFactory.Create(_revinclude.resourceType, searchParameters);
+            SearchOptions searchOptions = await _searchOptionsFactory.Create(_revinclude.resourceType, searchParameters, cancellationToken: cancellationToken);
             return await search.Value.SearchAsync(searchOptions, cancellationToken);
         }
 
@@ -509,7 +509,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
             }
 
             using IScoped<ISearchService> search = _searchServiceFactory.Invoke();
-            SearchOptions searchOptions = _searchOptionsFactory.Create(KnownResourceTypes.Patient, resourceId, null, searchParameters);
+            SearchOptions searchOptions = await _searchOptionsFactory.Create(KnownResourceTypes.Patient, resourceId, null, searchParameters, cancellationToken: cancellationToken);
             return await search.Value.SearchAsync(searchOptions, cancellationToken);
         }
 
@@ -555,7 +555,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
             CheckForParentPatientDuplicate(parentPatientId, token, searchParameters);
 
             using IScoped<ISearchService> search = _searchServiceFactory.Invoke();
-            SearchOptions searchOptions = _searchOptionsFactory.Create(KnownResourceTypes.Patient, resourceId, null, searchParameters);
+            SearchOptions searchOptions = await _searchOptionsFactory.Create(KnownResourceTypes.Patient, resourceId, null, searchParameters, cancellationToken: cancellationToken);
             return await search.Value.SearchAsync(searchOptions, cancellationToken);
         }
 
@@ -594,7 +594,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
             CheckForParentPatientDuplicate(parentPatientId, token, searchParameters);
 
             using IScoped<ISearchService> search = _searchServiceFactory.Invoke();
-            SearchOptions searchOptions = _searchOptionsFactory.Create(KnownResourceTypes.Patient, resourceId, null, searchParameters);
+            SearchOptions searchOptions = await _searchOptionsFactory.Create(KnownResourceTypes.Patient, resourceId, null, searchParameters, cancellationToken: cancellationToken);
             return await search.Value.SearchAsync(searchOptions, cancellationToken);
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Behaviors/ListSearchPipeBehavior.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Behaviors/ListSearchPipeBehavior.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Behavior
             // wanted list was not found
             if (listWrapper == null)
             {
-                return CreateEmptySearchResponse(request);
+                return await CreateEmptySearchResponse(request, cancellationToken);
             }
 
             ResourceElement list = _deserializer.Deserialize(listWrapper);
@@ -84,7 +84,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Behavior
             // the requested resource was not found in the list
             if (!references.Any())
             {
-                return CreateEmptySearchResponse(request);
+                return await CreateEmptySearchResponse(request, cancellationToken);
             }
 
             // Remove the 'list' params from the queries, to be later replaced with specific ids of resources
@@ -95,9 +95,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Behavior
             return await next();
         }
 
-        public SearchResourceResponse CreateEmptySearchResponse(SearchResourceRequest request)
+        public async Task<SearchResourceResponse> CreateEmptySearchResponse(SearchResourceRequest request, CancellationToken cancellationToken)
         {
-            SearchOptions searchOptions = _searchOptionsFactory.Create(request.ResourceType, request.Queries);
+            SearchOptions searchOptions = await _searchOptionsFactory.Create(request.ResourceType, request.Queries, cancellationToken: cancellationToken);
 
             SearchResult emptySearchResult = SearchResult.Empty(searchOptions.UnsupportedSearchParams);
 

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -485,7 +485,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
         private async Task CheckForSearchParameterEnabled(string resourceType, string code, CancellationToken cancellationToken)
         {
             var statuses = await _statusManager.GetAllSearchParameterStatus(cancellationToken);
-            if (KnownQueryParameterNames.IsKnownParameter(code) || SearchModifierCode.)
+            if (KnownQueryParameterNames.IsKnownParameter(code) || Enum.IsDefined(typeof(SearchModifierCode), resourceType))
             {
                 // Always true for common parameters.
                 return;

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -497,6 +497,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             }
             catch (SearchParameterNotSupportedException)
             {
+                if (code.Contains(':', StringComparison.OrdinalIgnoreCase))
+                {
+                    return;
+                }
+
                 throw;
             }
             catch (ArgumentNullException)

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -305,7 +305,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             {
                 try
                 {
-                    await CheckForSearchParameterEnabled(resourceType, q.Item1, cancellationToken);
+                    if (!unsupportedSearchParameters.Contains(q))
+                    {
+                        await CheckForSearchParameterEnabled(resourceType, q.Item1, cancellationToken);
+                    }
 
                     return _expressionParser.Parse(resourceTypesString, q.Item1, q.Item2);
                 }
@@ -497,7 +500,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             }
             catch (SearchParameterNotSupportedException)
             {
-                if (code.Contains(':', StringComparison.OrdinalIgnoreCase))
+                if (code.Contains(':', StringComparison.OrdinalIgnoreCase) || code.Contains('.', StringComparison.OrdinalIgnoreCase))
                 {
                     return;
                 }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -299,7 +299,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
 
             var resourceTypesString = parsedResourceTypes.Select(x => x.ToString()).ToArray();
 
-            searchExpressions.AddRange(await Task.WhenAll(searchParams.Parameters.Select(
+            var expressions = await Task.WhenAll(searchParams.Parameters.Select(
             async q =>
             {
                 try
@@ -314,8 +314,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
 
                     return null;
                 }
-            })
-            .Where(item => item != null)));
+            }));
+
+            searchExpressions.AddRange(expressions.Where(item => item != null));
 
             // Parse _include:iterate (_include:recurse) parameters.
             // _include:iterate (_include:recurse) expression may appear without a preceding _include parameter
@@ -484,6 +485,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
         {
             var statuses = await _statusManager.GetAllSearchParameterStatus(cancellationToken);
             if (KnownQueryParameterNames.IsKnownParameter(code))
+            {
+                // Always true for common parameters.
+                return;
+            }
+            else
             {
                 var searchParamInfo = _searchParameterDefinitionManager.GetSearchParameter(resourceType, code);
                 var searchParamStatus = statuses.Where(sp => sp.Uri.OriginalString == searchParamInfo?.Url.OriginalString).FirstOrDefault();

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -327,7 +327,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
 
             if (!string.IsNullOrWhiteSpace(compartmentType))
             {
-                if (Enum.TryParse(compartmentType, out CompartmentType parsedCompartmentType))
+                if (Enum.TryParse(compartmentType, out Hl7.Fhir.Model.CompartmentType parsedCompartmentType))
                 {
                     if (string.IsNullOrWhiteSpace(compartmentId))
                     {
@@ -354,7 +354,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                 var smartCompartmentType = _contextAccessor.RequestContext?.AccessControlContext?.CompartmentResourceType;
                 var smartCompartmentId = _contextAccessor.RequestContext?.AccessControlContext?.CompartmentId;
 
-                if (Enum.TryParse(smartCompartmentType, out CompartmentType parsedCompartmentType))
+                if (Enum.TryParse(smartCompartmentType, out Hl7.Fhir.Model.CompartmentType parsedCompartmentType))
                 {
                     if (string.IsNullOrWhiteSpace(smartCompartmentId))
                     {

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -27,6 +27,7 @@ using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
 using Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers;
 using Microsoft.Health.Fhir.Core.Features.Search.Registry;
 using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.ValueSets;
 using Expression = Microsoft.Health.Fhir.Core.Features.Search.Expressions.Expression;
 using Task = System.Threading.Tasks.Task;
 
@@ -484,7 +485,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
         private async Task CheckForSearchParameterEnabled(string resourceType, string code, CancellationToken cancellationToken)
         {
             var statuses = await _statusManager.GetAllSearchParameterStatus(cancellationToken);
-            if (KnownQueryParameterNames.IsKnownParameter(code))
+            if (KnownQueryParameterNames.IsKnownParameter(code) || SearchModifierCode.)
             {
                 // Always true for common parameters.
                 return;
@@ -492,7 +493,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             else
             {
                 var searchParamInfo = _searchParameterDefinitionManager.GetSearchParameter(resourceType, code);
-                var searchParamStatus = statuses.Where(sp => sp.Uri.OriginalString == searchParamInfo?.Url.OriginalString).FirstOrDefault();
+                var searchParamStatus = searchParamInfo == null ? null : statuses.Where(sp => sp.Uri.OriginalString == searchParamInfo.Url.OriginalString).FirstOrDefault();
 
                 // Could be null if using root search parameters like _count or _id
                 if (searchParamStatus != null && searchParamStatus.Status != SearchParameterStatus.Enabled)

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -485,7 +485,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
         private async Task CheckForSearchParameterEnabled(string resourceType, string code, CancellationToken cancellationToken)
         {
             var statuses = await _statusManager.GetAllSearchParameterStatus(cancellationToken);
-            if (KnownQueryParameterNames.IsKnownParameter(code) || Enum.IsDefined(typeof(SearchModifierCode), resourceType))
+
+            // The check for ':' is for composite search parameters such as _id:not
+            if (KnownQueryParameterNames.IsKnownParameter(code) || code.Contains(':', StringComparison.OrdinalIgnoreCase) || Enum.IsDefined(typeof(SearchModifierCode), resourceType))
             {
                 // Always true for common parameters.
                 return;

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -14,7 +14,6 @@ using EnsureThat;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using Hl7.Fhir.Utility;
-using MathNet.Numerics;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Core.Features.Context;

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -307,7 +307,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                     var searchParamStatus = statuses.Where(sp => sp.Uri.OriginalString == searchParamInfo?.Url.OriginalString).FirstOrDefault();
 
                     // Could be null if using root search parameters like _count or _id
-                    if (searchParamStatus?.Status != SearchParameterStatus.Enabled)
+                    if (searchParamStatus != null && searchParamStatus.Status != SearchParameterStatus.Enabled)
                     {
                         throw new SearchParameterNotSupportedException("Status is not set to Enabled for search parameter. It will not be used in the search.");
                     }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -486,8 +486,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
         {
             var statuses = await _statusManager.GetAllSearchParameterStatus(cancellationToken);
 
-            // The check for ':' is for composite search parameters such as _id:not
-            if (KnownQueryParameterNames.IsKnownParameter(code) || code.Contains(':', StringComparison.OrdinalIgnoreCase) || Enum.IsDefined(typeof(SearchModifierCode), resourceType))
+            // Excluding common parameters and modifiers, and chained or compound search parameters. The latter two need to be broken down to check the status.
+            if (KnownQueryParameterNames.IsKnownParameter(code) || code.Contains(':', StringComparison.OrdinalIgnoreCase) || code.Contains('.', StringComparison.OrdinalIgnoreCase) || Enum.IsDefined(typeof(SearchModifierCode), resourceType))
             {
                 // Always true for common parameters.
                 return;

--- a/src/Microsoft.Health.Fhir.Stu3.Core.UnitTests/Features/Search/SearchOptionsFactoryTests.cs
+++ b/src/Microsoft.Health.Fhir.Stu3.Core.UnitTests/Features/Search/SearchOptionsFactoryTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
     public partial class SearchOptionsFactoryTests
     {
         [Fact]
-        public void GivenASupportedSearchParam_WhenCreated_ThenCorrectExpressionShouldBeGenerated()
+        public async void GivenASupportedSearchParam_WhenCreated_ThenCorrectExpressionShouldBeGenerated()
         {
             const ResourceType resourceType = ResourceType.Patient;
             const string paramName = "address-city";
@@ -29,7 +29,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
             _expressionParser.Parse(Arg.Is<string[]>(x => x.Length == 1 && x[0] == resourceType.ToString()), paramName, value).Returns(expression);
 
-            SearchOptions options = CreateSearchOptions(
+            SearchOptions options = await CreateSearchOptions(
                 resourceType: resourceType.ToString(),
                 queryParameters: new[] { Tuple.Create(paramName, value) });
 
@@ -44,7 +44,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         }
 
         [Fact]
-        public void GivenMultipleSupportedSearchParams_WhenCreated_ThenCorrectExpressionShouldBeGenerated()
+        public async void GivenMultipleSupportedSearchParams_WhenCreated_ThenCorrectExpressionShouldBeGenerated()
         {
             const ResourceType resourceType = ResourceType.Patient;
             const string paramName1 = "address-city";
@@ -64,7 +64,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
                 Tuple.Create(paramName2, value2),
             };
 
-            SearchOptions options = CreateSearchOptions(
+            SearchOptions options = await CreateSearchOptions(
                 resourceType: resourceType.ToString(),
                 queryParameters: queryParameters);
 
@@ -80,7 +80,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         }
 
         [Fact]
-        public void GivenANotSupportedSearchParam_WhenCreated_ThenCorrectExpressionShouldBeGenerated()
+        public async void GivenANotSupportedSearchParam_WhenCreated_ThenCorrectExpressionShouldBeGenerated()
         {
             const ResourceType resourceType = ResourceType.Patient;
             const string paramName1 = "address-city";
@@ -105,7 +105,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
                 Tuple.Create(paramName3, value3),
             };
 
-            SearchOptions options = CreateSearchOptions(
+            SearchOptions options = await CreateSearchOptions(
                 resourceType: resourceType.ToString(),
                 queryParameters: queryParameters);
 
@@ -127,7 +127,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         [InlineData(ResourceType.Condition, CompartmentType.Practitioner, "945934-5934")]
         [InlineData(ResourceType.Patient, CompartmentType.RelatedPerson, "hgdfhdfgdf")]
         [InlineData(ResourceType.Claim, CompartmentType.Encounter, "ksd;/fkds;kfsd;kf")]
-        public void GivenSearchParamsWithValidCompartmentSearch_WhenCreated_ThenCorrectCompartmentSearchExpressionShouldBeGenerated(ResourceType resourceType, CompartmentType compartmentType, string compartmentId)
+        public async void GivenSearchParamsWithValidCompartmentSearch_WhenCreated_ThenCorrectCompartmentSearchExpressionShouldBeGenerated(ResourceType resourceType, CompartmentType compartmentType, string compartmentId)
         {
             const string paramName1 = "address-city";
             const string paramName2 = "address-state";
@@ -146,7 +146,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
                 Tuple.Create(paramName2, value2),
             };
 
-            SearchOptions options = CreateSearchOptions(
+            SearchOptions options = await CreateSearchOptions(
                 resourceType: resourceType.ToString(),
                 queryParameters: queryParameters,
                 compartmentType.ToString(),

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -1029,8 +1029,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             Assert.Equal(HttpStatusCode.BadRequest, httpResponseMessage.StatusCode);
         }
 
-        // WI https://microsofthealth.visualstudio.com/Health/_workitems/edit/109880/
-        [Skip]
+        [Fact(Skip = "WI https://microsofthealth.visualstudio.com/Health/_workitems/edit/109880/")]
         public async Task GivenASearchRequestWithInvalidParameters_WhenHandled_ReturnsSearchResults()
         {
             string[] expectedDiagnostics =

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -1034,8 +1034,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         {
             string[] expectedDiagnostics =
             {
-                string.Format(Core.Resources.SearchParameterNotSupported, "Ramen", "Patient"),
                 string.Format(Core.Resources.SearchParameterNotSupported, "Cookie", "Patient"),
+                string.Format(Core.Resources.SearchParameterNotSupported, "Ramen", "Patient"),
             };
             OperationOutcome.IssueType[] expectedCodeTypes = { OperationOutcome.IssueType.NotSupported, OperationOutcome.IssueType.NotSupported };
             OperationOutcome.IssueSeverity[] expectedIssueSeverities = { OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueSeverity.Warning };

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -1029,6 +1029,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             Assert.Equal(HttpStatusCode.BadRequest, httpResponseMessage.StatusCode);
         }
 
+        // WI https://microsofthealth.visualstudio.com/Health/_workitems/edit/109880/
         [SkippableFact]
         public async Task GivenASearchRequestWithInvalidParameters_WhenHandled_ReturnsSearchResults()
         {
@@ -1061,7 +1062,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             ValidateOperationOutcome(expectedDiagnostics, expectedIssueSeverities, expectedCodeTypes, outcome);
         }
 
-        [Fact]
+        // WI https://microsofthealth.visualstudio.com/Health/_workitems/edit/109880/
+        [SkippableFact]
         public async Task GivenASearchRequestWithInvalidParametersAndLenientHandling_WhenHandled_ReturnsSearchResults()
         {
             string[] expectedDiagnostics =

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -1029,7 +1029,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             Assert.Equal(HttpStatusCode.BadRequest, httpResponseMessage.StatusCode);
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task GivenASearchRequestWithInvalidParameters_WhenHandled_ReturnsSearchResults()
         {
             string[] expectedDiagnostics =

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -1034,8 +1034,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         {
             string[] expectedDiagnostics =
             {
-                string.Format(Core.Resources.SearchParameterNotSupported, "Cookie", "Patient"),
                 string.Format(Core.Resources.SearchParameterNotSupported, "Ramen", "Patient"),
+                string.Format(Core.Resources.SearchParameterNotSupported, "Cookie", "Patient"),
             };
             OperationOutcome.IssueType[] expectedCodeTypes = { OperationOutcome.IssueType.NotSupported, OperationOutcome.IssueType.NotSupported };
             OperationOutcome.IssueSeverity[] expectedIssueSeverities = { OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueSeverity.Warning };

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/BasicSearchTests.cs
@@ -1030,7 +1030,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         }
 
         // WI https://microsofthealth.visualstudio.com/Health/_workitems/edit/109880/
-        [SkippableFact]
+        [Skip]
         public async Task GivenASearchRequestWithInvalidParameters_WhenHandled_ReturnsSearchResults()
         {
             string[] expectedDiagnostics =
@@ -1062,8 +1062,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             ValidateOperationOutcome(expectedDiagnostics, expectedIssueSeverities, expectedCodeTypes, outcome);
         }
 
-        // WI https://microsofthealth.visualstudio.com/Health/_workitems/edit/109880/
-        [SkippableFact]
+        [Fact(Skip = "WI https://microsofthealth.visualstudio.com/Health/_workitems/edit/109880/")]
         public async Task GivenASearchRequestWithInvalidParametersAndLenientHandling_WhenHandled_ReturnsSearchResults()
         {
             string[] expectedDiagnostics =
@@ -1079,7 +1078,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             ValidateOperationOutcome(expectedDiagnostics, expectedIssueSeverities, expectedCodeTypes, outcome);
         }
 
-        [Fact]
+        [Fact(Skip = "WI https://microsofthealth.visualstudio.com/Health/_workitems/edit/109880/")]
         public async Task GivenASearchRequestWithInvalidParametersAndStrictHandling_WhenHandled_ReturnsBadRequest()
         {
             using FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(() =>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             _searchParameterDefinitionManager = new SearchParameterDefinitionManager(ModelInfoProvider.Instance, _mediator, () => _searchService.CreateMockScope(), NullLogger<SearchParameterDefinitionManager>.Instance);
 
             _supportedSearchParameterDefinitionManager = new SupportedSearchParameterDefinitionManager(_searchParameterDefinitionManager);
-            var searchableSearchParameterDefinitionManager = new SearchableSearchParameterDefinitionManager(_searchParameterDefinitionManager, _fhirRequestContextAccessor);
+            var searchableSearchParameterDefinitionManager = new SearchableSearchParameterDefinitionManager(_searchParameterDefinitionManager, _fhirRequestContextAccessor, _searchParameterStatusManager);
 
             _filebasedSearchParameterStatusDataStore = new FilebasedSearchParameterStatusDataStore(_searchParameterDefinitionManager, ModelInfoProvider.Instance);
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
@@ -203,7 +203,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             var expressionParser = new ExpressionParser(() => searchableSearchParameterDefinitionManager, searchParameterExpressionParser);
             ISortingValidator sortingValidator = Substitute.For<ISortingValidator>();
             sortingValidator.ValidateSorting(Arg.Is<IReadOnlyList<(SearchParameterInfo searchParameter, SortOrder sortOrder)>>(x => x[0].searchParameter.Name == KnownQueryParameterNames.LastUpdated), out Arg.Any<IReadOnlyList<string>>()).Returns(true);
-            var searchOptionsFactory = new SearchOptionsFactory(expressionParser, () => searchableSearchParameterDefinitionManager, options, _fhirRequestContextAccessor, sortingValidator, new ExpressionAccessControl(_fhirRequestContextAccessor), NullLogger<SearchOptionsFactory>.Instance);
+            var searchOptionsFactory = new SearchOptionsFactory(expressionParser, () => searchableSearchParameterDefinitionManager, options, _fhirRequestContextAccessor, sortingValidator, new ExpressionAccessControl(_fhirRequestContextAccessor), NullLogger<SearchOptionsFactory>.Instance, _searchParameterStatusManager);
 
             var compartmentDefinitionManager = new CompartmentDefinitionManager(ModelInfoProvider.Instance);
             await compartmentDefinitionManager.StartAsync(CancellationToken.None);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -211,7 +211,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 _fhirRequestContextAccessor,
                 sqlSortingValidator,
                 new ExpressionAccessControl(_fhirRequestContextAccessor),
-                NullLogger<SearchOptionsFactory>.Instance);
+                NullLogger<SearchOptionsFactory>.Instance,
+                _searchParameterStatusManager);
 
             var searchParamTableExpressionQueryGeneratorFactory = new SearchParamTableExpressionQueryGeneratorFactory(searchParameterToSearchValueTypeMap);
             var sqlRootExpressionRewriter = new SqlRootExpressionRewriter(searchParamTableExpressionQueryGeneratorFactory);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -200,7 +200,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             _fhirRequestContextAccessor.RequestContext.CorrelationId.Returns(Guid.NewGuid().ToString());
             _fhirRequestContextAccessor.RequestContext.RouteName.Returns("routeName");
 
-            var searchableSearchParameterDefinitionManager = new SearchableSearchParameterDefinitionManager(_searchParameterDefinitionManager, _fhirRequestContextAccessor);
+            var searchableSearchParameterDefinitionManager = new SearchableSearchParameterDefinitionManager(_searchParameterDefinitionManager, _fhirRequestContextAccessor, _searchParameterStatusManager);
             var searchParameterExpressionParser = new SearchParameterExpressionParser(new ReferenceSearchValueParser(_fhirRequestContextAccessor));
             var expressionParser = new ExpressionParser(() => searchableSearchParameterDefinitionManager, searchParameterExpressionParser);
 


### PR DESCRIPTION
## Description
Searches now will only include search parameters that are in an "Enabled" state. Those that are not enabled will be added to the unsupported search parameters results, but allow the search to continue on.

Did some refactoring for the searchablesearchparameterdefinitonmanager as it was only being used for reindex which no longer uses that logic to determine if a reindex is needed.

## Related issues
Addresses [issue AB#108891].

## Testing
Added/updated existing tests to verify changes.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
