### PR TITLE
Rename duration property for shoebox logs

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditHelper.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditHelper.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
     /// </summary>
     public class AuditHelper : IAuditHelper
     {
+        internal const string ProcessingDurationMs = "ProcessingDurationMs";
         internal const string DefaultCallerAgent = "Microsoft.Health.Fhir.Server";
         internal const string UnknownOperationType = "Unknown";
 
@@ -122,7 +123,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
                 if (durationMs != null)
                 {
                     additionalProperties = new Dictionary<string, string>();
-                    additionalProperties["durationMs"] = durationMs.ToString();
+                    additionalProperties[ProcessingDurationMs] = durationMs.ToString();
                 }
 
                 _auditLogger.LogAudit(

--- a/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditHelper.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Audit/AuditHelper.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Audit
     /// </summary>
     public class AuditHelper : IAuditHelper
     {
-        internal const string ProcessingDurationMs = "ProcessingDurationMs";
+        internal const string ProcessingDurationMs = "processingDurationMs";
         internal const string DefaultCallerAgent = "Microsoft.Health.Fhir.Server";
         internal const string UnknownOperationType = "Unknown";
 

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Audit/AuditHelperTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Audit/AuditHelperTests.cs
@@ -213,7 +213,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Audit
                 customHeaders: _auditHeaderReader.Read(_httpContext),
                 operationType: Arg.Any<string>(),
                 callerAgent: Arg.Any<string>(),
-                additionalProperties: Arg.Is<Dictionary<string, string>>(d => d.ContainsKey("durationMs") && d.ContainsValue(durationMs.ToString())));
+                additionalProperties: Arg.Is<Dictionary<string, string>>(d => d.ContainsKey(AuditHelper.ProcessingDurationMs) && d.ContainsValue(durationMs.ToString())));
         }
 
         [Fact]


### PR DESCRIPTION
## Description
This PR just rename the durationMs property to ProcessingDurationMs

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
