### PR TITLE
Update StypleCop.Analyzers for .NET8 Collection Initializers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -104,7 +104,7 @@
     <PackageVersion Include="prometheus-net.AspNetCore" Version="8.0.1" />
     <PackageVersion Include="prometheus-net.DotNetRuntime" Version="4.4.0" />
     <PackageVersion Include="prometheus-net.SystemMetrics" Version="2.0.0" />
-    <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.507" />
+    <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="System.Collections.Immutable" Version="7.0.0" />
     <PackageVersion Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />

--- a/tools/Importer/BearerTokenHandler.cs
+++ b/tools/Importer/BearerTokenHandler.cs
@@ -16,8 +16,6 @@ using Azure.Identity;
 
 namespace Microsoft.Health.Fhir.Importer;
 
-#pragma warning disable SA1010 // Opening square brackets should be spaced correctly. Fixed https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3745 but not available yet.
-
 public class BearerTokenHandler : DelegatingHandler
 {
     private readonly Dictionary<string, AccessTokenCache> _accessTokenCaches = [];

--- a/tools/Importer/Importer.cs
+++ b/tools/Importer/Importer.cs
@@ -51,8 +51,6 @@ namespace Microsoft.Health.Fhir.Importer
         private static HttpClient httpClient = new();
         private static DelegatingHandler handler;
 
-#pragma warning disable SA1010 // Opening square brackets should be spaced correctly. Fixed https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3745 but not available yet.
-
         internal static void Run()
         {
             if (string.IsNullOrEmpty(Endpoints))


### PR DESCRIPTION
## Description
Updates StyleCop.Analyzers to latest version to fix [issue with rule SA1010](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3745) that doesn't allow new collection initializers in .NET 8.

## Testing
Building solution.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
