### PR TITLE
[CI] Remove flag -EnableRbacAuthorization and Restore Deleted KVs

### DIFF
--- a/build/jobs/add-aad-test-environment.yml
+++ b/build/jobs/add-aad-test-environment.yml
@@ -36,34 +36,21 @@ steps:
           resource   = $resource
       }
 
-      # If a deleted keyvault exists, remove it first
+      # If a deleted keyvault with purge protection exists, try to restore it.
       $environmentName = "$(DeploymentEnvironmentName)".ToLower() -replace "\.", "" 
       Write-Host "Installed module and set variables"
 
       $vaultName = "${environmentName}-ts"
-      if (Get-AzKeyVault -VaultName $vaultName -Location "westus" -InRemovedState)
+      $vaultLocation = "westus"
+      $vaultResourceGroupName = $ResourceGroupName
+      if (Get-AzKeyVault -VaultName $vaultName -Location $vaultLocation -InRemovedState)
       {
-          Write-Host "Attempting to delete vault ${vaultName}"
-          try
-          {
-              Remove-AzKeyVault -VaultName $vaultName -InRemovedState -Location "westus" -Force
-          }
-          catch
-          {
-              if ($_.ErrorDetails -eq "Operation 'DeletedVaultPurge' is not allowed.")
-              {
-                  # With purge protection enabled, it's impossible to delete a Key Vault before its expiration.
+          Write-Host "Attempting to restore vault ${vaultName}"
 
-                  Write-Error "Unable to delete vault ${vaultName}."
-                  Write-Error $_.ErrorDetails
-              }
-              else
-              { 
-                  throw $_
-              }
-          }
+          Undo-AzKeyVaultRemoval -VaultName $vaultName -ResourceGroupName $vaultResourceGroupName -Location $vaultLocation -Confirm
+          Write-Host "KeyVault $vaultName is restored"
       }
-      Write-Host "Cleaned up keyvaults"
+      Write-Host "Restored keyvaults"
 
       try 
       {

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -95,8 +95,8 @@ jobs:
         Write-Host "Check for keyvaults in removed state..."
         if (Get-AzKeyVault -VaultName $webAppName -Location $(ResourceGroupRegion) -InRemovedState)
         {
-            Remove-AzKeyVault -VaultName $webAppName -InRemovedState -Location $(ResourceGroupRegion) -Force
-            Write-Host "Deleted KeyVault in RemovedState."
+            Undo-AzKeyVaultRemoval -VaultName $webAppName -ResourceGroupName $parameters.resourceGroup -Location $(ResourceGroupRegion) -Confirm
+            Write-Host "KeyVault $webAppName is restored"
         }
 
         Write-Host "Provisioning Resource Group"

--- a/release/scripts/PowerShell/FhirServerRelease/Public/Add-AadTestAuthEnvironment.ps1
+++ b/release/scripts/PowerShell/FhirServerRelease/Public/Add-AadTestAuthEnvironment.ps1
@@ -64,7 +64,7 @@ function Add-AadTestAuthEnvironment {
 
     if (!$keyVault) {
         Write-Host "Creating keyvault with the name $KeyVaultName"
-        New-AzKeyVault -VaultName $KeyVaultName -ResourceGroupName $ResourceGroupName -Location $EnvironmentLocation -EnableRbacAuthorization | Out-Null
+        New-AzKeyVault -VaultName $KeyVaultName -ResourceGroupName $ResourceGroupName -Location $EnvironmentLocation | Out-Null
     }
 
     $retryCount = 0


### PR DESCRIPTION
## Description
Removing the flag -EnableRbacAuthorization during the creation of Key Vaults due changes on most recent version of the Azure ARM SDK. Now, RBAC authorization is enabled by default. 

Additionally, changing our CI logic to recover deleted purge protected Key Vaults instead of just forcing its deletion. 

The image below shows that Key Vaults are now created with RBAC authorization by default. 

![image](https://github.com/user-attachments/assets/7504032b-ba06-4737-8d9b-5fff04ac9aa6)

## Related issues
Addresses [AB#124372](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/124372)


