### PR TITLE
Adding a manage image lifecycle script.

### DIFF
--- a/build/manage-image-lifecycle.ps1
+++ b/build/manage-image-lifecycle.ps1
@@ -1,0 +1,36 @@
+$buildNumber = "$(Release.Artifacts.CIBuild.BuildNumber)"
+$versions = "stu3", "r4", "r4b", "r5"
+$registry = "healthplatformregistry.azurecr.io"
+$repositories = $versions | ForEach-Object { "$_`_fhir-server"; "public/healthcareapis/$_-fhir-server"; }
+
+# Log in to the registry
+$userName = "00000000-0000-0000-0000-000000000000"
+$password = $(az acr login --name $registry --expose-token --output tsv --query accessToken)
+oras login -u $userName -p $password $registry
+
+foreach ($repo in $repositories) {
+    # Get all tags from the repository except the latest ones
+    $tags = oras repo tags "${registry}/${repo}"
+    $tags = $tags.Where({ !$_.Contains($buildNumber) -and !$_.Contains("latest") })
+
+    # Attach the lifecycle metadata to older images
+    foreach ($tag in $tags) {
+        $image = "${registry}/${repo}:${tag}"
+        $artifact = oras discover -o json --artifact-type "application/vnd.microsoft.artifact.lifecycle" $image
+        $json = $artifact -join "" | ConvertFrom-Json
+        if ($null -eq $json.manifests) {
+            Write-Output "'${tag}' needs the lifestyle metadata."
+            $annotation = "vnd.microsoft.artifact.lifecycle.end-of-life.date=" + [DateTime]::UtcNow.ToString("O")
+            oras attach --artifact-type "application/vnd.microsoft.artifact.lifecycle" --annotation $annotation $image
+        }
+        else {
+            Write-Output "'${tag}' already has the lifestyle metadata."
+        }
+    }
+
+    # Attach the lineage metadata to the new image
+    Write-Output "'${buildNumber}' needs the lineage metadata."
+    $image = "${registry}/${repo}:${buildNumber}"
+    $annotation = "vnd.microsoft.artifact.lineage.rolling-tag=${buildNumber}"
+    oras attach --artifact-type "application/vnd.microsoft.artifact.lineage" --annotation $annotation $image
+}

--- a/build/manage-image-lifecycle.ps1
+++ b/build/manage-image-lifecycle.ps1
@@ -1,4 +1,6 @@
 $buildNumber = "$(Release.Artifacts.CIBuild.BuildNumber)"
+$build = "$(Build.BuildNumber)"
+$timestamp= $build.Substring($build.IndexOf('-')+1)
 $versions = "stu3", "r4", "r4b", "r5"
 $registry = "healthplatformregistry.azurecr.io"
 $repositories = $versions | ForEach-Object { "$_`_fhir-server"; "public/healthcareapis/$_-fhir-server"; }
@@ -11,7 +13,7 @@ oras login -u $userName -p $password $registry
 foreach ($repo in $repositories) {
     # Get all tags from the repository except the latest ones
     $tags = oras repo tags "${registry}/${repo}"
-    $tags = $tags.Where({ !$_.Contains($buildNumber) -and !$_.Contains("latest") })
+    $tags = $tags.Where({ !$_.Contains($buildNumber) -and !$_.Contains($timestamp) -and !$_.Contains("latest") -and !$_.Contains("release") })
 
     # Attach the lifecycle metadata to older images
     foreach ($tag in $tags) {
@@ -19,18 +21,25 @@ foreach ($repo in $repositories) {
         $artifact = oras discover -o json --artifact-type "application/vnd.microsoft.artifact.lifecycle" $image
         $json = $artifact -join "" | ConvertFrom-Json
         if ($null -eq $json.manifests) {
-            Write-Output "'${tag}' needs the lifestyle metadata."
+            Write-Output "'${image}' needs the lifestyle metadata."
             $annotation = "vnd.microsoft.artifact.lifecycle.end-of-life.date=" + [DateTime]::UtcNow.ToString("O")
             oras attach --artifact-type "application/vnd.microsoft.artifact.lifecycle" --annotation $annotation $image
         }
         else {
-            Write-Output "'${tag}' already has the lifestyle metadata."
+            Write-Output "'${image}' already has the lifestyle metadata."
         }
     }
 
     # Attach the lineage metadata to the new image
-    Write-Output "'${buildNumber}' needs the lineage metadata."
     $image = "${registry}/${repo}:${buildNumber}"
-    $annotation = "vnd.microsoft.artifact.lineage.rolling-tag=${buildNumber}"
-    oras attach --artifact-type "application/vnd.microsoft.artifact.lineage" --annotation $annotation $image
+    $artifact = oras discover -o json --artifact-type "application/vnd.microsoft.artifact.lineage" $image
+    $json = $artifact -join "" | ConvertFrom-Json
+    if ($null -eq $json.manifests) {
+        Write-Output "'${image}' needs the lineage metadata."
+        $annotation = "vnd.microsoft.artifact.lineage.rolling-tag=${buildNumber}"
+        oras attach --artifact-type "application/vnd.microsoft.artifact.lineage" --annotation $annotation $image
+    }
+    else {
+        Write-Output "'${image}' already has the lineage metadata."
+    }
 }


### PR DESCRIPTION
## Description
Adding a manage image lifecycle script that will be executed during Publish Release.

## Related issues
Addresses [issue #115205].
[User Story 115205](https://microsofthealth.visualstudio.com/Health/_workitems/edit/115205): [s360] Published OSS Images require an " Lifecycle.end-of-life.date" tag

## Testing
Tested with my test container registry. 

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
