### PR TITLE
SQL Server managed identity authentication instead of secrets

### DIFF
--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -408,7 +408,7 @@
                     "type": "basicPublishingCredentialsPolicies",
                     "kind": "string",
                     "location": "[resourceGroup().location]",
-                    "dependsOn":[
+                    "dependsOn": [
                         "[variables('serviceName')]"
                     ],
                     "properties": {
@@ -455,7 +455,7 @@
                     }
                 ]
             }
-        },
+        },    
         {
             "condition": "[and(equals(parameters('solutionType'),'FhirServerSqlServer'),equals(parameters('sqlServerNewOrExisting'), 'new'))]",
             "name": "[variables('sqlServerDerivedName')]",
@@ -470,7 +470,7 @@
                 "administratorLoginPassword": "[parameters('sqlAdminPassword')]",
                 "version": "12.0",
                 "administrators": {
-                    "azureADOnlyAuthentication": true           
+                    "azureADOnlyAuthentication": true
                 }
             },
             "resources": [
@@ -497,6 +497,7 @@
                     "type": "databases"
                 },
                 {
+                    "condition": "[equals(parameters('solutionType'),'FhirServerSqlServer')]",
                     "type": "administrators",
                     "name": "activeDirectory",
                     "apiVersion": "2023-05-01-preview",
@@ -506,7 +507,7 @@
                         "login": "[variables('serviceName')]",
                         "sid": "[reference(variables('appServiceResourceId'), '2015-08-01', 'Full').Identity.principalId]",
                         "tenantId": "[reference(variables('appServiceResourceId'), '2015-08-01', 'Full').Identity.tenantId]",
-                        "azureADOnlyAuthentication": true                         
+                        "azureADOnlyAuthentication": true
                     },
                     "dependsOn": [
                         "[variables('sqlServerDerivedName')]"
@@ -515,6 +516,7 @@
             ]
         },
         {
+            "condition": "[equals(parameters('solutionType'),'FhirServerSqlServer')]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2022-09-01",
             "name": "webAppIPsSQLFirewall",
@@ -534,7 +536,7 @@
                 "template": {
                     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
-                   
+
                     "parameters": {
                         "webAppOutboundIpAddresses": {
                             "type": "array",
@@ -621,7 +623,7 @@
                 "principalId": "[reference(variables('appServiceResourceId'), '2015-08-01', 'Full').Identity.principalId]"
             }
         },
-                {
+        {
             "type": "Microsoft.KeyVault/vaults/providers/roleAssignments",
             "apiVersion": "2022-04-01",
             "name": "[concat(variables('serviceName'), '/Microsoft.Authorization/', guid(uniqueString('Reader', parameters('fhirVersion'), variables('serviceName'))))]",

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -468,7 +468,10 @@
             "properties": {
                 "administratorLogin": "fhirAdmin",
                 "administratorLoginPassword": "[parameters('sqlAdminPassword')]",
-                "version": "12.0"
+                "version": "12.0",
+                "administrators": {
+                    "azureADOnlyAuthentication": true           
+                }
             },
             "resources": [
                 {
@@ -492,6 +495,22 @@
                         "tier": "[variables('sqlSkuTier')]"
                     },
                     "type": "databases"
+                },
+                {
+                    "type": "administrators",
+                    "name": "activeDirectory",
+                    "apiVersion": "2023-05-01-preview",
+                    "location": "[resourceGroup().location]",
+                    "properties": {
+                        "administratorType": "ActiveDirectory",
+                        "login": "[variables('serviceName')]",
+                        "sid": "[reference(variables('appServiceResourceId'), '2015-08-01', 'Full').Identity.principalId]",
+                        "tenantId": "[reference(variables('appServiceResourceId'), '2015-08-01', 'Full').Identity.tenantId]",
+                        "azureADOnlyAuthentication": true                         
+                    },
+                    "dependsOn": [
+                        "[variables('sqlServerDerivedName')]"
+                    ]
                 }
             ]
         },
@@ -649,7 +668,7 @@
             "apiVersion": "2015-06-01",
             "properties": {
                 "contentType": "text/plain",
-                "value": "[concat('Server=tcp:', if(equals(parameters('solutionType'),'FhirServerSqlServer'), reference(variables('computedSqlServerReference'), '2015-05-01-preview').fullyQualifiedDomainName, ''),',1433;Initial Catalog=',variables('sqlDatabaseName'),';Persist Security Info=False;User ID=', if(equals(parameters('solutionType'),'FhirServerSqlServer'), reference(variables('computedSqlServerReference'), '2015-05-01-preview').administratorLogin, ''),';Password=',parameters('sqlAdminPassword'),';MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;')]"
+                "value": "[concat('Server=tcp:', if(equals(parameters('solutionType'),'FhirServerSqlServer'), reference(variables('computedSqlServerReference'), '2015-05-01-preview').fullyQualifiedDomainName, ''),',1433;Initial Catalog=',variables('sqlDatabaseName'),';Persist Security Info=False;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;Authentication=Active Directory Managed Identity;')]"
             },
             "dependsOn": [
                 "[resourceId('Microsoft.KeyVault/vaults', variables('serviceName'))]",
@@ -662,7 +681,8 @@
             "apiVersion": "2019-06-01",
             "location": "[resourceGroup().location]",
             "properties": {
-                "supportsHttpsTrafficOnly": true
+                "supportsHttpsTrafficOnly": true,
+                "allowSharedKeyAccess": false
             },
             "condition": "[variables('enableIntegrationStore')]",
             "dependsOn": [],


### PR DESCRIPTION
## Description
Made changes to support Managed Identity Authentication for SQL Server DB instead of using Secrets.

## Related issues
Addresses [[issue 122770](https://microsofthealth.visualstudio.com/Health/_workitems/edit/122770)].

## Testing
Tested by creating FHIR service instance using the updated ARM template. 
Validated different settings after deployments.
Executed CRUD operations on FHIR service instance.
Executed Export operation on FHIR service instance.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
