### PR TITLE
Changed search parameter init to run every schema upgrade

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SchemaUpgradedHandler.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SchemaUpgradedHandler.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             // If it is a snapshot upgrade, then we need to run initialization for all schema versions up to the current version.
             // When schema is run via tool, then the notification will be sent out from SqlSchemaManager.cs and if schema is initialized
             // by the fhir-server itself on startup then the notification will be sent out from SchemaInitializer.cs
-            await _sqlServerFhirModel.Initialize(notification.Version, notification.IsFullSchemaSnapshot, cancellationToken);
+            await _sqlServerFhirModel.Initialize(notification.Version, cancellationToken);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
@@ -373,10 +373,10 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                         DECLARE @lastUpdated datetimeoffset(7) = SYSDATETIMEOFFSET()
 
                         UPDATE dbo.SearchParam
-                        SET Status = sps.Status, LastUpdated = @lastUpdated, IsPartiallySupported = sps.IsPartiallySupported
+                        SET Status = ISNULL(dbo.SearchParam.Status, sps.Status), LastUpdated = @lastUpdated, IsPartiallySupported = sps.IsPartiallySupported
                         FROM dbo.SearchParam INNER JOIN @searchParamStatuses as sps
                         ON dbo.SearchParam.Uri = sps.Uri
-                        WHERE dbo.SearchParam.Status IS NULL
+                        WHERE dbo.SearchParam.Status IS NULL OR dbo.SearchParam.IsPartiallySupported IS NULL OR dbo.SearchParam.LastUpdated IS NULL
                         COMMIT TRANSACTION
 
                         SELECT @@ROWCOUNT AS RowsAffected";

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
@@ -33,7 +33,6 @@ using Microsoft.Health.SqlServer.Features.Schema.Model;
 using Microsoft.Health.SqlServer.Features.Storage;
 using Namotion.Reflection;
 using Newtonsoft.Json;
-using SemVer;
 
 namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 {

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
@@ -186,10 +186,10 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             ThrowIfCurrentSchemaVersionIsNull();
 
             // If the fhir-server is just starting up, synchronize the fhir-server dictionaries with the SQL database
-            await Initialize((int)_schemaInformation.Current, true, CancellationToken.None);
+            await Initialize((int)_schemaInformation.Current, CancellationToken.None);
         }
 
-        public async Task Initialize(int version, bool runAllInitialization, CancellationToken cancellationToken)
+        public async Task Initialize(int version, CancellationToken cancellationToken)
         {
             // This also covers the scenario when database is not setup so _highestInitializedVersion and version is 0.
             if (_highestInitializedVersion == version)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Microsoft.Health.Fhir.Shared.Tests.Integration.projitems
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Microsoft.Health.Fhir.Shared.Tests.Integration.projitems
@@ -33,6 +33,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlServerColumnTypeChangeTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlServerWatchdogTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlServerSchemaUpgradeTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlServerSearchParameterInitializationTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\CosmosDbFhirStorageTestHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\CosmosDbFhirStorageTestsFixture.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\FhirStorageTests.cs" />
@@ -48,5 +49,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\QueueClientTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlServerTransactionScopeTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\TestSqlHashCalculator.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)persistence\SqlServerSearchParameterInitializationTests.cs" />
   </ItemGroup>
 </Project>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Microsoft.Health.Fhir.Shared.Tests.Integration.projitems
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Microsoft.Health.Fhir.Shared.Tests.Integration.projitems
@@ -50,7 +50,4 @@
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\SqlServerTransactionScopeTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Persistence\TestSqlHashCalculator.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)persistence\SqlServerSearchParameterInitializationTests.cs" />
-  </ItemGroup>
 </Project>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             await _dbSetupRetryPolicy.ExecuteAsync(async () => { await schemaInitializer.InitializeAsync(forceIncrementalSchemaUpgrade, cancellationToken); });
             await InitWatchdogsParameters(databaseName);
             await EnableDatabaseLogging(databaseName);
-            await _sqlServerFhirModel.Initialize(maximumSupportedSchemaVersion, true, cancellationToken);
+            await _sqlServerFhirModel.Initialize(maximumSupportedSchemaVersion, cancellationToken);
         }
 
         public async Task EnableDatabaseLogging(string databaseName)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerSearchParameterInitializationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerSearchParameterInitializationTests.cs
@@ -76,9 +76,6 @@ public class SqlServerSearchParameterInitializationTests : IClassFixture<SqlServ
     public async Task GivenADatabaseWithNullSearchParameterStatuses_WhenInitializing_ThenSearchParameterStatusesNotNull()
     {
         // Arrange
-        var defaultSearchParameterStatuses = (await _fixture.SqlServerSearchParameterStatusDataStore.GetSearchParameterStatuses(CancellationToken.None)).ToList();
-        List<ResourceSearchParameterStatus> updatedSearchparameterStatuses = [];
-
         using (SqlConnectionWrapper sqlConnectionWrapper = await _fixture.SqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(CancellationToken.None, true))
         using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand())
         {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerSearchParameterInitializationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerSearchParameterInitializationTests.cs
@@ -1,0 +1,137 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Health.Fhir.Core.Features.Search.Registry;
+using Microsoft.Health.Fhir.Core.UnitTests.Extensions;
+using Microsoft.Health.Fhir.SqlServer.Features.Schema;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.SqlServer.Features.Client;
+using Microsoft.Health.Test.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Health.Fhir.Tests.Integration.Persistence;
+
+[Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+[Trait(Traits.Category, Categories.SearchParameterStatus)]
+public class SqlServerSearchParameterInitializationTests : IClassFixture<SqlServerFhirStorageTestsFixture>
+{
+    private readonly SqlServerFhirStorageTestsFixture _fixture;
+    private readonly ITestOutputHelper _testOutputHelper;
+
+    public SqlServerSearchParameterInitializationTests(SqlServerFhirStorageTestsFixture fixture, ITestOutputHelper testOutputHelper)
+    {
+        _fixture = fixture;
+        _testOutputHelper = testOutputHelper;
+    }
+
+    [Fact]
+    public async Task GivenANewDatabase_WhenGettingSearchParameters_ThenNoneAreInvalid()
+    {
+        // Assert off base database.
+        await CheckSearchParametersForInvalid();
+    }
+
+    [Fact]
+    public async Task GivenADatabaseWithSearchParametersDisabled_WhenInitializing_ThenDisabledSearchParametersStayDisabled()
+    {
+        // Arrange
+        var defaultSearchParameterStatuses = (await _fixture.SqlServerSearchParameterStatusDataStore.GetSearchParameterStatuses(CancellationToken.None)).ToList();
+        List<ResourceSearchParameterStatus> updatedSearchparameterStatuses = [];
+
+        // Disable every 5th search parameter
+        for (int i = 0; i < defaultSearchParameterStatuses.Count; i++)
+        {
+            if ((i + 1) % 5 == 0)
+            {
+                defaultSearchParameterStatuses[i].Status = SearchParameterStatus.Disabled;
+                updatedSearchparameterStatuses.Add(defaultSearchParameterStatuses[i]);
+            }
+        }
+
+        await _fixture.SqlServerSearchParameterStatusDataStore.UpsertStatuses(updatedSearchparameterStatuses, CancellationToken.None);
+
+        // Act - exception will be thrown when getting status if any are null.
+        await _fixture.SqlServerFhirModel.Initialize(SchemaVersionConstants.Max, true, CancellationToken.None);
+        var reInitializedSearchParameterStatuses = (await _fixture.SqlServerSearchParameterStatusDataStore.GetSearchParameterStatuses(CancellationToken.None)).ToList();
+
+        // Assert
+        updatedSearchparameterStatuses.ForEach(
+            updatedSearchParameterStatus =>
+            {
+                var reInitializedSearchParameterStatus = reInitializedSearchParameterStatuses.Single(s => s.Uri == updatedSearchParameterStatus.Uri);
+                Assert.Equal(updatedSearchParameterStatus.Status, reInitializedSearchParameterStatus.Status);
+            });
+    }
+
+    [Fact]
+    public async Task GivenADatabaseWithNullSearchParameterStatuses_WhenInitializing_ThenSearchParameterStatusesNotNull()
+    {
+        // Arrange
+        var defaultSearchParameterStatuses = (await _fixture.SqlServerSearchParameterStatusDataStore.GetSearchParameterStatuses(CancellationToken.None)).ToList();
+        List<ResourceSearchParameterStatus> updatedSearchparameterStatuses = [];
+
+        using (SqlConnectionWrapper sqlConnectionWrapper = await _fixture.SqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(CancellationToken.None, true))
+        using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand())
+        {
+            sqlCommandWrapper.CommandText = @"
+                SET XACT_ABORT ON;
+                BEGIN TRANSACTION;
+
+                WITH NumberedRows AS (
+                    SELECT 
+                        *,
+                        ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) AS RowNum
+                    FROM 
+                        dbo.SearchParam
+                )
+                UPDATE NumberedRows
+                SET Status = NULL, LastUpdated = NULL, IsPartiallySupported = NULL
+                WHERE RowNum % 5 = 0;
+
+                COMMIT TRANSACTION;
+            ";
+
+            await sqlCommandWrapper.ExecuteNonQueryAsync(CancellationToken.None);
+        }
+
+        // Act - Max + 1 is okay as we're not applying schema but testing init.
+        await _fixture.SqlServerFhirModel.Initialize(SchemaVersionConstants.Max + 1, true, CancellationToken.None);
+
+        // Assert
+        await CheckSearchParametersForInvalid();
+    }
+
+    private async Task CheckSearchParametersForInvalid()
+    {
+        // Assert - will throw SearchParameterNotSupportedException is invalid search parameters exist.
+        await _fixture.SqlServerSearchParameterStatusDataStore.GetSearchParameterStatuses(CancellationToken.None);
+
+        // Assert again - ensure there are no null rows.
+        using (SqlConnectionWrapper sqlConnectionWrapper = await _fixture.SqlConnectionWrapperFactory.ObtainSqlConnectionWrapperAsync(CancellationToken.None, true))
+        using (SqlCommandWrapper sqlCommandWrapper = sqlConnectionWrapper.CreateRetrySqlCommand())
+        {
+            sqlCommandWrapper.CommandText = @"
+                SELECT *
+                FROM dbo.SearchParam
+                WHERE LastUpdated IS NULL OR Status IS NULL OR IsPartiallySupported IS NULL;
+            ";
+
+            using (var reader = await sqlCommandWrapper.ExecuteReaderAsync(CancellationToken.None))
+            {
+                if (reader.HasRows)
+                {
+                    Assert.Fail("Rows exist where LastUpdated IS NULL OR Status IS NULL OR IsPartiallySupported IS NULL");
+                }
+            }
+        }
+    }
+}

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerSearchParameterInitializationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerSearchParameterInitializationTests.cs
@@ -60,7 +60,7 @@ public class SqlServerSearchParameterInitializationTests : IClassFixture<SqlServ
         await _fixture.SqlServerSearchParameterStatusDataStore.UpsertStatuses(updatedSearchparameterStatuses, CancellationToken.None);
 
         // Act - exception will be thrown when getting status if any are null.
-        await _fixture.SqlServerFhirModel.Initialize(SchemaVersionConstants.Max, true, CancellationToken.None);
+        await _fixture.SqlServerFhirModel.Initialize(SchemaVersionConstants.Max, CancellationToken.None);
         var reInitializedSearchParameterStatuses = (await _fixture.SqlServerSearchParameterStatusDataStore.GetSearchParameterStatuses(CancellationToken.None)).ToList();
 
         // Assert
@@ -101,7 +101,7 @@ public class SqlServerSearchParameterInitializationTests : IClassFixture<SqlServ
         }
 
         // Act - Max + 1 is okay as we're not applying schema but testing init.
-        await _fixture.SqlServerFhirModel.Initialize(SchemaVersionConstants.Max + 1, true, CancellationToken.None);
+        await _fixture.SqlServerFhirModel.Initialize(SchemaVersionConstants.Max + 1, CancellationToken.None);
 
         // Assert
         await CheckSearchParametersForInvalid();


### PR DESCRIPTION
## Description
Changed search parameter initialization to run for every schema upgrade. This the fixes scenario when schema management runs before the FHIR Service runs. Also adds stability my making search parameter initialization idempotent.

## Related issues
Addresses [AB#119890](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/119890)

## Testing
Integration testing, manual testing.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
