### PR TITLE
Fixes for Bundle Routing

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleRouter.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleRouter.cs
@@ -33,26 +33,26 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
     /// </summary>
     internal class BundleRouter : IRouter
     {
-        private readonly TemplateBinderFactory _parameterPolicies;
+        private readonly TemplateBinderFactory _templateBinderFactory;
         private readonly IEnumerable<MatcherPolicy> _matcherPolicies;
         private readonly EndpointDataSource _endpointDataSource;
         private readonly EndpointSelector _endpointSelector;
         private readonly ILogger<BundleRouter> _logger;
 
         public BundleRouter(
-            TemplateBinderFactory parameterPolicies,
+            TemplateBinderFactory templateBinderFactory,
             IEnumerable<MatcherPolicy> matcherPolicies,
             EndpointDataSource endpointDataSource,
             EndpointSelector endpointSelector,
             ILogger<BundleRouter> logger)
         {
-            EnsureArg.IsNotNull(parameterPolicies, nameof(parameterPolicies));
+            EnsureArg.IsNotNull(templateBinderFactory, nameof(templateBinderFactory));
             EnsureArg.IsNotNull(matcherPolicies, nameof(matcherPolicies));
             EnsureArg.IsNotNull(endpointDataSource, nameof(endpointDataSource));
             EnsureArg.IsNotNull(endpointSelector, nameof(endpointSelector));
             EnsureArg.IsNotNull(logger, nameof(logger));
 
-            _parameterPolicies = parameterPolicies;
+            _templateBinderFactory = templateBinderFactory;
             _matcherPolicies = matcherPolicies;
             _endpointDataSource = endpointDataSource;
             _endpointSelector = endpointSelector;
@@ -78,7 +78,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                 var routeDefaults = new RouteValueDictionary(endpoint.RoutePattern.Defaults);
 
                 RoutePattern pattern = endpoint.RoutePattern;
-                TemplateBinder templateBinder = _parameterPolicies.Create(pattern);
+                TemplateBinder templateBinder = _templateBinderFactory.Create(pattern);
 
                 var templateMatcher = new TemplateMatcher(new RouteTemplate(pattern), routeDefaults);
 

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleRouter.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleRouter.cs
@@ -78,11 +78,13 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
 
                 var templateMatcher = new TemplateMatcher(new RouteTemplate(pattern), routeDefaults);
 
+                // Pattern match
                 if (!templateMatcher.TryMatch(path, routeValues))
                 {
                     continue;
                 }
 
+                // Eliminate routes that don't match constraints
                 if (!templateBinder.TryProcessConstraints(context.HttpContext, routeValues, out var parameterName, out IRouteConstraint constraint))
                 {
                     _logger.LogDebug("Constraint '{ConstraintType}' not met for parameter '{ParameterName}'", constraint, parameterName);
@@ -99,10 +101,10 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
 
             RouteEndpoint[] potentialRoutes = routeCandidates.Select(x => x.Key).ToArray();
 
+            // Covered things like Consumes, HttpVerbs etc...
             foreach (IEndpointSelectorPolicy policy in _matcherPolicies
                          .OrderBy(x => x.Order)
-                         .OfType<IEndpointSelectorPolicy>()
-                         .Where(x => x.AppliesToEndpoints(potentialRoutes)))
+                         .OfType<IEndpointSelectorPolicy>())
             {
                 await policy.ApplyAsync(context.HttpContext, candidateSet);
             }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleRouter.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleRouter.cs
@@ -99,8 +99,6 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                 routeCandidates.Select(x => x.Value).ToArray(),
                 Enumerable.Repeat(1, routeCandidates.Count).ToArray());
 
-            RouteEndpoint[] potentialRoutes = routeCandidates.Select(x => x.Key).ToArray();
-
             // Covered things like Consumes, HttpVerbs etc...
             foreach (IEndpointSelectorPolicy policy in _matcherPolicies
                          .OrderBy(x => x.Order)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BundleEdgeCaseTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BundleEdgeCaseTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Hl7.Fhir.Model;
@@ -94,6 +95,65 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
                 Assert.Equal(localResourceIdentier, remoteResourceIdentifier);
                 Assert.Equal("2", bundleResponse2.Resource.Entry[i].Resource.Meta.VersionId);
             }
+        }
+
+        [Fact]
+        public async Task WhenProcessingABundle_IfItContainsHistoryEndpointRequests_ThenReturnTheResourcesAsExpected()
+        {
+            CancellationToken cancellationToken = CancellationToken.None;
+
+            // 1 - Post first patient who is created as the base resources to handle all following operations.
+            Patient patient = new Patient()
+            {
+                Name = new List<HumanName> { new HumanName() { Family = "Rush", Given = new List<string> { $"John" } } },
+                Gender = AdministrativeGender.Male,
+                BirthDate = "1974-12-21",
+                Text = new Narrative($"<div>{DateTime.UtcNow.ToString("o")}</div>"),
+            };
+            var firstPatientResponse = await _client.PostAsync("Patient", patient.ToJson(), cancellationToken);
+            Assert.True(firstPatientResponse.Response.IsSuccessStatusCode, "First patient ingestion did not complete as expected.");
+            string patientId = firstPatientResponse.Resource.ToResourceElement().ToPoco<Patient>().Id;
+
+            Bundle bundle = new Bundle() { Type = BundleType.Batch };
+
+            // 2 - Create a query on top of _history endpoint.
+            EntryComponent entryComponent = new EntryComponent()
+            {
+                Resource = null,
+                Request = new RequestComponent()
+                {
+                    Method = HTTPVerb.GET,
+                    Url = $"Patient/{patientId}/_history",
+                },
+            };
+            bundle.Entry.Add(entryComponent);
+
+            // 3 - Create a query on top of _history/version endpoint.
+            entryComponent = new EntryComponent()
+            {
+                Resource = null,
+                Request = new RequestComponent()
+                {
+                    Method = HTTPVerb.GET,
+                    Url = $"Patient/{patientId}/_history/1",
+                },
+            };
+            bundle.Entry.Add(entryComponent);
+
+            FhirResponse<Bundle> bundleResponse = await _client.PostBundleAsync(bundle, new Client.FhirBundleOptions(), cancellationToken);
+            Assert.True(bundleResponse.StatusCode == HttpStatusCode.OK, "Bundle ingestion did not complete as expected.");
+
+            // 4 - Validate the response of _history endpoint.
+            EntryComponent firstEntry = bundleResponse.Resource.Entry.First();
+            Assert.True(firstEntry.Response.Status == "200", $"The HTTP status code for the _history query is '{firstEntry.Response.Status}'.");
+            Assert.True(firstEntry.Resource is Bundle, "The resource returned by the _history query is not a Bundle.");
+            Assert.True(((Bundle)firstEntry.Resource).Entry.First().Resource.Id == patientId, "The resource returned by the _history query is not the original Patient.");
+
+            // 5 - Validate the response of _history/version endpoint.
+            EntryComponent secondEntry = bundleResponse.Resource.Entry.Last();
+            Assert.True(secondEntry.Response.Status == "200", $"The HTTP status code for the _history/version query is '{secondEntry.Response.Status}'.");
+            Assert.True(secondEntry.Resource is Patient, "The resource returned by the _history/version query is not a Patient.");
+            Assert.True(secondEntry.Resource.Id == patientId, "The resource returned by the _history/version query is not the original Patient.");
         }
 
         [Fact]


### PR DESCRIPTION
## Description
Fixes for Bundle Routing

This pull request includes changes to the `src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleRouter.cs` and `test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BundleEdgeCaseTests.cs` files. The changes in `BundleRouter.cs` involve adding new dependencies, modifying the constructor to accommodate these dependencies, and refactoring the `RouteAsync` method. The changes in `BundleEdgeCaseTests.cs` involve adding a new test case.

Changes to `BundleRouter.cs`:

* Modified the `BundleRouter` constructor to include new parameters: `TemplateBinderFactory parameterPolicies`, `IEnumerable<MatcherPolicy> matcherPolicies`, and `EndpointSelector endpointSelector`. The constructor now also ensures these new parameters are not null.
* Refactored the `RouteAsync` method: The method is now asynchronous and includes changes to the logic for routing. The refactoring involves changes to the way route candidates are handled, the way the route endpoint is selected, and the way the selected endpoint is processed.

Changes to `BundleEdgeCaseTests.cs`:

* Added a new dependency: `System.Net`.
* Added a new test case: `WhenProcessingABundle_IfItContainsHistoryEndpointRequests_ThenReturnTheResourcesAsExpected` which tests the scenario where a bundle contains history endpoint requests.

## Related issues
Addresses #3821, [AB#119362](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/119362)

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
