### PR TITLE
fixes delete unittest issue #105965

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/DeleteTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/DeleteTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
+using Hl7.Fhir.ElementModel.Types;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Client;
 using Microsoft.Health.Fhir.Core.Extensions;
@@ -27,6 +28,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
     {
         private readonly HttpIntegrationTestFixture _fixture;
         private readonly TestFhirClient _client;
+        private const string Divcontent = "Generated Narrative with Details";
 
         public DeleteTests(HttpIntegrationTestFixture fixture)
         {
@@ -169,6 +171,11 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             // Update the observation.
             for (int i = 0; i < 50; i++)
             {
+                observation.Text = new Narrative
+                {
+                    Status = Narrative.NarrativeStatus.Generated,
+                    Div = $"<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>{Divcontent + " Version:" + i.ToString()}</b></p></div>",
+                };
                 using FhirResponse<Observation> loopResponse = await _client.UpdateAsync(observation);
 
                 versionIds.Add(loopResponse.Resource.Meta.VersionId);


### PR DESCRIPTION
## Description
This PR fixes delete unittest issue.
GivenAResourceWithLargeNumberOfHistory_WhenHardDeleting_ThenServerShouldDeleteAllRelatedResourcesSuccessfully
Updated functionality for above unit test, now versions(history) are generated for resource before deleting it.

## Related issues
Addresses issue  https://microsofthealth.visualstudio.com/Health/_workitems/edit/105965/.

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
