### PR TITLE
Fixed Image Cleanup Pipeline Stage Name for R4B

### DIFF
--- a/build/cleanup-images.yml
+++ b/build/cleanup-images.yml
@@ -20,7 +20,7 @@ stages:
     parameters: 
       version: 'r4'
 
-- stage: CleanupR4
+- stage: CleanupR4B
   displayName: 'Cleanup R4B'
   dependsOn: []
   jobs:


### PR DESCRIPTION
## Description
For the cleanup image pipeline, fixed the stage name for R4B as it was on conflict

## Related issues

## Testing
Manual Testing.

https://dev.azure.com/microsofthealthoss/FhirServer/_build/results?buildId=36206&view=results

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
