### PR TITLE
Fix _include bug

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
@@ -762,6 +762,10 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
                     // break from the for loop because enough results have been found
                     return false;
                 }
+                else if (includes.Count == maxCount && !string.IsNullOrEmpty(includeResponse.continuationToken))
+                {
+                    return false;
+                }
             }
 
             return true;


### PR DESCRIPTION
## Description
Fixes a bug in _include/_revinclude where the following can happen:
1. Makes request with _include/_revinclude
2. The max count is set to 200 for the include search.
3. Include search returns EXACTLY 100 results and a continuation token. This can only happen with multiple partitions and the right data distribution.
4. The search tries to run again with a max count of 0, which throws an exception.

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
