### PR TITLE
[Feature] Changes Cosmos to use MI connection

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,6 +32,7 @@
   <ItemGroup>
     <PackageVersion Include="AngleSharp" Version="1.1.2" />
     <PackageVersion Include="Azure.Identity" Version="1.12.0" />
+    <PackageVersion Include="Azure.ResourceManager.CosmosDB" Version="1.3.2" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.2.0" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.20.0" />

--- a/build/jobs/add-aad-test-environment.yml
+++ b/build/jobs/add-aad-test-environment.yml
@@ -42,12 +42,12 @@ steps:
 
       $vaultName = "${environmentName}-ts"
       $vaultLocation = "westus"
-      $vaultResourceGroupName = $ResourceGroupName
+      $vaultResourceGroupName = "$(ResourceGroupName)"
       if (Get-AzKeyVault -VaultName $vaultName -Location $vaultLocation -InRemovedState)
       {
           Write-Host "Attempting to restore vault ${vaultName}"
 
-          Undo-AzKeyVaultRemoval -VaultName $vaultName -Location $vaultLocation -Confirm
+          Undo-AzKeyVaultRemoval -VaultName $vaultName -ResourceGroupName $vaultResourceGroupName -Location $vaultLocation
           Write-Host "KeyVault $vaultName is restored"
       }
       Write-Host "Restored keyvaults"

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -92,18 +92,18 @@ jobs:
             $templateParameters["sqlSchemaAutomaticUpdatesEnabled"] = "${{parameters.schemaAutomaticUpdatesEnabled}}"
         }
 
+        $deploymentName = $webAppName
+        $resourceGroupName = "${{ parameters.resourceGroup }}"
+
         Write-Host "Check for keyvaults in removed state..."
         if (Get-AzKeyVault -VaultName $webAppName -Location $(ResourceGroupRegion) -InRemovedState)
         {
-            Undo-AzKeyVaultRemoval -VaultName $webAppName -ResourceGroupName $parameters.resourceGroup -Location $(ResourceGroupRegion) -Confirm
+            Undo-AzKeyVaultRemoval -VaultName $webAppName -ResourceGroupName $resourceGroupName -Location $(ResourceGroupRegion)
             Write-Host "KeyVault $webAppName is restored"
         }
 
         Write-Host "Provisioning Resource Group"
         Write-Host "ResourceGroupName: ${{ parameters.resourceGroup }}"
-
-        $deploymentName = $webAppName
-        $resourceGroupName = "${{ parameters.resourceGroup }}"
 
         # Check if a deployment with the specified name already exists
         $existingDeployment = Get-AzResourceGroupDeployment -Name $deploymentName -ResourceGroupName $resourceGroupName -ErrorAction SilentlyContinue

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -250,7 +250,8 @@
         "appInsightsName": "[concat('AppInsights-', variables('serviceName'))]",
         "storageBlobDataContributerRoleId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')]",
         "acrPullRoleId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '7f951dda-4ed3-4680-a7ca-43fe172d538d')]",
-        "cosmosDbDataContributerRoleId": "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions', variables('serviceName'), '00000000-0000-0000-0000-000000000002')]",
+        "cosmosDbDataContributorRoleId": "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions', variables('serviceName'), '00000000-0000-0000-0000-000000000002')]",
+        "cosmosDbControlPlaneContributorRoleId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '230815da-be43-4aae-9cb4-875f7bd000aa')]",
         "blobStorageUri": "[if(variables('isMAG'), '.blob.core.usgovcloudapi.net', '.blob.core.windows.net')]",
         "enableIntegrationStore": "[or(parameters('enableExport'), parameters('enableImport'))]",
         "staticFhirServerConfigProperties": {
@@ -283,7 +284,6 @@
         "sqlServerDerivedName": "[if(empty(parameters('sqlServerName')),variables('serviceName'),parameters('sqlServerName'))]",
         "managedIdentityName": "[concat(if(empty(parameters('sqlServerName')), variables('serviceName'), parameters('sqlServerName')), '-uami')]",
         "sqlDatabaseName": "[concat('FHIR', parameters('fhirVersion'))]",
-        "cosmosCollectionName": "[if(equals(parameters('fhirVersion'),'Stu3'), 'fhir', concat('fhir', parameters('fhirVersion')))]",
         "computedSqlServerReference": "[concat('Microsoft.Sql/servers/', variables('sqlServerDerivedName'))]",
         "storageAccountName": "[concat(substring(replace(variables('serviceName'), '-', ''), 0, min(11, length(replace(variables('serviceName'), '-', '')))), uniquestring(resourceGroup().id, variables('serviceName')))]",
         "registryName": "healthplatformregistry.azurecr.io",
@@ -367,7 +367,8 @@
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]",
-                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('managedIdentityName'))]"
+                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('managedIdentityName'))]",
+                "[if(variables('deployAppInsights'),concat('Microsoft.Insights/components/', variables('appInsightsName')),resourceId('Microsoft.KeyVault/vaults', variables('serviceName')))]"
             ],
             "resources": [
                 {
@@ -379,7 +380,7 @@
                         "[if(variables('deployAppInsights'),concat('Microsoft.Insights/components/', variables('appInsightsName')),resourceId('Microsoft.KeyVault/vaults', variables('serviceName')))]",
                         "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), resourceId('Microsoft.KeyVault/vaults/secrets', variables('serviceName'), 'CosmosDb--Host'), resourceId('Microsoft.KeyVault/vaults/secrets', variables('serviceName'), 'SqlServer--ConnectionString'))]"
                     ],
-                    "properties": "[if(variables('deployAppInsights'), union(variables('combinedFhirServerConfigProperties'), json(concat('{', '\"Telemetry__Provider\": \"', parameters('telemetryProviderType'), '\",', '\"Telemetry__InstrumentationKey\": \"', reference(concat('Microsoft.Insights/components/', variables('appInsightsName'))).InstrumentationKey, '\",', '\"Telemetry__ConnectionString\": \"', reference(concat('Microsoft.Insights/components/', variables('appInsightsName'))).ConnectionString, '\"', '}'))), variables('combinedFhirServerConfigProperties'))]"
+                    "properties": "[union(variables('combinedFhirServerConfigProperties'), json(concat('{ \"FhirServer__ResourceManager__DataStoreResourceId\": \"', if(equals(parameters('solutionType'),'FhirServerCosmosDB'), resourceId('Microsoft.DocumentDb/databaseAccounts', variables('serviceName')), resourceId('Microsoft.Sql/servers/', variables('sqlServerDerivedName'))), '\", ', if(variables('deployAppInsights'), concat('\"Telemetry__Provider\": \"', parameters('telemetryProviderType'), '\",', '\"Telemetry__InstrumentationKey\": \"', reference(resourceId('Microsoft.Insights/components', variables('appInsightsName'))).InstrumentationKey, '\",', '\"Telemetry__ConnectionString\": \"', reference(resourceId('Microsoft.Insights/components', variables('appInsightsName'))).ConnectionString, '\"'), ''), '}')))]"
                 },
                 {
                     "apiVersion": "2018-11-01",
@@ -466,6 +467,21 @@
         },
         {
             "condition": "[equals(parameters('solutionType'),'FhirServerCosmosDB')]",
+            "type": "Microsoft.Authorization/roleAssignments",
+            "apiVersion": "2020-04-01-preview",
+            "name": "[guid(uniqueString(variables('cosmosDbControlPlaneContributorRoleId'), parameters('fhirVersion'), variables('serviceName')))]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites/', variables('serviceName'))]",
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('serviceName'))]"
+            ],
+            "properties": {
+                "roleDefinitionId": "[variables('cosmosDbControlPlaneContributorRoleId')]",
+                "principalId": "[reference(resourceId('Microsoft.Web/sites/', variables('serviceName')), '2020-06-01', 'Full').identity.principalId]",
+                "principalType": "ServicePrincipal"
+            }
+        },
+        {
+            "condition": "[equals(parameters('solutionType'),'FhirServerCosmosDB')]",
             "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases",
             "apiVersion": "2022-11-15",
             "name": "[concat(variables('serviceName'), '/health')]",
@@ -480,93 +496,6 @@
         },
         {
             "condition": "[equals(parameters('solutionType'),'FhirServerCosmosDB')]",
-            "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers",
-            "apiVersion": "2022-11-15",
-            "name": "[concat(variables('serviceName'), '/health/', variables('cosmosCollectionName'))]",
-            "dependsOn": [
-                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', variables('serviceName'), 'health')]",
-                "[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('serviceName'))]"
-            ],
-            "properties": {
-                "resource": {
-                    "id": "[variables('cosmosCollectionName')]",
-                    "indexingPolicy": {
-                        "indexingMode": "consistent",
-                        "automatic": true,
-                        "includedPaths": [
-                            {
-                                "path": "/*"
-                            }
-                        ],
-                        "excludedPaths": [
-                            {
-                                "path": "/rawResource/*"
-                            },
-                            {
-                                "path": "/\"_etag\"/?"
-                            }
-                        ]
-                    },
-                    "partitionKey": {
-                        "paths": [
-                            "/partitionKey"
-                        ],
-                        "kind": "Hash"
-                    },
-                    "defaultTtl": -1,
-                    "conflictResolutionPolicy": {
-                        "mode": "LastWriterWins",
-                        "conflictResolutionPath": "/_ts"
-                    }
-                }
-            }
-        },
-        {
-            "condition": "[equals(parameters('solutionType'),'FhirServerCosmosDB')]",
-            "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/throughputSettings",
-            "apiVersion": "2022-11-15",
-            "name": "[concat(variables('serviceName'), '/health/', variables('cosmosCollectionName'), '/default')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers', variables('serviceName'), 'health', variables('cosmosCollectionName'))]",
-                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', variables('serviceName'), 'health')]",
-                "[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('serviceName'))]"
-            ],
-            "properties": {
-                "resource": {
-                    "throughput": 1000
-                }
-            }
-        },
-        {
-            "condition": "[equals(parameters('solutionType'),'FhirServerCosmosDB')]",
-            "type": "Microsoft.KeyVault/vaults/secrets",
-            "name": "[concat(variables('serviceName'), '/CosmosDb--Host')]",
-            "apiVersion": "2015-06-01",
-            "properties": {
-                "contentType": "text/plain",
-                "value": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), reference(concat('Microsoft.DocumentDb/databaseAccounts/', variables('serviceName'))).documentEndpoint, '')]"
-            },
-            "dependsOn": [
-                "[resourceId('Microsoft.KeyVault/vaults', variables('serviceName'))]",
-                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers', variables('serviceName'), 'health', variables('cosmosCollectionName'))]"
-            ]
-        },
-        {
-            "condition": "[equals(parameters('solutionType'),'FhirServerCosmosDB')]",
-            "type": "Microsoft.KeyVault/vaults/secrets",
-            "name": "[concat(variables('serviceName'), '/CosmosDb--Key')]",
-            "apiVersion": "2015-06-01",
-            "properties": {
-                "contentType": "text/plain",
-                "value": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), listKeys(resourceId('Microsoft.DocumentDb/databaseAccounts', variables('serviceName')), '2015-04-08').primaryMasterKey, '')]"
-            },
-            "dependsOn": [
-                "[resourceId('Microsoft.KeyVault/vaults', variables('serviceName'))]",
-                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers', variables('serviceName'), 'health', variables('cosmosCollectionName'))]"
-            ]
-        },
-        {
-            "condition": "[equals(parameters('solutionType'),'FhirServerCosmosDB')]",
             "apiVersion": "2022-11-15",
             "name": "[concat(variables('serviceName'), '/', guid(uniqueString('CosmosDB', parameters('fhirVersion'), variables('serviceName'))))]",
             "type": "Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments",
@@ -575,7 +504,7 @@
                 "[variables('appServiceResourceId')]"
             ],
             "properties": {
-                "roleDefinitionId": "[variables('cosmosDbDataContributerRoleId')]",
+                "roleDefinitionId": "[variables('cosmosDbDataContributorRoleId')]",
                 "principalId": "[reference(concat('Microsoft.Web/sites/', variables('serviceName')), '2018-11-01', 'full').identity.principalId]",
                 "scope": "[resourceId('Microsoft.DocumentDb/databaseAccounts', variables('serviceName'))]"
             }
@@ -633,6 +562,7 @@
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2022-09-01",
             "name": "webAppIPsSQLFirewall",
+            "condition": "[equals(parameters('solutionType'),'FhirServerSqlServer')]",
             "properties": {
                 "expressionEvaluationOptions": {
                     "scope": "inner"

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -250,6 +250,7 @@
         "appInsightsName": "[concat('AppInsights-', variables('serviceName'))]",
         "storageBlobDataContributerRoleId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')]",
         "acrPullRoleId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '7f951dda-4ed3-4680-a7ca-43fe172d538d')]",
+        "cosmosDbDataContributerRoleId": "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions', variables('serviceName'), '00000000-0000-0000-0000-000000000002')]",
         "blobStorageUri": "[if(variables('isMAG'), '.blob.core.usgovcloudapi.net', '.blob.core.windows.net')]",
         "enableIntegrationStore": "[or(parameters('enableExport'), parameters('enableImport'))]",
         "staticFhirServerConfigProperties": {
@@ -262,6 +263,7 @@
             "FhirServer__Security__EnableAadSmartOnFhirProxy": "[parameters('enableAadSmartOnFhirProxy')]",
             "FhirServer__Security__Authentication__Authority": "[parameters('securityAuthenticationAuthority')]",
             "FhirServer__Security__Authentication__Audience": "[parameters('securityAuthenticationAudience')]",
+            "CosmosDb__UseManagedIdentity": "true",
             "CosmosDb__ContinuationTokenSizeLimitInKb": "1",
             "CosmosDb__UseQueueClientJobs": "true",
             "SqlServer__Initialize": "[equals(parameters('solutionType'),'FhirServerSqlServer')]",
@@ -281,6 +283,7 @@
         "sqlServerDerivedName": "[if(empty(parameters('sqlServerName')),variables('serviceName'),parameters('sqlServerName'))]",
         "managedIdentityName": "[concat(if(empty(parameters('sqlServerName')), variables('serviceName'), parameters('sqlServerName')), '-uami')]",
         "sqlDatabaseName": "[concat('FHIR', parameters('fhirVersion'))]",
+        "cosmosCollectionName": "[if(equals(parameters('fhirVersion'),'Stu3'), 'fhir', concat('fhir', parameters('fhirVersion')))]",
         "computedSqlServerReference": "[concat('Microsoft.Sql/servers/', variables('sqlServerDerivedName'))]",
         "storageAccountName": "[concat(substring(replace(variables('serviceName'), '-', ''), 0, min(11, length(replace(variables('serviceName'), '-', '')))), uniquestring(resourceGroup().id, variables('serviceName')))]",
         "registryName": "healthplatformregistry.azurecr.io",
@@ -459,6 +462,122 @@
                         "failoverPriority": 0
                     }
                 ]
+            }
+        },
+        {
+            "condition": "[equals(parameters('solutionType'),'FhirServerCosmosDB')]",
+            "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases",
+            "apiVersion": "2022-11-15",
+            "name": "[concat(variables('serviceName'), '/health')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('serviceName'))]"
+            ],
+            "properties": {
+                "resource": {
+                    "id": "health"
+                }
+            }
+        },
+        {
+            "condition": "[equals(parameters('solutionType'),'FhirServerCosmosDB')]",
+            "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers",
+            "apiVersion": "2022-11-15",
+            "name": "[concat(variables('serviceName'), '/health/', variables('cosmosCollectionName'))]",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', variables('serviceName'), 'health')]",
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('serviceName'))]"
+            ],
+            "properties": {
+                "resource": {
+                    "id": "[variables('cosmosCollectionName')]",
+                    "indexingPolicy": {
+                        "indexingMode": "consistent",
+                        "automatic": true,
+                        "includedPaths": [
+                            {
+                                "path": "/*"
+                            }
+                        ],
+                        "excludedPaths": [
+                            {
+                                "path": "/rawResource/*"
+                            },
+                            {
+                                "path": "/\"_etag\"/?"
+                            }
+                        ]
+                    },
+                    "partitionKey": {
+                        "paths": [
+                            "/partitionKey"
+                        ],
+                        "kind": "Hash"
+                    },
+                    "defaultTtl": -1,
+                    "conflictResolutionPolicy": {
+                        "mode": "LastWriterWins",
+                        "conflictResolutionPath": "/_ts"
+                    }
+                }
+            }
+        },
+        {
+            "condition": "[equals(parameters('solutionType'),'FhirServerCosmosDB')]",
+            "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/throughputSettings",
+            "apiVersion": "2022-11-15",
+            "name": "[concat(variables('serviceName'), '/health/', variables('cosmosCollectionName'), '/default')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers', variables('serviceName'), 'health', variables('cosmosCollectionName'))]",
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', variables('serviceName'), 'health')]",
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('serviceName'))]"
+            ],
+            "properties": {
+                "resource": {
+                    "throughput": 1000
+                }
+            }
+        },
+        {
+            "condition": "[equals(parameters('solutionType'),'FhirServerCosmosDB')]",
+            "type": "Microsoft.KeyVault/vaults/secrets",
+            "name": "[concat(variables('serviceName'), '/CosmosDb--Host')]",
+            "apiVersion": "2015-06-01",
+            "properties": {
+                "contentType": "text/plain",
+                "value": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), reference(concat('Microsoft.DocumentDb/databaseAccounts/', variables('serviceName'))).documentEndpoint, '')]"
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.KeyVault/vaults', variables('serviceName'))]",
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers', variables('serviceName'), 'health', variables('cosmosCollectionName'))]"
+            ]
+        },
+        {
+            "condition": "[equals(parameters('solutionType'),'FhirServerCosmosDB')]",
+            "type": "Microsoft.KeyVault/vaults/secrets",
+            "name": "[concat(variables('serviceName'), '/CosmosDb--Key')]",
+            "apiVersion": "2015-06-01",
+            "properties": {
+                "contentType": "text/plain",
+                "value": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), listKeys(resourceId('Microsoft.DocumentDb/databaseAccounts', variables('serviceName')), '2015-04-08').primaryMasterKey, '')]"
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.KeyVault/vaults', variables('serviceName'))]",
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers', variables('serviceName'), 'health', variables('cosmosCollectionName'))]"
+            ]
+        },
+        {
+            "condition": "[equals(parameters('solutionType'),'FhirServerCosmosDB')]",
+            "apiVersion": "2022-11-15",
+            "name": "[concat(variables('serviceName'), '/', guid(uniqueString('CosmosDB', parameters('fhirVersion'), variables('serviceName'))))]",
+            "type": "Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('serviceName'))]",
+                "[variables('appServiceResourceId')]"
+            ],
+            "properties": {
+                "roleDefinitionId": "[variables('cosmosDbDataContributerRoleId')]",
+                "principalId": "[reference(concat('Microsoft.Web/sites/', variables('serviceName')), '2018-11-01', 'full').identity.principalId]",
+                "scope": "[resourceId('Microsoft.DocumentDb/databaseAccounts', variables('serviceName'))]"
             }
         },
         {

--- a/src/Microsoft.Health.Fhir.Api/Configs/FhirServerConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Api/Configs/FhirServerConfiguration.cs
@@ -36,5 +36,7 @@ namespace Microsoft.Health.Fhir.Api.Configs
         public ImplementationGuidesConfiguration ImplementationGuides { get; } = new ImplementationGuidesConfiguration();
 
         public EncryptionConfiguration Encryption { get; } = new EncryptionConfiguration();
+
+        public ResourceManagerConfig ResourceManager { get; } = new ResourceManagerConfig();
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Configs/ResourceManagerConfig.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/ResourceManagerConfig.cs
@@ -1,0 +1,11 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Fhir.Core.Configs;
+
+public class ResourceManagerConfig
+{
+    public string DataStoreResourceId { get; set; }
+}

--- a/src/Microsoft.Health.Fhir.CosmosDb.Core/Configs/CosmosDataStoreConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.Core/Configs/CosmosDataStoreConfiguration.cs
@@ -22,6 +22,8 @@ namespace Microsoft.Health.Fhir.CosmosDb.Core.Configs
 
         public bool AllowDatabaseCreation { get; set; } = true;
 
+        public bool AllowCollectionSetup { get; set; } = true;
+
         public string DatabaseId { get; set; }
 
         public int? InitialDatabaseThroughput { get; set; }

--- a/src/Microsoft.Health.Fhir.CosmosDb.Core/Configs/CosmosDataStoreConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.Core/Configs/CosmosDataStoreConfiguration.cs
@@ -14,6 +14,17 @@ namespace Microsoft.Health.Fhir.CosmosDb.Core.Configs
 
         public string Key { get; set; }
 
+        /// <summary>
+        /// When true, the application will use the managed identity of the Azure resource to authenticate to Cosmos DB.
+        /// Key configuration will be ignored if this is set to true.
+        /// </summary>
+        public bool UseManagedIdentity { get; set; }
+
+        /// <summary>
+        /// ManagedIdentity does not allow Database creation
+        /// </summary>
+        public bool AllowDatabaseCreation { get; set; } = true;
+
         public string DatabaseId { get; set; }
 
         public int? InitialDatabaseThroughput { get; set; }
@@ -21,8 +32,6 @@ namespace Microsoft.Health.Fhir.CosmosDb.Core.Configs
         public ConnectionMode ConnectionMode { get; set; } = ConnectionMode.Direct;
 
         public ConsistencyLevel? DefaultConsistencyLevel { get; set; }
-
-        public bool AllowDatabaseCreation { get; set; } = true;
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "This is a configuration class")]
         public IList<string> PreferredLocations { get; set; }

--- a/src/Microsoft.Health.Fhir.CosmosDb.Core/Configs/CosmosDataStoreConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.Core/Configs/CosmosDataStoreConfiguration.cs
@@ -20,9 +20,6 @@ namespace Microsoft.Health.Fhir.CosmosDb.Core.Configs
         /// </summary>
         public bool UseManagedIdentity { get; set; }
 
-        /// <summary>
-        /// ManagedIdentity does not allow Database creation
-        /// </summary>
         public bool AllowDatabaseCreation { get; set; } = true;
 
         public string DatabaseId { get; set; }

--- a/src/Microsoft.Health.Fhir.CosmosDb.Core/Features/Storage/ICollectionSetup.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.Core/Features/Storage/ICollectionSetup.cs
@@ -6,6 +6,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Health.Fhir.CosmosDb.Core.Features.Storage.Versioning;
 using Polly;
 
 namespace Microsoft.Health.Fhir.CosmosDb.Core.Features.Storage
@@ -16,6 +17,8 @@ namespace Microsoft.Health.Fhir.CosmosDb.Core.Features.Storage
 
         public Task CreateCollectionAsync(IEnumerable<ICollectionInitializer> collectionInitializers, AsyncPolicy retryPolicy, CancellationToken cancellationToken = default);
 
-        public Task UpdateFhirCollectionSettingsAsync(CancellationToken cancellationToken);
+        Task InstallStoredProcs(CancellationToken cancellationToken);
+
+        public Task UpdateFhirCollectionSettingsAsync(CollectionVersion version, CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb.Core/Features/Storage/ICosmosClientTestProvider.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.Core/Features/Storage/ICosmosClientTestProvider.cs
@@ -12,6 +12,6 @@ namespace Microsoft.Health.Fhir.CosmosDb.Core.Features.Storage
 {
     public interface ICosmosClientTestProvider
     {
-        Task PerformTestAsync(Container container, CosmosDataStoreConfiguration configuration, CosmosCollectionConfiguration cosmosCollectionConfiguration, CancellationToken cancellationToken = default);
+        Task PerformTestAsync(Container container, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb.Initialization/Features/Storage/ArmSdkCollectionSetup.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.Initialization/Features/Storage/ArmSdkCollectionSetup.cs
@@ -1,0 +1,196 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Core;
+using Azure.Identity;
+using Azure.ResourceManager;
+using Azure.ResourceManager.CosmosDB;
+using Azure.ResourceManager.CosmosDB.Models;
+using EnsureThat;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using Microsoft.Health.Fhir.CosmosDb.Core.Configs;
+using Microsoft.Health.Fhir.CosmosDb.Core.Features.Storage;
+using Microsoft.Health.Fhir.CosmosDb.Core.Features.Storage.StoredProcedures;
+using Polly;
+
+namespace Microsoft.Health.Fhir.CosmosDb.Initialization.Features.Storage;
+
+public class ArmSdkCollectionSetup : ICollectionSetup
+{
+    private readonly ArmClient _armClient;
+    private readonly IOptionsMonitor<CosmosCollectionConfiguration> _cosmosCollectionConfiguration;
+    private readonly CosmosDataStoreConfiguration _cosmosDataStoreConfiguration;
+    private readonly IEnumerable<IStoredProcedureMetadata> _storeProceduresMetadata;
+    private readonly ResourceIdentifier _resourceIdentifier;
+    private CosmosDBSqlDatabaseResource _database;
+
+    public ArmSdkCollectionSetup(
+        IOptionsMonitor<CosmosCollectionConfiguration> cosmosCollectionConfiguration,
+        CosmosDataStoreConfiguration cosmosDataStoreConfiguration,
+        IConfiguration genericConfiguration,
+        IEnumerable<IStoredProcedureMetadata> storedProcedures)
+    {
+        EnsureArg.IsNotNull(storedProcedures, nameof(storedProcedures));
+
+        _cosmosCollectionConfiguration = EnsureArg.IsNotNull(cosmosCollectionConfiguration, nameof(cosmosCollectionConfiguration));
+        _cosmosDataStoreConfiguration = EnsureArg.IsNotNull(cosmosDataStoreConfiguration, nameof(cosmosDataStoreConfiguration));
+        _storeProceduresMetadata = EnsureArg.IsNotNull(storedProcedures, nameof(storedProcedures));
+        _armClient = new ArmClient(new DefaultAzureCredential());
+        var dataStoreResourceId = genericConfiguration.GetValue("FhirServer:ResourceManager:DataStoreResourceId", string.Empty);
+        _resourceIdentifier = ResourceIdentifier.Parse(dataStoreResourceId);
+    }
+
+    private CosmosDBSqlDatabaseResource Database
+    {
+        get
+        {
+            if (_database != null)
+            {
+                return _database;
+            }
+
+            CosmosDBAccountResource account = _armClient.GetCosmosDBAccountResource(_resourceIdentifier);
+            _database = account.GetCosmosDBSqlDatabase(_cosmosDataStoreConfiguration.DatabaseId);
+            return _database;
+        }
+    }
+
+    private string CollectionId
+    {
+        get
+        {
+            return _cosmosCollectionConfiguration.Get(Core.Constants.CollectionConfigurationName).CollectionId;
+        }
+    }
+
+    public async Task CreateDatabaseAsync(AsyncPolicy retryPolicy, CancellationToken cancellationToken)
+    {
+        CosmosDBAccountResource account = _armClient.GetCosmosDBAccountResource(_resourceIdentifier);
+        CosmosDBSqlDatabaseCollection databaseCollection = account.GetCosmosDBSqlDatabases();
+
+        if (!(await databaseCollection.ExistsAsync(_cosmosDataStoreConfiguration.DatabaseId, cancellationToken)).Value)
+        {
+            await databaseCollection.CreateOrUpdateAsync(
+                WaitUntil.Completed,
+                _cosmosDataStoreConfiguration.DatabaseId,
+                new CosmosDBSqlDatabaseCreateOrUpdateContent(
+                    _resourceIdentifier.Location.GetValueOrDefault(),
+                    new CosmosDBSqlDatabaseResourceInfo(_cosmosDataStoreConfiguration.DatabaseId)),
+                cancellationToken);
+        }
+    }
+
+    public async Task CreateCollectionAsync(IEnumerable<ICollectionInitializer> collectionInitializers, AsyncPolicy retryPolicy, CancellationToken cancellationToken = default)
+    {
+        Response<CosmosDBSqlContainerResource> containers = await Database.GetCosmosDBSqlContainerAsync(CollectionId, cancellationToken);
+
+        if (containers.Value == null)
+        {
+            var containerResourceInfo = new CosmosDBSqlContainerResourceInfo(CollectionId)
+            {
+                PartitionKey = new CosmosDBContainerPartitionKey
+                {
+                    Paths = { $"/{KnownDocumentProperties.PartitionKey}" },
+                    Kind = CosmosDBPartitionKind.Hash,
+                },
+                IndexingPolicy = CreateCosmosDbIndexingPolicy(),
+            };
+
+            var content = new CosmosDBSqlContainerCreateOrUpdateContent(
+                new AzureLocation(_resourceIdentifier.Location.GetValueOrDefault()),
+                containerResourceInfo);
+
+            CosmosDBSqlContainerCollection containerCollection = Database.GetCosmosDBSqlContainers();
+            await containerCollection.CreateOrUpdateAsync(WaitUntil.Completed, CollectionId, content, cancellationToken);
+
+            containers = await Database.GetCosmosDBSqlContainerAsync(CollectionId, cancellationToken);
+
+            var throughput =
+                _cosmosCollectionConfiguration.Get(Core.Constants.CollectionConfigurationName)
+                    .InitialCollectionThroughput;
+
+            if (throughput.HasValue)
+            {
+                await containers.Value.GetCosmosDBSqlContainerThroughputSetting()
+                    .CreateOrUpdateAsync(
+                        WaitUntil.Completed,
+                        new ThroughputSettingsUpdateData(
+                            _resourceIdentifier.Location.GetValueOrDefault(),
+                            new ThroughputSettingsResourceInfo
+                            {
+                                Throughput = throughput,
+                            }),
+                        cancellationToken);
+            }
+        }
+
+        var meta = _storeProceduresMetadata.ToList();
+
+        CosmosDBSqlStoredProcedureCollection cosmosDbSqlStoredProcedures = containers.Value.GetCosmosDBSqlStoredProcedures();
+        var existing = cosmosDbSqlStoredProcedures.Select(x => x.Data.Resource.StoredProcedureName).ToList();
+
+        foreach (IStoredProcedureMetadata storedProc in meta)
+        {
+            if (!existing.Contains(storedProc.FullName))
+            {
+                var cosmosDbSqlStoredProcedureResource = new CosmosDBSqlStoredProcedureResourceInfo(storedProc.FullName)
+                {
+                    Body = storedProc.ToStoredProcedureProperties().Body,
+                };
+
+                var storedProcedureCreateOrUpdateContent = new CosmosDBSqlStoredProcedureCreateOrUpdateContent(_resourceIdentifier.Location.GetValueOrDefault(), cosmosDbSqlStoredProcedureResource);
+                await cosmosDbSqlStoredProcedures.CreateOrUpdateAsync(WaitUntil.Completed, storedProc.FullName, storedProcedureCreateOrUpdateContent, cancellationToken);
+            }
+        }
+    }
+
+    public async Task UpdateFhirCollectionSettingsAsync(CancellationToken cancellationToken)
+    {
+        var containerResourceInfo = new CosmosDBSqlContainerResourceInfo(CollectionId);
+
+        containerResourceInfo.IndexingPolicy = CreateCosmosDbIndexingPolicy();
+
+        var content = new CosmosDBSqlContainerCreateOrUpdateContent(
+            new AzureLocation(_resourceIdentifier.Location.GetValueOrDefault()),
+            containerResourceInfo);
+
+        CosmosDBSqlContainerCollection containers = Database.GetCosmosDBSqlContainers();
+        await containers.CreateOrUpdateAsync(WaitUntil.Completed, CollectionId, content, cancellationToken);
+    }
+
+    private static CosmosDBIndexingPolicy CreateCosmosDbIndexingPolicy()
+    {
+        var indexingPolicy = new CosmosDBIndexingPolicy
+        {
+            IsAutomatic = true, // Enable automatic indexing
+            IndexingMode = CosmosDBIndexingMode.Consistent, // Choose indexing mode (Consistent or Lazy)
+            IncludedPaths =
+            {
+                new CosmosDBIncludedPath
+                {
+                    Path = "/*", // Include all properties
+                },
+            },
+            ExcludedPaths =
+            {
+                new CosmosDBExcludedPath
+                {
+                    Path = $"/{"rawResource"}/*", // Exclude properties under /excludedPath
+                },
+                new CosmosDBExcludedPath
+                {
+                    Path = "/\"_etag\"/?",
+                },
+            },
+        };
+        return indexingPolicy;
+    }
+}

--- a/src/Microsoft.Health.Fhir.CosmosDb.Initialization/Features/Storage/DefaultCollectionSetup.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.Initialization/Features/Storage/DefaultCollectionSetup.cs
@@ -3,13 +3,14 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Health.Fhir.CosmosDb.Core.Features.Storage;
+using Microsoft.Health.Fhir.CosmosDb.Core.Features.Storage.Versioning;
 using Polly;
 
-namespace Microsoft.Health.Fhir.CosmosDb.Core.Features.Storage
+namespace Microsoft.Health.Fhir.CosmosDb.Initialization.Features.Storage
 {
     /// <summary>
     /// This class does not execute any real initialization.
@@ -22,12 +23,17 @@ namespace Microsoft.Health.Fhir.CosmosDb.Core.Features.Storage
             return Task.CompletedTask;
         }
 
+        public Task InstallStoredProcs(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
         public Task CreateDatabaseAsync(AsyncPolicy retryPolicy, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }
 
-        public Task UpdateFhirCollectionSettingsAsync(CancellationToken cancellationToken)
+        public Task UpdateFhirCollectionSettingsAsync(CollectionVersion version, CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }

--- a/src/Microsoft.Health.Fhir.CosmosDb.Initialization/Features/Storage/ResourceManagerCollectionSetup.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.Initialization/Features/Storage/ResourceManagerCollectionSetup.cs
@@ -40,6 +40,7 @@ public class ResourceManagerCollectionSetup : ICollectionSetup
     private CosmosDBSqlDatabaseResource _database;
     private AzureLocation? _location;
     private readonly CosmosDBAccountResource _account;
+    private const string FhirServerResourceManagerDataStoreResourceId = "FhirServer:ResourceManager:DataStoreResourceId";
 
     public ResourceManagerCollectionSetup(
         IOptionsMonitor<CosmosCollectionConfiguration> cosmosCollectionConfiguration,
@@ -55,8 +56,12 @@ public class ResourceManagerCollectionSetup : ICollectionSetup
         _storeProceduresMetadata = EnsureArg.IsNotNull(storedProcedures, nameof(storedProcedures));
         _logger = EnsureArg.IsNotNull(logger, nameof(logger));
 
+        var dataStoreResourceId = EnsureArg.IsNotNullOrWhiteSpace(
+                genericConfiguration.GetValue(FhirServerResourceManagerDataStoreResourceId, string.Empty),
+                nameof(genericConfiguration),
+                fn => fn.WithMessage($"{FhirServerResourceManagerDataStoreResourceId} must be set."));
+
         _armClient = new ArmClient(new DefaultAzureCredential());
-        var dataStoreResourceId = genericConfiguration.GetValue("FhirServer:ResourceManager:DataStoreResourceId", string.Empty);
         _resourceIdentifier = ResourceIdentifier.Parse(dataStoreResourceId);
         _account = _armClient.GetCosmosDBAccountResource(_resourceIdentifier);
     }
@@ -75,6 +80,9 @@ public class ResourceManagerCollectionSetup : ICollectionSetup
         }
     }
 
+    /// <summary>
+    /// Reads the location from an existing CosmosDB account.
+    /// </summary>
     private AzureLocation Location
     {
         get

--- a/src/Microsoft.Health.Fhir.CosmosDb.Initialization/Microsoft.Health.Fhir.CosmosDb.Initialization.csproj
+++ b/src/Microsoft.Health.Fhir.CosmosDb.Initialization/Microsoft.Health.Fhir.CosmosDb.Initialization.csproj
@@ -2,7 +2,8 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection"></PackageReference>
+    <PackageReference Include="Azure.ResourceManager.CosmosDB" />
+    <PackageReference Include="Microsoft.Health.Extensions.DependencyInjection" />
   </ItemGroup>
   
   <ItemGroup>
@@ -19,10 +20,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Health.Fhir.CosmosDb.Core\Microsoft.Health.Fhir.CosmosDb.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Features\Storage\Versioning\" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Health/CosmosHealthCheckTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Health/CosmosHealthCheckTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Health
             var diagnostics = Substitute.For<CosmosDiagnostics>();
             var coce = new CosmosOperationCanceledException(originalException: new OperationCanceledException(), diagnostics);
 
-            _testProvider.PerformTestAsync(default, default, _cosmosCollectionConfiguration, CancellationToken.None).ThrowsForAnyArgs(coce);
+            _testProvider.PerformTestAsync(default, CancellationToken.None).ThrowsForAnyArgs(coce);
             HealthCheckResult result = await _healthCheck.CheckHealthAsync(new HealthCheckContext());
 
             Assert.Equal(HealthStatus.Unhealthy, result.Status);
@@ -98,7 +98,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Health
                 return Task.CompletedTask;
             };
 
-            _testProvider.PerformTestAsync(default, default, _cosmosCollectionConfiguration, CancellationToken.None).ReturnsForAnyArgs(x => fakeRetry());
+            _testProvider.PerformTestAsync(default, CancellationToken.None).ReturnsForAnyArgs(x => fakeRetry());
             HealthCheckResult result = await _healthCheck.CheckHealthAsync(new HealthCheckContext());
 
             Assert.Equal(HealthStatus.Healthy, result.Status);
@@ -108,7 +108,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Health
         [Fact]
         public async Task GivenCosmosDbCannotBeQueried_WhenHealthIsChecked_ThenUnhealthyStateShouldBeReturned()
         {
-            _testProvider.PerformTestAsync(default, default, _cosmosCollectionConfiguration, CancellationToken.None).ThrowsForAnyArgs<HttpRequestException>();
+            _testProvider.PerformTestAsync(default, CancellationToken.None).ThrowsForAnyArgs<HttpRequestException>();
             HealthCheckResult result = await _healthCheck.CheckHealthAsync(new HealthCheckContext());
 
             Assert.Equal(HealthStatus.Unhealthy, result.Status);
@@ -121,7 +121,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Health
             {
                 var cosmosException = new CosmosException("Some error message", HttpStatusCode.Forbidden, subStatusCode: clientCmkIssue, activityId: null, requestCharge: 0);
                 _testProvider.ClearSubstitute();
-                _testProvider.PerformTestAsync(default, default, _cosmosCollectionConfiguration, CancellationToken.None).ThrowsForAnyArgs(cosmosException);
+                _testProvider.PerformTestAsync(default, CancellationToken.None).ThrowsForAnyArgs(cosmosException);
 
                 HealthCheckResult result = await _healthCheck.CheckHealthAsync(new HealthCheckContext());
 
@@ -142,7 +142,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Health
         public async Task GivenCosmosAccessIsForbidden_IsNotClientCmkError_WhenHealthIsChecked_ThenUnhealthyStateShouldBeReturned()
         {
             const int SomeNonClientErrorSubstatusCode = 12345;
-            _testProvider.PerformTestAsync(default, default, _cosmosCollectionConfiguration, CancellationToken.None)
+            _testProvider.PerformTestAsync(default, CancellationToken.None)
                 .ThrowsForAnyArgs(new CosmosException(
                     "An error message",
                     HttpStatusCode.Forbidden,
@@ -164,7 +164,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Health
         [Fact]
         public async Task GivenCosmosDbWithTooManyRequests_WhenHealthIsChecked_ThenHealthyStateShouldBeReturned()
         {
-            _testProvider.PerformTestAsync(default, default, _cosmosCollectionConfiguration, CancellationToken.None)
+            _testProvider.PerformTestAsync(default, CancellationToken.None)
                 .ThrowsForAnyArgs(new Exception(null, new RequestRateExceededException(TimeSpan.Zero)));
 
             HealthCheckResult result = await _healthCheck.CheckHealthAsync(new HealthCheckContext());

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/Versioning/DataPlaneCollectionSetupTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/Versioning/DataPlaneCollectionSetupTests.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Storage.Versioning
         private readonly DataPlaneCollectionSetup _setup;
         private readonly ContainerResponse _containerResponse;
         private readonly ILogger<DataPlaneCollectionSetup> _logger = Substitute.For<ILogger<DataPlaneCollectionSetup>>();
+        private readonly CollectionVersion _version;
 
         private readonly CosmosDataStoreConfiguration _cosmosDataStoreConfiguration = new CosmosDataStoreConfiguration
         {
@@ -52,6 +53,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Storage.Versioning
         {
             _container = Substitute.For<Container>();
             _containerResponse = Substitute.ForPartsOf<ContainerResponse>();
+            _version = new CollectionVersion();
 
             var containerProperties = new ContainerProperties();
             containerProperties.IndexingPolicy = new IndexingPolicy
@@ -89,23 +91,14 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Storage.Versioning
         [Fact]
         public async Task GivenACollection_WhenSettingUpCollection_ThenTheCollectionIndexIsUpdated()
         {
-            await _setup.UpdateFhirCollectionSettingsAsync(CancellationToken.None);
+            await _setup.UpdateFhirCollectionSettingsAsync(_version, CancellationToken.None);
             await _container.Received(1).ReplaceContainerAsync(Arg.Any<ContainerProperties>(), null, Arg.Any<CancellationToken>());
-        }
-
-        [Fact]
-        public async Task GivenACollection_WhenSettingUpCollection_ThenTheCollectionVersionWrapperIsSaved()
-        {
-            await _setup.UpdateFhirCollectionSettingsAsync(CancellationToken.None);
-
-            await _container.Received(1)
-                .UpsertItemAsync(Arg.Is<CollectionVersion>(x => x.Version == 3), Arg.Any<PartitionKey?>(), null, Arg.Any<CancellationToken>());
         }
 
         [Fact]
         public async Task GivenACollection_WhenSettingUpCollection_ThenTheCollectionTTLIsSetToNeg1()
         {
-            await _setup.UpdateFhirCollectionSettingsAsync(CancellationToken.None);
+            await _setup.UpdateFhirCollectionSettingsAsync(_version, CancellationToken.None);
             Assert.Equal(-1, _containerResponse.Resource.DefaultTimeToLive);
         }
     }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Health/CosmosHealthCheck.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Health/CosmosHealthCheck.cs
@@ -71,12 +71,10 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Health
                 cancellationToken.ThrowIfCancellationRequested();
                 try
                 {
-                    using (CancellationTokenSource timeBasedTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(maxExecutionTimeInSeconds)))
-                    using (CancellationTokenSource operationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeBasedTokenSource.Token))
-                    {
-                        await _testProvider.PerformTestAsync(_container.Value, _configuration, _cosmosCollectionConfiguration, operationTokenSource.Token);
-                        return HealthCheckResult.Healthy("Successfully connected.");
-                    }
+                    using var timeBasedTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(maxExecutionTimeInSeconds));
+                    using var operationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeBasedTokenSource.Token);
+                    await _testProvider.PerformTestAsync(_container.Value, operationTokenSource.Token);
+                    return HealthCheckResult.Healthy("Successfully connected.");
                 }
                 catch (CosmosOperationCanceledException coce)
                 {

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosClientReadWriteTestProvider.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosClientReadWriteTestProvider.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
             _partitionKey = new PartitionKey(_document.PartitionKey);
         }
 
-        public async Task PerformTestAsync(Container container, CosmosDataStoreConfiguration configuration, CosmosCollectionConfiguration cosmosCollectionConfiguration, CancellationToken cancellationToken = default)
+        public async Task PerformTestAsync(Container container, CancellationToken cancellationToken = default)
         {
             var requestOptions = new ItemRequestOptions
             {
@@ -32,7 +32,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
             };
 
             // Upsert '__healthcheck__' record.
-            var resourceResponse = await container.UpsertItemAsync(
+            ItemResponse<HealthCheckDocument> resourceResponse = await container.UpsertItemAsync(
                 _document,
                 _partitionKey,
                 requestOptions,

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/FhirCosmosClientInitializer.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/FhirCosmosClientInitializer.cs
@@ -4,22 +4,18 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Azure.Identity;
 using EnsureThat;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Cosmos.Fluent;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.Abstractions.Exceptions;
 using Microsoft.Health.Fhir.CosmosDb.Core.Configs;
 using Microsoft.Health.Fhir.CosmosDb.Core.Features.Storage;
-using Microsoft.Health.Fhir.CosmosDb.Initialization.Features.Storage;
 using Microsoft.IO;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -95,7 +91,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
             try
             {
                 await _retryExceptionPolicyFactory.RetryPolicy.ExecuteAsync(async () =>
-                    await _testProvider.PerformTestAsync(client.GetContainer(configuration.DatabaseId, cosmosCollectionConfiguration.CollectionId), configuration, cosmosCollectionConfiguration));
+                    await _testProvider.PerformTestAsync(client.GetContainer(configuration.DatabaseId, cosmosCollectionConfiguration.CollectionId)));
 
                 _logger.LogInformation("Established CosmosClient connection to {CollectionId}", cosmosCollectionConfiguration.CollectionId);
             }
@@ -126,14 +122,9 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
 
             CosmosClientBuilder builder;
 
-            if (configuration.UseManagedIdentity)
-            {
-                builder = new CosmosClientBuilder(host, new DefaultAzureCredential());
-            }
-            else
-            {
-                builder = new CosmosClientBuilder(host, key);
-            }
+            builder = configuration.UseManagedIdentity ?
+                new CosmosClientBuilder(host, new DefaultAzureCredential()) :
+                new CosmosClientBuilder(host, key);
 
             builder
                 .WithConnectionModeDirect(enableTcpConnectionEndpointRediscovery: true)

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/FhirCosmosClientInitializer.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/FhirCosmosClientInitializer.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Identity;
 using EnsureThat;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Cosmos.Fluent;
@@ -123,7 +124,18 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
 
             IEnumerable<RequestHandler> requestHandlers = _requestHandlerFactory.Invoke();
 
-            var builder = new CosmosClientBuilder(host, key)
+            CosmosClientBuilder builder;
+
+            if (configuration.UseManagedIdentity)
+            {
+                builder = new CosmosClientBuilder(host, new ManagedIdentityCredential());
+            }
+            else
+            {
+                builder = new CosmosClientBuilder(host, key);
+            }
+
+            builder
                 .WithConnectionModeDirect(enableTcpConnectionEndpointRediscovery: true)
                 .WithCustomSerializer(new FhirCosmosSerializer(_logger))
                 .WithThrottlingRetryOptions(TimeSpan.FromSeconds(configuration.RetryOptions.MaxWaitTimeInSeconds), configuration.RetryOptions.MaxNumberOfRetries)
@@ -145,6 +157,11 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
         private bool IsNewConnectionKey(CosmosDataStoreConfiguration configuration)
         {
             // Configuration key is not empty and hashcode is empty - first process access.
+            if (configuration.UseManagedIdentity)
+            {
+                return false;
+            }
+
             if (!string.IsNullOrWhiteSpace(configuration.Key) && _cosmosKeyHashCode == 0)
             {
                 return true;

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/FhirCosmosClientInitializer.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/FhirCosmosClientInitializer.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
 
             if (configuration.UseManagedIdentity)
             {
-                builder = new CosmosClientBuilder(host, new ManagedIdentityCredential());
+                builder = new CosmosClientBuilder(host, new DefaultAzureCredential());
             }
             else
             {

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Registry/CosmosDbSearchParameterStatusInitializer.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Registry/CosmosDbSearchParameterStatusInitializer.cs
@@ -13,8 +13,6 @@ using Microsoft.Health.Fhir.Core.Features.Search.Registry;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.CosmosDb.Core.Configs;
 using Microsoft.Health.Fhir.CosmosDb.Core.Features.Storage;
-using Microsoft.Health.Fhir.CosmosDb.Core.Features.Storage.Versioning;
-using Microsoft.Health.Fhir.CosmosDb.Features.Storage;
 using Microsoft.Health.Fhir.CosmosDb.Initialization.Features.Storage.StoredProcedures.UpdateUnsupportedSearchParametersToUnsupported;
 
 namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Registry
@@ -24,8 +22,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Registry
         private readonly ISearchParameterStatusDataStore _filebasedSearchParameterStatusDataStore;
         private readonly ICosmosQueryFactory _queryFactory;
         private readonly CosmosDataStoreConfiguration _configuration;
-        private readonly UpdateUnsupportedSearchParameters _updateSP = new UpdateUnsupportedSearchParameters();
-        private const int CollectionSettingsVersion = 3;
+        private readonly UpdateUnsupportedSearchParameters _updateSP = new();
 
         public CosmosDbSearchParameterStatusInitializer(
             FilebasedSearchParameterStatusDataStore.Resolver filebasedSearchParameterStatusDataStoreResolver,
@@ -43,8 +40,6 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Registry
         public async Task ExecuteAsync(Container container, CancellationToken cancellationToken)
         {
             EnsureArg.IsNotNull(container, nameof(container));
-
-            CollectionVersion thisVersion = await GetLatestCollectionVersion(container, cancellationToken);
 
             // Detect if registry has been initialized
             var partitionKey = new PartitionKey(SearchParameterStatusWrapper.SearchParameterStatusPartitionKey);
@@ -80,23 +75,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Registry
             else
             {
                 await _updateSP.Execute(container.Scripts, cancellationToken);
-                thisVersion.Version = CollectionSettingsVersion;
-                await container.UpsertItemAsync(thisVersion, new PartitionKey(thisVersion.PartitionKey), cancellationToken: cancellationToken);
             }
-        }
-
-        private static async Task<CollectionVersion> GetLatestCollectionVersion(Container container, CancellationToken cancellationToken)
-        {
-            FeedIterator<CollectionVersion> query = container.GetItemQueryIterator<CollectionVersion>(
-                new QueryDefinition("SELECT * FROM root r"),
-                requestOptions: new QueryRequestOptions
-                {
-                    PartitionKey = new PartitionKey(CollectionVersion.CollectionVersionPartition),
-                });
-
-            FeedResponse<CollectionVersion> result = await query.ReadNextAsync(cancellationToken);
-
-            return result.FirstOrDefault() ?? new CollectionVersion();
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Registry/CosmosDbSearchParameterStatusInitializer.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Registry/CosmosDbSearchParameterStatusInitializer.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Registry
         {
             EnsureArg.IsNotNull(container, nameof(container));
 
-            var thisVersion = await GetLatestCollectionVersion(container, cancellationToken);
+            CollectionVersion thisVersion = await GetLatestCollectionVersion(container, cancellationToken);
 
             // Detect if registry has been initialized
             var partitionKey = new PartitionKey(SearchParameterStatusWrapper.SearchParameterStatusPartitionKey);

--- a/src/Microsoft.Health.Fhir.CosmosDb/Microsoft.Health.Fhir.CosmosDb.csproj
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Microsoft.Health.Fhir.CosmosDb.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.Azure.Cosmos" />
     <PackageReference Include="System.Private.ServiceModel" /><!-- Microsoft.Azure.Cosmos.Direct is referencing an insecure version of System.Private.ServiceModel (4.5.0) -->
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />

--- a/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .Transient()
                 .AsService<ICollectionDataUpdater>();
 
-            services.Add<ArmSdkCollectionSetup>()
+            services.Add<ResourceManagerCollectionSetup>()
                 .Singleton()
                 .AsSelf();
 
@@ -193,7 +193,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 {
                     CosmosDataStoreConfiguration config = c.GetRequiredService<CosmosDataStoreConfiguration>();
                     return config.UseManagedIdentity
-                        ? (ICollectionSetup)c.GetRequiredService<ArmSdkCollectionSetup>()
+                        ? (ICollectionSetup)c.GetRequiredService<ResourceManagerCollectionSetup>()
                         : c.GetRequiredService<DataPlaneCollectionSetup>();
                 })
                 .Singleton()

--- a/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
@@ -181,7 +181,21 @@ namespace Microsoft.Extensions.DependencyInjection
                 .Transient()
                 .AsService<ICollectionDataUpdater>();
 
+            services.Add<ArmSdkCollectionSetup>()
+                .Singleton()
+                .AsSelf();
+
             services.Add<DataPlaneCollectionSetup>()
+                .Singleton()
+                .AsSelf();
+
+            services.Add(c =>
+                {
+                    CosmosDataStoreConfiguration config = c.GetRequiredService<CosmosDataStoreConfiguration>();
+                    return config.UseManagedIdentity
+                        ? (ICollectionSetup)c.GetRequiredService<ArmSdkCollectionSetup>()
+                        : c.GetRequiredService<DataPlaneCollectionSetup>();
+                })
                 .Singleton()
                 .AsService<ICollectionSetup>();
 

--- a/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Registration/FhirServerBuilderCosmosDbRegistrationExtensions.cs
@@ -192,9 +192,16 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Add(c =>
                 {
                     CosmosDataStoreConfiguration config = c.GetRequiredService<CosmosDataStoreConfiguration>();
-                    return config.UseManagedIdentity
-                        ? (ICollectionSetup)c.GetRequiredService<ResourceManagerCollectionSetup>()
-                        : c.GetRequiredService<DataPlaneCollectionSetup>();
+
+                    if (config.AllowDatabaseCreation || config.AllowCollectionSetup)
+                    {
+                        return config.UseManagedIdentity
+                            ? (ICollectionSetup)c.GetRequiredService<ResourceManagerCollectionSetup>()
+                            : c.GetRequiredService<DataPlaneCollectionSetup>();
+                    }
+
+                    // If collection setup is not required then return the noop implementation.
+                    return new DefaultCollectionSetup();
                 })
                 .Singleton()
                 .AsService<ICollectionSetup>();

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/SearchParameterFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/SearchParameterFilterAttribute.cs
@@ -5,12 +5,9 @@
 
 using System;
 using EnsureThat;
-using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Health.Fhir.Api.Features.Routing;
-using Microsoft.Health.Fhir.Core.Extensions;
-using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Shared.Core.Features.Search.Parameters;
 using Task = System.Threading.Tasks.Task;
 

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/SearchParameterFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/SearchParameterFilterAttribute.cs
@@ -5,9 +5,12 @@
 
 using System;
 using EnsureThat;
+using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Health.Fhir.Api.Features.Routing;
+using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Shared.Core.Features.Search.Parameters;
 using Task = System.Threading.Tasks.Task;
 

--- a/src/Microsoft.Health.Fhir.Shared.Web/DummyMeterFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web/DummyMeterFactory.cs
@@ -1,0 +1,19 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Metrics;
+
+namespace Microsoft.Health.Fhir.Web;
+
+[SuppressMessage("Design", "CA1812", Justification = "False positive.")]
+internal sealed class DummyMeterFactory : IMeterFactory
+{
+    public Meter Create(MeterOptions options) => new(options);
+
+    public void Dispose()
+    {
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Web/Microsoft.Health.Fhir.Shared.Web.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Web/Microsoft.Health.Fhir.Shared.Web.projitems
@@ -15,6 +15,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)DevelopmentIdentityProviderRegistrationExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DevelopmentIdentityProviderUserConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AzureMonitorOpenTelemetryLogEnricher.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)DummyMeterFactory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Program.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PrometheusMetricsConfig.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PrometheusMetricsApplicationBuilderExtensions.cs" />

--- a/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.Metrics;
 using System.Globalization;
 using System.Linq;
 using Azure.Monitor.OpenTelemetry.AspNetCore;
@@ -355,6 +356,7 @@ namespace Microsoft.Health.Fhir.Web
         {
             var configuration = new TelemetryConfiguration();
             Configuration.GetSection("Telemetry").Bind(configuration);
+            services.AddTransient<IMeterFactory, DummyMeterFactory>();
 
             switch (configuration.Provider)
             {

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -152,6 +152,8 @@
     "CosmosDb": {
         "Host": null,
         "Key": null,
+        "UseManagedIdentity": false,
+        "AllowDatabaseCreation": true,
         "DatabaseId": "health",
         "InitialDatabaseThroughput": null,
         "ConnectionMode": "Direct",

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -152,8 +152,9 @@
     "CosmosDb": {
         "Host": null,
         "Key": null,
-        "UseManagedIdentity": false,
+        "UseManagedIdentity": false, // False for localhost/emulator
         "AllowDatabaseCreation": true,
+        "AllowCollectionSetup": true,
         "DatabaseId": "health",
         "InitialDatabaseThroughput": null,
         "ConnectionMode": "Direct",


### PR DESCRIPTION
## Description

This pull request introduces several changes across multiple files to enhance Azure resource management, improve Cosmos DB configuration, and add new features to the FHIR server configuration. The most important changes include adding new package versions, modifying Azure deployment templates, and updating Cosmos DB configurations to support managed identity.

### Azure Deployment Template Updates:
* [`samples/templates/default-azuredeploy-docker.json`](diffhunk://#diff-8f12d2301c516589ac0d2aa63d5e045b1afac1caf1434ff9bae355ee8d62f494R253-R254): Added Cosmos DB role assignments, database, and configuration settings for FHIR server deployments. [[1]](diffhunk://#diff-8f12d2301c516589ac0d2aa63d5e045b1afac1caf1434ff9bae355ee8d62f494R253-R254) [[2]](diffhunk://#diff-8f12d2301c516589ac0d2aa63d5e045b1afac1caf1434ff9bae355ee8d62f494R267) [[3]](diffhunk://#diff-8f12d2301c516589ac0d2aa63d5e045b1afac1caf1434ff9bae355ee8d62f494L367-R371) [[4]](diffhunk://#diff-8f12d2301c516589ac0d2aa63d5e045b1afac1caf1434ff9bae355ee8d62f494L379-R383) [[5]](diffhunk://#diff-8f12d2301c516589ac0d2aa63d5e045b1afac1caf1434ff9bae355ee8d62f494R468-R511) [[6]](diffhunk://#diff-8f12d2301c516589ac0d2aa63d5e045b1afac1caf1434ff9bae355ee8d62f494R565)

### Cosmos DB Configuration Improvements:
* [`src/Microsoft.Health.Fhir.CosmosDb.Core/Configs/CosmosDataStoreConfiguration.cs`](diffhunk://#diff-4e5a137347c5118a0cc1676f000c044015b9b54b87ab854d4f3d6feed6d37065R17-R26): Added properties to support managed identity and refined database creation settings. [[1]](diffhunk://#diff-4e5a137347c5118a0cc1676f000c044015b9b54b87ab854d4f3d6feed6d37065R17-R26) [[2]](diffhunk://#diff-4e5a137347c5118a0cc1676f000c044015b9b54b87ab854d4f3d6feed6d37065L25-L26)
* [`src/Microsoft.Health.Fhir.CosmosDb.Core/Features/Storage/ICollectionSetup.cs`](diffhunk://#diff-c3b2ebd956424f20fcf65453803b96cf9c30261619610a062bdd3e0e3200d1a4L19-R22): Updated interface to include a method for installing stored procedures and versioned collection settings updates.
* [`src/Microsoft.Health.Fhir.CosmosDb.Core/Features/Storage/ICosmosClientTestProvider.cs`](diffhunk://#diff-1b4f8f292ec3ee95130f47fef3b69a8e17480870f0f2c2e0e3221db21a189d23L15-R15): Simplified the `PerformTestAsync` method signature.

### FHIR Server Configuration Updates:
* [`src/Microsoft.Health.Fhir.Api/Configs/FhirServerConfiguration.cs`](diffhunk://#diff-9033b3c39bfbc07fec1efd6ff7781a2b3261ad611462bd51b61f2dcb28675b93R39-R40): Added `ResourceManagerConfig` to the FHIR server configuration.
* [`src/Microsoft.Health.Fhir.Core/Configs/ResourceManagerConfig.cs`](diffhunk://#diff-efc7925c17ff2774086e600ed1cd1bde47b09382d8ebf7ddd6eb0261d2b36b33R1-R11): Introduced a new configuration class for resource management.

### Azure Resource Management Enhancements:
* [`Directory.Packages.props`](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156R35): Added `Azure.ResourceManager.CosmosDB` package version `1.3.2`.
* [`build/jobs/add-aad-test-environment.yml`](diffhunk://#diff-4b1d377c692c6c38650f83f50a7347de4275bbba9e6b23c1c9609ff916c098a5L45-R50): Fixed resource group name handling in the Azure Key Vault restoration script.
* [`build/jobs/provision-deploy.yml`](diffhunk://#diff-96e510a6dff7e5dadab5de4fd09bd73429703125d6bf40296f7aeb4ccc75052cR95-L107): Introduced variables for deployment name and resource group name to streamline the script.

These changes collectively enhance the Azure resource management capabilities, improve the deployment process, and add new configuration options for Cosmos DB and FHIR server setups.

## Related issues
Addresses [AB#95002](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/95002).

## Supersedes/includes relevant changes from the following PRs:
- #3969
- #3950

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Feature (new capability to connect to Cosmos with MI)
