### PR TITLE
User story 100880 - Changes for Routing and Binders namespace.

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Binders/DictionaryExpansionConfigurationProvider.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Binders/DictionaryExpansionConfigurationProvider.cs
@@ -48,7 +48,7 @@ public class DictionaryExpansionConfigurationProvider : ConfigurationProvider
 
         var data = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-        EnumerateKeys(keys, data);
+        EnumerateKeys((IReadOnlyCollection<string>)keys, data);
 
         Data = data;
     }
@@ -86,7 +86,7 @@ public class DictionaryExpansionConfigurationProvider : ConfigurationProvider
         }
     }
 
-    private void EnumerateKeys(IEnumerable<string> keys, Dictionary<string, string> data, string path = null)
+    private void EnumerateKeys(IReadOnlyCollection<string> keys, Dictionary<string, string> data, string path = null)
     {
         foreach (string keyName in keys.Distinct())
         {
@@ -103,7 +103,7 @@ public class DictionaryExpansionConfigurationProvider : ConfigurationProvider
                 }
             }
 
-            IEnumerable<string> innerKeys = _configurationProvider.GetChildKeys(Array.Empty<string>(), keyPath);
+            var innerKeys = (IReadOnlyCollection<string>)_configurationProvider.GetChildKeys(Array.Empty<string>(), keyPath);
             EnumerateKeys(innerKeys, data, keyPath);
         }
     }

--- a/src/Microsoft.Health.Fhir.Api/Features/Routing/UrlResolver.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Routing/UrlResolver.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
                 Request.Host.Value);
         }
 
-        public Uri ResolveRouteUrl(IEnumerable<Tuple<string, string>> unsupportedSearchParams = null, IReadOnlyList<(SearchParameterInfo searchParameterInfo, SortOrder sortOrder)> resultSortOrder = null, string continuationToken = null, bool removeTotalParameter = false)
+        public Uri ResolveRouteUrl(IReadOnlyCollection<Tuple<string, string>> unsupportedSearchParams = null, IReadOnlyList<(SearchParameterInfo searchParameterInfo, SortOrder sortOrder)> resultSortOrder = null, string continuationToken = null, bool removeTotalParameter = false)
         {
             string routeName = _fhirRequestContextAccessor.RequestContext.RouteName;
 
@@ -193,7 +193,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
                     else
                     {
                         // 3. The exclude unsupported parameters
-                        IEnumerable<string> removedValues = searchParamsToRemove[searchParam.Key];
+                        var removedValues = searchParamsToRemove[searchParam.Key].ToList();
                         StringValues usedValues = removedValues.Any()
                             ? new StringValues(
                                 searchParam.Value.Select(x => x.SplitByOrSeparator().Except(removedValues).JoinByOrSeparator())

--- a/src/Microsoft.Health.Fhir.Core/Features/Routing/IUrlResolver.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Routing/IUrlResolver.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Routing
         /// <param name="continuationToken">The continuation token.</param>
         /// <param name="removeTotalParameter">True if the _total parameter should be removed from the url, false otherwise.</param>
         /// <returns>The URL.</returns>
-        Uri ResolveRouteUrl(IEnumerable<Tuple<string, string>> unsupportedSearchParams = null, IReadOnlyList<(SearchParameterInfo searchParameterInfo, SortOrder sortOrder)> resultSortOrder = null, string continuationToken = null, bool removeTotalParameter = false);
+        Uri ResolveRouteUrl(IReadOnlyCollection<Tuple<string, string>> unsupportedSearchParams = null, IReadOnlyList<(SearchParameterInfo searchParameterInfo, SortOrder sortOrder)> resultSortOrder = null, string continuationToken = null, bool removeTotalParameter = false);
 
         /// <summary>
         /// Resolves the URL for the specified routeName.


### PR DESCRIPTION
## Description
changes to below namespaces for user story 100880
Microsoft.Health.Fhir.Api.Features.Binders
Microsoft.Health.Fhir.Api.Features.Routing

## Related issues
user story [AB#100880](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/100880)

## Testing
ran unit tests.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
