### PR TITLE
Hardcoded Git version tool to 5.12.0

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -9,9 +9,14 @@ ignore:
 branches:
   main:
     is-release-branch: true
+    tag: ''
   pull-request:
     regex: ^(pull|pull\-requests|pr)[/-]
+    tag: pr
+    tag-number-pattern: '[/-](?<number>\d+)[-/]'
   hotfix:
     regex: ^hotfix(es)?[/-]
+    tag: useBranchName
   feature:
     regex: ^(personal|dev|feature|auto\-nuget\-update|dependabot)[/-]
+    tag: useBranchName

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -11,11 +11,8 @@ branches:
     is-release-branch: true
   pull-request:
     regex: ^(pull|pull\-requests|pr)[/-]
-    tag: pr
     tag-number-pattern: '[/-](?<number>\d+)[-/]'
   hotfix:
     regex: ^hotfix(es)?[/-]
-    tag: useBranchName
   feature:
     regex: ^(personal|dev|feature|auto\-nuget\-update|dependabot)[/-]
-    tag: useBranchName

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -11,7 +11,6 @@ branches:
     is-release-branch: true
   pull-request:
     regex: ^(pull|pull\-requests|pr)[/-]
-    tag-number-pattern: '[/-](?<number>\d+)[-/]'
   hotfix:
     regex: ^hotfix(es)?[/-]
   feature:

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -9,7 +9,6 @@ ignore:
 branches:
   main:
     is-release-branch: true
-    tag: ''
   pull-request:
     regex: ^(pull|pull\-requests|pr)[/-]
     tag: pr

--- a/build/jobs/update-semver.yml
+++ b/build/jobs/update-semver.yml
@@ -11,7 +11,7 @@ steps:
     useGlobalJson: true
     
 - powershell: |
-    dotnet tool install --global GitVersion.Tool
+    dotnet tool install --global GitVersion.Tool --version 5.12.0
 
     $gitVersionJson = & 'dotnet-gitversion'  | ConvertFrom-Json
 

--- a/build/jobs/update-semver.yml
+++ b/build/jobs/update-semver.yml
@@ -11,11 +11,9 @@ steps:
     useGlobalJson: true
     
 - powershell: |
-    dotnet tool install --global GitVersion.Tool
+    dotnet tool update --global GitVersion.Tool
 
-    $gitVersionJson = & 'dotnet-gitversion'
-    Write-Host "GitVersion Output: $gitVersionJson"
-    $gitVersionJson = $gitVersionJson | ConvertFrom-Json
+    $gitVersionJson = & 'dotnet-gitversion'  | ConvertFrom-Json
 
     Write-Host "##vso[task.setvariable variable=semVer]$($gitVersionJson.semVer)"
     Write-Host "##vso[task.setvariable variable=informationalVersion;isOutput=true]$($gitVersionJson.informationalVersion)"

--- a/build/jobs/update-semver.yml
+++ b/build/jobs/update-semver.yml
@@ -11,9 +11,15 @@ steps:
     useGlobalJson: true
     
 - powershell: |
-    dotnet tool update --global GitVersion.Tool
+    dotnet tool install --global GitVersion.Tool
 
-    $gitVersionJson = & 'dotnet-gitversion'  | ConvertFrom-Json
+    $gitVersionJson = & 'dotnet-gitversion'
+    write-host "GitVersion: $gitVersionJson"
+    # Replace Infinity values with null in the JSON part
+    $gitVersionJson = $gitVersionJson -replace 'Infinity', 'null'
+    write-host "GitVersion after replacing null: $gitVersionJson"
+
+    $gitVersionJson = $gitVersionJson  | ConvertFrom-Json
 
     Write-Host "##vso[task.setvariable variable=semVer]$($gitVersionJson.semVer)"
     Write-Host "##vso[task.setvariable variable=informationalVersion;isOutput=true]$($gitVersionJson.informationalVersion)"

--- a/build/jobs/update-semver.yml
+++ b/build/jobs/update-semver.yml
@@ -13,7 +13,9 @@ steps:
 - powershell: |
     dotnet tool install --global GitVersion.Tool
 
-    $gitVersionJson = & 'dotnet-gitversion'  | ConvertFrom-Json
+    $gitVersionJson = & 'dotnet-gitversion'
+    Write-Host "GitVersion Output: $gitVersionJson"
+    $gitVersionJson = $gitVersionJson | ConvertFrom-Json
 
     Write-Host "##vso[task.setvariable variable=semVer]$($gitVersionJson.semVer)"
     Write-Host "##vso[task.setvariable variable=informationalVersion;isOutput=true]$($gitVersionJson.informationalVersion)"

--- a/build/jobs/update-semver.yml
+++ b/build/jobs/update-semver.yml
@@ -11,15 +11,9 @@ steps:
     useGlobalJson: true
     
 - powershell: |
-    dotnet tool install --global GitVersion.Tool --version 5.12.0
+    dotnet tool install --global GitVersion.Tool
 
-    $gitVersionJson = & 'dotnet-gitversion'
-    write-host "GitVersion: $gitVersionJson"
-    # Replace Infinity values with null in the JSON part
-    $gitVersionJson = $gitVersionJson -replace 'Infinity', 'null'
-    write-host "GitVersion after replacing null: $gitVersionJson"
-
-    $gitVersionJson = $gitVersionJson  | ConvertFrom-Json
+    $gitVersionJson = & 'dotnet-gitversion'  | ConvertFrom-Json
 
     Write-Host "##vso[task.setvariable variable=semVer]$($gitVersionJson.semVer)"
     Write-Host "##vso[task.setvariable variable=informationalVersion;isOutput=true]$($gitVersionJson.informationalVersion)"

--- a/build/jobs/update-semver.yml
+++ b/build/jobs/update-semver.yml
@@ -11,7 +11,7 @@ steps:
     useGlobalJson: true
     
 - powershell: |
-    dotnet tool install --global GitVersion.Tool
+    dotnet tool install --global GitVersion.Tool --version 5.12.0
 
     $gitVersionJson = & 'dotnet-gitversion'
     write-host "GitVersion: $gitVersionJson"


### PR DESCRIPTION
## Description
Determine SemVer step is failing in PR Pipelines. Git version tool updated from 5.12.0 to 6.0.0 and it has breaking changes. In this PR, I am hardcoding git version tool to 5.12.0 to unblock PR pipeline. I am going to create a new work item to add long term fix to use latest git version tool.

https://microsofthealthoss.visualstudio.com/FhirServer/_build/results?buildId=41694&view=logs&j=095683c9-70e3-5811-9c3b-e1630e5f845d

## Related issues
Addresses [issue #].
AB#[123261](https://microsofthealth.visualstudio.com/Health/_workitems/edit/123261)

## Testing
PR Pipeline

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
