### PR TITLE
Adding an option for enabling endpoint routing.

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Configs/FeatureConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Api/Configs/FeatureConfiguration.cs
@@ -24,5 +24,10 @@ namespace Microsoft.Health.Fhir.Api.Configs
         /// Gets or sets a value indicating whether anonymized export is enabled or not.
         /// </summary>
         public bool SupportsAnonymizedExport { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to enable Asp.Net Core endpoint routing.
+        /// </summary>
+        public bool EnableEndpointRouting { get; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Configs/FeatureConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Api/Configs/FeatureConfiguration.cs
@@ -28,6 +28,6 @@ namespace Microsoft.Health.Fhir.Api.Configs
         /// <summary>
         /// Gets or sets a value indicating whether to enable Asp.Net Core endpoint routing.
         /// </summary>
-        public bool EnableEndpointRouting { get; }
+        public bool EnableEndpointRouting { get; set; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Registration/FhirServerApplicationBuilderExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Api/Registration/FhirServerApplicationBuilderExtensions.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Builder
             app.UseHealthChecksExtension(new PathString(KnownRoutes.HealthCheck), predicate);
 
             var config = app.ApplicationServices.GetRequiredService<IOptions<FhirServerConfiguration>>();
-
+            var enableEndpointRouting = config.Value?.Features?.EnableEndpointRouting ?? false;
             var pathBase = config.Value.PathBase?.TrimEnd('/');
             if (!string.IsNullOrWhiteSpace(pathBase))
             {
@@ -40,7 +40,18 @@ namespace Microsoft.AspNetCore.Builder
             }
 
             app.UseStaticFiles();
-            app.UseMvc();
+            if (!enableEndpointRouting)
+            {
+                app.UseMvc();
+            }
+            else
+            {
+                app.UseRouting();
+                app.UseEndpoints(endpoints =>
+                {
+                    endpoints.MapControllers();
+                });
+            }
 
             return app;
         }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
@@ -51,10 +51,11 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             EnsureArg.IsNotNull(services, nameof(services));
 
+            bool enableEndpointRouting = configurationRoot != null ? bool.TryParse(configurationRoot["EnableEndpointRouting"], out enableEndpointRouting) : false;
             services.AddOptions();
             services.AddMvc(options =>
                 {
-                    options.EnableEndpointRouting = false;
+                    options.EnableEndpointRouting = enableEndpointRouting;
                     options.RespectBrowserAcceptHeader = true;
                 })
                 .AddNewtonsoftJson(options =>

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -19,7 +19,8 @@
         "Features": {
             "SupportsUI": false,
             "SupportsXml": true,
-            "SupportsAnonymizedExport": true
+            "SupportsAnonymizedExport": true,
+            "EnableEndpointRouting": false
         },
         "CoreFeatures": {
             "SupportsBatch": true,


### PR DESCRIPTION
## Description
Adding an option for enabling endpoint routing.

## Related issues
Addresses [issue #112288].

[User Story 112288](https://microsofthealth.visualstudio.com/Health/_workitems/edit/112288): Add inbound and outbound request logs for fhir

## Testing
Tested it manually by locally running the Fhir service.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
