### PR TITLE
Allow a searchParam create when PendingDelete one exists.

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
@@ -130,11 +130,15 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
                 var searchParam = _modelInfoProvider.ToTypedElement(searchParamResource);
                 var searchParameterUrl = searchParam.GetStringScalar("url");
 
-                // First we delete the status metadata from the data store as this fuction depends on the
+                // First we delete the status metadata from the data store as this function depends on
                 // the in memory definition manager.  Once complete we remove the SearchParameter from
                 // the definition manager.
                 _logger.LogTrace("Deleting the search parameter '{Url}'", searchParameterUrl);
                 await _searchParameterStatusManager.UpdateSearchParameterStatusAsync(new List<string>() { searchParameterUrl }, SearchParameterStatus.PendingDelete, cancellationToken);
+
+                // Delete the search parameter from the definition manager to allow a user to create a new
+                // search parameter when one exiting in the store is in PendingDelete state.
+                _searchParameterDefinitionManager.DeleteSearchParameter(searchParameterUrl, false);
             }
             catch (FhirException fex)
             {


### PR DESCRIPTION
## Description
Allow a searchParam create when PendingDelete one exists.

## Related issues
Addresses [issue #124704].

[Bug 124704](https://microsofthealth.visualstudio.com/Health/_workitems/edit/124704): A $reindex request fails to update a search param in PendingDelete to Deleted state when the service is restarted.

## Testing
Tested search parameter scenarios manually by running the service locally.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
