### PR TITLE
Added dynamic handling for default Export isParallel value

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ExportControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ExportControllerTests.cs
@@ -3,10 +3,18 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
+using System.Collections.Generic;
+using System.Threading;
 using Hl7.Fhir.Model;
+using Hl7.Fhir.Rest;
 using MediatR;
+using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Fhir.Api.Configs;
 using Microsoft.Health.Fhir.Api.Controllers;
@@ -15,6 +23,8 @@ using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Features.ArtifactStore;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Routing;
+using Microsoft.Health.Fhir.Core.Messages.Export;
+using Microsoft.Health.Fhir.Core.Registration;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Test.Utilities;
 using NSubstitute;
@@ -286,7 +296,55 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
                 typeParameter: ResourceType.Patient.ToString()));
         }
 
-        private ExportController GetController(ExportJobConfiguration exportConfig, FeatureConfiguration features, ArtifactStoreConfiguration artifactStoreConfig)
+        [Theory]
+        [InlineData(true, false, null)]
+        [InlineData(false, true, null)]
+        [InlineData(true, true, true)]
+        [InlineData(true, false, false)]
+        [InlineData(false, true, true)]
+        [InlineData(false, false, false)]
+        public async Task GivenASystemLevelExport_WhenRequestSentToMediator_CorrectIsParallelValueInRequest(bool isApiForFhir, bool expectedIsParallel, bool? inputIsParallelValue)
+        {
+            IFhirRuntimeConfiguration fhirConfig = isApiForFhir ? Substitute.For<AzureApiForFhirRuntimeConfiguration>() : Substitute.For<IFhirRuntimeConfiguration>();
+            var exportController = GetController(_exportEnabledJobConfiguration, _featureConfiguration, _artifactStoreConfig, fhirConfig);
+            exportController.ControllerContext.HttpContext = new DefaultHttpContext();
+
+            _fhirRequestContextAccessor.RequestContext = new FhirRequestContext(
+               method: "export",
+               uriString: "https://test.com/",
+               baseUriString: "https://test.com/",
+               correlationId: "export",
+               requestHeaders: new Dictionary<string, StringValues>(),
+               responseHeaders: new Dictionary<string, StringValues>());
+
+            _urlResolver
+                .ResolveOperationResultUrl(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(new Uri("http://test.com/"));
+
+            _mediator
+                .Send(Arg.Any<CreateExportRequest>(), Arg.Any<CancellationToken>())
+                .Returns(callInfo =>
+                {
+                    var request = callInfo.Arg<CreateExportRequest>();
+                    if (request.IsParallel != expectedIsParallel)
+                    {
+                        throw new InvalidOperationException($"Expected isParallel value of {expectedIsParallel} but got {request.IsParallel}.");
+                    }
+
+                    return new CreateExportResponse("ExportTestJobId");
+                });
+
+            try
+            {
+                await exportController.Export(null, null, string.Empty, string.Empty, string.Empty, string.Empty, isParallel: inputIsParallelValue);
+            }
+            catch (InvalidOperationException ex)
+            {
+                Assert.Fail(ex.Message);
+            }
+        }
+
+        private ExportController GetController(ExportJobConfiguration exportConfig, FeatureConfiguration features, ArtifactStoreConfiguration artifactStoreConfig, IFhirRuntimeConfiguration fhirConfig = null)
         {
             var operationConfig = new OperationsConfiguration()
             {
@@ -309,7 +367,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
                 optionsOperationConfiguration,
                 optionsArtifactStoreConfiguration,
                 optionsFeatures,
-                NullLogger<ExportController>.Instance);
+                fhirConfig ?? Substitute.For<IFhirRuntimeConfiguration>());
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ExportControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ExportControllerTests.cs
@@ -305,8 +305,11 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
         [InlineData(false, false, false)]
         public async Task GivenASystemLevelExport_WhenRequestSentToMediator_CorrectIsParallelValueInRequest(bool isApiForFhir, bool expectedIsParallel, bool? inputIsParallelValue)
         {
+            // Get export controller with specific runtime configuration (if needed).
             IFhirRuntimeConfiguration fhirConfig = isApiForFhir ? Substitute.For<AzureApiForFhirRuntimeConfiguration>() : Substitute.For<IFhirRuntimeConfiguration>();
             var exportController = GetController(_exportEnabledJobConfiguration, _featureConfiguration, _artifactStoreConfig, fhirConfig);
+
+            // Setup additional dependencies needed for test execution.
             exportController.ControllerContext.HttpContext = new DefaultHttpContext();
 
             _fhirRequestContextAccessor.RequestContext = new FhirRequestContext(
@@ -321,6 +324,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
                 .ResolveOperationResultUrl(Arg.Any<string>(), Arg.Any<string>())
                 .Returns(new Uri("http://test.com/"));
 
+            // Mock mediator call for CreateExportRequest - throw exception to fail test if we get unexpected value.
             _mediator
                 .Send(Arg.Any<CreateExportRequest>(), Arg.Any<CancellationToken>())
                 .Returns(callInfo =>

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ExportController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ExportController.cs
@@ -397,13 +397,12 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                 return isParallelFromRequest.Value;
             }
 
-            // We want Gen1 to not export parallel by default.
+            // Api For FHIR defaults to non-parallel export.
             if (fhirConfig is AzureApiForFhirRuntimeConfiguration)
             {
                 return false;
             }
 
-            // Else keep current behavior.
             return true;
         }
     }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ExportController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ExportController.cs
@@ -31,6 +31,7 @@ using Microsoft.Health.Fhir.Core.Features.Operations.Export;
 using Microsoft.Health.Fhir.Core.Features.Routing;
 using Microsoft.Health.Fhir.Core.Messages.Export;
 using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.Core.Registration;
 using Microsoft.Health.Fhir.TemplateManagement.Models;
 using Microsoft.Health.Fhir.ValueSets;
 using Microsoft.Identity.Client;
@@ -60,6 +61,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         private readonly ConvertDataConfiguration _convertConfig;
         private readonly ArtifactStoreConfiguration _artifactStoreConfig;
         private readonly FeatureConfiguration _features;
+        private readonly IFhirRuntimeConfiguration _fhirConfig;
 
         public ExportController(
             IMediator mediator,
@@ -68,7 +70,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             IOptions<OperationsConfiguration> operationsConfig,
             IOptions<ArtifactStoreConfiguration> artifactStoreConfig,
             IOptions<FeatureConfiguration> features,
-            ILogger<ExportController> logger)
+            IFhirRuntimeConfiguration fhirConfig)
         {
             EnsureArg.IsNotNull(mediator, nameof(mediator));
             EnsureArg.IsNotNull(fhirRequestContextAccessor, nameof(fhirRequestContextAccessor));
@@ -76,7 +78,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             EnsureArg.IsNotNull(artifactStoreConfig, nameof(artifactStoreConfig));
             EnsureArg.IsNotNull(operationsConfig?.Value?.Export, nameof(operationsConfig));
             EnsureArg.IsNotNull(features?.Value, nameof(features));
-            EnsureArg.IsNotNull(logger, nameof(logger));
+            EnsureArg.IsNotNull(fhirConfig, nameof(fhirConfig));
 
             _mediator = mediator;
             _fhirRequestContextAccessor = fhirRequestContextAccessor;
@@ -85,6 +87,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             _convertConfig = operationsConfig.Value.ConvertData;
             _artifactStoreConfig = artifactStoreConfig.Value;
             _features = features.Value;
+            _fhirConfig = fhirConfig;
         }
 
         [HttpGet]
@@ -98,7 +101,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             [FromQuery(Name = KnownQueryParameterNames.Container)] string containerName,
             [FromQuery(Name = KnownQueryParameterNames.TypeFilter)] string typeFilter,
             [FromQuery(Name = KnownQueryParameterNames.Format)] string formatName,
-            [FromQuery(Name = KnownQueryParameterNames.IsParallel)] bool isParallel = true,
+            [FromQuery(Name = KnownQueryParameterNames.IsParallel)] bool? isParallel = null,
             [FromQuery(Name = KnownQueryParameterNames.IncludeAssociatedData)] string includeAssociatedData = null,
             [FromQuery(Name = KnownQueryParameterNames.MaxCount)] uint maxCount = 0,
             [FromQuery(Name = KnownQueryParameterNames.AnonymizationConfigurationCollectionReference)] string anonymizationConfigCollectionReference = null,
@@ -255,7 +258,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             string groupId = null,
             string containerName = null,
             string formatName = null,
-            bool isParallel = true,
+            bool? isParallel = true,
             bool includeHistory = false,
             bool includeDeleted = false,
             uint maxCount = 0,
@@ -263,6 +266,8 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             string anonymizationConfigLocation = null,
             string anonymizationConfigFileETag = null)
         {
+            bool isParallelWithDefault = GetExportParallelSetting(isParallel, _fhirConfig);
+
             CreateExportResponse response = await _mediator.ExportAsync(
                 _fhirRequestContextAccessor.RequestContext.Uri,
                 exportType,
@@ -273,7 +278,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                 groupId,
                 containerName,
                 formatName,
-                isParallel,
+                isParallelWithDefault,
                 includeDeleted,
                 includeHistory,
                 maxCount,
@@ -383,6 +388,23 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             }
 
             return (includeHistory, includeDeleted);
+        }
+
+        private static bool GetExportParallelSetting(bool? isParallelFromRequest, IFhirRuntimeConfiguration fhirConfig)
+        {
+            if (isParallelFromRequest is not null)
+            {
+                return isParallelFromRequest.Value;
+            }
+
+            // We want Gen1 to not export parallel by default.
+            if (fhirConfig is AzureApiForFhirRuntimeConfiguration)
+            {
+                return false;
+            }
+
+            // Else keep current behavior.
+            return true;
         }
     }
 }


### PR DESCRIPTION
## Description
Changed `$export` controller so `isParallel` defaults to false for Cosmos and true for SQL.

## Testing
Unit testing

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
