### PR TITLE
[SQL] Adding logs to SqlRetryService

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlRetry/SqlRetryService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlRetry/SqlRetryService.cs
@@ -233,6 +233,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                     {
                         sqlException = sqlEx;
                     }
+
+                    logger.LogInformation(ex, $"Attempt {retry}: {ex.Message}");
                 }
 
                 await Task.Delay(_retryMillisecondsDelay, cancellationToken);
@@ -474,6 +476,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                 // Connection is never opened by the _sqlConnectionBuilder but RetryLogicProvider is set to the old, deprecated retry implementation. According to the .NET spec, RetryLogicProvider
                 // must be set before opening connection to take effect. Therefore we must reset it to null here before opening the connection.
                 conn.RetryLogicProvider = null; // To remove this line _sqlConnectionBuilder in healthcare-shared-components must be modified.
+                logger.LogInformation($"Retrieved {isReadOnlyConnection}connection to the database in {sw.Elapsed.TotalSeconds} seconds.");
+
+                sw = Stopwatch.StartNew();
                 await conn.OpenAsync(cancel);
                 logger.LogInformation($"Opened {isReadOnlyConnection}connection to the database in {sw.Elapsed.TotalSeconds} seconds.");
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlRetryServiceTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlRetryServiceTests.cs
@@ -493,7 +493,8 @@ END
                         CancellationToken.None);
                 }
 
-                Assert.Contains("Opened", logger.LogRecords[0].Message); // Check that logging of connection open was logged.
+                Assert.StartsWith("Retrieved", logger.LogRecords[0].Message); // Check that logging of connection open was logged.
+                Assert.StartsWith("Opened", logger.LogRecords[1].Message); // Check that logging of connection open was logged.
                 logger.LogRecords.RemoveAll(_ => _.Exception == null);
                 Assert.Single(logger.LogRecords);
 


### PR DESCRIPTION
## Description
Adding new logs to SqlRetryService to better understand:
* Number of retries during search
* Time taken to retrieve and open a SQL connection. 

## Related issues
Addresses [AB#123992](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/123992)

## FHIR Team Checklist
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
