### PR TITLE
Fixed historical/deleted export test flakiness

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Export/ExportDataTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Export/ExportDataTestFixture.cs
@@ -37,23 +37,27 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Export
 
         internal DataStore DataStore { get; private set; }
 
+        // ALL versions of generated tests resources by this fixture (including soft deleted ones). Resource generation methods below add to this dictionary.
         internal Dictionary<(string resourceType, string resourceId, string versionId), Resource> TestResourcesWithHistoryAndDeletes { get; } = new();
 
+        // TestResourcesWithHistoryAndDeletes filtered to exclude soft deleted resources (only historical and current version resources).
         internal Dictionary<(string resourceType, string resourceId, string versionId), Resource> TestResourcesWithHistory => TestResourcesWithHistoryAndDeletes
             .Where(entry => !entry.Value.Meta.Extension.Any(extension =>
                 extension.Url == "http://azurehealthcareapis.com/data-extensions/deleted-state"
                 && ((FhirString)extension.Value).Value == "soft-deleted"))
             .ToDictionary(entry => entry.Key, entry => entry.Value);
 
+        // TestResourcesWithHistoryAndDeletes filtered to exclude historical resources (only soft deleted and current version resources).
         internal Dictionary<(string resourceType, string resourceId, string versionId), Resource> TestResourcesWithDeletes => TestResourcesWithHistoryAndDeletes
             .GroupBy(entry => entry.Key.resourceId)
             .Select(group => group.OrderByDescending(entry => entry.Value.Meta.LastUpdated).First())
             .ToDictionary(entry => entry.Key, entry => entry.Value);
 
+        // TestResourcesWithHistoryAndDeletes filtered to exclude soft deleted and historical resources (only current version resources).
         internal Dictionary<(string resourceType, string resourceId, string versionId), Resource> TestResources =>
             TestResourcesWithHistory.Where(pair => TestResourcesWithDeletes.ContainsKey(pair.Key)).ToDictionary(pair => pair.Key, pair => pair.Value);
 
-        // If the patient is deleted but the child resources are not, they should not be returned in patient centric exports.
+        // TestResourcesWithHistoryAndDeletes filtered for patient compartment tests - if the patient is deleted but the child resources are not, child resources should not be returned in patient centric exports.
         internal Dictionary<(string resourceType, string resourceId, string versionId), Resource> TestPatientCompartmentResources => TestResources
             .Where(x => x.Key.resourceType != "Encounter" || TestResources.Keys.Any(pat => pat.resourceType == "Patient" && pat.resourceId == (x.Value as Encounter).Subject.Reference.Split("/")[1]))
             .Where(x => x.Key.resourceType != "Observation" || TestResources.Keys.Any(pat => pat.resourceType == "Patient" && pat.resourceId == (x.Value as Observation).Subject.Reference.Split("/")[1]))
@@ -63,6 +67,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Export
 
         internal DateTime TestDataInsertionTime { get; } = DateTime.UtcNow;
 
+        // Common query parameter used by tests (tag, type, and typeFilter) to improve test performance.
         internal string ExportTestFilterQueryParameters(params string[] uniqueResourceTypes)
         {
             if (uniqueResourceTypes.Length == 0)
@@ -80,6 +85,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Export
             await SaveTestResourcesToServer();
         }
 
+        // Generates and saves test resources to the server. ALL of these resources will be created after TestDataInsertionTime and will have the FixtureTag.
+        // NOTE: Soft-deleted resources will not have the fixture tag since soft deleted resources don't export with the resource body.
         private async Task SaveTestResourcesToServer()
         {
             void AddResourceToTestResources(Resource resource) =>
@@ -207,7 +214,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Export
             return rtn;
         }
 
-        // 27 patients, 54 encounters, and, 108 observations.
+        // Generates test patients. Current parameters will generate 27 patients, 54 encounters, and, 108 observations.
         private List<Resource> GenerateTestResources(int numberOfPatients = 27, int numberOfEncountersPerPatient = 2, int numberOfObservationsPerEncounter = 2)
         {
             var resources = new List<Resource>();

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Export/ExportDataTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Export/ExportDataTests.cs
@@ -204,6 +204,11 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Export
             Dictionary<(string resourceType, string resourceId, string versionId), Resource> dataFromExport =
                 await ExportTestHelper.DownloadBlobAndParse(blobUris, _fhirJsonParser, _outputHelper);
 
+            // Filter data from export to ONLY look for resource ids of test data from the fixture. This will reduce test flakiness from other resources from other tests.
+            var filteredDataFromExport = dataFromExport
+                .Where(exp => _fixture.TestResourcesWithHistoryAndDeletes.Any(test => test.Key.resourceType == exp.Key.resourceType && test.Key.resourceId == exp.Key.resourceId))
+                .ToDictionary(x => x.Key, x => x.Value);
+
             var expectedResources = _fixture.TestResourcesWithHistoryAndDeletes;
 
             if (!history)
@@ -217,7 +222,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Export
             }
 
             // Assert both data are equal
-            Assert.True(ExportTestHelper.ValidateDataFromBothSources(expectedResources, dataFromExport, _outputHelper));
+            Assert.True(ExportTestHelper.ValidateDataFromBothSources(expectedResources, filteredDataFromExport, _outputHelper));
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Export/ExportTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Export/ExportTestHelper.cs
@@ -250,12 +250,11 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Export
         internal static bool ValidateDataFromBothSources(
             Dictionary<(string resourceType, string resourceId, string versionId), Resource> dataFromServer,
             Dictionary<(string resourceType, string resourceId, string versionId), Resource> dataFromStorageAccount,
-            ITestOutputHelper outputHelper,
-            bool allowDataFromServerToBeSubsetOfExportData = false)
+            ITestOutputHelper outputHelper)
         {
             bool result = true;
 
-            if (dataFromStorageAccount.Count != dataFromServer.Count && !(allowDataFromServerToBeSubsetOfExportData && dataFromServer.Count < dataFromStorageAccount.Count))
+            if (dataFromStorageAccount.Count != dataFromServer.Count)
             {
                 outputHelper.WriteLine($"Count differs. Exported data count: {dataFromStorageAccount.Count} Fhir Server Count: {dataFromServer.Count}");
                 result = false;


### PR DESCRIPTION
## Description
I got a report of `GivenFhirServer_WhenDataIsExportedWithHistoryAndSoftDeletesParallel_ThenExportedDataIsSameAsDataInFhirServer` being flaky today. I restricted the "checking" of the exported data to only the resource ids actually created by the test fixture. This should help with flakiness.

## Related issues
AB113092

## Testing
Tested running test locally

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
