### PR TITLE
Add content-type constraint for the $convert endpoint.

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ConvertDataController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ConvertDataController.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
 {
     [ServiceFilter(typeof(AuditLoggingFilterAttribute))]
     [ServiceFilter(typeof(OperationOutcomeExceptionFilterAttribute))]
+    [Consumes("application/json")]
     [ValidateResourceTypeFilter]
     [ValidateModelState]
     public class ConvertDataController : Controller

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ConvertDataController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ConvertDataController.cs
@@ -29,7 +29,8 @@ namespace Microsoft.Health.Fhir.Api.Controllers
 {
     [ServiceFilter(typeof(AuditLoggingFilterAttribute))]
     [ServiceFilter(typeof(OperationOutcomeExceptionFilterAttribute))]
-    [Consumes("application/json")]
+    [ServiceFilter(typeof(ValidateFormatParametersAttribute))]
+    [Consumes("application/json", "application/fhir+json")]
     [ValidateResourceTypeFilter]
     [ValidateModelState]
     public class ConvertDataController : Controller


### PR DESCRIPTION
## Description
Add content-type constraint for the $convert endpoint.

## Related issues
We have found that customers can use other MIME types on the payload which can result in parsing errors.

## Testing
Tested locally, the FHIR server started successfully and the $convert endpoint only accepts application/json after the code change.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
