### PR TITLE
Removed resource type expansion for global search

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/PartitionEliminationRewriterTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/Expressions/PartitionEliminationRewriterTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
                 .AcceptVisitor(_rewriter);
 
             Assert.Equal(
-                "(SqlRoot (SearchParamTables:) (ResourceTable: (Param _id (StringEquals TokenCode 'foo')) (Param _type (TokenCode IN (AllergyIntolerance, Claim, Condition, Device, DiagnosticReport)))))",
+                "(SqlRoot (SearchParamTables:) (ResourceTable: (Param _id (StringEquals TokenCode 'foo'))))",
                 rewritten.ToString());
         }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/PartitionEliminationRewriter.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/PartitionEliminationRewriter.cs
@@ -73,7 +73,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
             // Look for primary key continuation token (PrimaryKeyParameter) or _type parameters
 
             int primaryKeyValueIndex = -1;
-            bool hasTypeRestriction = false;
             for (var i = 0; i < expression.ResourceTableExpressions.Count; i++)
             {
                 SearchParameterInfo parameter = expression.ResourceTableExpressions[i].Parameter;
@@ -82,29 +81,13 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors
                 {
                     primaryKeyValueIndex = i;
                 }
-                else if (ReferenceEquals(parameter, _resourceTypeSearchParameter))
-                {
-                    hasTypeRestriction = true;
-                }
             }
 
             if (primaryKeyValueIndex < 0)
             {
                 // no continuation token
 
-                if (hasTypeRestriction)
-                {
-                    // This is already constrained to be one or more resource types.
-                    return expression;
-                }
-
-                // Explicitly allow all resource types. SQL tends to create far better query plans than when there is no filter on ResourceTypeId.
-
-                var updatedResourceTableExpressions = new List<SearchParameterExpressionBase>(expression.ResourceTableExpressions.Count + 1);
-                updatedResourceTableExpressions.AddRange(expression.ResourceTableExpressions);
-                updatedResourceTableExpressions.Add(GetAllTypesExpression());
-
-                return new SqlRootExpression(expression.SearchParamTableExpressions, updatedResourceTableExpressions);
+                return expression;
             }
 
             // There is a primary key continuation token.


### PR DESCRIPTION
## Description
For system wide search, resource type expansion is removed. With new secondary indexes, we do not need to expand on resource types.

## Related issues
Addresses [issue [#].](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Olympus/Stories/?workitem=110323)

## Testing
Unit tests

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
