### PR TITLE
Fixes some usages of Task.WaitAll => Task.WhenAll

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs
@@ -456,7 +456,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                 }
             }
 
-            Task.WaitAll(queryTasks.ToArray(), _cancellationToken);
+            await Task.WhenAll(queryTasks);
         }
 
         private async Task<ReindexJobQueryStatus> ProcessQueryAsync(ReindexJobQueryStatus query, SearchResultReindex searchResultReindex, CancellationToken cancellationToken)

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeletionService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeletionService.cs
@@ -160,8 +160,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
                         break;
                     }
 
-                    deleteTasks.Where((task) => task.IsCompletedSuccessfully).ToList().ForEach((Task<long> result) => numDeleted += result.Result);
-                    deleteTasks = deleteTasks.Where((task) => !task.IsCompletedSuccessfully).ToList();
+                    numDeleted += deleteTasks.Where(x => x.IsCompletedSuccessfully).Sum(x => x.Result);
+                    deleteTasks = deleteTasks.Where(task => !task.IsCompletedSuccessfully).ToList();
 
                     if (deleteTasks.Count >= MaxParallelThreads)
                     {
@@ -197,7 +197,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
             try
             {
                 // We need to wait until all running tasks are cancelled to get a count of resources deleted.
-                Task.WaitAll(deleteTasks.ToArray(), cancellationToken);
+                await Task.WhenAll(deleteTasks);
             }
             catch (AggregateException age) when (age.InnerExceptions.Any(e => e is not TaskCanceledException))
             {
@@ -212,7 +212,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
                 _logger.LogError(ex, "Error deleting");
             }
 
-            deleteTasks.Where((task) => task.IsCompletedSuccessfully).ToList().ForEach((Task<long> result) => numDeleted += result.Result);
+            numDeleted += deleteTasks.Where(x => x.IsCompletedSuccessfully).Sum(x => x.Result);
 
             if (deleteTasks.Any((task) => task.IsFaulted || task.IsCanceled))
             {
@@ -230,8 +230,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
                             }
                         }
                     });
-                var aggrigateException = new AggregateException(exceptions);
-                throw new IncompleteOperationException<long>(aggrigateException, numDeleted);
+                var aggregateException = new AggregateException(exceptions);
+                throw new IncompleteOperationException<long>(aggregateException, numDeleted);
             }
 
             return numDeleted;


### PR DESCRIPTION
## Description
This pull request includes changes to the `src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobTask.cs` and `src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeletionService.cs` files. The changes mainly focus on improving the handling of asynchronous tasks.

Changes in `ReindexJobTask.cs`:

* [`private async Task ProcessJob()`](diffhunk://#diff-f84013fc1aa1907129ec7ba459d7369cf42b73e8cf3cfb8a9fab17c41fee9f5eL459-R459): Replaced `Task.WaitAll` with `await Task.WhenAll` to improve handling of asynchronous tasks. This change allows the method to continue once all tasks in `queryTasks` have completed, rather than blocking the thread until they're done.

Changes in `DeletionService.cs`:

* [`public async Task<long> DeleteMultipleAsync(ConditionalDeleteResourceRequest req)`](diffhunk://#diff-d39379fb3be9bc5cb0fe9bce65997629589cd6c7244ded4b0a4cf408dec31bafL163-R164): Replaced the way `numDeleted` is updated by using LINQ's `Sum` method instead of a `ForEach` loop. This change simplifies the code and potentially improves performance. [[1]](diffhunk://#diff-d39379fb3be9bc5cb0fe9bce65997629589cd6c7244ded4b0a4cf408dec31bafL163-R164) [[2]](diffhunk://#diff-d39379fb3be9bc5cb0fe9bce65997629589cd6c7244ded4b0a4cf408dec31bafL215-R215)
* [`public async Task<long> DeleteMultipleAsync(ConditionalDeleteResourceRequest req)`](diffhunk://#diff-d39379fb3be9bc5cb0fe9bce65997629589cd6c7244ded4b0a4cf408dec31bafL200-R200): Replaced `Task.WaitAll` with `await Task.WhenAll` to improve handling of asynchronous tasks. This change allows the method to continue once all tasks in `deleteTasks` have completed, rather than blocking the thread until they're done.
* [`public async Task<long> DeleteMultipleAsync(ConditionalDeleteResourceRequest req)`](diffhunk://#diff-d39379fb3be9bc5cb0fe9bce65997629589cd6c7244ded4b0a4cf408dec31bafL233-R234): Corrected a typo in the variable name `aggrigateException` to `aggregateException`. This change improves code readability.

## Testing
Existing tests

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
