### PR TITLE
[Enhancement] Optimizations for Bundle serialization

### DIFF
--- a/docs/flow diagrams/bundle-processing.md
+++ b/docs/flow diagrams/bundle-processing.md
@@ -1,0 +1,28 @@
+```mermaid
+---
+title: Bundle Processing
+---
+
+sequenceDiagram
+    Request->>JsonFormatter: http
+    JsonFormatter->>FHIRController: Deserialize
+    FHIRController->>Mediatr: Handle
+    Mediatr->>BundleHandler: Process
+    
+loop Each Request
+    BundleHandler-->>+Request: Passes model through FHIRContext
+    Request-->>JsonFormatter: Begin Sub-request
+    JsonFormatter-->>FHIRController: Read model
+    FHIRController-->>Mediatr: Handle operation
+    Mediatr-->>DataStore: Serialize and persist
+    DataStore--)Mediatr: Returns a "RawResource"
+    Mediatr--)FHIRController: Raw Response
+    FHIRController--)JsonFormatter: 
+    JsonFormatter--)Request: Writes raw response
+    Request--)-BundleHandler: Return Raw Entry response
+end
+
+    BundleHandler->>FHIRController: Build Bundle
+    FHIRController-)JsonFormatter: Serialize Raw Bundle
+    JsonFormatter-)Request: http
+```

--- a/docs/rest/SearchExamples.http
+++ b/docs/rest/SearchExamples.http
@@ -18,6 +18,7 @@ grant_type=client_credentials
 POST https://{{hostname}}
 Content-Type: application/json
 Authorization: Bearer {{bearer.response.body.access_token}}
+x-bundle-processing-logic: Parallel
 
 < ./Data/SearchDataBatch.json
 

--- a/src/Microsoft.Health.Fhir.Api/Features/Bundle/BundleSubRequest.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Bundle/BundleSubRequest.cs
@@ -3,9 +3,9 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-namespace Microsoft.Health.Fhir.Core.Features.Context;
+namespace Microsoft.Health.Fhir.Api.Features.Bundle;
 
-internal class SubRequest
+internal class BundleSubRequest
 {
-    public const string SubRequestResource = nameof(SubRequestResource);
+    public const string Model = nameof(Model);
 }

--- a/src/Microsoft.Health.Fhir.Core/Extensions/RawResourceElementExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Extensions/RawResourceElementExtensions.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
 using EnsureThat;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Core.Extensions
@@ -38,7 +39,7 @@ namespace Microsoft.Health.Fhir.Core.Extensions
             EnsureArg.IsNotNull(rawResource, nameof(rawResource));
 
             var buffer = SerializeToBytes(rawResource, pretty);
-            using var memory = new MemoryStream(buffer);
+            using MemoryStream memory = ResourceDeserializer.MemoryStreamManager.GetStream(buffer);
             await memory.CopyToAsync(outputStream);
         }
 
@@ -46,7 +47,7 @@ namespace Microsoft.Health.Fhir.Core.Extensions
         {
             EnsureArg.IsNotNull(rawResource, nameof(rawResource));
 
-            using var output = new MemoryStream();
+            using MemoryStream output = ResourceDeserializer.MemoryStreamManager.GetStream();
 
             if (rawResource.RawResource.IsMetaSet && !pretty)
             {

--- a/src/Microsoft.Health.Fhir.Core/Features/Context/SubRequest.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Context/SubRequest.cs
@@ -1,0 +1,11 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Fhir.Core.Features.Context;
+
+internal class SubRequest
+{
+    public const string SubRequestResource = nameof(SubRequestResource);
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Persistence/ResourceTypeDetector.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Persistence/ResourceTypeDetector.cs
@@ -11,6 +11,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence;
 
 internal static class ResourceTypeDetector
 {
+    /// <summary>
+    /// Attempts to find the resource type of the given FHIR JSON.
+    /// </summary>
+    /// <param name="resourceJson">The resource as JSON.</param>
+    /// <param name="resourceType">Found resource type.</param>
+    /// <returns>True if the resourceType was found.</returns>
     public static bool TryPeek(string resourceJson, out string resourceType)
     {
         resourceType = null;

--- a/src/Microsoft.Health.Fhir.Core/Features/Persistence/ResourceTypeDetector.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Persistence/ResourceTypeDetector.cs
@@ -1,0 +1,36 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Text;
+using System.Text.Json;
+
+namespace Microsoft.Health.Fhir.Core.Features.Persistence;
+
+internal static class ResourceTypeDetector
+{
+    public static bool TryPeek(string resourceJson, out string resourceType)
+    {
+        resourceType = null;
+
+        var span = new ReadOnlyMemory<byte>(Encoding.UTF8.GetBytes(resourceJson));
+        var reader = new Utf8JsonReader(span.Span);
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.PropertyName && reader.GetString() == "resourceType")
+            {
+                // Move to the value associated with the key "resourceType"
+                reader.Read();
+
+                // Assuming the value is a string
+                resourceType = reader.GetString();
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Models/RawResourceElement.cs
+++ b/src/Microsoft.Health.Fhir.Core/Models/RawResourceElement.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Health.Fhir.Core.Models
 
             RawResource = rawResource;
             InstanceType = instanceType;
+            Format = rawResource.Format;
         }
 
         public RawResource RawResource { get; protected set; }

--- a/src/Microsoft.Health.Fhir.Core/Models/RawResourceElement.cs
+++ b/src/Microsoft.Health.Fhir.Core/Models/RawResourceElement.cs
@@ -25,6 +25,15 @@ namespace Microsoft.Health.Fhir.Core.Models
             LastUpdated = wrapper.LastModified;
         }
 
+        public RawResourceElement(RawResource rawResource, string instanceType)
+        {
+            EnsureArg.IsNotNull(rawResource, nameof(rawResource));
+            EnsureArg.IsNotNull(instanceType, nameof(instanceType));
+
+            RawResource = rawResource;
+            InstanceType = instanceType;
+        }
+
         public RawResource RawResource { get; protected set; }
 
         public FhirResourceFormat Format { get; protected set; }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Formatters/FhirJsonInputFormatterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Formatters/FhirJsonInputFormatterTests.cs
@@ -18,6 +18,7 @@ using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Microsoft.Health.Fhir.Api.Features.Formatters;
 using Microsoft.Health.Fhir.Api.Features.Routing;
+using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Test.Utilities;
 using Newtonsoft.Json.Linq;
@@ -157,7 +158,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Formatters
 
         private static async Task<InputFormatterResult> ReadRequestBody(string sampleJson, ModelStateDictionary modelStateDictionary, bool isBundle)
         {
-            var formatter = new FhirJsonInputFormatter(new FhirJsonParser(), ArrayPool<char>.Shared);
+            var formatter = new FhirJsonInputFormatter(new FhirJsonParser(), ArrayPool<char>.Shared, new FhirRequestContextAccessor());
 
             var metaData = new DefaultModelMetadata(
                 new EmptyModelMetadataProvider(),
@@ -181,7 +182,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Formatters
 
         private bool CanRead(Type modelType, string contentType)
         {
-            var formatter = new FhirJsonInputFormatter(new FhirJsonParser(), ArrayPool<char>.Shared);
+            var formatter = new FhirJsonInputFormatter(new FhirJsonParser(), ArrayPool<char>.Shared, new FhirRequestContextAccessor());
             var modelMetadata = Substitute.For<ModelMetadata>(ModelMetadataIdentity.ForType(modelType));
             var defaultHttpContext = new DefaultHttpContext();
             defaultHttpContext.Request.ContentType = contentType;

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Formatters/FhirJsonOutputFormatterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Formatters/FhirJsonOutputFormatterTests.cs
@@ -57,7 +57,6 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Formatters
                new FhirJsonSerializer(),
                Deserializers.ResourceDeserializer,
                ArrayPool<char>.Shared,
-               new BundleSerializer(),
                ModelInfoProvider.Instance);
 
             var defaultHttpContext = new DefaultHttpContext();

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Formatters/FormatterConfigurationTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Formatters/FormatterConfigurationTests.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Api.Configs;
 using Microsoft.Health.Fhir.Api.Features.Formatters;
 using Microsoft.Health.Fhir.Api.Features.Resources.Bundle;
+using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Validation.Narratives;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Tests.Common;
@@ -26,7 +27,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Formatters
     public class FormatterConfigurationTests
     {
         private readonly FeatureConfiguration _featureConfiguration = new FeatureConfiguration();
-        private readonly FhirJsonInputFormatter _fhirJsonInputFormatter = new FhirJsonInputFormatter(new FhirJsonParser(), ArrayPool<char>.Shared);
+        private readonly FhirJsonInputFormatter _fhirJsonInputFormatter = new FhirJsonInputFormatter(new FhirJsonParser(), ArrayPool<char>.Shared, new FhirRequestContextAccessor());
         private readonly FhirXmlInputFormatter _fhirXmlInputFormatter = new FhirXmlInputFormatter(new FhirXmlParser());
         private readonly FhirXmlOutputFormatter _fhirXmlOutputFormatter = new FhirXmlOutputFormatter(new FhirXmlSerializer(), Deserializers.ResourceDeserializer, ModelInfoProvider.Instance);
         private readonly HtmlOutputFormatter _htmlOutputFormatter;

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Formatters/FormatterConfigurationTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Formatters/FormatterConfigurationTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Formatters
             var serializer = new FhirJsonSerializer();
 
             _htmlOutputFormatter = new HtmlOutputFormatter(serializer, NullLogger<HtmlOutputFormatter>.Instance, new NarrativeHtmlSanitizer(NullLogger<NarrativeHtmlSanitizer>.Instance), ArrayPool<char>.Shared);
-            _fhirJsonOutputFormatter = new FhirJsonOutputFormatter(serializer, Deserializers.ResourceDeserializer, ArrayPool<char>.Shared, new BundleSerializer(), ModelInfoProvider.Instance);
+            _fhirJsonOutputFormatter = new FhirJsonOutputFormatter(serializer, Deserializers.ResourceDeserializer, ArrayPool<char>.Shared, ModelInfoProvider.Instance);
 
             _configuration = new FormatterConfiguration(
                 Options.Create(_featureConfiguration),

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerEdgeCaseTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerEdgeCaseTests.cs
@@ -168,6 +168,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
                 fhirRequestContextAccessor,
                 fhirJsonSerializer,
                 fhirJsonParser,
+                Deserializers.ResourceDeserializer,
                 transactionHandler,
                 bundleHttpContextAccessor,
                 bundleOrchestrator,

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerTests.cs
@@ -119,6 +119,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
                 fhirRequestContextAccessor,
                 fhirJsonSerializer,
                 fhirJsonParser,
+                Deserializers.ResourceDeserializer,
                 transactionHandler,
                 bundleHttpContextAccessor,
                 bundleOrchestrator,

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleSerializerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleSerializerTests.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using Microsoft.Extensions.Primitives;
@@ -38,7 +37,6 @@ namespace Microsoft.Health.Fhir.Shared.Api.UnitTests.Features.Resources.Bundle
     public class BundleSerializerTests
     {
         private readonly ResourceWrapperFactory _wrapperFactory;
-        private readonly BundleSerializer _bundleSerializer = new BundleSerializer();
 
         public BundleSerializerTests()
         {
@@ -118,7 +116,7 @@ namespace Microsoft.Health.Fhir.Shared.Api.UnitTests.Features.Resources.Bundle
             using (var ms = new MemoryStream())
                using (var sr = new StreamReader(ms))
             {
-                await _bundleSerializer.Serialize(rawBundle, ms);
+                await BundleSerializer.Serialize(rawBundle, ms);
 
                 ms.Seek(0, SeekOrigin.Begin);
                 serialized = await sr.ReadToEndAsync();

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Formatters/FhirJsonInputFormatter.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Formatters/FhirJsonInputFormatter.cs
@@ -12,6 +12,7 @@ using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.Health.Fhir.Api.Features.Bundle;
 using Microsoft.Health.Fhir.Api.Features.ContentTypes;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Newtonsoft.Json;
@@ -60,7 +61,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Formatters
             EnsureArg.IsNotNull(encoding, nameof(encoding));
 
             if (_fhirRequestContextAccessor.RequestContext != null &&
-                _fhirRequestContextAccessor.RequestContext.Properties.TryGetValue(SubRequest.SubRequestResource, out var subRequestModel))
+                _fhirRequestContextAccessor.RequestContext.Properties.TryGetValue(BundleSubRequest.Model, out var subRequestModel))
             {
                 return await InputFormatterResult.SuccessAsync(subRequestModel);
             }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Formatters/FhirJsonInputFormatter.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Formatters/FhirJsonInputFormatter.cs
@@ -13,6 +13,7 @@ using Hl7.Fhir.Serialization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.Health.Fhir.Api.Features.ContentTypes;
+using Microsoft.Health.Fhir.Core.Features.Context;
 using Newtonsoft.Json;
 
 namespace Microsoft.Health.Fhir.Api.Features.Formatters
@@ -20,14 +21,17 @@ namespace Microsoft.Health.Fhir.Api.Features.Formatters
     internal class FhirJsonInputFormatter : TextInputFormatter
     {
         private readonly FhirJsonParser _parser;
+        private readonly FhirRequestContextAccessor _fhirRequestContextAccessor;
         private readonly IArrayPool<char> _charPool;
 
-        public FhirJsonInputFormatter(FhirJsonParser parser, ArrayPool<char> charPool)
+        public FhirJsonInputFormatter(FhirJsonParser parser, ArrayPool<char> charPool, FhirRequestContextAccessor fhirRequestContextAccessor)
         {
             EnsureArg.IsNotNull(parser, nameof(parser));
             EnsureArg.IsNotNull(charPool, nameof(charPool));
+            EnsureArg.IsNotNull(fhirRequestContextAccessor, nameof(fhirRequestContextAccessor));
 
             _parser = parser;
+            _fhirRequestContextAccessor = fhirRequestContextAccessor;
             _charPool = new JsonArrayPool(charPool);
 
             SupportedEncodings.Add(UTF8EncodingWithoutBOM);
@@ -54,6 +58,12 @@ namespace Microsoft.Health.Fhir.Api.Features.Formatters
         {
             EnsureArg.IsNotNull(context, nameof(context));
             EnsureArg.IsNotNull(encoding, nameof(encoding));
+
+            if (_fhirRequestContextAccessor.RequestContext != null &&
+                _fhirRequestContextAccessor.RequestContext.Properties.TryGetValue(SubRequest.SubRequestResource, out var subRequestModel))
+            {
+                return await InputFormatterResult.SuccessAsync(subRequestModel);
+            }
 
             var request = context.HttpContext.Request;
 

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Formatters/FhirJsonOutputFormatter.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Formatters/FhirJsonOutputFormatter.cs
@@ -84,8 +84,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Formatters
                 resource = bundle;
 
                 if (hasElements ||
-                    summarySearchParameter != Hl7.Fhir.Rest.SummaryType.False ||
-                    !bundle.Entry.All(x => x is RawBundleEntryComponent))
+                    summarySearchParameter != Hl7.Fhir.Rest.SummaryType.False)
                 {
                     // _elements is not supported for a raw resource, revert to using FhirJsonSerializer
                     foreach (var rawBundleEntryComponent in bundle.Entry)

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Formatters/FhirJsonOutputFormatter.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Formatters/FhirJsonOutputFormatter.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Formatters
                     {
                         if (rawBundleEntryComponent is RawBundleEntryComponent { ResourceElement: not null } entry)
                         {
-                            var poco = entry.ResourceElement.ToPoco<Resource>(_deserializer);
+                            Resource poco = entry.ResourceElement.ToPoco<Resource>(_deserializer);
                             if (poco.TypeName == KnownResourceTypes.OperationOutcome)
                             {
                                 rawBundleEntryComponent.Response.Outcome = poco;
@@ -123,7 +123,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Formatters
                     summarySearchParameter != Hl7.Fhir.Rest.SummaryType.False)
                 {
                     // _elements is not supported for a raw resource, revert to using FhirJsonSerializer
-                    resource = (context.Object as RawResourceElement).ToPoco<Resource>(_deserializer);
+                    resource = ((RawResourceElement)context.Object).ToPoco<Resource>(_deserializer);
                     if (hasElements)
                     {
                         var typeinfo = summaryProvider.Provide(resource.TypeName);

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Formatters/FhirJsonOutputFormatter.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Formatters/FhirJsonOutputFormatter.cs
@@ -18,6 +18,7 @@ using Microsoft.Health.Fhir.Api.Features.ContentTypes;
 using Microsoft.Health.Fhir.Api.Features.Resources.Bundle;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Shared.Core.Features.Search;
 using Newtonsoft.Json;
@@ -92,13 +93,11 @@ namespace Microsoft.Health.Fhir.Api.Features.Formatters
                         if (rawBundleEntryComponent is RawBundleEntryComponent { ResourceElement: not null } entry)
                         {
                             Resource poco = entry.ResourceElement.ToPoco<Resource>(_deserializer);
-                            if (poco.TypeName == KnownResourceTypes.OperationOutcome)
+                            rawBundleEntryComponent.Resource = poco;
+
+                            if (rawBundleEntryComponent.Response is RawBundleResponseComponent { OutcomeElement: not null } outcomeElement)
                             {
-                                rawBundleEntryComponent.Response.Outcome = poco;
-                            }
-                            else
-                            {
-                                rawBundleEntryComponent.Resource = poco;
+                                rawBundleEntryComponent.Response.Outcome = outcomeElement.OutcomeElement.ToPoco<OperationOutcome>(_deserializer);
                             }
 
                             if (hasElements)

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Formatters/FhirXmlOutputFormatter.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Formatters/FhirXmlOutputFormatter.cs
@@ -81,11 +81,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Formatters
                     additionalElements.UnionWith(required.Select(x => x.ElementName));
                 }
             }
-            else if (typeof(Hl7.Fhir.Model.Bundle).IsAssignableFrom(context.ObjectType))
+            else if (context.Object is Hl7.Fhir.Model.Bundle bundle)
             {
                 // Need to set Resource property for resources in entries
-                var bundle = context.Object as Hl7.Fhir.Model.Bundle;
-
                 foreach (var entry in bundle.Entry)
                 {
                     if (entry is RawBundleEntryComponent { ResourceElement: not null } rawResource)

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
@@ -53,6 +53,7 @@ using Microsoft.Health.Fhir.Core.Features.Resources.Bundle;
 using Microsoft.Health.Fhir.Core.Features.Security;
 using Microsoft.Health.Fhir.Core.Messages.Bundle;
 using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.Shared.Core.Features.Search;
 using Microsoft.Health.Fhir.ValueSets;
 using SharpCompress.Common;
 using static Hl7.Fhir.Model.Bundle;
@@ -195,6 +196,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                     var responseBundle = new Hl7.Fhir.Model.Bundle
                     {
                         Type = BundleType.BatchResponse,
+                        Id = _originalFhirRequestContext.CorrelationId,
                     };
 
                     await ProcessAllResourcesInABundleAsRequestsAsync(responseBundle, processingLogic, cancellationToken);
@@ -215,6 +217,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                     var responseBundle = new Hl7.Fhir.Model.Bundle
                     {
                         Type = BundleType.TransactionResponse,
+                        Id = _originalFhirRequestContext.CorrelationId,
                     };
 
                     var response = await ExecuteTransactionForAllRequestsAsync(responseBundle, processingLogic, cancellationToken);
@@ -487,6 +490,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
         private async Task GenerateRequest(EntryComponent entry, int order, CancellationToken cancellationToken)
         {
             string persistedId = default;
+            Resource subResource = null;
             HttpContext httpContext = new DefaultHttpContext { RequestServices = _requestServices };
 
             var requestUrl = entry.Request?.Url;
@@ -539,9 +543,8 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
 
                 if (entry.Resource != null)
                 {
-                    var memoryStream = new MemoryStream(await _fhirJsonSerializer.SerializeToBytesAsync(entry.Resource));
-                    memoryStream.Seek(0, SeekOrigin.Begin);
-                    httpContext.Request.Body = memoryStream;
+                    // Passed through FHIR Context to avoid serialization
+                    subResource = entry.Resource;
                 }
             }
 
@@ -580,7 +583,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                 RouteData = routeContext.RouteData,
             };
 
-            _requests[requestMethod].Add(new ResourceExecutionContext(requestMethod, routeContext, order, persistedId));
+            _requests[requestMethod].Add(new ResourceExecutionContext(requestMethod, routeContext, order, persistedId, subResource));
         }
 
         private static void AddHeaderIfNeeded(string headerKey, string headerValue, HttpContext httpContext)
@@ -702,32 +705,37 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
 
             ResponseHeaders responseHeaders = httpContext.Response.GetTypedHeaders();
 
-            var entryComponent = new EntryComponent
-            {
-                Response = new ResponseComponent
-                {
-                    Status = httpContext.Response.StatusCode.ToString(),
-                    Location = responseHeaders.Location?.OriginalString,
-                    Etag = responseHeaders.ETag?.ToString(),
-                    LastModified = responseHeaders.LastModified,
-                },
-            };
-
             if (!string.IsNullOrWhiteSpace(bodyContent))
             {
-                var entryComponentResource = fhirJsonParser.Parse<Resource>(bodyContent);
+                var rawResource = new RawResource(bodyContent, FhirResourceFormat.Json, true);
+                ResourceTypeDetector.TryPeek(bodyContent, out var resourceType);
 
-                if (entryComponentResource.TypeName == KnownResourceTypes.OperationOutcome)
+                var entryComponent = new RawBundleEntryComponent(new RawResourceElement(rawResource, resourceType))
                 {
-                    entryComponent.Response.Outcome = entryComponentResource;
-                }
-                else
-                {
-                    entryComponent.Resource = entryComponentResource;
-                }
+                    Response = new ResponseComponent
+                    {
+                        Status = httpContext.Response.StatusCode.ToString(),
+                        Location = responseHeaders.Location?.OriginalString,
+                        Etag = responseHeaders.ETag?.ToString(),
+                        LastModified = responseHeaders.LastModified,
+                    },
+                };
+
+                return entryComponent;
             }
             else
             {
+                var entryComponent = new EntryComponent
+                {
+                    Response = new ResponseComponent
+                    {
+                        Status = httpContext.Response.StatusCode.ToString(),
+                        Location = responseHeaders.Location?.OriginalString,
+                        Etag = responseHeaders.ETag?.ToString(),
+                        LastModified = responseHeaders.LastModified,
+                    },
+                };
+
                 if (httpContext.Response.StatusCode == (int)HttpStatusCode.Forbidden)
                 {
                     entryComponent.Response.Outcome = CreateOperationOutcome(
@@ -735,9 +743,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                         OperationOutcome.IssueType.Forbidden,
                         Api.Resources.Forbidden);
                 }
-            }
 
-            return entryComponent;
+                return entryComponent;
+            }
         }
 
         /// <summary>
@@ -755,6 +763,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                 auditEventTypeMapping: _auditEventTypeMapping,
                 requestContextAccessor: _fhirRequestContextAccessor,
                 bundleHttpContextAccessor: _bundleHttpContextAccessor,
+                subResource: resourceExecutionContext.Resource,
                 logger: _logger);
         }
 
@@ -775,6 +784,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
             IAuditEventTypeMapping auditEventTypeMapping,
             RequestContextAccessor<IFhirRequestContext> requestContextAccessor,
             IBundleHttpContextAccessor bundleHttpContextAccessor,
+            Resource subResource,
             ILogger<BundleHandler> logger)
         {
             request.RouteData.Values.TryGetValue("controller", out object controllerName);
@@ -797,6 +807,11 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                 ExecutingBatchOrTransaction = true,
                 AccessControlContext = requestContext.AccessControlContext.Clone() as AccessControlContext,
             };
+
+            if (subResource != null)
+            {
+                newFhirRequestContext.Properties[SubRequest.SubRequestResource] = subResource;
+            }
 
             // Copy allowed resource actions to the new FHIR Request Context.
             foreach (var scopeRestriction in requestContext.AccessControlContext.AllowedResourceActions)

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
@@ -817,7 +817,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
 
             if (subResource != null)
             {
-                newFhirRequestContext.Properties[SubRequest.SubRequestResource] = subResource;
+                newFhirRequestContext.Properties[BundleSubRequest.Model] = subResource;
             }
 
             // Copy allowed resource actions to the new FHIR Request Context.

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
@@ -66,6 +66,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
     /// </summary>
     public partial class BundleHandler : IRequestHandler<BundleRequest, BundleResponse>
     {
+        private readonly ResourceDeserializer _resourceDeserializer;
         private const BundleProcessingLogic DefaultBundleProcessingLogic = BundleProcessingLogic.Sequential;
 
         private readonly RequestContextAccessor<IFhirRequestContext> _fhirRequestContextAccessor;
@@ -114,6 +115,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
             RequestContextAccessor<IFhirRequestContext> fhirRequestContextAccessor,
             FhirJsonSerializer fhirJsonSerializer,
             FhirJsonParser fhirJsonParser,
+            ResourceDeserializer resourceDeserializer,
             ITransactionHandler transactionHandler,
             IBundleHttpContextAccessor bundleHttpContextAccessor,
             IBundleOrchestrator bundleOrchestrator,
@@ -132,6 +134,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
             _fhirRequestContextAccessor = EnsureArg.IsNotNull(fhirRequestContextAccessor, nameof(fhirRequestContextAccessor));
             _fhirJsonSerializer = EnsureArg.IsNotNull(fhirJsonSerializer, nameof(fhirJsonSerializer));
             _fhirJsonParser = EnsureArg.IsNotNull(fhirJsonParser, nameof(fhirJsonParser));
+            _resourceDeserializer = EnsureArg.IsNotNull(resourceDeserializer, nameof(resourceDeserializer));
             _transactionHandler = EnsureArg.IsNotNull(transactionHandler, nameof(transactionHandler));
             _bundleHttpContextAccessor = EnsureArg.IsNotNull(bundleHttpContextAccessor, nameof(bundleHttpContextAccessor));
             _bundleOrchestrator = EnsureArg.IsNotNull(bundleOrchestrator, nameof(bundleOrchestrator));
@@ -390,7 +393,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
             {
                 if (_bundleProcessingTypeIsInvalid)
                 {
-                    var entryComponent = new EntryComponent
+                    var entryComponent = new RawBundleEntryComponent
                     {
                         Response = new ResponseComponent
                         {
@@ -438,11 +441,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
             {
                 if (processingLogic == BundleProcessingLogic.Sequential)
                 {
-                    using (var transaction = _transactionHandler.BeginTransaction())
-                    {
-                        await ProcessAllResourcesInABundleAsRequestsAsync(responseBundle, processingLogic, cancellationToken);
-                        transaction.Complete();
-                    }
+                    using ITransactionScope transaction = _transactionHandler.BeginTransaction();
+                    await ProcessAllResourcesInABundleAsRequestsAsync(responseBundle, processingLogic, cancellationToken);
+                    transaction.Complete();
                 }
                 else
                 {
@@ -664,7 +665,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                 }
                 else
                 {
-                    entryComponent = new EntryComponent
+                    entryComponent = new RawBundleEntryComponent
                     {
                         Response = new ResponseComponent
                         {
@@ -679,7 +680,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
 
                 statistics.RegisterNewEntry(httpVerb, resourceContext.Index, entryComponent.Response.Status, watch.Elapsed);
 
-                if (_bundleType.Equals(BundleType.Transaction) && entryComponent.Response.Outcome != null)
+                if (_bundleType.Equals(BundleType.Transaction)
+                    && (entryComponent is RawBundleEntryComponent { ResourceElement.InstanceType: KnownResourceTypes.OperationOutcome }
+                        || entryComponent.Response.Outcome != null))
                 {
                     var errorMessage = string.Format(Api.Resources.TransactionFailed, resourceContext.Context.HttpContext.Request.Method, resourceContext.Context.HttpContext.Request.Path);
 
@@ -688,7 +691,10 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                         httpStatusCode = HttpStatusCode.BadRequest;
                     }
 
-                    TransactionExceptionHandler.ThrowTransactionException(errorMessage, httpStatusCode, (OperationOutcome)entryComponent.Response.Outcome);
+                    OperationOutcome outcome = entryComponent.Response.Outcome as OperationOutcome
+                                               ?? ((RawBundleEntryComponent)entryComponent).ResourceElement.ToPoco<OperationOutcome>(_resourceDeserializer);
+
+                    TransactionExceptionHandler.ThrowTransactionException(errorMessage, httpStatusCode, outcome);
                 }
 
                 responseBundle.Entry[resourceContext.Index] = entryComponent;
@@ -697,7 +703,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
             return throttledEntryComponent;
         }
 
-        private static EntryComponent CreateEntryComponent(FhirJsonParser fhirJsonParser, HttpContext httpContext)
+        private static RawBundleEntryComponent CreateEntryComponent(FhirJsonParser fhirJsonParser, HttpContext httpContext)
         {
             httpContext.Response.Body.Seek(0, SeekOrigin.Begin);
             using var reader = new StreamReader(httpContext.Response.Body);
@@ -725,7 +731,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
             }
             else
             {
-                var entryComponent = new EntryComponent
+                var entryComponent = new RawBundleEntryComponent
                 {
                     Response = new ResponseComponent
                     {
@@ -893,7 +899,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
             {
                 Issue = new List<OperationOutcome.IssueComponent>
                 {
-                    new OperationOutcome.IssueComponent
+                    new()
                     {
                         Severity = issueSeverity,
                         Code = issueType,

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
@@ -55,6 +55,7 @@ using Microsoft.Health.Fhir.Core.Messages.Bundle;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Shared.Core.Features.Search;
 using Microsoft.Health.Fhir.ValueSets;
+using Microsoft.IO;
 using SharpCompress.Common;
 using static Hl7.Fhir.Model.Bundle;
 using Task = System.Threading.Tasks.Task;
@@ -513,7 +514,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
             }
 
             httpContext.Features[typeof(IHttpAuthenticationFeature)] = _httpAuthenticationFeature;
-            httpContext.Response.Body = new MemoryStream();
+            httpContext.Response.Body = ResourceDeserializer.MemoryStreamManager.GetStream();
 
             var requestUri = new Uri(_fhirRequestContextAccessor.RequestContext.BaseUri, requestUrl);
             httpContext.Request.Scheme = requestUri.Scheme;
@@ -557,7 +558,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                 entry.Resource is Parameters parametersResource)
             {
                 httpContext.Request.Headers[HeaderNames.ContentType] = new StringValues(KnownContentTypes.JsonContentType);
-                var memoryStream = new MemoryStream(await _fhirJsonSerializer.SerializeToBytesAsync(parametersResource));
+                var memoryStream = ResourceDeserializer.MemoryStreamManager.GetStream(await _fhirJsonSerializer.SerializeToBytesAsync(parametersResource));
                 memoryStream.Seek(0, SeekOrigin.Begin);
                 httpContext.Request.Body = memoryStream;
             }
@@ -569,7 +570,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                 entry.Resource is Binary binaryResource && string.Equals(KnownMediaTypeHeaderValues.ApplicationJsonPatch.ToString(), binaryResource.ContentType, StringComparison.OrdinalIgnoreCase))
             {
                 httpContext.Request.Headers[HeaderNames.ContentType] = new StringValues(binaryResource.ContentType);
-                var memoryStream = new MemoryStream(binaryResource.Data);
+                var memoryStream = ResourceDeserializer.MemoryStreamManager.GetStream(binaryResource.Data);
                 memoryStream.Seek(0, SeekOrigin.Begin);
                 httpContext.Request.Body = memoryStream;
             }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerParallelOperations.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerParallelOperations.cs
@@ -108,6 +108,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                             resourceIdProvider,
                             fhirJsonParser,
                             _logger,
+                            resourceExecutionContext.Resource,
                             ct);
 
                         statistics.RegisterNewEntry(resourceExecutionContext.HttpVerb, resourceExecutionContext.Index, entry.Response.Status, watch.Elapsed);
@@ -251,6 +252,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
             ResourceIdProvider resourceIdProvider,
             FhirJsonParser fhirJsonParser,
             ILogger<BundleHandler> logger,
+            Resource subRequestResource,
             CancellationToken cancellationToken)
         {
             EntryComponent entryComponent;
@@ -285,6 +287,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                         auditEventTypeMapping,
                         requestContext,
                         bundleHttpContextAccessor,
+                        subRequestResource,
                         logger);
 
                     // Attempt 1.
@@ -365,12 +368,13 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
 
         private struct ResourceExecutionContext
         {
-            public ResourceExecutionContext(HTTPVerb httpVerb, RouteContext context, int index, string persistedId)
+            public ResourceExecutionContext(HTTPVerb httpVerb, RouteContext context, int index, string persistedId, Resource resource = null)
             {
                 HttpVerb = httpVerb;
                 Context = context;
                 Index = index;
                 PersistedId = persistedId;
+                Resource = resource;
             }
 
             public HTTPVerb HttpVerb { get; private set; }
@@ -380,6 +384,8 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
             public int Index { get; private set; }
 
             public string PersistedId { get; private set; }
+
+            public Resource Resource { get; }
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerParallelOperations.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerParallelOperations.cs
@@ -319,7 +319,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
 
                     resourceIdProvider.Create = originalResourceIdProvider;
 
-                    entryComponent = CreateEntryComponent(fhirJsonParser, httpContext);
+                    entryComponent = CreateEntryComponent(httpContext);
 
                     foreach (string headerName in HeadersToAccumulate)
                     {

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleIfElse.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleIfElse.cs
@@ -1,0 +1,35 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using EnsureThat;
+
+namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle;
+
+public sealed class BundleIfElse
+{
+    private readonly FhirJsonWriter _writer;
+    private readonly bool _hasRun;
+
+    internal BundleIfElse(FhirJsonWriter writer, bool hasRun)
+    {
+        EnsureArg.IsNotNull(writer, nameof(writer));
+
+        _writer = writer;
+        _hasRun = hasRun;
+    }
+
+    public FhirJsonWriter ElseIf(bool predicate, Action<FhirJsonWriter> action)
+    {
+        EnsureArg.IsNotNull(action, nameof(action));
+
+        if (!_hasRun && predicate)
+        {
+            action(_writer);
+        }
+
+        return _writer;
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleSerializer.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleSerializer.cs
@@ -6,8 +6,8 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Text.Json;
 using System.Threading.Tasks;
+using EnsureThat;
 using Hl7.Fhir.Serialization;
 using Hl7.Fhir.Utility;
 using Microsoft.Health.Fhir.Core.Extensions;
@@ -16,188 +16,75 @@ using Microsoft.Health.Fhir.Shared.Core.Features.Search;
 
 namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
 {
-    public class BundleSerializer
+    public static class BundleSerializer
     {
-        private readonly JsonWriterOptions _writerOptions = new JsonWriterOptions
+        /// <summary>
+        /// Serializer for Bundles made up of RawBundleEntryComponents
+        /// </summary>
+        /// <param name="bundle">Bundle</param>
+        /// <param name="outputStream">OutputStream</param>
+        /// <param name="pretty">Pretty formatting</param>
+        public static async Task Serialize(Hl7.Fhir.Model.Bundle bundle, Stream outputStream, bool pretty = false)
         {
-            Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-        };
+            EnsureArg.IsNotNull(bundle, nameof(bundle));
+            EnsureArg.IsNotNull(outputStream, nameof(outputStream));
 
-        private readonly JsonWriterOptions _indentedWriterOptions = new JsonWriterOptions
-        {
-            Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-            Indented = true,
-        };
-
-        public BundleSerializer()
-        {
-        }
-
-        public async Task Serialize(Hl7.Fhir.Model.Bundle bundle, Stream outputStream, bool pretty = false)
-        {
-            await using Utf8JsonWriter writer = new Utf8JsonWriter(outputStream, pretty ? _indentedWriterOptions : _writerOptions);
-            await using StreamWriter streamWriter = new StreamWriter(outputStream, leaveOpen: true);
-
-            writer.WriteStartObject();
-
-            writer.WriteString("resourceType", bundle.TypeName);
-
-            if (!string.IsNullOrEmpty(bundle.Id))
-            {
-                writer.WriteString("id", bundle.Id);
-            }
-
-            SerializeMetadata();
-
-            writer.WriteString("type", bundle.Type?.GetLiteral());
-
-            SerializeLinks();
-
-            if (bundle.Total.HasValue)
-            {
-                writer.WriteNumber("total", bundle.Total.Value);
-            }
-
-            await SerializeEntries();
-
-            writer.WriteEndObject();
-            await writer.FlushAsync();
-
-            void SerializeMetadata()
-            {
-                if (bundle.Meta != null)
-                {
-                    writer.WriteStartObject("meta");
-                    writer.WriteString("lastUpdated", bundle.Meta?.LastUpdated?.ToInstantString());
-                    writer.WriteEndObject();
-                }
-            }
-
-            void SerializeLinks()
-            {
-                if (bundle.Link?.Any() == true)
-                {
-                    writer.WriteStartArray("link");
-
-                    foreach (var link in bundle.Link)
-                    {
-                        writer.WriteStartObject();
-                        writer.WritePropertyName("relation");
-                        writer.WriteStringValue(link.Relation);
-                        writer.WritePropertyName("url");
-                        writer.WriteStringValue(link.Url);
-                        writer.WriteEndObject();
-                    }
-
-                    writer.WriteEndArray();
-                }
-            }
-
-            async Task SerializeEntries()
-            {
-                if (bundle.Entry?.Any() == true)
-                {
-                    writer.WriteStartArray("entry");
-                    foreach (var entry in bundle.Entry)
-                    {
-                        if (!(entry is RawBundleEntryComponent rawBundleEntry))
+            await using BundleWriter writer = BundleWriter.Create(outputStream, pretty)
+                .WriteStartObject()
+                .WriteString("resourceType", bundle.TypeName)
+                .WriteOptionalString("id", bundle.Id)
+                .Condition(
+                    () => bundle.Meta != null,
+                    b => b.WriteObject(
+                            "meta",
+                            _ => b.WriteOptionalString("lastUpdated", bundle.Meta?.LastUpdated?.ToInstantString())))
+                .WriteOptionalString("type", bundle.Type?.GetLiteral())
+                .Condition(
+                    () => bundle.Link?.Any() == true,
+                    b => b.WriteArray(
+                        "link",
+                        bundle.Link,
+                        (_, link) =>
+                            b.WriteString("relation", link.Relation)
+                                .WriteString("url", link.Url)))
+                .WriteOptionalNumber("total", bundle.Total)
+                .Condition(
+                    () => bundle.Entry?.Count > 0,
+                    b => b.WriteArray(
+                        name: "entry",
+                        values: bundle.Entry.Cast<RawBundleEntryComponent>(),
+                        itemWriter: (_, component) =>
                         {
-                            throw new ArgumentException("BundleSerializer can only be used when all Entry elements are of type RawBundleEntryComponent.", nameof(bundle));
-                        }
-
-                        bool wroteFullUrl = false;
-                        writer.WriteStartObject();
-
-                        if (!string.IsNullOrEmpty(rawBundleEntry.FullUrl))
-                        {
-                            writer.WriteString("fullUrl", rawBundleEntry.FullUrl);
-                            await writer.FlushAsync();
-                            await streamWriter.WriteAsync(",");
-                            wroteFullUrl = true;
-                        }
-
-                        await writer.FlushAsync();
-
-                        if (rawBundleEntry.ResourceElement != null &&
-                            !string.Equals(rawBundleEntry.ResourceElement.InstanceType, KnownResourceTypes.OperationOutcome, StringComparison.Ordinal))
-                        {
-                            await streamWriter.WriteAsync("\"resource\":");
-                            await streamWriter.FlushAsync();
-
-                            await rawBundleEntry.ResourceElement.SerializeToStreamAsUtf8Json(outputStream);
-
-                            if (!wroteFullUrl && (rawBundleEntry?.Search?.Mode != null || rawBundleEntry.Request != null || rawBundleEntry.Response != null))
-                            {
-                                // If fullUrl was written, the Utf8JsonWriter knows it needs to write a comma before the next property since a comma is needed, and will do so.
-                                // If fullUrl wasn't written, since we are writing resource in a separate writer, we need to add this comma manually.
-                                await streamWriter.WriteAsync(",");
-                                await streamWriter.FlushAsync();
-                            }
-                        }
-
-                        if (rawBundleEntry?.Search?.Mode != null)
-                        {
-                            writer.WriteStartObject("search");
-                            writer.WriteString("mode", rawBundleEntry.Search?.Mode?.GetLiteral());
-                            writer.WriteEndObject();
-                        }
-
-                        if (rawBundleEntry.Request != null)
-                        {
-                            writer.WriteStartObject("request");
-
-                            writer.WriteString("method", rawBundleEntry.Request.Method.GetLiteral());
-                            writer.WriteString("url", rawBundleEntry.Request.Url);
-
-                            writer.WriteEndObject();
-                        }
-
-                        if (rawBundleEntry.Response != null)
-                        {
-                            writer.WriteStartObject("response");
-
-                            writer.WriteString("status", rawBundleEntry.Response.Status);
-
-                            if (!string.IsNullOrEmpty(rawBundleEntry.Response.Etag))
-                            {
-                                writer.WriteString("etag", rawBundleEntry.Response.Etag);
-                            }
-
-                            if (rawBundleEntry.Response.LastModified.HasValue)
-                            {
-                                writer.WriteString("lastModified", rawBundleEntry.Response.LastModified?.ToInstantString());
-                            }
-
-                            if (string.Equals(rawBundleEntry.ResourceElement?.InstanceType, KnownResourceTypes.OperationOutcome, StringComparison.Ordinal))
-                            {
-                                await writer.FlushAsync();
-
-                                await streamWriter.WriteAsync(",\"outcome\":");
-                                await streamWriter.FlushAsync();
-
-                                await rawBundleEntry.ResourceElement.SerializeToStreamAsUtf8Json(outputStream);
-
-                                await writer.FlushAsync();
-                            }
-                            else if (rawBundleEntry.Response.Outcome != null)
-                            {
-                                await writer.FlushAsync();
-
-                                await streamWriter.WriteAsync(",\"outcome\":");
-                                await streamWriter.WriteAsync(await rawBundleEntry.Response.Outcome.ToJsonAsync());
-
-                                await writer.FlushAsync();
-                            }
-
-                            writer.WriteEndObject();
-                        }
-
-                        writer.WriteEndObject();
-                    }
-
-                    writer.WriteEndArray();
-                }
-            }
+                            b.WriteOptionalString("fullUrl", component.FullUrl)
+                                .Condition(
+                                    () => component.ResourceElement != null && !string.Equals(component.ResourceElement.InstanceType, KnownResourceTypes.OperationOutcome, StringComparison.Ordinal),
+                                    _ => b.WriteRawProperty("resource", component.ResourceElement.SerializeToBytes()))
+                                .Condition(
+                                    () => component.Search?.Mode != null,
+                                    _ => b.WriteObject(
+                                        "search",
+                                        _ => b.WriteString("mode", component.Search?.Mode?.GetLiteral())))
+                                .Condition(
+                                    () => component.Request != null,
+                                    _ => b.WriteObject(
+                                        "request",
+                                        _ => b.WriteString("method", component.Request.Method.GetLiteral())
+                                            .WriteString("url", component.Request.Url)))
+                                .Condition(
+                                    () => component.Response != null,
+                                    _ => b.WriteObject(
+                                        "response",
+                                        _ => b.WriteString("status", component.Response.Status)
+                                            .WriteOptionalString("etag", component.Response.Etag)
+                                            .WriteOptionalString("lastModified", component.Response.LastModified?.ToInstantString())
+                                            .Condition(
+                                                () => string.Equals(component.ResourceElement?.InstanceType, KnownResourceTypes.OperationOutcome, StringComparison.Ordinal),
+                                                _ => b.WriteRawProperty("outcome", component.ResourceElement.SerializeToBytes()))
+                                            .Condition(
+                                                () => component.ResourceElement == null && component.Response.Outcome != null,
+                                                _ => b.WriteRawProperty("outcome", component.Response.Outcome.ToJsonBytes()))));
+                        }))
+                .WriteEndObject();
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleSerializer.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleSerializer.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
             EnsureArg.IsNotNull(bundle, nameof(bundle));
             EnsureArg.IsNotNull(outputStream, nameof(outputStream));
 
-            await using BundleWriter writer = BundleWriter.Create(outputStream, pretty)
+            await using FhirJsonWriter writer = FhirJsonWriter.Create(outputStream, pretty)
                 .WriteStartObject()
                 .WriteString("resourceType", bundle.TypeName)
                 .WriteOptionalString("id", bundle.Id)

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleWriter.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleWriter.cs
@@ -1,0 +1,182 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using EnsureThat;
+
+namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle;
+
+public class BundleWriter : IDisposable, IAsyncDisposable
+{
+    private readonly JsonWriterOptions _writerOptions = new()
+    {
+        Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    };
+
+    private readonly JsonWriterOptions _indentedWriterOptions = new()
+    {
+        Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        Indented = true,
+    };
+
+    private readonly Utf8JsonWriter _writer;
+
+    private BundleWriter(Stream outputStream, bool pretty = false)
+    {
+        _writer = new Utf8JsonWriter(outputStream, pretty ? _indentedWriterOptions : _writerOptions);
+    }
+
+    public static BundleWriter Create(Stream outputStream, bool pretty = false)
+    {
+        return new BundleWriter(outputStream, pretty);
+    }
+
+    public BundleWriter WriteStartObject()
+    {
+        _writer.WriteStartObject();
+        return this;
+    }
+
+    public BundleWriter WriteStartObject(string propertyName)
+    {
+        EnsureArg.IsNotNullOrEmpty(propertyName, nameof(propertyName));
+        _writer.WriteStartObject(propertyName);
+        return this;
+    }
+
+    public BundleWriter WriteEndObject()
+    {
+        _writer.WriteEndObject();
+        return this;
+    }
+
+    public BundleWriter WriteObject(string propertyName, Action<BundleWriter> action)
+    {
+        EnsureArg.IsNotNullOrEmpty(propertyName, nameof(propertyName));
+        _writer.WriteStartObject(propertyName);
+        action(this);
+        _writer.WriteEndObject();
+        return this;
+    }
+
+    public BundleWriter WriteOptionalString(string name, string value)
+    {
+        EnsureArg.IsNotNullOrEmpty(name, nameof(name));
+
+        if (!string.IsNullOrEmpty(value))
+        {
+            _writer.WriteString(name, value);
+        }
+
+        return this;
+    }
+
+    public BundleWriter WriteString(string name, string value)
+    {
+        EnsureArg.IsNotNullOrEmpty(name, nameof(name));
+        EnsureArg.IsNotNullOrEmpty(value, nameof(value));
+
+        return WriteOptionalString(name, value);
+    }
+
+    public BundleWriter WriteNumber(string name, int value)
+    {
+        EnsureArg.IsNotNullOrEmpty(name, nameof(name));
+
+        _writer.WriteNumber(name, value);
+
+        return this;
+    }
+
+    public BundleWriter WriteOptionalNumber(string name, int? value)
+    {
+        EnsureArg.IsNotNullOrEmpty(name, nameof(name));
+
+        if (value.HasValue)
+        {
+            _writer.WriteNumber(name, value.Value);
+        }
+
+        return this;
+    }
+
+    public BundleWriter WriteRawProperty(string name, ReadOnlySpan<byte> value)
+    {
+        EnsureArg.IsNotNullOrEmpty(name, nameof(name));
+
+        _writer.WritePropertyName(name);
+        _writer.WriteRawValue(value, true);
+
+        return this;
+    }
+
+    public BundleWriter WriteArray<T>(string name, IEnumerable<T> values, Action<BundleWriter, T> itemWriter)
+    {
+        EnsureArg.IsNotNullOrEmpty(name, nameof(name));
+        EnsureArg.IsNotNull(values, nameof(values));
+        EnsureArg.IsNotNull(itemWriter, nameof(itemWriter));
+
+        _writer.WriteStartArray(name);
+
+        foreach (T item in values)
+        {
+            _writer.WriteStartObject();
+            itemWriter(this, item);
+            _writer.WriteEndObject();
+        }
+
+        _writer.WriteEndArray();
+
+        return this;
+    }
+
+    public BundleWriter Condition(Action<BundleWriter> action)
+    {
+        action(this);
+        return this;
+    }
+
+    public BundleWriter Condition(Func<bool> predicate, Action<BundleWriter> action)
+    {
+        if (predicate())
+        {
+            action(this);
+        }
+
+        return this;
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _writer?.Dispose();
+        }
+    }
+
+    protected virtual async ValueTask DisposeAsyncCore()
+    {
+        if (_writer != null)
+        {
+            await _writer.DisposeAsync();
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await DisposeAsyncCore();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/FhirJsonWriter.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/FhirJsonWriter.cs
@@ -12,7 +12,10 @@ using EnsureThat;
 
 namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle;
 
-public class BundleWriter : IDisposable, IAsyncDisposable
+/// <summary>
+/// A low level writer for FHIR JSON.
+/// </summary>
+public class FhirJsonWriter : IDisposable, IAsyncDisposable
 {
     private readonly JsonWriterOptions _writerOptions = new()
     {
@@ -27,36 +30,36 @@ public class BundleWriter : IDisposable, IAsyncDisposable
 
     private readonly Utf8JsonWriter _writer;
 
-    private BundleWriter(Stream outputStream, bool pretty = false)
+    private FhirJsonWriter(Stream outputStream, bool pretty = false)
     {
         _writer = new Utf8JsonWriter(outputStream, pretty ? _indentedWriterOptions : _writerOptions);
     }
 
-    public static BundleWriter Create(Stream outputStream, bool pretty = false)
+    public static FhirJsonWriter Create(Stream outputStream, bool pretty = false)
     {
-        return new BundleWriter(outputStream, pretty);
+        return new FhirJsonWriter(outputStream, pretty);
     }
 
-    public BundleWriter WriteStartObject()
+    public FhirJsonWriter WriteStartObject()
     {
         _writer.WriteStartObject();
         return this;
     }
 
-    public BundleWriter WriteStartObject(string propertyName)
+    public FhirJsonWriter WriteStartObject(string propertyName)
     {
         EnsureArg.IsNotNullOrEmpty(propertyName, nameof(propertyName));
         _writer.WriteStartObject(propertyName);
         return this;
     }
 
-    public BundleWriter WriteEndObject()
+    public FhirJsonWriter WriteEndObject()
     {
         _writer.WriteEndObject();
         return this;
     }
 
-    public BundleWriter WriteObject(string propertyName, Action<BundleWriter> action)
+    public FhirJsonWriter WriteObject(string propertyName, Action<FhirJsonWriter> action)
     {
         EnsureArg.IsNotNullOrEmpty(propertyName, nameof(propertyName));
         _writer.WriteStartObject(propertyName);
@@ -65,7 +68,7 @@ public class BundleWriter : IDisposable, IAsyncDisposable
         return this;
     }
 
-    public BundleWriter WriteOptionalString(string name, string value)
+    public FhirJsonWriter WriteOptionalString(string name, string value)
     {
         EnsureArg.IsNotNullOrEmpty(name, nameof(name));
 
@@ -77,7 +80,7 @@ public class BundleWriter : IDisposable, IAsyncDisposable
         return this;
     }
 
-    public BundleWriter WriteString(string name, string value)
+    public FhirJsonWriter WriteString(string name, string value)
     {
         EnsureArg.IsNotNullOrEmpty(name, nameof(name));
         EnsureArg.IsNotNullOrEmpty(value, nameof(value));
@@ -85,7 +88,7 @@ public class BundleWriter : IDisposable, IAsyncDisposable
         return WriteOptionalString(name, value);
     }
 
-    public BundleWriter WriteNumber(string name, int value)
+    public FhirJsonWriter WriteNumber(string name, int value)
     {
         EnsureArg.IsNotNullOrEmpty(name, nameof(name));
 
@@ -94,7 +97,7 @@ public class BundleWriter : IDisposable, IAsyncDisposable
         return this;
     }
 
-    public BundleWriter WriteOptionalNumber(string name, int? value)
+    public FhirJsonWriter WriteOptionalNumber(string name, int? value)
     {
         EnsureArg.IsNotNullOrEmpty(name, nameof(name));
 
@@ -106,7 +109,7 @@ public class BundleWriter : IDisposable, IAsyncDisposable
         return this;
     }
 
-    public BundleWriter WriteRawProperty(string name, ReadOnlySpan<byte> value)
+    public FhirJsonWriter WriteRawProperty(string name, ReadOnlySpan<byte> value)
     {
         EnsureArg.IsNotNullOrEmpty(name, nameof(name));
 
@@ -116,7 +119,7 @@ public class BundleWriter : IDisposable, IAsyncDisposable
         return this;
     }
 
-    public BundleWriter WriteArray<T>(string name, IEnumerable<T> values, Action<BundleWriter, T> itemWriter)
+    public FhirJsonWriter WriteArray<T>(string name, IEnumerable<T> values, Action<FhirJsonWriter, T> itemWriter)
     {
         EnsureArg.IsNotNullOrEmpty(name, nameof(name));
         EnsureArg.IsNotNull(values, nameof(values));
@@ -136,13 +139,19 @@ public class BundleWriter : IDisposable, IAsyncDisposable
         return this;
     }
 
-    public BundleWriter Condition(Action<BundleWriter> action)
+    public FhirJsonWriter Condition(Action<FhirJsonWriter> action)
     {
         action(this);
         return this;
     }
 
-    public BundleWriter Condition(Func<bool> predicate, Action<BundleWriter> action)
+    /// <summary>
+    /// Conditionally writes the provided action if the predicate is true.
+    /// </summary>
+    /// <param name="predicate">Expression to test.</param>
+    /// <param name="action">Action to run.</param>
+    /// <returns><see cref="FhirJsonWriter" /></returns>
+    public FhirJsonWriter Condition(Func<bool> predicate, Action<FhirJsonWriter> action)
     {
         if (predicate())
         {

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/FhirJsonWriter.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/FhirJsonWriter.cs
@@ -139,26 +139,30 @@ public class FhirJsonWriter : IDisposable, IAsyncDisposable
         return this;
     }
 
-    public FhirJsonWriter Condition(Action<FhirJsonWriter> action)
-    {
-        action(this);
-        return this;
-    }
-
     /// <summary>
     /// Conditionally writes the provided action if the predicate is true.
     /// </summary>
     /// <param name="predicate">Expression to test.</param>
     /// <param name="action">Action to run.</param>
     /// <returns><see cref="FhirJsonWriter" /></returns>
-    public FhirJsonWriter Condition(Func<bool> predicate, Action<FhirJsonWriter> action)
+    public FhirJsonWriter Condition(bool predicate, Action<FhirJsonWriter> action)
     {
-        if (predicate())
+        if (predicate)
         {
             action(this);
         }
 
         return this;
+    }
+
+    public BundleIfElse ConditionIf(bool predicate, Action<FhirJsonWriter> action)
+    {
+        if (predicate)
+        {
+            action(this);
+        }
+
+        return new BundleIfElse(this, predicate);
     }
 
     public void Dispose()

--- a/src/Microsoft.Health.Fhir.Shared.Api/Microsoft.Health.Fhir.Shared.Api.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Microsoft.Health.Fhir.Shared.Api.projitems
@@ -44,6 +44,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Bundle\BundleProcessingLogic.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Bundle\BundleRouter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Bundle\BundleSerializer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Bundle\BundleWriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\ConditionalQueryProcessingLogic.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\IProvenanceHeaderState.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\ProfileResourcesBehaviour.cs" />

--- a/src/Microsoft.Health.Fhir.Shared.Api/Microsoft.Health.Fhir.Shared.Api.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Microsoft.Health.Fhir.Shared.Api.projitems
@@ -44,7 +44,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Bundle\BundleProcessingLogic.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Bundle\BundleRouter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Bundle\BundleSerializer.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Bundle\BundleWriter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Bundle\FhirJsonWriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\ConditionalQueryProcessingLogic.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\IProvenanceHeaderState.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\ProfileResourcesBehaviour.cs" />

--- a/src/Microsoft.Health.Fhir.Shared.Api/Microsoft.Health.Fhir.Shared.Api.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Microsoft.Health.Fhir.Shared.Api.projitems
@@ -39,6 +39,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\Import\ImportRequestExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\OperationsCapabilityProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\ParametersExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Bundle\BundleIfElse.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Bundle\BundleHandlerParallelOperations.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Bundle\BundleHandlerStatistics.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Bundle\BundleProcessingLogic.cs" />

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs
@@ -67,8 +67,15 @@ namespace Microsoft.Health.Fhir.Api.Modules
 
             ResourceElement SetMetadata(Resource resource, string versionId, DateTimeOffset lastModified)
             {
-                resource.VersionId = versionId;
-                resource.Meta.LastUpdated = lastModified;
+                if (!string.IsNullOrEmpty(versionId))
+                {
+                    resource.VersionId = versionId;
+                }
+
+                if (lastModified != DateTimeOffset.MinValue)
+                {
+                    resource.Meta.LastUpdated = lastModified;
+                }
 
                 return resource.ToResourceElement();
             }
@@ -88,7 +95,6 @@ namespace Microsoft.Health.Fhir.Api.Modules
                         FhirResourceFormat.Xml, (str, version, lastModified) =>
                         {
                             var resource = xmlParser.Parse<Resource>(str);
-
                             return SetMetadata(resource, version, lastModified);
                         }
                     },

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs
@@ -66,12 +66,15 @@ namespace Microsoft.Health.Fhir.Api.Modules
 
             ResourceElement SetMetadata(Resource resource, bool isMetaSet, string versionId, DateTimeOffset? lastModified)
             {
-                if (!isMetaSet)
+                // There is no longer any consistency.
+                // In various different functions, Cosmos assumes IsMetaSet is true for versionId, Sql assumes IsMetaSet is true for lastModified
+
+                if (!string.IsNullOrEmpty(versionId))
                 {
                     resource.VersionId = versionId;
                 }
 
-                if (lastModified.HasValue && lastModified != DateTimeOffset.MinValue)
+                if (lastModified.GetValueOrDefault() != DateTimeOffset.MinValue)
                 {
                     resource.Meta.LastUpdated = lastModified;
                 }
@@ -87,11 +90,6 @@ namespace Microsoft.Health.Fhir.Api.Modules
                         FhirResourceFormat.Json, (rawResource, version, lastModified) =>
                         {
                             var resource = jsonParser.Parse<Resource>(rawResource.Data);
-                            if (rawResource.IsMetaSet)
-                            {
-                                return resource.ToResourceElement();
-                            }
-
                             return SetMetadata(resource, rawResource.IsMetaSet, version, lastModified);
                         }
                     },
@@ -99,11 +97,6 @@ namespace Microsoft.Health.Fhir.Api.Modules
                         FhirResourceFormat.Xml, (rawResource, version, lastModified) =>
                         {
                             var resource = xmlParser.Parse<Resource>(rawResource.Data);
-                            if (rawResource.IsMetaSet)
-                            {
-                                return resource.ToResourceElement();
-                            }
-
                             return SetMetadata(resource, rawResource.IsMetaSet, version, lastModified);
                         }
                     },

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs
@@ -61,7 +61,6 @@ namespace Microsoft.Health.Fhir.Api.Modules
             services.AddSingleton(jsonSerializer);
             services.AddSingleton(xmlParser);
             services.AddSingleton(xmlSerializer);
-            services.AddSingleton<BundleSerializer>();
 
             FhirPathCompiler.DefaultSymbolTable.AddFhirExtensions();
 

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs
@@ -64,14 +64,14 @@ namespace Microsoft.Health.Fhir.Api.Modules
 
             FhirPathCompiler.DefaultSymbolTable.AddFhirExtensions();
 
-            ResourceElement SetMetadata(Resource resource, string versionId, DateTimeOffset lastModified)
+            ResourceElement SetMetadata(Resource resource, bool isMetaSet, string versionId, DateTimeOffset? lastModified)
             {
-                if (!string.IsNullOrEmpty(versionId))
+                if (!isMetaSet)
                 {
                     resource.VersionId = versionId;
                 }
 
-                if (lastModified != DateTimeOffset.MinValue)
+                if (lastModified.HasValue && lastModified != DateTimeOffset.MinValue)
                 {
                     resource.Meta.LastUpdated = lastModified;
                 }
@@ -79,22 +79,32 @@ namespace Microsoft.Health.Fhir.Api.Modules
                 return resource.ToResourceElement();
             }
 
-            services.AddSingleton<IReadOnlyDictionary<FhirResourceFormat, Func<string, string, DateTimeOffset, ResourceElement>>>(_ =>
+            services.AddSingleton<IReadOnlyDictionary<FhirResourceFormat, DeserializeFromString>>(_ =>
             {
-                return new Dictionary<FhirResourceFormat, Func<string, string, DateTimeOffset, ResourceElement>>
+                return new Dictionary<FhirResourceFormat, DeserializeFromString>
                 {
                     {
-                        FhirResourceFormat.Json, (str, version, lastModified) =>
+                        FhirResourceFormat.Json, (rawResource, version, lastModified) =>
                         {
-                            var resource = jsonParser.Parse<Resource>(str);
-                            return SetMetadata(resource, version, lastModified);
+                            var resource = jsonParser.Parse<Resource>(rawResource.Data);
+                            if (rawResource.IsMetaSet)
+                            {
+                                return resource.ToResourceElement();
+                            }
+
+                            return SetMetadata(resource, rawResource.IsMetaSet, version, lastModified);
                         }
                     },
                     {
-                        FhirResourceFormat.Xml, (str, version, lastModified) =>
+                        FhirResourceFormat.Xml, (rawResource, version, lastModified) =>
                         {
-                            var resource = xmlParser.Parse<Resource>(str);
-                            return SetMetadata(resource, version, lastModified);
+                            var resource = xmlParser.Parse<Resource>(rawResource.Data);
+                            if (rawResource.IsMetaSet)
+                            {
+                                return resource.ToResourceElement();
+                            }
+
+                            return SetMetadata(resource, rawResource.IsMetaSet, version, lastModified);
                         }
                     },
                 };

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Export/GroupMemberExtractorTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Export/GroupMemberExtractorTests.cs
@@ -54,10 +54,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
             });
 
             _resourceDeserializer = new ResourceDeserializer(
-                (FhirResourceFormat.Json, new Func<string, string, DateTimeOffset, ResourceElement>((str, version, lastUpdated) =>
-                {
-                    return _resourceElement;
-                })));
+                (FhirResourceFormat.Json, (str, version, lastUpdated) => _resourceElement));
 
             _groupMemberExtractor = new GroupMemberExtractor(
                 () => _fhirDataStore.CreateMockScope(),
@@ -159,7 +156,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
 
             var callCount = 0;
             var resourceDeserializer = new ResourceDeserializer(
-                (FhirResourceFormat.Json, new Func<string, string, DateTimeOffset, ResourceElement>((str, version, lastUpdated) =>
+                (FhirResourceFormat.Json, (str, version, lastUpdated) =>
                 {
                     callCount++;
                     if (callCount == 1)
@@ -170,7 +167,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
                     {
                         return new ResourceElement(Substitute.For<ITypedElement>(), nestedGroup);
                     }
-                })));
+                }));
 
             _groupMemberExtractor = new GroupMemberExtractor(
                 () => _fhirDataStore.CreateMockScope(),

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Export/ResourceToNdjsonBytesSerializerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Export/ResourceToNdjsonBytesSerializerTests.cs
@@ -36,8 +36,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
         public ResourceToNdjsonBytesSerializerTests()
         {
             _resourceDeserializaer = new ResourceDeserializer(
-                (FhirResourceFormat.Json, new Func<string, string, DateTimeOffset, ResourceElement>((str, version, lastModified) => _jsonParser.Parse<Resource>(str).ToResourceElement())),
-                (FhirResourceFormat.Xml, new Func<string, string, DateTimeOffset, ResourceElement>((str, version, lastModified) => _xmlParser.Parse<Resource>(str).ToResourceElement())));
+                (FhirResourceFormat.Json, new DeserializeFromString((str, version, lastModified) => _jsonParser.Parse<Resource>(str.Data).ToResourceElement())),
+                (FhirResourceFormat.Xml, new DeserializeFromString((str, version, lastModified) => _xmlParser.Parse<Resource>(str.Data).ToResourceElement())));
 
             _serializer = new ResourceToNdjsonBytesSerializer();
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/ResourceHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/ResourceHandlerTests.cs
@@ -138,8 +138,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Resources
             ServiceProvider provider = collection.BuildServiceProvider();
             _mediator = new Mediator(provider);
 
-            _deserializer = new ResourceDeserializer(
-                (FhirResourceFormat.Json, new Func<string, string, DateTimeOffset, ResourceElement>((str, version, lastUpdated) => _fhirJsonParser.Parse(str).ToResourceElement())));
+            _deserializer = Deserializers.ResourceDeserializer;
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/RawBundleEntryComponent.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/RawBundleEntryComponent.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Diagnostics;
 using EnsureThat;
 using Hl7.Fhir.Introspection;
 using Hl7.Fhir.Model;
@@ -15,6 +16,8 @@ namespace Microsoft.Health.Fhir.Shared.Core.Features.Search
     [FhirType("EntryComponent")]
     public class RawBundleEntryComponent : Bundle.EntryComponent
     {
+        private readonly RawResourceElement _resourceElement;
+
         public RawBundleEntryComponent(ResourceWrapper resourceWrapper)
         {
             EnsureArg.IsNotNull(resourceWrapper, nameof(resourceWrapper));
@@ -36,7 +39,18 @@ namespace Microsoft.Health.Fhir.Shared.Core.Features.Search
         {
         }
 
-        public RawResourceElement ResourceElement { get; set; }
+        public RawResourceElement ResourceElement
+        {
+            get => _resourceElement;
+            init
+            {
+                Debug.Assert(
+                    !string.Equals(value?.InstanceType, KnownResourceTypes.OperationOutcome, StringComparison.Ordinal),
+                    "OperationOutcome should not be set as a resource element.");
+
+                _resourceElement = value;
+            }
+        }
 
         public override IDeepCopyable DeepCopy()
         {

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/RawBundleEntryComponent.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/RawBundleEntryComponent.cs
@@ -22,6 +22,13 @@ namespace Microsoft.Health.Fhir.Shared.Core.Features.Search
             ResourceElement = new RawResourceElement(resourceWrapper);
         }
 
+        public RawBundleEntryComponent(RawResourceElement rawResourceElement)
+        {
+            EnsureArg.IsNotNull(rawResourceElement, nameof(rawResourceElement));
+
+            ResourceElement = rawResourceElement;
+        }
+
         public RawResourceElement ResourceElement { get; set; }
 
         public override IDeepCopyable DeepCopy()

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/RawBundleEntryComponent.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/RawBundleEntryComponent.cs
@@ -29,6 +29,13 @@ namespace Microsoft.Health.Fhir.Shared.Core.Features.Search
             ResourceElement = rawResourceElement;
         }
 
+        /// <summary>
+        /// A RawBundleEntryComponent with no payload.
+        /// </summary>
+        public RawBundleEntryComponent()
+        {
+        }
+
         public RawResourceElement ResourceElement { get; set; }
 
         public override IDeepCopyable DeepCopy()

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/RawBundleResponseComponent.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/RawBundleResponseComponent.cs
@@ -1,0 +1,31 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using EnsureThat;
+using Hl7.Fhir.Introspection;
+using Hl7.Fhir.Model;
+using Microsoft.Health.Fhir.Core.Models;
+
+namespace Microsoft.Health.Fhir.Core.Features.Search;
+
+[FhirType("ResponseComponent")]
+public class RawBundleResponseComponent : Bundle.ResponseComponent
+{
+    public RawBundleResponseComponent(RawResourceElement rawOutcomeResourceElement)
+    {
+        EnsureArg.IsNotNull(rawOutcomeResourceElement, nameof(rawOutcomeResourceElement));
+
+        OutcomeElement = rawOutcomeResourceElement;
+    }
+
+    /// <summary>
+    /// A <see cref="RawResponseComponent"/> with no payload.
+    /// </summary>
+    public RawBundleResponseComponent()
+    {
+    }
+
+    public RawResourceElement OutcomeElement { get; set; }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Core/Microsoft.Health.Fhir.Shared.Core.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Microsoft.Health.Fhir.Shared.Core.projitems
@@ -56,6 +56,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Patch\FhirPathPatch\FhirPathPatchBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Patch\FhirPathPatch\Helpers\ElementModelExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Patch\FhirPathPatch\Helpers\FhirParametersExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Search\RawBundleResponseComponent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Features\Resources\Patch\FhirPathPatch\Operations\PatchOperationType.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Patch\FhirPathPatch\Operations\OperationAdd.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Patch\FhirPathPatch\Operations\OperationBase.cs" />

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -432,7 +432,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
 
                                 if (!clonedSearchOptions.OnlyIds)
                                 {
-                                    using var rawResourceStream = new MemoryStream(rawResourceBytes);
+                                    using var rawResourceStream = ResourceDeserializer.MemoryStreamManager.GetStream(rawResourceBytes);
                                     rawResource = _compressedRawResourceConverter.ReadCompressedRawResource(rawResourceStream);
                                 }
 
@@ -629,7 +629,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                             continue;
                         }
 
-                        using var rawResourceStream = new MemoryStream(rawResourceBytes);
+                        using var rawResourceStream = ResourceDeserializer.MemoryStreamManager.GetStream(rawResourceBytes);
                         var rawResource = _compressedRawResourceConverter.ReadCompressedRawResource(rawResourceStream);
 
                         if (string.IsNullOrEmpty(rawResource))

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlStoreClient.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlStoreClient.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             }
             else
             {
-                using var rawResourceStream = new MemoryStream(rawResourceBytes);
+                using var rawResourceStream = ResourceDeserializer.MemoryStreamManager.GetStream(rawResourceBytes);
                 rawResource = decompress(rawResourceStream);
             }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BundleBatchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BundleBatchTests.cs
@@ -352,7 +352,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             if (profileValidation)
             {
-                var bundleOptions = new FhirBundleOptions()
+                var bundleOptions = new FhirBundleOptions
                 {
                     ProfileValidation = profileValidation,
                     BundleProcessingLogic = processingLogic,

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTestsFixture.cs
@@ -205,8 +205,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
             Mediator = new Mediator(services);
 
-            Deserializer = new ResourceDeserializer(
-                (FhirResourceFormat.Json, new Func<string, string, DateTimeOffset, ResourceElement>((str, version, lastUpdated) => JsonParser.Parse(str).ToResourceElement())));
+            Deserializer = Deserializers.ResourceDeserializer;
         }
 
         public async Task DisposeAsync()

--- a/tools/Microsoft.Health.Fhir.R4.ResourceParser/ResourceWrapperParser.cs
+++ b/tools/Microsoft.Health.Fhir.R4.ResourceParser/ResourceWrapperParser.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Health.Fhir.R4.ResourceParser
             var fhirJsonParser = new FhirJsonParser();
             var rawResourceFactory = new RawResourceFactory(fhirJsonSerializer);
             var claimsExtractor = new MockClaimsExtractor();
-            var resourceDeserializer = new ResourceDeserializer((FhirResourceFormat.Json, new Func<string, string, DateTimeOffset, ResourceElement>((str, version, lastUpdated) => fhirJsonParser.Parse(str).ToResourceElement())));
+            var resourceDeserializer = new ResourceDeserializer((FhirResourceFormat.Json, (str, version, lastUpdated) => fhirJsonParser.Parse(str.Data).ToResourceElement()));
             var resourceWrapperFactory = new ResourceWrapperFactory(rawResourceFactory, fhirRequestContextAccessor, searchIndexer, claimsExtractor, compartmentIndexer, searchParameterDefinitionManager, resourceDeserializer);
 
             var definitionManagerTask = searchParameterDefinitionManager.StartAsync(CancellationToken.None);


### PR DESCRIPTION
## Description

### High-level goals:

- Allow Bundle Sub-request Resource to be passed through with async cotext
- Allows Bundle Handler to use Raw strings when building response
- This should reduce overall CPU, Memory and Latency while processing bundles.

### Sequence of requests:
```mermaid
---
title: Bundle Processing
---

sequenceDiagram
    Request->>JsonFormatter: http
    JsonFormatter->>FHIRController: Deserialize
    FHIRController->>Mediatr: Handle
    Mediatr->>BundleHandler: Process
    
loop Each Request
    BundleHandler-->>+Request: Passes model through FHIRContext
    Request-->>JsonFormatter: Begin Sub-request
    JsonFormatter-->>FHIRController: Read model
    FHIRController-->>Mediatr: Handle operation
    Mediatr-->>DataStore: Serialize and persist
    DataStore--)Mediatr: Returns a "RawResource"
    Mediatr--)FHIRController: Raw Response
    FHIRController--)JsonFormatter: 
    JsonFormatter--)Request: Writes raw response
    Request--)-BundleHandler: Return Raw Entry response
end

    BundleHandler->>FHIRController: Build Bundle
    FHIRController-)JsonFormatter: Serialize Raw Bundle
    JsonFormatter-)Request: http
```

### Details:

This pull request primarily involves changes to the `Microsoft.Health.Fhir.Core` project to improve serialization and deserialization of FHIR resources. The most significant changes include refactoring the `RawResourceElementExtensions.cs` and `ResourceDeserializer.cs` files to enhance serialization and deserialization respectively, adding a new `SubRequest.cs` class, and modifying the `ResourceDeserializer.cs` and `RawResourceElement.cs` files to improve resource deserialization.

#### Major changes:

* Serialization improvements:
  * [`src/Microsoft.Health.Fhir.Core/Extensions/RawResourceElementExtensions.cs`](diffhunk://#diff-47ec6ea0f4eede0cbfe299f3aa2a22c72d421e0d37da5d20e0deb3596d78efe6R6-R11): Refactored the `SerializeToStreamAsUtf8Json` method to use a memory stream for serialization, and added a new `SerializeToBytes` method for byte array serialization. [[1]](diffhunk://#diff-47ec6ea0f4eede0cbfe299f3aa2a22c72d421e0d37da5d20e0deb3596d78efe6R6-R11) [[2]](diffhunk://#diff-47ec6ea0f4eede0cbfe299f3aa2a22c72d421e0d37da5d20e0deb3596d78efe6R41-R68) [[3]](diffhunk://#diff-47ec6ea0f4eede0cbfe299f3aa2a22c72d421e0d37da5d20e0deb3596d78efe6L126-R142)

* Deserialization improvements:
  * [`src/Microsoft.Health.Fhir.Core/Features/Persistence/ResourceDeserializer.cs`](diffhunk://#diff-ca6e73ca599d81cd462aa1e4e0adf34016765f22db556168e814a9bf0bbc0683R11-R34): Added a `RecyclableMemoryStreamManager` for reusable memory streams, and changed the `DeserializeRaw` and `DeserializeRawResourceElement` methods to accept a `RawResource` object instead of a string. [[1]](diffhunk://#diff-ca6e73ca599d81cd462aa1e4e0adf34016765f22db556168e814a9bf0bbc0683R11-R34) [[2]](diffhunk://#diff-ca6e73ca599d81cd462aa1e4e0adf34016765f22db556168e814a9bf0bbc0683L59-R68) [[3]](diffhunk://#diff-ca6e73ca599d81cd462aa1e4e0adf34016765f22db556168e814a9bf0bbc0683L71-R80)

* New class addition:
  * [`src/Microsoft.Health.Fhir.Core/Features/Context/SubRequest.cs`](diffhunk://#diff-10f350ca04be19a74c07fae254274adeeb455cd6f0851a05ffb5712599fa9d6cR1-R11): Added a new `SubRequest` class.

* Resource deserialization changes:
  * [`src/Microsoft.Health.Fhir.Core/Models/RawResourceElement.cs`](diffhunk://#diff-563becd482530317d688cea764ad2edccd1b20e48db287ee93a5dd2a84cd28f0R28-R37): Added a new constructor to the `RawResourceElement` class that accepts a `RawResource` object and an instance type.
  * [`src/Microsoft.Health.Fhir.Core/Features/Persistence/ResourceTypeDetector.cs`](diffhunk://#diff-27e56367d2f917dd4f87e4f240e61301e2debb635009f196f5c9c736cedc83fbR1-R42): Added a new `ResourceTypeDetector` class to find the resource type of a given FHIR JSON.

#### Minor changes:

* [`docs/rest/SearchExamples.http`](diffhunk://#diff-ed5a5d7c8b0438439b10a65d6db4d3bb228a0f39e5ea51e8bc46cd964cec6a8cR21): Added a `x-bundle-processing-logic: Parallel` header to the HTTP request.
* [`src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Formatters/FhirJsonInputFormatterTests.cs`](diffhunk://#diff-065cb7d6eede0e41613e31aaad72f70e535ddc5e0c4d8f9607445c5ca7925922L160-R161): Updated the `FhirJsonInputFormatter` constructor calls to include a `FhirRequestContextAccessor` object. [[1]](diffhunk://#diff-065cb7d6eede0e41613e31aaad72f70e535ddc5e0c4d8f9607445c5ca7925922L160-R161) [[2]](diffhunk://#diff-065cb7d6eede0e41613e31aaad72f70e535ddc5e0c4d8f9607445c5ca7925922L184-R185)
* [`src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerEdgeCaseTests.cs`](diffhunk://#diff-1a0e703ef3bbe4f19e45655a9360328b6e3d0979677a21e169f2f6b623944c50R171): Added `Deserializers.ResourceDeserializer` to the `BundleHandler` constructor call.
* [`src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerTests.cs`](diffhunk://#diff-2325fa4d6df027eea834bb9ab00fe1b622a5f116c2b806dccef166cfdff35807R122): Added `Deserializers.ResourceDeserializer` to the `BundleHandler` constructor call.
* [`src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleSerializerTests.cs`](diffhunk://#diff-d8919b1e2c17f52d4d5dc630d3e8539c768a0de89aa126d994e2d4a8b155512cL40): Updated the `BundleSerializerTests` to handle `OperationOutcome` resources differently, and removed the `BundleSerializer` object. [[1]](diffhunk://#diff-d8919b1e2c17f52d4d5dc630d3e8539c768a0de89aa126d994e2d4a8b155512cL40) [[2]](diffhunk://#diff-d8919b1e2c17f52d4d5dc630d3e8539c768a0de89aa126d994e2d4a8b155512cR89-R119) [[3]](diffhunk://#diff-d8919b1e2c17f52d4d5dc630d3e8539c768a0de89aa126d994e2d4a8b155512cL138-R177)

## Related issues
Addresses [AB#117384](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/117384)

## Testing
Adds tests, existing e2e tests. Manual testing.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch (enhancement)
