### PR TITLE
Reenable Queue Client in Cosmos

### DIFF
--- a/R4.slnf
+++ b/R4.slnf
@@ -28,6 +28,8 @@
       "src\\Microsoft.Health.Fhir.SqlServer\\Microsoft.Health.Fhir.SqlServer.csproj",
       "src\\Microsoft.Health.Fhir.Tests.Common\\Microsoft.Health.Fhir.Tests.Common.csproj",
       "src\\Microsoft.Health.Fhir.ValueSets\\Microsoft.Health.Fhir.ValueSets.csproj",
+      "src\\Microsoft.Health.TaskManagement.UnitTests\\Microsoft.Health.TaskManagement.UnitTests.csproj",
+      "src\\Microsoft.Health.TaskManagement\\Microsoft.Health.TaskManagement.csproj",
       "test\\Microsoft.Health.Fhir.R4.Tests.E2E\\Microsoft.Health.Fhir.R4.Tests.E2E.csproj",
       "test\\Microsoft.Health.Fhir.R4.Tests.Integration\\Microsoft.Health.Fhir.R4.Tests.Integration.csproj",
       "test\\Microsoft.Health.Fhir.Shared.Tests.Crucible\\Microsoft.Health.Fhir.Shared.Tests.Crucible.shproj",

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportProcessingJob.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportProcessingJob.cs
@@ -83,7 +83,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                 record = exportJobRecord;
                 progress.Report(JsonConvert.SerializeObject(exportJobRecord));
 
-                if (record.Status == OperationStatus.Running)
+                if (record.Status == OperationStatus.Running
+                    && (record.ExportType != ExportJobType.All || record.Filters.Any()))
                 {
                     // Update Export Job is called in three scenarios:
                     // 1. A page of search results is processed and there is a continuation token.
@@ -94,9 +95,16 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                     // For single threaded jobs this section will complete a job after every page of results is processed and make a new job for the next page.
                     // This will allow for saving intermediate states of the job.
 
-                    var definition = jobInfo.DeserializeDefinition<ExportJobRecord>();
-                    definition.Progress = exportJobRecord.Progress;
-                    await _queueClient.EnqueueAsync(QueueType.Export, innerCancellationToken, jobInfo.GroupId, definitions: definition);
+                    record.Status = OperationStatus.Completed;
+                    var existingJobs = await _queueClient.GetJobByGroupIdAsync(QueueType.Export, jobInfo.GroupId, false, cancellationToken);
+
+                    // Checks that a followup job has not already been made.
+                    if (!existingJobs.Any((job) => job.Id > jobInfo.Id))
+                    {
+                        var definition = jobInfo.DeserializeDefinition<ExportJobRecord>();
+                        definition.Progress = exportJobRecord.Progress;
+                        await _queueClient.EnqueueAsync(QueueType.Export, innerCancellationToken, jobInfo.GroupId, definitions: definition);
+                    }
 
                     // TODO: When legacy export support is removed from Cosmos remove this exception and refactor ExportJobTask to expect only one page of results will be processed.
                     throw new JobSegmentCompletedException();

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportProcessingJob.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportProcessingJob.cs
@@ -83,8 +83,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                 record = exportJobRecord;
                 progress.Report(JsonConvert.SerializeObject(exportJobRecord));
 
-                if (record.Status == OperationStatus.Running
-                    && (record.ExportType != ExportJobType.All || record.Filters.Any()))
+                if (record.Status == OperationStatus.Running)
                 {
                     // Update Export Job is called in three scenarios:
                     // 1. A page of search results is processed and there is a continuation token.

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Queues/CosmosQueueClient.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Queues/CosmosQueueClient.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Runtime;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
@@ -77,7 +78,7 @@ public class CosmosQueueClient : IQueueClient
             .WithParameter("@groupId", groupId);
 
         // Add existing job records to the list of job infos
-        IReadOnlyList<JobGroupWrapper> existingJobs = await ExecuteQueryAsync(existingJobsSpec, 100, cancellationToken);
+        IReadOnlyList<JobGroupWrapper> existingJobs = await ExecuteQueryAsync(existingJobsSpec, 100, queueType, cancellationToken);
         if (existingJobs.Count > 0)
         {
             IEnumerable<JobInfo> existingJobInfos =
@@ -111,7 +112,7 @@ public class CosmosQueueClient : IQueueClient
                     container.Value,
                     new CosmosQueryContext(
                         sqlQuerySpec,
-                        new QueryRequestOptions { PartitionKey = new PartitionKey(JobGroupWrapper.JobInfoPartitionKey) }));
+                        new QueryRequestOptions { PartitionKey = new PartitionKey(JobGroupWrapper.GetJobInfoPartitionKey(queueType)) }));
 
                 FeedResponse<int> itemResponse = await query.ExecuteNextAsync(cancellationToken);
 
@@ -159,7 +160,7 @@ public class CosmosQueueClient : IQueueClient
         }
 
         using IScoped<Container> container = _containerFactory.Invoke();
-        ItemResponse<JobGroupWrapper> result = await container.Value.CreateItemAsync(jobInfo, new PartitionKey(JobGroupWrapper.JobInfoPartitionKey), cancellationToken: cancellationToken);
+        ItemResponse<JobGroupWrapper> result = await container.Value.CreateItemAsync(jobInfo, new PartitionKey(jobInfo.PartitionKey), cancellationToken: cancellationToken);
 
         return result.Resource.ToJobInfo().ToList();
     }
@@ -185,7 +186,7 @@ public class CosmosQueueClient : IQueueClient
 
         return await _retryPolicy.ExecuteAsync(async () =>
             {
-                IReadOnlyList<JobGroupWrapper> response = await ExecuteQueryAsync(sqlQuerySpec, numberOfJobsToDequeue, cancellationToken);
+                IReadOnlyList<JobGroupWrapper> response = await ExecuteQueryAsync(sqlQuerySpec, numberOfJobsToDequeue, queueType, cancellationToken);
 
                 foreach (JobGroupWrapper item in response)
                 {
@@ -453,7 +454,7 @@ public class CosmosQueueClient : IQueueClient
                 .WithParameter("@groupId", groupId.ToString())
                 .WithParameter("@queueType", queueType);
 
-            var response = await ExecuteQueryAsync(sqlQuerySpec, 100, cancellationToken);
+            var response = await ExecuteQueryAsync(sqlQuerySpec, 100, queueType, cancellationToken);
 
             return response.ToList();
     }
@@ -465,7 +466,7 @@ public class CosmosQueueClient : IQueueClient
            AND ARRAY_CONTAINS([{string.Join(",", jobIds.Select(x => $"'{x}'"))}], d.jobId)")
             .WithParameter("@queueType", queueType);
 
-        var response = await ExecuteQueryAsync(sqlQuerySpec, jobIds.Length, cancellationToken);
+        var response = await ExecuteQueryAsync(sqlQuerySpec, jobIds.Length, queueType, cancellationToken);
 
         var infos = new List<(JobGroupWrapper JobGroup, IReadOnlyList<JobDefinitionWrapper> MatchingJob)>();
         var jobIdsString = jobIds.Select(x => x.ToString()).ToHashSet();
@@ -496,7 +497,7 @@ public class CosmosQueueClient : IQueueClient
         }
     }
 
-    private async Task<IReadOnlyList<JobGroupWrapper>> ExecuteQueryAsync(QueryDefinition sqlQuerySpec, int itemCount, CancellationToken cancellationToken)
+    private async Task<IReadOnlyList<JobGroupWrapper>> ExecuteQueryAsync(QueryDefinition sqlQuerySpec, int itemCount, byte queueType, CancellationToken cancellationToken)
     {
         using IScoped<Container> container = _containerFactory.Invoke();
 
@@ -504,7 +505,7 @@ public class CosmosQueueClient : IQueueClient
             container.Value,
             new CosmosQueryContext(
                 sqlQuerySpec,
-                new QueryRequestOptions { PartitionKey = new PartitionKey(JobGroupWrapper.JobInfoPartitionKey), MaxItemCount = itemCount }));
+                new QueryRequestOptions { PartitionKey = new PartitionKey(JobGroupWrapper.GetJobInfoPartitionKey(queueType)), MaxItemCount = itemCount }));
 
         var items = new List<JobGroupWrapper>();
         FeedResponse<JobGroupWrapper> response = await _retryPolicy.ExecuteAsync(async () => await query.ExecuteNextAsync(cancellationToken));
@@ -526,7 +527,7 @@ public class CosmosQueueClient : IQueueClient
         {
             await container.Value.UpsertItemAsync(
                 definition,
-                new PartitionKey(JobGroupWrapper.JobInfoPartitionKey),
+                new PartitionKey(definition.PartitionKey),
                 new ItemRequestOptions { IfMatchEtag = definition.ETag },
                 cancellationToken: cancellationToken);
         }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Queues/JobGroupWrapper.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Queues/JobGroupWrapper.cs
@@ -11,13 +11,19 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Queues;
 
 public class JobGroupWrapper : SystemData
 {
-    public const string JobInfoPartitionKey = "__jobs__";
+    private const string JobInfoPartitionKey = "__jobs__";
 
     [JsonProperty("groupId")]
     public string GroupId { get; set; }
 
     [JsonProperty(KnownDocumentProperties.PartitionKey)]
-    public string PartitionKey { get; } = JobInfoPartitionKey;
+    public string PartitionKey
+    {
+        get
+        {
+            return GetJobInfoPartitionKey(QueueType);
+        }
+    }
 
     [JsonProperty("queueType")]
     public byte QueueType { get; set; }
@@ -33,4 +39,9 @@ public class JobGroupWrapper : SystemData
 
     [JsonProperty("ttl")]
     public long TimeToLive { get; set; }
+
+    public static string GetJobInfoPartitionKey(byte type)
+    {
+        return $"{JobInfoPartitionKey}{type}__";
+    }
 }


### PR DESCRIPTION
## Description
Fixes an issue with queue client in Cosmos so it can be reenabled.

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
