### PR TITLE
Fix export comparison

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,25 +4,18 @@
     <HealthcareSharedPackageVersion>7.0.29</HealthcareSharedPackageVersion>
     <Hl7FhirVersion>4.3.0</Hl7FhirVersion>
   </PropertyGroup>
-
   <ItemGroup Label="CVE Mitigation">
     <!--Please include the CGA id if possible-->
-
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="7.0.1" />
-
     <!--CVE-2023-29331-->
     <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="7.0.3" />
-
     <!-- CVE-2021-26701 -->
     <PackageVersion Include="System.Text.Encodings.Web" Version="7.0.0" />
-
     <!-- CVE-2020-1045 -->
     <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-
     <!-- CVE-2022-26907 -->
     <PackageVersion Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
   </ItemGroup>
-
   <!-- SDK Packages -->
   <Choose>
     <When Condition="'$(TargetFramework)' == 'net7.0'">
@@ -47,7 +40,7 @@
   <ItemGroup>
     <PackageVersion Include="AngleSharp" Version="1.0.4" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.2.2" />
-    <PackageVersion Include="Azure.Identity" Version="1.10.1" />
+    <PackageVersion Include="Azure.Identity" Version="1.10.3" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.0.0-beta.6" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.17.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />

--- a/build/jobs/build.yml
+++ b/build/jobs/build.yml
@@ -29,14 +29,6 @@ steps:
       arguments: '--configuration $(buildConfiguration) -p:ContinuousIntegrationBuild=true -p:AssemblyVersion="$(assemblySemVer)" -p:FileVersion="$(assemblySemFileVer)" -p:InformationalVersion="$(informationalVersion)" -p:Version="$(majorMinorPatch)" -warnaserror -f ${{parameters.targetBuildFramework}}'
       workingDirectory: $(System.DefaultWorkingDirectory)
 
-- ${{ if eq(parameters.componentGovernance, 'true') }}:
-  - task: ComponentGovernanceComponentDetection@0
-    inputs:
-      scanType: 'Register'
-      verbosity: 'Verbose'
-      alertWarningLevel: 'High'
-      failOnAlert: true
-
 - ${{ if eq(parameters.unitTest, 'true') }}:
   - task: DotNetCoreCLI@2
     displayName: 'dotnet test'

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobFilter.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobFilter.cs
@@ -31,5 +31,28 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
 
         [JsonProperty(JobRecordProperties.SearchParams)]
         public IList<Tuple<string, string>> Parameters { get; private set; }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null || GetType() != obj.GetType())
+            {
+                return false;
+            }
+
+            return GetHashCode() == obj.GetHashCode();
+        }
+
+        public override int GetHashCode()
+        {
+            var paramHash = default(HashCode);
+            foreach (var param in Parameters)
+            {
+                paramHash.Add(param.Item1);
+                paramHash.Add(param.Item2);
+            }
+
+            paramHash.Add(ResourceType);
+            return paramHash.ToHashCode();
+        }
     }
 }


### PR DESCRIPTION
## Description
Fix comparison of filters in export.

## Related issues
Addresses [Bug 110851](https://microsofthealth.visualstudio.com/Health/_workitems/edit/110851): Export Task is creating multiple repeated child jobs and filling jobqueue table

## Testing
Manual testing

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
