### PR TITLE
default-azuredeploy-docker.json updated with new service principal

### DIFF
--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -564,7 +564,7 @@
             ],
             "properties": {
                 "roleDefinitionId": "[concat(subscription().Id, '/providers/Microsoft.Authorization/roleDefinitions/', 'b86a8fe4-44ce-4948-aee5-eccb2c155cd7')]", // Role definition ID for "Key Vault Secrets Officer"
-                "principalId": "3cd8f0ad-3c21-47f1-9a15-b01d9958909a"
+                "principalId": "360dc5cd-5236-4ac9-9674-b18fea801e00"
             }
         },
         {

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -564,7 +564,7 @@
             ],
             "properties": {
                 "roleDefinitionId": "[concat(subscription().Id, '/providers/Microsoft.Authorization/roleDefinitions/', 'b86a8fe4-44ce-4948-aee5-eccb2c155cd7')]", // Role definition ID for "Key Vault Secrets Officer"
-                "principalId": "360dc5cd-5236-4ac9-9674-b18fea801e00"
+                "principalId": "89e25294-a480-4657-a77d-bf69c28a836c"
             }
         },
         {


### PR DESCRIPTION
## Description
https://microsofthealthoss.visualstudio.com/FhirServer/_build/results?buildId=40824&view=results, this pipeline fails with a missing service principal id error.
I have created new service principal with workloadidentity auth schema. default-azuredeploy-docker.json file is updated to use that.

## Related issues
Addresses [issue [AB#120094](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Olympus/Stories/?workitem=120094)].

## Testing
PR and CI Pipeline

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
