### PR TITLE
118017 - Invalid 500 cast exception 

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Routing/KnownActionParameterNames.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Routing/KnownActionParameterNames.cs
@@ -13,5 +13,6 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
         public const string Vid = "vidParameter";
         public const string CompartmentType = "compartmentTypeParameter";
         public const string Bundle = "bundle";
+        public const string ParamsResource = "paramsResource";
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/ValidateResourceTypeFilterTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Filters/ValidateResourceTypeFilterTests.cs
@@ -80,12 +80,34 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Filters
             Assert.Throws<ResourceNotValidException>(() => filter.OnActionExecuting(context));
         }
 
-        private static ActionExecutingContext CreateContext(Base type)
+        [Fact]
+        public void GivenAnPatchFhirAction_WhenPostingAParametersObject_ThenTheResultIsSuccessful()
+        {
+            var filter = new ValidateResourceTypeFilterAttribute();
+
+            var parameters = new Parameters();
+            parameters.Add("resource", new Observation());
+            var context = CreateContext(parameters, true);
+
+            filter.OnActionExecuting(context);
+        }
+
+        [Fact]
+        public void GivenAnPatchFhirAction_WhenPostingAParametersObservationObject_ThenATypeMistatchExceptionShouldBeThrown()
+        {
+            var filter = new ValidateResourceTypeFilterAttribute();
+
+            var context = CreateContext(new Observation(), true);
+
+            Assert.Throws<ResourceNotValidException>(() => filter.OnActionExecuting(context));
+        }
+
+        private static ActionExecutingContext CreateContext(Base type, bool paramsResource = false)
         {
             return new ActionExecutingContext(
                 new ActionContext(new DefaultHttpContext(), new RouteData { Values = { [KnownActionParameterNames.ResourceType] = "Observation" } }, new ActionDescriptor()),
                 new List<IFilterMetadata>(),
-                new Dictionary<string, object> { { "resource", type } },
+                new Dictionary<string, object> { { (!paramsResource) ? "resource" : "paramsResource", type } },
                 FilterTestsHelper.CreateMockFhirController());
         }
     }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/ValidateResourceTypeFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/ValidateResourceTypeFilterAttribute.cs
@@ -11,6 +11,7 @@ using Hl7.Fhir.Model;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Health.Fhir.Api.Features.Routing;
 using Microsoft.Health.Fhir.Core.Features.Validation;
+using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Api.Features.Filters
 {
@@ -31,6 +32,13 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
             {
                 var resource = ParseResource((Resource)parsedModel);
                 ValidateType(resource, (string)actionModelType);
+            }
+
+            // Validated Resource Type of Parameters
+            if (context.ActionArguments.TryGetValue(KnownActionParameterNames.ParamsResource, out var parsedParamModel))
+            {
+                var resource = ParseResource((Resource)parsedParamModel);
+                ValidateType(resource, KnownResourceTypes.Parameters);
             }
         }
 


### PR DESCRIPTION
## Description
User Story [AB#118017](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/118017) - Invalid 500 cast exception fixed for FHIR Patch request.

## Related issues
Addresses [issue [AB#118017](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/118017)].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
