### PR TITLE
Fixing flaky query plan test 

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlComplexQueryTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlComplexQueryTests.cs
@@ -48,7 +48,20 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         [Fact]
         public async Task GivenSearchQuery_IfReuseQueryPlansIsEnabled_ThenPlansAreReusedAcrossDifferentParameterValues()
         {
-            await DisableResuseQueryPlans();
+            await SetGranularQueryStore();
+
+            await ResetQueryStore();
+            await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City1")], CancellationToken.None);
+            await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City2")], CancellationToken.None);
+            //// values are different and plans are NOT reused
+            await CheckQueryStore(2, 2);
+
+            await ResetQueryStore();
+            await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City")], CancellationToken.None);
+            await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City")], CancellationToken.None);
+            //// values are same and plans are reused
+            await CheckQueryStore(2, 1);
+
             await EnableResuseQueryPlans();
             await ResetQueryStore();
             SqlServerSearchService.ResetReuseQueryPlans();
@@ -56,25 +69,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City2")], CancellationToken.None);
             await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City3")], CancellationToken.None);
             await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City4")], CancellationToken.None);
-            await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City5")], CancellationToken.None);
             //// values are different but plans are reused
-            await CheckQueryStore(5, 1);
-
-            await DisableResuseQueryPlans();
-            await ResetQueryStore();
-            SqlServerSearchService.ResetReuseQueryPlans();
-            await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City1")], CancellationToken.None);
-            await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City2")], CancellationToken.None);
-            //// values are different and plans are NOT reused
-            await CheckQueryStore(2, 2);
-
-            await DisableResuseQueryPlans();
-            await ResetQueryStore();
-            SqlServerSearchService.ResetReuseQueryPlans();
-            await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City1")], CancellationToken.None);
-            await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City1")], CancellationToken.None);
-            //// values are same and plans are reused
-            await CheckQueryStore(2, 1);
+            await CheckQueryStore(4, 1);
         }
 
         private async Task CheckQueryStore(int expected_executions, int expected_compiles)
@@ -132,14 +128,20 @@ END CATCH
             cmd.ExecuteNonQuery();
         }
 
+        private async Task SetGranularQueryStore()
+        {
+            using var conn = await _fixture.SqlHelper.GetSqlConnectionAsync();
+            conn.Open();
+            using var cmd = new SqlCommand("DECLARE @db varchar(100) = db_name() EXECUTE('ALTER DATABASE ['+@db+'] SET QUERY_STORE = ON (QUERY_CAPTURE_MODE = ALL)')", conn);
+            cmd.ExecuteNonQuery();
+        }
+
         private async Task ResetQueryStore()
         {
             using var conn = await _fixture.SqlHelper.GetSqlConnectionAsync();
             conn.Open();
             using var cmd = new SqlCommand("DECLARE @db varchar(100) = db_name() EXECUTE('ALTER DATABASE ['+@db+'] SET QUERY_STORE CLEAR')", conn);
             cmd.ExecuteNonQuery();
-            using var cmd2 = new SqlCommand("DECLARE @db varchar(100) = db_name() EXECUTE('ALTER DATABASE ['+@db+'] SET QUERY_STORE = ON (QUERY_CAPTURE_MODE = ALL)')", conn);
-            cmd2.ExecuteNonQuery();
         }
 
         [SkippableFact]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlComplexQueryTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlComplexQueryTests.cs
@@ -48,26 +48,26 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         [Fact]
         public async Task GivenSearchQuery_IfReuseQueryPlansIsEnabled_ThenPlansAreReusedAcrossDifferentParameterValues()
         {
-            SqlServerSearchService.ResetReuseQueryPlans();
             await DisableResuseQueryPlans();
             await EnableResuseQueryPlans();
             await ResetQueryStore();
+            SqlServerSearchService.ResetReuseQueryPlans();
             await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City1")], CancellationToken.None);
             await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City2")], CancellationToken.None);
             //// values are different but plans are reused
             await CheckQueryStore(2, 1);
 
-            SqlServerSearchService.ResetReuseQueryPlans();
             await DisableResuseQueryPlans();
             await ResetQueryStore();
+            SqlServerSearchService.ResetReuseQueryPlans();
             await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City1")], CancellationToken.None);
             await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City2")], CancellationToken.None);
             //// values are different and plans are NOT reused
             await CheckQueryStore(2, 2);
 
-            SqlServerSearchService.ResetReuseQueryPlans();
             await DisableResuseQueryPlans();
             await ResetQueryStore();
+            SqlServerSearchService.ResetReuseQueryPlans();
             await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City1")], CancellationToken.None);
             await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City1")], CancellationToken.None);
             //// values are same and plans are reused

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlComplexQueryTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlComplexQueryTests.cs
@@ -53,16 +53,17 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             await ResetQueryStore();
             SqlServerSearchService.ResetReuseQueryPlans();
             await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City1")], CancellationToken.None);
-            await Task.Delay(1000);
             await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City2")], CancellationToken.None);
+            await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City3")], CancellationToken.None);
+            await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City4")], CancellationToken.None);
+            await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City5")], CancellationToken.None);
             //// values are different but plans are reused
-            await CheckQueryStore(2, 1);
+            await CheckQueryStore(5, 1);
 
             await DisableResuseQueryPlans();
             await ResetQueryStore();
             SqlServerSearchService.ResetReuseQueryPlans();
             await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City1")], CancellationToken.None);
-            await Task.Delay(1000);
             await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City2")], CancellationToken.None);
             //// values are different and plans are NOT reused
             await CheckQueryStore(2, 2);
@@ -71,7 +72,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             await ResetQueryStore();
             SqlServerSearchService.ResetReuseQueryPlans();
             await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City1")], CancellationToken.None);
-            await Task.Delay(1000);
             await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City1")], CancellationToken.None);
             //// values are same and plans are reused
             await CheckQueryStore(2, 1);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlComplexQueryTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlComplexQueryTests.cs
@@ -52,12 +52,14 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
             await ResetQueryStore();
             await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City1")], CancellationToken.None);
+            await Task.Delay(1000);
             await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City2")], CancellationToken.None);
             //// values are different and plans are NOT reused
             await CheckQueryStore(2, 2);
 
             await ResetQueryStore();
             await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City")], CancellationToken.None);
+            await Task.Delay(1000);
             await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City")], CancellationToken.None);
             //// values are same and plans are reused
             await CheckQueryStore(2, 1);
@@ -66,8 +68,11 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             await ResetQueryStore();
             SqlServerSearchService.ResetReuseQueryPlans();
             await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City1")], CancellationToken.None);
+            await Task.Delay(1000);
             await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City2")], CancellationToken.None);
+            await Task.Delay(1000);
             await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City3")], CancellationToken.None);
+            await Task.Delay(1000);
             await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City4")], CancellationToken.None);
             //// values are different but plans are reused
             await CheckQueryStore(4, 1);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlComplexQueryTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlComplexQueryTests.cs
@@ -53,6 +53,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             await ResetQueryStore();
             SqlServerSearchService.ResetReuseQueryPlans();
             await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City1")], CancellationToken.None);
+            await Task.Delay(1000);
             await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City2")], CancellationToken.None);
             //// values are different but plans are reused
             await CheckQueryStore(2, 1);
@@ -61,6 +62,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             await ResetQueryStore();
             SqlServerSearchService.ResetReuseQueryPlans();
             await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City1")], CancellationToken.None);
+            await Task.Delay(1000);
             await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City2")], CancellationToken.None);
             //// values are different and plans are NOT reused
             await CheckQueryStore(2, 2);
@@ -69,6 +71,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             await ResetQueryStore();
             SqlServerSearchService.ResetReuseQueryPlans();
             await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City1")], CancellationToken.None);
+            await Task.Delay(1000);
             await _fixture.SearchService.SearchAsync(KnownResourceTypes.Patient, [Tuple.Create("address-city", "City1")], CancellationToken.None);
             //// values are same and plans are reused
             await CheckQueryStore(2, 1);


### PR DESCRIPTION
Plans reuse test I added in previous check-in appeared to be flaky. This is an attempt to make it more stable. All this is related to query store not instantly updated with execution stats and compilations happening too close to each other.

https://microsofthealth.visualstudio.com/Health/_workitems/edit/123488/
