### PR TITLE
Adds exception block to handle invalid storage URL

### DIFF
--- a/src/Microsoft.Health.Fhir.Azure/IntegrationDataStore/AzureBlobIntegrationDataStoreClient.cs
+++ b/src/Microsoft.Health.Fhir.Azure/IntegrationDataStore/AzureBlobIntegrationDataStoreClient.cs
@@ -181,8 +181,7 @@ namespace Microsoft.Health.Fhir.Azure.IntegrationDataStore
             catch (AggregateException ex) when (ex.InnerExceptions[0] is RequestFailedException)
             {
                 var innerException = (RequestFailedException)ex.InnerExceptions[0];
-                _logger.LogInformation(innerException, "{Error}", innerException.Message);
-                Exception exception = HandleRequestFailedException(innerException, "Failed to get properties of blob {Url}");
+                Exception exception = HandleRequestFailedException(innerException, $"Failed to get properties of blob {resourceUri}");
                 throw new IntegrationDataStoreException(exception, (HttpStatusCode)innerException.Status);
             }
             catch (RequestFailedException se)

--- a/src/Microsoft.Health.Fhir.Azure/IntegrationDataStore/AzureBlobIntegrationDataStoreClient.cs
+++ b/src/Microsoft.Health.Fhir.Azure/IntegrationDataStore/AzureBlobIntegrationDataStoreClient.cs
@@ -178,6 +178,13 @@ namespace Microsoft.Health.Fhir.Azure.IntegrationDataStore
                                 return result;
                             });
             }
+            catch (AggregateException ex) when (ex.InnerExceptions[0] is RequestFailedException)
+            {
+                var innerException = (RequestFailedException)ex.InnerExceptions[0];
+                _logger.LogInformation(innerException, "{Error}", innerException.Message);
+                Exception exception = HandleRequestFailedException(innerException, "Failed to get properties of blob {Url}");
+                throw new IntegrationDataStoreException(exception, (HttpStatusCode)innerException.Status);
+            }
             catch (RequestFailedException se)
             {
                 Exception exception = HandleRequestFailedException(se, $"Failed to get properties of blob {resourceUri}");


### PR DESCRIPTION
This PR will log information for invalid blob storage URL instead of throwing exception .
It will avoid triggering ICM.



## Related issues
Addresses issue https://microsofthealth.visualstudio.com/Health/_workitems/edit/113620/ 

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
