### PR TITLE
Remove AllowAllAzureWindowsIps

### DIFF
--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -132,7 +132,12 @@ jobs:
             }
           }
         }
-
+         if("${{ parameters.sql }}" -eq "true")
+        {
+          $sqlName = "${{ parameters.sqlServerName }}".ToLower()
+          $agentIP = (New-Object net.webclient).downloadstring("https://api.ipify.org")
+          New-AzSqlServerFirewallRule -ResourceGroupName $resourceGroupName -ServerName $sqlName -FirewallRuleName "AzureAgentFirewall" -StartIPAddress $agentIp -EndIPAddress $agentIP
+        }
   - template: ./provision-healthcheck.yml
     parameters: 
       webAppName: ${{ parameters.webAppName }}

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -135,8 +135,9 @@ jobs:
          if("${{ parameters.sql }}" -eq "true")
         {
           $sqlName = "${{ parameters.sqlServerName }}".ToLower()
+          $fireWallRuleName = "AzureAgentFirewall-${{ parameters.version }}"
           $agentIP = (New-Object net.webclient).downloadstring("https://api.ipify.org")
-          New-AzSqlServerFirewallRule -ResourceGroupName $resourceGroupName -ServerName $sqlName -FirewallRuleName "AzureAgentFirewall" -StartIPAddress $agentIp -EndIPAddress $agentIP
+          New-AzSqlServerFirewallRule -ResourceGroupName $resourceGroupName -ServerName $sqlName -FirewallRuleName $fireWallRuleName -StartIPAddress $agentIp -EndIPAddress $agentIP
         }
   - template: ./provision-healthcheck.yml
     parameters: 

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -496,6 +496,67 @@
             ]
         },
         {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2022-09-01",
+            "name": "webAppIPsSQLFirewall",
+            "properties": {
+                "expressionEvaluationOptions": {
+                    "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                    "webAppOutboundIpAddresses": {
+                        "value": "[split(reference(concat('Microsoft.Web/sites/',variables('serviceName'))).possibleOutboundIpAddresses,',')]"
+                    },
+                    "sqlServerName": {
+                        "value": "[variables('sqlServerDerivedName')]"
+                    }
+                },
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                   
+                    "parameters": {
+                        "webAppOutboundIpAddresses": {
+                            "type": "array",
+                            "metadata": {
+                                "description": "Array of possible Outbound IP addresses for the Web Application"
+                            }
+                        },
+                        "sqlServerName": {
+                            "type": "string",
+                            "metadata": {
+                                "description": "Name of the logical SQL Server"
+                            }
+                        }
+                    },
+                    "resources": [
+                        {
+                            "comments": "Add the Outbound IP Addresses from the Web App",
+                            "type": "Microsoft.Sql/servers/firewallRules",
+                            "apiVersion": "2015-05-01-preview",
+                            "name": "[concat(parameters('sqlServerName'), '/Allow WebApp Outbound IP ',copyIndex('webAppOutboundIPAddressesCopy'))]",
+                            "properties": {
+                                "startIpAddress": "[parameters('webAppOutboundIpAddresses')[copyIndex('webAppOutboundIPAddressesCopy')]]",
+                                "endIpAddress": "[parameters('webAppOutboundIpAddresses')[copyIndex('webAppOutboundIPAddressesCopy')]]"
+                            },
+                            "copy": {
+                                "name": "webAppOutboundIPAddressesCopy",
+                                "count": "[length(parameters('webAppOutboundIpAddresses'))]"
+                            }
+                        }
+                    ]
+                }
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Sql/servers', variables('sqlServerDerivedName'))]",
+                "[resourceId('Microsoft.Web/sites', variables('serviceName'))]"
+            ],
+            "metadata": {
+                "description": "FireWall Rule setup"
+            }
+        },
+        {
             "type": "Microsoft.KeyVault/vaults",
             "name": "[variables('serviceName')]",
             "apiVersion": "2022-07-01",

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -492,20 +492,6 @@
                         "tier": "[variables('sqlSkuTier')]"
                     },
                     "type": "databases"
-                },
-                {
-                    "condition": "[equals(parameters('solutionType'),'FhirServerSqlServer')]",
-                    "apiVersion": "2014-04-01",
-                    "dependsOn": [
-                        "[variables('sqlServerDerivedName')]"
-                    ],
-                    "location": "[resourceGroup().location]",
-                    "name": "AllowAllWindowsAzureIps",
-                    "properties": {
-                        "endIpAddress": "0.0.0.0",
-                        "startIpAddress": "0.0.0.0"
-                    },
-                    "type": "firewallrules"
                 }
             ]
         },

--- a/samples/templates/default-sqlServer.json
+++ b/samples/templates/default-sqlServer.json
@@ -48,22 +48,7 @@
                 "administratorLogin": "fhirAdmin",
                 "administratorLoginPassword": "[parameters('sqlAdminPassword')]",
                 "version": "12.0"
-            },
-            "resources": [
-                {
-                    "apiVersion": "2014-04-01",
-                    "dependsOn": [
-                        "[parameters('sqlServerName')]"
-                    ],
-                    "location": "[resourceGroup().location]",
-                    "name": "AllowAllWindowsAzureIps",
-                    "properties": {
-                        "endIpAddress": "0.0.0.0",
-                        "startIpAddress": "0.0.0.0"
-                    },
-                    "type": "firewallrules"
-                }
-            ]
+            }
         }
     ]
 }


### PR DESCRIPTION
## Description
Updates SQL Server to deploy without `AllowAllAzureWindowsIps`. Updates server to accept requests from App Services and test execution VM.

## Related issues
Addresses [AB#121543](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/121543)

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
