### PR TITLE
Watchdog cleanup

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlRetry/ISqlRetryService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlRetry/ISqlRetryService.cs
@@ -16,10 +16,10 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
     {
         Task TryLogEvent(string process, string status, string text, DateTime? startDate, CancellationToken cancellationToken);
 
-        Task ExecuteSql<TLogger>(Func<SqlConnection, CancellationToken, SqlException, Task> action, ILogger<TLogger> logger, CancellationToken cancellationToken, bool isReadOnly = false);
+        Task ExecuteSql(Func<SqlConnection, CancellationToken, SqlException, Task> action, ILogger logger, CancellationToken cancellationToken, bool isReadOnly = false);
 
-        Task ExecuteSql<TLogger>(SqlCommand sqlCommand, Func<SqlCommand, CancellationToken, Task> action, ILogger<TLogger> logger, string logMessage, CancellationToken cancellationToken, bool isReadOnly = false, bool disableRetries = false);
+        Task ExecuteSql(SqlCommand sqlCommand, Func<SqlCommand, CancellationToken, Task> action, ILogger logger, string logMessage, CancellationToken cancellationToken, bool isReadOnly = false, bool disableRetries = false);
 
-        Task<IReadOnlyList<TResult>> ExecuteReaderAsync<TResult, TLogger>(SqlCommand sqlCommand, Func<SqlDataReader, TResult> readerToResult, ILogger<TLogger> logger, string logMessage, CancellationToken cancellationToken, bool isReadOnly = false);
+        Task<IReadOnlyList<TResult>> ExecuteReaderAsync<TResult>(SqlCommand sqlCommand, Func<SqlDataReader, TResult> readerToResult, ILogger logger, string logMessage, CancellationToken cancellationToken, bool isReadOnly = false);
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlRetry/SqlCommandExtensions.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlRetry/SqlCommandExtensions.cs
@@ -14,17 +14,17 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 {
     public static class SqlCommandExtensions
     {
-        public static async Task ExecuteNonQueryAsync<TLogger>(this SqlCommand cmd, ISqlRetryService retryService, ILogger<TLogger> logger, CancellationToken cancellationToken, string logMessage = null, bool isReadOnly = false, bool disableRetries = false)
+        public static async Task ExecuteNonQueryAsync(this SqlCommand cmd, ISqlRetryService retryService, ILogger logger, CancellationToken cancellationToken, string logMessage = null, bool isReadOnly = false, bool disableRetries = false)
         {
             await retryService.ExecuteSql(cmd, async (sql, cancel) => await sql.ExecuteNonQueryAsync(cancel), logger, logMessage, cancellationToken, isReadOnly, disableRetries);
         }
 
-        public static async Task<IReadOnlyList<TResult>> ExecuteReaderAsync<TResult, TLogger>(this SqlCommand cmd, ISqlRetryService retryService, Func<SqlDataReader, TResult> readerToResult, ILogger<TLogger> logger, CancellationToken cancellationToken, string logMessage = null, bool isReadOnly = false)
+        public static async Task<IReadOnlyList<TResult>> ExecuteReaderAsync<TResult>(this SqlCommand cmd, ISqlRetryService retryService, Func<SqlDataReader, TResult> readerToResult, ILogger logger, CancellationToken cancellationToken, string logMessage = null, bool isReadOnly = false)
         {
             return await retryService.ExecuteReaderAsync(cmd, readerToResult, logger, logMessage, cancellationToken, isReadOnly);
         }
 
-        public static async Task<object> ExecuteScalarAsync<TLogger>(this SqlCommand cmd, ISqlRetryService retryService, ILogger<TLogger> logger, CancellationToken cancellationToken, string logMessage = null, bool isReadOnly = false, bool disableRetries = false)
+        public static async Task<object> ExecuteScalarAsync(this SqlCommand cmd, ISqlRetryService retryService, ILogger logger, CancellationToken cancellationToken, string logMessage = null, bool isReadOnly = false, bool disableRetries = false)
         {
             object scalar = null;
             await retryService.ExecuteSql(cmd, async (sql, cancel) => { scalar = await sql.ExecuteScalarAsync(cancel); }, logger, logMessage, cancellationToken, isReadOnly, disableRetries);

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlRetry/SqlRetryService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlRetry/SqlRetryService.cs
@@ -201,14 +201,13 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
         /// Executes delegate <paramref name="action"/> and retries it's execution if retriable error is encountered error.
         /// In the case if non-retriable exception or if the last retry failed tha same exception is thrown.
         /// </summary>
-        /// <typeparam name="TLogger">Type used for the <paramref name="logger"/>. <see cref="ILogger{TCategoryName}"/></typeparam>
         /// <param name="action">Delegate to be executed.</param>
         /// <param name="logger">Logger used on first try error (or retry error) and connection open.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <param name="isReadOnly">"Flag indicating whether connection to read only replica can be used."</param>
         /// <returns>A task representing the asynchronous operation.</returns>
         /// <exception>When executing this method, if exception is thrown that is not retriable or if last retry fails, then same exception is thrown by this method.</exception>
-        public async Task ExecuteSql<TLogger>(Func<SqlConnection, CancellationToken, SqlException, Task> action, ILogger<TLogger> logger, CancellationToken cancellationToken, bool isReadOnly = false)
+        public async Task ExecuteSql(Func<SqlConnection, CancellationToken, SqlException, Task> action, ILogger logger, CancellationToken cancellationToken, bool isReadOnly = false)
         {
             EnsureArg.IsNotNull(action, nameof(action));
 
@@ -247,7 +246,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
         /// and retries entire process on SQL error or failed SQL connection error. In the case if non-retriable exception or if the last retry failed
         /// tha same exception is thrown.
         /// </summary>
-        /// <typeparam name="TLogger">Type used for the <paramref name="logger"/>. <see cref="ILogger{TCategoryName}"/></typeparam>
         /// <param name="sqlCommand">SQL command to be executed.</param>
         /// <param name="action">Delegate to be executed by passing <paramref name="sqlCommand"/> as input parameter.</param>
         /// <param name="logger">Logger used on first try error (or retry error) and connection open.</param>
@@ -257,7 +255,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
         /// <param name="disableRetries">"Flag indicating whether retries are disabled."</param>
         /// <returns>A task representing the asynchronous operation.</returns>
         /// <exception>When executing this method, if exception is thrown that is not retriable or if last retry fails, then same exception is thrown by this method.</exception>
-        public async Task ExecuteSql<TLogger>(SqlCommand sqlCommand, Func<SqlCommand, CancellationToken, Task> action, ILogger<TLogger> logger, string logMessage, CancellationToken cancellationToken, bool isReadOnly = false, bool disableRetries = false)
+        public async Task ExecuteSql(SqlCommand sqlCommand, Func<SqlCommand, CancellationToken, Task> action, ILogger logger, string logMessage, CancellationToken cancellationToken, bool isReadOnly = false, bool disableRetries = false)
         {
             EnsureArg.IsNotNull(sqlCommand, nameof(sqlCommand));
             EnsureArg.IsNotNull(action, nameof(action));
@@ -309,7 +307,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             }
         }
 
-        private async Task<IReadOnlyList<TResult>> ExecuteSqlDataReaderAsync<TResult, TLogger>(SqlCommand sqlCommand, Func<SqlDataReader, TResult> readerToResult, ILogger<TLogger> logger, string logMessage, bool allRows, bool isReadOnly, CancellationToken cancellationToken)
+        private async Task<IReadOnlyList<TResult>> ExecuteSqlDataReaderAsync<TResult>(SqlCommand sqlCommand, Func<SqlDataReader, TResult> readerToResult, ILogger logger, string logMessage, bool allRows, bool isReadOnly, CancellationToken cancellationToken)
         {
             EnsureArg.IsNotNull(sqlCommand, nameof(sqlCommand));
             EnsureArg.IsNotNull(readerToResult, nameof(readerToResult));
@@ -345,7 +343,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
         /// SQL connection error. In the case if non-retriable exception or if the last retry failed tha same exception is thrown.
         /// </summary>
         /// <typeparam name="TResult">Defines data type for the returned SQL rows.</typeparam>
-        /// <typeparam name="TLogger">Type used for the <paramref name="logger"/>. <see cref="ILogger{TCategoryName}"/></typeparam>
         /// <param name="sqlCommand">SQL command to be executed.</param>
         /// <param name="readerToResult">Translation delegate that translates the row returned by <paramref name="sqlCommand"/> execution into the <typeparamref name="TResult"/> data type.</param>
         /// <param name="logger">Logger used on first try error or retry error.</param>
@@ -355,7 +352,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
         /// <returns>A task representing the asynchronous operation that returns all the rows that result from <paramref name="sqlCommand"/> execution. The rows are translated by <paramref name="readerToResult"/> delegate
         /// into <typeparamref name="TResult"/> data type.</returns>
         /// <exception>When executing this method, if exception is thrown that is not retriable or if last retry fails, then same exception is thrown by this method.</exception>
-        public async Task<IReadOnlyList<TResult>> ExecuteReaderAsync<TResult, TLogger>(SqlCommand sqlCommand, Func<SqlDataReader, TResult> readerToResult, ILogger<TLogger> logger, string logMessage, CancellationToken cancellationToken, bool isReadOnly = false)
+        public async Task<IReadOnlyList<TResult>> ExecuteReaderAsync<TResult>(SqlCommand sqlCommand, Func<SqlDataReader, TResult> readerToResult, ILogger logger, string logMessage, CancellationToken cancellationToken, bool isReadOnly = false)
         {
             return await ExecuteSqlDataReaderAsync(sqlCommand, readerToResult, logger, logMessage, true, isReadOnly, cancellationToken);
         }
@@ -372,7 +369,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
         {
             try
             {
-                using var cmd = new SqlCommand() { CommandType = CommandType.StoredProcedure, CommandText = "dbo.LogEvent" };
+                await using var cmd = new SqlCommand { CommandType = CommandType.StoredProcedure, CommandText = "dbo.LogEvent" };
                 cmd.Parameters.AddWithValue("@Process", process);
                 cmd.Parameters.AddWithValue("@Status", status);
                 cmd.Parameters.AddWithValue("@Text", text);
@@ -438,7 +435,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             {
             }
 
-            public async Task<SqlConnection> GetConnection<TLogger>(ISqlConnectionBuilder sqlConnectionBuilder, bool isReadOnly, ILogger<TLogger> logger, CancellationToken cancel)
+            public async Task<SqlConnection> GetConnection(ISqlConnectionBuilder sqlConnectionBuilder, bool isReadOnly, ILogger logger, CancellationToken cancel)
             {
                 SqlConnection conn;
                 var sw = Stopwatch.StartNew();

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
         private readonly IBundleOrchestrator _bundleOrchestrator;
         private readonly CoreFeatureConfiguration _coreFeatures;
         private readonly ISqlRetryService _sqlRetryService;
-        private readonly SqlStoreClient<SqlServerFhirDataStore> _sqlStoreClient;
+        private readonly SqlStoreClient _sqlStoreClient;
         private readonly SqlConnectionWrapperFactory _sqlConnectionWrapperFactory;
         private readonly ICompressedRawResourceConverter _compressedRawResourceConverter;
         private readonly ILogger<SqlServerFhirDataStore> _logger;
@@ -76,14 +76,15 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             SchemaInformation schemaInformation,
             IModelInfoProvider modelInfoProvider,
             RequestContextAccessor<IFhirRequestContext> requestContextAccessor,
-            IImportErrorSerializer importErrorSerializer)
+            IImportErrorSerializer importErrorSerializer,
+            SqlStoreClient storeClient)
         {
             _model = EnsureArg.IsNotNull(model, nameof(model));
             _searchParameterTypeMap = EnsureArg.IsNotNull(searchParameterTypeMap, nameof(searchParameterTypeMap));
             _coreFeatures = EnsureArg.IsNotNull(coreFeatures?.Value, nameof(coreFeatures));
             _bundleOrchestrator = EnsureArg.IsNotNull(bundleOrchestrator, nameof(bundleOrchestrator));
             _sqlRetryService = EnsureArg.IsNotNull(sqlRetryService, nameof(sqlRetryService));
-            _sqlStoreClient = new SqlStoreClient<SqlServerFhirDataStore>(_sqlRetryService, logger);
+            _sqlStoreClient = EnsureArg.IsNotNull(storeClient, nameof(storeClient));
             _sqlConnectionWrapperFactory = EnsureArg.IsNotNull(sqlConnectionWrapperFactory, nameof(sqlConnectionWrapperFactory));
             _compressedRawResourceConverter = EnsureArg.IsNotNull(compressedRawResourceConverter, nameof(compressedRawResourceConverter));
             _logger = EnsureArg.IsNotNull(logger, nameof(logger));
@@ -119,7 +120,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             }
         }
 
-        internal SqlStoreClient<SqlServerFhirDataStore> StoreClient => _sqlStoreClient;
+        internal SqlStoreClient StoreClient => _sqlStoreClient;
 
         internal static TimeSpan MergeResourcesTransactionHeartbeatPeriod => TimeSpan.FromSeconds(10);
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlStoreClient.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlStoreClient.cs
@@ -25,14 +25,13 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
     /// <summary>
     /// Lightweight SQL store client.
     /// </summary>
-    /// <typeparam name="T">class used in logger</typeparam>
-    internal class SqlStoreClient<T>
+    internal class SqlStoreClient
     {
         private readonly ISqlRetryService _sqlRetryService;
-        private readonly ILogger<T> _logger;
+        private readonly ILogger _logger;
         private const string _invisibleResource = " ";
 
-        public SqlStoreClient(ISqlRetryService sqlRetryService, ILogger<T> logger)
+        public SqlStoreClient(ISqlRetryService sqlRetryService, ILogger<SqlStoreClient> logger)
         {
             _sqlRetryService = EnsureArg.IsNotNull(sqlRetryService, nameof(sqlRetryService));
             _logger = EnsureArg.IsNotNull(logger, nameof(logger));
@@ -147,7 +146,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
         internal async Task<IReadOnlyList<ResourceWrapper>> GetResourcesByTransactionIdAsync(long transactionId, Func<MemoryStream, string> decompress, Func<short, string> getResourceTypeName, CancellationToken cancellationToken)
         {
-            using var cmd = new SqlCommand() { CommandText = "dbo.GetResourcesByTransactionId", CommandType = CommandType.StoredProcedure, CommandTimeout = 600 };
+            await using var cmd = new SqlCommand() { CommandText = "dbo.GetResourcesByTransactionId", CommandType = CommandType.StoredProcedure, CommandTimeout = 600 };
             cmd.Parameters.AddWithValue("@TransactionId", transactionId);
             //// ignore invisible resources
             return (await cmd.ExecuteReaderAsync(_sqlRetryService, (reader) => { return ReadResourceWrapper(reader, true, decompress, getResourceTypeName); }, _logger, cancellationToken)).Where(_ => _.RawResource.Data != _invisibleResource).ToList();
@@ -187,7 +186,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
         {
             try
             {
-                using var cmd = new SqlCommand() { CommandText = "dbo.MergeResourcesPutTransactionHeartbeat", CommandType = CommandType.StoredProcedure, CommandTimeout = (heartbeatPeriod.Seconds / 3) + 1 }; // +1 to avoid = SQL default timeout value
+                await using var cmd = new SqlCommand() { CommandText = "dbo.MergeResourcesPutTransactionHeartbeat", CommandType = CommandType.StoredProcedure, CommandTimeout = (heartbeatPeriod.Seconds / 3) + 1 }; // +1 to avoid = SQL default timeout value
                 cmd.Parameters.AddWithValue("@TransactionId", transactionId);
                 await cmd.ExecuteNonQueryAsync(_sqlRetryService, _logger, cancellationToken);
             }
@@ -210,7 +209,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
         internal async Task<long> MergeResourcesGetTransactionVisibilityAsync(CancellationToken cancellationToken)
         {
-            using var cmd = new SqlCommand() { CommandText = "dbo.MergeResourcesGetTransactionVisibility", CommandType = CommandType.StoredProcedure };
+            await using var cmd = new SqlCommand() { CommandText = "dbo.MergeResourcesGetTransactionVisibility", CommandType = CommandType.StoredProcedure };
             var transactionIdParam = new SqlParameter("@TransactionId", SqlDbType.BigInt) { Direction = ParameterDirection.Output };
             cmd.Parameters.Add(transactionIdParam);
             await cmd.ExecuteNonQueryAsync(_sqlRetryService, _logger, cancellationToken);
@@ -219,7 +218,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
         internal async Task<(long TransactionId, int Sequence)> MergeResourcesBeginTransactionAsync(int resourceVersionCount, CancellationToken cancellationToken, DateTime? heartbeatDate = null)
         {
-            using var cmd = new SqlCommand() { CommandText = "dbo.MergeResourcesBeginTransaction", CommandType = CommandType.StoredProcedure };
+            await using var cmd = new SqlCommand() { CommandText = "dbo.MergeResourcesBeginTransaction", CommandType = CommandType.StoredProcedure };
             cmd.Parameters.AddWithValue("@Count", resourceVersionCount);
             var transactionIdParam = new SqlParameter("@TransactionId", SqlDbType.BigInt) { Direction = ParameterDirection.Output };
             cmd.Parameters.Add(transactionIdParam);
@@ -259,7 +258,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
         internal async Task<int> MergeResourcesDeleteInvisibleHistory(long transactionId, CancellationToken cancellationToken)
         {
-            using var cmd = new SqlCommand() { CommandText = "dbo.MergeResourcesDeleteInvisibleHistory", CommandType = CommandType.StoredProcedure };
+            await using var cmd = new SqlCommand() { CommandText = "dbo.MergeResourcesDeleteInvisibleHistory", CommandType = CommandType.StoredProcedure };
             cmd.Parameters.AddWithValue("@TransactionId", transactionId);
             var affectedRowsParam = new SqlParameter("@affectedRows", SqlDbType.Int) { Direction = ParameterDirection.Output };
             cmd.Parameters.Add(affectedRowsParam);
@@ -269,7 +268,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
         internal async Task MergeResourcesCommitTransactionAsync(long transactionId, string failureReason, CancellationToken cancellationToken)
         {
-            using var cmd = new SqlCommand() { CommandText = "dbo.MergeResourcesCommitTransaction", CommandType = CommandType.StoredProcedure };
+            await using var cmd = new SqlCommand() { CommandText = "dbo.MergeResourcesCommitTransaction", CommandType = CommandType.StoredProcedure };
             cmd.Parameters.AddWithValue("@TransactionId", transactionId);
             if (failureReason != null)
             {
@@ -281,14 +280,14 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
         internal async Task MergeResourcesPutTransactionInvisibleHistoryAsync(long transactionId, CancellationToken cancellationToken)
         {
-            using var cmd = new SqlCommand() { CommandText = "dbo.MergeResourcesPutTransactionInvisibleHistory", CommandType = CommandType.StoredProcedure };
+            await using var cmd = new SqlCommand() { CommandText = "dbo.MergeResourcesPutTransactionInvisibleHistory", CommandType = CommandType.StoredProcedure };
             cmd.Parameters.AddWithValue("@TransactionId", transactionId);
             await cmd.ExecuteNonQueryAsync(_sqlRetryService, _logger, cancellationToken);
         }
 
         internal async Task<int> MergeResourcesAdvanceTransactionVisibilityAsync(CancellationToken cancellationToken)
         {
-            using var cmd = new SqlCommand() { CommandText = "dbo.MergeResourcesAdvanceTransactionVisibility", CommandType = CommandType.StoredProcedure };
+            await using var cmd = new SqlCommand { CommandText = "dbo.MergeResourcesAdvanceTransactionVisibility", CommandType = CommandType.StoredProcedure };
             var affectedRowsParam = new SqlParameter("@AffectedRows", SqlDbType.Int) { Direction = ParameterDirection.Output };
             cmd.Parameters.Add(affectedRowsParam);
             await cmd.ExecuteNonQueryAsync(_sqlRetryService, _logger, cancellationToken);
@@ -298,14 +297,14 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
         internal async Task<IReadOnlyList<long>> MergeResourcesGetTimeoutTransactionsAsync(int timeoutSec, CancellationToken cancellationToken)
         {
-            using var cmd = new SqlCommand() { CommandText = "dbo.MergeResourcesGetTimeoutTransactions", CommandType = CommandType.StoredProcedure };
+            await using var cmd = new SqlCommand { CommandText = "dbo.MergeResourcesGetTimeoutTransactions", CommandType = CommandType.StoredProcedure };
             cmd.Parameters.AddWithValue("@TimeoutSec", timeoutSec);
-            return await cmd.ExecuteReaderAsync(_sqlRetryService, (reader) => { return reader.GetInt64(0); }, _logger, cancellationToken);
+            return await cmd.ExecuteReaderAsync(_sqlRetryService, reader => reader.GetInt64(0), _logger, cancellationToken);
         }
 
         internal async Task<IReadOnlyList<(long TransactionId, DateTime? VisibleDate, DateTime? InvisibleHistoryRemovedDate)>> GetTransactionsAsync(long startNotInclusiveTranId, long endInclusiveTranId, CancellationToken cancellationToken, DateTime? endDate = null)
         {
-            using var cmd = new SqlCommand() { CommandText = "dbo.GetTransactions", CommandType = CommandType.StoredProcedure };
+            await using var cmd = new SqlCommand { CommandText = "dbo.GetTransactions", CommandType = CommandType.StoredProcedure };
             cmd.Parameters.AddWithValue("@StartNotInclusiveTranId", startNotInclusiveTranId);
             cmd.Parameters.AddWithValue("@EndInclusiveTranId", endInclusiveTranId);
             if (endDate.HasValue)
@@ -327,7 +326,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
         internal async Task<IReadOnlyList<ResourceDateKey>> GetResourceDateKeysByTransactionIdAsync(long transactionId, CancellationToken cancellationToken)
         {
-            using var cmd = new SqlCommand() { CommandText = "dbo.GetResourcesByTransactionId", CommandType = CommandType.StoredProcedure, CommandTimeout = 600 };
+            await using var cmd = new SqlCommand { CommandText = "dbo.GetResourcesByTransactionId", CommandType = CommandType.StoredProcedure, CommandTimeout = 600 };
             cmd.Parameters.AddWithValue("@TransactionId", transactionId);
             cmd.Parameters.AddWithValue("@IncludeHistory", true);
             cmd.Parameters.AddWithValue("@ReturnResourceKeysOnly", true);

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Watchdogs/InvisibleHistoryCleanupWatchdog.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Watchdogs/InvisibleHistoryCleanupWatchdog.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,15 +15,13 @@ using Microsoft.Health.Fhir.SqlServer.Features.Storage;
 
 namespace Microsoft.Health.Fhir.SqlServer.Features.Watchdogs
 {
-    internal class InvisibleHistoryCleanupWatchdog : Watchdog<InvisibleHistoryCleanupWatchdog>
+    internal sealed class InvisibleHistoryCleanupWatchdog : Watchdog<InvisibleHistoryCleanupWatchdog>
     {
-        private readonly SqlStoreClient<InvisibleHistoryCleanupWatchdog> _store;
+        private readonly SqlStoreClient _store;
         private readonly ILogger<InvisibleHistoryCleanupWatchdog> _logger;
         private readonly ISqlRetryService _sqlRetryService;
-        private CancellationToken _cancellationToken;
-        private double _retentionPeriodDays = 7;
 
-        public InvisibleHistoryCleanupWatchdog(SqlStoreClient<InvisibleHistoryCleanupWatchdog> store, ISqlRetryService sqlRetryService, ILogger<InvisibleHistoryCleanupWatchdog> logger)
+        public InvisibleHistoryCleanupWatchdog(SqlStoreClient store, ISqlRetryService sqlRetryService, ILogger<InvisibleHistoryCleanupWatchdog> logger)
             : base(sqlRetryService, logger)
         {
             _sqlRetryService = EnsureArg.IsNotNull(sqlRetryService, nameof(sqlRetryService));
@@ -31,48 +30,47 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Watchdogs
         }
 
         internal InvisibleHistoryCleanupWatchdog()
-            : base()
         {
             // this is used to get param names for testing
         }
 
-        internal string LastCleanedUpTransactionId => $"{Name}.LastCleanedUpTransactionId";
+        public string LastCleanedUpTransactionId => $"{Name}.LastCleanedUpTransactionId";
 
-        internal async Task StartAsync(CancellationToken cancellationToken, double? periodSec = null, double? leasePeriodSec = null, double? retentionPeriodDays = null)
-        {
-            _cancellationToken = cancellationToken;
-            await InitLastCleanedUpTransactionId();
-            await StartAsync(true, periodSec ?? 3600, leasePeriodSec ?? 2 * 3600, cancellationToken);
-            if (retentionPeriodDays.HasValue)
-            {
-                _retentionPeriodDays = retentionPeriodDays.Value;
-            }
-        }
+        public override double LeasePeriodSec { get; internal set; } = 2 * 3600;
 
-        protected override async Task ExecuteAsync()
+        public override bool AllowRebalance { get; internal set; } = true;
+
+        public override double PeriodSec { get; internal set; } = 3600;
+
+        public double RetentionPeriodDays { get; internal set; } = 7;
+
+        protected override async Task RunWorkAsync(CancellationToken cancellationToken)
         {
             _logger.LogInformation($"{Name}: starting...");
-            var lastTranId = await GetLastCleanedUpTransactionId();
-            var visibility = await _store.MergeResourcesGetTransactionVisibilityAsync(_cancellationToken);
+            var lastTranId = await GetLastCleanedUpTransactionIdAsync(cancellationToken);
+            var visibility = await _store.MergeResourcesGetTransactionVisibilityAsync(cancellationToken);
             _logger.LogInformation($"{Name}: last cleaned up transaction={lastTranId} visibility={visibility}.");
 
-            var transToClean = await _store.GetTransactionsAsync(lastTranId, visibility, _cancellationToken, DateTime.UtcNow.AddDays((-1) * _retentionPeriodDays));
+            IReadOnlyList<(long TransactionId, DateTime? VisibleDate, DateTime? InvisibleHistoryRemovedDate)> transToClean =
+                await _store.GetTransactionsAsync(lastTranId, visibility, cancellationToken, DateTime.UtcNow.AddDays(-1 * RetentionPeriodDays));
+
             _logger.LogInformation($"{Name}: found transactions={transToClean.Count}.");
 
             if (transToClean.Count == 0)
             {
-                _logger.LogInformation($"{Name}: completed. transactions=0.");
+                _logger.LogDebug($"{Name}: completed. transactions=0.");
                 return;
             }
 
             var totalRows = 0;
-            foreach (var tran in transToClean.Where(_ => !_.InvisibleHistoryRemovedDate.HasValue).OrderBy(_ => _.TransactionId))
+            foreach ((long TransactionId, DateTime? VisibleDate, DateTime? InvisibleHistoryRemovedDate) tran in
+                     transToClean.Where(x => !x.InvisibleHistoryRemovedDate.HasValue).OrderBy(x => x.TransactionId))
             {
-                var rows = await _store.MergeResourcesDeleteInvisibleHistory(tran.TransactionId, _cancellationToken);
+                var rows = await _store.MergeResourcesDeleteInvisibleHistory(tran.TransactionId, cancellationToken);
                 _logger.LogInformation($"{Name}: transaction={tran.TransactionId} removed rows={rows}.");
                 totalRows += rows;
 
-                await _store.MergeResourcesPutTransactionInvisibleHistoryAsync(tran.TransactionId, _cancellationToken);
+                await _store.MergeResourcesPutTransactionInvisibleHistoryAsync(tran.TransactionId, cancellationToken);
             }
 
             await UpdateLastCleanedUpTransactionId(transToClean.Max(_ => _.TransactionId));
@@ -80,21 +78,21 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Watchdogs
             _logger.LogInformation($"{Name}: completed. transactions={transToClean.Count} removed rows={totalRows}");
         }
 
-        private async Task<long> GetLastCleanedUpTransactionId()
+        private async Task<long> GetLastCleanedUpTransactionIdAsync(CancellationToken cancellationToken)
         {
-            return await GetLongParameterByIdAsync(LastCleanedUpTransactionId, _cancellationToken);
+            return await GetLongParameterByIdAsync(LastCleanedUpTransactionId, cancellationToken);
         }
 
-        private async Task InitLastCleanedUpTransactionId()
+        protected override async Task InitAdditionalParamsAsync()
         {
-            using var cmd = new SqlCommand("INSERT INTO dbo.Parameters (Id, Bigint) SELECT @Id, 5105975696064002770"); // surrogate id for the past. does not matter.
+            await using var cmd = new SqlCommand("INSERT INTO dbo.Parameters (Id, Bigint) SELECT @Id, 5105975696064002770"); // surrogate id for the past. does not matter.
             cmd.Parameters.AddWithValue("@Id", LastCleanedUpTransactionId);
             await cmd.ExecuteNonQueryAsync(_sqlRetryService, _logger, CancellationToken.None);
         }
 
         private async Task UpdateLastCleanedUpTransactionId(long lastTranId)
         {
-            using var cmd = new SqlCommand("UPDATE dbo.Parameters SET Bigint = @LastTranId WHERE Id = @Id");
+            await using var cmd = new SqlCommand("UPDATE dbo.Parameters SET Bigint = @LastTranId WHERE Id = @Id");
             cmd.Parameters.AddWithValue("@Id", LastCleanedUpTransactionId);
             cmd.Parameters.AddWithValue("@LastTranId", lastTranId);
             await cmd.ExecuteNonQueryAsync(_sqlRetryService, _logger, CancellationToken.None);

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Watchdogs/Watchdog.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Watchdogs/Watchdog.cs
@@ -10,25 +10,27 @@ using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
+using Microsoft.Health.Core;
 using Microsoft.Health.Fhir.SqlServer.Features.Storage;
 
 namespace Microsoft.Health.Fhir.SqlServer.Features.Watchdogs
 {
-    public abstract class Watchdog<T> : FhirTimer<T>
+    internal abstract class Watchdog<T>
+        where T : Watchdog<T>
     {
-        private ISqlRetryService _sqlRetryService;
+        private readonly ISqlRetryService _sqlRetryService;
         private readonly ILogger<T> _logger;
         private readonly WatchdogLease<T> _watchdogLease;
-        private bool _disposed = false;
         private double _periodSec;
         private double _leasePeriodSec;
+        private readonly FhirTimer _fhirTimer;
 
         protected Watchdog(ISqlRetryService sqlRetryService, ILogger<T> logger)
-            : base(logger)
         {
             _sqlRetryService = EnsureArg.IsNotNull(sqlRetryService, nameof(sqlRetryService));
             _logger = EnsureArg.IsNotNull(logger, nameof(logger));
             _watchdogLease = new WatchdogLease<T>(_sqlRetryService, _logger);
+            _fhirTimer = new FhirTimer(_logger);
         }
 
         protected Watchdog()
@@ -36,63 +38,83 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Watchdogs
             // this is used to get param names for testing
         }
 
-        internal string Name => GetType().Name;
+        public string Name => GetType().Name;
 
-        internal string PeriodSecId => $"{Name}.PeriodSec";
+        public string PeriodSecId => $"{Name}.PeriodSec";
 
-        internal string LeasePeriodSecId => $"{Name}.LeasePeriodSec";
+        public string LeasePeriodSecId => $"{Name}.LeasePeriodSec";
 
-        internal bool IsLeaseHolder => _watchdogLease.IsLeaseHolder;
+        public bool IsLeaseHolder => _watchdogLease.IsLeaseHolder;
 
-        internal string LeaseWorker => _watchdogLease.Worker;
+        public string LeaseWorker => _watchdogLease.Worker;
 
-        internal double LeasePeriodSec => _watchdogLease.PeriodSec;
+        public abstract double LeasePeriodSec { get; internal set; }
 
-        protected internal async Task StartAsync(bool allowRebalance, double periodSec, double leasePeriodSec, CancellationToken cancellationToken)
+        public abstract bool AllowRebalance { get; internal set; }
+
+        public abstract double PeriodSec { get; internal set; }
+
+        public bool IsInitialized { get; private set; }
+
+        public async Task ExecuteAsync(CancellationToken cancellationToken)
         {
-            _logger.LogInformation($"{Name}.StartAsync: starting...");
-            await InitParamsAsync(periodSec, leasePeriodSec);
-            await StartAsync(_periodSec, cancellationToken);
-            await _watchdogLease.StartAsync(allowRebalance, _leasePeriodSec, cancellationToken);
-            _logger.LogInformation($"{Name}.StartAsync: completed.");
+            _logger.LogInformation($"{Name}.ExecuteAsync: starting...");
+
+            await InitParamsAsync(PeriodSec, LeasePeriodSec);
+
+            await Task.WhenAll(
+                _fhirTimer.ExecuteAsync(_periodSec, OnNextTickAsync, cancellationToken),
+                _watchdogLease.ExecuteAsync(AllowRebalance, _leasePeriodSec, cancellationToken));
+
+            _logger.LogInformation($"{Name}.ExecuteAsync: completed.");
         }
 
-        protected abstract Task ExecuteAsync();
+        protected abstract Task RunWorkAsync(CancellationToken cancellationToken);
 
-        protected override async Task RunAsync()
+        private async Task OnNextTickAsync(CancellationToken cancellationToken)
         {
             if (!_watchdogLease.IsLeaseHolder)
             {
-                _logger.LogInformation($"{Name}.RunAsync: Skipping because watchdog is not a lease holder.");
+                _logger.LogDebug($"{Name}.OnNextTickAsync: Skipping because watchdog is not a lease holder.");
                 return;
             }
 
-            _logger.LogInformation($"{Name}.RunAsync: Starting...");
-            await ExecuteAsync();
-            _logger.LogInformation($"{Name}.RunAsync: Completed.");
+            using (_logger.BeginTimedScope($"{Name}.OnNextTickAsync"))
+            {
+                await RunWorkAsync(cancellationToken);
+            }
         }
 
         private async Task InitParamsAsync(double periodSec, double leasePeriodSec) // No CancellationToken is passed since we shouldn't cancel initialization.
         {
-            _logger.LogInformation($"{Name}.InitParamsAsync: starting...");
+            using (_logger.BeginTimedScope($"{Name}.InitParamsAsync"))
+            {
+                // Offset for other instances running init
+                await Task.Delay(TimeSpan.FromSeconds(RandomNumberGenerator.GetInt32(10) / 10.0), CancellationToken.None);
 
-            // Offset for other instances running init
-            await Task.Delay(TimeSpan.FromSeconds(RandomNumberGenerator.GetInt32(10) / 10.0), CancellationToken.None);
-
-            using var cmd = new SqlCommand(@"
+                await using var cmd = new SqlCommand(
+                    @"
 INSERT INTO dbo.Parameters (Id,Number) SELECT @PeriodSecId, @PeriodSec
 INSERT INTO dbo.Parameters (Id,Number) SELECT @LeasePeriodSecId, @LeasePeriodSec
             ");
-            cmd.Parameters.AddWithValue("@PeriodSecId", PeriodSecId);
-            cmd.Parameters.AddWithValue("@PeriodSec", periodSec);
-            cmd.Parameters.AddWithValue("@LeasePeriodSecId", LeasePeriodSecId);
-            cmd.Parameters.AddWithValue("@LeasePeriodSec", leasePeriodSec);
-            await cmd.ExecuteNonQueryAsync(_sqlRetryService, _logger, CancellationToken.None);
+                cmd.Parameters.AddWithValue("@PeriodSecId", PeriodSecId);
+                cmd.Parameters.AddWithValue("@PeriodSec", periodSec);
+                cmd.Parameters.AddWithValue("@LeasePeriodSecId", LeasePeriodSecId);
+                cmd.Parameters.AddWithValue("@LeasePeriodSec", leasePeriodSec);
+                await cmd.ExecuteNonQueryAsync(_sqlRetryService, _logger, CancellationToken.None);
 
-            _periodSec = await GetPeriodAsync(CancellationToken.None);
-            _leasePeriodSec = await GetLeasePeriodAsync(CancellationToken.None);
+                _periodSec = await GetPeriodAsync(CancellationToken.None);
+                _leasePeriodSec = await GetLeasePeriodAsync(CancellationToken.None);
 
-            _logger.LogInformation($"{Name}.InitParamsAsync: completed.");
+                await InitAdditionalParamsAsync();
+
+                IsInitialized = true;
+            }
+        }
+
+        protected virtual Task InitAdditionalParamsAsync()
+        {
+            return Task.CompletedTask;
         }
 
         private async Task<double> GetPeriodAsync(CancellationToken cancellationToken)
@@ -111,7 +133,7 @@ INSERT INTO dbo.Parameters (Id,Number) SELECT @LeasePeriodSecId, @LeasePeriodSec
         {
             EnsureArg.IsNotNullOrEmpty(id, nameof(id));
 
-            using var cmd = new SqlCommand("SELECT Number FROM dbo.Parameters WHERE Id = @Id");
+            await using var cmd = new SqlCommand("SELECT Number FROM dbo.Parameters WHERE Id = @Id");
             cmd.Parameters.AddWithValue("@Id", id);
             var value = await cmd.ExecuteScalarAsync(_sqlRetryService, _logger, cancellationToken);
 
@@ -127,7 +149,7 @@ INSERT INTO dbo.Parameters (Id,Number) SELECT @LeasePeriodSecId, @LeasePeriodSec
         {
             EnsureArg.IsNotNullOrEmpty(id, nameof(id));
 
-            using var cmd = new SqlCommand("SELECT Bigint FROM dbo.Parameters WHERE Id = @Id");
+            await using var cmd = new SqlCommand("SELECT Bigint FROM dbo.Parameters WHERE Id = @Id");
             cmd.Parameters.AddWithValue("@Id", id);
             var value = await cmd.ExecuteScalarAsync(_sqlRetryService, _logger, cancellationToken);
 
@@ -137,28 +159,6 @@ INSERT INTO dbo.Parameters (Id,Number) SELECT @LeasePeriodSecId, @LeasePeriodSec
             }
 
             return (long)value;
-        }
-
-        public new void Dispose()
-        {
-            Dispose(true);
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            if (_disposed)
-            {
-                return;
-            }
-
-            if (disposing)
-            {
-                _watchdogLease?.Dispose();
-            }
-
-            base.Dispose(disposing);
-
-            _disposed = true;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Registration/FhirServerBuilderSqlServerRegistrationExtensions.cs
@@ -162,7 +162,9 @@ namespace Microsoft.Extensions.DependencyInjection
                             .Singleton()
                             .AsSelf();
 
-            services.Add<SqlStoreClient<InvisibleHistoryCleanupWatchdog>>().Singleton().AsSelf();
+            services.Add<SqlStoreClient>()
+                .Singleton()
+                .AsSelf();
 
             services.Add<DefragWatchdog>().Singleton().AsSelf();
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTestsFixture.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading;
 using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
@@ -160,7 +161,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             medicationResource.Versioning = CapabilityStatement.ResourceVersionPolicy.VersionedUpdate;
 
             ConformanceProvider = Substitute.For<ConformanceProviderBase>();
-            ConformanceProvider.GetCapabilityStatementOnStartup().Returns(CapabilityStatement.ToTypedElement().ToResourceElement());
+            ConformanceProvider.GetCapabilityStatementOnStartup(Arg.Any<CancellationToken>()).Returns(CapabilityStatement.ToTypedElement().ToResourceElement());
 
             // TODO: FhirRepository instantiate ResourceDeserializer class directly
             // which will try to deserialize the raw resource. We should mock it as well.

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlRetryServiceTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlRetryServiceTests.cs
@@ -380,7 +380,7 @@ END
 
                 using var sqlCommand = new SqlCommand();
                 sqlCommand.CommandText = $"dbo.{storedProcedureName}";
-                var result = await sqlRetryService.ExecuteReaderAsync<long, SqlRetryService>(
+                var result = await sqlRetryService.ExecuteReaderAsync<long>(
                     sqlCommand,
                     testConnectionInitializationFailure ? ReaderToResult : ReaderToResultAndKillConnection,
                     logger,
@@ -420,7 +420,7 @@ END
                 try
                 {
                     _output.WriteLine($"{DateTime.Now:O}: Start executing ExecuteSqlDataReader.");
-                    await sqlRetryService.ExecuteReaderAsync<long, SqlRetryService>(
+                    await sqlRetryService.ExecuteReaderAsync<long>(
                         sqlCommand,
                         testConnectionInitializationFailure ? ReaderToResult : ReaderToResultAndKillConnection,
                         logger,

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -244,7 +244,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 SchemaInformation,
                 ModelInfoProvider.Instance,
                 _fhirRequestContextAccessor,
-                importErrorSerializer);
+                importErrorSerializer,
+                new SqlStoreClient(SqlRetryService, NullLogger<SqlStoreClient>.Instance));
 
             _fhirOperationDataStore = new SqlServerFhirOperationDataStore(SqlConnectionWrapperFactory, queueClient, NullLogger<SqlServerFhirOperationDataStore>.Instance, NullLoggerFactory.Instance);
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerWatchdogTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerWatchdogTests.cs
@@ -89,12 +89,12 @@ EXECUTE dbo.LogEvent @Process='Build',@Status='Warn',@Mode='',@Target='DefragTes
             using var cts = new CancellationTokenSource();
             cts.CancelAfter(TimeSpan.FromMinutes(10));
 
-            await wd.StartAsync(cts.Token);
+            Task wsTask = wd.ExecuteAsync(cts.Token);
 
-            var startTime = DateTime.UtcNow;
+            DateTime startTime = DateTime.UtcNow;
             while (!wd.IsLeaseHolder && (DateTime.UtcNow - startTime).TotalSeconds < 60)
             {
-                await Task.Delay(TimeSpan.FromSeconds(1));
+                await Task.Delay(TimeSpan.FromSeconds(1), cts.Token);
             }
 
             Assert.True(wd.IsLeaseHolder, "Is lease holder");
@@ -102,7 +102,7 @@ EXECUTE dbo.LogEvent @Process='Build',@Status='Warn',@Mode='',@Target='DefragTes
             var completed = CheckQueue(current);
             while (!completed && (DateTime.UtcNow - startTime).TotalSeconds < 120)
             {
-                await Task.Delay(TimeSpan.FromSeconds(1));
+                await Task.Delay(TimeSpan.FromSeconds(1), cts.Token);
                 completed = CheckQueue(current);
             }
 
@@ -112,7 +112,8 @@ EXECUTE dbo.LogEvent @Process='Build',@Status='Warn',@Mode='',@Target='DefragTes
             var sizeAfter = GetSize();
             Assert.True(sizeAfter * 9 < sizeBefore, $"{sizeAfter} * 9 < {sizeBefore}");
 
-            wd.Dispose();
+            await cts.CancelAsync();
+            await wsTask;
         }
 
         [Fact]
@@ -136,12 +137,12 @@ END
             using var cts = new CancellationTokenSource();
             cts.CancelAfter(TimeSpan.FromMinutes(10));
 
-            await wd.StartAsync(cts.Token);
+            Task wdTask = wd.ExecuteAsync(cts.Token);
 
             var startTime = DateTime.UtcNow;
             while (!wd.IsLeaseHolder && (DateTime.UtcNow - startTime).TotalSeconds < 60)
             {
-                await Task.Delay(TimeSpan.FromSeconds(1));
+                await Task.Delay(TimeSpan.FromSeconds(1), cts.Token);
             }
 
             Assert.True(wd.IsLeaseHolder, "Is lease holder");
@@ -149,13 +150,14 @@ END
 
             while ((GetCount("EventLog") > 1000) && (DateTime.UtcNow - startTime).TotalSeconds < 120)
             {
-                await Task.Delay(TimeSpan.FromSeconds(1));
+                await Task.Delay(TimeSpan.FromSeconds(1), cts.Token);
             }
 
             _testOutputHelper.WriteLine($"EventLog.Count={GetCount("EventLog")}.");
             Assert.True(GetCount("EventLog") <= 1000, "Count is low");
 
-            wd.Dispose();
+            await cts.CancelAsync();
+            await wdTask;
         }
 
         [Fact]
@@ -203,12 +205,18 @@ END
 
             ExecuteSql("DROP TRIGGER dbo.tmp_NumberSearchParam");
 
-            var wd = new TransactionWatchdog(_fixture.SqlServerFhirDataStore, factory, _fixture.SqlRetryService, XUnitLogger<TransactionWatchdog>.Create(_testOutputHelper));
-            await wd.StartAsync(true, 1, 2, cts.Token);
-            var startTime = DateTime.UtcNow;
+            var wd = new TransactionWatchdog(_fixture.SqlServerFhirDataStore, factory, _fixture.SqlRetryService, XUnitLogger<TransactionWatchdog>.Create(_testOutputHelper))
+            {
+                AllowRebalance = true,
+                PeriodSec = 1,
+                LeasePeriodSec = 2,
+            };
+
+            Task wdTask = wd.ExecuteAsync(cts.Token);
+            DateTime startTime = DateTime.UtcNow;
             while (!wd.IsLeaseHolder && (DateTime.UtcNow - startTime).TotalSeconds < 10)
             {
-                await Task.Delay(TimeSpan.FromSeconds(0.2));
+                await Task.Delay(TimeSpan.FromSeconds(0.2), cts.Token);
             }
 
             Assert.True(wd.IsLeaseHolder, "Is lease holder");
@@ -222,7 +230,8 @@ END
 
             Assert.Equal(1, GetCount("NumberSearchParam")); // wd rolled forward transaction
 
-            wd.Dispose();
+            await cts.CancelAsync();
+            await wdTask;
         }
 
         [Fact]
@@ -233,12 +242,18 @@ END
             using var cts = new CancellationTokenSource();
             cts.CancelAfter(TimeSpan.FromSeconds(60));
 
-            var wd = new TransactionWatchdog(_fixture.SqlServerFhirDataStore, CreateResourceWrapperFactory(), _fixture.SqlRetryService, XUnitLogger<TransactionWatchdog>.Create(_testOutputHelper));
-            await wd.StartAsync(true, 1, 2, cts.Token);
+            var wd = new TransactionWatchdog(_fixture.SqlServerFhirDataStore, CreateResourceWrapperFactory(), _fixture.SqlRetryService, XUnitLogger<TransactionWatchdog>.Create(_testOutputHelper))
+            {
+                AllowRebalance = true,
+                PeriodSec = 1,
+                LeasePeriodSec = 2,
+            };
+
+            Task wdTask = wd.ExecuteAsync(cts.Token);
             var startTime = DateTime.UtcNow;
             while (!wd.IsLeaseHolder && (DateTime.UtcNow - startTime).TotalSeconds < 10)
             {
-                await Task.Delay(TimeSpan.FromSeconds(0.2));
+                await Task.Delay(TimeSpan.FromSeconds(0.2), cts.Token);
             }
 
             Assert.True(wd.IsLeaseHolder, "Is lease holder");
@@ -259,7 +274,7 @@ END
             startTime = DateTime.UtcNow;
             while ((visibility = await _fixture.SqlServerFhirDataStore.StoreClient.MergeResourcesGetTransactionVisibilityAsync(cts.Token)) != tran1.TransactionId && (DateTime.UtcNow - startTime).TotalSeconds < 10)
             {
-                await Task.Delay(TimeSpan.FromSeconds(0.1));
+                await Task.Delay(TimeSpan.FromSeconds(0.1), cts.Token);
             }
 
             _testOutputHelper.WriteLine($"Visibility={visibility}");
@@ -272,7 +287,7 @@ END
             startTime = DateTime.UtcNow;
             while ((visibility = await _fixture.SqlServerFhirDataStore.StoreClient.MergeResourcesGetTransactionVisibilityAsync(cts.Token)) != tran2.TransactionId && (DateTime.UtcNow - startTime).TotalSeconds < 10)
             {
-                await Task.Delay(TimeSpan.FromSeconds(0.1));
+                await Task.Delay(TimeSpan.FromSeconds(0.1), cts.Token);
             }
 
             _testOutputHelper.WriteLine($"Visibility={visibility}");
@@ -285,13 +300,14 @@ END
             startTime = DateTime.UtcNow;
             while ((visibility = await _fixture.SqlServerFhirDataStore.StoreClient.MergeResourcesGetTransactionVisibilityAsync(cts.Token)) != tran3.TransactionId && (DateTime.UtcNow - startTime).TotalSeconds < 10)
             {
-                await Task.Delay(TimeSpan.FromSeconds(0.1));
+                await Task.Delay(TimeSpan.FromSeconds(0.1), cts.Token);
             }
 
             _testOutputHelper.WriteLine($"Visibility={visibility}");
             Assert.Equal(tran3.TransactionId, visibility);
 
-            wd.Dispose();
+            await cts.CancelAsync();
+            await wdTask;
         }
 
         private ResourceWrapperFactory CreateResourceWrapperFactory()

--- a/tools/EventsReader/Program.cs
+++ b/tools/EventsReader/Program.cs
@@ -16,14 +16,14 @@ namespace Microsoft.Health.Internal.Fhir.EventsReader
     {
         private static readonly string _connectionString = ConfigurationManager.ConnectionStrings["Database"].ConnectionString;
         private static SqlRetryService _sqlRetryService;
-        private static SqlStoreClient<SqlServerFhirDataStore> _store;
+        private static SqlStoreClient _store;
         private static string _parameterId = "Events.LastProcessedTransactionId";
 
         public static void Main()
         {
             ISqlConnectionBuilder iSqlConnectionBuilder = new Sql.SqlConnectionBuilder(_connectionString);
             _sqlRetryService = SqlRetryService.GetInstance(iSqlConnectionBuilder);
-            _store = new SqlStoreClient<SqlServerFhirDataStore>(_sqlRetryService, NullLogger<SqlServerFhirDataStore>.Instance);
+            _store = new SqlStoreClient(_sqlRetryService, NullLogger<SqlStoreClient>.Instance);
 
             ExecuteAsync().Wait();
         }

--- a/tools/PerfTester/Program.cs
+++ b/tools/PerfTester/Program.cs
@@ -48,14 +48,14 @@ namespace Microsoft.Health.Internal.Fhir.PerfTester
         private static readonly int _repeat = int.Parse(ConfigurationManager.AppSettings["Repeat"]);
 
         private static SqlRetryService _sqlRetryService;
-        private static SqlStoreClient<SqlServerFhirDataStore> _store;
+        private static SqlStoreClient _store;
 
         public static void Main()
         {
             Console.WriteLine("!!!See App.config for the details!!!");
             ISqlConnectionBuilder iSqlConnectionBuilder = new Sql.SqlConnectionBuilder(_connectionString);
             _sqlRetryService = SqlRetryService.GetInstance(iSqlConnectionBuilder);
-            _store = new SqlStoreClient<SqlServerFhirDataStore>(_sqlRetryService, NullLogger<SqlServerFhirDataStore>.Instance);
+            _store = new SqlStoreClient(_sqlRetryService, NullLogger<SqlStoreClient>.Instance);
 
             DumpResourceIds();
 


### PR DESCRIPTION
## Description
Replaces Timer with [PeriodicTimer](https://learn.microsoft.com/en-us/dotnet/api/system.threading.periodictimer?view=net-8.0). Looking at the code overall PeriodicTimer is a better conceptual fit and it also natively async.

This pull request includes changes to the SQL retry service and SQL store client in the `Microsoft.Health.Fhir.SqlServer` project. The changes mainly involve the removal of generic logger types and the replacement of `using` statements with `await using` for asynchronous disposal of SQL connections and commands.

Changes to the SQL Retry Service:

* [`src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlRetry/ISqlRetryService.cs`](diffhunk://#diff-a12430e16f36c4ce16952b0bf9fa8e1f4121b3205e95b2010fe925e597477fb6L21-R23): Removed generic logger types from `ExecuteSql` and `ExecuteReaderAsync` methods.
* [`src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlRetry/SqlRetryService.cs`](diffhunk://#diff-0b7ec72a985c301fef74fdf5c02c4b042056002e31d41a644824d344cec1caa8L218-R218): Replaced `using` with `await using` for asynchronous disposal of `SqlConnection` instances. Also, removed generic logger types from several methods. [[1]](diffhunk://#diff-0b7ec72a985c301fef74fdf5c02c4b042056002e31d41a644824d344cec1caa8L218-R218) [[2]](diffhunk://#diff-0b7ec72a985c301fef74fdf5c02c4b042056002e31d41a644824d344cec1caa8L244) [[3]](diffhunk://#diff-0b7ec72a985c301fef74fdf5c02c4b042056002e31d41a644824d344cec1caa8L254-R253) [[4]](diffhunk://#diff-0b7ec72a985c301fef74fdf5c02c4b042056002e31d41a644824d344cec1caa8L271-R270) [[5]](diffhunk://#diff-0b7ec72a985c301fef74fdf5c02c4b042056002e31d41a644824d344cec1caa8L306-R305) [[6]](diffhunk://#diff-0b7ec72a985c301fef74fdf5c02c4b042056002e31d41a644824d344cec1caa8L342) [[7]](diffhunk://#diff-0b7ec72a985c301fef74fdf5c02c4b042056002e31d41a644824d344cec1caa8L352-R350) [[8]](diffhunk://#diff-0b7ec72a985c301fef74fdf5c02c4b042056002e31d41a644824d344cec1caa8L369-R367)

Changes to the SQL Store Client:

* [`src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs`](diffhunk://#diff-22028a775b80d042ccb73a3b18dc0266a1d6356bc22af001d43db82f2cdcdcecL55-R55): Removed generic type from `SqlStoreClient` field and constructor parameter. [[1]](diffhunk://#diff-22028a775b80d042ccb73a3b18dc0266a1d6356bc22af001d43db82f2cdcdcecL55-R55) [[2]](diffhunk://#diff-22028a775b80d042ccb73a3b18dc0266a1d6356bc22af001d43db82f2cdcdcecL78-R86) [[3]](diffhunk://#diff-22028a775b80d042ccb73a3b18dc0266a1d6356bc22af001d43db82f2cdcdcecL113-R114)
* [`src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlStoreClient.cs`](diffhunk://#diff-89b796902c780ca1e06934da25396710e9470254444ddf2f6e7c3fe9295b3975L28-R34): Removed generic type from `SqlStoreClient` class and replaced `using` with `await using` for asynchronous disposal of `SqlCommand` instances. [[1]](diffhunk://#diff-89b796902c780ca1e06934da25396710e9470254444ddf2f6e7c3fe9295b3975L28-R34) [[2]](diffhunk://#diff-89b796902c780ca1e06934da25396710e9470254444ddf2f6e7c3fe9295b3975L122-R121) [[3]](diffhunk://#diff-89b796902c780ca1e06934da25396710e9470254444ddf2f6e7c3fe9295b3975L174-R173) [[4]](diffhunk://#diff-89b796902c780ca1e06934da25396710e9470254444ddf2f6e7c3fe9295b3975L197-R196) [[5]](diffhunk://#diff-89b796902c780ca1e06934da25396710e9470254444ddf2f6e7c3fe9295b3975L206-R205) [[6]](diffhunk://#diff-89b796902c780ca1e06934da25396710e9470254444ddf2f6e7c3fe9295b3975L246-R245) [[7]](diffhunk://#diff-89b796902c780ca1e06934da25396710e9470254444ddf2f6e7c3fe9295b3975L256-R255)

Changes to the SQL Command Extensions:

* [`src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlRetry/SqlCommandExtensions.cs`](diffhunk://#diff-c051711d0b95dbefbe90362a965fcd37dae98653d33f705c001d0d76a32d7354L17-R27): Removed generic logger types from `ExecuteNonQueryAsync`, `ExecuteReaderAsync`, and `ExecuteScalarAsync` methods.

## Related issues
Addresses #3736 , [AB#117180](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/117180).

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
