### PR TITLE
Adds exception block for handling managed identity for import

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/ImportOrchestratorJob.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/ImportOrchestratorJob.cs
@@ -11,6 +11,7 @@ using System.Net;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Identity;
 using EnsureThat;
 using Hl7.Fhir.Rest;
 using Hl7.Fhir.Utility;
@@ -140,6 +141,12 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
                     _logger.LogJobInformation(ex, jobInfo, "Failed to register processing jobs.");
                 }
 
+                await SendNotification(JobStatus.Failed, jobInfo, 0, 0, result.TotalBytes, inputData.ImportMode, fhirRequestContext, _logger, _auditLogger, _mediator);
+            }
+            catch (CredentialUnavailableException ex)
+            {
+                _logger.LogJobError(ex, jobInfo, "Failed to register processing jobs.-CredentialUnavailableException");
+                errorResult = new ImportJobErrorResult() { ErrorMessage = "Managed Identity cannot access storage account.", ErrorDetails = ex.ToString(), HttpStatusCode = HttpStatusCode.BadRequest };
                 await SendNotification(JobStatus.Failed, jobInfo, 0, 0, result.TotalBytes, inputData.ImportMode, fhirRequestContext, _logger, _auditLogger, _mediator);
             }
             catch (Exception ex)


### PR DESCRIPTION
## Description
We have added additional catch block to handle exceptions of "CredentialUnavailableException," which are thrown due to managed identity issues. 
In this catch block, we can return a 400 status code with complete stack as error message. 

## Related issues
Addresses [issue AB#116962.](https://microsofthealth.visualstudio.com/Health/_workitems/edit/116962)

## Testing
Created New OSS server with the latest changes 
Managed Identity disabled for the Web app. 
Run the Import request 
Result - Getting 400 status code with error message ("import operation failed for reason: Managed Identity cannot access storage account.").
 

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
