### PR TITLE
[Do not Review] Prep work for Resource.Version change to long

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaVersion.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaVersion.cs
@@ -87,5 +87,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema
         V75 = 75,
         V76 = 76,
         V77 = 77,
+        V78 = 78,
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaVersionConstants.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaVersionConstants.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema
         public const int ExportTimeTravel = (int)SchemaVersion.V44;
         public const int Merge = (int)SchemaVersion.V50;
         public const int IncrementalImport = (int)SchemaVersion.V53;
+        public const int ResourceVersionTypeChange = (int)SchemaVersion.V78;
 
         // It is currently used in Azure Healthcare APIs.
         public const int ParameterizedRemovePartitionFromResourceChangesVersion = (int)SchemaVersion.V21;

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -807,7 +807,16 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
         {
             resourceTypeId = reader.Read(VLatest.Resource.ResourceTypeId, 0);
             resourceId = reader.Read(VLatest.Resource.ResourceId, 1);
-            version = reader.Read(VLatest.Resource.Version, 2);
+
+            if (_schemaInformation.Current >= SchemaVersionConstants.ResourceVersionTypeChange)
+            {
+                version = (int)reader.GetInt64(2);
+            }
+            else
+            {
+                version = reader.GetInt32(2);
+            }
+
             isDeleted = reader.Read(VLatest.Resource.IsDeleted, 3);
             resourceSurrogateId = reader.Read(VLatest.Resource.ResourceSurrogateId, 4);
             requestMethod = reader.Read(VLatest.Resource.RequestMethod, 5);

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             _coreFeatures = EnsureArg.IsNotNull(coreFeatures?.Value, nameof(coreFeatures));
             _bundleOrchestrator = EnsureArg.IsNotNull(bundleOrchestrator, nameof(bundleOrchestrator));
             _sqlRetryService = EnsureArg.IsNotNull(sqlRetryService, nameof(sqlRetryService));
-            _sqlStoreClient = new SqlStoreClient<SqlServerFhirDataStore>(_sqlRetryService, logger);
+            _sqlStoreClient = new SqlStoreClient<SqlServerFhirDataStore>(_sqlRetryService, schemaInformation, logger);
             _sqlConnectionWrapperFactory = EnsureArg.IsNotNull(sqlConnectionWrapperFactory, nameof(sqlConnectionWrapperFactory));
             _compressedRawResourceConverter = EnsureArg.IsNotNull(compressedRawResourceConverter, nameof(compressedRawResourceConverter));
             _logger = EnsureArg.IsNotNull(logger, nameof(logger));


### PR DESCRIPTION
## Description
This PR contains prep work that is needed to handle forward and backward compatibilities when schema is changed.

## Related issues
Addresses [issue [#](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Olympus/Stories/?workitem=117328)].

## Testing
Current PR pipeline Test cases.
Updated DB manually to version 78 and tests POST/Search/Import/Export

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
