### PR TITLE
Validation for Disabled SearchParameters used in Searches

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/Registry/SearchParameterStatusManagerTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/Registry/SearchParameterStatusManagerTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Registry
         private static readonly string ResourceSecurity = "http://hl7.org/fhir/SearchParameter/Resource-security";
         private static readonly string ResourceQuery = "http://hl7.org/fhir/SearchParameter/Resource-query";
 
-        private readonly SearchParameterStatusManager _manager;
+        private readonly ISearchParameterStatusManager _manager;
         private readonly ISearchParameterStatusDataStore _searchParameterStatusDataStore;
         private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager;
         private readonly IMediator _mediator;

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/CapabilityStatementBuilder.cs
@@ -62,8 +62,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
             ISearchParameterDefinitionManager searchParameterDefinitionManager,
             IOptions<CoreFeatureConfiguration> configuration,
             ISupportedProfilesStore supportedProfiles,
-            Uri metadataUrl,
-            SearchParameterStatusManager searchParameterStatusManager)
+            Uri metadataUrl)
         {
             EnsureArg.IsNotNull(modelInfoProvider, nameof(modelInfoProvider));
             EnsureArg.IsNotNull(searchParameterDefinitionManager, nameof(searchParameterDefinitionManager));

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/SystemConformanceProvider.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/SystemConformanceProvider.cs
@@ -47,7 +47,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
         private readonly IOptions<CoreFeatureConfiguration> _configuration;
         private readonly ISupportedProfilesStore _supportedProfiles;
         private readonly ILogger _logger;
-        private readonly SearchParameterStatusManager _searchParameterStatusManager;
 
         private ResourceElement _listedCapabilityStatement;
         private ResourceElement _backgroundJobCapabilityStatement;
@@ -64,8 +63,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
             ISupportedProfilesStore supportedProfiles,
             ILogger<SystemConformanceProvider> logger,
             IUrlResolver urlResolver,
-            RequestContextAccessor<IFhirRequestContext> contextAccessor,
-            SearchParameterStatusManager searchParameterStatusManager)
+            RequestContextAccessor<IFhirRequestContext> contextAccessor)
         {
             EnsureArg.IsNotNull(modelInfoProvider, nameof(modelInfoProvider));
             EnsureArg.IsNotNull(searchParameterDefinitionManagerResolver, nameof(searchParameterDefinitionManagerResolver));
@@ -75,7 +73,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
             EnsureArg.IsNotNull(logger, nameof(logger));
             EnsureArg.IsNotNull(urlResolver, nameof(urlResolver));
             EnsureArg.IsNotNull(contextAccessor, nameof(contextAccessor));
-            EnsureArg.IsNotNull(searchParameterStatusManager, nameof(searchParameterStatusManager));
 
             _modelInfoProvider = modelInfoProvider;
             _searchParameterDefinitionManager = searchParameterDefinitionManagerResolver();
@@ -86,7 +83,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
             _disposed = false;
             _urlResolver = urlResolver;
             _contextAccessor = contextAccessor;
-            _searchParameterStatusManager = searchParameterStatusManager;
         }
 
         public override async Task<ResourceElement> GetCapabilityStatementOnStartup(CancellationToken cancellationToken = default(CancellationToken))
@@ -127,7 +123,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
                             metadataUrl = _urlResolver.ResolveMetadataUrl(false);
                         }
 
-                        _builder = CapabilityStatementBuilder.Create(_modelInfoProvider, _searchParameterDefinitionManager, _configuration, _supportedProfiles, metadataUrl, _searchParameterStatusManager);
+                        _builder = CapabilityStatementBuilder.Create(_modelInfoProvider, _searchParameterDefinitionManager, _configuration, _supportedProfiles, metadataUrl);
 
                         using (IScoped<IEnumerable<IProvideCapability>> providerFactory = _capabilityProviders())
                         {

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
         private readonly ReindexJobConfiguration _reindexJobConfiguration;
         private readonly Func<IScoped<ISearchService>> _searchServiceFactory;
         private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager;
-        private readonly SearchParameterStatusManager _searchParameterStatusManager;
+        private readonly ISearchParameterStatusManager _searchParameterStatusManager;
         private readonly IReindexUtilities _reindexUtilities;
         private readonly RequestContextAccessor<IFhirRequestContext> _contextAccessor;
         private readonly IReindexJobThrottleController _throttleController;
@@ -60,7 +60,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             IReindexJobThrottleController throttleController,
             IModelInfoProvider modelInfoProvider,
             ILogger<ReindexJobTask> logger,
-            SearchParameterStatusManager searchParameterStatusManager)
+            ISearchParameterStatusManager searchParameterStatusManager)
         {
             EnsureArg.IsNotNull(fhirOperationDataStoreFactory, nameof(fhirOperationDataStoreFactory));
             EnsureArg.IsNotNull(fhirDataStoreFactory, nameof(fhirDataStoreFactory));

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
     public class SearchParameterOperations : ISearchParameterOperations
     {
         private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager;
-        private readonly SearchParameterStatusManager _searchParameterStatusManager;
+        private readonly ISearchParameterStatusManager _searchParameterStatusManager;
         private readonly IModelInfoProvider _modelInfoProvider;
         private readonly ISearchParameterSupportResolver _searchParameterSupportResolver;
         private readonly IDataStoreSearchParameterValidator _dataStoreSearchParameterValidator;
@@ -33,7 +33,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
         private readonly ILogger _logger;
 
         public SearchParameterOperations(
-            SearchParameterStatusManager searchParameterStatusManager,
+            ISearchParameterStatusManager searchParameterStatusManager,
             ISearchParameterDefinitionManager searchParameterDefinitionManager,
             IModelInfoProvider modelInfoProvider,
             ISearchParameterSupportResolver searchParameterSupportResolver,

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/ISearchParameterStatusManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/ISearchParameterStatusManager.cs
@@ -13,12 +13,19 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
     public interface ISearchParameterStatusManager
     {
         Task AddSearchParameterStatusAsync(IReadOnlyCollection<string> searchParamUris, CancellationToken cancellationToken);
+
         Task ApplySearchParameterStatus(IReadOnlyCollection<ResourceSearchParameterStatus> updatedSearchParameterStatus, CancellationToken cancellationToken);
+
         Task DeleteSearchParameterStatusAsync(string url, CancellationToken cancellationToken);
+
         Task EnsureInitializedAsync(CancellationToken cancellationToken);
+
         Task<IReadOnlyCollection<ResourceSearchParameterStatus>> GetAllSearchParameterStatus(CancellationToken cancellationToken);
+
         Task<IReadOnlyCollection<ResourceSearchParameterStatus>> GetSearchParameterStatusUpdates(CancellationToken cancellationToken);
+
         Task Handle(SearchParameterDefinitionManagerInitialized notification, CancellationToken cancellationToken);
+
         Task UpdateSearchParameterStatusAsync(IReadOnlyCollection<string> searchParameterUris, SearchParameterStatus status, CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/ISearchParameterStatusManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/ISearchParameterStatusManager.cs
@@ -1,0 +1,24 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Health.Fhir.Core.Messages.Search;
+
+namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
+{
+    public interface ISearchParameterStatusManager
+    {
+        Task AddSearchParameterStatusAsync(IReadOnlyCollection<string> searchParamUris, CancellationToken cancellationToken);
+        Task ApplySearchParameterStatus(IReadOnlyCollection<ResourceSearchParameterStatus> updatedSearchParameterStatus, CancellationToken cancellationToken);
+        Task DeleteSearchParameterStatusAsync(string url, CancellationToken cancellationToken);
+        Task EnsureInitializedAsync(CancellationToken cancellationToken);
+        Task<IReadOnlyCollection<ResourceSearchParameterStatus>> GetAllSearchParameterStatus(CancellationToken cancellationToken);
+        Task<IReadOnlyCollection<ResourceSearchParameterStatus>> GetSearchParameterStatusUpdates(CancellationToken cancellationToken);
+        Task Handle(SearchParameterDefinitionManagerInitialized notification, CancellationToken cancellationToken);
+        Task UpdateSearchParameterStatusAsync(IReadOnlyCollection<string> searchParameterUris, SearchParameterStatus status, CancellationToken cancellationToken);
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/SearchModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/SearchModule.cs
@@ -84,8 +84,8 @@ namespace Microsoft.Health.Fhir.Api.Modules
                 .AsDelegate<FilebasedSearchParameterStatusDataStore.Resolver>();
 
             services
-                .RemoveServiceTypeExact<SearchParameterStatusManager, INotificationHandler<SearchParameterDefinitionManagerInitialized>>()
-                .Add<SearchParameterStatusManager>()
+                .RemoveServiceTypeExact<ISearchParameterStatusManager, INotificationHandler<SearchParameterDefinitionManagerInitialized>>()
+                .Add<ISearchParameterStatusManager>()
                 .Singleton()
                 .AsSelf()
                 .AsService<INotificationHandler<SearchParameterDefinitionManagerInitialized>>();

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Conformance/ConformanceBuilderTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Conformance/ConformanceBuilderTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Conformance
         private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager;
         private readonly ISupportedProfilesStore _supportedProfiles;
         private readonly Uri _metadataUrl;
-        private readonly SearchParameterStatusManager _searchParameterStatusManager;
+        private readonly ISearchParameterStatusManager _searchParameterStatusManager;
 
         public ConformanceBuilderTests()
         {
@@ -61,8 +61,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Conformance
                 _searchParameterDefinitionManager,
                 configuration,
                 _supportedProfiles,
-                _metadataUrl,
-                _searchParameterStatusManager);
+                _metadataUrl);
         }
 
         [Fact]
@@ -103,8 +102,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Conformance
                 _searchParameterDefinitionManager,
                 configuration,
                 supportedProfiles,
-                _metadataUrl,
-                _searchParameterStatusManager);
+                _metadataUrl);
             ICapabilityStatementBuilder capabilityStatement = builder.ApplyToResource("Patient", c =>
             {
                 c.Interaction.Add(new ResourceInteractionComponent
@@ -135,8 +133,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Conformance
                 _searchParameterDefinitionManager,
                 configuration,
                 supportedProfiles,
-                _metadataUrl,
-                _searchParameterStatusManager);
+                _metadataUrl);
             ICapabilityStatementBuilder capabilityStatement = builder.ApplyToResource("Patient", c =>
             {
                 c.Interaction.Add(new ResourceInteractionComponent
@@ -166,8 +163,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Conformance
                 _searchParameterDefinitionManager,
                 configuration,
                 supportedProfiles,
-                _metadataUrl,
-                _searchParameterStatusManager);
+                _metadataUrl);
             ICapabilityStatementBuilder capabilityStatement = builder.ApplyToResource("Patient", c =>
             {
                 c.Interaction.Add(new ResourceInteractionComponent

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexJobTaskTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexJobTaskTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
         private readonly IMediator _mediator = Substitute.For<IMediator>();
         private Func<IReindexJobTask> _reindexJobTaskFactory;
-        private SearchParameterStatusManager _searchParameterStatusmanager;
+        private ISearchParameterStatusManager _searchParameterStatusmanager;
         private readonly ISearchParameterSupportResolver _searchParameterSupportResolver = Substitute.For<ISearchParameterSupportResolver>();
         private readonly ISearchParameterStatusDataStore _searchParameterStatusDataStore = Substitute.For<ISearchParameterStatusDataStore>();
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexUtilitiesTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexUtilitiesTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
         private readonly ISearchParameterStatusDataStore _searchParameterStatusDataStore = Substitute.For<ISearchParameterStatusDataStore>();
         private readonly ResourceDeserializer _resourceDeserializer = Deserializers.ResourceDeserializer;
         private readonly ISupportedSearchParameterDefinitionManager _searchParameterDefinitionManager = Substitute.For<ISupportedSearchParameterDefinitionManager>();
-        private readonly SearchParameterStatusManager _searchParameterStatusManager;
+        private readonly ISearchParameterStatusManager _searchParameterStatusManager;
         private readonly ISearchParameterSupportResolver _searchParameterSupportResolver = Substitute.For<ISearchParameterSupportResolver>();
         private readonly IMediator _mediator = Substitute.For<IMediator>();
         private readonly IResourceWrapperFactory _resourceWrapperFactory = Substitute.For<IResourceWrapperFactory>();

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/SearchParameterState/SearchParameterStateHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/SearchParameterState/SearchParameterStateHandlerTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Search
         private readonly IAuthorizationService<DataActions> _authorizationService = Substitute.For<IAuthorizationService<DataActions>>();
         private readonly SearchParameterStateHandler _searchParameterHandler;
         private readonly SearchParameterDefinitionManager _searchParameterDefinitionManager;
-        private readonly SearchParameterStatusManager _searchParameterStatusManager;
+        private readonly ISearchParameterStatusManager _searchParameterStatusManager;
         private readonly CancellationToken _cancellationToken;
 
         private readonly ISearchParameterStatusDataStore _searchParameterStatusDataStore = Substitute.For<ISearchParameterStatusDataStore>();

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/SearchParameterState/SearchParameterStateUpdateHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/SearchParameterState/SearchParameterStateUpdateHandlerTests.cs
@@ -49,14 +49,14 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Search
 
         private readonly IAuthorizationService<DataActions> _authorizationService = Substitute.For<IAuthorizationService<DataActions>>();
         private readonly SearchParameterStateUpdateHandler _searchParameterStateUpdateHandler;
-        private readonly SearchParameterStatusManager _searchParameterStatusManager;
+        private readonly ISearchParameterStatusManager _searchParameterStatusManager;
         private readonly ISearchParameterStatusDataStore _searchParameterStatusDataStore = Substitute.For<ISearchParameterStatusDataStore>();
         private readonly SearchParameterDefinitionManager _searchParameterDefinitionManager;
         private readonly ISearchParameterSupportResolver _searchParameterSupportResolver = Substitute.For<ISearchParameterSupportResolver>();
         private readonly IMediator _mediator = Substitute.For<IMediator>();
         private readonly CancellationToken _cancellationToken = default;
         private ISearchService _searchService = Substitute.For<ISearchService>();
-        private readonly ILogger<SearchParameterStatusManager> _logger = Substitute.For<ILogger<SearchParameterStatusManager>>();
+        private readonly ILogger<ISearchParameterStatusManager> _logger = Substitute.For<ILogger<ISearchParameterStatusManager>>();
         private readonly ILogger<SearchParameterStateUpdateHandler> _logger2 = Substitute.For<ILogger<SearchParameterStateUpdateHandler>>();
         private readonly IAuditLogger _auditLogger = Substitute.For<IAuditLogger>();
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchOptionsFactoryTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchOptionsFactoryTests.cs
@@ -19,6 +19,7 @@ using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Features.Search.Access;
 using Microsoft.Health.Fhir.Core.Features.Search.Expressions;
 using Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers;
+using Microsoft.Health.Fhir.Core.Features.Search.Registry;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Core.UnitTests.Features.Context;
 using Microsoft.Health.Fhir.Tests.Common;
@@ -47,6 +48,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         private readonly CoreFeatureConfiguration _coreFeatures;
         private DefaultFhirRequestContext _defaultFhirRequestContext;
         private readonly ISortingValidator _sortingValidator;
+        private readonly ISearchParameterStatusManager _searchParameterStatusManager;
 
         public SearchOptionsFactoryTests()
         {
@@ -60,7 +62,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             _defaultFhirRequestContext = new DefaultFhirRequestContext();
 
             _sortingValidator = Substitute.For<ISortingValidator>();
-
+            _searchParameterStatusManager = Substitute.For<ISearchParameterStatusManager>();
             RequestContextAccessor<IFhirRequestContext> contextAccessor = _defaultFhirRequestContext.SetupAccessor();
             _factory = new SearchOptionsFactory(
                 _expressionParser,
@@ -69,7 +71,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
                 contextAccessor,
                 _sortingValidator,
                 new ExpressionAccessControl(contextAccessor),
-                NullLogger<SearchOptionsFactory>.Instance);
+                NullLogger<SearchOptionsFactory>.Instance,
+                _searchParameterStatusManager);
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterDefinitionManagerTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         private static readonly string ResourceQuery = "http://hl7.org/fhir/SearchParameter/Resource-query";
         private static readonly string ResourceTest = "http://hl7.org/fhir/SearchParameter/Resource-test";
 
-        private readonly SearchParameterStatusManager _manager;
+        private readonly ISearchParameterStatusManager _manager;
         private readonly ISearchParameterStatusDataStore _searchParameterStatusDataStore;
         private readonly SearchParameterDefinitionManager _searchParameterDefinitionManager;
         private readonly IMediator _mediator;

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Reindex/ReindexUtilities.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Reindex/ReindexUtilities.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
         private ISearchIndexer _searchIndexer;
         private ResourceDeserializer _deserializer;
         private readonly ISupportedSearchParameterDefinitionManager _searchParameterDefinitionManager;
-        private readonly SearchParameterStatusManager _searchParameterStatusManager;
+        private readonly ISearchParameterStatusManager _searchParameterStatusManager;
         private readonly IResourceWrapperFactory _resourceWrapperFactory;
 
         public ReindexUtilities(
@@ -31,7 +31,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             ISearchIndexer searchIndexer,
             ResourceDeserializer deserializer,
             ISupportedSearchParameterDefinitionManager searchParameterDefinitionManager,
-            SearchParameterStatusManager searchParameterStatusManager,
+            ISearchParameterStatusManager searchParameterStatusManager,
             IResourceWrapperFactory resourceWrapperFactory)
         {
             EnsureArg.IsNotNull(fhirDataStoreFactory, nameof(fhirDataStoreFactory));

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/SearchParameterState/SearchParameterStateHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/SearchParameterState/SearchParameterStateHandler.cs
@@ -27,9 +27,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.SearchParameterState
     {
         private readonly IAuthorizationService<DataActions> _authorizationService;
         private readonly SearchParameterDefinitionManager _searchParameterDefinitionManager;
-        private readonly SearchParameterStatusManager _searchParameterStatusManager;
+        private readonly ISearchParameterStatusManager _searchParameterStatusManager;
 
-        public SearchParameterStateHandler(IAuthorizationService<DataActions> authorizationService, SearchParameterDefinitionManager searchParameterDefinitionManager, SearchParameterStatusManager searchParameterStatusManager)
+        public SearchParameterStateHandler(IAuthorizationService<DataActions> authorizationService, SearchParameterDefinitionManager searchParameterDefinitionManager, ISearchParameterStatusManager searchParameterStatusManager)
         {
             EnsureArg.IsNotNull(authorizationService, nameof(authorizationService));
             EnsureArg.IsNotNull(searchParameterDefinitionManager, nameof(searchParameterDefinitionManager));

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/SearchParameterState/SearchParameterStateUpdateHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/SearchParameterState/SearchParameterStateUpdateHandler.cs
@@ -30,12 +30,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.SearchParameterState
     {
         private const string FailedSearchParameterUpdates = "FailedSearchParameterUpdates";
         private readonly IAuthorizationService<DataActions> _authorizationService;
-        private readonly SearchParameterStatusManager _searchParameterStatusManager;
+        private readonly ISearchParameterStatusManager _searchParameterStatusManager;
         private IReadOnlyCollection<ResourceSearchParameterStatus> _resourceSearchParameterStatus = null;
         private readonly ILogger<SearchParameterStateUpdateHandler> _logger;
         private readonly IAuditLogger _auditLogger;
 
-        public SearchParameterStateUpdateHandler(IAuthorizationService<DataActions> authorizationService, SearchParameterStatusManager searchParameterStatusManager, ILogger<SearchParameterStateUpdateHandler> logger, IAuditLogger auditLogger)
+        public SearchParameterStateUpdateHandler(IAuthorizationService<DataActions> authorizationService, ISearchParameterStatusManager searchParameterStatusManager, ILogger<SearchParameterStateUpdateHandler> logger, IAuditLogger auditLogger)
         {
             EnsureArg.IsNotNull(authorizationService, nameof(authorizationService));
             EnsureArg.IsNotNull(searchParameterStatusManager, nameof(searchParameterStatusManager));

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -70,9 +70,9 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
         private ReindexUtilities _reindexUtilities;
         private readonly ISearchIndexer _searchIndexer = Substitute.For<ISearchIndexer>();
         private ISupportedSearchParameterDefinitionManager _supportedSearchParameterDefinitionManager;
-        private SearchParameterStatusManager _searchParameterStatusManager;
+        private ISearchParameterStatusManager _searchParameterStatusManager;
         private ISupportedSearchParameterDefinitionManager _supportedSearchParameterDefinitionManager2;
-        private SearchParameterStatusManager _searchParameterStatusManager2;
+        private ISearchParameterStatusManager _searchParameterStatusManager2;
         private readonly ISearchParameterSupportResolver _searchParameterSupportResolver = Substitute.For<ISearchParameterSupportResolver>();
 
         private readonly ITestOutputHelper _output;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Smart/SmartSearchTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Smart
         private ISearchIndexer _searchIndexer;
         private readonly ISearchParameterSupportResolver _searchParameterSupportResolver = Substitute.For<ISearchParameterSupportResolver>();
         private ISupportedSearchParameterDefinitionManager _supportedSearchParameterDefinitionManager;
-        private SearchParameterStatusManager _searchParameterStatusManager;
+        private ISearchParameterStatusManager _searchParameterStatusManager;
 
         private IScoped<ISearchService> _searchService;
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTestsFixture.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
         public SchemaUpgradeRunner SchemaUpgradeRunner => _fixture.GetRequiredService<SchemaUpgradeRunner>();
 
-        public SearchParameterStatusManager SearchParameterStatusManager => _fixture.GetRequiredService<SearchParameterStatusManager>();
+        public ISearchParameterStatusManager SearchParameterStatusManager => _fixture.GetRequiredService<ISearchParameterStatusManager>();
 
         public RequestContextAccessor<IFhirRequestContext> FhirRequestContextAccessor => _fixture.GetRequiredService<RequestContextAccessor<IFhirRequestContext>>();
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         private readonly ISearchService _searchService;
         private readonly SearchParameterDefinitionManager _searchParameterDefinitionManager;
         private readonly SupportedSearchParameterDefinitionManager _supportedSearchParameterDefinitionManager;
-        private readonly SearchParameterStatusManager _searchParameterStatusManager;
+        private readonly ISearchParameterStatusManager _searchParameterStatusManager;
         private readonly IMediator _mediator = Substitute.For<IMediator>();
         private readonly RequestContextAccessor<IFhirRequestContext> _fhirRequestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
         private readonly SqlQueueClient _sqlQueueClient;
@@ -209,7 +209,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 _fhirRequestContextAccessor,
                 sqlSortingValidator,
                 new ExpressionAccessControl(_fhirRequestContextAccessor),
-                NullLogger<SearchOptionsFactory>.Instance);
+                NullLogger<SearchOptionsFactory>.Instance,
+                _searchParameterStatusManager);
 
             var searchParamTableExpressionQueryGeneratorFactory = new SearchParamTableExpressionQueryGeneratorFactory(searchParameterToSearchValueTypeMap);
             var sqlRootExpressionRewriter = new SqlRootExpressionRewriter(searchParamTableExpressionQueryGeneratorFactory);


### PR DESCRIPTION
## Description
This fixes an issue where searches don't remove the disabled search parameters during a search.

## Related issues
Addresses [issue #108894, #108891].

## Testing
Ran through existing tests and adding new ones.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
