### PR TITLE
Add new health check for improper behavior

### DIFF
--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -62,6 +62,7 @@ jobs:
      
         $additionalProperties["SqlServer__DeleteAllDataOnStartup"] = "false"
         $additionalProperties["SqlServer__AllowDatabaseCreation"] = "true"
+        $additionalProperties["CosmosDb__InitialDatabaseThroughput"] = 1500
         $additionalProperties["FhirServer__Operations__Import__PollingFrequencyInSeconds"] = 1
         $additionalProperties["FhirServer__Operations__Export__PollingFrequencyInSeconds"] = 1
         $additionalProperties["ASPNETCORE_FORWARDEDHEADERS_ENABLED"] = "true"

--- a/src/Microsoft.Health.Fhir.Api/Features/Health/ImproperBehaviorHealthCheck.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Health/ImproperBehaviorHealthCheck.cs
@@ -3,10 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;

--- a/src/Microsoft.Health.Fhir.Api/Features/Health/ImproperBehaviorHealthCheck.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Health/ImproperBehaviorHealthCheck.cs
@@ -1,0 +1,40 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Health.Fhir.Core.Features.Health;
+
+namespace Microsoft.Health.Fhir.Api.Features.Health
+{
+    public class ImproperBehaviorHealthCheck : IHealthCheck, INotificationHandler<ImproperBehaviorNotification>
+    {
+        private bool _isHealthy = true;
+        private string _message = string.Empty;
+
+        public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+        {
+            if (_isHealthy)
+            {
+                return Task.FromResult(HealthCheckResult.Healthy());
+            }
+
+            return Task.FromResult(new HealthCheckResult(HealthStatus.Unhealthy, "Improper server behavior has been detected." + _message));
+        }
+
+        public Task Handle(ImproperBehaviorNotification notification, CancellationToken cancellationToken)
+        {
+            _isHealthy = false;
+            _message += " " + notification.Message;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Exceptions/InitializationException.cs
+++ b/src/Microsoft.Health.Fhir.Core/Exceptions/InitializationException.cs
@@ -1,0 +1,21 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Health.Fhir.Core.Exceptions
+{
+    public class InitializationException : Exception
+    {
+        public InitializationException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Exceptions/InitializationException.cs
+++ b/src/Microsoft.Health.Fhir.Core/Exceptions/InitializationException.cs
@@ -4,10 +4,6 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.Health.Fhir.Core.Exceptions
 {

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
@@ -262,10 +262,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             }
         }
 
-        private Task LoadSearchParamsFromDataStore(CancellationToken cancellationToken)
+        private async Task LoadSearchParamsFromDataStore(CancellationToken cancellationToken)
         {
-            throw new NotImplementedException("LoadSearchParamsFromDataStore is not implemented");
-            /*
             // now read in any previously POST'd SearchParameter resources
             using IScoped<ISearchService> search = _searchServiceFactory.Invoke();
             string continuationToken = null;
@@ -319,7 +317,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
                 }
             }
             while (continuationToken != null);
-            */
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Health/ImproperBehaviorNotification.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Health/ImproperBehaviorNotification.cs
@@ -1,0 +1,27 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using EnsureThat;
+using MediatR;
+
+namespace Microsoft.Health.Fhir.Core.Features.Health
+{
+    public class ImproperBehaviorNotification : INotification
+    {
+        public ImproperBehaviorNotification(string message)
+        {
+            EnsureArg.IsNotNull(message, nameof(message));
+
+            Message = message;
+        }
+
+        public string Message { get; }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Health/ImproperBehaviorNotification.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Health/ImproperBehaviorNotification.cs
@@ -3,11 +3,6 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using EnsureThat;
 using MediatR;
 

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/FhirModule.cs
@@ -15,6 +15,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Core.Features.Security;
@@ -22,12 +23,14 @@ using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Api.Features.Context;
 using Microsoft.Health.Fhir.Api.Features.Filters;
 using Microsoft.Health.Fhir.Api.Features.Formatters;
+using Microsoft.Health.Fhir.Api.Features.Health;
 using Microsoft.Health.Fhir.Api.Features.Resources;
 using Microsoft.Health.Fhir.Api.Features.Resources.Bundle;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features;
 using Microsoft.Health.Fhir.Core.Features.Conformance;
 using Microsoft.Health.Fhir.Core.Features.Context;
+using Microsoft.Health.Fhir.Core.Features.Health;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Security;
@@ -162,6 +165,16 @@ namespace Microsoft.Health.Fhir.Api.Modules
 
             // Register a router for Bundle requests.
             services.AddSingleton<IRouter, BundleRouter>();
+
+            // Registers a health check for improper behavior
+            services.RemoveServiceTypeExact<ImproperBehaviorHealthCheck, INotificationHandler<ImproperBehaviorNotification>>()
+                .Add<ImproperBehaviorHealthCheck>()
+                .Singleton()
+                .AsSelf()
+                .AsService<IHealthCheck>()
+                .AsService<INotificationHandler<ImproperBehaviorNotification>>();
+
+            services.AddHealthChecks().AddCheck<ImproperBehaviorHealthCheck>(name: "BehaviorHealthCheck");
 
             services.AddLazy();
             services.AddScoped();

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/SearchParameterState/SearchParameterStateUpdateHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/SearchParameterState/SearchParameterStateUpdateHandlerTests.cs
@@ -63,6 +63,7 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Search
         public SearchParameterStateUpdateHandlerTests()
         {
             _searchParameterDefinitionManager = Substitute.For<SearchParameterDefinitionManager>(ModelInfoProvider.Instance, _mediator, _searchService.CreateMockScopeProvider(), NullLogger<SearchParameterDefinitionManager>.Instance);
+
             _searchParameterStatusManager = new SearchParameterStatusManager(_searchParameterStatusDataStore, _searchParameterDefinitionManager, _searchParameterSupportResolver, _mediator, _logger);
             _searchParameterStateUpdateHandler = new SearchParameterStateUpdateHandler(_authorizationService, _searchParameterStatusManager, _logger2, _auditLogger);
             _cancellationToken = CancellationToken.None;
@@ -178,6 +179,8 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Search
         [Fact]
         public async void GivenARequestToUpdateSearchParameterStatus_WhenTheStatusIsEnabled_ThenTheStatusShouldBeUpdated()
         {
+            await _searchParameterDefinitionManager.EnsureInitializedAsync(CancellationToken.None);
+
             List<Tuple<Uri, SearchParameterStatus>> updates = new List<Tuple<Uri, SearchParameterStatus>>()
             {
                 new Tuple<Uri, SearchParameterStatus>(new Uri(ResourceId), SearchParameterStatus.Supported),
@@ -239,6 +242,8 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Search
         [Fact]
         public async void GivenARequestToUpdateSearchParameterStatus_WhenStatusIsDisabled_ThenTheStatusIsUpdatedAsPendingDisable()
         {
+            await _searchParameterDefinitionManager.EnsureInitializedAsync(CancellationToken.None);
+
             List<Tuple<Uri, SearchParameterStatus>> updates = new List<Tuple<Uri, SearchParameterStatus>>()
             {
                 new Tuple<Uri, SearchParameterStatus>(new Uri(ResourceId), SearchParameterStatus.Disabled),
@@ -260,6 +265,8 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Search
         [Fact]
         public async void GivenARequestToUpdateSearchParameterStatus_WhenRequestIsValied_ThenAuditLogContainsStateChange()
         {
+            await _searchParameterDefinitionManager.EnsureInitializedAsync(CancellationToken.None);
+
             var loggers = CreateTestAuditLogger();
             var searchParameterStateUpdateHandler = new SearchParameterStateUpdateHandler(_authorizationService, _searchParameterStatusManager, _logger2, loggers.auditLogger);
             List<Tuple<Uri, SearchParameterStatus>> updates = new List<Tuple<Uri, SearchParameterStatus>>()

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -55,8 +55,13 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         private const string LocalConnectionString = "server=(local);Integrated Security=true;TrustServerCertificate=True";
         private const string MasterDatabaseName = "master";
 
-        private int _maximumSupportedSchemaVersion;
-        private string _databaseName;
+        private readonly string _initialConnectionString;
+        private readonly IOptions<CoreFeatureConfiguration> _options;
+        private readonly int _maximumSupportedSchemaVersion;
+        private readonly string _databaseName;
+        private readonly IMediator _mediator = Substitute.For<IMediator>();
+        private readonly RequestContextAccessor<IFhirRequestContext> _fhirRequestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
+
         private SqlServerFhirDataStore _fhirDataStore;
         private IFhirOperationDataStore _fhirOperationDataStore;
         private SqlServerFhirOperationDataStore _sqlServerFhirOperationDataStore;
@@ -68,11 +73,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         private SearchParameterDefinitionManager _searchParameterDefinitionManager;
         private SupportedSearchParameterDefinitionManager _supportedSearchParameterDefinitionManager;
         private SearchParameterStatusManager _searchParameterStatusManager;
-        private IMediator _mediator = Substitute.For<IMediator>();
-        private RequestContextAccessor<IFhirRequestContext> _fhirRequestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
         private SqlQueueClient _sqlQueueClient;
-        private string _initialConnectionString;
-        private IOptions<CoreFeatureConfiguration> _options;
 
         public SqlServerFhirStorageTestsFixture()
             : this(SchemaVersionConstants.Max, $"FHIRINTEGRATIONTEST_{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}_{BigInteger.Abs(new BigInteger(Guid.NewGuid().ToByteArray()))}")
@@ -85,7 +86,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
             _maximumSupportedSchemaVersion = maximumSupportedSchemaVersion;
             _databaseName = databaseName;
-            TestConnectionString = new SqlConnectionStringBuilder(_initialConnectionString) { InitialCatalog = _databaseName }.ToString();
+            TestConnectionString = new SqlConnectionStringBuilder(_initialConnectionString) { InitialCatalog = _databaseName, Encrypt = true }.ToString();
 
             var schemaOptions = new SqlServerSchemaOptions { AutomaticUpdatesEnabled = true };
             SqlServerDataStoreConfiguration = Options.Create(new SqlServerDataStoreConfiguration

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Numerics;
 using System.Threading;
 using MediatR;
+using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -54,22 +55,24 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         private const string LocalConnectionString = "server=(local);Integrated Security=true;TrustServerCertificate=True";
         private const string MasterDatabaseName = "master";
 
-        private readonly int _maximumSupportedSchemaVersion;
-        private readonly string _databaseName;
-        private readonly SqlServerFhirDataStore _fhirDataStore;
-        private readonly IFhirOperationDataStore _fhirOperationDataStore;
-        private readonly SqlServerFhirOperationDataStore _sqlServerFhirOperationDataStore;
-        private readonly SqlServerFhirStorageTestHelper _testHelper;
-        private readonly SchemaInitializer _schemaInitializer;
-        private readonly SchemaUpgradeRunner _schemaUpgradeRunner;
-        private readonly FilebasedSearchParameterStatusDataStore _filebasedSearchParameterStatusDataStore;
-        private readonly ISearchService _searchService;
-        private readonly SearchParameterDefinitionManager _searchParameterDefinitionManager;
-        private readonly SupportedSearchParameterDefinitionManager _supportedSearchParameterDefinitionManager;
-        private readonly SearchParameterStatusManager _searchParameterStatusManager;
-        private readonly IMediator _mediator = Substitute.For<IMediator>();
-        private readonly RequestContextAccessor<IFhirRequestContext> _fhirRequestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
-        private readonly SqlQueueClient _sqlQueueClient;
+        private int _maximumSupportedSchemaVersion;
+        private string _databaseName;
+        private SqlServerFhirDataStore _fhirDataStore;
+        private IFhirOperationDataStore _fhirOperationDataStore;
+        private SqlServerFhirOperationDataStore _sqlServerFhirOperationDataStore;
+        private SqlServerFhirStorageTestHelper _testHelper;
+        private SchemaInitializer _schemaInitializer;
+        private SchemaUpgradeRunner _schemaUpgradeRunner;
+        private FilebasedSearchParameterStatusDataStore _filebasedSearchParameterStatusDataStore;
+        private ISearchService _searchService;
+        private SearchParameterDefinitionManager _searchParameterDefinitionManager;
+        private SupportedSearchParameterDefinitionManager _supportedSearchParameterDefinitionManager;
+        private SearchParameterStatusManager _searchParameterStatusManager;
+        private IMediator _mediator = Substitute.For<IMediator>();
+        private RequestContextAccessor<IFhirRequestContext> _fhirRequestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
+        private SqlQueueClient _sqlQueueClient;
+        private string _initialConnectionString;
+        private IOptions<CoreFeatureConfiguration> _options;
 
         public SqlServerFhirStorageTestsFixture()
             : this(SchemaVersionConstants.Max, $"FHIRINTEGRATIONTEST_{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}_{BigInteger.Abs(new BigInteger(Guid.NewGuid().ToByteArray()))}")
@@ -78,11 +81,11 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
         internal SqlServerFhirStorageTestsFixture(int maximumSupportedSchemaVersion, string databaseName, IOptions<CoreFeatureConfiguration> coreFeatures = null)
         {
-            var initialConnectionString = Environment.GetEnvironmentVariable("SqlServer:ConnectionString") ?? LocalConnectionString;
+            _initialConnectionString = Environment.GetEnvironmentVariable("SqlServer:ConnectionString") ?? LocalConnectionString;
 
             _maximumSupportedSchemaVersion = maximumSupportedSchemaVersion;
             _databaseName = databaseName;
-            TestConnectionString = new SqlConnectionStringBuilder(initialConnectionString) { InitialCatalog = _databaseName }.ToString();
+            TestConnectionString = new SqlConnectionStringBuilder(_initialConnectionString) { InitialCatalog = _databaseName }.ToString();
 
             var schemaOptions = new SqlServerSchemaOptions { AutomaticUpdatesEnabled = true };
             SqlServerDataStoreConfiguration = Options.Create(new SqlServerDataStoreConfiguration
@@ -95,6 +98,34 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             });
 
             SchemaInformation = new SchemaInformation(SchemaVersionConstants.Min, maximumSupportedSchemaVersion);
+
+            _options = coreFeatures ?? Options.Create(new CoreFeatureConfiguration());
+        }
+
+        public string TestConnectionString { get; private set; }
+
+        internal SqlTransactionHandler SqlTransactionHandler { get; private set; }
+
+        internal SqlConnectionWrapperFactory SqlConnectionWrapperFactory { get; private set; }
+
+        internal SqlServerFhirDataStore SqlServerFhirDataStore => _fhirDataStore;
+
+        internal IOptions<SqlServerDataStoreConfiguration> SqlServerDataStoreConfiguration { get; private set; }
+
+        internal ISqlConnectionBuilder SqlConnectionBuilder { get; private set; }
+
+        internal SqlRetryService SqlRetryService { get; private set; }
+
+        internal SqlServerSearchParameterStatusDataStore SqlServerSearchParameterStatusDataStore { get; private set; }
+
+        internal SqlServerFhirModel SqlServerFhirModel { get; private set; }
+
+        internal SchemaInformation SchemaInformation { get; private set; }
+
+        internal ISqlQueryHashCalculator SqlQueryHashCalculator { get; private set; }
+
+        public async Task InitializeAsync()
+        {
             var scriptProvider = new ScriptProvider<SchemaVersion>();
             var baseScriptProvider = new BaseScriptProvider();
             var mediator = Substitute.For<IMediator>();
@@ -140,6 +171,12 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 NullLogger<SqlServerFhirModel>.Instance);
             SqlServerFhirModel = sqlServerFhirModel;
 
+            // the test queue client may not be enough for these tests. will need to look back into this.
+            var queueClient = new TestQueueClient();
+
+            _testHelper = new SqlServerFhirStorageTestHelper(_initialConnectionString, MasterDatabaseName, sqlServerFhirModel, SqlConnectionBuilder, queueClient);
+            await _testHelper.CreateAndInitializeDatabase(_databaseName, _maximumSupportedSchemaVersion, forceIncrementalSchemaUpgrade: false, _schemaInitializer, CancellationToken.None);
+
             var searchParameterToSearchValueTypeMap = new SearchParameterToSearchValueTypeMap();
 
             var serviceCollection = new ServiceCollection();
@@ -165,8 +202,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 sqlServerFhirModel,
                 _searchParameterDefinitionManager);
 
-            IOptions<CoreFeatureConfiguration> options = coreFeatures ?? Options.Create(new CoreFeatureConfiguration());
-
             var bundleConfiguration = new BundleConfiguration() { SupportsBundleOrchestrator = true };
             var bundleOptions = Substitute.For<IOptions<BundleConfiguration>>();
             bundleOptions.Value.Returns(bundleConfiguration);
@@ -180,7 +215,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             _fhirDataStore = new SqlServerFhirDataStore(
                 sqlServerFhirModel,
                 searchParameterToSearchValueTypeMap,
-                options,
+                _options,
                 bundleOrchestrator,
                 SqlRetryService,
                 SqlConnectionWrapperFactory,
@@ -191,8 +226,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 _fhirRequestContextAccessor,
                 importErrorSerializer);
 
-            // the test queue client may not be enough for these tests. will need to look back into this.
-            var queueClient = new TestQueueClient();
             _fhirOperationDataStore = new SqlServerFhirOperationDataStore(SqlConnectionWrapperFactory, queueClient, NullLogger<SqlServerFhirOperationDataStore>.Instance, NullLoggerFactory.Instance);
 
             var sqlQueueClient = new SqlQueueClient(SchemaInformation, SqlRetryService, NullLogger<SqlQueueClient>.Instance);
@@ -208,7 +241,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             var searchOptionsFactory = new SearchOptionsFactory(
                 expressionParser,
                 () => searchableSearchParameterDefinitionManager,
-                options,
+                _options,
                 _fhirRequestContextAccessor,
                 sqlSortingValidator,
                 new ExpressionAccessControl(_fhirRequestContextAccessor),
@@ -254,36 +287,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 mediator,
                 NullLogger<SearchParameterStatusManager>.Instance);
 
-            _testHelper = new SqlServerFhirStorageTestHelper(initialConnectionString, MasterDatabaseName, sqlServerFhirModel, SqlConnectionBuilder, queueClient);
-
             _sqlQueueClient = new SqlQueueClient(SchemaInformation, SqlRetryService, NullLogger<SqlQueueClient>.Instance);
-        }
 
-        public string TestConnectionString { get; }
-
-        internal SqlTransactionHandler SqlTransactionHandler { get; }
-
-        internal SqlConnectionWrapperFactory SqlConnectionWrapperFactory { get; }
-
-        internal SqlServerFhirDataStore SqlServerFhirDataStore => _fhirDataStore;
-
-        internal IOptions<SqlServerDataStoreConfiguration> SqlServerDataStoreConfiguration { get; }
-
-        internal ISqlConnectionBuilder SqlConnectionBuilder { get; }
-
-        internal SqlRetryService SqlRetryService { get; }
-
-        internal SqlServerSearchParameterStatusDataStore SqlServerSearchParameterStatusDataStore { get; }
-
-        internal SqlServerFhirModel SqlServerFhirModel { get; }
-
-        internal SchemaInformation SchemaInformation { get; }
-
-        internal ISqlQueryHashCalculator SqlQueryHashCalculator { get; }
-
-        public async Task InitializeAsync()
-        {
-            await _testHelper.CreateAndInitializeDatabase(_databaseName, _maximumSupportedSchemaVersion, forceIncrementalSchemaUpgrade: false, _schemaInitializer, CancellationToken.None);
             await _searchParameterDefinitionManager.EnsureInitializedAsync(CancellationToken.None);
         }
 


### PR DESCRIPTION
## Description
Add new health check for improper behavior.

## Related issues
Addresses [Bug 119273](https://dev.azure.com/microsofthealth/Health/_workitems/edit/119273): Sort tests failing in Cosmos DB

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
