### PR TITLE
Logs FHIR resource versions on Application startup

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/SystemConformanceProvider.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/SystemConformanceProvider.cs
@@ -92,11 +92,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
             // Link for Mediatr bug https://github.com/jbogard/MediatR.Extensions.Microsoft.DependencyInjection/issues/34
             if (!string.IsNullOrEmpty(_configuration.Value.Versioning.Default))
             {
-                _logger.LogInformation("Default version is: {VersioningDefault}.", _configuration.Value.Versioning.Default);
+                _logger.LogInformation("Default version is:{VersioningDefault}.", _configuration.Value.Versioning.Default);
 
                 foreach (var resourcetype in _configuration.Value.Versioning.ResourceTypeOverrides)
                 {
-                    _logger.LogInformation($"{resourcetype.Key} version overridden to:{resourcetype.Value}.");
+                    _logger.LogInformation("{ResourceTypeKey} version overridden to:{ResourceTypeValue}.", resourcetype.Key, resourcetype.Value);
                 }
             }
         }

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/SystemConformanceProvider.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/SystemConformanceProvider.cs
@@ -87,6 +87,18 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
             _urlResolver = urlResolver;
             _contextAccessor = contextAccessor;
             _searchParameterStatusManager = searchParameterStatusManager;
+
+            // Following code block will log same information multiple times due to Mediatr bug.
+            // Link for Mediatr bug https://github.com/jbogard/MediatR.Extensions.Microsoft.DependencyInjection/issues/34
+            if (!string.IsNullOrEmpty(_configuration.Value.Versioning.Default))
+            {
+                _logger.LogInformation($"Default version is:{_configuration.Value.Versioning.Default}.");
+
+                foreach (var resourcetype in _configuration.Value.Versioning.ResourceTypeOverrides)
+                {
+                    _logger.LogInformation($"{resourcetype.Key} version overridden to:{resourcetype.Value}.");
+                }
+            }
         }
 
         public override async Task<ResourceElement> GetCapabilityStatementOnStartup(CancellationToken cancellationToken = default(CancellationToken))

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/SystemConformanceProvider.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/SystemConformanceProvider.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
 
                 foreach (var resourcetype in _configuration.Value.Versioning.ResourceTypeOverrides)
                 {
-                    _logger.LogInformation("{ResourceTypeKey} version overridden to:{ResourceTypeValue}.", resourcetype.Key, resourcetype.Value);
+                    _logger.LogInformation("{ResourceTypeKey} version overridden to:{ResourceTypeVersioningOverride}.", resourcetype.Key, resourcetype.Value);
                 }
             }
         }

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/SystemConformanceProvider.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/SystemConformanceProvider.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
             // Link for Mediatr bug https://github.com/jbogard/MediatR.Extensions.Microsoft.DependencyInjection/issues/34
             if (!string.IsNullOrEmpty(_configuration.Value.Versioning.Default))
             {
-                _logger.LogInformation($"Default version is:{_configuration.Value.Versioning.Default}.");
+                _logger.LogInformation("Default version is: {VersioningDefault}.", _configuration.Value.Versioning.Default);
 
                 foreach (var resourcetype in _configuration.Value.Versioning.ResourceTypeOverrides)
                 {

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/SystemConformanceProvider.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/SystemConformanceProvider.cs
@@ -88,8 +88,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
             _contextAccessor = contextAccessor;
             _searchParameterStatusManager = searchParameterStatusManager;
 
-            // Following code block will log same information multiple times due to Mediatr bug.
-            // Link for Mediatr bug https://github.com/jbogard/MediatR.Extensions.Microsoft.DependencyInjection/issues/34
             if (!string.IsNullOrEmpty(_configuration.Value.Versioning.Default))
             {
                 _logger.LogInformation("Default version is:{VersioningDefault}.", _configuration.Value.Versioning.Default);

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs
@@ -10,6 +10,7 @@ using Hl7.Fhir.FhirPath;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using Hl7.FhirPath;
+using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.Extensions.DependencyInjection;
@@ -27,6 +28,7 @@ using Microsoft.Health.Fhir.Core.Features.Conformance;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Security;
+using Microsoft.Health.Fhir.Core.Messages.CapabilityStatement;
 using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Api.Modules
@@ -128,7 +130,8 @@ namespace Microsoft.Health.Fhir.Api.Modules
             services.AddSingleton<CorrelationIdProvider>(_ => () => Guid.NewGuid().ToString());
 
             // Add conformance provider for implementation metadata.
-            services.Add<SystemConformanceProvider>()
+            services.RemoveServiceTypeExact<SystemConformanceProvider, INotificationHandler<RebuildCapabilityStatement>>()
+                .Add<SystemConformanceProvider>()
                 .Singleton()
                 .AsSelf()
                 .AsImplementedInterfaces();


### PR DESCRIPTION
## Description
This PR logs FHIR resource versions (versioned/ no-version / versioned-update ) on Application startup .

## Related issues
Addresses user story AB#105518

## Testing
NA

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
