### PR TITLE
Return bad request on too many surrogate ids

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/ImportProcessingJob.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/ImportProcessingJob.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Azure;
 using EnsureThat;
 using MediatR;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Health.Core.Features.Audit;
@@ -22,6 +23,7 @@ using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Operations.Import;
 using Microsoft.Health.JobManagement;
+using Microsoft.Health.SqlServer.Features.Storage;
 using Newtonsoft.Json;
 
 namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
@@ -31,6 +33,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
     {
         private const string CancelledErrorMessage = "Import processing job is canceled.";
         internal const string DefaultCallerAgent = "Microsoft.Health.Fhir.Server";
+        internal const string SurrogateIdsErrorMessage = "Unable to generate internal IDs. If the lastUpdated meta element is provided as input, reduce the number of resources with the same up to millisecond lastUpdated below 10,000.";
 
         private readonly IMediator _mediator;
         private readonly IQueueClient _queueClient;
@@ -151,6 +154,12 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
                 _logger.LogJobInformation(canceledEx, jobInfo, "Import processing operation is canceled.");
                 var error = new ImportJobErrorResult() { ErrorMessage = CancelledErrorMessage };
                 throw new JobExecutionException(canceledEx.Message, error, canceledEx);
+            }
+            catch (SqlException ex) when (ex.Number == SqlErrorCodes.Conflict)
+            {
+                _logger.LogJobInformation(ex, jobInfo, "Exceeded retries on conflicts. Most likely reason - too many input resources with the same last updated.");
+                var error = new ImportJobErrorResult() { ErrorMessage = SurrogateIdsErrorMessage, HttpStatusCode = HttpStatusCode.BadRequest, ErrorDetails = ex.ToString() };
+                throw new JobExecutionException(ex.Message, error, ex);
             }
             catch (Exception ex)
             {

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -400,7 +400,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                     if (sqlEx != null && sqlEx.Number == SqlErrorCodes.Conflict && retries++ < 30)
                     {
                         _logger.LogWarning(e, $"Error on {nameof(ImportResourcesInternalAsync)} retries={{Retries}}", retries);
-                        await Task.Delay(5000, cancellationToken);
+                        await Task.Delay(1000, cancellationToken);
                         continue;
                     }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTests.cs
@@ -170,7 +170,7 @@ IF (SELECT count(*) FROM EventLog WHERE Process = 'MergeResourcesCommitTransacti
             for (int i = 0;  i < 80001; i++)
             {
                 var id = Guid.NewGuid().ToString("N");
-                var str = CreateTestPatient(id, DateTimeOffset.Parse("2020-01-01Z00:00"));
+                var str = CreateTestPatient(id, DateTimeOffset.Parse("1900-01-01Z00:00")); // make sure this date is not used by other tests.
                 ndJson.Append(str);
             }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -14,6 +14,7 @@ using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using MediatR;
+using Microsoft.Data.SqlClient;
 using Microsoft.Health.Abstractions.Exceptions;
 using Microsoft.Health.Abstractions.Features.Transactions;
 using Microsoft.Health.Fhir.Core;
@@ -67,6 +68,50 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         }
 
         protected Mediator Mediator { get; }
+
+        [Theory]
+        [InlineData(5)] // should succeed
+        [InlineData(35)] // shoul fail
+        [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]
+        public async Task RetriesOnConflict(int requestedExceptions)
+        {
+            try
+            {
+                await _fixture.SqlHelper.ExecuteSqlCmd("TRUNCATE TABLE EventLog");
+                await _fixture.SqlHelper.ExecuteSqlCmd(@$"
+CREATE TRIGGER Resource_Trigger ON Resource FOR INSERT
+AS
+IF (SELECT count(*) FROM EventLog WHERE Process = 'MergeResources' AND Status = 'Error') < {requestedExceptions}
+  INSERT INTO Resource SELECT * FROM inserted -- this will cause dup key exception which is treated as a conflict
+                    ");
+
+                var patient = (Patient)Samples.GetJsonSample("Patient").ToPoco();
+                patient.Id = Guid.NewGuid().ToString();
+                try
+                {
+                    await Mediator.UpsertResourceAsync(patient.ToResourceElement());
+                    if (requestedExceptions > 30)
+                    {
+                        Assert.Fail("This point should not be reached");
+                    }
+                }
+                catch (SqlException e)
+                {
+                    if (requestedExceptions > 30)
+                    {
+                        Assert.Contains("Resource has been recently updated or added", e.Message);
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+            }
+            finally
+            {
+                await _fixture.SqlHelper.ExecuteSqlCmd("IF object_id('Resource_Trigger') IS NOT NULL DROP TRIGGER Resource_Trigger");
+            }
+        }
 
         [Fact]
         [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]


### PR DESCRIPTION
When >80K resources with the same last updated are ingested, code fails with
Current - 500
After fix - 400 with good message

fixes https://microsofthealth.visualstudio.com/Health/_workitems/edit/120027/
