### PR TITLE
Ensure all jobs complete before disposing parent scope

### DIFF
--- a/src/Microsoft.Health.TaskManagement/JobHosting.cs
+++ b/src/Microsoft.Health.TaskManagement/JobHosting.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Health.JobManagement
             }
             catch (OperationCanceledException ex)
             {
-                _logger.LogWarning(ex, "Job with id: {JobId} and group id: {GroupId} of type: {JobType} canceled.", jobInfo.Id, jobInfo.GroupId, jobInfo.QueueType);
+                _logger.LogWarning(ex, "Job with id: {JobId} and group id: {GroupId} of type: {JobType} canceled due to unhandled cancellation exception.", jobInfo.Id, jobInfo.GroupId, jobInfo.QueueType);
                 jobInfo.Status = JobStatus.Cancelled;
 
                 try

--- a/src/Microsoft.Health.TaskManagement/JobHosting.cs
+++ b/src/Microsoft.Health.TaskManagement/JobHosting.cs
@@ -111,7 +111,8 @@ namespace Microsoft.Health.JobManagement
 
             try
             {
-                 // If any worker crashes or complete cancellation due to shutwdown, cancel all workers and wait for completion.
+                 // If any worker crashes or complete after cancellation due to shutdown,
+                 // cancel all workers and wait for completion so they don't crash unnecessarily.
                 await Task.WhenAny(workers.ToArray());
 #if NET6_0
                 cancellationTokenSource.Cancel();

--- a/src/Microsoft.Health.TaskManagement/JobHosting.cs
+++ b/src/Microsoft.Health.TaskManagement/JobHosting.cs
@@ -112,7 +112,11 @@ namespace Microsoft.Health.JobManagement
             try
             {
                 await Task.WhenAny(workers.ToArray());
+#if NET6_0
+                cancellationTokenSource.Cancel();
+#else
                 await cancellationTokenSource.CancelAsync();
+#endif
                 await Task.WhenAll(workers.ToArray());
             }
             catch (Exception ex)


### PR DESCRIPTION
## Description
Changes JobHosting to wait for all jobs to complete before starting disposal. We have been getting ObjectDisposedExceptions after the HostingBackgroundService exist. This tells me that the background service is exiting before all jobs are done.

This PR changes the JobHosting error logic to request cancellation before returning, thus delaying the HostingBackgroundService exit until jobs are complete.

## Related issues
[AB#121830](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/121830)

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
