### PR TITLE
Add throw on failed initialization

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
@@ -96,6 +96,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             catch
             {
                 _initialized = false;
+                throw;
             }
         }
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
@@ -100,18 +100,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             }
         }
 
-#pragma warning disable CA1822 // Mark members as static. Disabled while investigating why bad search parameters could be in databases
         public void EnsureInitialized()
-#pragma warning restore CA1822 // Mark members as static
         {
-            return;
-
-            /*
             if (!_initialized)
             {
-                throw new InitializationException("Failed to initialize search parameters");
+                _logger.LogWarning("Search parameters are not initialized.");
+
+                // throw new InitializationException("Failed to initialize search parameters");
             }
-            */
         }
 
         public IEnumerable<SearchParameterInfo> GetSearchParameters(string resourceType)

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
@@ -100,12 +100,18 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             }
         }
 
+#pragma warning disable CA1822 // Mark members as static. Disabled while investigating why bad search parameters could be in databases
         public void EnsureInitialized()
+#pragma warning restore CA1822 // Mark members as static
         {
+            return;
+
+            /*
             if (!_initialized)
             {
                 throw new InitializationException("Failed to initialize search parameters");
             }
+            */
         }
 
         public IEnumerable<SearchParameterInfo> GetSearchParameters(string resourceType)
@@ -259,7 +265,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
                 }
             }
 
-            await _mediator.Publish(new ImproperBehaviorNotification("Error calculating search parameter hash"), cancellationToken);
+            // Not reporting notification while we investigate why this could happen
+            // await _mediator.Publish(new ImproperBehaviorNotification("Error calculating search parameter hash"), cancellationToken);
         }
 
         public async Task Handle(StorageInitializedNotification notification, CancellationToken cancellationToken)
@@ -280,7 +287,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
                 }
             }
 
-            await _mediator.Publish(new ImproperBehaviorNotification("Error initializing search parameters"), cancellationToken);
+            // Not reporting notification while we investigate why this could happen
+            // await _mediator.Publish(new ImproperBehaviorNotification("Error initializing search parameters"), cancellationToken);
         }
 
         private async Task LoadSearchParamsFromDataStore(CancellationToken cancellationToken)


### PR DESCRIPTION
## Description
Adds a throw for failed search parameter initialization.

## Related issues
Addresses [AB#119273](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/119273)

## Testing
Manual testing

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
