### PR TITLE
Enable writing events to external database

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlRetry/SqlRetryService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlRetry/SqlRetryService.cs
@@ -8,17 +8,13 @@ using System.Collections.Generic;
 using System.Data;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Xml.Linq;
 using EnsureThat;
-using Microsoft.Build.Framework;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.SqlServer;
 using Microsoft.Health.SqlServer.Configs;
 using Microsoft.Health.SqlServer.Features.Storage;
-using Microsoft.SqlServer.Management.Smo;
 
 namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 {

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlRetry/SqlRetryService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlRetry/SqlRetryService.cs
@@ -416,7 +416,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
         private class ReplicaHandler
         {
             private DateTime? _lastUpdated;
-            private object _databaseAccessLocker = new object();
+            private readonly object _databaseAccessLocker = new object();
             private double _replicaTrafficRatio = 0;
             private long _usageCounter = 0;
 
@@ -503,7 +503,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
         private class EventLogHandler
         {
             private bool _initialized = false;
-            private object _databaseAccessLocker = new object();
+            private readonly object _databaseAccessLocker = new object();
             private string _eventLogDatabaseName = null;
 
             public EventLogHandler()


### PR DESCRIPTION
This simple PR introduces ability to route TryLogEvent calls to external database specified in Parameters.EventLogConnectionString. On service startup there is one extra database call to cache external connection string. If connection string value is NULL or not present (normal case) calls are made to the same database as today. 