### PR TITLE
Add relevant labels in the PR if new schema version is added

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,2 @@
+SQL Scripts:
+- src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaVersionConstants.cs

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,7 @@ Describe how this change was tested.
 - **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
 - Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
 - Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
+- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
 - [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
 - Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)
 

--- a/.github/workflows/validate-prs.yml
+++ b/.github/workflows/validate-prs.yml
@@ -24,6 +24,7 @@ jobs:
     name: Check Metadata
     runs-on: "ubuntu-latest"
     steps:
+      - uses: actions/labeler@v4
       - uses: actions/github-script@v6
         with:
           script: |

--- a/.github/workflows/validate-prs.yml
+++ b/.github/workflows/validate-prs.yml
@@ -24,6 +24,9 @@ jobs:
     name: Check Metadata
     runs-on: "ubuntu-latest"
     steps:
+      - uses: actions/checkout@v3 # Uploads repository content to the runner
+        with:
+          repository: "microsoft/fhir-server"
       - uses: actions/labeler@v4
       - uses: actions/github-script@v6
         with:

--- a/.github/workflows/validate-prs.yml
+++ b/.github/workflows/validate-prs.yml
@@ -58,6 +58,12 @@ jobs:
               errors += '- Tag the PR with **Open source only**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released. ';
             }
 
+            if(labels.includes("SQL Scripts") == true && 
+               (labels.includes("Schema Version backward incompatible") == false || 
+               labels.includes("Schema Version backward compatible") == false)) {
+              errors += '- Tag the PR with the type of update: **Schema Version backward incompatible**, **Schema Version backward compatible**. \n';
+            }
+
             if(errors != "") {
               core.setFailed(errors)
             }

--- a/.github/workflows/validate-prs.yml
+++ b/.github/workflows/validate-prs.yml
@@ -63,8 +63,8 @@ jobs:
             }
 
             if(labels.includes("SQL Scripts") == true && 
-               (labels.includes("Schema Version backward incompatible") == false || 
-               labels.includes("Schema Version backward compatible") == false)) {
+               labels.includes("Schema Version backward incompatible") == false && 
+               labels.includes("Schema Version backward compatible") == false) {
               errors += '- Tag the PR with the type of update: **Schema Version backward incompatible**, **Schema Version backward compatible**. \n';
             }
 

--- a/.github/workflows/validate-prs.yml
+++ b/.github/workflows/validate-prs.yml
@@ -63,7 +63,8 @@ jobs:
             }
 
             if(labels.includes("SQL Scripts") == true && 
-               labels.includes("Schema Version backward incompatible") == false && 
+               labels.includes("Schema Version backward incompatible") == false &&
+               labels.includes("Schema Version unchanged") == false &&              
                labels.includes("Schema Version backward compatible") == false) {
               errors += '- Tag the PR with the type of update: **Schema Version backward incompatible**, **Schema Version backward compatible**. \n';
             }

--- a/SquashMergeRequirements.md
+++ b/SquashMergeRequirements.md
@@ -6,6 +6,7 @@ When commiting your PR, please make sure to do these steps at Squash/Merge to as
 1. **Add a milestone** to your PR for the sprint that it is merged (i.e. add S47)
 1. Tag the PR with the type of update: **Bug**, **Enhancement**, or **New-Feature**
 1. Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR and a tag for **Azure Healthcare APIs** if this will release to the FHIR service in the Azure Healthcare APIs.
+1. Tag the PR with **Schema Version backward compatible** or  **Schema Version backward incompatible** if this adds new Sql script which is/is not backward compatible with the code.
 1. Include a user friendly, 1-2 sentence in the Squash/Merge **description** wrapped at 72 characters
 1. Note if it **addresses a GitHub issue and/or a VSTS item** in the Squash/Merge description (i.e. #1234 or AB#12345)
 

--- a/SquashMergeRequirements.md
+++ b/SquashMergeRequirements.md
@@ -6,7 +6,7 @@ When commiting your PR, please make sure to do these steps at Squash/Merge to as
 1. **Add a milestone** to your PR for the sprint that it is merged (i.e. add S47)
 1. Tag the PR with the type of update: **Bug**, **Enhancement**, or **New-Feature**
 1. Tag the PR with **Azure API for FHIR** if this will release to the Azure API for FHIR and a tag for **Azure Healthcare APIs** if this will release to the FHIR service in the Azure Healthcare APIs.
-1. Tag the PR with **Schema Version backward compatible** or  **Schema Version backward incompatible** if this adds new Sql script which is/is not backward compatible with the code.
+1. Tag the PR with **Schema Version backward compatible** or  **Schema Version backward incompatible** or **Schema Version unchanged** if this adds/updates Sql script which is/is not backward compatible with the code.
 1. Include a user friendly, 1-2 sentence in the Squash/Merge **description** wrapped at 72 characters
 1. Note if it **addresses a GitHub issue and/or a VSTS item** in the Squash/Merge description (i.e. #1234 or AB#12345)
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaVersionConstants.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaVersionConstants.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema
 {
     public static class SchemaVersionConstants
     {
-        // no change
         public const int Min = (int)SchemaVersion.V63;
         public const int Max = (int)SchemaVersion.V64;
         public const int MinForUpgrade = (int)SchemaVersion.V60; // this is used for upgrade tests only

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaVersionConstants.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaVersionConstants.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema
 {
     public static class SchemaVersionConstants
     {
+        // no change
         public const int Min = (int)SchemaVersion.V63;
         public const int Max = (int)SchemaVersion.V64;
         public const int MinForUpgrade = (int)SchemaVersion.V60; // this is used for upgrade tests only


### PR DESCRIPTION
## Description
This PR 
- Adds the automated github action to label the PR 'SQL Scripts' if there is any change in SchemaVersionConstants.cs file. Since if there is any new schema version added, this file will be updated for min/max schema version.
- If the PR has "SQL Scripts" label, then metadata check will fail if one of the below label is not added 
       - Schema version backward compatible
       - Schema Version backward incompatible
       - Schema Version unchanged

## Related issues
Addresses [109356](https://microsofthealth.visualstudio.com/Health/_workitems/edit/109356)

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
