### PR TITLE
[CI] Remove use of Resource Group when restoring KeyVault

### DIFF
--- a/build/jobs/add-aad-test-environment.yml
+++ b/build/jobs/add-aad-test-environment.yml
@@ -47,7 +47,7 @@ steps:
       {
           Write-Host "Attempting to restore vault ${vaultName}"
 
-          Undo-AzKeyVaultRemoval -VaultName $vaultName -ResourceGroupName $vaultResourceGroupName -Location $vaultLocation -Confirm
+          Undo-AzKeyVaultRemoval -VaultName $vaultName -Location $vaultLocation -Confirm
           Write-Host "KeyVault $vaultName is restored"
       }
       Write-Host "Restored keyvaults"

--- a/src/Microsoft.Health.Fhir.Core/Extensions/SearchServiceExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Extensions/SearchServiceExtensions.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Health.Fhir.Core.Extensions
                         throw new PreconditionFailedException(string.Format(CultureInfo.InvariantCulture, Core.Resources.ConditionalOperationNotSelectiveEnough, instanceType));
                     }
 
-                    if (results?.Results.Any() == true)
+                    if (results?.Results?.Any() == true)
                     {
                         matchedResults.AddRange(
                             results?.Results

--- a/src/Microsoft.Health.Fhir.Core/Extensions/SearchServiceExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Extensions/SearchServiceExtensions.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Health.Fhir.Core.Extensions
                         throw new PreconditionFailedException(string.Format(CultureInfo.InvariantCulture, Core.Resources.ConditionalOperationNotSelectiveEnough, instanceType));
                     }
 
-                    if (results?.Results?.Any() == true)
+                    if (results?.Results.Any() == true)
                     {
                         matchedResults.AddRange(
                             results?.Results


### PR DESCRIPTION
## Description
Remove the use of Resouce Group when restoring a deleted purge-protected Key Vault. 

## Related issues
[AB#123456](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/123456)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
