### PR TITLE
Suppressing NU1902.

### DIFF
--- a/src/Microsoft.Health.Fhir.R4.Web/Microsoft.Health.Fhir.R4.Web.csproj
+++ b/src/Microsoft.Health.Fhir.R4.Web/Microsoft.Health.Fhir.R4.Web.csproj
@@ -3,12 +3,11 @@
   <PropertyGroup>
     <UserSecretsId>29a71f18-2146-4ff0-a511-da3cf615d951</UserSecretsId>
     <RootNamespace>Microsoft.Health.Fhir.Web</RootNamespace>
-    <WarningsNotAsErrors>NU1902</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" />
-    <PackageReference Include="IdentityServer4" />
+    <PackageReference Include="IdentityServer4" NoWarn="NU1902" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" />

--- a/src/Microsoft.Health.Fhir.R4.Web/Microsoft.Health.Fhir.R4.Web.csproj
+++ b/src/Microsoft.Health.Fhir.R4.Web/Microsoft.Health.Fhir.R4.Web.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <UserSecretsId>29a71f18-2146-4ff0-a511-da3cf615d951</UserSecretsId>
     <RootNamespace>Microsoft.Health.Fhir.Web</RootNamespace>
+    <WarningsNotAsErrors>NU1902</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Health.Fhir.R4B.Web/Microsoft.Health.Fhir.R4B.Web.csproj
+++ b/src/Microsoft.Health.Fhir.R4B.Web/Microsoft.Health.Fhir.R4B.Web.csproj
@@ -3,12 +3,11 @@
   <PropertyGroup>
     <UserSecretsId>29a71f18-2146-4ff0-a511-da3cf615d951</UserSecretsId>
     <RootNamespace>Microsoft.Health.Fhir.Web</RootNamespace>
-    <WarningsNotAsErrors>NU1902</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" />
-    <PackageReference Include="IdentityServer4" />
+    <PackageReference Include="IdentityServer4" NoWarn="NU1902" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" />

--- a/src/Microsoft.Health.Fhir.R4B.Web/Microsoft.Health.Fhir.R4B.Web.csproj
+++ b/src/Microsoft.Health.Fhir.R4B.Web/Microsoft.Health.Fhir.R4B.Web.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <UserSecretsId>29a71f18-2146-4ff0-a511-da3cf615d951</UserSecretsId>
     <RootNamespace>Microsoft.Health.Fhir.Web</RootNamespace>
+    <WarningsNotAsErrors>NU1902</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Health.Fhir.R5.Web/Microsoft.Health.Fhir.R5.Web.csproj
+++ b/src/Microsoft.Health.Fhir.R5.Web/Microsoft.Health.Fhir.R5.Web.csproj
@@ -3,12 +3,11 @@
   <PropertyGroup>
     <UserSecretsId>29a71f18-2146-4ff0-a511-da3cf615d951</UserSecretsId>
     <RootNamespace>Microsoft.Health.Fhir.Web</RootNamespace>
-    <WarningsNotAsErrors>NU1902</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" />
-    <PackageReference Include="IdentityServer4" />
+    <PackageReference Include="IdentityServer4" NoWarn="NU1902" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" />

--- a/src/Microsoft.Health.Fhir.R5.Web/Microsoft.Health.Fhir.R5.Web.csproj
+++ b/src/Microsoft.Health.Fhir.R5.Web/Microsoft.Health.Fhir.R5.Web.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <UserSecretsId>29a71f18-2146-4ff0-a511-da3cf615d951</UserSecretsId>
     <RootNamespace>Microsoft.Health.Fhir.Web</RootNamespace>
+    <WarningsNotAsErrors>NU1902</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Health.Fhir.Stu3.Web/Microsoft.Health.Fhir.Stu3.Web.csproj
+++ b/src/Microsoft.Health.Fhir.Stu3.Web/Microsoft.Health.Fhir.Stu3.Web.csproj
@@ -3,12 +3,11 @@
   <PropertyGroup>
     <UserSecretsId>29a71f18-2146-4ff0-a511-da3cf615d951</UserSecretsId>
     <RootNamespace>Microsoft.Health.Fhir.Web</RootNamespace>
-    <WarningsNotAsErrors>NU1902</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" />
-    <PackageReference Include="IdentityServer4" />
+    <PackageReference Include="IdentityServer4" NoWarn="NU1902" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" />

--- a/src/Microsoft.Health.Fhir.Stu3.Web/Microsoft.Health.Fhir.Stu3.Web.csproj
+++ b/src/Microsoft.Health.Fhir.Stu3.Web/Microsoft.Health.Fhir.Stu3.Web.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <UserSecretsId>29a71f18-2146-4ff0-a511-da3cf615d951</UserSecretsId>
     <RootNamespace>Microsoft.Health.Fhir.Web</RootNamespace>
+    <WarningsNotAsErrors>NU1902</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description
Suppressing NU1902.

## Related issues
Addresses [issue #123725].

[Bug 123725](https://microsofthealth.visualstudio.com/Health/_workitems/edit/123725): Fhir OSS PR pipeline is broken due to vulnerability issues in IdentityServer4 package.

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
