### PR TITLE
Added exception handling to WaitAll in DeletionService

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeletionService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeletionService.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
 
             try
             {
-                // We need to wait until all running tasks are cancelled to get a count of partial deletes.
+                // We need to wait until all running tasks are cancelled to get a count of resources deleted.
                 Task.WaitAll(deleteTasks.ToArray(), cancellationToken);
             }
             catch (AggregateException age)

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeletionService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeletionService.cs
@@ -198,12 +198,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
                 // We need to wait until all running tasks are cancelled to get a count of resources deleted.
                 Task.WaitAll(deleteTasks.ToArray(), cancellationToken);
             }
-            catch (AggregateException age)
+            catch (AggregateException age) when (age.InnerExceptions.Any(e => e is not TaskCanceledException))
             {
                 // If one of the tasks fails, the rest may throw a cancellation exception. Filtering those out as they are noise.
                 foreach (var coreException in age.InnerExceptions.Where(e => e is not TaskCanceledException))
                 {
-                    _logger.LogError(age, "Error deleting");
+                    _logger.LogError(coreException, "Error deleting");
                 }
             }
             catch (Exception ex)
@@ -220,10 +220,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
                     {
                         if (result.Exception != null)
                         {
+                            // Count the number of resources deleted before the exception was thrown. Update the total.
                             result.Exception.InnerExceptions.Where((ex) => ex is IncompleteOperationException<long>).ToList().ForEach((ex) => numDeleted += ((IncompleteOperationException<long>)ex).PartialResults);
                             if (result.IsFaulted)
                             {
-                                exceptions.AddRange(result.Exception.InnerExceptions);
+                                // Filter out noise from the cancellation exceptions caused by the core exception.
+                                exceptions.AddRange(result.Exception.InnerExceptions.Where(e => e is not TaskCanceledException));
                             }
                         }
                     });

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeletionService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeletionService.cs
@@ -206,10 +206,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
                     _logger.LogError(coreException, "Error deleting");
                 }
             }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error deleting");
-            }
 
             deleteTasks.Where((task) => task.IsCompletedSuccessfully).ToList().ForEach((Task<long> result) => numDeleted += result.Result);
 

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeletionService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeletionService.cs
@@ -206,6 +206,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
                     _logger.LogError(coreException, "Error deleting");
                 }
             }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error deleting");
+            }
 
             deleteTasks.Where((task) => task.IsCompletedSuccessfully).ToList().ForEach((Task<long> result) => numDeleted += result.Result);
 


### PR DESCRIPTION
## Description
Added needed exception handling and logging in `DeletionService` for `DeleteMultipleAsync`. 

## Related issues
AB#115277

## Testing


## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
