### PR TITLE
Fix Custom Test Fixture Name Format

### DIFF
--- a/build/jobs/e2e-tests.yml
+++ b/build/jobs/e2e-tests.yml
@@ -106,6 +106,8 @@ steps:
       rerunFailedTests: true
       rerunType: 'basedOnTestFailurePercentage'
       rerunFailedThreshold: 10
+      batchingBasedOnAgentsOption: 'customBatchSize'
+      customBatchSizeValue: '9999999'
     env:
       'TestEnvironmentUrl': $(TestEnvironmentUrl)
       'TestEnvironmentUrl_${{ parameters.version }}': $(TestEnvironmentUrl_${{ parameters.version }})

--- a/build/jobs/run-export-tests.yml
+++ b/build/jobs/run-export-tests.yml
@@ -83,6 +83,8 @@ jobs:
       rerunFailedTests: true
       rerunType: 'basedOnTestFailurePercentage'
       rerunFailedThreshold: 10
+      batchingBasedOnAgentsOption: 'customBatchSize'
+      customBatchSizeValue: '9999999'
     env:
       'TestEnvironmentUrl': $(TestEnvironmentUrl)
       'TestEnvironmentUrl_${{ parameters.version }}': $(TestEnvironmentUrl_${{ parameters.version }})
@@ -197,6 +199,8 @@ jobs:
       rerunFailedTests: true
       rerunType: 'basedOnTestFailurePercentage'
       rerunFailedThreshold: 10
+      batchingBasedOnAgentsOption: 'customBatchSize'
+      customBatchSizeValue: '9999999'
     env:
       'TestEnvironmentUrl_Sql': $(TestEnvironmentUrl_Sql)
       'TestEnvironmentUrl_${{ parameters.version }}_Sql': $(TestEnvironmentUrl_${{ parameters.version }}_Sql)

--- a/build/jobs/run-tests.yml
+++ b/build/jobs/run-tests.yml
@@ -50,6 +50,8 @@ jobs:
       rerunFailedTests: true
       rerunType: 'basedOnTestFailurePercentage'
       rerunFailedThreshold: 10
+      batchingBasedOnAgentsOption: 'customBatchSize'
+      customBatchSizeValue: '9999999'
     env:
       'CosmosDb:Host': $(CosmosDb--Host)
       'CosmosDb:Key': $(CosmosDb--Key)

--- a/src/Microsoft.Health.Extensions.Xunit/CustomXunitTestFrameworkExecutor.cs
+++ b/src/Microsoft.Health.Extensions.Xunit/CustomXunitTestFrameworkExecutor.cs
@@ -197,7 +197,7 @@ namespace Microsoft.Health.Extensions.Xunit
         private sealed class CustomAssemblyInfo : IAssemblyInfo
         {
             private readonly IAssemblyInfo _assemblyInfoImplementation;
-            private readonly Regex _argumentsRegex = new Regex(@"\((\s*(?<VALUE>[^, )]+)\s*,?)*\)");
+            private readonly Regex _argumentsRegex = new Regex(@"\[(\s*(?<VALUE>[^, \]]+)\s*,?)*\]");
 
             public CustomAssemblyInfo(IAssemblyInfo assemblyInfoImplementation)
             {

--- a/src/Microsoft.Health.Extensions.Xunit/CustomXunitTestFrameworkExecutor.cs
+++ b/src/Microsoft.Health.Extensions.Xunit/CustomXunitTestFrameworkExecutor.cs
@@ -197,7 +197,7 @@ namespace Microsoft.Health.Extensions.Xunit
         private sealed class CustomAssemblyInfo : IAssemblyInfo
         {
             private readonly IAssemblyInfo _assemblyInfoImplementation;
-            private readonly Regex _argumentsRegex = new Regex(@"\[(\s*(?<VALUE>[^, \]]+)\s*,?)*\]");
+            private readonly Regex _argumentsRegex = new Regex(@"\((\s*(?<VALUE>[^, \)]+)\s*,?)*\)");
 
             public CustomAssemblyInfo(IAssemblyInfo assemblyInfoImplementation)
             {

--- a/src/Microsoft.Health.Extensions.Xunit/TestClassWithFixtureArgumentsTypeInfo.cs
+++ b/src/Microsoft.Health.Extensions.Xunit/TestClassWithFixtureArgumentsTypeInfo.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Health.Extensions.Xunit
 
             _typeInfoImplementation = typeInfoImplementation;
             FixtureArguments = fixtureArguments;
-            Name = $"{typeInfoImplementation.Name}({string.Join(", ", fixtureArguments.Select(v => $"{v.EnumValue}"))})";
+            Name = $"{typeInfoImplementation.Name} ({string.Join(", ", fixtureArguments.Select(v => $"{v.EnumValue}"))})";
         }
 
         public IReadOnlyList<SingleFlag> FixtureArguments { get; }
@@ -54,7 +54,6 @@ namespace Microsoft.Health.Extensions.Xunit
 
         public IEnumerable<IAttributeInfo> GetCustomAttributes(string assemblyQualifiedAttributeTypeName)
         {
-            // return _typeInfoImplementation.GetCustomAttributes(assemblyQualifiedAttributeTypeName.Replace('[', '(').Replace(']', ')'));
             return _typeInfoImplementation.GetCustomAttributes(assemblyQualifiedAttributeTypeName);
         }
 

--- a/src/Microsoft.Health.Extensions.Xunit/TestClassWithFixtureArgumentsTypeInfo.cs
+++ b/src/Microsoft.Health.Extensions.Xunit/TestClassWithFixtureArgumentsTypeInfo.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Health.Extensions.Xunit
 
             _typeInfoImplementation = typeInfoImplementation;
             FixtureArguments = fixtureArguments;
-            Name = $"{typeInfoImplementation.Name} ({string.Join(", ", fixtureArguments.Select(v => $"{v.EnumValue}"))})";
+            Name = $"{typeInfoImplementation.Name}[{string.Join(", ", fixtureArguments.Select(v => $"{v.EnumValue}"))}]";
         }
 
         public IReadOnlyList<SingleFlag> FixtureArguments { get; }

--- a/src/Microsoft.Health.Extensions.Xunit/TestClassWithFixtureArgumentsTypeInfo.cs
+++ b/src/Microsoft.Health.Extensions.Xunit/TestClassWithFixtureArgumentsTypeInfo.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Health.Extensions.Xunit
 
             _typeInfoImplementation = typeInfoImplementation;
             FixtureArguments = fixtureArguments;
-            Name = $"{typeInfoImplementation.Name}[{string.Join(", ", fixtureArguments.Select(v => $"{v.EnumValue}"))}]";
+            Name = $"{typeInfoImplementation.Name} ({string.Join(", ", fixtureArguments.Select(v => $"{v.EnumValue}"))})";
         }
 
         public IReadOnlyList<SingleFlag> FixtureArguments { get; }

--- a/src/Microsoft.Health.Extensions.Xunit/TestClassWithFixtureArgumentsTypeInfo.cs
+++ b/src/Microsoft.Health.Extensions.Xunit/TestClassWithFixtureArgumentsTypeInfo.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Health.Extensions.Xunit
 
             _typeInfoImplementation = typeInfoImplementation;
             FixtureArguments = fixtureArguments;
-            Name = $"{typeInfoImplementation.Name}[{string.Join(", ", fixtureArguments.Select(v => $"{v.EnumValue}"))}]";
+            Name = $"{typeInfoImplementation.Name}({string.Join(", ", fixtureArguments.Select(v => $"{v.EnumValue}"))})";
         }
 
         public IReadOnlyList<SingleFlag> FixtureArguments { get; }
@@ -54,6 +54,7 @@ namespace Microsoft.Health.Extensions.Xunit
 
         public IEnumerable<IAttributeInfo> GetCustomAttributes(string assemblyQualifiedAttributeTypeName)
         {
+            // return _typeInfoImplementation.GetCustomAttributes(assemblyQualifiedAttributeTypeName.Replace('[', '(').Replace(']', ')'));
             return _typeInfoImplementation.GetCustomAttributes(assemblyQualifiedAttributeTypeName);
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeletionService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeletionService.cs
@@ -185,6 +185,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
                         break;
                     }
                 }
+
+                System.Threading.Tasks.Task.WaitAll(deleteTasks.ToArray(), cancellationToken);
             }
             catch (Exception ex)
             {
@@ -192,7 +194,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
                 await cancellationTokenSource.CancelAsync();
             }
 
-            System.Threading.Tasks.Task.WaitAll(deleteTasks.ToArray(), cancellationToken);
             deleteTasks.Where((task) => task.IsCompletedSuccessfully).ToList().ForEach((Task<long> result) => numDeleted += result.Result);
 
             if (deleteTasks.Any((task) => task.IsFaulted || task.IsCanceled))
@@ -209,8 +210,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
                             }
                         }
                     });
-                var aggrigateException = new AggregateException(exceptions);
-                throw new IncompleteOperationException<long>(aggrigateException, numDeleted);
+                var aggregateException = new AggregateException(exceptions);
+                throw new IncompleteOperationException<long>(aggregateException, numDeleted);
             }
 
             return numDeleted;


### PR DESCRIPTION
## Description
Changing `TestClassWithFixtureArgumentsTypeInfo` name format to the recommend `TestClass (Param1, Param2)`. Originally, it was `TestClass(Param1, Param2)` but this didn't work with the VSTest ADO task. I replaced the parenthesis with brackets, but this didn't work correctly (mainly because I forgot to update the parsing regex).

Instead of sticking with brackets, I'm moving this back to parenthesis with a space between the class name and the parameters. Our orig format was incorrect - the space is needed for processing in VSTest filters per [this issue](https://github.com/microsoft/azure-pipelines-tasks/issues/16990#issuecomment-1694159977).

## Work Item

AB#115252

## Testing
- Ran tests locally
- Ran in pipeline and observed working retry

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
