### PR TITLE
Handle 405 errors

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
@@ -565,6 +565,15 @@ namespace Microsoft.Health.Fhir.Api {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The requested operation is not supported..
+        /// </summary>
+        public static string OperationNotSupported {
+            get {
+                return ResourceManager.GetString("OperationNotSupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to FHIR Server.
         /// </summary>
         public static string PageTitle {

--- a/src/Microsoft.Health.Fhir.Api/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Api/Resources.resx
@@ -182,6 +182,9 @@
     <value>The requested "{0}" operation is not supported.</value>
     <comment>{0} is the operation name</comment>
   </data>
+  <data name="OperationNotSupported" xml:space="preserve">
+    <value>The requested operation is not supported.</value>
+  </data>
   <data name="PageTitle" xml:space="preserve">
     <value>FHIR Server</value>
     <comment>{NumberedPlaceHolder="FHIR"}</comment>

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
@@ -126,6 +126,11 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                     returnCode = HttpStatusCode.NotFound;
                     diagnosticInfo = Resources.NotFoundException;
                     break;
+                case (int)HttpStatusCode.MethodNotAllowed:
+                    issueType = OperationOutcome.IssueType.NotSupported;
+                    returnCode = HttpStatusCode.MethodNotAllowed;
+                    diagnosticInfo = Resources.OperationNotImplemented;
+                    break;
                 default:
                     issueType = OperationOutcome.IssueType.Exception;
                     returnCode = HttpStatusCode.InternalServerError;

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                 case (int)HttpStatusCode.MethodNotAllowed:
                     issueType = OperationOutcome.IssueType.NotSupported;
                     returnCode = HttpStatusCode.MethodNotAllowed;
-                    diagnosticInfo = Resources.OperationNotImplemented;
+                    diagnosticInfo = Resources.OperationNotSupported;
                     break;
                 default:
                     issueType = OperationOutcome.IssueType.Exception;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ExceptionTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ExceptionTests.cs
@@ -107,8 +107,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenANotAllowedMethod_WhenRequestIsSent_TheServerShouldReturnMethodNotSupported()
         {
-            var requestMessage = new HttpRequestMessage();
-            string uriString = _client.HttpClient.BaseAddress.ToString() + "admin.html";
+            using var requestMessage = new HttpRequestMessage();
+            string uriString = _client.HttpClient.BaseAddress + "admin.html";
             requestMessage.RequestUri = new Uri(uriString);
             requestMessage.Method = HttpMethod.Head;
             HttpResponseMessage response = await _client.HttpClient.SendAsync(requestMessage);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ExceptionTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ExceptionTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Net;
+using System.Net.Http;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Validation;
 using Microsoft.AspNetCore.Builder;
@@ -100,6 +101,18 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             TestHelper.AssertSecurityHeaders(fhirException.Headers);
 
             DotNetAttributeValidation.Validate(operationOutcome, true);
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenANotAllowedMethod_WhenRequestIsSent_TheServerShouldReturnMethodNotSupported()
+        {
+            var requestMessage = new HttpRequestMessage();
+            string uriString = _client.HttpClient.BaseAddress.ToString() + "admin.html";
+            requestMessage.RequestUri = new Uri(uriString);
+            requestMessage.Method = HttpMethod.Head;
+            HttpResponseMessage response = await _client.HttpClient.SendAsync(requestMessage);
+            Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
         }
 
         public class StartupWithThrowingMiddleware : StartupBaseForCustomProviders


### PR DESCRIPTION
## Description
The server should return Method not supported 405 to the user for requests operation types which are not supported instead of 500

## Related issues
Addresses [AB118198](https://microsofthealth.visualstudio.com/Health/_workitems/edit/118198)

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
