### PR TITLE
fix to avoid using plain text in powershell script

### DIFF
--- a/build/jobs/add-aad-test-environment.yml
+++ b/build/jobs/add-aad-test-environment.yml
@@ -13,7 +13,7 @@ steps:
     ScriptType: inlineScript
     Inline: |
       Install-Module -Name AzureAD -Force -Verbose -Scope CurrentUser
-      Install-Module -Name Microsoft.PowerShell.SecretManagement
+      Install-Module -Name Microsoft.PowerShell.SecretManagement -Force -Verbose -Scope CurrentUser
 
       $module = Get-Module -Name AzureAD
       Write-Host $module.version

--- a/build/jobs/add-aad-test-environment.yml
+++ b/build/jobs/add-aad-test-environment.yml
@@ -13,6 +13,8 @@ steps:
     ScriptType: inlineScript
     Inline: |
       Install-Module -Name AzureAD -Force -Verbose -Scope CurrentUser
+      Install-Module -Name Microsoft.PowerShell.SecretManagement
+
       $module = Get-Module -Name AzureAD
       Write-Host $module.version
 

--- a/release/scripts/PowerShell/FhirServerRelease/Private/Set-FhirServerApiUsers.ps1
+++ b/release/scripts/PowerShell/FhirServerRelease/Private/Set-FhirServerApiUsers.ps1
@@ -63,7 +63,7 @@ function Set-FhirServerApiUsers {
 
         Add-Type -AssemblyName System.Web
         $password = [System.Web.Security.Membership]::GeneratePassword(16, 5)
-        $passwordSecureString = ConvertTo-SecureString $password -AsPlainText -Force
+        $passwordSecureString = ConvertTo-SecureString $password -AsSecureString -Force
 
         if ($aadUser) {
             Set-AzureADUserPassword -ObjectId $aadUser.ObjectId -Password $passwordSecureString -EnforceChangePasswordPolicy $false -ForceChangePasswordNextLogin $false
@@ -77,7 +77,7 @@ function Set-FhirServerApiUsers {
             $aadUser = New-AzureADUser -DisplayName $userId -PasswordProfile $PasswordProfile -UserPrincipalName $userUpn -AccountEnabled $true -MailNickName $userId
         }
 
-        $upnSecureString = ConvertTo-SecureString -string $userUpn -AsPlainText -Force
+        $upnSecureString = ConvertTo-SecureString -string $userUpn -AsSecureString -Force
         Set-AzKeyVaultSecret -VaultName $KeyVaultName -Name "user--$($user.id)--id" -SecretValue $upnSecureString | Out-Null
         Set-AzKeyVaultSecret -VaultName $KeyVaultName -Name "user--$($user.id)--secret" -SecretValue $passwordSecureString | Out-Null
 

--- a/release/scripts/PowerShell/FhirServerRelease/Private/Set-FhirServerApiUsers.ps1
+++ b/release/scripts/PowerShell/FhirServerRelease/Private/Set-FhirServerApiUsers.ps1
@@ -64,8 +64,6 @@ function Set-FhirServerApiUsers {
         Add-Type -AssemblyName System.Web
         $password = [System.Web.Security.Membership]::GeneratePassword(16, 5)
 
-        # $passwordSecureString = ConvertTo-SecureString $password -AsPlainText -Force
-
         Set-Secret -Name passwordSecure -Secret $password
         $passwordSecureString = Get-Secret -Name passwordSecure
 
@@ -80,8 +78,6 @@ function Set-FhirServerApiUsers {
 
             $aadUser = New-AzureADUser -DisplayName $userId -PasswordProfile $PasswordProfile -UserPrincipalName $userUpn -AccountEnabled $true -MailNickName $userId
         }
-
-        # $upnSecureString = ConvertTo-SecureString -string $userUpn -AsPlainText -Force
 
         Set-Secret -Name upnSecure -Secret $userUpn
         $upnSecureString = Get-Secret -Name upnSecure

--- a/release/scripts/PowerShell/FhirServerRelease/Private/Set-FhirServerApiUsers.ps1
+++ b/release/scripts/PowerShell/FhirServerRelease/Private/Set-FhirServerApiUsers.ps1
@@ -63,7 +63,11 @@ function Set-FhirServerApiUsers {
 
         Add-Type -AssemblyName System.Web
         $password = [System.Web.Security.Membership]::GeneratePassword(16, 5)
-        $passwordSecureString = ConvertTo-SecureString $password -AsSecureString -Force
+
+        # $passwordSecureString = ConvertTo-SecureString $password -AsPlainText -Force
+
+        Set-Secret -Name passwordSecure -Secret $password
+        $passwordSecureString = Get-Secret -Name passwordSecure
 
         if ($aadUser) {
             Set-AzureADUserPassword -ObjectId $aadUser.ObjectId -Password $passwordSecureString -EnforceChangePasswordPolicy $false -ForceChangePasswordNextLogin $false
@@ -77,7 +81,11 @@ function Set-FhirServerApiUsers {
             $aadUser = New-AzureADUser -DisplayName $userId -PasswordProfile $PasswordProfile -UserPrincipalName $userUpn -AccountEnabled $true -MailNickName $userId
         }
 
-        $upnSecureString = ConvertTo-SecureString -string $userUpn -AsSecureString -Force
+        # $upnSecureString = ConvertTo-SecureString -string $userUpn -AsPlainText -Force
+
+        Set-Secret -Name upnSecure -Secret $userUpn
+        $upnSecureString = Get-Secret -Name upnSecure
+
         Set-AzKeyVaultSecret -VaultName $KeyVaultName -Name "user--$($user.id)--id" -SecretValue $upnSecureString | Out-Null
         Set-AzKeyVaultSecret -VaultName $KeyVaultName -Name "user--$($user.id)--secret" -SecretValue $passwordSecureString | Out-Null
 

--- a/release/scripts/PowerShell/FhirServerRelease/Public/Add-AadTestAuthEnvironment.ps1
+++ b/release/scripts/PowerShell/FhirServerRelease/Public/Add-AadTestAuthEnvironment.ps1
@@ -173,16 +173,12 @@ function Add-AadTestAuthEnvironment {
 
             $aadClientApplication = New-FhirServerClientApplicationRegistration -ApiAppId $application.AppId -DisplayName "$displayName" -PublicClient:$publicClient
 
-            # $secretSecureString = ConvertTo-SecureString $aadClientApplication.AppSecret -AsPlainText -Force
-
             Set-Secret -Name secretSecure -Secret $aadClientApplication.AppSecret
             $secretSecureString = Get-Secret -Name secretSecure
         }
         else {
             $existingPassword = Get-AzureADApplicationPasswordCredential -ObjectId $aadClientApplication.ObjectId | Remove-AzureADApplicationPasswordCredential -ObjectId $aadClientApplication.ObjectId
             $newPassword = New-AzureADApplicationPasswordCredential -ObjectId $aadClientApplication.ObjectId
-
-            # $secretSecureString = ConvertTo-SecureString $newPassword.Value -AsPlainText -Force
 
             Set-Secret -Name secretSecure -Secret $aadClientApplication.AppSecret
             $secretSecureString = Get-Secret -Name secretSecure
@@ -200,8 +196,6 @@ function Add-AadTestAuthEnvironment {
             displayName = $displayName
             appId       = $aadClientApplication.AppId
         }
-
-        # $appIdSecureString = ConvertTo-SecureString -String $aadClientApplication.AppId -AsPlainText -Force
 
         Set-Secret -Name appIdSecure -Secret $aadClientApplication.AppId | Out-Null
         $appIdSecureString = Get-Secret -Name appIdSecure

--- a/release/scripts/PowerShell/FhirServerRelease/Public/Add-AadTestAuthEnvironment.ps1
+++ b/release/scripts/PowerShell/FhirServerRelease/Public/Add-AadTestAuthEnvironment.ps1
@@ -156,14 +156,14 @@ function Add-AadTestAuthEnvironment {
 
             $aadClientApplication = New-FhirServerClientApplicationRegistration -ApiAppId $application.AppId -DisplayName "$displayName" -PublicClient:$publicClient
 
-            $secretSecureString = ConvertTo-SecureString $aadClientApplication.AppSecret -AsPlainText -Force
+            $secretSecureString = ConvertTo-SecureString $aadClientApplication.AppSecret -AsSecureString -Force
 
         }
         else {
             $existingPassword = Get-AzureADApplicationPasswordCredential -ObjectId $aadClientApplication.ObjectId | Remove-AzureADApplicationPasswordCredential -ObjectId $aadClientApplication.ObjectId
             $newPassword = New-AzureADApplicationPasswordCredential -ObjectId $aadClientApplication.ObjectId
 
-            $secretSecureString = ConvertTo-SecureString $newPassword.Value -AsPlainText -Force
+            $secretSecureString = ConvertTo-SecureString $newPassword.Value -AsSecureString -Force
         }
 
         if ($publicClient) {
@@ -179,7 +179,7 @@ function Add-AadTestAuthEnvironment {
             appId       = $aadClientApplication.AppId
         }
 
-        $appIdSecureString = ConvertTo-SecureString -String $aadClientApplication.AppId -AsPlainText -Force
+        $appIdSecureString = ConvertTo-SecureString -String $aadClientApplication.AppId -AsSecureString -Force
         Set-AzKeyVaultSecret -VaultName $KeyVaultName -Name "app--$($clientApp.Id)--id" -SecretValue $appIdSecureString | Out-Null
         Set-AzKeyVaultSecret -VaultName $KeyVaultName -Name "app--$($clientApp.Id)--secret" -SecretValue $secretSecureString | Out-Null
 


### PR DESCRIPTION
## Description
This PR fix the issue of getting psscriptanalyzer:Error: PSAvoidUsingConvertToSecureStringWithPlainText

## Related issues
Addresses [issue AB#[106893](https://microsofthealth.visualstudio.com/Health/_workitems/edit/106893)].

## Testing
Ran the PS script Analyzer and there was no error.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
