### PR TITLE
Allow a searchParam create when PendingDelete one exists.

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/ISearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/ISearchParameterDefinitionManager.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using Hl7.Fhir.ElementModel;
+using Microsoft.Health.Fhir.Core.Features.Search.Registry;
 using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Core.Features.Definition
@@ -50,6 +51,16 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         /// </summary>
         /// <param name="resourceType">The resource type.</param>
         /// <param name="code">The code of the search parameter.</param>
+        /// <param name="excludePendingDelete">The flag indicating whether the search parameter in PendingDelete status should be included.</param>
+        /// <param name="searchParameter">When this method returns, the search parameter with the given <paramref name="code"/> associated with the <paramref name="resourceType"/> if it exists; otherwise, the default value.</param>
+        /// <returns><c>true</c> if the search parameter exists; otherwise, <c>false</c>.</returns>
+        bool TryGetSearchParameter(string resourceType, string code, bool excludePendingDelete, out SearchParameterInfo searchParameter);
+
+        /// <summary>
+        /// Retrieves the search parameter with <paramref name="code"/> associated with <paramref name="resourceType"/>.
+        /// </summary>
+        /// <param name="resourceType">The resource type.</param>
+        /// <param name="code">The code of the search parameter.</param>
         /// <returns>The search parameter with the given <paramref name="code"/> associated with the <paramref name="resourceType"/>.</returns>
         SearchParameterInfo GetSearchParameter(string resourceType, string code);
 
@@ -60,6 +71,15 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         /// <param name="value">The SearchParameterInfo pertaining to the specified <paramref name="definitionUri"/></param>
         /// <returns>True if the search parameter is found <paramref name="definitionUri"/>.</returns>
         public bool TryGetSearchParameter(string definitionUri, out SearchParameterInfo value);
+
+        /// <summary>
+        /// Retrieves the search parameter with <paramref name="definitionUri"/>.
+        /// </summary>
+        /// <param name="definitionUri">The search parameter definition URL.</param>
+        /// <param name="excludePendingDelete">The flag indicating whether the search parameter in PendingDelete status should be included.</param>
+        /// <param name="value">The SearchParameterInfo pertaining to the specified <paramref name="definitionUri"/></param>
+        /// <returns>True if the search parameter is found <paramref name="definitionUri"/>.</returns>
+        public bool TryGetSearchParameter(string definitionUri, bool excludePendingDelete, out SearchParameterInfo value);
 
         /// <summary>
         /// Retrieves the search parameter with <paramref name="definitionUri"/>.
@@ -100,5 +120,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         /// <param name="url">The url identifying the custom search parameter to remove.</param>
         /// <param name="calculateHash">Indicated whether the search parameter hash values should be recalulated after this delete.</param>
         void DeleteSearchParameter(string url, bool calculateHash = true);
+
+        /// <summary>
+        /// Allows update of a custom search parameter status.
+        /// </summary>
+        /// <param name="url">The url identifying the custom search parameter to update.</param>
+        /// <param name="desiredStatus">The desired status for the custom search parameter to update.</param>
+        void UpdateSearchParameterStatus(string url, SearchParameterStatus desiredStatus);
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionBuilder.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionBuilder.cs
@@ -156,7 +156,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
                         searchParameterInfo.Type = SearchParamType.Uri;
                     }
 
-                    uriDictionary.Add(searchParameter.Url, searchParameterInfo);
+                    if (uriDictionary.ContainsKey(searchParameter.Url))
+                    {
+                        uriDictionary[searchParameter.Url] = searchParameterInfo;
+                    }
+                    else
+                    {
+                        uriDictionary.Add(searchParameter.Url, searchParameterInfo);
+                    }
                 }
                 catch (FormatException)
                 {

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchableSearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchableSearchParameterDefinitionManager.cs
@@ -11,6 +11,7 @@ using Hl7.Fhir.ElementModel;
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Search;
+using Microsoft.Health.Fhir.Core.Features.Search.Registry;
 using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Core.Features.Definition
@@ -56,6 +57,21 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             searchParameter = null;
 
             if (_inner.TryGetSearchParameter(resourceType, code, out var parameter) &&
+                (parameter.IsSearchable || UsePartialSearchParams(parameter)))
+            {
+                searchParameter = parameter;
+
+                return true;
+            }
+
+            return false;
+        }
+
+        public bool TryGetSearchParameter(string resourceType, string code, bool excludePendingDelete, out SearchParameterInfo searchParameter)
+        {
+            searchParameter = null;
+
+            if (_inner.TryGetSearchParameter(resourceType, code, excludePendingDelete, out var parameter) &&
                 (parameter.IsSearchable || UsePartialSearchParams(parameter)))
             {
                 searchParameter = parameter;
@@ -137,9 +153,28 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             return false;
         }
 
+        public bool TryGetSearchParameter(string definitionUri, bool excludePendingDelete, out SearchParameterInfo value)
+        {
+            _inner.TryGetSearchParameter(definitionUri, excludePendingDelete, out var parameter);
+
+            if (parameter.IsSearchable || UsePartialSearchParams(parameter))
+            {
+                value = parameter;
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+
         public void DeleteSearchParameter(string url, bool calculateHash = true)
         {
             throw new NotImplementedException();
+        }
+
+        public void UpdateSearchParameterStatus(string url, SearchParameterStatus desiredStatus)
+        {
+            _inner.UpdateSearchParameterStatus(url, desiredStatus);
         }
 
         private bool UsePartialSearchParams(SearchParameterInfo parameter)

--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SupportedSearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SupportedSearchParameterDefinitionManager.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using EnsureThat;
 using Hl7.Fhir.ElementModel;
 using Microsoft.Health.Fhir.Core.Features.Search;
+using Microsoft.Health.Fhir.Core.Features.Search.Registry;
 using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Core.Features.Definition
@@ -41,6 +42,19 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
         {
             searchParameter = null;
             if (_inner.TryGetSearchParameter(resourceType, code, out var parameter) && parameter.IsSupported)
+            {
+                searchParameter = parameter;
+
+                return true;
+            }
+
+            return false;
+        }
+
+        public bool TryGetSearchParameter(string resourceType, string code, bool excludePendingDelete, out SearchParameterInfo searchParameter)
+        {
+            searchParameter = null;
+            if (_inner.TryGetSearchParameter(resourceType, code, excludePendingDelete, out var parameter) && parameter.IsSupported)
             {
                 searchParameter = parameter;
 
@@ -110,9 +124,27 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             return false;
         }
 
+        public bool TryGetSearchParameter(string definitionUri, bool excludePendingDelete, out SearchParameterInfo value)
+        {
+            value = null;
+            if (_inner.TryGetSearchParameter(definitionUri, excludePendingDelete, out var parameter) && parameter.IsSupported)
+            {
+                value = parameter;
+
+                return true;
+            }
+
+            return false;
+        }
+
         public void DeleteSearchParameter(string url, bool calculateHash = true)
         {
             throw new NotImplementedException();
+        }
+
+        public void UpdateSearchParameterStatus(string url, SearchParameterStatus desiredStatus)
+        {
+            _inner.UpdateSearchParameterStatus(url, desiredStatus);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
@@ -130,10 +130,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
                 var searchParam = _modelInfoProvider.ToTypedElement(searchParamResource);
                 var searchParameterUrl = searchParam.GetStringScalar("url");
 
-                // First we delete the status metadata from the data store as this fuction depends on the
+                // First we delete the status metadata from the data store as this function depends on
                 // the in memory definition manager.  Once complete we remove the SearchParameter from
                 // the definition manager.
                 _logger.LogTrace("Deleting the search parameter '{Url}'", searchParameterUrl);
+                _searchParameterDefinitionManager.UpdateSearchParameterStatus(searchParameterUrl, SearchParameterStatus.PendingDelete);
                 await _searchParameterStatusManager.UpdateSearchParameterStatusAsync(new List<string>() { searchParameterUrl }, SearchParameterStatus.PendingDelete, cancellationToken);
             }
             catch (FhirException fex)

--- a/tools/Microsoft.Health.Fhir.R4.ResourceParser/Code/MinimalSearchParameterDefinitionManager.cs
+++ b/tools/Microsoft.Health.Fhir.R4.ResourceParser/Code/MinimalSearchParameterDefinitionManager.cs
@@ -13,6 +13,7 @@ using Microsoft.Health.Fhir.Core.Features;
 using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Definition.BundleWrappers;
 using Microsoft.Health.Fhir.Core.Features.Search;
+using Microsoft.Health.Fhir.Core.Features.Search.Registry;
 using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.R4.ResourceParser.Code
@@ -203,6 +204,21 @@ namespace Microsoft.Health.Fhir.R4.ResourceParser.Code
         }
 
         public IEnumerable<SearchParameterInfo> GetSearchParametersByIds(ICollection<string> ids)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void UpdateSearchParameterStatus(string url, SearchParameterStatus desiredStatus)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool TryGetSearchParameter(string resourceType, string code, bool excludePendingDelete, out SearchParameterInfo searchParameter)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool TryGetSearchParameter(string definitionUri, bool excludePendingDelete, out SearchParameterInfo value)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
## Description
Allow a searchParam create when PendingDelete one exists.

## Related issues
Addresses [issue #124704].

[Bug 124704](https://microsofthealth.visualstudio.com/Health/_workitems/edit/124704): A $reindex request fails to update a search param in PendingDelete to Deleted state when the service is restarted.

## Testing
Tested manually by running the service locally.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
