### PR TITLE
[Logging] Adding better logging to Bad Request

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Search/FhirCosmosSearchService.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
             CompartmentSearchRewriter compartmentSearchRewriter,
             SmartCompartmentSearchRewriter smartCompartmentSearchRewriter,
             ILogger<FhirCosmosSearchService> logger)
-            : base(searchOptionsFactory, fhirDataStore)
+            : base(searchOptionsFactory, fhirDataStore, logger)
         {
             EnsureArg.IsNotNull(fhirDataStore, nameof(fhirDataStore));
             EnsureArg.IsNotNull(queryBuilder, nameof(queryBuilder));
@@ -129,6 +129,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
                 if (includeExpressions.Any(e => e.Iterate) || revIncludeExpressions.Any(e => e.Iterate))
                 {
                     // We haven't implemented this yet.
+                    _logger.LogWarning("Bad Request (IncludeIterateNotSupported)");
                     throw new BadRequestException(Resources.IncludeIterateNotSupported);
                 }
             }
@@ -294,11 +295,13 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
                     chainedOptions,
                     queryTimeout.Token))
                 {
+                    _logger.LogWarning("Invalid Search Operation (ChainedExpressionSubqueryLimit)");
                     throw new InvalidSearchOperationException(string.Format(CultureInfo.InvariantCulture, Resources.ChainedExpressionSubqueryLimit, _chainedSearchMaxSubqueryItemLimit));
                 }
             }
             catch (OperationCanceledException)
             {
+                _logger.LogWarning("Request Too Costly (ConditionalRequestTooCostly)");
                 throw new RequestTooCostlyException(Core.Resources.ConditionalRequestTooCostly);
             }
 
@@ -496,6 +499,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
                         }
                         catch (ArgumentException)
                         {
+                            _logger.LogWarning("Bad Request (InvalidFeedRange)");
                             throw new BadRequestException(Resources.InvalidFeedRange);
                         }
                     }
@@ -516,7 +520,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
                     {
                         // ExecuteDocumentQueryAsync gave up on filling the pages. This suggests that we would have been better off querying in parallel.
 
-                        _logger.LogInformation(
+                        _logger.LogWarning(
                             "Failed to fill items, found {ItemCount}, needed {DesiredItemCount}. Physical partition count {PhysicalPartitionCount}",
                             results.Count,
                             desiredItemCount,
@@ -553,6 +557,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Search
                         OperationOutcomeConstants.IssueType.NotSupported,
                         string.Format(Core.Resources.SearchCountResultsExceedLimit, count, int.MaxValue)));
 
+                _logger.LogWarning("Invalid Search Operation (SearchCountResultsExceedLimit)");
                 throw new InvalidSearchOperationException(string.Format(Core.Resources.SearchCountResultsExceedLimit, count, int.MaxValue));
             }
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchServiceTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchServiceTests.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using Hl7.Fhir.Serialization;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features;
@@ -196,7 +197,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
         private class TestSearchService : SearchService
         {
             public TestSearchService(ISearchOptionsFactory searchOptionsFactory, IFhirDataStore fhirDataStore)
-                : base(searchOptionsFactory, fhirDataStore)
+                : base(searchOptionsFactory, fhirDataStore, NullLogger.Instance)
             {
                 SearchImplementation = options => null;
             }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
             ICompressedRawResourceConverter compressedRawResourceConverter,
             ISqlQueryHashCalculator queryHashCalculator,
             ILogger<SqlServerSearchService> logger)
-            : base(searchOptionsFactory, fhirDataStore)
+            : base(searchOptionsFactory, fhirDataStore, logger)
         {
             EnsureArg.IsNotNull(sqlRootExpressionRewriter, nameof(sqlRootExpressionRewriter));
             EnsureArg.IsNotNull(chainFlatteningRewriter, nameof(chainFlatteningRewriter));
@@ -146,8 +146,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                         // a "special" ct so that we the subsequent request will be handled correctly.
                         var ct = new ContinuationToken(new object[]
                             {
-                                    SqlSearchConstants.SortSentinelValueForCt,
-                                    0,
+                                SqlSearchConstants.SortSentinelValueForCt,
+                                0,
                             });
 
                         searchResult = new SearchResult(searchResult.Results, ct.ToJson(), searchResult.SortOrder, searchResult.UnsupportedSearchParameters);
@@ -266,6 +266,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                 }
                 else
                 {
+                    _logger.LogWarning("Bad Request (InvalidContinuationToken)");
                     throw new BadRequestException(Resources.InvalidContinuationToken);
                 }
             }
@@ -374,6 +375,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                                             OperationOutcomeConstants.IssueType.NotSupported,
                                             string.Format(Core.Resources.SearchCountResultsExceedLimit, count, int.MaxValue)));
 
+                                    _logger.LogWarning("Invalid Search Operation (SearchCountResultsExceedLimit)");
                                     throw new InvalidSearchOperationException(string.Format(Core.Resources.SearchCountResultsExceedLimit, count, int.MaxValue));
                                 }
 
@@ -507,6 +509,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
 
                             if (isResultPartial)
                             {
+                                _logger.LogWarning("Bundle Partial Result (TruncatedIncludeMessage)");
                                 _requestContextAccessor.RequestContext.BundleIssues.Add(
                                     new OperationOutcomeIssue(
                                         OperationOutcomeConstants.IssueSeverity.Warning,

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -251,6 +251,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                             continue;
                         }
 
+                        _logger.LogInformation("BadRequest: IfMatchHeaderRequiredForResource");
                         results.Add(identifier, new DataStoreOperationOutcome(new BadRequestException(string.Format(Core.Resources.IfMatchHeaderRequiredForResource, resource.ResourceTypeName))));
                         continue;
                     }


### PR DESCRIPTION
Adding better logging to Bad Request errors. 
Sometimes the origin of the bad requests is not clear, and we need to rely on the customer feedback to support their scenarios. 

In this PR, I'm trying to improve that by adding more clear logs to bad requests. 

[AB#120197](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/120197)

- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

