### PR TITLE
Changing MVC routing to Asp.Net Core endpoint routing.

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Modules/SecurityModule.cs
+++ b/src/Microsoft.Health.Fhir.Api/Modules/SecurityModule.cs
@@ -42,13 +42,11 @@ namespace Microsoft.Health.Fhir.Api.Modules
             {
                 _securityConfiguration.AddAuthenticationLibrary(services, _securityConfiguration);
 
-                services.AddControllers(mvcOptions =>
+                services.AddAuthorization(options =>
                 {
-                    var policy = new AuthorizationPolicyBuilder()
-                        .RequireAuthenticatedUser()
-                        .Build();
-
-                    mvcOptions.Filters.Add(new AuthorizeFilter(policy));
+                    options.DefaultPolicy = new AuthorizationPolicyBuilder()
+                      .RequireAuthenticatedUser()
+                      .Build();
                 });
 
                 if (_securityConfiguration.Authorization.Enabled)

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/FeatureFlags/HtmlUi/HtmlUiFeatureModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/FeatureFlags/HtmlUi/HtmlUiFeatureModule.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Health.Fhir.Api.Modules.FeatureFlags.HtmlUi
                 services.Configure<MvcRazorRuntimeCompilationOptions>(options =>
                 {
                     options.FileProviders.Add(new EmbeddedFileProvider(typeof(CodePreviewModel).Assembly));
-                }).AddMvc().AddRazorRuntimeCompilation();
+                }).AddControllers().AddRazorRuntimeCompilation();
             }
         }
     }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
@@ -52,9 +52,9 @@ namespace Microsoft.Extensions.DependencyInjection
             EnsureArg.IsNotNull(services, nameof(services));
 
             services.AddOptions();
-            services.AddMvc(options =>
+            services.AddControllers(options =>
                 {
-                    options.EnableEndpointRouting = false;
+                    options.EnableEndpointRouting = true;
                     options.RespectBrowserAcceptHeader = true;
                 })
                 .AddNewtonsoftJson(options =>
@@ -176,8 +176,6 @@ namespace Microsoft.Extensions.DependencyInjection
 
                     // This middleware will add delegates to the OnStarting method of httpContext.Response for setting headers.
                     app.UseBaseHeaders();
-
-                    app.UseCors(Constants.DefaultCorsPolicy);
 
                     // This middleware should be registered at the beginning since it generates correlation id among other things,
                     // which will be used in other middlewares.

--- a/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
@@ -201,8 +201,9 @@ namespace Microsoft.Health.Fhir.Web
             }
 
             app.UsePrometheusHttpMetrics();
-            app.UseFhirServer();
-            app.UseDevelopmentIdentityProviderIfConfigured();
+            app.UseFhirServer(
+                DevelopmentIdentityProviderRegistrationExtensions.UseDevelopmentIdentityProviderIfConfigured,
+                null);
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
Changing MVC routing to Asp.Net Core endpoint routing.

## Related issues
Addresses [issue #112288].
[User Story 112288](https://microsofthealth.visualstudio.com/Health/_workitems/edit/112288): Add outbound request logs for fhir

## Testing
Tested in the PR pipeline and manual test locally with the sample http files.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
