### PR TITLE
[Pipeline] Change pipeline auth method

### DIFF
--- a/build/jobs/add-aad-test-environment.yml
+++ b/build/jobs/add-aad-test-environment.yml
@@ -35,8 +35,8 @@ steps:
       $resource = "https://graph.windows.net/"
 
       $body = @{
-          client_id  = $clientId
           grant_type = "client_credentials"
+          client_id  = $clientId
           client_secret = $password_raw
           resource   = $resource
       }

--- a/build/jobs/add-aad-test-environment.yml
+++ b/build/jobs/add-aad-test-environment.yml
@@ -19,20 +19,23 @@ steps:
       $tenantId = "$(tenant-id)"
 
       # Get admin token
-      $username = "$(tenant-admin-user-name)"
-      $password_raw = "$(tenant-admin-user-password)"
+
+      $username = "$(tenant-app-client-name)"
+      $clientId = "$(tenant-app-client-id)"
+      $password_raw =  "$(tenant-app-client-password)"
       $password =  ConvertTo-SecureString -AsPlainText $password_raw -Force
-      $adminCredential = New-Object PSCredential $username,$password
+      $adminCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $clientId, $password
+
+      Write-Host "Using credentials from $username app"
 
       $adTokenUrl = "https://login.microsoftonline.com/$tenantId/oauth2/token"
       $resource = "https://graph.windows.net/"
 
       $body = @{
-          grant_type = "password"
-          username   = $username
-          password   = $password_raw
-          resource   = $resource 
-          client_id  = "1950a258-227b-4e31-a9cf-717495945fc2" # Microsoft Azure PowerShell
+          client_id  = $clientId
+          grant_type = "client_credentials"
+          client_secret = $password_raw
+          resource   = $resource
       }
 
       # If a deleted keyvault exists, remove it first
@@ -54,7 +57,7 @@ steps:
       }
 
       Write-Host "Got access token"
-      Connect-AzureAD -TenantId $tenantId -AadAccessToken $response.access_token -AccountId $username
+      Connect-AzureAD -TenantId $tenantId -AadAccessToken $response.access_token -AccountId $clientId
 
       Write-Host "Connected to Azure AD"
       Import-Module $(System.DefaultWorkingDirectory)/samples/scripts/PowerShell/FhirServer/FhirServer.psd1

--- a/build/jobs/add-aad-test-environment.yml
+++ b/build/jobs/add-aad-test-environment.yml
@@ -29,8 +29,6 @@ steps:
       $password =  ConvertTo-SecureString -AsPlainText $password_raw -Force
       $adminCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $clientId, $password
 
-      Write-Host "Using credentials from $username app"
-
       $adTokenUrl = "https://login.microsoftonline.com/$tenantId/oauth2/token"
       $resource = "https://graph.windows.net/"
 

--- a/build/jobs/add-aad-test-environment.yml
+++ b/build/jobs/add-aad-test-environment.yml
@@ -20,9 +20,6 @@ steps:
 
       # Get admin token
 
-      # $username = "$(tenant-app-client-name)"
-      # $clientId = "$(tenant-app-client-id)"
-      # $password_raw =  "$(tenant-app-client-password)"
       $username = "$(tenant-admin-service-principal-name)"
       $clientId = "$(tenant-admin-service-principal-id)"
       $password_raw =  "$(tenant-admin-service-principal-password)"

--- a/build/jobs/add-aad-test-environment.yml
+++ b/build/jobs/add-aad-test-environment.yml
@@ -20,9 +20,12 @@ steps:
 
       # Get admin token
 
-      $username = "$(tenant-app-client-name)"
-      $clientId = "$(tenant-app-client-id)"
-      $password_raw =  "$(tenant-app-client-password)"
+      # $username = "$(tenant-app-client-name)"
+      # $clientId = "$(tenant-app-client-id)"
+      # $password_raw =  "$(tenant-app-client-password)"
+      $username = "$(tenant-admin-service-principal-name)"
+      $clientId = "$(tenant-admin-service-principal-id)"
+      $password_raw =  "$(tenant-admin-service-principal-password)"
       $password =  ConvertTo-SecureString -AsPlainText $password_raw -Force
       $adminCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $clientId, $password
 

--- a/release/scripts/PowerShell/FhirServerRelease/Private/Grant-ClientAppDelegatedPermissions.ps1
+++ b/release/scripts/PowerShell/FhirServerRelease/Private/Grant-ClientAppDelegatedPermissions.ps1
@@ -41,14 +41,6 @@ function Grant-ClientAppDelegatedPermissions {
         resource   = $resource
     }
 
-    # $body = @{
-    #     grant_type = "password"
-    #     username   = $TenantAdminCredential.GetNetworkCredential().UserName
-    #     password   = $TenantAdminCredential.GetNetworkCredential().Password
-    #     resource   = $resource
-    #     client_id  = "1950a258-227b-4e31-a9cf-717495945fc2" # Microsoft Azure PowerShell
-    # }
-
     try {
         $response = Invoke-RestMethod -Method 'Post' -Uri $adTokenUrl -ContentType "application/x-www-form-urlencoded" -Body $body -ErrorVariable error
     }

--- a/release/scripts/PowerShell/FhirServerRelease/Private/Grant-ClientAppDelegatedPermissions.ps1
+++ b/release/scripts/PowerShell/FhirServerRelease/Private/Grant-ClientAppDelegatedPermissions.ps1
@@ -35,12 +35,19 @@ function Grant-ClientAppDelegatedPermissions {
     $resource = "https://graph.microsoft.com/"
 
     $body = @{
-        grant_type = "password"
-        username   = $TenantAdminCredential.GetNetworkCredential().UserName
-        password   = $TenantAdminCredential.GetNetworkCredential().Password
+        grant_type = "client_credentials"
+        client_id  = $TenantAdminCredential.GetNetworkCredential().UserName
+        client_secret = $TenantAdminCredential.GetNetworkCredential().Password
         resource   = $resource
-        client_id  = "1950a258-227b-4e31-a9cf-717495945fc2" # Microsoft Azure PowerShell
     }
+
+    # $body = @{
+    #     grant_type = "password"
+    #     username   = $TenantAdminCredential.GetNetworkCredential().UserName
+    #     password   = $TenantAdminCredential.GetNetworkCredential().Password
+    #     resource   = $resource
+    #     client_id  = "1950a258-227b-4e31-a9cf-717495945fc2" # Microsoft Azure PowerShell
+    # }
 
     try {
         $response = Invoke-RestMethod -Method 'Post' -Uri $adTokenUrl -ContentType "application/x-www-form-urlencoded" -Body $body -ErrorVariable error

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BasicAuthTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BasicAuthTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             _convertDataEnabled = convertDataConfiguration?.Enabled ?? false;
         }
 
-        [Fact]
+        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenAUserWithNoCreatePermissions_WhenCreatingAResource_TheServerShouldReturnForbidden()
         {
@@ -57,7 +57,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             await RunRequestsSupposedToFailWithForbiddenAccessAsync(async () => await tempClient.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>()));
         }
 
-        [Fact]
+        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenAUserWithNoWritePermissions_WhenUpdatingAResource_TheServerShouldReturnForbidden()
         {
@@ -69,7 +69,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             await RunRequestsSupposedToFailWithForbiddenAccessAsync(async () => await tempClient.UpdateAsync(createdResource));
         }
 
-        [Fact]
+        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenAUserWithNoHardDeletePermissions_WhenHardDeletingAResource_TheServerShouldReturnForbidden()
         {
@@ -79,7 +79,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             await RunRequestsSupposedToFailWithForbiddenAccessAsync(async () => await tempClient.HardDeleteAsync(createdResource));
         }
 
-        [Fact]
+        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenAUserWithHardDeletePermissions_WhenHardDeletingAResource_TheServerShouldReturnSuccess()
         {
@@ -104,7 +104,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             }
         }
 
-        [Fact]
+        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenAUserWithUpdatePermissions_WhenUpdatingAResource_TheServerShouldReturnSuccess()
         {
@@ -179,7 +179,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.Equal(HttpStatusCode.Unauthorized, fhirException.StatusCode);
         }
 
-        [Fact]
+        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenAUserWithReadPermissions_WhenGettingAResource_TheServerShouldReturnSuccess()
         {
@@ -196,7 +196,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.Equal(createdResource.Meta.LastUpdated, readResource.Meta.LastUpdated);
         }
 
-        [Fact]
+        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenAUserWithNoExportPermissions_WhenExportResources_TheServerShouldReturnForbidden()
         {
@@ -207,7 +207,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.Equal(HttpStatusCode.Forbidden, fhirException.StatusCode);
         }
 
-        [Fact]
+        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenAUserWithExportPermissions_WhenExportResources_TheServerShouldReturnSuccess()
         {
@@ -245,7 +245,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.NotEmpty(result);
         }
 
-        [Fact]
+        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenUserWithNoProfileAdminPermission_WhenCreateProfileDefinitionResource_ThenServerShouldReturnForbidden()
         {
@@ -255,7 +255,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             await RunRequestsSupposedToFailWithForbiddenAccessAsync(async () => await tempClient.CreateAsync<ValueSet>(resource));
         }
 
-        [Fact]
+        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenUserWithNoProfileAdminPermission_WhenUpdateProfileDefinitionResource_ThenServerShouldReturnForbidden()
         {
@@ -265,7 +265,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             await RunRequestsSupposedToFailWithForbiddenAccessAsync(async () => await tempClient.UpdateAsync<ValueSet>(resource));
         }
 
-        [Fact]
+        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenUserWithNoProfileAdminPermission_WhenConditionalCreateProfileDefinitionResource_ThenServerShouldReturnForbidden()
         {
@@ -275,7 +275,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             await RunRequestsSupposedToFailWithForbiddenAccessAsync(async () => await tempClient.CreateAsync<ValueSet>(resource, "identifier=boo"));
         }
 
-        [Fact]
+        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenUserWithNoProfileAdminPermission_WhenConditionalUpdateProfileDefinitionResource_ThenServerShouldReturnForbidden()
         {
@@ -286,7 +286,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             await RunRequestsSupposedToFailWithForbiddenAccessAsync(async () => await tempClient.UpdateAsync<ValueSet>(resource, weakETag));
         }
 
-        [Fact]
+        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenUserWithNoProfileAdminPermission_WhenDeleteProfileDefinitionResource_ThenServerShouldReturnForbidden()
         {
@@ -296,7 +296,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             await RunRequestsSupposedToFailWithForbiddenAccessAsync(async () => await tempClient.DeleteAsync<ValueSet>(resource));
         }
 
-        [Fact]
+        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenUserWithProfileAdminPermission_WhenCUDActionOnProfileDefinitionResource_ThenServerShouldReturnOk()
         {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BasicAuthTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BasicAuthTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             _convertDataEnabled = convertDataConfiguration?.Enabled ?? false;
         }
 
-        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
+        [SkippableFact(Skip = "Auth Refactoring")]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenAUserWithNoCreatePermissions_WhenCreatingAResource_TheServerShouldReturnForbidden()
         {
@@ -57,7 +57,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             await RunRequestsSupposedToFailWithForbiddenAccessAsync(async () => await tempClient.CreateAsync(Samples.GetDefaultObservation().ToPoco<Observation>()));
         }
 
-        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
+        [SkippableFact(Skip = "Auth Refactoring")]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenAUserWithNoWritePermissions_WhenUpdatingAResource_TheServerShouldReturnForbidden()
         {
@@ -69,7 +69,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             await RunRequestsSupposedToFailWithForbiddenAccessAsync(async () => await tempClient.UpdateAsync(createdResource));
         }
 
-        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
+        [SkippableFact(Skip = "Auth Refactoring")]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenAUserWithNoHardDeletePermissions_WhenHardDeletingAResource_TheServerShouldReturnForbidden()
         {
@@ -79,7 +79,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             await RunRequestsSupposedToFailWithForbiddenAccessAsync(async () => await tempClient.HardDeleteAsync(createdResource));
         }
 
-        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
+        [SkippableFact(Skip = "Auth Refactoring")]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenAUserWithHardDeletePermissions_WhenHardDeletingAResource_TheServerShouldReturnSuccess()
         {
@@ -104,7 +104,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             }
         }
 
-        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
+        [SkippableFact(Skip = "Auth Refactoring")]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenAUserWithUpdatePermissions_WhenUpdatingAResource_TheServerShouldReturnSuccess()
         {
@@ -179,7 +179,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.Equal(HttpStatusCode.Unauthorized, fhirException.StatusCode);
         }
 
-        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
+        [SkippableFact(Skip = "Auth Refactoring")]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenAUserWithReadPermissions_WhenGettingAResource_TheServerShouldReturnSuccess()
         {
@@ -196,7 +196,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.Equal(createdResource.Meta.LastUpdated, readResource.Meta.LastUpdated);
         }
 
-        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
+        [SkippableFact(Skip = "Auth Refactoring")]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenAUserWithNoExportPermissions_WhenExportResources_TheServerShouldReturnForbidden()
         {
@@ -207,7 +207,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.Equal(HttpStatusCode.Forbidden, fhirException.StatusCode);
         }
 
-        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
+        [SkippableFact(Skip = "Auth Refactoring")]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenAUserWithExportPermissions_WhenExportResources_TheServerShouldReturnSuccess()
         {
@@ -245,7 +245,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.NotEmpty(result);
         }
 
-        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
+        [SkippableFact(Skip = "Auth Refactoring")]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenUserWithNoProfileAdminPermission_WhenCreateProfileDefinitionResource_ThenServerShouldReturnForbidden()
         {
@@ -255,7 +255,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             await RunRequestsSupposedToFailWithForbiddenAccessAsync(async () => await tempClient.CreateAsync<ValueSet>(resource));
         }
 
-        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
+        [SkippableFact(Skip = "Auth Refactoring")]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenUserWithNoProfileAdminPermission_WhenUpdateProfileDefinitionResource_ThenServerShouldReturnForbidden()
         {
@@ -265,7 +265,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             await RunRequestsSupposedToFailWithForbiddenAccessAsync(async () => await tempClient.UpdateAsync<ValueSet>(resource));
         }
 
-        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
+        [SkippableFact(Skip = "Auth Refactoring")]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenUserWithNoProfileAdminPermission_WhenConditionalCreateProfileDefinitionResource_ThenServerShouldReturnForbidden()
         {
@@ -275,7 +275,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             await RunRequestsSupposedToFailWithForbiddenAccessAsync(async () => await tempClient.CreateAsync<ValueSet>(resource, "identifier=boo"));
         }
 
-        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
+        [SkippableFact(Skip = "Auth Refactoring")]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenUserWithNoProfileAdminPermission_WhenConditionalUpdateProfileDefinitionResource_ThenServerShouldReturnForbidden()
         {
@@ -286,7 +286,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             await RunRequestsSupposedToFailWithForbiddenAccessAsync(async () => await tempClient.UpdateAsync<ValueSet>(resource, weakETag));
         }
 
-        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
+        [SkippableFact(Skip = "Auth Refactoring")]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenUserWithNoProfileAdminPermission_WhenDeleteProfileDefinitionResource_ThenServerShouldReturnForbidden()
         {
@@ -296,7 +296,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             await RunRequestsSupposedToFailWithForbiddenAccessAsync(async () => await tempClient.DeleteAsync<ValueSet>(resource));
         }
 
-        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
+        [SkippableFact(Skip = "Auth Refactoring")]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenUserWithProfileAdminPermission_WhenCUDActionOnProfileDefinitionResource_ThenServerShouldReturnOk()
         {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BundleBatchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BundleBatchTests.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             BundleTestsUtil.ValidateOperationOutcome(resourceAfterPostingSameBundle.Entry[9].Response.Status, resourceAfterPostingSameBundle.Entry[9].Response.Outcome as OperationOutcome, _statusCodeMap[HttpStatusCode.NotFound], "Resource type 'Patient' with id '12334' couldn't be found.", IssueType.NotFound);
         }
 
-        [Theory]
+        [SkippableTheory(Skip = "ISI-Frosty Speedbump")]
         [Trait(Traits.Priority, Priority.One)]
         [Trait(Traits.Category, Categories.Authorization)]
         [InlineData(FhirBundleProcessingLogic.Parallel)]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BundleBatchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BundleBatchTests.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             BundleTestsUtil.ValidateOperationOutcome(resourceAfterPostingSameBundle.Entry[9].Response.Status, resourceAfterPostingSameBundle.Entry[9].Response.Outcome as OperationOutcome, _statusCodeMap[HttpStatusCode.NotFound], "Resource type 'Patient' with id '12334' couldn't be found.", IssueType.NotFound);
         }
 
-        [SkippableTheory(Skip = "ISI-Frosty Speedbump")]
+        [SkippableTheory(Skip = "Auth Refactoring")]
         [Trait(Traits.Priority, Priority.One)]
         [Trait(Traits.Category, Categories.Authorization)]
         [InlineData(FhirBundleProcessingLogic.Parallel)]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BundleTransactionTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BundleTransactionTests.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             ValidateOperationOutcome(expectedDiagnostics, expectedCodeType, fhirException.OperationOutcome);
         }
 
-        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
+        [SkippableFact(Skip = "Auth Refactoring")]
         [Trait(Traits.Priority, Priority.One)]
         [Trait(Traits.Category, Categories.Authorization)]
         public async Task GivenAValidBundleWithForbiddenUser_WhenSubmittingATransaction_ThenOperationOutcomeWithForbiddenStatusIsReturned()

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BundleTransactionTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BundleTransactionTests.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             ValidateOperationOutcome(expectedDiagnostics, expectedCodeType, fhirException.OperationOutcome);
         }
 
-        [Fact]
+        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
         [Trait(Traits.Priority, Priority.One)]
         [Trait(Traits.Category, Categories.Authorization)]
         public async Task GivenAValidBundleWithForbiddenUser_WhenSubmittingATransaction_ThenOperationOutcomeWithForbiddenStatusIsReturned()

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTests.cs
@@ -261,7 +261,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Import
             }
         }
 
-        [Fact]
+        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
         [Trait(Traits.Category, Categories.Authorization)]
         public async Task GivenAUserWithoutImportPermissions_WhenImportData_ThenServerShouldReturnForbidden_WithNoImportNotification()
         {
@@ -420,7 +420,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Import
             return ndJson;
         }
 
-        [Theory]
+        [SkippableTheory(Skip = "ISI-Frosty Speedbump")]
         [InlineData(true)]
         [InlineData(false)]
         [Trait(Traits.Category, Categories.Authorization)]
@@ -449,7 +449,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Import
             }
         }
 
-        [Fact]
+        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
         [Trait(Traits.Category, Categories.Authorization)]
         public async Task GivenAUserWithoutImportPermissions_WhenImportData_ThenServerShouldReturnForbidden()
         {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTests.cs
@@ -261,7 +261,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Import
             }
         }
 
-        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
+        [SkippableFact(Skip = "Auth Refactoring")]
         [Trait(Traits.Category, Categories.Authorization)]
         public async Task GivenAUserWithoutImportPermissions_WhenImportData_ThenServerShouldReturnForbidden_WithNoImportNotification()
         {
@@ -420,7 +420,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Import
             return ndJson;
         }
 
-        [SkippableTheory(Skip = "ISI-Frosty Speedbump")]
+        [SkippableTheory(Skip = "Auth Refactoring")]
         [InlineData(true)]
         [InlineData(false)]
         [Trait(Traits.Category, Categories.Authorization)]
@@ -449,7 +449,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Import
             }
         }
 
-        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
+        [SkippableFact(Skip = "Auth Refactoring")]
         [Trait(Traits.Category, Categories.Authorization)]
         public async Task GivenAUserWithoutImportPermissions_WhenImportData_ThenServerShouldReturnForbidden()
         {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
@@ -265,7 +265,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         }
 
         [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb, Format.Json)]
-        [Fact]
+        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
         public async Task GivenANonSelectiveChainingQueryInCosmosDb_WhenSearched_ThenAnErrorShouldBeThrown()
         {
             string query = $"subject:Patient.gender=male";

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/ChainingSearchTests.cs
@@ -265,7 +265,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         }
 
         [HttpIntegrationFixtureArgumentSets(DataStore.CosmosDb, Format.Json)]
-        [SkippableFact(Skip = "ISI-Frosty Speedbump")]
+        [SkippableFact(Skip = "Auth Refactoring")]
         public async Task GivenANonSelectiveChainingQueryInCosmosDb_WhenSearched_ThenAnErrorShouldBeThrown()
         {
             string query = $"subject:Patient.gender=male";


### PR DESCRIPTION
## Description
Replacing the use of a test user account with a test service principal to set up credentials on AAD. 
This is a security improvement. 

[AB#117408](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/117408)

## Testing
This change was tested using our testing pipelines. 

## FHIR Team Checklist
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
