### PR TITLE
Don't require work items for some PRs

### DIFF
--- a/.github/workflows/validate-prs.yml
+++ b/.github/workflows/validate-prs.yml
@@ -46,7 +46,7 @@ jobs:
 
             if(body.toLowerCase().includes('ab#') == false &&
                body.toLowerCase().includes('/_workitems') == false &&
-               !excludeAuthors.includes(author){
+               !excludeAuthors.includes(author)) {
               errors += '- FHIR Team: A DevOps workitem is required. Use AB#123 syntax or link to DevOps item. \n';
             }
 

--- a/.github/workflows/validate-prs.yml
+++ b/.github/workflows/validate-prs.yml
@@ -38,7 +38,7 @@ jobs:
             const labels = "${{env.LABELS}}";
             const author = "${{env.AUTHOR}}";
 
-            const excludeAuthors = ["dependabot", "LTA-Thinking"];
+            const excludeAuthors = ["dependabot"];
             
             if(title.toLowerCase().includes('personal') || (title.length > 65)) {
               errors += '- Title of the PR to be succinct and less than 65 characters. \n';
@@ -46,7 +46,8 @@ jobs:
 
             if(body.toLowerCase().includes('ab#') == false &&
                body.toLowerCase().includes('/_workitems') == false &&
-               !excludeAuthors.includes(author)) {
+               excludeAuthors.includes(author) == false &&
+               labels.includes("External Author") == false) {
               errors += '- FHIR Team: A DevOps workitem is required. Use AB#123 syntax or link to DevOps item. \n';
             }
 

--- a/.github/workflows/validate-prs.yml
+++ b/.github/workflows/validate-prs.yml
@@ -18,6 +18,7 @@ env:
   LABELS: ${{ join( github.event.pull_request.labels.*.name, ' ' ) }}
   TITLE: ${{ github.event.pull_request.title }}
   NO_MILESTONE: ${{ github.event.pull_request.milestone == null }}
+  AUTHOR: ${{ github.event.pull_request.user.login}}
 
 jobs:
   js-title:
@@ -35,12 +36,17 @@ jobs:
             const title = "${{env.TITLE}}";
             const body = context.payload.pull_request.body;
             const labels = "${{env.LABELS}}";
+            const author = "${{env.AUTHOR}}";
+
+            const excludeAuthors = ["dependabot", "LTA-Thinking"];
             
             if(title.toLowerCase().includes('personal') || (title.length > 65)) {
               errors += '- Title of the PR to be succinct and less than 65 characters. \n';
             }
 
-            if(body.toLowerCase().includes('ab#') == false && body.toLowerCase().includes('/_workitems') == false && !labels.includes("Dependencies") && !labels.includes("External Author")) {
+            if(body.toLowerCase().includes('ab#') == false &&
+               body.toLowerCase().includes('/_workitems') == false &&
+               !excludeAuthors.includes(author){
               errors += '- FHIR Team: A DevOps workitem is required. Use AB#123 syntax or link to DevOps item. \n';
             }
 

--- a/.github/workflows/validate-prs.yml
+++ b/.github/workflows/validate-prs.yml
@@ -40,7 +40,7 @@ jobs:
               errors += '- Title of the PR to be succinct and less than 65 characters. \n';
             }
 
-            if(body.toLowerCase().includes('ab#') == false && body.toLowerCase().includes('/_workitems') == false) {
+            if(body.toLowerCase().includes('ab#') == false && body.toLowerCase().includes('/_workitems') == false && !labels.includes("Dependencies") && !labels.includes("External Author")) {
               errors += '- FHIR Team: A DevOps workitem is required. Use AB#123 syntax or link to DevOps item. \n';
             }
 


### PR DESCRIPTION
## Description
Don't require work items for dependabot and external user PRs.

## Related issues
[AB#120349](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/120349)

## Testing
Tested on this PR's validation

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Skip (reason)
