### PR TITLE
Add Throw for Cancellation for DeletionService

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/BackgroundJobService/HostingBackgroundService.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/BackgroundJobService/HostingBackgroundService.cs
@@ -86,6 +86,9 @@ namespace Microsoft.Health.Fhir.Api.Features.BackgroundJobService
             finally
             {
                 _logger.LogInformation("HostingBackgroundService end.");
+
+                // Stopgap to help logs flush before the process exits.
+                await Task.Delay(TimeSpan.FromSeconds(15), stoppingToken);
             }
         }
 

--- a/src/Microsoft.Health.Fhir.Api/Features/BackgroundJobService/HostingBackgroundService.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/BackgroundJobService/HostingBackgroundService.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Health.Fhir.Api.Features.BackgroundJobService
                 _logger.LogInformation("HostingBackgroundService end.");
 
                 // Stopgap to help logs flush before the process exits.
-                await Task.Delay(TimeSpan.FromSeconds(15), stoppingToken);
+                await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
             }
         }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/BulkDelete/BulkDeleteProcessingJob.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/BulkDelete/BulkDeleteProcessingJob.cs
@@ -99,7 +99,22 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.BulkDelete
 
                 result.ResourcesDeleted.Add(types[0], numDeleted);
 
-                await _mediator.Publish(new BulkDeleteMetricsNotification(jobInfo.Id, numDeleted), cancellationToken);
+                try
+                {
+                    await _mediator.Publish(new BulkDeleteMetricsNotification(jobInfo.Id, numDeleted), cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    if (exception is null)
+                    {
+                        exception = ex;
+                    }
+                    else
+                    {
+                        AggregateException aggregateException = new(exception, ex);
+                        exception = aggregateException;
+                    }
+                }
 
                 if (exception != null)
                 {

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeletionService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeletionService.cs
@@ -201,10 +201,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
                 // We need to wait until all running tasks are cancelled to get a count of resources deleted.
                 Task.WaitAll(deleteTasks.ToArray(), cancellationToken);
             }
-            catch (AggregateException age) when (age.InnerExceptions.Any(e => e is not TaskCanceledException))
+            catch (AggregateException age) when (age.InnerExceptions.Any(e => e is not TaskCanceledException && e is not OperationCanceledException))
             {
                 // If one of the tasks fails, the rest may throw a cancellation exception. Filtering those out as they are noise.
-                foreach (var coreException in age.InnerExceptions.Where(e => e is not TaskCanceledException))
+                foreach (var coreException in age.InnerExceptions.Where(e => e is not TaskCanceledException && e is not OperationCanceledException))
                 {
                     _logger.LogError(coreException, "Error deleting");
                 }
@@ -228,7 +228,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
                             if (result.IsFaulted)
                             {
                                 // Filter out noise from the cancellation exceptions caused by the core exception.
-                                exceptions.AddRange(result.Exception.InnerExceptions.Where(e => e is not TaskCanceledException));
+                                exceptions.AddRange(result.Exception.InnerExceptions.Where(e => e is not TaskCanceledException && e is not OperationCanceledException));
                             }
                         }
                     });

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeletionService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeletionService.cs
@@ -168,6 +168,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
                         await deleteTasks[0];
                     }
 
+                    cancellationToken.ThrowIfCancellationRequested();
+
                     if (!string.IsNullOrEmpty(ct) && (request.DeleteAll || (int)(request.MaxDeleteCount - numQueuedForDeletion) > 0))
                     {
                         using (var searchService = _searchServiceFactory.Invoke())
@@ -248,6 +250,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
                 return new ResourceWrapperOperation(deletedWrapper, true, keepHistory, null, false, false, bundleResourceContext: request.BundleResourceContext);
             }).ToArray();
 
+            cancellationToken.ThrowIfCancellationRequested();
+
             try
             {
                 using var fhirDataStore = _fhirDataStoreFactory.Invoke();
@@ -271,6 +275,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
         private async Task<long> HardDeleteResourcePage(ConditionalDeleteResourceRequest request, IReadOnlyCollection<SearchResultEntry> resourcesToDelete, CancellationToken cancellationToken)
         {
             await CreateAuditLog(request.ResourceType, request.DeleteOperation, false, resourcesToDelete.Select((item) => item.Resource.ResourceId));
+
+            cancellationToken.ThrowIfCancellationRequested();
 
             var parallelBag = new ConcurrentBag<string>();
             try


### PR DESCRIPTION
## Description
`DeleteMultipleAsync` is `DeletionService` is a long running/looped operation. This PR checks the cancellation token and  throws before starting operations in the loop.

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
