### PR TITLE
Grants sync-to-devops issues: write permissions

### DIFF
--- a/.github/workflows/sync-to-devops.yml
+++ b/.github/workflows/sync-to-devops.yml
@@ -7,6 +7,10 @@ on:
 
 jobs:
   alert:
+    permissions:
+      actions: read
+      contents: read
+      issues: write
     runs-on: ubuntu-latest
     name: Sync to DevOps workflow
     steps:


### PR DESCRIPTION
## Description
This pull request includes changes to the `sync-to-devops.yml` GitHub workflow file.

The most significant change is:

* [`.github/workflows/sync-to-devops.yml`](diffhunk://#diff-2c4b4efd751dd3b0d662dc12172f9d9d86fbb70fbb73d3650be060f261cf171fR10-R13): Added `read` permissions for `actions` and `contents`, and `write` permissions for `issues`. This change allows the job to read actions and contents, and write issues, which can help in syncing with DevOps workflows more effectively.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
