### PR TITLE
Added support for extension_fhirUser claim for SMART auth

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
@@ -134,15 +134,13 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
 
                     if (includeFhirUserClaim)
                     {
+                        // Check if the "fhirUser" claim is present.
                         var fhirUser = principal.FindFirstValue(authorizationConfiguration.FhirUserClaim);
                         if (string.IsNullOrEmpty(fhirUser))
                         {
-                            // look for the fhirUser info in a header
-                            if (context.Request.Headers.ContainsKey(KnownHeaders.FhirUserHeader)
-                                && context.Request.Headers.TryGetValue(KnownHeaders.FhirUserHeader, out var hValue))
-                            {
-                                fhirUser = hValue.ToString();
-                            }
+                            // The "fhirUser" claim is not present, check if the "extension_fhirUser" claim is present.
+                            // Azure B2C will prefix the claim with "extension_" if the value is added to the user using a graph extension.
+                            fhirUser = principal.FindFirstValue(authorizationConfiguration.ExtensionFhirUserClaim);
                         }
 
                         try

--- a/src/Microsoft.Health.Fhir.Core/Configs/AuthorizationConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/AuthorizationConfiguration.cs
@@ -21,6 +21,8 @@ namespace Microsoft.Health.Fhir.Core.Configs
 
         public string FhirUserClaim { get; set; } = "fhirUser";
 
+        public string ExtensionFhirUserClaim { get; set; } = "extension_fhirUser";
+
         public bool ErrorOnMissingFhirUserClaim { get; set; } = false;
 
         public bool EnableSmartWithoutAuth { get; set; } = false;

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
@@ -231,7 +231,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
         }
 
         [Fact]
-        public async Task GivenFhirUserInHeader_WhenRequestMade_ThenFhirUserIsSaved()
+        public async Task GivenFhirUserInExtensionClaim_WhenRequestMade_ThenFhirUserIsSaved()
         {
             var fhirRequestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
 
@@ -240,7 +240,6 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
             fhirRequestContextAccessor.RequestContext.Returns(fhirRequestContext);
 
             HttpContext httpContext = new DefaultHttpContext();
-            httpContext.Request.Headers.Add(KnownHeaders.FhirUserHeader, "https://fhirServer/Patient/foo");
 
             var fhirConfiguration = new FhirServerConfiguration();
             fhirConfiguration.Security.Enabled = true;
@@ -248,12 +247,13 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
             authorizationConfiguration.EnableSmartWithoutAuth = true;
             await LoadRoles(authorizationConfiguration);
 
+            var fhirUserClaim = new Claim(authorizationConfiguration.ExtensionFhirUserClaim, "https://fhirServer/Patient/foo");
             var rolesClaim = new Claim(authorizationConfiguration.RolesClaim, "smartUser");
 
             foreach (string singleClaim in authorizationConfiguration.ScopesClaim)
             {
                 var scopesClaim = new Claim(singleClaim, "patient.patient.read");
-                var claimsIdentity = new ClaimsIdentity(new List<Claim>() { scopesClaim, rolesClaim });
+                var claimsIdentity = new ClaimsIdentity(new List<Claim>() { scopesClaim, rolesClaim, fhirUserClaim });
                 var expectedPrincipal = new ClaimsPrincipal(claimsIdentity);
 
                 httpContext.User = expectedPrincipal;


### PR DESCRIPTION
## Description
This PR adds support for extension_fhirUser token claim which can be used with Azure B2C to map FHIR user resources with B2C user accounts. This PR also removes support for sending FHIR user data in a request header.

Milestone S126

## Testing
Manual testing was performed to ensure these changes work with Azure B2C.
Unit tests have been updated to ensure code quality and guard against regression.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
