### PR TITLE
[Cosmos DB] Query max concurrency flag

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/KnownHeaders.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/KnownHeaders.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Health.Fhir.Core.Features
         public const string ProfileValidation = "x-ms-profile-validation";
         public const string CustomAuditHeaderPrefix = "X-MS-AZUREFHIR-AUDIT-";
         public const string FhirUserHeader = "x-ms-fhiruser";
+        public const string QueryLatencyOverEfficiency = "x-ms-query-latency-over-efficiency";
 
         // #conditionalQueryParallelism - Header used to activate parallel conditional-query processing.
         public const string ConditionalQueryProcessingLogic = "x-conditionalquery-processing-logic";

--- a/src/Microsoft.Health.Fhir.Core/Registration/AzureApiForFhirRuntimeConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Registration/AzureApiForFhirRuntimeConfiguration.cs
@@ -18,5 +18,7 @@ namespace Microsoft.Health.Fhir.Core.Registration
         public bool IsCustomerKeyValidationBackgroundWorkerSupported => false;
 
         public bool IsTransactionSupported => false;
+
+        public bool IsLatencyOverEfficiencySupported => true;
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Registration/AzureHealthDataServicesRuntimeConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Registration/AzureHealthDataServicesRuntimeConfiguration.cs
@@ -18,5 +18,7 @@ namespace Microsoft.Health.Fhir.Core.Registration
         public bool IsCustomerKeyValidationBackgroundWorkerSupported => true;
 
         public bool IsTransactionSupported => true;
+
+        public bool IsLatencyOverEfficiencySupported => false;
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Registration/IFhirRuntimeConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Registration/IFhirRuntimeConfiguration.cs
@@ -28,5 +28,10 @@ namespace Microsoft.Health.Fhir.Core.Registration
         /// Support to transactions.
         /// </summary>
         bool IsTransactionSupported { get; }
+
+        /// <summary>
+        /// Supports the 'latency-over-efficiency' HTTP header.
+        /// </summary>
+        bool IsLatencyOverEfficiencySupported { get; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/FhirControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/FhirControllerTests.cs
@@ -1,0 +1,45 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Health.Api.Features.Audit;
+using Microsoft.Health.Fhir.Api.Controllers;
+using Microsoft.Health.Fhir.Api.Features.Filters;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
+{
+    public sealed class FhirControllerTests
+    {
+        [Fact]
+        public void WhenProviderAFhirController_CheckIfAllExpectedServiceFilterAttributesArePresent()
+        {
+            Type[] expectedCustomAttributes = new Type[]
+            {
+                typeof(AuditLoggingFilterAttribute),
+                typeof(OperationOutcomeExceptionFilterAttribute),
+                typeof(ValidateFormatParametersAttribute),
+                typeof(QueryLatencyOverEfficiencyFilterAttribute),
+            };
+
+            ServiceFilterAttribute[] serviceFilterAttributes = Attribute.GetCustomAttributes(typeof(FhirController), typeof(ServiceFilterAttribute))
+                .Select(a => a as ServiceFilterAttribute)
+                .ToArray();
+
+            foreach (Type expectedCustomAttribute in expectedCustomAttributes)
+            {
+                bool attributeWasFound = serviceFilterAttributes.Any(s => s.ServiceType == expectedCustomAttribute);
+
+                if (!attributeWasFound)
+                {
+                    string errorMessage = $"The custom attribute '{expectedCustomAttribute.ToString()}' is not assigned to '{nameof(FhirController)}'.";
+                    Assert.Fail(errorMessage);
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/FhirControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/FhirControllerTests.cs
@@ -9,10 +9,14 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Health.Api.Features.Audit;
 using Microsoft.Health.Fhir.Api.Controllers;
 using Microsoft.Health.Fhir.Api.Features.Filters;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
 {
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.Web)]
     public sealed class FhirControllerTests
     {
         [Fact]

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/QueryLatencyOverEfficiencyFilterAttributeTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/QueryLatencyOverEfficiencyFilterAttributeTests.cs
@@ -1,0 +1,81 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Health.Core.Features.Context;
+using Microsoft.Health.Fhir.Api.Features.Filters;
+using Microsoft.Health.Fhir.Core.Features;
+using Microsoft.Health.Fhir.Core.Features.Context;
+using Microsoft.Health.Fhir.Core.UnitTests.Features.Context;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Test.Utilities;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
+{
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.Web)]
+    public sealed class QueryLatencyOverEfficiencyFilterAttributeTests
+    {
+        [Fact]
+        public void GivenAValidHttpContext_WhenItContainsALatencyOverEfficiencyFlag_ThenFhirContextIsDecorated()
+        {
+            var httpRequest = GetFakeHttpContext(isLatencyOverEfficiencyEnabled: true);
+
+            var filter = new QueryLatencyOverEfficiencyFilterAttribute(httpRequest.RequestContext);
+            filter.OnActionExecuted(httpRequest.ActionContext);
+
+            var fhirContextPropertyBag = httpRequest.RequestContext.RequestContext.Properties;
+
+            Assert.True(fhirContextPropertyBag.ContainsKey(KnownQueryParameterNames.OptimizeConcurrency));
+            Assert.Equal(true, fhirContextPropertyBag[KnownQueryParameterNames.OptimizeConcurrency]);
+        }
+
+        [Fact]
+        public void GivenAValidHttpContext_WhenItDoesNotContainALatencyOverEfficiencyFlag_ThenFhirContextIsClean()
+        {
+            var httpRequest = GetFakeHttpContext(isLatencyOverEfficiencyEnabled: false);
+
+            var filter = new QueryLatencyOverEfficiencyFilterAttribute(httpRequest.RequestContext);
+            filter.OnActionExecuted(httpRequest.ActionContext);
+
+            var fhirContextPropertyBag = httpRequest.RequestContext.RequestContext.Properties;
+
+            Assert.False(fhirContextPropertyBag.ContainsKey(KnownQueryParameterNames.OptimizeConcurrency));
+        }
+
+        private static (RequestContextAccessor<IFhirRequestContext> RequestContext, ActionExecutedContext ActionContext) GetFakeHttpContext(bool isLatencyOverEfficiencyEnabled)
+        {
+            var httpContext = new DefaultHttpContext();
+
+            if (isLatencyOverEfficiencyEnabled)
+            {
+                httpContext.Request.Headers[KnownHeaders.QueryLatencyOverEfficiency] = "true";
+            }
+
+            ActionExecutedContext context = new ActionExecutedContext(
+                new ActionContext(
+                    httpContext,
+                    new RouteData(),
+                    new ActionDescriptor()),
+                new List<IFilterMetadata>(),
+                FilterTestsHelper.CreateMockFhirController());
+
+            DefaultFhirRequestContext fhirRequestContext = new DefaultFhirRequestContext();
+
+            var fhirRequestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
+            fhirRequestContextAccessor.RequestContext.Returns(fhirRequestContext);
+
+            return (fhirRequestContextAccessor, context);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/QueryLatencyOverEfficiencyFilterAttributeTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/QueryLatencyOverEfficiencyFilterAttributeTests.cs
@@ -13,6 +13,7 @@ using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Fhir.Api.Features.Filters;
 using Microsoft.Health.Fhir.Core.Features;
 using Microsoft.Health.Fhir.Core.Features.Context;
+using Microsoft.Health.Fhir.Core.Registration;
 using Microsoft.Health.Fhir.Core.UnitTests.Features.Context;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Test.Utilities;
@@ -25,13 +26,16 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
     [Trait(Traits.Category, Categories.Web)]
     public sealed class QueryLatencyOverEfficiencyFilterAttributeTests
     {
+        private readonly IFhirRuntimeConfiguration _azureApiForFhirConfiguration = new AzureApiForFhirRuntimeConfiguration();
+        private readonly IFhirRuntimeConfiguration _azureHealthDataServicesFhirConfiguration = new AzureHealthDataServicesRuntimeConfiguration();
+
         [Fact]
-        public void GivenAValidHttpContext_WhenItContainsALatencyOverEfficiencyFlag_ThenFhirContextIsDecorated()
+        public void GivenAValidHttpContextForAzureApiForFhir_WhenItContainsALatencyOverEfficiencyFlag_ThenFhirContextIsDecorated()
         {
             var httpRequest = GetFakeHttpContext(isLatencyOverEfficiencyEnabled: true);
 
-            var filter = new QueryLatencyOverEfficiencyFilterAttribute(httpRequest.RequestContext);
-            filter.OnActionExecuted(httpRequest.ActionContext);
+            var filter = new QueryLatencyOverEfficiencyFilterAttribute(httpRequest.RequestContext, _azureApiForFhirConfiguration);
+            filter.OnActionExecuting(httpRequest.ActionContext);
 
             var fhirContextPropertyBag = httpRequest.RequestContext.RequestContext.Properties;
 
@@ -40,19 +44,34 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
         }
 
         [Fact]
-        public void GivenAValidHttpContext_WhenItDoesNotContainALatencyOverEfficiencyFlag_ThenFhirContextIsClean()
+        public void GivenAValidHttpContextForAzureHealthDataService_WhenItContainsALatencyOverEfficiencyFlag_ThenFhirContextIsNotDecorated()
         {
-            var httpRequest = GetFakeHttpContext(isLatencyOverEfficiencyEnabled: false);
+            // The latency-over-efficiency flag is only applicable to Azure API for FHIR.
 
-            var filter = new QueryLatencyOverEfficiencyFilterAttribute(httpRequest.RequestContext);
-            filter.OnActionExecuted(httpRequest.ActionContext);
+            var httpRequest = GetFakeHttpContext(isLatencyOverEfficiencyEnabled: true);
+
+            var filter = new QueryLatencyOverEfficiencyFilterAttribute(httpRequest.RequestContext, _azureHealthDataServicesFhirConfiguration);
+            filter.OnActionExecuting(httpRequest.ActionContext);
 
             var fhirContextPropertyBag = httpRequest.RequestContext.RequestContext.Properties;
 
             Assert.False(fhirContextPropertyBag.ContainsKey(KnownQueryParameterNames.OptimizeConcurrency));
         }
 
-        private static (RequestContextAccessor<IFhirRequestContext> RequestContext, ActionExecutedContext ActionContext) GetFakeHttpContext(bool isLatencyOverEfficiencyEnabled)
+        [Fact]
+        public void GivenAValidHttpContext_WhenItDoesNotContainALatencyOverEfficiencyFlag_ThenFhirContextIsClean()
+        {
+            var httpRequest = GetFakeHttpContext(isLatencyOverEfficiencyEnabled: false);
+
+            var filter = new QueryLatencyOverEfficiencyFilterAttribute(httpRequest.RequestContext, _azureApiForFhirConfiguration);
+            filter.OnActionExecuting(httpRequest.ActionContext);
+
+            var fhirContextPropertyBag = httpRequest.RequestContext.RequestContext.Properties;
+
+            Assert.False(fhirContextPropertyBag.ContainsKey(KnownQueryParameterNames.OptimizeConcurrency));
+        }
+
+        private static (RequestContextAccessor<IFhirRequestContext> RequestContext, ActionExecutingContext ActionContext) GetFakeHttpContext(bool isLatencyOverEfficiencyEnabled)
         {
             var httpContext = new DefaultHttpContext();
 
@@ -61,12 +80,13 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
                 httpContext.Request.Headers[KnownHeaders.QueryLatencyOverEfficiency] = "true";
             }
 
-            ActionExecutedContext context = new ActionExecutedContext(
+            ActionExecutingContext context = new ActionExecutingContext(
                 new ActionContext(
                     httpContext,
                     new RouteData(),
                     new ActionDescriptor()),
                 new List<IFilterMetadata>(),
+                actionArguments: new Dictionary<string, object>(),
                 FilterTestsHelper.CreateMockFhirController());
 
             DefaultFhirRequestContext fhirRequestContext = new DefaultFhirRequestContext();

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/QueryLatencyOverEfficiencyFilterAttributeTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/QueryLatencyOverEfficiencyFilterAttributeTests.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Headers/HttpContextExtensionsTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Headers/HttpContextExtensionsTests.cs
@@ -1,0 +1,155 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Health.Fhir.Api.Features.Headers;
+using Microsoft.Health.Fhir.Api.Features.Resources;
+using Microsoft.Health.Fhir.Api.Features.Resources.Bundle;
+using Microsoft.Health.Fhir.Core.Features;
+using Microsoft.Health.Fhir.Core.Features.Context;
+using Microsoft.Health.Fhir.Core.Features.Persistence.Orchestration;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Headers
+{
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.Web)]
+    public sealed class HttpContextExtensionsTests
+    {
+        [Fact]
+        public void WhenHttpContextDoesNotHaveCustomHeaders_ReturnDefaultValues()
+        {
+            HttpContext httpContext = GetFakeHttpContext();
+
+            bool isLatencyOverEfficiencyEnabled = httpContext.IsLatencyOverEfficiencyEnabled();
+            Assert.False(isLatencyOverEfficiencyEnabled);
+
+            BundleProcessingLogic bundleProcessingLogic = httpContext.GetBundleProcessingLogic();
+            Assert.Equal(BundleProcessingLogic.Sequential, bundleProcessingLogic);
+
+            // #conditionalQueryParallelism
+            ConditionalQueryProcessingLogic conditionalQueryProcessingLogic = httpContext.GetConditionalQueryProcessingLogic();
+            Assert.Equal(ConditionalQueryProcessingLogic.Sequential, conditionalQueryProcessingLogic);
+        }
+
+        [Theory]
+        [InlineData("", false)]
+        [InlineData(null, false)]
+        [InlineData("false", false)]
+        [InlineData("falsE", false)]
+        [InlineData("FALSE", false)]
+        [InlineData("2112", false)]
+        [InlineData("true", true)]
+        [InlineData("true ", true)]
+        [InlineData("TRUE", true)]
+        [InlineData(" TRUE ", true)]
+        [InlineData("   tRuE   ", true)]
+        public void WhenHttpContextHasCustomHeaders_ReturnIfLatencyOverEfficiencyIsEnabled(string value, bool isEnabled)
+        {
+            var httpHeaders = new Dictionary<string, string>() { { KnownHeaders.QueryLatencyOverEfficiency, value } };
+            HttpContext httpContext = GetFakeHttpContext(httpHeaders);
+
+            bool isLatencyOverEfficiencyEnabled = httpContext.IsLatencyOverEfficiencyEnabled();
+
+            Assert.Equal(isEnabled, isLatencyOverEfficiencyEnabled);
+        }
+
+        [Theory]
+        [InlineData("", ConditionalQueryProcessingLogic.Sequential)]
+        [InlineData(null, ConditionalQueryProcessingLogic.Sequential)]
+        [InlineData("sequential", ConditionalQueryProcessingLogic.Sequential)]
+        [InlineData("sequential ", ConditionalQueryProcessingLogic.Sequential)]
+        [InlineData("Sequential", ConditionalQueryProcessingLogic.Sequential)]
+        [InlineData("2112", ConditionalQueryProcessingLogic.Sequential)]
+        [InlineData("red barchetta", ConditionalQueryProcessingLogic.Sequential)]
+        [InlineData("parallel", ConditionalQueryProcessingLogic.Parallel)]
+        [InlineData("parallel  ", ConditionalQueryProcessingLogic.Parallel)]
+        [InlineData("Parallel", ConditionalQueryProcessingLogic.Parallel)]
+        [InlineData(" pArAllEl  ", ConditionalQueryProcessingLogic.Parallel)]
+        [InlineData("PARALLEL", ConditionalQueryProcessingLogic.Parallel)]
+        public void WhenHttpContextHasCustomHeaders_ReturnIfConditionalQueryProcessingLogicIsSet(string value, ConditionalQueryProcessingLogic processingLogic)
+        {
+            // #conditionalQueryParallelism
+
+            var httpHeaders = new Dictionary<string, string>() { { KnownHeaders.ConditionalQueryProcessingLogic, value } };
+            HttpContext httpContext = GetFakeHttpContext(httpHeaders);
+
+            ConditionalQueryProcessingLogic conditionalQueryProcessingLogic = httpContext.GetConditionalQueryProcessingLogic();
+
+            Assert.Equal(processingLogic, conditionalQueryProcessingLogic);
+        }
+
+        [Theory]
+        [InlineData("", BundleProcessingLogic.Sequential)]
+        [InlineData(null, BundleProcessingLogic.Sequential)]
+        [InlineData("sequential", BundleProcessingLogic.Sequential)]
+        [InlineData("sequential ", BundleProcessingLogic.Sequential)]
+        [InlineData("Sequential", BundleProcessingLogic.Sequential)]
+        [InlineData("2112", BundleProcessingLogic.Sequential)]
+        [InlineData("red barchetta", BundleProcessingLogic.Sequential)]
+        [InlineData("parallel", BundleProcessingLogic.Parallel)]
+        [InlineData("parallel  ", BundleProcessingLogic.Parallel)]
+        [InlineData("Parallel", BundleProcessingLogic.Parallel)]
+        [InlineData(" pArAllEl  ", BundleProcessingLogic.Parallel)]
+        [InlineData("PARALLEL", BundleProcessingLogic.Parallel)]
+        public void WhenHttpContextHasCustomHeaders_ReturnIfBundleProcessingLogicIsSet(string value, BundleProcessingLogic processingLogic)
+        {
+            // #conditionalQueryParallelism
+
+            var httpHeaders = new Dictionary<string, string>() { { BundleOrchestratorNamingConventions.HttpHeaderBundleProcessingLogic, value } };
+            HttpContext httpContext = GetFakeHttpContext(httpHeaders);
+
+            BundleProcessingLogic bundleProcessingLogic = httpContext.GetBundleProcessingLogic();
+
+            Assert.Equal(processingLogic, bundleProcessingLogic);
+        }
+
+        [Fact]
+        public void WhenProvidedAFhirRequestContext_ThenDecorateItWithOptimizeConcurrency()
+        {
+            // #conditionalQueryParallelism
+
+            IFhirRequestContext fhirRequestContext = new Core.UnitTests.Features.Context.DefaultFhirRequestContext()
+            {
+                BaseUri = new Uri("https://localhost/"),
+                CorrelationId = Guid.NewGuid().ToString(),
+                ResponseHeaders = new HeaderDictionary(),
+                RequestHeaders = new HeaderDictionary(),
+            };
+
+            fhirRequestContext.DecorateRequestContextWithOptimizedConcurrency();
+
+            Assert.True(fhirRequestContext.Properties.ContainsKey(KnownQueryParameterNames.OptimizeConcurrency));
+            Assert.Equal(true, fhirRequestContext.Properties[KnownQueryParameterNames.OptimizeConcurrency]);
+        }
+
+        private static HttpContext GetFakeHttpContext(IReadOnlyDictionary<string, string> optionalHttpHeaders = default)
+        {
+            var httpContext = new DefaultHttpContext()
+            {
+                Request =
+                {
+                    Scheme = "https",
+                    Host = new HostString("localhost"),
+                    PathBase = new PathString("/"),
+                },
+            };
+
+            if (optionalHttpHeaders != null)
+            {
+                foreach (var header in optionalHttpHeaders)
+                {
+                    httpContext.Request.Headers.Append(header.Key, header.Value);
+                }
+            }
+
+            return httpContext;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Headers/HttpContextExtensionsTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Headers/HttpContextExtensionsTests.cs
@@ -100,8 +100,6 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Headers
         [InlineData("PARALLEL", BundleProcessingLogic.Parallel)]
         public void WhenHttpContextHasCustomHeaders_ReturnIfBundleProcessingLogicIsSet(string value, BundleProcessingLogic processingLogic)
         {
-            // #conditionalQueryParallelism
-
             var httpHeaders = new Dictionary<string, string>() { { BundleOrchestratorNamingConventions.HttpHeaderBundleProcessingLogic, value } };
             HttpContext httpContext = GetFakeHttpContext(httpHeaders);
 

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerEdgeCaseTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerEdgeCaseTests.cs
@@ -77,30 +77,6 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void GivenABundle_WhenProcessedWithQueryLatencyOverEfficiency_TheFhirContextPropertyBagsShouldBePopulatedAsExpected(bool queryLatencyOverEfficiency)
-        {
-            // Create HTTP request with the flag "x-ms-query-latency-over-efficiency".
-            // If the flag is set to true, then the FHIR Request Context property bag contains the key "_optimizeConcurrency" as it's set with the expected value.
-            // Otherwise, the FHIR Request Context property bag will not contain the key "_optimizeConcurrency".
-
-            var requestContext = CreateRequestContextForBundleHandlerProcessing(new BundleRequestOptions() { QueryLatencyOverEfficiency = queryLatencyOverEfficiency });
-
-            var fhirContextPropertyBag = requestContext.Properties;
-
-            if (queryLatencyOverEfficiency)
-            {
-                Assert.True(fhirContextPropertyBag.ContainsKey(KnownQueryParameterNames.OptimizeConcurrency));
-                Assert.Equal(true, fhirContextPropertyBag[KnownQueryParameterNames.OptimizeConcurrency]);
-            }
-            else
-            {
-                Assert.False(fhirContextPropertyBag.ContainsKey(KnownQueryParameterNames.OptimizeConcurrency));
-            }
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
         public void GivenABundle_WhenProcessedWithConditionalQueryMaxParallelism_TheFhirContextPropertyBagsShouldBePopulatedAsExpected(bool maxParallelism)
         {
             // #conditionalQueryParallelism

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Microsoft.Health.Fhir.Shared.Api.UnitTests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Microsoft.Health.Fhir.Shared.Api.UnitTests.projitems
@@ -13,6 +13,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)AssemblyValidationsTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controllers\AadSmartOnFhirClaimsExtractorTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controllers\AadSmartOnFhirProxyControllerTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Controllers\FhirControllerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controllers\ImportControllerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controllers\ConvertDataControllerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controllers\ExportControllerTests.cs" />

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Microsoft.Health.Fhir.Shared.Api.UnitTests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Microsoft.Health.Fhir.Shared.Api.UnitTests.projitems
@@ -51,6 +51,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Formatters\FormatterConfigurationTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Formatters\HttpContextExtensionsTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Formatters\JsonArrayPoolTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Headers\HttpContextExtensionsTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Headers\ImportResultExtensionsTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Headers\ExportResultExtensionsTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Headers\FhirResultExtensionsTests.cs" />

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Microsoft.Health.Fhir.Shared.Api.UnitTests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Microsoft.Health.Fhir.Shared.Api.UnitTests.projitems
@@ -34,6 +34,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Context\FhirRequestContextMiddlewareTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Exceptions\BaseExceptionMiddlewareTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Exceptions\ExceptionNotificationMiddlewareTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Filters\QueryLatencyOverEfficiencyFilterAttributeTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Filters\ValidateBulkImportRequestFilterAttributeTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Filters\FhirRequestContextRouteDataPopulatingFilterAttributeTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Filters\FilterTestsHelper.cs" />

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         {
             StringValues conditionalCreateHeader = HttpContext.Request.Headers[KnownHeaders.IfNoneExist];
 
-            SetupRequestContextWithConditionalQueryMaxParallelism();
+            SetupConditionalRequestWithQueryOptimizeConcurrency();
 
             Tuple<string, string>[] conditionalParameters = QueryHelpers.ParseQuery(conditionalCreateHeader)
                 .SelectMany(query => query.Value, (query, value) => Tuple.Create(query.Key, value)).ToArray();
@@ -230,7 +230,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         [AuditEventType(AuditEventSubType.ConditionalUpdate)]
         public async Task<IActionResult> ConditionalUpdate([FromBody] Resource resource)
         {
-            SetupRequestContextWithConditionalQueryMaxParallelism();
+            SetupConditionalRequestWithQueryOptimizeConcurrency();
 
             IReadOnlyList<Tuple<string, string>> conditionalParameters = GetQueriesForSearch();
 
@@ -432,7 +432,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         {
             IReadOnlyList<Tuple<string, string>> conditionalParameters = GetQueriesForSearch();
 
-            SetupRequestContextWithConditionalQueryMaxParallelism();
+            SetupConditionalRequestWithQueryOptimizeConcurrency();
 
             DeleteResourceResponse response = await _mediator.Send(
                 new ConditionalDeleteResourceRequest(
@@ -493,7 +493,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             IReadOnlyList<Tuple<string, string>> conditionalParameters = GetQueriesForSearch();
             var payload = new JsonPatchPayload(patchDocument);
 
-            SetupRequestContextWithConditionalQueryMaxParallelism();
+            SetupConditionalRequestWithQueryOptimizeConcurrency();
 
             UpsertResourceResponse response = await _mediator.ConditionalPatchResourceAsync(
                 new ConditionalPatchResourceRequest(typeParameter, payload, conditionalParameters, GetBundleResourceContext(), ifMatchHeader),
@@ -538,7 +538,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             IReadOnlyList<Tuple<string, string>> conditionalParameters = GetQueriesForSearch();
             var payload = new FhirPathPatchPayload(paramsResource);
 
-            SetupRequestContextWithConditionalQueryMaxParallelism();
+            SetupConditionalRequestWithQueryOptimizeConcurrency();
 
             UpsertResourceResponse response = await _mediator.ConditionalPatchResourceAsync(
                 new ConditionalPatchResourceRequest(typeParameter, payload, conditionalParameters, GetBundleResourceContext(), ifMatchHeader),
@@ -687,7 +687,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             return null;
         }
 
-        private void SetupRequestContextWithConditionalQueryMaxParallelism()
+        private void SetupConditionalRequestWithQueryOptimizeConcurrency()
         {
             if (HttpContext?.Request?.Headers != null && _fhirRequestContextAccessor != null)
             {

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
@@ -59,6 +59,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
     [ServiceFilter(typeof(AuditLoggingFilterAttribute))]
     [ServiceFilter(typeof(OperationOutcomeExceptionFilterAttribute))]
     [ServiceFilter(typeof(ValidateFormatParametersAttribute))]
+    [ServiceFilter(typeof(QueryLatencyOverEfficiencyFilterAttribute))]
     [ValidateResourceTypeFilter]
     [ValidateModelState]
     public class FhirController : Controller

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/QueryLatencyOverEfficiencyFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/QueryLatencyOverEfficiencyFilterAttribute.cs
@@ -1,0 +1,54 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using EnsureThat;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Health.Core.Features.Context;
+using Microsoft.Health.Fhir.Api.Features.Headers;
+using Microsoft.Health.Fhir.Core.Features.Context;
+
+namespace Microsoft.Health.Fhir.Api.Features.Filters
+{
+    /// <summary>
+    /// Latency over efficiency filter.
+    /// Decorates controller classes witch requests can contain requests with HTTP Readers decorated by latency over efficiency flag.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class QueryLatencyOverEfficiencyFilterAttribute : ActionFilterAttribute
+    {
+        private readonly RequestContextAccessor<IFhirRequestContext> _fhirRequestContextAccessor;
+
+        public QueryLatencyOverEfficiencyFilterAttribute(RequestContextAccessor<IFhirRequestContext> fhirRequestContextAccessor)
+        {
+            EnsureArg.IsNotNull(fhirRequestContextAccessor, nameof(fhirRequestContextAccessor));
+
+            _fhirRequestContextAccessor = fhirRequestContextAccessor;
+        }
+
+        public override void OnActionExecuted(ActionExecutedContext context)
+        {
+            EnsureArg.IsNotNull(context, nameof(context));
+
+            SetupConditionalRequestWithQueryOptimizeConcurrency(context.HttpContext, _fhirRequestContextAccessor.RequestContext);
+
+            base.OnActionExecuted(context);
+        }
+
+        private static void SetupConditionalRequestWithQueryOptimizeConcurrency(HttpContext context, IFhirRequestContext fhirRequestContext)
+        {
+            if (context?.Request?.Headers != null && fhirRequestContext != null)
+            {
+                bool latencyOverEfficiencyEnabled = context.IsLatencyOverEfficiencyEnabled();
+
+                if (latencyOverEfficiencyEnabled)
+                {
+                    fhirRequestContext.DecorateRequestContextWithOptimizedConcurrency();
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
         private readonly string _originalRequestBase;
         private readonly IMediator _mediator;
         private readonly BundleProcessingLogic _bundleProcessingLogic;
-        private readonly ConditionalQueryProcessingLogic _conditionalQueryProcessingLogic;
+        private readonly bool _optimizedQuerySet;
 
         private int _requestCount;
         private BundleType? _bundleType;
@@ -156,8 +156,8 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
             // Retrieve bundle processing logic.
             _bundleProcessingLogic = GetBundleProcessingLogic(outerHttpContext, _logger);
 
-            // Set conditional-query processing logic.
-            _conditionalQueryProcessingLogic = SetRequestContextWithConditionalQueryProcessingLogic(outerHttpContext, fhirRequestContextAccessor.RequestContext, _logger);
+            // Set optimized-query processing logic.
+            _optimizedQuerySet = SetRequestContextWithOptimizedQuerying(outerHttpContext, fhirRequestContextAccessor.RequestContext, _logger);
         }
 
         public async Task<BundleResponse> Handle(BundleRequest request, CancellationToken cancellationToken)
@@ -233,7 +233,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
             }
         }
 
-        private static ConditionalQueryProcessingLogic SetRequestContextWithConditionalQueryProcessingLogic(HttpContext outerHttpContext, IFhirRequestContext fhirRequestContext, ILogger<BundleHandler> logger)
+        private static bool SetRequestContextWithOptimizedQuerying(HttpContext outerHttpContext, IFhirRequestContext fhirRequestContext, ILogger<BundleHandler> logger)
         {
             try
             {
@@ -242,16 +242,30 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                 if (conditionalQueryProcessingLogic == ConditionalQueryProcessingLogic.Parallel)
                 {
                     fhirRequestContext.DecorateRequestContextWithOptimizedConcurrency();
+                    return true;
                 }
-
-                return conditionalQueryProcessingLogic;
             }
             catch (Exception e)
             {
                 logger.LogWarning(e, "Error while extracting the Conditional-Query Processing Logic out of the HTTP Header: {ErrorMessage}", e.Message);
             }
 
-            return ConditionalQueryProcessingLogic.Sequential;
+            try
+            {
+                bool latencyOverEfficiency = outerHttpContext.IsLatencyOverEfficiencyEnabled();
+
+                if (latencyOverEfficiency)
+                {
+                    fhirRequestContext.DecorateRequestContextWithOptimizedConcurrency();
+                    return true;
+                }
+            }
+            catch (Exception e)
+            {
+                logger.LogWarning(e, "Error while extracting the Latency Over Efficiency out of the HTTP Header: {ErrorMessage}", e.Message);
+            }
+
+            return false;
         }
 
         private BundleProcessingLogic GetBundleProcessingLogic(HttpContext outerHttpContext, ILogger<BundleHandler> logger)
@@ -911,7 +925,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
 
         private BundleHandlerStatistics CreateNewBundleHandlerStatistics(BundleProcessingLogic processingLogic)
         {
-            BundleHandlerStatistics statistics = new BundleHandlerStatistics(_bundleType, processingLogic, _conditionalQueryProcessingLogic, _requestCount);
+            BundleHandlerStatistics statistics = new BundleHandlerStatistics(_bundleType, processingLogic, _optimizedQuerySet, _requestCount);
 
             statistics.StartCollectingResults();
 

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
@@ -250,21 +250,6 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                 logger.LogWarning(e, "Error while extracting the Conditional-Query Processing Logic out of the HTTP Header: {ErrorMessage}", e.Message);
             }
 
-            try
-            {
-                bool latencyOverEfficiency = outerHttpContext.IsLatencyOverEfficiencyEnabled();
-
-                if (latencyOverEfficiency)
-                {
-                    fhirRequestContext.DecorateRequestContextWithOptimizedConcurrency();
-                    return true;
-                }
-            }
-            catch (Exception e)
-            {
-                logger.LogWarning(e, "Error while extracting the Latency Over Efficiency out of the HTTP Header: {ErrorMessage}", e.Message);
-            }
-
             return false;
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerStatistics.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerStatistics.cs
@@ -24,13 +24,13 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
         public BundleHandlerStatistics(
             BundleType? bundleType,
             BundleProcessingLogic bundleProcessingLogic,
-            ConditionalQueryProcessingLogic conditionalQueryProcessingLogic,
+            bool optimizedQuerySet,
             int numberOfResources)
             : base()
         {
             BundleType = bundleType;
             BundleProcessingLogic = bundleProcessingLogic;
-            ConditionalQueryProcessingLogic = conditionalQueryProcessingLogic;
+            OptimizedQueryProcessing = optimizedQuerySet;
             NumberOfResources = numberOfResources;
             _entries = new List<BundleHandlerStatisticEntry>();
         }
@@ -41,7 +41,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
 
         public BundleProcessingLogic BundleProcessingLogic { get; }
 
-        public ConditionalQueryProcessingLogic ConditionalQueryProcessingLogic { get; }
+        public bool OptimizedQueryProcessing { get; }
 
         public override string GetLoggingCategory() => LoggingCategory;
 
@@ -61,7 +61,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                 label = GetLoggingCategory(),
                 bundleType = BundleType.ToString(),
                 processingLogic = BundleProcessingLogic.ToString(),
-                conditionalQuery = ConditionalQueryProcessingLogic.ToString(),
+                optimizedQuerySet = OptimizedQueryProcessing.ToString(),
                 numberOfResources = NumberOfResources,
                 executionTime = ElapsedMilliseconds,
                 success = successedRequests,

--- a/src/Microsoft.Health.Fhir.Shared.Api/Microsoft.Health.Fhir.Shared.Api.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Microsoft.Health.Fhir.Shared.Api.projitems
@@ -26,6 +26,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\ActionResults\OperationOutcomeResult.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\ActionResults\OperationSmartConfigurationResult.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\ActionResults\OperationVersionsResult.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Filters\QueryLatencyOverEfficiencyFilterAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Formatters\FormatParametersValidator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Filters\ParameterCompatibleFilter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Filters\SearchParameterFilterAttribute.cs" />

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs
@@ -109,6 +109,7 @@ namespace Microsoft.Health.Fhir.Api.Modules
             services.AddSingleton<ValidateImportRequestFilterAttribute>();
             services.AddSingleton<ValidateAsyncRequestFilterAttribute>();
             services.AddSingleton<ValidateParametersResourceAttribute>();
+            services.AddSingleton<QueryLatencyOverEfficiencyFilterAttribute>();
 
             // Support for resolve()
             FhirPathCompiler.DefaultSymbolTable.AddFhirExtensions();


### PR DESCRIPTION
Query max concurrency flag corresponds to a new HTTP header that customers can rely on to execute queries using Cosmos DB max parallelism. 

To use this feature, requests should have the HTTP header "_x-ms-query-latency-over-efficiency_" set to "_true_".

A new ASP.NET Core Filter "_QueryLatencyOverEfficiencyFilterAttribute_" will decorate the IFhirRequestContext property bag with the KnownQueryParameterNames.OptimizeConcurrency property, that activates the MaxParallelism in FhirCosmosSearchService.

> **[Applicable to both Gen1 and gen2]**

1. Parallel bundles Processing Logic 
-  Request created by bundles are executed in parallel. 
-  Header **x-bundle-processing-logic** is sent with Parallel value
 

> **[Applicable to Gen1 only]**

1. Conditional-Query Processing Logic 
-  Cosmos DB queries executed by conditional operations are executed in parallel. 
-  Header **x-conditionalquery-processing-logic** is sent with true
 
2. Latency Over Efficiency 
- All Cosmos DB queries are executed in parallel (Conditional + others)
-  Header **x-ms-query-latency-over-efficiency** is sent with true

## Testing
- New tests:
  - FhirControllerTests - Unit tests to make sure that all expected filters are included in FhirController.
  - QueryLatencyOverEfficiencyFilterAttributeTests - Unit tests validating if the IFhirRequestContext property bag is properly populated with the KnownQueryParameterNames.OptimizeConcurrency property. 
  - HttpContextExtensionsTests - Unit tests validating if the IFhirRequestContext is decorated as expected with KnownQueryParameterNames.OptimizeConcurrency and if header in HttpContext are correctly detected. 
- Besides the new unit and integration tests, this feature was tested locally and on Azure Web Apps, where the impact in Cosmos DB RUs was validated.

## FHIR Team Checklist
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
