### PR TITLE
Add IsDeleted check in search queries

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -253,10 +253,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
                     AppendHistoryClause(delimitedClause, context.ResourceVersionTypes); // This does not hurt today, but will be neded with resource history separation
 
-                    if (expression.SearchParamTableExpressions.Count == 0)
-                    {
-                        AppendDeletedClause(delimitedClause, context.ResourceVersionTypes);
-                    }
+                    AppendDeletedClause(delimitedClause, context.ResourceVersionTypes);
                 }
 
                 if (!searchOptions.CountOnly)

--- a/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
+++ b/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
 	  <EmbeddedResource Include="TestFiles\Normative\Bundle-BatchWithDuplicatedItems.json" />
 	  <EmbeddedResource Include="TestFiles\Normative\Bundle-BatchWithConditionalUpdateByIdentifier.json" />
+	  <EmbeddedResource Include="TestFiles\Normative\Flag.json" />
 	  <EmbeddedResource Include="TestFiles\Normative\Import-Observation.ndjson" />
     <EmbeddedResource Include="TestFiles\Normative\LegacyRawReindexJobRecord.json" />
     <EmbeddedResource Include="DefinitionFiles\R5\SearchParameters.json" />

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/Flag.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/Flag.json
@@ -1,0 +1,48 @@
+{
+    "resourceType": "Flag",
+    "id": "example",
+    "text": {
+        "status": "generated",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Large Dog warning for Peter Patient</div>"
+    },
+    "identifier": [
+        {
+            "value": "12345"
+        }
+    ],
+    "status": "inactive",
+    "category": [
+        {
+            "coding": [
+                {
+                    "system": "http://terminology.hl7.org/CodeSystem/flag-category",
+                    "code": "safety",
+                    "display": "Safety"
+                }
+            ],
+            "text": "Safety"
+        }
+    ],
+    "code": {
+        "coding": [
+            {
+                "system": "http://example.org/local",
+                "code": "bigdog",
+                "display": "Big dog"
+            }
+        ],
+        "text": "Patient has a big dog at his home. Always always wear a suit of armor or take other active counter-measures"
+    },
+    "subject": {
+        "reference": "Patient/example",
+        "display": "Peter Patient"
+    },
+    "period": {
+        "start": "2015-01-17",
+        "end": "2016-12-01"
+    },
+    "author": {
+        "reference": "Practitioner/example",
+        "display": "Nancy Nurse"
+    }
+}

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/DeleteTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/DeleteTests.cs
@@ -76,12 +76,12 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Fact]
         public async Task GivenADeletedResource_WhenSearchWithNotModifier_ThenDeletedResourcesShouldNotBeReturned()
         {
-            using FhirResponse<Flag> response = await _client.CreateAsync(Samples.GetJsonSample("Flag").ToPoco<Flag>());
+            FhirResponse<Flag> response = await _client.CreateAsync(Samples.GetJsonSample("Flag").ToPoco<Flag>());
 
             // Delete all Flag resources
             await _client.DeleteAllResources(ResourceType.Flag, null);
 
-            var searchResults = await _client.SearchAsync("Flag?_identifier:not=123");
+            var searchResults = await _client.SearchAsync("Flag?identifier:not=123");
 
             Assert.True(searchResults.Resource.Entry == null || searchResults.Resource.Entry.Count == 0);
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/DeleteTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/DeleteTests.cs
@@ -74,6 +74,19 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         }
 
         [Fact]
+        public async Task GivenADeletedResource_WhenSearchWithNotModifier_ThenDeletedResourcesShouldNotBeReturned()
+        {
+            using FhirResponse<Flag> response = await _client.CreateAsync(Samples.GetJsonSample("Flag").ToPoco<Flag>());
+
+            // Delete all Flag resources
+            await _client.DeleteAllResources(ResourceType.Flag, null);
+
+            var searchResults = await _client.SearchAsync("Flag?_identifier:not=123");
+
+            Assert.True(searchResults.Resource.Entry == null || searchResults.Resource.Entry.Count == 0);
+        }
+
+        [Fact]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenAResource_WhenHardDeleting_ThenServerShouldDeleteAllRelatedResourcesSuccessfully()
         {


### PR DESCRIPTION
## Description
We do not have a check for resources being in the deleted state on search queries.  This can result in deleted resources being returned in result sets under some conditions.

## Related issues
Addresses [issue #3920].  DevOps [issue [AB#121553](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/121553)]

## Testing
New E2E test added.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
