### PR TITLE
Retry logic added for connection time out error

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlRetry/SqlRetryService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlRetry/SqlRetryService.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                 }
                 catch (Exception ex)
                 {
-                    if (++retry >= _maxRetries || !IsRetriable(ex))
+                    if (++retry >= _maxRetries || !IsRetriable(ex) || !ex.IsExecutionTimeout())
                     {
                         throw;
                     }
@@ -284,7 +284,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                 catch (Exception ex)
                 {
                     lastException = ex;
-                    if (disableRetries || !IsRetriable(ex))
+                    if (disableRetries || !IsRetriable(ex) || !ex.IsExecutionTimeout())
                     {
                         throw;
                     }


### PR DESCRIPTION
## Description
Retry logic added for connection time out error

## Related issues
Addresses [issue [AB#120902](https://microsofthealth.visualstudio.com/Health/_boards/board/t/Olympus/Stories/?workitem=120902)].

## Testing
Tests in PR and CI pipeline

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
