### PR TITLE
Enable export for SMART clinical scope : read

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/SMART/SmartClinicalScopesMiddleware.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Smart
                         switch (accessLevel)
                         {
                             case "read":
-                                permittedDataActions = DataActions.Read;
+                                permittedDataActions = DataActions.Read | DataActions.Export;
                                 break;
                             case "write":
                                 permittedDataActions = DataActions.Write;

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/SMART/SmartClinicalScopesMiddlewareTests.cs
@@ -313,8 +313,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
                 "patient/Observation.read",
                 new List<ScopeRestriction>()
                 {
-                    new ScopeRestriction("Patient", DataActions.Read, "patient"),
-                    new ScopeRestriction("Observation", DataActions.Read, "patient"),
+                    new ScopeRestriction("Patient", DataActions.Read | DataActions.Export, "patient"),
+                    new ScopeRestriction("Observation", DataActions.Read | DataActions.Export, "patient"),
                 },
             };
             yield return new object[]
@@ -323,7 +323,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
                 "user.Observation.write",
                 new List<ScopeRestriction>()
                 {
-                    new ScopeRestriction("Patient", DataActions.Read, "patient"),
+                    new ScopeRestriction("Patient", DataActions.Read | DataActions.Export, "patient"),
                     new ScopeRestriction("Observation", DataActions.Write, "user"),
                 },
             };
@@ -333,7 +333,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
                 "practitioner/Observation.write",
                 new List<ScopeRestriction>()
                 {
-                    new ScopeRestriction("Patient", DataActions.Read, "patient"),
+                    new ScopeRestriction("Patient", DataActions.Read | DataActions.Export, "patient"),
                 },
             };
             yield return new object[]
@@ -348,14 +348,14 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
 
         public static IEnumerable<object[]> GetTestScopes()
         {
-            yield return new object[] { "patient/Patient.read", new List<ScopeRestriction>() { new ScopeRestriction("Patient", DataActions.Read, "patient") } };
+            yield return new object[] { "patient/Patient.read", new List<ScopeRestriction>() { new ScopeRestriction("Patient", DataActions.Read | DataActions.Export, "patient") } };
             yield return new object[]
             {
                 "patient/Patient.read patient/Observation.read",
                 new List<ScopeRestriction>()
                 {
-                    new ScopeRestriction("Patient", DataActions.Read, "patient"),
-                    new ScopeRestriction("Observation", DataActions.Read, "patient"),
+                    new ScopeRestriction("Patient", DataActions.Read | DataActions.Export, "patient"),
+                    new ScopeRestriction("Observation", DataActions.Read | DataActions.Export, "patient"),
                 },
             };
             yield return new object[]
@@ -363,7 +363,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
                 "patient.Patient.read user.Observation.write",
                 new List<ScopeRestriction>()
                 {
-                    new ScopeRestriction("Patient", DataActions.Read, "patient"),
+                    new ScopeRestriction("Patient", DataActions.Read | DataActions.Export, "patient"),
                     new ScopeRestriction("Observation", DataActions.Write, "user"),
                 },
             };
@@ -374,7 +374,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
                 new List<ScopeRestriction>()
                 {
                     new ScopeRestriction("VisionPrescription", DataActions.Write, "user"),
-                    new ScopeRestriction(KnownResourceTypes.All, DataActions.Read, "user"),
+                    new ScopeRestriction(KnownResourceTypes.All, DataActions.Read | DataActions.Export, "user"),
                 },
             };
 
@@ -383,16 +383,16 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
             yield return new object[] { "user/all.*", new List<ScopeRestriction>() { new ScopeRestriction(KnownResourceTypes.All, DataActions.Read | DataActions.Write | DataActions.Export, "user") } };
             yield return new object[] { "user/all.all", new List<ScopeRestriction>() { new ScopeRestriction(KnownResourceTypes.All, DataActions.Read | DataActions.Write | DataActions.Export, "user") } };
             yield return new object[] { "system.all.all", new List<ScopeRestriction>() { new ScopeRestriction(KnownResourceTypes.All, DataActions.Read | DataActions.Write | DataActions.Export, "system") } };
-            yield return new object[] { "patient.Patient.read", new List<ScopeRestriction>() { new ScopeRestriction("Patient", DataActions.Read, "patient") } };
+            yield return new object[] { "patient.Patient.read", new List<ScopeRestriction>() { new ScopeRestriction("Patient", DataActions.Read | DataActions.Export, "patient") } };
             yield return new object[] { "patient.Patient.all", new List<ScopeRestriction>() { new ScopeRestriction("Patient", DataActions.Read | DataActions.Write | DataActions.Export, "patient") } };
-            yield return new object[] { "patient.*.read", new List<ScopeRestriction>() { new ScopeRestriction(KnownResourceTypes.All, DataActions.Read, "patient") } };
-            yield return new object[] { "patient.all.read", new List<ScopeRestriction>() { new ScopeRestriction(KnownResourceTypes.All, DataActions.Read, "patient") } };
+            yield return new object[] { "patient.*.read", new List<ScopeRestriction>() { new ScopeRestriction(KnownResourceTypes.All, DataActions.Read | DataActions.Export, "patient") } };
+            yield return new object[] { "patient.all.read", new List<ScopeRestriction>() { new ScopeRestriction(KnownResourceTypes.All, DataActions.Read | DataActions.Export, "patient") } };
             yield return new object[]
             {
                 "patient$Patient.read practitioner/Observation.write",
                 new List<ScopeRestriction>()
                 {
-                    new ScopeRestriction("Patient", DataActions.Read, "patient"),
+                    new ScopeRestriction("Patient", DataActions.Read | DataActions.Export, "patient"),
                 },
             };
             yield return new object[]
@@ -414,8 +414,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Smart
                 "patient/Patient.read launch/patient user/Observation.read offline_access openid user/Encounter.* fhirUser",
                 new List<ScopeRestriction>()
                 {
-                    new ScopeRestriction("Patient", DataActions.Read, "patient"),
-                    new ScopeRestriction("Observation", DataActions.Read, "user"),
+                    new ScopeRestriction("Patient", DataActions.Read | DataActions.Export, "patient"),
+                    new ScopeRestriction("Observation", DataActions.Read | DataActions.Export, "user"),
                     new ScopeRestriction("Encounter", DataActions.Read | DataActions.Write | DataActions.Export, "user"),
                 },
             };


### PR DESCRIPTION
## Description
This adds an allowed DataAction of Export when a SMART scope of "read" is requested.  This change is being made because prior to this it was necessary to grant "write" privileges to a SMART user if they needed export.  This was too much privilege for an export request.

Note that there is still another layer of protection before a SMART user could actually initiate an export job.  They will need to be a member of the FHIR Export role in RBAC in addition to requesting the "read" SMART clinical scope.

## Related issues
Addresses [issue [AB#120097](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/120097)].

## Testing
Unit tests were updated.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
