### PR TITLE
Replace batch last updated deduping by sorting

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTests.cs
@@ -301,7 +301,7 @@ IF (SELECT count(*) FROM EventLog WHERE Process = 'MergeResourcesCommitTransacti
             var ndJson3 = PrepareResource(id, "3", "2003");
             var location2 = (await ImportTestHelper.UploadFileAsync(ndJson1 + ndJson3, _fixture.StorageAccount)).location;
             var request2 = CreateImportRequest(location2, ImportMode.IncrementalLoad);
-            await ImportCheckAsync(request2, null, 1);
+            await ImportCheckAsync(request2, null, 0);
 
             result = await _client.ReadAsync<Patient>(ResourceType.Patient, id);
             Assert.Equal("3", result.Resource.Meta.VersionId);

--- a/tools/BlobRewriter/App.config
+++ b/tools/BlobRewriter/App.config
@@ -31,5 +31,7 @@
     <add key="ExtensionFilter" value="ndjson" />
     <!-- If true tries to replace {"resourceType": by {"meta":{"versionId":"seconds from last updated","lastUpdated":"YYYY-MM-DDThh:mm:ss"},"resourceType": -->
     <add key="AddMeta" value="false" />
+    <!-- If false does not add versionId above -->
+    <add key="AddVersion" value="false" />
   </appSettings>
 </configuration>


### PR DESCRIPTION
This PR reverts to previous behavior (no deduping by last updated). 
Correct versioning behavior when same last updated and multiple versions are provided is achieved by extra sorting.