### PR TITLE
Enhancement(import):Import should error for SearchParameter

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Import/ImportResourceLoaderTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Import/ImportResourceLoaderTests.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Import
             Func<long, long> idGenerator = (i) => i;
             ImportResourceLoader loader = new ImportResourceLoader(integrationDataStoreClient, importResourceParser, serializer, NullLogger<ImportResourceLoader>.Instance);
 
-            (Channel<ImportResource> outputChannel, Task importTask) = loader.LoadResources("http://dummy", 0, (int)1e9, "SearchParameter", ImportMode.InitialLoad, CancellationToken.None);
+            (Channel<ImportResource> outputChannel, Task importTask) = loader.LoadResources("http://dummy", 0, (int)1e9, null, ImportMode.InitialLoad, CancellationToken.None);
 
             int errorCount = 0;
             await foreach (ImportResource resource in outputChannel.Reader.ReadAllAsync())

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Import/ImportResourceLoaderTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Import/ImportResourceLoaderTests.cs
@@ -137,6 +137,54 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Import
         }
 
         [Fact]
+        public async Task GivenResourceLoader_WhenLoadResourcesWithSearchParameterResourceType_ThenResourcesWithSearchParameterTypeShouldBeSkipped()
+        {
+            string errorMessage = "SearchParameter is not a supported resource type.";
+            using MemoryStream stream = new MemoryStream();
+            using StreamWriter writer = new StreamWriter(stream);
+            await writer.WriteLineAsync("test");
+            await writer.FlushAsync();
+
+            stream.Position = 0;
+
+            IIntegrationDataStoreClient integrationDataStoreClient = Substitute.For<IIntegrationDataStoreClient>();
+            integrationDataStoreClient.DownloadResource(Arg.Any<Uri>(), Arg.Any<long>(), Arg.Any<CancellationToken>()).ReturnsForAnyArgs(stream);
+            integrationDataStoreClient.TryAcquireLeaseAsync(Arg.Any<Uri>(), Arg.Any<string>(), Arg.Any<CancellationToken>()).ReturnsForAnyArgs(string.Empty);
+
+            IImportResourceParser importResourceParser = Substitute.For<IImportResourceParser>();
+            importResourceParser.Parse(Arg.Any<long>(), Arg.Any<long>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<ImportMode>())
+                .Returns(callInfo =>
+                {
+                    ImportResource importResource = new ImportResource(null);
+                    return importResource;
+                });
+
+            IImportErrorSerializer serializer = Substitute.For<IImportErrorSerializer>();
+            serializer.Serialize(Arg.Any<long>(), Arg.Any<Exception>(), Arg.Any<long>())
+                .Returns(callInfo =>
+                {
+                    Exception ex = (Exception)callInfo[1];
+                    return ex.Message;
+                });
+
+            Func<long, long> idGenerator = (i) => i;
+            ImportResourceLoader loader = new ImportResourceLoader(integrationDataStoreClient, importResourceParser, serializer, NullLogger<ImportResourceLoader>.Instance);
+
+            (Channel<ImportResource> outputChannel, Task importTask) = loader.LoadResources("http://dummy", 0, (int)1e9, "SearchParameter", ImportMode.InitialLoad, CancellationToken.None);
+
+            int errorCount = 0;
+            await foreach (ImportResource resource in outputChannel.Reader.ReadAllAsync())
+            {
+                Assert.Equal(errorMessage, resource.ImportError);
+                ++errorCount;
+            }
+
+            await importTask;
+
+            Assert.Equal(1, errorCount);
+        }
+
+        [Fact]
         public async Task GivenResourceLoader_WhenCancelLoadTask_ThenDataLoadTaskShouldBeCanceled()
         {
             string errorMessage = "error";

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Import/ImportResourceLoaderTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Import/ImportResourceLoaderTests.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Import
         [Fact]
         public async Task GivenResourceLoader_WhenLoadResourcesWithSearchParameterResourceType_ThenResourcesWithSearchParameterTypeShouldBeSkipped()
         {
-            string errorMessage = "SearchParameter is not a supported resource type.";
+            string errorMessage = "SearchParameter resources cannot be processed by import.";
             using MemoryStream stream = new MemoryStream();
             using StreamWriter writer = new StreamWriter(stream);
             await writer.WriteLineAsync("test");
@@ -155,8 +155,21 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Import
             importResourceParser.Parse(Arg.Any<long>(), Arg.Any<long>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<ImportMode>())
                 .Returns(callInfo =>
                 {
-                    ImportResource importResource = new ImportResource(null);
-                    return importResource;
+                    long index = (long)callInfo[0];
+                    string content = (string)callInfo[3];
+                    ResourceWrapper resourceWrapper = new ResourceWrapper(
+                            content,
+                            "0",
+                            "SearchParameter",
+                            new RawResource(content, Core.Models.FhirResourceFormat.Json, true),
+                            new ResourceRequest("POST"),
+                            DateTimeOffset.UtcNow,
+                            false,
+                            null,
+                            null,
+                            null,
+                            "SearchParam");
+                    return new ImportResource(index, 0, 0, false, false, false, resourceWrapper);
                 });
 
             IImportErrorSerializer serializer = Substitute.For<IImportErrorSerializer>();

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportResourceLoader.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportResourceLoader.cs
@@ -152,9 +152,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
                     throw new FormatException("Resource type not match.");
                 }
 
-                if (!string.IsNullOrEmpty(resourceType) && resourceType.Equals("SearchParameter", StringComparison.Ordinal))
+                if (!string.IsNullOrEmpty(resourceType) && importResource.ResourceWrapper != null && importResource.ResourceWrapper.ResourceTypeName.Equals("SearchParameter", StringComparison.Ordinal))
                 {
-                    throw new ArgumentException("SearchParameter is not a supported resource type.");
+                    throw new ArgumentException("SearchParameter resources cannot be processed by import.");
                 }
             }
             catch (Exception ex)

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportResourceLoader.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportResourceLoader.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
                     throw new FormatException("Resource type not match.");
                 }
 
-                if (!string.IsNullOrEmpty(resourceType) && importResource.ResourceWrapper != null && importResource.ResourceWrapper.ResourceTypeName.Equals("SearchParameter", StringComparison.Ordinal))
+                if (importResource.ResourceWrapper != null && importResource.ResourceWrapper.ResourceTypeName.Equals("SearchParameter", StringComparison.Ordinal))
                 {
                     throw new ArgumentException("SearchParameter resources cannot be processed by import.");
                 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportResourceLoader.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportResourceLoader.cs
@@ -151,6 +151,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
                 {
                     throw new FormatException("Resource type not match.");
                 }
+
+                if (!string.IsNullOrEmpty(resourceType) && resourceType.Equals("SearchParameter", StringComparison.Ordinal))
+                {
+                    throw new ArgumentException("SearchParameter is not a supported resource type.");
+                }
             }
             catch (Exception ex)
             {

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ImportControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ImportControllerTests.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
                 GetBulkImportRequestConfigurationWithUnsupportedInputFormat(),
                 GetBulkImportRequestConfigurationWithUnsupportedStorageType(),
                 GetBulkImportRequestConfigurationWithUnsupportedResourceType(),
+                GetBulkImportRequestConfigurationWithSearchParameterResourceType(),
                 GetBulkImportRequestConfigurationWithNoInputFile(),
                 GetBulkImportRequestConfigurationWithNoInputUrl(),
                 GetBulkImportRequestConfigurationWithSASToken(),
@@ -214,6 +215,25 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
                 new InputResource
                 {
                     Type = "Fake",
+                    Url = new Uri("https://client.example.org/patient_file_2.ndjson"),
+                },
+            };
+
+            var bulkImportRequestConfiguration = new ImportRequest();
+            bulkImportRequestConfiguration.InputFormat = "application/fhir+ndjson";
+            bulkImportRequestConfiguration.InputSource = new Uri("https://other-server.example.org");
+            bulkImportRequestConfiguration.Input = input;
+
+            return bulkImportRequestConfiguration;
+        }
+
+        private static ImportRequest GetBulkImportRequestConfigurationWithSearchParameterResourceType()
+        {
+            var input = new List<InputResource>
+            {
+                new InputResource
+                {
+                    Type = "SearchParameter",
                     Url = new Uri("https://client.example.org/patient_file_2.ndjson"),
                 },
             };

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ImportController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ImportController.cs
@@ -219,6 +219,11 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                     throw new RequestNotValidException(string.Format(Resources.ImportRequestValueNotValid, "input.url"));
                 }
             }
+
+            if (input.Any(i => i.Type == "SearchParameter"))
+            {
+                throw new RequestNotValidException(string.Format(Resources.UnsupportedResourceType, "SearchParameter"));
+            }
         }
     }
 }


### PR DESCRIPTION
## Description
US 121465: Import should report "SearchParameter" type resources as error
Handle the following cases
- If the type = "SearchParameter", the $import request should return HTTP 400 Bad Request
- During import processing, for mixed files, error if a search parameter is encountered.

## Related issues
Addresses [[issue #121465](https://microsofthealth.visualstudio.com/Health/_workitems/edit/121465/)].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
