### PR TITLE
Add support for partial delete success

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Exceptions/IncompleteDeleteException.cs
+++ b/src/Microsoft.Health.Fhir.Core/Exceptions/IncompleteDeleteException.cs
@@ -12,10 +12,10 @@ using Microsoft.Health.Abstractions.Exceptions;
 
 namespace Microsoft.Health.Fhir.Core.Exceptions
 {
-    public class PartialDeleteSuccessException : MicrosoftHealthException
+    public class IncompleteDeleteException : RequestTooCostlyException
     {
-        public PartialDeleteSuccessException(int numberOfResourceVersionsDeleted)
-            : base(Resources.PartialDeleteSuccess.Replace("{0}", numberOfResourceVersionsDeleted.ToString(), StringComparison.Ordinal))
+        public IncompleteDeleteException(int numberOfResourceVersionsDeleted)
+            : base(message: string.Format(Resources.PartialDeleteSuccess, numberOfResourceVersionsDeleted.ToString(), StringComparison.Ordinal))
         {
         }
     }

--- a/src/Microsoft.Health.Fhir.Core/Exceptions/IncompleteDeleteException.cs
+++ b/src/Microsoft.Health.Fhir.Core/Exceptions/IncompleteDeleteException.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Health.Fhir.Core.Exceptions
     public class IncompleteDeleteException : RequestTooCostlyException
     {
         public IncompleteDeleteException(int numberOfResourceVersionsDeleted)
-            : base(message: string.Format(Resources.PartialDeleteSuccess, numberOfResourceVersionsDeleted.ToString(), StringComparison.Ordinal))
+            : base(message: string.Format(Resources.PartialDeleteSuccess, numberOfResourceVersionsDeleted, StringComparison.Ordinal))
         {
         }
     }

--- a/src/Microsoft.Health.Fhir.Core/Exceptions/PartialDeleteSuccessException.cs
+++ b/src/Microsoft.Health.Fhir.Core/Exceptions/PartialDeleteSuccessException.cs
@@ -1,0 +1,22 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Health.Abstractions.Exceptions;
+
+namespace Microsoft.Health.Fhir.Core.Exceptions
+{
+    public class PartialDeleteSuccessException : MicrosoftHealthException
+    {
+        public PartialDeleteSuccessException(int numberOfResourceVersionsDeleted)
+            : base(Resources.PartialDeleteSuccess.Replace("{0}", numberOfResourceVersionsDeleted.ToString(), StringComparison.Ordinal))
+        {
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/BulkDelete/BulkDeleteProcessingJob.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/BulkDelete/BulkDeleteProcessingJob.cs
@@ -87,7 +87,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.BulkDelete
                             definition.DeleteOperation,
                             maxDeleteCount: null,
                             deleteAll: true,
-                            versionType: definition.VersionType),
+                            versionType: definition.VersionType,
+                            allowPartialSuccess: false), // Explicitly setting to call out that this can be changed in the future if we want to. Bulk delete offers the possibility of automatically rerunning the operation until it succeeds, fully automating the process.
                         cancellationToken);
                 }
                 catch (IncompleteOperationException<long> ex)

--- a/src/Microsoft.Health.Fhir.Core/Features/Persistence/IFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Persistence/IFhirDataStore.cs
@@ -21,7 +21,15 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
 
         Task<ResourceWrapper> GetAsync(ResourceKey key, CancellationToken cancellationToken);
 
-        Task HardDeleteAsync(ResourceKey key, bool keepCurrentVersion, CancellationToken cancellationToken);
+        /// <summary>
+        /// Hard deletes a resource.
+        /// </summary>
+        /// <param name="key">Identifier of the resource</param>
+        /// <param name="keepCurrentVersion">Keeps the current version of the resource, only deleting history</param>
+        /// <param name="allowPartialSuccess">Only for Cosmos. Allows for a delete to partially succeed if it fails to delete all versions of a resource in one try.</param>
+        /// <param name="cancellationToken">Cancellation Token</param>
+        /// <returns>Async Task</returns>
+        Task HardDeleteAsync(ResourceKey key, bool keepCurrentVersion, bool allowPartialSuccess, CancellationToken cancellationToken);
 
         Task BulkUpdateSearchParameterIndicesAsync(IReadOnlyCollection<ResourceWrapper> resources, CancellationToken cancellationToken);
 

--- a/src/Microsoft.Health.Fhir.Core/Messages/Delete/ConditionalDeleteResourceRequest.cs
+++ b/src/Microsoft.Health.Fhir.Core/Messages/Delete/ConditionalDeleteResourceRequest.cs
@@ -23,7 +23,8 @@ namespace Microsoft.Health.Fhir.Core.Messages.Delete
             int? maxDeleteCount,
             BundleResourceContext bundleResourceContext = null,
             bool deleteAll = false,
-            ResourceVersionType versionType = ResourceVersionType.Latest)
+            ResourceVersionType versionType = ResourceVersionType.Latest,
+            bool allowPartialSuccess = false)
             : base(resourceType, conditionalParameters, bundleResourceContext)
         {
             EnsureArg.IsNotNull(conditionalParameters, nameof(conditionalParameters));
@@ -32,6 +33,7 @@ namespace Microsoft.Health.Fhir.Core.Messages.Delete
             MaxDeleteCount = maxDeleteCount;
             DeleteAll = deleteAll;
             VersionType = versionType;
+            AllowPartialSuccess = allowPartialSuccess;
         }
 
         public DeleteOperation DeleteOperation { get; }
@@ -41,6 +43,8 @@ namespace Microsoft.Health.Fhir.Core.Messages.Delete
         public bool DeleteAll { get; }
 
         public ResourceVersionType VersionType { get; }
+
+        public bool AllowPartialSuccess { get; }
 
         protected override IEnumerable<string> GetCapabilities() => Capabilities;
     }

--- a/src/Microsoft.Health.Fhir.Core/Messages/Delete/DeleteResourceRequest.cs
+++ b/src/Microsoft.Health.Fhir.Core/Messages/Delete/DeleteResourceRequest.cs
@@ -14,16 +14,17 @@ namespace Microsoft.Health.Fhir.Core.Messages.Delete
 {
     public class DeleteResourceRequest : IRequest<DeleteResourceResponse>, IRequireCapability
     {
-        public DeleteResourceRequest(ResourceKey resourceKey, DeleteOperation deleteOperation, BundleResourceContext bundleResourceContext = null)
+        public DeleteResourceRequest(ResourceKey resourceKey, DeleteOperation deleteOperation, BundleResourceContext bundleResourceContext = null, bool allowPartialSuccess = false)
         {
             EnsureArg.IsNotNull(resourceKey, nameof(resourceKey));
 
             ResourceKey = resourceKey;
             DeleteOperation = deleteOperation;
             BundleResourceContext = bundleResourceContext;
+            AllowPartialSuccess = allowPartialSuccess;
         }
 
-        public DeleteResourceRequest(string type, string id, DeleteOperation deleteOperation, BundleResourceContext bundleResourceContext = null)
+        public DeleteResourceRequest(string type, string id, DeleteOperation deleteOperation, BundleResourceContext bundleResourceContext = null, bool allowPartialSuccess = false)
         {
             EnsureArg.IsNotNull(type, nameof(type));
             EnsureArg.IsNotNull(id, nameof(id));
@@ -31,6 +32,7 @@ namespace Microsoft.Health.Fhir.Core.Messages.Delete
             ResourceKey = new ResourceKey(type, id);
             DeleteOperation = deleteOperation;
             BundleResourceContext = bundleResourceContext;
+            AllowPartialSuccess = allowPartialSuccess;
         }
 
         public ResourceKey ResourceKey { get; }
@@ -38,6 +40,8 @@ namespace Microsoft.Health.Fhir.Core.Messages.Delete
         public BundleResourceContext BundleResourceContext { get; }
 
         public DeleteOperation DeleteOperation { get; }
+
+        public bool AllowPartialSuccess { get; }
 
         public IEnumerable<CapabilityQuery> RequiredCapabilities()
         {

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -989,6 +989,15 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Deleted {0} versions of the target resource..
+        /// </summary>
+        internal static string PartialDeleteSuccess {
+            get {
+                return ResourceManager.GetString("PartialDeleteSuccess", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Patching immutable properties is not allowed..
         /// </summary>
         internal static string PatchImmutablePropertiesIsNotValid {

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -736,4 +736,8 @@
     <value>A resource should only appear once in each Bundle.</value>
     <comment>Error message for a duplicate resource key in the same bundle</comment>
   </data>
+  <data name="PartialDeleteSuccess" xml:space="preserve">
+    <value>Deleted {0} versions of the target resource.</value>
+    <comment>{0} is replaced with the number of deleted versions of the resource.</comment>
+  </data>
 </root>

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/CosmosFhirDataStoreTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/CosmosFhirDataStoreTests.cs
@@ -11,9 +11,11 @@ using System.Net.Http;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Threading.Tasks;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.Cosmos.Scripts;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -21,6 +23,7 @@ using Microsoft.Health.Abstractions.Exceptions;
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Configs;
+using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Definition;
@@ -281,6 +284,23 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Storage
             }
 
             await _container.Value.ReceivedWithAnyArgs(7).CreateItemAsync(Arg.Any<FhirCosmosResourceWrapper>(), Arg.Any<PartitionKey>(), Arg.Any<ItemRequestOptions>(), Arg.Any<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task GivenAHardDeleteRequest_WhenPartiallySuccessful_ThenAnExceptionIsThrown()
+        {
+            var resourceKey = new ResourceKey(KnownResourceTypes.Patient, "test");
+
+            var scripts = Substitute.For<Scripts>();
+            scripts.ExecuteStoredProcedureAsync<int>(Arg.Any<string>(), Arg.Any<PartitionKey>(), Arg.Any<object[]>(), cancellationToken: Arg.Any<CancellationToken>()).Returns((x) =>
+            {
+                var response = Substitute.For<StoredProcedureExecuteResponse<int>>();
+                response.Resource.Returns(1);
+                return Task.FromResult(response);
+            });
+            _container.Value.Scripts.Returns(scripts);
+
+            await Assert.ThrowsAsync<PartialDeleteSuccessException>(() => _dataStore.HardDeleteAsync(resourceKey, false, true, CancellationToken.None));
         }
 
         private void CreateResponses(int pageSize, string continuationToken, params FeedResponse<int>[] responses)

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/CosmosFhirDataStoreTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/CosmosFhirDataStoreTests.cs
@@ -300,7 +300,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Storage
             });
             _container.Value.Scripts.Returns(scripts);
 
-            await Assert.ThrowsAsync<PartialDeleteSuccessException>(() => _dataStore.HardDeleteAsync(resourceKey, false, true, CancellationToken.None));
+            await Assert.ThrowsAsync<IncompleteDeleteException>(() => _dataStore.HardDeleteAsync(resourceKey, false, true, CancellationToken.None));
         }
 
         private void CreateResponses(int pageSize, string continuationToken, params FeedResponse<int>[] responses)

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -509,7 +509,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
                 if (response.Resource > 0)
                 {
                     _logger.LogInformation("Partial success of delete operation. Deleted {NumDeleted} versions of the resource.", response.Resource);
-                    throw new PartialDeleteSuccessException(response.Resource);
+                    throw new IncompleteDeleteException(response.Resource);
                 }
             }
             catch (CosmosException exception)

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/StoredProcedures/HardDelete/HardDelete.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/StoredProcedures/HardDelete/HardDelete.cs
@@ -14,12 +14,12 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.StoredProcedures.HardD
 {
     internal class HardDelete : StoredProcedureBase
     {
-        public async Task<StoredProcedureExecuteResponse<IList<string>>> Execute(Scripts client, ResourceKey key, bool keepCurrentVersion, CancellationToken cancellationToken)
+        public async Task<StoredProcedureExecuteResponse<int>> Execute(Scripts client, ResourceKey key, bool keepCurrentVersion, bool allowPartialSuccess, CancellationToken cancellationToken)
         {
             EnsureArg.IsNotNull(client, nameof(client));
             EnsureArg.IsNotNull(key, nameof(key));
 
-            return await ExecuteStoredProc<IList<string>>(client, key.ToPartitionKey(), cancellationToken, key.ResourceType, key.Id, keepCurrentVersion);
+            return await ExecuteStoredProc<int>(client, key.ToPartitionKey(), cancellationToken, key.ResourceType, key.Id, keepCurrentVersion, allowPartialSuccess);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
@@ -386,17 +386,19 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         /// <param name="typeParameter">The type.</param>
         /// <param name="idParameter">The identifier.</param>
         /// <param name="hardDelete">A flag indicating whether to hard-delete the resource or not.</param>
+        /// <param name="allowPartialSuccess">Allows for partial success of delete operation. Only applicable for hard delete on Cosmos services</param>
         [HttpDelete]
         [ValidateIdSegmentAttribute]
         [Route(KnownRoutes.ResourceTypeById)]
         [AuditEventType(AuditEventSubType.Delete)]
-        public async Task<IActionResult> Delete(string typeParameter, string idParameter, [FromQuery] bool hardDelete)
+        public async Task<IActionResult> Delete(string typeParameter, string idParameter, [FromQuery] bool hardDelete, [FromQuery] bool allowPartialSuccess)
         {
             DeleteResourceResponse response = await _mediator.DeleteResourceAsync(
                 new DeleteResourceRequest(
                     new ResourceKey(typeParameter, idParameter),
                     hardDelete ? DeleteOperation.HardDelete : DeleteOperation.SoftDelete,
-                    GetBundleResourceContext()),
+                    GetBundleResourceContext(),
+                    allowPartialSuccess),
                 HttpContext.RequestAborted);
 
             return FhirResult.NoContent().SetETagHeader(response.WeakETag);
@@ -407,17 +409,19 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         /// </summary>
         /// <param name="typeParameter">The type.</param>
         /// <param name="idParameter">The identifier.</param>
+        /// <param name="allowPartialSuccess">Allows for partial success of delete operation. Only applicable on Cosmos services</param>
         [HttpDelete]
         [ValidateIdSegmentAttribute]
         [Route(KnownRoutes.PurgeHistoryResourceTypeById)]
         [AuditEventType(AuditEventSubType.PurgeHistory)]
-        public async Task<IActionResult> PurgeHistory(string typeParameter, string idParameter)
+        public async Task<IActionResult> PurgeHistory(string typeParameter, string idParameter, [FromQuery] bool allowPartialSuccess)
         {
             DeleteResourceResponse response = await _mediator.DeleteResourceAsync(
                 new DeleteResourceRequest(
                     new ResourceKey(typeParameter, idParameter),
                     DeleteOperation.PurgeHistory,
-                    GetBundleResourceContext()),
+                    GetBundleResourceContext(),
+                    allowPartialSuccess),
                 HttpContext.RequestAborted);
 
             return FhirResult.NoContent().SetETagHeader(response.WeakETag);

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
@@ -218,6 +218,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
                     case AuditHeaderTooLargeException _:
                         healthExceptionResult = CreateOperationOutcomeResult(microsoftHealthException.Message, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid, HttpStatusCode.RequestHeaderFieldsTooLarge);
                         break;
+                    case PartialDeleteSuccessException partialDeleteSuccessException:
+                        healthExceptionResult = CreateOperationOutcomeResult(partialDeleteSuccessException.Message, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Throttled, HttpStatusCode.TooManyRequests);
+                        break;
                     default:
                         healthExceptionResult = CreateOperationOutcomeResult(string.Empty, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Unknown, HttpStatusCode.InternalServerError);
                         break;

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
@@ -111,6 +111,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
 
                         operationOutcomeResult.StatusCode = HttpStatusCode.BadRequest;
                         break;
+                    case IncompleteDeleteException:
+                        operationOutcomeResult.StatusCode = HttpStatusCode.RequestEntityTooLarge;
+                        break;
                     case BadRequestException _:
                     case RequestNotValidException _:
                     case BundleEntryLimitExceededException _:
@@ -217,9 +220,6 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
                     case AuditHeaderCountExceededException _:
                     case AuditHeaderTooLargeException _:
                         healthExceptionResult = CreateOperationOutcomeResult(microsoftHealthException.Message, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Invalid, HttpStatusCode.RequestHeaderFieldsTooLarge);
-                        break;
-                    case PartialDeleteSuccessException partialDeleteSuccessException:
-                        healthExceptionResult = CreateOperationOutcomeResult(partialDeleteSuccessException.Message, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Throttled, HttpStatusCode.TooManyRequests);
                         break;
                     default:
                         healthExceptionResult = CreateOperationOutcomeResult(string.Empty, OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Unknown, HttpStatusCode.InternalServerError);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/ResourceHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/ResourceHandlerTests.cs
@@ -314,7 +314,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Resources
 
             ResourceKey resultKey = (await _mediator.DeleteResourceAsync(resourceKey, DeleteOperation.HardDelete)).ResourceKey;
 
-            await _fhirDataStore.Received(1).HardDeleteAsync(resourceKey, Arg.Any<bool>(), Arg.Any<CancellationToken>());
+            await _fhirDataStore.Received(1).HardDeleteAsync(resourceKey, Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
 
             Assert.NotNull(resultKey);
             Assert.Equal(resourceKey.Id, resultKey.Id);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/ResourceHandlerTests_ConditionalDelete.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/ResourceHandlerTests_ConditionalDelete.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Resources
 
             await _fhirDataStore.DidNotReceive().UpsertAsync(Arg.Any<ResourceWrapperOperation>(), Arg.Any<CancellationToken>());
 
-            await _fhirDataStore.Received().HardDeleteAsync(Arg.Any<ResourceKey>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+            await _fhirDataStore.Received().HardDeleteAsync(Arg.Any<ResourceKey>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         }
 
         [Fact]
@@ -128,7 +128,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Resources
 
             if (hardDelete)
             {
-                _fhirDataStore.HardDeleteAsync(Arg.Any<ResourceKey>(), Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+                _fhirDataStore.HardDeleteAsync(Arg.Any<ResourceKey>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
             }
             else
             {

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeletionService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeletionService.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
                     break;
                 case DeleteOperation.HardDelete:
                 case DeleteOperation.PurgeHistory:
-                    await _retryPolicy.ExecuteAsync(async () => await fhirDataStore.Value.HardDeleteAsync(key, request.DeleteOperation == DeleteOperation.PurgeHistory, cancellationToken));
+                    await _retryPolicy.ExecuteAsync(async () => await fhirDataStore.Value.HardDeleteAsync(key, request.DeleteOperation == DeleteOperation.PurgeHistory, request.AllowPartialSuccess, cancellationToken));
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(request));
@@ -280,7 +280,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
                 // This throws AggrigateExceptions
                 await Parallel.ForEachAsync(resourcesToDelete, cancellationToken, async (item, innerCt) =>
                 {
-                    await _retryPolicy.ExecuteAsync(async () => await fhirDataStore.Value.HardDeleteAsync(new ResourceKey(item.Resource.ResourceTypeName, item.Resource.ResourceId), request.DeleteOperation == DeleteOperation.PurgeHistory, innerCt));
+                    await _retryPolicy.ExecuteAsync(async () => await fhirDataStore.Value.HardDeleteAsync(new ResourceKey(item.Resource.ResourceTypeName, item.Resource.ResourceId), request.DeleteOperation == DeleteOperation.PurgeHistory, request.AllowPartialSuccess, innerCt));
                     parallelBag.Add(item.Resource.ResourceId);
                 });
             }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -611,7 +611,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             return results.Count == 0 ? null : results[0];
         }
 
-        public async Task HardDeleteAsync(ResourceKey key, bool keepCurrentVersion, CancellationToken cancellationToken)
+        public async Task HardDeleteAsync(ResourceKey key, bool keepCurrentVersion, bool allowPartialSuccess, CancellationToken cancellationToken)
         {
             await _sqlStoreClient.HardDeleteAsync(_model.GetResourceTypeId(key.ResourceType), key.Id, keepCurrentVersion, _coreFeatures.SupportsResourceChangeCapture, cancellationToken);
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/ChangeFeed/SqlServerFhirResourceChangeCaptureEnabledTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/ChangeFeed/SqlServerFhirResourceChangeCaptureEnabledTests.cs
@@ -172,7 +172,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.ChangeFeed
             var resource = await store.GetAsync(new ResourceKey("Organization", create.Id, create.VersionId), CancellationToken.None);
             Assert.NotNull(resource);
 
-            await store.HardDeleteAsync(new ResourceKey("Organization", create.Id), false, cts.Token);
+            await store.HardDeleteAsync(new ResourceKey("Organization", create.Id), false, false, cts.Token);
 
             resource = await store.GetAsync(new ResourceKey("Organization", create.Id, create.VersionId), CancellationToken.None);
             Assert.Null(resource);
@@ -204,7 +204,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.ChangeFeed
             var id = create.Id;
 
             var store = (SqlServerFhirDataStore)_fixture.DataStore;
-            await store.HardDeleteAsync(new ResourceKey("Organization", id), false, CancellationToken.None);
+            await store.HardDeleteAsync(new ResourceKey("Organization", id), false, false, CancellationToken.None);
 
             var reCreate = await _fixture.Mediator.UpsertResourceAsync(Samples.GetDefaultOrganization().UpdateId(id));
             Assert.Equal(id, reCreate.RawResourceElement.Id);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -346,8 +346,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                 _searchParameterDefinitionManager.DeleteSearchParameter(searchParam.ToTypedElement());
                 await _testHelper.DeleteSearchParameterStatusAsync(searchParam.Url, CancellationToken.None);
 
-                await _fixture.DataStore.HardDeleteAsync(sample1.Wrapper.ToResourceKey(), false, CancellationToken.None);
-                await _fixture.DataStore.HardDeleteAsync(sample2.Wrapper.ToResourceKey(), false, CancellationToken.None);
+                await _fixture.DataStore.HardDeleteAsync(sample1.Wrapper.ToResourceKey(), false, false, CancellationToken.None);
+                await _fixture.DataStore.HardDeleteAsync(sample2.Wrapper.ToResourceKey(), false, false, CancellationToken.None);
             }
         }
 
@@ -466,8 +466,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                 _searchParameterDefinitionManager.DeleteSearchParameter(searchParam.ToTypedElement());
                 await _testHelper.DeleteSearchParameterStatusAsync(searchParam.Url, CancellationToken.None);
 
-                await _fixture.DataStore.HardDeleteAsync(sample1.Wrapper.ToResourceKey(), false, CancellationToken.None);
-                await _fixture.DataStore.HardDeleteAsync(sample2.Wrapper.ToResourceKey(), false, CancellationToken.None);
+                await _fixture.DataStore.HardDeleteAsync(sample1.Wrapper.ToResourceKey(), false, false, CancellationToken.None);
+                await _fixture.DataStore.HardDeleteAsync(sample2.Wrapper.ToResourceKey(), false, false, CancellationToken.None);
             }
         }
 
@@ -547,10 +547,10 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                 _searchParameterDefinitionManager.DeleteSearchParameter(searchParam.ToTypedElement());
                 await _testHelper.DeleteSearchParameterStatusAsync(searchParam.Url, CancellationToken.None);
 
-                await _fixture.DataStore.HardDeleteAsync(sample1.Wrapper.ToResourceKey(), false, CancellationToken.None);
-                await _fixture.DataStore.HardDeleteAsync(sample2.Wrapper.ToResourceKey(), false, CancellationToken.None);
-                await _fixture.DataStore.HardDeleteAsync(sample3.Wrapper.ToResourceKey(), false, CancellationToken.None);
-                await _fixture.DataStore.HardDeleteAsync(sample4.Wrapper.ToResourceKey(), false, CancellationToken.None);
+                await _fixture.DataStore.HardDeleteAsync(sample1.Wrapper.ToResourceKey(), false, false, CancellationToken.None);
+                await _fixture.DataStore.HardDeleteAsync(sample2.Wrapper.ToResourceKey(), false, false, CancellationToken.None);
+                await _fixture.DataStore.HardDeleteAsync(sample3.Wrapper.ToResourceKey(), false, false, CancellationToken.None);
+                await _fixture.DataStore.HardDeleteAsync(sample4.Wrapper.ToResourceKey(), false, false, CancellationToken.None);
             }
         }
 
@@ -615,8 +615,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                 _searchParameterDefinitionManager.DeleteSearchParameter(searchParam.ToTypedElement());
                 await _testHelper.DeleteSearchParameterStatusAsync(searchParam.Url, CancellationToken.None);
 
-                await _fixture.DataStore.HardDeleteAsync(sample1.Wrapper.ToResourceKey(), false, CancellationToken.None);
-                await _fixture.DataStore.HardDeleteAsync(sample2.Wrapper.ToResourceKey(), false, CancellationToken.None);
+                await _fixture.DataStore.HardDeleteAsync(sample1.Wrapper.ToResourceKey(), false, false, CancellationToken.None);
+                await _fixture.DataStore.HardDeleteAsync(sample2.Wrapper.ToResourceKey(), false, false, CancellationToken.None);
             }
         }
 
@@ -704,9 +704,9 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                 _searchParameterDefinitionManager2.DeleteSearchParameter(searchParam.ToTypedElement());
                 await _testHelper.DeleteSearchParameterStatusAsync(searchParam.Url, CancellationToken.None);
 
-                await _fixture.DataStore.HardDeleteAsync(sample1.Wrapper.ToResourceKey(), false, CancellationToken.None);
-                await _fixture.DataStore.HardDeleteAsync(sample2.Wrapper.ToResourceKey(), false, CancellationToken.None);
-                await _fixture.DataStore.HardDeleteAsync(searchParamWrapper.ToResourceKey(), false, CancellationToken.None);
+                await _fixture.DataStore.HardDeleteAsync(sample1.Wrapper.ToResourceKey(), false, false, CancellationToken.None);
+                await _fixture.DataStore.HardDeleteAsync(sample2.Wrapper.ToResourceKey(), false, false, CancellationToken.None);
+                await _fixture.DataStore.HardDeleteAsync(searchParamWrapper.ToResourceKey(), false, false, CancellationToken.None);
             }
         }
 
@@ -764,7 +764,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                 _searchParameterDefinitionManager.DeleteSearchParameter(searchParam.ToTypedElement());
                 await _testHelper.DeleteSearchParameterStatusAsync(searchParam.Url, CancellationToken.None);
 
-                await _fixture.DataStore.HardDeleteAsync(searchParamWrapper.ToResourceKey(), false, CancellationToken.None);
+                await _fixture.DataStore.HardDeleteAsync(searchParamWrapper.ToResourceKey(), false, false, CancellationToken.None);
             }
         }
 
@@ -838,8 +838,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                 _searchParameterDefinitionManager.DeleteSearchParameter(searchParam.ToTypedElement());
                 await _testHelper.DeleteSearchParameterStatusAsync(searchParam.Url, CancellationToken.None);
 
-                await _fixture.DataStore.HardDeleteAsync(samplePatient.Wrapper.ToResourceKey(), false, CancellationToken.None);
-                await _fixture.DataStore.HardDeleteAsync(sampleObservation.Wrapper.ToResourceKey(), false, CancellationToken.None);
+                await _fixture.DataStore.HardDeleteAsync(samplePatient.Wrapper.ToResourceKey(), false, false, CancellationToken.None);
+                await _fixture.DataStore.HardDeleteAsync(sampleObservation.Wrapper.ToResourceKey(), false, false, CancellationToken.None);
             }
         }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexSearchTests.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
             {
                 if (testPatient != null)
                 {
-                    await _scopedDataStore.Value.HardDeleteAsync(testPatient.ToResourceKey(), false, CancellationToken.None);
+                    await _scopedDataStore.Value.HardDeleteAsync(testPatient.ToResourceKey(), false, false, CancellationToken.None);
                 }
             }
         }
@@ -110,7 +110,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
             {
                 if (testPatient != null)
                 {
-                    await _scopedDataStore.Value.HardDeleteAsync(testPatient.ToResourceKey(), false, CancellationToken.None);
+                    await _scopedDataStore.Value.HardDeleteAsync(testPatient.ToResourceKey(), false, false, CancellationToken.None);
                 }
             }
         }


### PR DESCRIPTION
## Description
If Cosmos DB runs out of RUs while performing a delete operation it will roll back the transaction. This can lead to a situation where it is impossible to delete a resource because it has too much history to delete in one pass. This PR add the ability to optionally support partial delete success. This allows for the service to delete as much of a resource as it can, and leave the rest for a later delete operation. By rerunning the delete operation eventually the resource will be deleted.

## Related issues
Addresses [AB#118312](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/118312)

## Testing
Manually tested. Working on unit tests. E2E tests aren't possible as the scenario is hard to manufacture. 

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
