### PR TITLE
Disabling EXISTS

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/SqlQueryGeneratorTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/SqlQueryGeneratorTests.cs
@@ -50,8 +50,7 @@ public class SqlQueryGeneratorTests
             _strBuilder,
             parameters,
             _fhirModel,
-            _schemaInformation,
-            "hash");
+            _schemaInformation);
     }
 
     [Fact]

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -1229,7 +1229,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             }
             else
             {
-                return false;
+                return true;
             }
         }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -42,7 +42,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
         private List<string> _includeFromCteIds;
 
         private int _curFromCteIndex = -1;
-        private readonly string _searchParameterHash;
         private int _tableExpressionCounter = -1;
         private SqlRootExpression _rootExpression;
         private readonly SchemaInformation _schemaInfo;
@@ -60,7 +59,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             HashingSqlQueryParameterManager parameters,
             ISqlServerFhirModel model,
             SchemaInformation schemaInfo,
-            string searchParameterHash,
             SqlException sqlException = null)
         {
             EnsureArg.IsNotNull(sb, nameof(sb));
@@ -72,7 +70,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             Parameters = parameters;
             Model = model;
             _schemaInfo = schemaInfo;
-            _searchParameterHash = searchParameterHash;
 
             if (sqlException?.Number == SqlErrorCodes.QueryProcessorNoQueryPlan)
             {

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -1230,7 +1230,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             else
             {
                 // Firstly, we were still using JOINs for filtering conditions for queries with include clauses.
-                // This does not make sense because filtering SQL should not be dependent on exiestence of include.
+                // This does not make sense because filtering SQL should not be dependent on existence of include.
                 // It also appeared that SQL Server compiles plans for JOINs 5x faster than for EXISTSs.
                 // Though EXISTS plans should be more "precise" I am disabling them in favor of fast compilation times.
                 return true;

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
         {
             SqlSearchOptions sqlSearchOptions = new SqlSearchOptions(searchOptions);
 
-            SearchResult searchResult = await SearchImpl(sqlSearchOptions, null, cancellationToken);
+            SearchResult searchResult = await SearchImpl(sqlSearchOptions, cancellationToken);
             int resultCount = searchResult.Results.Count();
 
             if (!sqlSearchOptions.IsSortWithFilter &&
@@ -159,7 +159,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                         sqlSearchOptions.SortQuerySecondPhase = true;
                         sqlSearchOptions.MaxItemCount -= resultCount;
 
-                        searchResult = await SearchImpl(sqlSearchOptions, null, cancellationToken);
+                        searchResult = await SearchImpl(sqlSearchOptions, cancellationToken);
 
                         finalResultsInOrder.AddRange(searchResult.Results);
                         searchResult = new SearchResult(
@@ -188,7 +188,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                         sqlSearchOptions.CountOnly = true;
 
                         // And perform a second read.
-                        var countOnlySearchResult = await SearchImpl(sqlSearchOptions, null, cancellationToken);
+                        var countOnlySearchResult = await SearchImpl(sqlSearchOptions, cancellationToken);
 
                         searchResult.TotalCount = countOnlySearchResult.TotalCount;
                     }
@@ -203,7 +203,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
             return searchResult;
         }
 
-        private async Task<SearchResult> SearchImpl(SqlSearchOptions sqlSearchOptions, string currentSearchParameterHash, CancellationToken cancellationToken)
+        private async Task<SearchResult> SearchImpl(SqlSearchOptions sqlSearchOptions, CancellationToken cancellationToken)
         {
             Expression searchExpression = sqlSearchOptions.Expression;
 
@@ -335,7 +335,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                                 new HashingSqlQueryParameterManager(new SqlQueryParameterManager(sqlCommand.Parameters)),
                                 _model,
                                 _schemaInformation,
-                                currentSearchParameterHash,
                                 sqlException);
 
                             expression.AcceptVisitor(queryGenerator, clonedSearchOptions);


### PR DESCRIPTION
Firstly, we were still using JOINs for filtering conditions for queries with include clauses.
This does not make sense because filtering SQL should not be dependent on existence of include.
It also appeared that SQL Server compiles plans with JOINs 5x faster than with EXISTSs.
Though EXISTS plans should be more "precise" I am disabling them in favor of fast compilation times.

Nuance smart impression queries did have include clauses and were using JOINs. With this change filtering SQL in Nuance queries even without include will be the same as it is today for queries with include.  

https://microsofthealth.visualstudio.com/Health/_workitems/edit/123488/
