### PR TITLE
Use SnapshotSource for generating SD Snapshots

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Validation/ProfileValidator.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Validation/ProfileValidator.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
 
             try
             {
-                _resolver = new MultiResolver(new CachedResolver(ZipSource.CreateValidationSource(), options.Value.CacheDurationInSeconds), profilesResolver);
+                _resolver = new SnapshotSource(new MultiResolver(new CachedResolver(ZipSource.CreateValidationSource(), options.Value.CacheDurationInSeconds), profilesResolver));
             }
             catch (Exception)
             {
@@ -41,7 +41,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
             var ctx = new ValidationSettings()
             {
                 ResourceResolver = _resolver,
-                GenerateSnapshot = true,
+                GenerateSnapshot = false,
                 Trace = false,
                 ResolveExternalReferences = false,
             };


### PR DESCRIPTION
## Description
The snapshot generation done by the Validator does not automatically generate for structure definitions which again refer to other structure definitions. This is a [known issue](https://github.com/FirelyTeam/firely-net-sdk/issues/1786) with a known solution.

## Related issues
Addresses #4018.

## Testing
Tested by running the failing case in #4018. Needs some more testing for different use cases

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
