### PR TITLE
Splits unit tests into seperate step

### DIFF
--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -65,6 +65,19 @@ stages:
     - template: ./jobs/build.yml
       parameters:
         targetBuildFramework: 'net6.0'
+  
+ 
+- stage: BuildArtifacts
+  displayName: 'Build artifacts'
+  dependsOn:
+  - UpdateVersion
+  variables:
+    assemblySemVer: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.assemblySemVer']]
+    assemblySemFileVer: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.assemblySemFileVer']]
+    informationalVersion: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.informationalVersion']]
+    majorMinorPatch: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.majorMinorPatch']]
+    nuGetVersion: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.nuGetVersion']]
+  jobs:
   - job: Linux_BuildAndPackage
     pool:
       name: '$(DefaultLinuxPool)'
@@ -77,11 +90,12 @@ stages:
         componentGovernance: true
         packageArtifacts: true
         packageIntegrationTests: true
-    
+
 - stage: AnalyzeSecurity
   displayName: 'Run Security Analysis and Validate'
   dependsOn:
   - BuildUnitTests
+  - BuildArtifacts
   jobs:
   - job: Guardian
     pool:
@@ -145,6 +159,7 @@ stages:
   displayName: 'Deploy SQLServer'
   dependsOn:
   - setupEnvironment
+  - UpdateRandom
   jobs:
   - template: ./jobs/provision-sqlServer.yml
     parameters:
@@ -177,6 +192,7 @@ stages:
   - DockerBuild
   - setupEnvironment
   - deploySqlServer
+  - UpdateRandom
   jobs:
   - template: ./jobs/provision-deploy.yml
     parameters: 
@@ -218,6 +234,7 @@ stages:
   - DockerBuild
   - setupEnvironment
   - deploySqlServer
+  - UpdateRandom
   jobs:
   - template: ./jobs/provision-deploy.yml
     parameters: 
@@ -259,6 +276,7 @@ stages:
   - DockerBuild
   - setupEnvironment
   - deploySqlServer
+  - UpdateRandom
   jobs:
   - template: ./jobs/provision-deploy.yml
     parameters: 
@@ -300,6 +318,7 @@ stages:
   - DockerBuild
   - setupEnvironment
   - deploySqlServer
+  - UpdateRandom
   jobs:
   - template: ./jobs/provision-deploy.yml
     parameters: 
@@ -320,7 +339,7 @@ stages:
 - stage: testStu3
   displayName: 'Run Stu3 Tests'
   dependsOn:
-  - BuildUnitTests
+  - BuildArtifacts
   - setupEnvironment
   - deployStu3
   - deployStu3Sql
@@ -334,7 +353,7 @@ stages:
 - stage: testR4
   displayName: 'Run R4 Tests'
   dependsOn:
-  - BuildUnitTests
+  - BuildArtifacts
   - setupEnvironment
   - deployR4
   - deployR4Sql
@@ -348,7 +367,7 @@ stages:
 - stage: testR4B
   displayName: 'Run R4B Tests'
   dependsOn:
-  - BuildUnitTests
+  - BuildArtifacts
   - setupEnvironment
   - deployR4B
   - deployR4BSql
@@ -362,7 +381,7 @@ stages:
 - stage: testR5
   displayName: 'Run R5 Tests'
   dependsOn:
-  - BuildUnitTests
+  - BuildArtifacts
   - setupEnvironment
   - deployR5
   - deployR5Sql


### PR DESCRIPTION
## Description
Splits running the unit tests and building the integration tests into separate steps. This should save us ~8 minutes on PR builds.
Also fixes a bug where the SQL password wasn't being set correctly.

## Related issues
Addresses [issue #].

## Testing
Running the PR pipeline

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
