### PR TITLE
Fix flaky history count test

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -110,7 +110,7 @@
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.Configuration.Configuration" Version="6.0.1" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
-    <PackageVersion Include="System.Data.SqlClient" Version="4.8.5" />
+    <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="8.0.0" />
     <PackageVersion Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HistoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HistoryTests.cs
@@ -97,6 +97,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenTestResourcesWithUpdatesAndDeletes_WhenGettingResourceHistoryCount_TheServerShouldReturnCorrectCount()
         {
+            var sinceTime = HttpUtility.UrlEncode(_createdResource.Resource.Meta.LastUpdated.Value.ToString("o"));
+
             // 3 versions, 2 history 1 delete
             _createdResource.Resource.Effective = new FhirDateTime(DateTimeOffset.UtcNow);
             await _client.UpdateAsync(_createdResource.Resource);
@@ -113,8 +115,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             await _client.DeleteAsync(extraResource2.Resource);
             extraResource3.Resource.Effective = new FhirDateTime(DateTimeOffset.UtcNow);
             await _client.UpdateAsync(extraResource3.Resource);
-
-            var sinceTime = HttpUtility.UrlEncode(_createdResource.Resource.Meta.LastUpdated.Value.ToString("o"));
 
             var allSummaryCountResult = await _client.SearchAsync($"/_history?_since={sinceTime}&_summary=count");
             var allSummaryCountZero = await _client.SearchAsync($"/_history?_since={sinceTime}&_count=0");
@@ -134,6 +134,9 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             // 3 versions across single observation (create, update, delete).
             Assert.Equal(3, observationSummaryCountResult.Resource.Total);
             Assert.Equal(3, observationSummaryCountZero.Resource.Total);
+
+            // Cleanup
+            await _client.DeleteAsync(extraResource3.Resource);
         }
 
         [Fact]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HistoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HistoryTests.cs
@@ -128,19 +128,14 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             if (allSummaryCountResult.Resource.Total != 9 || allSummaryCountZero.Resource.Total != 9)
             {
                 Console.Write(await GetSummaryMessage($"/_history?_since={sinceTime}"));
+                Assert.Fail($"allSummaryCountResult or allSummaryCountZero not equal to 9. allSummaryCountResult {allSummaryCountResult.Resource.Total}. allSummaryCountZero {allSummaryCountZero.Resource.Total}");
             }
-
-            Assert.Equal(9, allSummaryCountResult.Resource.Total);
-            Assert.Equal(9, allSummaryCountZero.Resource.Total);
 
             if (allObservationSummaryCountResult.Resource.Total != 5 || allObservationSummaryCountZero.Resource.Total != 5)
             {
                 Console.Write(await GetSummaryMessage($"/Observation/_history?_since={sinceTime}"));
+                Assert.Fail($"allSummaryCountResult or allSummaryCountZero not equal to 5. allObservationSummaryCountResult {allObservationSummaryCountResult.Resource.Total}. allObservationSummaryCountZero {allObservationSummaryCountZero.Resource.Total}");
             }
-
-            // 5 versions across only observations (first one create, update, delete - second create, update).
-            Assert.Equal(5, allObservationSummaryCountResult.Resource.Total);
-            Assert.Equal(5, allObservationSummaryCountZero.Resource.Total);
 
             // 3 versions across single observation (create, update, delete).
             Assert.Equal(3, observationSummaryCountResult.Resource.Total);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HistoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HistoryTests.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             extraResource3.Resource.Effective = new FhirDateTime(DateTimeOffset.UtcNow);
             await _client.UpdateAsync(extraResource3.Resource);
 
-            var sinceTime = HttpUtility.UrlEncode(_createdResource.Resource.Meta.LastUpdated.Value.AddMilliseconds(-1).ToString("o"));
+            var sinceTime = HttpUtility.UrlEncode(_createdResource.Resource.Meta.LastUpdated.Value.ToString("o"));
 
             var allSummaryCountResult = await _client.SearchAsync($"/_history?_since={sinceTime}&_summary=count");
             var allSummaryCountZero = await _client.SearchAsync($"/_history?_since={sinceTime}&_count=0");

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HistoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HistoryTests.cs
@@ -97,7 +97,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenTestResourcesWithUpdatesAndDeletes_WhenGettingResourceHistoryCount_TheServerShouldReturnCorrectCount()
         {
-            Observation firstTestResource = _createdResource.Resource;
+            Thread.Sleep(5000); // summary count queries can't be filtered by tag. wait to ensure previous tests are done writing to db.
+            Observation firstTestResource = (await _client.CreateByUpdateAsync(Samples.GetDefaultObservation().ToPoco<Observation>())).Resource;
             var sinceTime = HttpUtility.UrlEncode(firstTestResource.Meta.LastUpdated.Value.UtcDateTime.ToString("o"));
 
             // 3 versions, 2 history 1 delete

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HistoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HistoryTests.cs
@@ -129,14 +129,14 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             // 9 versions total for all resources.
             if (allSummaryCountResult.Resource.Total != 9 || allSummaryCountZero.Resource.Total != 9)
             {
-                Console.Write(await GetSummaryMessage($"/_history?_since={sinceTime}&_before={beforeTime}"));
-                Assert.Fail($"allSummaryCountResult or allSummaryCountZero not equal to 9. allSummaryCountResult {allSummaryCountResult.Resource.Total}. allSummaryCountZero {allSummaryCountZero.Resource.Total}");
+                Assert.Fail($"allSummaryCountResult or allSummaryCountZero not equal to 9. allSummaryCountResult {allSummaryCountResult.Resource.Total}. " +
+                            $"allSummaryCountZero {allSummaryCountZero.Resource.Total}.\n{await GetSummaryMessage($"/_history?_since={sinceTime}&_before={beforeTime}")}.");
             }
 
             if (allObservationSummaryCountResult.Resource.Total != 5 || allObservationSummaryCountZero.Resource.Total != 5)
             {
-                Console.Write(await GetSummaryMessage($"/Observation/_history?_since={sinceTime}&_before={beforeTime}"));
-                Assert.Fail($"allSummaryCountResult or allSummaryCountZero not equal to 5. allObservationSummaryCountResult {allObservationSummaryCountResult.Resource.Total}. allObservationSummaryCountZero {allObservationSummaryCountZero.Resource.Total}");
+                Assert.Fail($"allSummaryCountResult or allSummaryCountZero not equal to 5. allObservationSummaryCountResult {allObservationSummaryCountResult.Resource.Total}. " +
+                            $"allObservationSummaryCountZero {allObservationSummaryCountZero.Resource.Total}\n{await GetSummaryMessage($"/Observation/_history?_since={sinceTime}&_before={beforeTime}")}.");
             }
 
             // 3 versions across single observation (create, update, delete).


### PR DESCRIPTION
## Description
The test for history count cannot be filtered by tags - so it must count all resources on the system. This makes the test vulnerable to flakiness as long as the DB is shared with other tests.

Adding a 5s delay before the test starts - with detailed logging I saw that a patient was being updated in another test during the test execution time of this test. In reality, another test may not be completing 100% before exiting but this delay will stop the flakiness.

## Testing
Automated testing

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
