### PR TITLE
Added fix for historical summary count tests

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HistoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HistoryTests.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             var expectedObservatinCount = 5 + stragglerResources.Count();
 
-            if (allObservationSummaryCountResult.Resource.Total != 5 || allObservationSummaryCountZero.Resource.Total != 5)
+            if (allObservationSummaryCountResult.Resource.Total != expectedObservatinCount || allObservationSummaryCountZero.Resource.Total != expectedObservatinCount)
             {
                 Assert.Fail($"allSummaryCountResult or allSummaryCountZero not equal to 5. allObservationSummaryCountResult {allObservationSummaryCountResult.Resource.Total}. " +
                             $"allObservationSummaryCountZero {allObservationSummaryCountZero.Resource.Total}\n{await GetSummaryMessage($"Observation/_history?_since={sinceTime}&_before={beforeTime}")}.\n" +

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HistoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HistoryTests.cs
@@ -97,7 +97,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenTestResourcesWithUpdatesAndDeletes_WhenGettingResourceHistoryCount_TheServerShouldReturnCorrectCount()
         {
-            Thread.Sleep(5000); // summary count queries can't be filtered by tag. wait to ensure previous tests are done writing to db.
             Observation firstTestResource = (await _client.CreateByUpdateAsync(Samples.GetDefaultObservation().ToPoco<Observation>())).Resource;
             var sinceTime = HttpUtility.UrlEncode(firstTestResource.Meta.LastUpdated.Value.UtcDateTime.ToString("o"));
 
@@ -120,6 +119,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             var beforeTime = thirdTestResource.Meta.LastUpdated.Value.UtcDateTime.AddMilliseconds(1).ToString("o");
 
+            // Run test queries
             var allSummaryCountResult = await _client.SearchAsync($"_history?_since={sinceTime}&_before={beforeTime}&_summary=count");
             var allSummaryCountZero = await _client.SearchAsync($"_history?_since={sinceTime}&_before={beforeTime}&_count=0");
             var allObservationSummaryCountResult = await _client.SearchAsync($"Observation/_history?_since={sinceTime}&_before={beforeTime}&_summary=count");
@@ -127,22 +127,35 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             var observationSummaryCountResult = await _client.SearchAsync($"Observation/{firstTestResource.Id}/_history?_since={sinceTime}&_before={beforeTime}&_summary=count");
             var observationSummaryCountZero = await _client.SearchAsync($"Observation/{firstTestResource.Id}/_history?_since={sinceTime}&_before={beforeTime}&_count=0");
 
+            // Find all resources in window - needed to filter out stragglers from other tests
+            var allResources = await _client.SearchAsync($"_history?_since={sinceTime}&_before={beforeTime}");
+            List<string> expectedResourceIds = [firstTestResource.Id, secondTestResource.Id, thirdTestResource.Id, fourthTestResource.Id];
+            var stragglerResources = allResources.Resource.Entry.Where(r => !expectedResourceIds.Contains(r.Resource.Id));
+
+            var expectedAllCount = 9 + stragglerResources.Count();
+
             // 9 versions total for all resources.
-            if (allSummaryCountResult.Resource.Total != 9 || allSummaryCountZero.Resource.Total != 9)
+            if (allSummaryCountResult.Resource.Total != expectedAllCount || allSummaryCountZero.Resource.Total != expectedAllCount)
             {
                 Assert.Fail($"allSummaryCountResult or allSummaryCountZero not equal to 9. allSummaryCountResult {allSummaryCountResult.Resource.Total}. " +
-                            $"allSummaryCountZero {allSummaryCountZero.Resource.Total}.\n{await GetSummaryMessage($"_history?_since={sinceTime}&_before={beforeTime}")}.");
+                            $"allSummaryCountZero {allSummaryCountZero.Resource.Total}.\n{await GetSummaryMessage($"_history?_since={sinceTime}&_before={beforeTime}")}.\n" +
+                            $"straggler resources {string.Join(',', stragglerResources.Select(r => r.Resource.Id))}.");
             }
+
+            var expectedObservatinCount = 5 + stragglerResources.Count();
 
             if (allObservationSummaryCountResult.Resource.Total != 5 || allObservationSummaryCountZero.Resource.Total != 5)
             {
                 Assert.Fail($"allSummaryCountResult or allSummaryCountZero not equal to 5. allObservationSummaryCountResult {allObservationSummaryCountResult.Resource.Total}. " +
-                            $"allObservationSummaryCountZero {allObservationSummaryCountZero.Resource.Total}\n{await GetSummaryMessage($"Observation/_history?_since={sinceTime}&_before={beforeTime}")}.");
+                            $"allObservationSummaryCountZero {allObservationSummaryCountZero.Resource.Total}\n{await GetSummaryMessage($"Observation/_history?_since={sinceTime}&_before={beforeTime}")}.\n" +
+                            $"straggler resources {{string.Join(',', stragglerResources.Select(r => r.Resource.Id))}}.");
             }
 
+            var expectedSpecificObservationCount = 3 + stragglerResources.Count();
+
             // 3 versions across single observation (create, update, delete).
-            Assert.Equal(3, observationSummaryCountResult.Resource.Total);
-            Assert.Equal(3, observationSummaryCountZero.Resource.Total);
+            Assert.Equal(expectedSpecificObservationCount, observationSummaryCountResult.Resource.Total);
+            Assert.Equal(expectedSpecificObservationCount, observationSummaryCountZero.Resource.Total);
 
             // Cleanup
             await _client.DeleteAsync(thirdTestResource);


### PR DESCRIPTION
## Description
Fixes historical _summary count tests by dynamically accounting for resources that "accidentally" make it into the test window. Previously a 5 second delay worked for these tests, but we are still seeing test failures in some regions.

## Related issues
Addresses AB#115486.
## Testing
PR pipeline

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
