### PR TITLE
Import without Manage Identity Throws 500

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/ImportOrchestratorJob.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/ImportOrchestratorJob.cs
@@ -149,6 +149,12 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
                 errorResult = new ImportJobErrorResult() { ErrorMessage = "Managed Identity cannot access storage account.", ErrorDetails = ex.ToString(), HttpStatusCode = HttpStatusCode.BadRequest };
                 await SendNotification(JobStatus.Failed, jobInfo, 0, 0, result.TotalBytes, inputData.ImportMode, fhirRequestContext, _logger, _auditLogger, _mediator);
             }
+            catch (AuthenticationFailedException ex)
+            {
+                _logger.LogJobError(ex, jobInfo, "Failed to register processing jobs.-AuthenticationFailedException");
+                errorResult = new ImportJobErrorResult() { ErrorMessage = "Managed Identity Credential authentication failed", ErrorDetails = ex.ToString(), HttpStatusCode = HttpStatusCode.BadRequest };
+                await SendNotification(JobStatus.Failed, jobInfo, 0, 0, result.TotalBytes, inputData.ImportMode, fhirRequestContext, _logger, _auditLogger, _mediator);
+            }
             catch (Exception ex)
             {
                 _logger.LogJobError(ex, jobInfo, "Failed to register processing jobs.");


### PR DESCRIPTION
## Description

A new catch block has been added to handle the authentication failure exception that arises when the import request is executed and managed identity is switched off.

## Related issues
user story [AB#123690](https://microsofthealth.visualstudio.com/Health/_workitems/edit/123690)


## Testing
Tested by turning off Managed Identity and executing the Import request.
400 Http Status code was returned instead of 500.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
