### PR TITLE
Add rollback tests to CI pipeline

### DIFF
--- a/build/ci-pipeline.yml
+++ b/build/ci-pipeline.yml
@@ -29,6 +29,31 @@ stages:
     parameters:
       environmentName: $(DeploymentEnvironmentName)
 
+- stage: cleanupIntegrationTestDatabases
+  displayName: 'Cleanup Integration Test DBs'
+  dependsOn: []
+  jobs:
+  - job: provisionEnvironment
+    pool:
+      name: '$(SharedLinuxPool)'
+      vmImage: '$(LinuxVmImage)'
+    steps:
+    - task: AzurePowerShell@5
+      displayName: 'Azure PowerShell script: InlineScript'
+      inputs:
+        azureSubscription: $(ConnectedServiceName)
+        azurePowerShellVersion: latestVersion
+        ScriptType: inlineScript
+        Inline: |
+          $testNamePatterns = @("SNAPSHOT*","FHIRCOMPATIBILITYTEST*","FHIRINTEGRATIONTEST*","FHIRRESOURCECHANGEDISABLEDTEST*","BASE*","SNAPSHOT*")
+          foreach ($pattern in $testNamePatterns) {
+            $resources = Get-AzResource -ResourceGroupName $(ResourceGroupName) -ResourceType 'Microsoft.Sql/servers/databases' -Name $pattern
+            foreach ($resource in $resources) {
+              Write-Host "Cleaning up $($resource.ResourceName)"
+              Remove-AzResource -ResourceId $resource.ResourceId
+            }
+          }
+          
 - stage: BuildUnitTests
   displayName: 'Build and run unit tests'
   dependsOn:

--- a/build/ci-pipeline.yml
+++ b/build/ci-pipeline.yml
@@ -9,6 +9,7 @@ variables:
 - template: build-variables.yml
 
 stages:
+# *********************** Setup ***********************
 - stage: UpdateVersion
   displayName: 'Determine Semver'
   dependsOn: []
@@ -19,6 +20,14 @@ stages:
       vmImage: '$(LinuxVmImage)'
     steps:
     - template: ./jobs/update-semver.yml  
+
+- stage: cleanStorageAccounts
+  displayName: 'Clean Storage Accounts'
+  dependsOn: []
+  jobs:
+  - template: ./jobs/clean-storage-accounts.yml
+    parameters:
+      environmentName: $(DeploymentEnvironmentName)
 
 - stage: BuildUnitTests
   displayName: 'Build and run unit tests'
@@ -84,6 +93,7 @@ stages:
     parameters: 
       tag: $(ImageTag)
 
+# *********************** Stu3 ***********************
 - stage: redeployStu3
   displayName: 'Redeploy STU3 CosmosDB Site'
   dependsOn:
@@ -108,6 +118,56 @@ stages:
       subscription: $(ConnectedServiceName)
       imageTag: $(ImageTag)
 
+- stage: testStu3
+  displayName: 'Run Stu3 Tests'
+  dependsOn:
+  - BuildUnitTests
+  - redeployStu3
+  - redeployStu3Sql
+  jobs:
+  - template: ./jobs/run-tests.yml
+    parameters:
+      version: Stu3
+      keyVaultName: $(DeploymentEnvironmentName)
+      appServiceName: $(DeploymentEnvironmentName)
+
+- stage: rollbackStu3
+  displayName: 'Rollback STU3 CosmosDB Site'
+  dependsOn:
+  - testStu3
+  jobs:
+  - template: ./jobs/redeploy-webapp.yml
+    parameters: 
+      version: Stu3
+      webAppName: $(DeploymentEnvironmentName)
+      subscription: $(ConnectedServiceName)
+      imageTag: release
+
+- stage: rollbackStu3Sql
+  displayName: 'Rollback STU3 SQL Site'
+  dependsOn:
+  - testStu3
+  jobs:
+  - template: ./jobs/redeploy-webapp.yml
+    parameters: 
+      version: Stu3
+      webAppName: $(DeploymentEnvironmentNameSql)
+      subscription: $(ConnectedServiceName)
+      imageTag: release
+
+- stage: testStu3Rollback
+  displayName: 'Run Stu3 Rollback Tests'
+  dependsOn:
+  - rollbackStu3
+  - rollbackStu3Sql
+  jobs:
+  - template: ./jobs/run-tests.yml
+    parameters:
+      version: Stu3
+      keyVaultName: $(DeploymentEnvironmentName)
+      appServiceName: $(DeploymentEnvironmentName)
+
+# *********************** R4 ***********************
 - stage: redeployR4
   displayName: 'Redeploy R4 CosmosDB Site'
   dependsOn:
@@ -132,6 +192,56 @@ stages:
       subscription: $(ConnectedServiceName)
       imageTag: $(ImageTag)
 
+- stage: testR4
+  displayName: 'Run R4 Tests'
+  dependsOn:
+  - BuildUnitTests
+  - redeployR4
+  - redeployR4Sql
+  jobs:
+  - template: ./jobs/run-tests.yml
+    parameters:
+      version: R4
+      keyVaultName: $(DeploymentEnvironmentNameR4)
+      appServiceName: $(DeploymentEnvironmentNameR4)
+
+- stage: rollbackR4
+  displayName: 'Rollback R4 CosmosDB Site'
+  dependsOn:
+  - testR4
+  jobs:
+  - template: ./jobs/redeploy-webapp.yml
+    parameters: 
+      version: R4
+      webAppName: $(DeploymentEnvironmentName)
+      subscription: $(ConnectedServiceName)
+      imageTag: release
+
+- stage: rollbackR4Sql
+  displayName: 'Rollback R4 SQL Site'
+  dependsOn:
+  - testR4
+  jobs:
+  - template: ./jobs/redeploy-webapp.yml
+    parameters: 
+      version: R4
+      webAppName: $(DeploymentEnvironmentNameSql)
+      subscription: $(ConnectedServiceName)
+      imageTag: release
+
+- stage: testR4Rollback
+  displayName: 'Run R4 Rollback Tests'
+  dependsOn:
+  - rollbackR4
+  - rollbackR4Sql
+  jobs:
+  - template: ./jobs/run-tests.yml
+    parameters:
+      version: R4
+      keyVaultName: $(DeploymentEnvironmentName)
+      appServiceName: $(DeploymentEnvironmentName)
+
+# *********************** R4B ***********************
 - stage: redeployR4B
   displayName: 'Redeploy R4B CosmosDB Site'
   dependsOn:
@@ -156,6 +266,56 @@ stages:
       subscription: $(ConnectedServiceName)
       imageTag: $(ImageTag)
 
+- stage: testR4B
+  displayName: 'Run R4B Tests'
+  dependsOn:
+  - BuildUnitTests
+  - redeployR4B
+  - redeployR4BSql
+  jobs:
+  - template: ./jobs/run-tests.yml
+    parameters:
+      version: R4B
+      keyVaultName: $(DeploymentEnvironmentNameR4B)
+      appServiceName: $(DeploymentEnvironmentNameR4B)
+
+- stage: rollbackR4B
+  displayName: 'Rollback R4B CosmosDB Site'
+  dependsOn:
+  - testR4B
+  jobs:
+  - template: ./jobs/redeploy-webapp.yml
+    parameters: 
+      version: R4B
+      webAppName: $(DeploymentEnvironmentName)
+      subscription: $(ConnectedServiceName)
+      imageTag: release
+
+- stage: rollbackR4BSql
+  displayName: 'Rollback R4B SQL Site'
+  dependsOn:
+  - testR4B
+  jobs:
+  - template: ./jobs/redeploy-webapp.yml
+    parameters: 
+      version: R4B
+      webAppName: $(DeploymentEnvironmentNameSql)
+      subscription: $(ConnectedServiceName)
+      imageTag: release
+
+- stage: testR4BRollback
+  displayName: 'Run R4B Rollback Tests'
+  dependsOn:
+  - rollbackR4B
+  - rollbackR4BSql
+  jobs:
+  - template: ./jobs/run-tests.yml
+    parameters:
+      version: R4B
+      keyVaultName: $(DeploymentEnvironmentName)
+      appServiceName: $(DeploymentEnvironmentName)
+
+# *********************** R5 ***********************
 - stage: redeployR5
   displayName: 'Redeploy R5 CosmosDB Site'
   dependsOn:
@@ -180,45 +340,6 @@ stages:
       subscription: $(ConnectedServiceName)
       imageTag: $(ImageTag)
 
-- stage: testStu3
-  displayName: 'Run Stu3 Tests'
-  dependsOn:
-  - BuildUnitTests
-  - redeployStu3
-  - redeployStu3Sql
-  jobs:
-  - template: ./jobs/run-tests.yml
-    parameters:
-      version: Stu3
-      keyVaultName: $(DeploymentEnvironmentName)
-      appServiceName: $(DeploymentEnvironmentName)
-
-- stage: testR4
-  displayName: 'Run R4 Tests'
-  dependsOn:
-  - BuildUnitTests
-  - redeployR4
-  - redeployR4Sql
-  jobs:
-  - template: ./jobs/run-tests.yml
-    parameters:
-      version: R4
-      keyVaultName: $(DeploymentEnvironmentNameR4)
-      appServiceName: $(DeploymentEnvironmentNameR4)
-
-- stage: testR4B
-  displayName: 'Run R4B Tests'
-  dependsOn:
-  - BuildUnitTests
-  - redeployR4B
-  - redeployR4BSql
-  jobs:
-  - template: ./jobs/run-tests.yml
-    parameters:
-      version: R4B
-      keyVaultName: $(DeploymentEnvironmentNameR4B)
-      appServiceName: $(DeploymentEnvironmentNameR4B)
-
 - stage: testR5
   displayName: 'Run R5 Tests'
   dependsOn:
@@ -232,6 +353,43 @@ stages:
       keyVaultName: $(DeploymentEnvironmentNameR5)
       appServiceName: $(DeploymentEnvironmentNameR5)
 
+- stage: rollbackR5
+  displayName: 'Rollback R5 CosmosDB Site'
+  dependsOn:
+  - testR5
+  jobs:
+  - template: ./jobs/redeploy-webapp.yml
+    parameters: 
+      version: R5
+      webAppName: $(DeploymentEnvironmentName)
+      subscription: $(ConnectedServiceName)
+      imageTag: release
+
+- stage: rollbackR5Sql
+  displayName: 'Rollback R5 SQL Site'
+  dependsOn:
+  - testR5
+  jobs:
+  - template: ./jobs/redeploy-webapp.yml
+    parameters: 
+      version: R5
+      webAppName: $(DeploymentEnvironmentNameSql)
+      subscription: $(ConnectedServiceName)
+      imageTag: release
+
+- stage: testR5Rollback
+  displayName: 'Run R5 Rollback Tests'
+  dependsOn:
+  - rollbackR5
+  - rollbackR5Sql
+  jobs:
+  - template: ./jobs/run-tests.yml
+    parameters:
+      version: R5
+      keyVaultName: $(DeploymentEnvironmentName)
+      appServiceName: $(DeploymentEnvironmentName)
+
+# *********************** Finalize ***********************
 - stage: DockerAddTag
   displayName: 'Docker add main tag'
   dependsOn:
@@ -244,11 +402,3 @@ stages:
     parameters:
       sourceTag: $(ImageTag)
       targetTag: 'master'
-
-- stage: cleanStorageAccounts
-  displayName: 'Clean Storage Accounts'
-  dependsOn: []
-  jobs:
-  - template: ./jobs/clean-storage-accounts.yml
-    parameters:
-      environmentName: $(DeploymentEnvironmentName)

--- a/build/ci-pipeline.yml
+++ b/build/ci-pipeline.yml
@@ -393,10 +393,10 @@ stages:
 - stage: DockerAddTag
   displayName: 'Docker add main tag'
   dependsOn:
-  - testStu3
-  - testR4
-  - testR4B
-  - testR5
+  - testStu3Rollback
+  - testR4Rollback
+  - testR4BRollback
+  - testR5Rollback
   jobs:
   - template: ./jobs/docker-add-tag.yml
     parameters:


### PR DESCRIPTION
## Description
Adds rollback tests to CI pipeline

## Related issues
Addresses [User Story 113052](https://microsofthealth.visualstudio.com/Health/_workitems/edit/113052): Add rollback tests to OSS CI

## Testing
Ran the CI pipeline with the new definition

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip
