### PR TITLE
Update $convert-data error log

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/ConvertDataEngine.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/ConvertDataEngine.cs
@@ -96,7 +96,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.ConvertData
                 }
 
                 _logger.LogError($"Convert data failed. An exception of type {convertException.GetType()} occurred with error code - {convertException.FhirConverterErrorCode}. {convertException.StackTrace}");
-
                 throw new ConvertDataFailedException(string.Format(Core.Resources.ConvertDataFailed, convertException.Message), convertException);
             }
             catch (Exception ex)

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/ConvertDataEngine.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/ConvertData/ConvertDataEngine.cs
@@ -95,14 +95,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.ConvertData
                     throw new ConvertDataTimeoutException(Core.Resources.ConvertDataOperationTimeout, convertException.InnerException);
                 }
 
-                if (convertException is PostprocessException)
-                {
-                    _logger.LogInformation($"An exception of type {convertException.GetType()} occurred during postprocessing. {convertException.StackTrace}", "Convert data failed.");
-                }
-                else
-                {
-                    _logger.LogInformation(convertException, "Convert data failed.");
-                }
+                _logger.LogError($"Convert data failed. An exception of type {convertException.GetType()} occurred with error code - {convertException.FhirConverterErrorCode}. {convertException.StackTrace}");
 
                 throw new ConvertDataFailedException(string.Format(Core.Resources.ConvertDataFailed, convertException.Message), convertException);
             }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/ConvertData/MockLogger.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/ConvertData/MockLogger.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Conver
     public abstract class MockLogger<T> : ILogger<T>
     {
         void ILogger.Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
-         => Log(logLevel, formatter(state, exception));
+         => Log(logLevel, formatter(state, exception), exception);
 
         public abstract void Log(LogLevel logLevel, object state, Exception exception = null);
 


### PR DESCRIPTION
## Description
Update $convert-data error log. Currently, the entire exception is logged in some cases (except post processing exceptions) which might not be ideal in case the message has text from the input data being processed.
Updating the log to only mention exception type, FHIRConverterErrorCode and stack trace.

## Related issues
Addresses [AB#120207](https://microsofthealth.visualstudio.com/Health/_workitems/edit/120207).

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
