### PR TITLE
Add null check for URL resolver, for background jobs

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Routing/UrlResolver.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Routing/UrlResolver.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
                     return _bundleHttpContextAccessor.HttpContext.Request;
                 }
 
-                return _httpContextAccessor.HttpContext.Request;
+                return _httpContextAccessor?.HttpContext?.Request;
             }
         }
 
@@ -321,11 +321,11 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
             }
 
             return GetRouteUri(
-                ActionContext.HttpContext,
+                ActionContext?.HttpContext,
                 routeName,
                 null,
-                Request.Scheme,
-                Request.Host.Value);
+                Request?.Scheme,
+                Request?.Host.Value);
         }
 
         private Uri GetRouteUri(HttpContext httpContext, string routeName, RouteValueDictionary routeValues, string scheme, string host)


### PR DESCRIPTION
## Description
When the capability statement is generated during background jobs, we try and build a url using the action context which is null during backgrounds jobs like bulk-delete

## Related issues
Addresses [issue [AB#122137](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/122137)].

## Testing
Manual testing of bulk-delete to repro the issue

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
