### PR TITLE
Adding AddFhirServerLite extensions method.

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Api/Microsoft.Health.Fhir.Shared.Api.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Microsoft.Health.Fhir.Shared.Api.projitems
@@ -46,7 +46,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Routing\QueryStringParser.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Modules\FeatureFlags\Validate\ValidateFeatureModule.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Modules\FeatureFlags\Validate\ValidatePostConfigureOptions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Modules\KnownModuleNames.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Modules\MediationModule.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Modules\ModuleRegistrationExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Modules\MvcModule.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Exceptions\BaseExceptionMiddleware.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Exceptions\BaseExceptionMiddlewareExtensions.cs" />
@@ -81,5 +83,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Modules\SearchModule.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Modules\ValidationModule.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Registration\FhirServerServiceCollectionExtensions.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)Modules\Directory.Build.props" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/KnownModuleNames.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/KnownModuleNames.cs
@@ -1,0 +1,24 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.Health.Fhir.Api.Modules
+{
+    [Flags]
+    public enum KnownModuleNames
+    {
+        None = 0,
+        Anonymization = 1,
+        Fhir = 1 << 1,
+        Mediation = 1 << 2,
+        Mvc = 1 << 3,
+        Operations = 1 << 4,
+        Persistence = 1 << 5,
+        Search = 1 << 6,
+        Validation = 1 << 7,
+        All = Anonymization | Fhir | Mediation | Mvc | Operations | Persistence | Search | Validation,
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/ModuleRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/ModuleRegistrationExtensions.cs
@@ -1,0 +1,63 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Health.Fhir.Api.Configs;
+using Microsoft.Health.Fhir.Api.Modules.FeatureFlags.HtmlUi;
+using Microsoft.Health.Fhir.Api.Modules.FeatureFlags.Validate;
+using Microsoft.Health.Fhir.Api.Modules.FeatureFlags.XmlFormatter;
+
+namespace Microsoft.Health.Fhir.Api.Modules
+{
+    public static class ModuleRegistrationExtensions
+    {
+        public static IServiceCollection RegisterModules(
+            this IServiceCollection services,
+            FhirServerConfiguration configuration,
+            KnownModuleNames modules = KnownModuleNames.All)
+        {
+            if ((modules & KnownModuleNames.Anonymization) == KnownModuleNames.Anonymization)
+            {
+                services.RegisterModule<AnonymizationModule>(configuration);
+            }
+
+            if ((modules & KnownModuleNames.Mediation) == KnownModuleNames.Mediation)
+            {
+                services.RegisterModule<MediationModule>(configuration);
+            }
+
+            if ((modules & KnownModuleNames.Mvc) == KnownModuleNames.Mvc)
+            {
+                services.RegisterModule<MvcModule>(configuration);
+                services.RegisterModule<HtmlUiFeatureModule>(configuration);
+                services.RegisterModule<ValidateFeatureModule>(configuration);
+                services.RegisterModule<XmlFormatterFeatureModule>(configuration);
+            }
+
+            if ((modules & KnownModuleNames.Operations) == KnownModuleNames.Operations)
+            {
+                services.RegisterModule<OperationsModule>(configuration);
+            }
+
+            if ((modules & KnownModuleNames.Persistence) == KnownModuleNames.Persistence)
+            {
+                services.RegisterModule<PersistenceModule>(configuration);
+            }
+
+            if ((modules & KnownModuleNames.Search) == KnownModuleNames.Search)
+            {
+                services.RegisterModule<SearchModule>(configuration);
+            }
+
+            if ((modules & KnownModuleNames.Validation) == KnownModuleNames.Validation)
+            {
+                services.RegisterModule<OperationsModule>(configuration);
+            }
+
+            return services;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/ModuleRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/ModuleRegistrationExtensions.cs
@@ -21,7 +21,9 @@ namespace Microsoft.Health.Fhir.Api.Modules
         {
             if ((modules & KnownModuleNames.Anonymization) == KnownModuleNames.Anonymization)
             {
+#if R4 && !R4B
                 services.RegisterModule<AnonymizationModule>(configuration);
+#endif
             }
 
             if ((modules & KnownModuleNames.Mediation) == KnownModuleNames.Mediation)

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/ModuleRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/ModuleRegistrationExtensions.cs
@@ -26,6 +26,11 @@ namespace Microsoft.Health.Fhir.Api.Modules
 #endif
             }
 
+            if ((modules & KnownModuleNames.Fhir) == KnownModuleNames.Fhir)
+            {
+                services.RegisterModule<FhirModule>(configuration);
+            }
+
             if ((modules & KnownModuleNames.Mediation) == KnownModuleNames.Mediation)
             {
                 services.RegisterModule<MediationModule>(configuration);

--- a/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
@@ -162,6 +162,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton(Options.Options.Create(fhirServerConfiguration.ArtifactStore));
             services.AddSingleton(Options.Options.Create(fhirServerConfiguration.ImplementationGuides));
 
+            services.RegisterModule<OperationsModule>(fhirServerConfiguration);
             services.RegisterModule<SearchModule>(fhirServerConfiguration);
 
             services.AddHttpClient(Options.Options.DefaultName)

--- a/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
@@ -162,12 +162,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton(Options.Options.Create(fhirServerConfiguration.ArtifactStore));
             services.AddSingleton(Options.Options.Create(fhirServerConfiguration.ImplementationGuides));
 
-            services.RegisterModule<FhirModule>(fhirServerConfiguration);
-            services.RegisterModule<MediationModule>(fhirServerConfiguration);
-            services.RegisterModule<OperationsModule>(fhirServerConfiguration);
-            services.RegisterModule<PersistenceModule>(fhirServerConfiguration);
             services.RegisterModule<SearchModule>(fhirServerConfiguration);
-            services.RegisterModule<ValidationModule>(fhirServerConfiguration);
 
             services.AddHttpClient(Options.Options.DefaultName)
                 .AddTransientHttpErrorPolicy(builder =>

--- a/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
@@ -162,13 +162,12 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton(Options.Options.Create(fhirServerConfiguration.ArtifactStore));
             services.AddSingleton(Options.Options.Create(fhirServerConfiguration.ImplementationGuides));
 
-            services.RegisterModule<AnonymizationModule>();
-            services.RegisterModule<FhirModule>();
-            services.RegisterModule<MediationModule>();
-            services.RegisterModule<OperationsModule>();
-            services.RegisterModule<PersistenceModule>();
-            services.RegisterModule<SearchModule>();
-            services.RegisterModule<ValidationModule>();
+            services.RegisterModule<FhirModule>(fhirServerConfiguration);
+            services.RegisterModule<MediationModule>(fhirServerConfiguration);
+            services.RegisterModule<OperationsModule>(fhirServerConfiguration);
+            services.RegisterModule<PersistenceModule>(fhirServerConfiguration);
+            services.RegisterModule<SearchModule>(fhirServerConfiguration);
+            services.RegisterModule<ValidationModule>(fhirServerConfiguration);
 
             services.AddHttpClient(Options.Options.DefaultName)
                 .AddTransientHttpErrorPolicy(builder =>


### PR DESCRIPTION
## Description
Adding a new extensions method, AddFhirServerLite, with an option to pick which modules to register for the hosting worker and schema management service in health-paas.

## Related issues
Addresses [issue #104170].

[User Story 104170](https://microsofthealth.visualstudio.com/Health/_workitems/edit/104170): [Short term] Add DepedencyInjectionTests for HostingWorkerService

## Testing
Tested by implementing dependency injection tests for the hosting worker service in health-paas.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
