### PR TITLE
Add backward compatibility for historical export SQL changes

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaVersionConstants.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaVersionConstants.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema
         public const int ExportTimeTravel = (int)SchemaVersion.V44;
         public const int Merge = (int)SchemaVersion.V50;
         public const int IncrementalImport = (int)SchemaVersion.V53;
+        public const int ExportHistorySoftDelete = (int)SchemaVersion.V68;
 
         // It is currently used in Azure Healthcare APIs.
         public const int ParameterizedRemovePartitionFromResourceChangesVersion = (int)SchemaVersion.V21;

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -550,16 +550,26 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
             PopulateSqlCommandFromQueryHints(command, resourceTypeId, startId, endId, globalStartId, globalEndId, options.ResourceVersionTypes.HasFlag(ResourceVersionType.Histoy), options.ResourceVersionTypes.HasFlag(ResourceVersionType.SoftDeleted));
         }
 
-        private static void PopulateSqlCommandFromQueryHints(SqlCommand command, short resourceTypeId, long startId, long endId, long? globalStartId, long? globalEndId, bool? includeHistory, bool? includeDeleted)
+        private void PopulateSqlCommandFromQueryHints(SqlCommand command, short resourceTypeId, long startId, long endId, long? globalStartId, long? globalEndId, bool? includeHistory, bool? includeDeleted)
         {
             command.CommandType = CommandType.StoredProcedure;
             command.CommandText = "dbo.GetResourcesByTypeAndSurrogateIdRange";
             command.Parameters.AddWithValue("@ResourceTypeId", resourceTypeId);
             command.Parameters.AddWithValue("@StartId", startId);
             command.Parameters.AddWithValue("@EndId", endId);
+
+            if (_schemaInformation.Current < SchemaVersionConstants.ExportHistorySoftDelete)
+            {
+                command.Parameters.AddWithValue("@GlobalStartId", globalStartId);
+            }
+
             command.Parameters.AddWithValue("@GlobalEndId", globalEndId);
-            command.Parameters.AddWithValue("@IncludeHistory", includeHistory);
-            command.Parameters.AddWithValue("@IncludeDeleted", includeDeleted);
+
+            if (_schemaInformation.Current >= SchemaVersionConstants.ExportHistorySoftDelete)
+            {
+                command.Parameters.AddWithValue("@IncludeHistory", includeHistory);
+                command.Parameters.AddWithValue("@IncludeDeleted", includeDeleted);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
Added logic to changes stored procedure parameters for `GetResourcesByTypeAndSurrogateIdRange`. In schema version 68, one parameter was removed and two were added.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
