### PR TITLE
Fix dependabot name

### DIFF
--- a/.github/workflows/validate-prs.yml
+++ b/.github/workflows/validate-prs.yml
@@ -36,7 +36,7 @@ jobs:
             const labels = "${{env.LABELS}}";
             const author = "${{env.AUTHOR}}";
 
-            const excludeAuthors = ["dependabot"];
+            const excludeAuthors = ["dependabot[bot]"];
             
             if(title.toLowerCase().includes('personal') || (title.length > 65)) {
               errors += '- Title of the PR to be succinct and less than 65 characters. \n';


### PR DESCRIPTION
## Description
Fix github action to not require work items for dependabot PRs.

## Related issues
Addresses [AB#118095](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/118095)

## Testing


## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
