### PR TITLE
Extend the max parallelism flag

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/KnownHeaders.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/KnownHeaders.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Health.Fhir.Core.Features
         public const string CustomAuditHeaderPrefix = "X-MS-AZUREFHIR-AUDIT-";
         public const string FhirUserHeader = "x-ms-fhiruser";
 
-        // #conditionalQueryParallelism - Header used to activate parallel conditional-query processing.
+        // #maxQueryParallelism - Header used to activate parallel conditional-query processing.
         public const string QueryProcessingLogic = "x-ms-query-processing-logic";
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/KnownHeaders.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/KnownHeaders.cs
@@ -32,6 +32,6 @@ namespace Microsoft.Health.Fhir.Core.Features
         public const string FhirUserHeader = "x-ms-fhiruser";
 
         // #conditionalQueryParallelism - Header used to activate parallel conditional-query processing.
-        public const string ConditionalQueryProcessingLogic = "x-conditionalquery-processing-logic";
+        public const string QueryProcessingLogic = "x-ms-query-processing-logic";
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerEdgeCaseTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerEdgeCaseTests.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
         [InlineData(false)]
         public void GivenABundle_WhenProcessedWithConditionalQueryMaxParallelism_TheFhirContextPropertyBagsShouldBePopulatedAsExpected(bool maxParallelism)
         {
-            // #conditionalQueryParallelism
+            // #maxQueryParallelism
 
             // In this test the following steps are executed/validated:
             // 1 - When the created HTTP request contains the header "x-ms-query-processing-logic" set as "parallel".

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerEdgeCaseTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerEdgeCaseTests.cs
@@ -81,10 +81,10 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
             // #conditionalQueryParallelism
 
             // In this test the following steps are executed/validated:
-            // 1 - When the created HTTP request contains the header "x-conditionalquery-processing-logic" set as "parallel".
+            // 1 - When the created HTTP request contains the header "x-ms-query-processing-logic" set as "parallel".
             // 2 - BundleHandler's constructor recognizes the presence of the header and adds "_optimizeConcurrency" to FHIR Request Context property bag.
             // 3 - A validation is executed to ensure that the FHIR Request Context property bag contains the key "_optimizeConcurrency" as it's set with the expected value.
-            // 4 - If the created HTTP request does not contain the header "x-conditionalquery-processing-logic" set as "parallel", then the key "_optimizeConcurrency"
+            // 4 - If the created HTTP request does not contain the header "x-ms-query-processing-logic" set as "parallel", then the key "_optimizeConcurrency"
             // is not expected in the FHIR Request Context property bag.
 
             var bundleHandlerComponents = GetBundleHandlerComponents(new BundleRequestOptions() { MaxParallelism = maxParallelism });
@@ -144,7 +144,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
 
             if (options.MaxParallelism)
             {
-                httpContext.Request.Headers[KnownHeaders.ConditionalQueryProcessingLogic] = new StringValues("parallel");
+                httpContext.Request.Headers[KnownHeaders.QueryProcessingLogic] = new StringValues("parallel");
             }
 
             httpContextAccessor.HttpContext.Returns(httpContext);

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
@@ -272,6 +272,8 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         [AuditEventType(AuditEventSubType.Read)]
         public async Task<IActionResult> Read(string typeParameter, string idParameter)
         {
+            SetupRequestContextWithConditionalQueryMaxParallelism();
+
             RawResourceElement response = await _mediator.GetResourceAsync(
                 new GetResourceRequest(new ResourceKey(typeParameter, idParameter), GetBundleResourceContext()),
                 HttpContext.RequestAborted);
@@ -290,6 +292,8 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         [AuditEventType(AuditEventSubType.HistorySystem)]
         public async Task<IActionResult> SystemHistory(HistoryModel historyModel)
         {
+            SetupRequestContextWithConditionalQueryMaxParallelism();
+
             ResourceElement response = await _mediator.SearchResourceHistoryAsync(
                 historyModel.Since,
                 historyModel.Before,
@@ -314,6 +318,8 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             string typeParameter,
             HistoryModel historyModel)
         {
+            SetupRequestContextWithConditionalQueryMaxParallelism();
+
             ResourceElement response = await _mediator.SearchResourceHistoryAsync(
                 typeParameter,
                 historyModel.Since,
@@ -341,6 +347,8 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             string idParameter,
             HistoryModel historyModel)
         {
+            SetupRequestContextWithConditionalQueryMaxParallelism();
+
             ResourceElement response = await _mediator.SearchResourceHistoryAsync(
                 typeParameter,
                 idParameter,
@@ -367,6 +375,8 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         [AuditEventType(AuditEventSubType.VRead)]
         public async Task<IActionResult> VRead(string typeParameter, string idParameter, string vidParameter)
         {
+            SetupRequestContextWithConditionalQueryMaxParallelism();
+
             RawResourceElement response = await _mediator.GetResourceAsync(
                 new GetResourceRequest(new ResourceKey(typeParameter, idParameter, vidParameter), GetBundleResourceContext()),
                 HttpContext.RequestAborted);
@@ -554,6 +564,8 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         [AuditEventType(AuditEventSubType.SearchSystem)]
         public async Task<IActionResult> Search()
         {
+            SetupRequestContextWithConditionalQueryMaxParallelism();
+
             return await SearchByResourceType(typeParameter: null);
         }
 
@@ -566,6 +578,8 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         [AuditEventType(AuditEventSubType.SearchType)]
         public async Task<IActionResult> SearchByResourceType(string typeParameter)
         {
+            SetupRequestContextWithConditionalQueryMaxParallelism();
+
             return await PerformSearch(typeParameter, GetQueriesForSearch());
         }
 
@@ -585,6 +599,8 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         [AuditEventType(AuditEventSubType.Search)]
         public async Task<IActionResult> SearchCompartmentByResourceType(string compartmentTypeParameter, string idParameter, string typeParameter)
         {
+            SetupRequestContextWithConditionalQueryMaxParallelism();
+
             IReadOnlyList<Tuple<string, string>> queries = GetQueriesForSearch();
             return await PerformCompartmentSearch(compartmentTypeParameter, idParameter, typeParameter, queries);
         }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Headers/HttpContextExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Headers/HttpContextExtensions.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Headers
                 return defaultValue;
             }
 
-            if (outerHttpContext.Request.Headers.TryGetValue(KnownHeaders.ConditionalQueryProcessingLogic, out StringValues headerValues))
+            if (outerHttpContext.Request.Headers.TryGetValue(KnownHeaders.QueryProcessingLogic, out StringValues headerValues))
             {
                 string processingLogicAsString = headerValues.FirstOrDefault();
                 if (string.IsNullOrWhiteSpace(processingLogicAsString))

--- a/src/Microsoft.Health.Fhir.Shared.Client/FhirClient.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Client/FhirClient.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Health.Fhir.Client
     public class FhirClient : IFhirClient
     {
         private const string BundleProcessingLogicHeader = "x-bundle-processing-logic";
-        private const string ConditionalQueryProcessingLogicHeader = "x-conditionalquery-processing-logic";
+        private const string QueryProcessingLogicHeader = "x-ms-query-processing-logic";
         private const string IfNoneExistHeaderName = "If-None-Exist";
         private const string ProvenanceHeader = "X-Provenance";
         private const string IfMatchHeaderName = "If-Match";
@@ -508,7 +508,7 @@ namespace Microsoft.Health.Fhir.Client
             // Conditional query processing logic.
             if (bundleOptions.MaximizeConditionalQueryParallelism)
             {
-                message.Headers.Add(ConditionalQueryProcessingLogicHeader, "parallel");
+                message.Headers.Add(QueryProcessingLogicHeader, "parallel");
             }
 
             using HttpResponseMessage response = await HttpClient.SendAsync(message, cancellationToken);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BundleEdgeCaseTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BundleEdgeCaseTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenABundleWithConditionalUpdateByReference_WhenExecutedWithMaximizedConditionalQueryParallelism_RunsTheQueryInParallelOnCosmosDb()
         {
-            // #conditionalQueryParallelism
+            // #maxQueryParallelism
 
             var bundleOptions = new FhirBundleOptions() { MaximizeConditionalQueryParallelism = true, BundleProcessingLogic = FhirBundleProcessingLogic.Parallel };
 


### PR DESCRIPTION
## Description
* Renaming the HTTP flag "x-conditionalquery-processing-logic" to a more generic name. 
* Extending the use of the max parallelism flag to more (GET) scenarios. 

## FHIR Team Checklist
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
