### PR TITLE
Fix fhirtimer crashing on shutdown

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Watchdogs/FhirTimer.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Watchdogs/FhirTimer.cs
@@ -58,9 +58,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Watchdogs
 
         private async Task RunInternalAsync()
         {
-            _cancellationToken.ThrowIfCancellationRequested();
-
-            if (_isRunning)
+            if (_isRunning || _cancellationToken.IsCancellationRequested)
             {
                 return;
             }


### PR DESCRIPTION
## Description
Fix FhirTimer crashing on shutdown since it throws an exception from an async void.

## Related issues
Addresses #3736, [AB#117180](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/117180)

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
