### PR TITLE
Add duration in audit logs

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- Shared dependencies versions.-->
   <PropertyGroup>
-    <HealthcareSharedPackageVersion>7.0.2</HealthcareSharedPackageVersion>
+    <HealthcareSharedPackageVersion>7.0.15</HealthcareSharedPackageVersion>
     <Hl7FhirVersion>4.3.0</Hl7FhirVersion>
   </PropertyGroup>
 
@@ -47,7 +47,7 @@
   <ItemGroup>
     <PackageVersion Include="AngleSharp" Version="1.0.4" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.2.2" />
-    <PackageVersion Include="Azure.Identity" Version="1.10.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.10.1" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.0.0-beta.6" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.17.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
@@ -111,7 +111,7 @@
     <PackageVersion Include="Microsoft.SqlServer.SqlManagementObjects" Version="170.18.0" />
     <PackageVersion Include="Newtonsoft.Json.Schema" Version="3.0.15" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="NSubstitute" Version="5.0.0" />
+    <PackageVersion Include="NSubstitute" Version="5.1.0" />
     <PackageVersion Include="Polly" Version="7.2.4" />
     <PackageVersion Include="prometheus-net.AspNetCore" Version="8.0.1" />
     <PackageVersion Include="prometheus-net.DotNetRuntime" Version="4.4.0" />

--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditHelper.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditHelper.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Reflection;
@@ -80,7 +81,8 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
         /// <param name="httpContext">The HTTP context.</param>
         /// <param name="claimsExtractor">The extractor used to extract claims.</param>
         /// <param name="shouldCheckForAuthXFailure">Only emit LogExecuted messages if this is an authentication error (401), since others would already have been logged.</param>
-        public void LogExecuted(HttpContext httpContext, IClaimsExtractor claimsExtractor, bool shouldCheckForAuthXFailure = false)
+        /// <param name="durationMs">Backend duration of the request processed in milliseconds.</param>
+        public void LogExecuted(HttpContext httpContext, IClaimsExtractor claimsExtractor, bool shouldCheckForAuthXFailure = false, long? durationMs = null)
         {
             EnsureArg.IsNotNull(claimsExtractor, nameof(claimsExtractor));
             EnsureArg.IsNotNull(httpContext, nameof(httpContext));
@@ -88,11 +90,11 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
             var responseStatusCode = (HttpStatusCode)httpContext.Response.StatusCode;
             if (!shouldCheckForAuthXFailure || responseStatusCode == HttpStatusCode.Unauthorized)
             {
-                Log(AuditAction.Executed, responseStatusCode, httpContext, claimsExtractor);
+                Log(AuditAction.Executed, responseStatusCode, httpContext, claimsExtractor, durationMs);
             }
         }
 
-        private void Log(AuditAction auditAction, HttpStatusCode? statusCode, HttpContext httpContext, IClaimsExtractor claimsExtractor)
+        private void Log(AuditAction auditAction, HttpStatusCode? statusCode, HttpContext httpContext, IClaimsExtractor claimsExtractor, long? durationMs = null)
         {
             IFhirRequestContext fhirRequestContext = _fhirRequestContextAccessor.RequestContext;
 
@@ -116,6 +118,13 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
                     sanitizedOperationType = UnknownOperationType;
                 }
 
+                Dictionary<string, string> additionalProperties = null;
+                if (durationMs != null)
+                {
+                    additionalProperties = new Dictionary<string, string>();
+                    additionalProperties["durationMs"] = durationMs.ToString();
+                }
+
                 _auditLogger.LogAudit(
                     auditAction,
                     operation: auditEventType,
@@ -128,7 +137,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
                     customHeaders: _auditHeaderReader.Read(httpContext),
                     operationType: sanitizedOperationType,
                     callerAgent: DefaultCallerAgent,
-                    additionalProperties: null);
+                    additionalProperties: additionalProperties);
             }
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Audit/AuditHelperTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Audit/AuditHelperTests.cs
@@ -8,7 +8,9 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Web;
+using Hl7.Fhir.Model;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -184,6 +186,34 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
                 customHeaders: _auditHeaderReader.Read(_httpContext),
                 operationType: Arg.Any<string>(),
                 callerAgent: Arg.Any<string>());
+        }
+
+        [Fact]
+        public void GivenDuration_WhenLogExecutedIsCalled_ThenAdditionalPropertiesIsNotNullInAuditLog()
+        {
+            long durationMs = 1123;
+            const HttpStatusCode expectedStatusCode = HttpStatusCode.Created;
+            const string expectedResourceType = "Patient";
+
+            _fhirRequestContext.AuditEventType.Returns(AuditEventType);
+            _fhirRequestContext.ResourceType.Returns(expectedResourceType);
+            _httpContext.Response.StatusCode = (int)expectedStatusCode;
+
+            _auditHelper.LogExecuted(_httpContext, _claimsExtractor, durationMs: durationMs);
+
+            _auditLogger.Received(1).LogAudit(
+                AuditAction.Executed,
+                AuditEventType,
+                expectedResourceType,
+                Uri,
+                expectedStatusCode,
+                CorrelationId,
+                CallerIpAddressInString,
+                Claims,
+                customHeaders: _auditHeaderReader.Read(_httpContext),
+                operationType: Arg.Any<string>(),
+                callerAgent: Arg.Any<string>(),
+                additionalProperties: Arg.Is<Dictionary<string, string>>(d => d.ContainsKey("durationMs") && d.ContainsValue(durationMs.ToString())));
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Audit/AuditLoggingFilterAttributeTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Audit/AuditLoggingFilterAttributeTests.cs
@@ -4,6 +4,8 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net.Http;
 using Hl7.Fhir.Model;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -56,6 +58,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
         public void GivenAController_WhenExecutedAction_ThenAuditLogShouldBeLogged()
         {
             var fhirResult = new FhirResult(new Patient() { Name = { new HumanName() { Text = "TestPatient" } } }.ToResourceElement());
+            _httpContext.Items["timer"] = Stopwatch.StartNew();
 
             var resultExecutedContext = new ResultExecutedContext(
                 new ActionContext(_httpContext, new RouteData(), new ControllerActionDescriptor() { DisplayName = "Executed Context Test Descriptor" }),
@@ -65,7 +68,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
 
             _filter.OnResultExecuted(resultExecutedContext);
 
-            _auditHelper.Received(1).LogExecuted(_httpContext, _claimsExtractor);
+            _auditHelper.Received(1).LogExecuted(_httpContext, _claimsExtractor, Arg.Any<bool>(), Arg.Any<long>());
         }
     }
 }


### PR DESCRIPTION
## Description
duration is hardcoded to 0 for shoebox logs. So passing the backend latency in audit logs to bubble it up to shoebox logs.

## Related issues
Addresses #[108768](https://microsofthealth.visualstudio.com/Health/_workitems/edit/108768).

## Testing
Added and updated unit test and tested manually

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
