### PR TITLE
Revert "Reenable Queue Client in Cosmos"

### DIFF
--- a/R4.slnf
+++ b/R4.slnf
@@ -28,8 +28,6 @@
       "src\\Microsoft.Health.Fhir.SqlServer\\Microsoft.Health.Fhir.SqlServer.csproj",
       "src\\Microsoft.Health.Fhir.Tests.Common\\Microsoft.Health.Fhir.Tests.Common.csproj",
       "src\\Microsoft.Health.Fhir.ValueSets\\Microsoft.Health.Fhir.ValueSets.csproj",
-      "src\\Microsoft.Health.TaskManagement.UnitTests\\Microsoft.Health.TaskManagement.UnitTests.csproj",
-      "src\\Microsoft.Health.TaskManagement\\Microsoft.Health.TaskManagement.csproj",
       "test\\Microsoft.Health.Fhir.R4.Tests.E2E\\Microsoft.Health.Fhir.R4.Tests.E2E.csproj",
       "test\\Microsoft.Health.Fhir.R4.Tests.Integration\\Microsoft.Health.Fhir.R4.Tests.Integration.csproj",
       "test\\Microsoft.Health.Fhir.Shared.Tests.Crucible\\Microsoft.Health.Fhir.Shared.Tests.Crucible.shproj",

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportProcessingJobTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportProcessingJobTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
             var expectedResults = GenerateJobRecord(status);
 
-            var processingJob = new ExportProcessingJob(new Func<IExportJobTask>(MakeMockJobThatReturnsImmediately), new TestQueueClient());
+            var processingJob = new ExportProcessingJob(new Func<IExportJobTask>(MakeMockJob), new TestQueueClient());
             await Assert.ThrowsAsync<RetriableJobException>(() => processingJob.ExecuteAsync(GenerateJobInfo(expectedResults), progress, CancellationToken.None));
         }
 
@@ -104,33 +104,6 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
             Assert.Single(queueClient.JobInfos);
             Assert.Contains(_progressToken, queueClient.JobInfos[0].Definition);
-        }
-
-        [Fact]
-        public async Task GivenAnExportJob_WhenItFinishesAPageOfResultsAndAFollowupJobExists_ThenANewProgressJobIsNotQueued()
-        {
-            string progressResult = string.Empty;
-
-            Progress<string> progress = new Progress<string>((result) =>
-            {
-                progressResult = result;
-            });
-
-            var expectedResults = GenerateJobRecord(OperationStatus.Running);
-
-            var queueClient = new TestQueueClient();
-            var processingJob = new ExportProcessingJob(MakeMockJobWithProgressUpdate, queueClient);
-
-            var runningJob = GenerateJobInfo(expectedResults);
-            var followUpJob = GenerateJobInfo(expectedResults);
-            followUpJob.Id = runningJob.Id + 1;
-            queueClient.JobInfos.Add(followUpJob);
-
-            var taskResult = await processingJob.ExecuteAsync(runningJob, progress, CancellationToken.None);
-
-            Assert.Single(queueClient.JobInfos);
-            Assert.DoesNotContain(_progressToken, queueClient.JobInfos[0].Definition);
-            Assert.Equal(followUpJob, queueClient.JobInfos[0]);
         }
 
         private string GenerateJobRecord(OperationStatus status, string failureReason = null)
@@ -167,17 +140,6 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
             mockJob.ExecuteAsync(Arg.Any<ExportJobRecord>(), Arg.Any<WeakETag>(), Arg.Any<CancellationToken>()).Returns(x =>
             {
                 return mockJob.UpdateExportJob(x.ArgAt<ExportJobRecord>(0), x.ArgAt<WeakETag>(1), x.ArgAt<CancellationToken>(2));
-            });
-
-            return mockJob;
-        }
-
-        private IExportJobTask MakeMockJobThatReturnsImmediately()
-        {
-            var mockJob = Substitute.For<IExportJobTask>();
-            mockJob.ExecuteAsync(Arg.Any<ExportJobRecord>(), Arg.Any<WeakETag>(), Arg.Any<CancellationToken>()).Returns(x =>
-            {
-                return Task.FromResult(new ExportJobOutcome(x.ArgAt<ExportJobRecord>(0), x.ArgAt<WeakETag>(1)));
             });
 
             return mockJob;

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportProcessingJob.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportProcessingJob.cs
@@ -94,16 +94,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                     // For single threaded jobs this section will complete a job after every page of results is processed and make a new job for the next page.
                     // This will allow for saving intermediate states of the job.
 
-                    record.Status = OperationStatus.Completed;
-                    var existingJobs = await _queueClient.GetJobByGroupIdAsync(QueueType.Export, jobInfo.GroupId, false, cancellationToken);
-
-                    // Checks that a followup job has not already been made.
-                    if (!existingJobs.Any((job) => job.Id > jobInfo.Id))
-                    {
-                        var definition = jobInfo.DeserializeDefinition<ExportJobRecord>();
-                        definition.Progress = exportJobRecord.Progress;
-                        await _queueClient.EnqueueAsync(QueueType.Export, innerCancellationToken, jobInfo.GroupId, definitions: definition);
-                    }
+                    var definition = jobInfo.DeserializeDefinition<ExportJobRecord>();
+                    definition.Progress = exportJobRecord.Progress;
+                    await _queueClient.EnqueueAsync(QueueType.Export, innerCancellationToken, jobInfo.GroupId, definitions: definition);
 
                     // TODO: When legacy export support is removed from Cosmos remove this exception and refactor ExportJobTask to expect only one page of results will be processed.
                     throw new JobSegmentCompletedException();

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Queues/JobGroupWrapper.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Queues/JobGroupWrapper.cs
@@ -11,19 +11,13 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Queues;
 
 public class JobGroupWrapper : SystemData
 {
-    private const string JobInfoPartitionKey = "__jobs__";
+    public const string JobInfoPartitionKey = "__jobs__";
 
     [JsonProperty("groupId")]
     public string GroupId { get; set; }
 
     [JsonProperty(KnownDocumentProperties.PartitionKey)]
-    public string PartitionKey
-    {
-        get
-        {
-            return GetJobInfoPartitionKey(QueueType);
-        }
-    }
+    public string PartitionKey { get; } = JobInfoPartitionKey;
 
     [JsonProperty("queueType")]
     public byte QueueType { get; set; }
@@ -39,9 +33,4 @@ public class JobGroupWrapper : SystemData
 
     [JsonProperty("ttl")]
     public long TimeToLive { get; set; }
-
-    public static string GetJobInfoPartitionKey(byte type)
-    {
-        return $"{JobInfoPartitionKey}{type}__";
-    }
 }


### PR DESCRIPTION
This reverts commit b74d8c24f8381741a3b0617035216cef2c654146.

## Description
Describe the changes in this PR.

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
