### PR TITLE
Fix Flaky History Test

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HistoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HistoryTests.cs
@@ -118,10 +118,10 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             List<string> expectedResourceIds = expectedResources.Select(r => r.Id).ToList();
             List<Resource> serverResources = [];
 
-            foreach (var testResource in expectedResources)
+            await Task.WhenAll(expectedResources.Select(async testResource =>
             {
                 serverResources.AddRange((await _client.SearchAsync($"{testResource.TypeName}/{testResource.Id}/_history")).Resource.Entry.Select(r => r.Resource));
-            }
+            }));
 
             var sinceTime = serverResources.Min(r => r.Meta.LastUpdated.Value).UtcDateTime.ToString("o");
             var beforeTime = serverResources.Max(r => r.Meta.LastUpdated.Value).UtcDateTime.AddMilliseconds(1).ToString("o");

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HistoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HistoryTests.cs
@@ -116,9 +116,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             // Calculate the min/max from db values.
             List<DomainResource> expectedResources = [firstTestResource, secondTestResource, thirdTestResource, fourthTestResource];
             List<string> expectedResourceIds = expectedResources.Select(r => r.Id).ToList();
-
             DateTimeOffset sinceTime = DateTimeOffset.MinValue, beforeTime = DateTimeOffset.MaxValue;
-            object lockObject = new object();
+            object lockObject = new();
 
             await Task.WhenAll(expectedResources.Select(async testResource =>
             {


### PR DESCRIPTION
## Description
The test `GivenTestResourcesWithUpdatesAndDeletes_WhenGettingResourceHistoryCount_TheServerShouldReturnCorrectCount` is behaving flakily and blocking PRs from executing for others devs. Changing the way it finds history for more reliability.

## Related issues
[AB#121007](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/121007)

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
