### PR TITLE
Update the job hosting to run the task count per queue type

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/BackgroundJobService/HostingBackgroundService.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/BackgroundJobService/HostingBackgroundService.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Health.Fhir.Api.Features.BackgroundJobService
 
                 foreach (var operation in _operationsConfiguration.HostingBackgroundServiceQueues)
                 {
-                    short runningJobCount = operation.MaxRunningTaskCount ?? _hostingConfiguration.MaxRunningTaskCount ?? Constants.DefaultMaxRunningJobCount;
+                    short runningJobCount = operation.MaxRunningTaskCount ?? _hostingConfiguration?.MaxRunningTaskCount ?? Constants.DefaultMaxRunningJobCount;
                     jobQueues.Add(jobHostingValue.ExecuteAsync((byte)operation.Queue, runningJobCount, Environment.MachineName, cancellationTokenSource));
                 }
 

--- a/src/Microsoft.Health.Fhir.Api/Features/BackgroundJobService/HostingBackgroundService.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/BackgroundJobService/HostingBackgroundService.cs
@@ -59,7 +59,6 @@ namespace Microsoft.Health.Fhir.Api.Features.BackgroundJobService
                 if (_hostingConfiguration != null)
                 {
                     jobHostingValue.PollingFrequencyInSeconds = _hostingConfiguration.PollingFrequencyInSeconds ?? jobHostingValue.PollingFrequencyInSeconds;
-                    jobHostingValue.MaxRunningJobCount = _hostingConfiguration.MaxRunningTaskCount ?? jobHostingValue.MaxRunningJobCount;
                     jobHostingValue.JobHeartbeatIntervalInSeconds = _hostingConfiguration.TaskHeartbeatIntervalInSeconds ?? jobHostingValue.JobHeartbeatIntervalInSeconds;
                     jobHostingValue.JobHeartbeatTimeoutThresholdInSeconds = _hostingConfiguration.TaskHeartbeatTimeoutThresholdInSeconds ?? jobHostingValue.JobHeartbeatTimeoutThresholdInSeconds;
                 }
@@ -74,8 +73,8 @@ namespace Microsoft.Health.Fhir.Api.Features.BackgroundJobService
 
                 foreach (var operation in _operationsConfiguration.HostingBackgroundServiceQueues)
                 {
-                    jobHostingValue.MaxRunningJobCount = operation.MaxRunningTaskCount ?? jobHostingValue.MaxRunningJobCount;
-                    jobQueues.Add(jobHostingValue.ExecuteAsync((byte)operation.Queue, Environment.MachineName, cancellationTokenSource));
+                    short runningJobCount = operation.MaxRunningTaskCount ?? _hostingConfiguration.MaxRunningTaskCount ?? Constants.DefaultMaxRunningJobCount;
+                    jobQueues.Add(jobHostingValue.ExecuteAsync((byte)operation.Queue, runningJobCount, Environment.MachineName, cancellationTokenSource));
                 }
 
                 await Task.WhenAll(jobQueues);

--- a/src/Microsoft.Health.Fhir.Api/Features/BackgroundJobService/HostingBackgroundService.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/BackgroundJobService/HostingBackgroundService.cs
@@ -74,6 +74,7 @@ namespace Microsoft.Health.Fhir.Api.Features.BackgroundJobService
 
                 foreach (var operation in _operationsConfiguration.HostingBackgroundServiceQueues)
                 {
+                    jobHostingValue.MaxRunningJobCount = operation.MaxRunningTaskCount ?? jobHostingValue.MaxRunningJobCount;
                     jobQueues.Add(jobHostingValue.ExecuteAsync((byte)operation.Queue, Environment.MachineName, cancellationTokenSource));
                 }
 

--- a/src/Microsoft.Health.Fhir.Core/Configs/HostingBackgroundServiceQueueItem.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/HostingBackgroundServiceQueueItem.cs
@@ -9,7 +9,15 @@ namespace Microsoft.Health.Fhir.Core.Configs;
 
 public class HostingBackgroundServiceQueueItem
 {
+    /// <summary>
+    /// Gets or sets the queue type.
+    /// </summary>
     public QueueType Queue { get; set; }
+
+    /// <summary>
+    /// Gets or sets the max running task count at the same time for this queue type.
+    /// </summary>
+    public short? MaxRunningTaskCount { get; set; }
 
     // TODO: This is not honored. Make sure that it is not used in PaaS and remove.
     public bool UpdateProgressOnHeartbeat { get; set; }

--- a/src/Microsoft.Health.TaskManagement.UnitTests/JobHostingTests.cs
+++ b/src/Microsoft.Health.TaskManagement.UnitTests/JobHostingTests.cs
@@ -56,12 +56,11 @@ namespace Microsoft.Health.JobManagement.UnitTests
 
             JobHosting jobHosting = new JobHosting(queueClient, factory, _logger);
             jobHosting.PollingFrequencyInSeconds = 0;
-            jobHosting.MaxRunningJobCount = 5;
 
             CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             tokenSource.CancelAfter(TimeSpan.FromSeconds(2));
-            await jobHosting.ExecuteAsync(0, "test", tokenSource);
+            await jobHosting.ExecuteAsync(0, 5, "test", tokenSource);
 
             Assert.Equal(jobCount, executedJobCount);
             foreach (JobInfo job in jobs)
@@ -121,12 +120,11 @@ namespace Microsoft.Health.JobManagement.UnitTests
 
             JobHosting jobHosting = new JobHosting(queueClient, factory, _logger);
             jobHosting.PollingFrequencyInSeconds = 0;
-            jobHosting.MaxRunningJobCount = 1;
 
             CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             tokenSource.CancelAfter(TimeSpan.FromSeconds(1));
-            await jobHosting.ExecuteAsync(0, "test", tokenSource);
+            await jobHosting.ExecuteAsync(0, 1, "test", tokenSource);
 
             Assert.Equal(2, executeCount);
 
@@ -163,13 +161,12 @@ namespace Microsoft.Health.JobManagement.UnitTests
 
             JobHosting jobHosting = new JobHosting(queueClient, factory, _logger);
             jobHosting.PollingFrequencyInSeconds = 0;
-            jobHosting.MaxRunningJobCount = 1;
             jobHosting.JobHeartbeatTimeoutThresholdInSeconds = 1;
 
             CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             tokenSource.CancelAfter(TimeSpan.FromSeconds(2));
-            await jobHosting.ExecuteAsync(0, "test", tokenSource);
+            await jobHosting.ExecuteAsync(0, 1, "test", tokenSource);
 
             Assert.Equal(JobStatus.Completed, job1.Status);
             Assert.Equal(1, executeCount0);
@@ -198,12 +195,11 @@ namespace Microsoft.Health.JobManagement.UnitTests
             JobInfo job1 = (await queueClient.EnqueueAsync(0, new string[] { "job1" }, null, false, false, CancellationToken.None)).First();
             JobHosting jobHosting = new JobHosting(queueClient, factory, _logger);
             jobHosting.PollingFrequencyInSeconds = 0;
-            jobHosting.MaxRunningJobCount = 1;
             jobHosting.JobHeartbeatTimeoutThresholdInSeconds = 1;
 
             CancellationTokenSource tokenSource = new CancellationTokenSource();
 
-            Task hostingTask = jobHosting.ExecuteAsync(0, "test", tokenSource);
+            Task hostingTask = jobHosting.ExecuteAsync(0, 1, "test", tokenSource);
             autoResetEvent.WaitOne();
             tokenSource.Cancel();
 
@@ -238,13 +234,12 @@ namespace Microsoft.Health.JobManagement.UnitTests
 
             JobHosting jobHosting = new JobHosting(queueClient, factory, _logger);
             jobHosting.PollingFrequencyInSeconds = 0;
-            jobHosting.MaxRunningJobCount = 1;
             jobHosting.JobHeartbeatTimeoutThresholdInSeconds = 1;
 
             CancellationTokenSource tokenSource = new CancellationTokenSource();
 
             tokenSource.CancelAfter(TimeSpan.FromSeconds(2));
-            await jobHosting.ExecuteAsync(0, "test", tokenSource);
+            await jobHosting.ExecuteAsync(0, 1, "test", tokenSource);
 
             Assert.Equal(JobStatus.Failed, job1.Status);
             Assert.Equal(1, executeCount0);
@@ -276,12 +271,11 @@ namespace Microsoft.Health.JobManagement.UnitTests
 
             JobHosting jobHosting = new JobHosting(queueClient, factory, _logger);
             jobHosting.PollingFrequencyInSeconds = 0;
-            jobHosting.MaxRunningJobCount = 1;
             jobHosting.JobHeartbeatTimeoutThresholdInSeconds = 15;
 
             CancellationTokenSource tokenSource = new CancellationTokenSource();
             tokenSource.CancelAfter(TimeSpan.FromSeconds(2));
-            await jobHosting.ExecuteAsync(0, "test", tokenSource);
+            await jobHosting.ExecuteAsync(0, 1, "test", tokenSource);
 
             Assert.Equal(JobStatus.Cancelled, job1.Status);
             Assert.Equal(1, executeCount0);
@@ -313,11 +307,10 @@ namespace Microsoft.Health.JobManagement.UnitTests
             JobHosting jobHosting = new JobHosting(queueClient, factory, _logger);
             jobHosting.PollingFrequencyInSeconds = 0;
             jobHosting.JobHeartbeatIntervalInSeconds = 1;
-            jobHosting.MaxRunningJobCount = 1;
 
             CancellationTokenSource tokenSource = new CancellationTokenSource();
             tokenSource.CancelAfter(TimeSpan.FromSeconds(2));
-            Task hostingTask = jobHosting.ExecuteAsync(0, "test", tokenSource);
+            Task hostingTask = jobHosting.ExecuteAsync(0, 1, "test", tokenSource);
 
             autoResetEvent.WaitOne();
             await queueClient.CancelJobByGroupIdAsync(0, job1.GroupId, CancellationToken.None);
@@ -392,13 +385,12 @@ namespace Microsoft.Health.JobManagement.UnitTests
 
             var jobHosting = new JobHosting(queueClient, factory, _logger);
             jobHosting.PollingFrequencyInSeconds = 0;
-            jobHosting.MaxRunningJobCount = 10;
             jobHosting.JobHeartbeatIntervalInSeconds = 0.001;
             jobHosting.JobHeartbeatTimeoutThresholdInSeconds = 1;
 
             var tokenSource = new CancellationTokenSource();
             tokenSource.CancelAfter(TimeSpan.FromSeconds(60));
-            var host = Task.Run(async () => await jobHosting.ExecuteAsync(0, "test", tokenSource));
+            var host = Task.Run(async () => await jobHosting.ExecuteAsync(0, 10, "test", tokenSource));
             while (jobs.Where(t => t.Status == JobStatus.Completed).Count() < numberOfJobs && !tokenSource.IsCancellationRequested)
             {
                 await Task.Delay(TimeSpan.FromSeconds(1));

--- a/src/Microsoft.Health.TaskManagement/JobHosting.cs
+++ b/src/Microsoft.Health.TaskManagement/JobHosting.cs
@@ -36,18 +36,16 @@ namespace Microsoft.Health.JobManagement
 
         public int PollingFrequencyInSeconds { get; set; } = Constants.DefaultPollingFrequencyInSeconds;
 
-        public short MaxRunningJobCount { get; set; } = Constants.DefaultMaxRunningJobCount;
-
         public int JobHeartbeatTimeoutThresholdInSeconds { get; set; } = Constants.DefaultJobHeartbeatTimeoutThresholdInSeconds;
 
         public double JobHeartbeatIntervalInSeconds { get; set; } = Constants.DefaultJobHeartbeatIntervalInSeconds;
 
-        public async Task ExecuteAsync(byte queueType, string workerName, CancellationTokenSource cancellationTokenSource)
+        public async Task ExecuteAsync(byte queueType, short runningJobCount, string workerName, CancellationTokenSource cancellationTokenSource)
         {
             var workers = new List<Task>();
 
             // parallel dequeue
-            for (var thread = 0; thread < MaxRunningJobCount; thread++)
+            for (var thread = 0; thread < runningJobCount; thread++)
             {
                 workers.Add(Task.Run(async () =>
                 {


### PR DESCRIPTION
Updating the job hosting to run the max running task count per queue type.

## Description
Added a new property, MaxRunningTaskCount, to HostingBackgroundServiceQueueItem. Also, changed JobHosting.ExecuteAsync to take an additional parameter "runningJobCount" that will allow us to run the number of tasks concurrently per a queue type. 

## Related issues
Addresses [issue #121963].

[User Story 121963](https://dev.azure.com/microsofthealth/Health/_workitems/edit/121963): Ensure Import on AKS runs with 4 workers (two per core)

## Testing
Tested by locally running Fhir service. Also, with UTs for job hosting.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
