### PR TITLE
[Refactoring] Moving SP initialization and avoid circular dependencies

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb.Core/Features/Storage/Versioning/CollectionUpgradeManager.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.Core/Features/Storage/Versioning/CollectionUpgradeManager.cs
@@ -20,7 +20,6 @@ namespace Microsoft.Health.Fhir.CosmosDb.Core.Features.Storage.Versioning
     public class CollectionUpgradeManager : IUpgradeManager
     {
         private readonly ICollectionDataUpdater _collectionDataUpdater;
-        private readonly IStoredProcedureInstaller _storedProcedureInstaller;
         private readonly CosmosDataStoreConfiguration _configuration;
         private readonly CosmosCollectionConfiguration _collectionConfiguration;
         private readonly ICosmosDbDistributedLockFactory _lockFactory;
@@ -28,22 +27,17 @@ namespace Microsoft.Health.Fhir.CosmosDb.Core.Features.Storage.Versioning
 
         public CollectionUpgradeManager(
             ICollectionDataUpdater collectionDataUpdater,
-            IStoredProcedureInstaller storedProcedureInstaller,
-            ICollectionSetup collectionSetup,
             CosmosDataStoreConfiguration configuration,
             IOptionsMonitor<CosmosCollectionConfiguration> namedCosmosCollectionConfigurationAccessor,
             ICosmosDbDistributedLockFactory lockFactory,
             ILogger<CollectionUpgradeManager> logger)
         {
             EnsureArg.IsNotNull(collectionDataUpdater, nameof(collectionDataUpdater));
-            EnsureArg.IsNotNull(storedProcedureInstaller, nameof(storedProcedureInstaller));
-            EnsureArg.IsNotNull(collectionSetup, nameof(collectionSetup));
             EnsureArg.IsNotNull(configuration, nameof(configuration));
             EnsureArg.IsNotNull(namedCosmosCollectionConfigurationAccessor, nameof(namedCosmosCollectionConfigurationAccessor));
             EnsureArg.IsNotNull(lockFactory, nameof(lockFactory));
             EnsureArg.IsNotNull(logger, nameof(logger));
             _collectionDataUpdater = collectionDataUpdater;
-            _storedProcedureInstaller = storedProcedureInstaller;
             _configuration = configuration;
             _collectionConfiguration = GetCosmosCollectionConfiguration(namedCosmosCollectionConfigurationAccessor, Constants.CollectionConfigurationName);
             _lockFactory = lockFactory;
@@ -67,7 +61,6 @@ namespace Microsoft.Health.Fhir.CosmosDb.Core.Features.Storage.Versioning
                     _logger.LogDebug("Attempting to acquire upgrade lock");
 
                     await distributedLock.AcquireLock(cancellationTokenSource.Token);
-                    await _storedProcedureInstaller.ExecuteAsync(container, cancellationToken);
                     await _collectionDataUpdater.ExecuteAsync(container, cancellationToken);
                     await distributedLock.ReleaseLock();
                 }

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/Versioning/CollectionUpgradeManagerTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/Versioning/CollectionUpgradeManagerTests.cs
@@ -76,6 +76,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Storage.Versioning
                 _cosmosDataStoreConfiguration,
                 optionsMonitor,
                 collectionInitializer,
+                storeProcedureInstaller,
                 NullLogger<DataPlaneCollectionSetup>.Instance);
 
             var collectionVersionWrappers = Substitute.ForPartsOf<FeedIterator<CollectionVersion>>();
@@ -88,8 +89,6 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Storage.Versioning
 
             _manager = new CollectionUpgradeManager(
                 collectionDataUpdater,
-                storeProcedureInstaller,
-                dataPlaneCollectionSetup,
                 _cosmosDataStoreConfiguration,
                 optionsMonitor,
                 factory,


### PR DESCRIPTION
* Removing dependencies to IStoredProcedureInstaller from CollectionUpgradeManager. 
* Moving Stored Procedure installation to DataPlaneCollectionSetup. 
* Refactoring tests as needed. 