### PR TITLE
Add pipeline to build images

### DIFF
--- a/build/build-image.yml
+++ b/build/build-image.yml
@@ -1,0 +1,37 @@
+# DESCRIPTION:
+# Builds a docker image for a branch
+
+trigger: none
+
+variables:
+- template: build-variables.yml
+
+stages:
+- stage: UpdateVersion
+  displayName: 'Determine Semver'
+  dependsOn: []
+  jobs:
+  - job: Semver
+    pool:
+      name: '$(DefaultLinuxPool)'
+      vmImage: '$(LinuxVmImage)'
+    steps:
+    - template: ./jobs/update-semver.yml  
+    - powershell: |
+        $buildNumber = "$(semVer)".replace(".", "").replace("-", "")
+        $buildNumber = $buildNumber.subString(0, [System.Math]::Min(15, $buildNumber.Length))
+
+        Write-Host "##vso[build.updatebuildnumber]$buildNumber" 
+        Write-Host "Updated  build number to '$buildNumber"
+      name: SetBuildVersion
+
+- stage: DockerBuild  
+  displayName: 'Build images'
+  dependsOn:
+  - UpdateVersion
+  variables:
+    assemblySemFileVer: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.assemblySemFileVer']]
+  jobs:
+  - template: ./jobs/docker-build-all.yml
+    parameters: 
+      tag: $(build.BuildNumber)

--- a/build/build-image.yml
+++ b/build/build-image.yml
@@ -4,6 +4,7 @@
 trigger: none
 
 variables:
+  
 - template: build-variables.yml
 
 stages:
@@ -18,14 +19,14 @@ stages:
     steps:
     - powershell: |
         Write-Host "##vso[task.setvariable variable=assemblySemFileVer;isOutput=true]0.0.1"
-      name: SetBuildVersion
+      name: SetAssemblyVersion
 
 - stage: DockerBuild  
   displayName: 'Build images'
   dependsOn:
   - UpdateVersion
   variables:
-    assemblySemFileVer: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.assemblySemFileVer']]
+    assemblySemFileVer: $[stageDependencies.UpdateVersion.Semver.outputs['SetAssemblyVersion.assemblySemFileVer']]
   jobs:
   - template: ./jobs/docker-build-all.yml
     parameters: 

--- a/build/build-image.yml
+++ b/build/build-image.yml
@@ -16,13 +16,8 @@ stages:
       name: '$(DefaultLinuxPool)'
       vmImage: '$(LinuxVmImage)'
     steps:
-    - template: ./jobs/update-semver.yml  
     - powershell: |
-        $buildNumber = "$(semVer)".replace(".", "").replace("-", "")
-        $buildNumber = $buildNumber.subString(0, [System.Math]::Min(15, $buildNumber.Length))
-
-        Write-Host "##vso[build.updatebuildnumber]$buildNumber" 
-        Write-Host "Updated  build number to '$buildNumber"
+        Write-Host "##vso[task.setvariable variable=assemblySemFileVer;isOutput=true]0.0.1"
       name: SetBuildVersion
 
 - stage: DockerBuild  

--- a/build/cleanup-images.yml
+++ b/build/cleanup-images.yml
@@ -20,6 +20,14 @@ stages:
     parameters: 
       version: 'r4'
 
+- stage: CleanupR4
+  displayName: 'Cleanup R4B'
+  dependsOn: []
+  jobs:
+  - template: ./jobs/cleanup-version-images.yml
+    parameters: 
+      version: 'r4b'
+
 - stage: CleanupR5
   displayName: 'Cleanup R5'
   dependsOn: []


### PR DESCRIPTION
## Description
Adds a new pipeline to build docker images for branches. This allows testing of branches without messing with the PR pipeline.
https://microsofthealthoss.visualstudio.com/FhirServer/_build?definitionId=109

## Related issues
Addresses [issue #].

## Testing
Ran pipeline from branch.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip
