### PR TITLE
Logging an exception message only for blob LeaseAlreadyPresent.

### DIFF
--- a/src/Microsoft.Health.Fhir.Azure/IntegrationDataStore/AzureBlobIntegrationDataStoreClient.cs
+++ b/src/Microsoft.Health.Fhir.Azure/IntegrationDataStore/AzureBlobIntegrationDataStoreClient.cs
@@ -203,12 +203,16 @@ namespace Microsoft.Health.Fhir.Azure.IntegrationDataStore
                 Response<BlobLease> response = await lease.AcquireAsync(BlobLeaseClient.InfiniteLeaseDuration, null, cancellationToken);
                 return response?.Value?.LeaseId;
             }
+            catch (RequestFailedException ex) when (ex.ErrorCode == BlobErrorCode.LeaseAlreadyPresent)
+            {
+                _logger.LogInformation(ex.Message);
+            }
             catch (RequestFailedException se)
             {
                 HandleRequestFailedException(se, $"Failed to acquire lease on the blob {resourceUri}");
-
-                return null;
             }
+
+            return null;
         }
 
         public async Task TryReleaseLeaseAsync(Uri resourceUri, string leaseId, CancellationToken cancellationToken)

--- a/src/Microsoft.Health.Fhir.Azure/IntegrationDataStore/AzureBlobIntegrationDataStoreClient.cs
+++ b/src/Microsoft.Health.Fhir.Azure/IntegrationDataStore/AzureBlobIntegrationDataStoreClient.cs
@@ -205,7 +205,7 @@ namespace Microsoft.Health.Fhir.Azure.IntegrationDataStore
             }
             catch (RequestFailedException ex) when (ex.ErrorCode == BlobErrorCode.LeaseAlreadyPresent)
             {
-                _logger.LogInformation(ex.Message);
+                _logger.LogInformation("{Message}: {ResourceUri}", ex.Message, resourceUri);
             }
             catch (RequestFailedException se)
             {


### PR DESCRIPTION
## Description
Logging an exception message only for blob LeaseAlreadyPresent, so it won't raise an IcM.

## Related issues
Addresses [issue #114099].

[Bug 114099](https://microsofthealth.visualstudio.com/Health/_workitems/edit/114099): Import RequestFailedException: There is already a lease present

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
