### PR TITLE
Fixing duplicate errors in OperationOutcome.

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Validation/ResourceProfileValidator.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Validation/ResourceProfileValidator.cs
@@ -76,12 +76,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
                             error);
                         failures.Add(validationFailure);
                     }
+
+                    failures.ForEach(x => context.AddFailure(x));
                 }
 
-                base.Validate(context);
+                ValidationResult baseValidation = base.Validate(context);
+                failures.AddRange(baseValidation.Errors);
             }
 
-            failures.ForEach(x => context.AddFailure(x));
             return new ValidationResult(failures);
         }
     }

--- a/src/Microsoft.Health.Fhir.Core/Features/Validation/ResourceProfileValidator.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Validation/ResourceProfileValidator.cs
@@ -78,8 +78,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
                     }
                 }
 
-                ValidationResult baseValidation = base.Validate(context);
-                failures.AddRange(baseValidation.Errors);
+                base.Validate(context);
             }
 
             failures.ForEach(x => context.AddFailure(x));

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Validation/ResourceProfileValidatorTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Validation/ResourceProfileValidatorTests.cs
@@ -5,8 +5,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Reflection;
+using DotLiquid.Util;
+using FluentValidation;
 using FluentValidation.Results;
 using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Support;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Context;
@@ -25,6 +30,7 @@ public class ResourceProfileValidatorTests
 {
     private readonly ResourceProfileValidator _validator;
     private readonly IProfileValidator _profileValidator;
+    private readonly IModelAttributeValidator _modelAttributeValidator;
     private readonly IFhirRequestContext _fhirRequestContext;
     private readonly OperationOutcomeIssue _operationOutcomeWarningIssue = new(OperationOutcomeConstants.IssueSeverity.Warning, OperationOutcomeConstants.IssueType.Invalid, detailsText: "Warning text.");
     private readonly Dictionary<string, StringValues> _strictHeader = new Dictionary<string, StringValues> { { "Prefer", "handling=strict" } };
@@ -37,11 +43,12 @@ public class ResourceProfileValidatorTests
         requestContextAccessor.RequestContext.Returns(_fhirRequestContext);
 
         _profileValidator = Substitute.For<IProfileValidator>();
+        _modelAttributeValidator = Substitute.For<IModelAttributeValidator>();
         _validator = new ResourceProfileValidator(
-        Substitute.For<IModelAttributeValidator>(),
-        _profileValidator,
-        requestContextAccessor,
-        true);
+            _modelAttributeValidator,
+            _profileValidator,
+            requestContextAccessor,
+            true);
     }
 
     [Fact]
@@ -100,9 +107,93 @@ public class ResourceProfileValidatorTests
         Assert.False(result.IsValid);
     }
 
+    [Fact]
+    public void GivenAResource_WhenValidatingInvalidResource_ThenTheValidationResultHasNoDuplicateErrors()
+    {
+        ResourceElement resource = Samples.GetJsonSample("ObservationWithNoCode");
+
+        var message = "Element with minimum cardinality 1 cannot be null. At Observation.Code.";
+        var memberName = "Code";
+        var propertyName = $"Observation.{memberName}";
+        _modelAttributeValidator.TryValidate(
+            Arg.Any<ResourceElement>(),
+            Arg.Do<ICollection<System.ComponentModel.DataAnnotations.ValidationResult>>(
+                x =>
+                {
+                    var result = new System.ComponentModel.DataAnnotations.ValidationResult(message, new string[] { memberName });
+                    x.Add(result);
+                }),
+            Arg.Any<bool>())
+            .Returns(false);
+
+        ValidationContext<ResourceElement> context = new ValidationContext<ResourceElement>(resource);
+        ValidationResult result = _validator.Validate(context);
+        Assert.False(result.IsValid);
+        Assert.Single(result.Errors);
+        Assert.Equal(Severity.Error, result.Errors[0].Severity);
+        Assert.Equal(message, result.Errors[0].ErrorMessage);
+        Assert.Equal(propertyName, result.Errors[0].PropertyName);
+
+        var failures = GetFailures(context);
+        Assert.Single(failures);
+        Assert.Equal(Severity.Error, failures[0].Severity);
+        Assert.Equal(message, failures[0].ErrorMessage);
+        Assert.Equal(propertyName, failures[0].PropertyName);
+    }
+
+    [Fact]
+    public void GivenAResource_WhenValidatingInvalidResource_ThenTheValidationResultHasProfileAndContentErrors()
+    {
+        ResourceElement resource = Samples.GetJsonSample("ObservationWithNoCode");
+
+        var message = "Element with minimum cardinality 1 cannot be null. At Observation.Code.";
+        var memberName = "Code";
+        var propertyName = $"Observation.{memberName}";
+        _modelAttributeValidator.TryValidate(
+            Arg.Any<ResourceElement>(),
+            Arg.Do<ICollection<System.ComponentModel.DataAnnotations.ValidationResult>>(
+                x =>
+                {
+                    var result = new System.ComponentModel.DataAnnotations.ValidationResult(message, new string[] { memberName });
+                    x.Add(result);
+                }),
+            Arg.Any<bool>())
+            .Returns(false);
+
+        var detailedMessage = "Error text.";
+        _profileValidator.TryValidate(Arg.Any<ITypedElement>(), Arg.Any<string>())
+            .Returns(new[] { new OperationOutcomeIssue(OperationOutcomeConstants.IssueSeverity.Error, OperationOutcomeConstants.IssueType.Invalid, detailsText: detailedMessage) });
+
+        ValidationContext<ResourceElement> context = new ValidationContext<ResourceElement>(resource);
+        ValidationResult result = _validator.Validate(context);
+        Assert.False(result.IsValid);
+        Assert.Equal(2, result.Errors.Count);
+        Assert.Contains(
+            result.Errors,
+            e => e.Severity == Severity.Error && e.ErrorMessage == message && e.PropertyName == propertyName);
+        Assert.Contains(
+            result.Errors,
+            e => e.Severity == Severity.Error && e.ErrorMessage == detailedMessage);
+
+        var failures = GetFailures(context);
+        Assert.Equal(2, failures.Count);
+        Assert.Contains(
+            failures,
+            e => e.Severity == Severity.Error && e.ErrorMessage == message && e.PropertyName == propertyName);
+        Assert.Contains(
+            failures,
+            e => e.Severity == Severity.Error && e.ErrorMessage == detailedMessage);
+    }
+
     public static IEnumerable<object[]> ErrorIssues()
     {
         yield return new object[] { new OperationOutcomeIssue(OperationOutcomeConstants.IssueSeverity.Error, OperationOutcomeConstants.IssueType.Invalid, detailsText: "Error text.") };
         yield return new object[] { new OperationOutcomeIssue(OperationOutcomeConstants.IssueSeverity.Fatal, OperationOutcomeConstants.IssueType.Invalid, detailsText: "Fatal text.") };
+    }
+
+    private static IList<ValidationFailure> GetFailures(ValidationContext<ResourceElement> context)
+    {
+        var failures = context?.GetType().GetProperty("Failures", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(context);
+        return failures != null ? new List<ValidationFailure>((IList<ValidationFailure>)failures) : new List<ValidationFailure>();
     }
 }


### PR DESCRIPTION
## Description
Fixing duplicate errors in OperationOutcome. 

Errors found by ResourceContentValidator (base class) were added to the validation context twice by the validator and also ResourceProfileValidator (derived class).

## Related issues
Addresses [issue #123153].

[Bug 123153](https://microsofthealth.visualstudio.com/Health/_workitems/edit/123153): Duplicated validation error messages for FHIR resources

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
