### PR TITLE
Integration tests use DevOps MI for Cosmos

### DIFF
--- a/build/jobs/add-resource-group-role-assignments.yml
+++ b/build/jobs/add-resource-group-role-assignments.yml
@@ -12,7 +12,24 @@ steps:
     azurePowerShellVersion: latestVersion
     ScriptType: inlineScript
     Inline: |
-      $clientId = (Get-AzContext).Account.Id
-      $servicePrincipalId = (Get-AzADServicePrincipal -Filter "appId eq '$clientId'").Id
+      $account = Get-AzContext
+      $principalId = (Get-AzADServicePrincipal -ApplicationId $account.Account.Id).Id
+      
       $resourceGroupResourceId = (Get-AzResourceGroup -Name ${{ parameters.resourceGroupName }}).ResourceId
-      New-AzRoleAssignment -ObjectId $servicePrincipalId -RoleDefinitionName "Storage Blob Data Contributor" -Scope $resourceGroupResourceId
+      
+      # Read and write PR storage accounts
+      New-AzRoleAssignment -ObjectId $principalId -RoleDefinitionName "Storage Blob Data Contributor" -Scope $resourceGroupResourceId
+
+      # Control Plane Actions on PR Cosmos accounts
+      $cosmosContributorRoleDefinitionId = "230815da-be43-4aae-9cb4-875f7bd000aa"
+      New-AzRoleAssignment `
+          -ObjectId $principalId `
+          -RoleDefinitionId $cosmosContributorRoleDefinitionId `
+          -Scope $resourceGroupResourceId
+
+      # Push on PR ACRs
+      $acrPushRoleDefinitionId = "8311e382-0749-4cb8-b61a-304f252e45ec"
+      New-AzRoleAssignment `
+          -ObjectId $principalId `
+          -RoleDefinitionId $acrPushRoleDefinitionId `
+          -Scope $resourceGroupResourceId

--- a/build/jobs/e2e-tests.yml
+++ b/build/jobs/e2e-tests.yml
@@ -53,7 +53,6 @@ steps:
         $exportStoreKey = Get-AzStorageAccountKey -ResourceGroupName $(ResourceGroupName) -Name "$exportStoreAccountName" | Where-Object {$_.KeyName -eq "key1"}
         
         Write-Host "##vso[task.setvariable variable=TestExportStoreUri]$($exportStoreUri)"
-        Write-Host "##vso[task.setvariable variable=TestExportStoreKey]$($exportStoreKey.Value)"
 
         $integrationStoreSettings = $appSettings | where {$_.Name -eq "FhirServer__Operations__IntegrationDataStore__StorageAccountUri"}
         $integrationStoreUri = $integrationStoreSettings[0].Value
@@ -100,9 +99,7 @@ steps:
       'Resource': $(Resource)
       'AllStorageAccounts': $(AllStorageAccounts)
       'TestExportStoreUri': $(TestExportStoreUri)
-      'TestExportStoreKey': $(TestExportStoreKey)
       'TestIntegrationStoreUri': $(TestIntegrationStoreUri)
-      'TestIntegrationStoreKey': $(TestIntegrationStoreKey)
       'tenant-admin-service-principal-name': $(tenant-admin-service-principal-name)
       'tenant-admin-service-principal-password': $(tenant-admin-service-principal-password)
       'tenant-admin-user-name': $(tenant-admin-user-name)

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -128,6 +128,28 @@ jobs:
             }
           }
         }
+
+        if("${{ parameters.sql }}" -eq "false"){
+            Write-Host "Add DevOps MI permission to Cosmos databases"
+
+            $principalId = (Get-AzContext).Account.Id
+
+            New-AzCosmosDBSqlRoleAssignment `
+              -AccountName $webAppName `
+              -ResourceGroupName $resourceGroupName `
+              -Scope "/" `
+              -PrincipalId $principalId `
+              -RoleDefinitionId "00000000-0000-0000-0000-000000000002"
+
+            $roleDefinitionId = "230815da-be43-4aae-9cb4-875f7bd000aa"
+            $scope = "/subscriptions/$((Get-AzContext).Subscription.Id)/resourceGroups/$($resourceGroupName)/providers/Microsoft.DocumentDB/databaseAccounts/$($webAppName)"
+
+            New-AzRoleAssignment `
+                -ObjectId $principalId `
+                -RoleDefinitionId $roleDefinitionId `
+                -Scope $scope
+        }
+
   - template: ./provision-healthcheck.yml
     parameters: 
       webAppName: ${{ parameters.webAppName }}

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -132,7 +132,8 @@ jobs:
         if("${{ parameters.sql }}" -eq "false"){
             Write-Host "Add DevOps MI permission to Cosmos databases"
 
-            $principalId = (Get-AzContext).Account.Id
+            $account = Get-AzContext
+            $principalId = (Get-AzADServicePrincipal -ApplicationId $account.Account.Id).Id
 
             New-AzCosmosDBSqlRoleAssignment `
               -AccountName $webAppName `

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -130,7 +130,7 @@ jobs:
         }
 
         if("${{ parameters.sql }}" -eq "false"){
-            Write-Host "Add DevOps MI permission to Cosmos databases"
+            Write-Host "Add DevOps MI permission to Cosmos database"
 
             $account = Get-AzContext
             $principalId = (Get-AzADServicePrincipal -ApplicationId $account.Account.Id).Id
@@ -141,14 +141,6 @@ jobs:
               -Scope "/" `
               -PrincipalId $principalId `
               -RoleDefinitionId "00000000-0000-0000-0000-000000000002"
-
-            $roleDefinitionId = "230815da-be43-4aae-9cb4-875f7bd000aa"
-            $scope = "/subscriptions/$((Get-AzContext).Subscription.Id)/resourceGroups/$($resourceGroupName)/providers/Microsoft.DocumentDB/databaseAccounts/$($webAppName)"
-
-            New-AzRoleAssignment `
-                -ObjectId $principalId `
-                -RoleDefinitionId $roleDefinitionId `
-                -Scope $scope
         }
 
   - template: ./provision-healthcheck.yml

--- a/build/jobs/run-tests.yml
+++ b/build/jobs/run-tests.yml
@@ -20,7 +20,7 @@ jobs:
       downloadType: 'single'
       downloadPath: '$(System.ArtifactsDirectory)'
       artifactName: 'IntegrationTests'
-  
+
   - task: ExtractFiles@1
     displayName: 'Extract Integration Test Binaries'
     inputs:
@@ -37,6 +37,24 @@ jobs:
       azureSubscription: $(ConnectedServiceName)
       KeyVaultName: '${{ parameters.keyVaultName }}'
 
+  - task: AzurePowerShell@5
+    displayName: 'Set Workload Identity Variables'
+    inputs:
+      azureSubscription: $(ConnectedServiceName)
+      azurePowerShellVersion: latestVersion
+      ScriptType: inlineScript
+      Inline: |
+        Write-Host "##vso[task.setvariable variable=AZURESUBSCRIPTION_CLIENT_ID]$env:AZURESUBSCRIPTION_CLIENT_ID"
+        Write-Host "##vso[task.setvariable variable=AZURESUBSCRIPTION_TENANT_ID]$env:AZURESUBSCRIPTION_TENANT_ID"
+        Write-Host "##vso[task.setvariable variable=AZURESUBSCRIPTION_SERVICE_CONNECTION_ID]$env:AZURESUBSCRIPTION_SERVICE_CONNECTION_ID"
+
+        $appSettings = (Get-AzWebApp -ResourceGroupName $(ResourceGroupName) -Name $appServiceName).SiteConfig.AppSettings
+        $dataStoreResourceId = $appSettings | where {$_.Name -eq "FhirServer__ResourceManager__DataStoreResourceId"}
+        $dataStoreResourceId = $dataStoreResourceId[0].Value
+        Write-Host "$dataStoreResourceId"
+        Write-Host "##vso[task.setvariable variable=DataStoreResourceId]$($dataStoreResourceId)"
+
+
   - task: DotNetCoreCLI@2
     displayName: 'Run Cosmos Integration Tests'
     inputs:
@@ -46,7 +64,11 @@ jobs:
       testRunTitle: '${{ parameters.version }} Integration'
     env:
       'CosmosDb:Host': $(CosmosDb--Host)
-      'CosmosDb:Key': $(CosmosDb--Key)
+      'FhirServer:ResourceManager:DataStoreResourceId': $(DataStoreResourceId)
+      'AZURESUBSCRIPTION_CLIENT_ID': '$(AZURESUBSCRIPTION_CLIENT_ID)'
+      'AZURESUBSCRIPTION_TENANT_ID': '$(AZURESUBSCRIPTION_TENANT_ID)'
+      'AZURESUBSCRIPTION_SERVICE_CONNECTION_ID': '$(AZURESUBSCRIPTION_SERVICE_CONNECTION_ID)'
+      'SYSTEM_ACCESSTOKEN': $(System.AccessToken)
 
 - job: "SqlIntegrationTests"
   pool:
@@ -59,7 +81,7 @@ jobs:
       downloadType: 'single'
       downloadPath: '$(System.ArtifactsDirectory)'
       artifactName: 'IntegrationTests'
-  
+
   - task: ExtractFiles@1
     displayName: 'Extract Integration Test Binaries'
     inputs:

--- a/build/jobs/run-tests.yml
+++ b/build/jobs/run-tests.yml
@@ -48,6 +48,7 @@ jobs:
         Write-Host "##vso[task.setvariable variable=AZURESUBSCRIPTION_TENANT_ID]$env:AZURESUBSCRIPTION_TENANT_ID"
         Write-Host "##vso[task.setvariable variable=AZURESUBSCRIPTION_SERVICE_CONNECTION_ID]$env:AZURESUBSCRIPTION_SERVICE_CONNECTION_ID"
 
+        $appServiceName = '${{ parameters.appServiceName }}'
         $appSettings = (Get-AzWebApp -ResourceGroupName $(ResourceGroupName) -Name $appServiceName).SiteConfig.AppSettings
         $dataStoreResourceId = $appSettings | where {$_.Name -eq "FhirServer__ResourceManager__DataStoreResourceId"}
         $dataStoreResourceId = $dataStoreResourceId[0].Value

--- a/build/jobs/run-tests.yml
+++ b/build/jobs/run-tests.yml
@@ -64,8 +64,9 @@ jobs:
       workingDirectory: "$(System.ArtifactsDirectory)"
       testRunTitle: '${{ parameters.version }} Integration'
     env:
-      'CosmosDb:Host': $(CosmosDb--Host)
-      'FhirServer:ResourceManager:DataStoreResourceId': $(DataStoreResourceId)
+      'CosmosDb__Host': $(CosmosDb--Host)
+      'FhirServer__ResourceManager__DataStoreResourceId': '$(DataStoreResourceId)'
+      'CosmosDb__UseManagedIdentity': true
       'AZURESUBSCRIPTION_CLIENT_ID': '$(AZURESUBSCRIPTION_CLIENT_ID)'
       'AZURESUBSCRIPTION_TENANT_ID': '$(AZURESUBSCRIPTION_TENANT_ID)'
       'AZURESUBSCRIPTION_SERVICE_CONNECTION_ID': '$(AZURESUBSCRIPTION_SERVICE_CONNECTION_ID)'

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -445,7 +445,7 @@
         },
         {
             "condition": "[equals(parameters('solutionType'),'FhirServerCosmosDB')]",
-            "apiVersion": "2019-12-12",
+            "apiVersion": "2021-06-15",
             "type": "Microsoft.DocumentDB/databaseAccounts",
             "tags": {
                 "FhirServerSolution": "[parameters('solutionType')]"
@@ -455,6 +455,7 @@
             "properties": {
                 "name": "[variables('serviceName')]",
                 "databaseAccountOfferType": "Standard",
+                "disableLocalAuth": true,
                 "consistencyPolicy": "[parameters('cosmosDbAccountConsistencyPolicy')]",
                 "keyVaultKeyUri": "[parameters('cosmosDbCmkUrl')]",
                 "locations": [
@@ -686,20 +687,6 @@
             "properties": {
                 "contentType": "text/plain",
                 "value": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), reference(concat('Microsoft.DocumentDb/databaseAccounts/', variables('serviceName'))).documentEndpoint, '')]"
-            },
-            "dependsOn": [
-                "[resourceId('Microsoft.KeyVault/vaults', variables('serviceName'))]",
-                "[resourceId('Microsoft.DocumentDb/databaseAccounts', variables('serviceName'))]"
-            ]
-        },
-        {
-            "condition": "[equals(parameters('solutionType'),'FhirServerCosmosDB')]",
-            "type": "Microsoft.KeyVault/vaults/secrets",
-            "name": "[concat(variables('serviceName'), '/CosmosDb--Key')]",
-            "apiVersion": "2015-06-01",
-            "properties": {
-                "contentType": "text/plain",
-                "value": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), listKeys(resourceId('Microsoft.DocumentDb/databaseAccounts', variables('serviceName')), '2015-04-08').primaryMasterKey, '')]"
             },
             "dependsOn": [
                 "[resourceId('Microsoft.KeyVault/vaults', variables('serviceName'))]",

--- a/src/Microsoft.Health.Fhir.CosmosDb.Initialization/Features/Storage/ResourceManagerCollectionSetup.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.Initialization/Features/Storage/ResourceManagerCollectionSetup.cs
@@ -47,6 +47,7 @@ public class ResourceManagerCollectionSetup : ICollectionSetup
         CosmosDataStoreConfiguration cosmosDataStoreConfiguration,
         IConfiguration genericConfiguration,
         IEnumerable<IStoredProcedureMetadata> storedProcedures,
+        TokenCredential tokenCredential,
         ILogger<ResourceManagerCollectionSetup> logger)
     {
         EnsureArg.IsNotNull(storedProcedures, nameof(storedProcedures));
@@ -55,13 +56,14 @@ public class ResourceManagerCollectionSetup : ICollectionSetup
         _cosmosDataStoreConfiguration = EnsureArg.IsNotNull(cosmosDataStoreConfiguration, nameof(cosmosDataStoreConfiguration));
         _storeProceduresMetadata = EnsureArg.IsNotNull(storedProcedures, nameof(storedProcedures));
         _logger = EnsureArg.IsNotNull(logger, nameof(logger));
+        EnsureArg.IsNotNull(tokenCredential, nameof(tokenCredential));
 
         var dataStoreResourceId = EnsureArg.IsNotNullOrWhiteSpace(
                 genericConfiguration.GetValue(FhirServerResourceManagerDataStoreResourceId, string.Empty),
                 nameof(genericConfiguration),
                 fn => fn.WithMessage($"{FhirServerResourceManagerDataStoreResourceId} must be set."));
 
-        _armClient = new ArmClient(new DefaultAzureCredential());
+        _armClient = new ArmClient(tokenCredential);
         _resourceIdentifier = ResourceIdentifier.Parse(dataStoreResourceId);
         _account = _armClient.GetCosmosDBAccountResource(_resourceIdentifier);
     }

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/FhirCosmosClientInitializerTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/FhirCosmosClientInitializerTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using Azure.Core;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Context;
@@ -39,6 +40,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Storage
                 clientTestProvider,
                 () => new[] { new TestRequestHandler() },
                 new RetryExceptionPolicyFactory(_cosmosDataStoreConfiguration, Substitute.For<RequestContextAccessor<IFhirRequestContext>>()),
+                new Lazy<TokenCredential>(() => Substitute.For<TokenCredential>()),
                 NullLogger<FhirCosmosClientInitializer>.Instance);
 
             _collectionInitializers = new List<ICollectionInitializer> { _collectionInitializer1, _collectionInitializer2 };

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/FhirCosmosClientInitializer.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/FhirCosmosClientInitializer.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using Azure.Identity;
+using Azure.Core;
 using EnsureThat;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Cosmos.Fluent;
@@ -30,6 +30,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
         private readonly ILogger<FhirCosmosClientInitializer> _logger;
         private readonly Func<IEnumerable<RequestHandler>> _requestHandlerFactory;
         private readonly RetryExceptionPolicyFactory _retryExceptionPolicyFactory;
+        private readonly Lazy<TokenCredential> _tokenCredential;
         private readonly object _lockObject;
 
         private CosmosClient _cosmosClient;
@@ -39,16 +40,19 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
             ICosmosClientTestProvider testProvider,
             Func<IEnumerable<RequestHandler>> requestHandlerFactory,
             RetryExceptionPolicyFactory retryExceptionPolicyFactory,
+            Lazy<TokenCredential> tokenCredential,
             ILogger<FhirCosmosClientInitializer> logger)
         {
             EnsureArg.IsNotNull(testProvider, nameof(testProvider));
             EnsureArg.IsNotNull(requestHandlerFactory, nameof(requestHandlerFactory));
             EnsureArg.IsNotNull(retryExceptionPolicyFactory, nameof(retryExceptionPolicyFactory));
+            EnsureArg.IsNotNull(tokenCredential, nameof(tokenCredential));
             EnsureArg.IsNotNull(logger, nameof(logger));
 
             _testProvider = testProvider;
             _requestHandlerFactory = requestHandlerFactory;
             _retryExceptionPolicyFactory = retryExceptionPolicyFactory;
+            _tokenCredential = tokenCredential;
             _logger = logger;
             _lockObject = new object();
 
@@ -123,7 +127,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
             CosmosClientBuilder builder;
 
             builder = configuration.UseManagedIdentity ?
-                new CosmosClientBuilder(host, new DefaultAzureCredential()) :
+                new CosmosClientBuilder(host, _tokenCredential.Value) :
                 new CosmosClientBuilder(host, key);
 
             builder

--- a/src/Microsoft.Health.Fhir.Shared.Api/Microsoft.Health.Fhir.Shared.Api.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Microsoft.Health.Fhir.Shared.Api.projitems
@@ -53,6 +53,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Routing\QueryStringParser.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Modules\FeatureFlags\Validate\ValidateFeatureModule.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Modules\FeatureFlags\Validate\ValidatePostConfigureOptions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Modules\IdentityModule.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Modules\MediationModule.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Modules\MvcModule.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Exceptions\BaseExceptionMiddleware.cs" />

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/IdentityModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/IdentityModule.cs
@@ -1,0 +1,21 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Azure.Core;
+using Azure.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Health.Extensions.DependencyInjection;
+
+namespace Microsoft.Health.Fhir.Api.Modules;
+
+public class IdentityModule : IStartupModule
+{
+    public void Load(IServiceCollection services)
+    {
+        // Provide support for Azure Managed Identity
+        services.TryAddSingleton<TokenCredential, DefaultAzureCredential>();
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api/Modules/SearchModule.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Modules/SearchModule.cs
@@ -11,7 +11,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Api.Configs;
 using Microsoft.Health.Fhir.Api.Features.Filters;
-using Microsoft.Health.Fhir.Api.Features.Resources.Bundle;
 using Microsoft.Health.Fhir.Api.Features.Routing;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Compartment;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
@@ -82,20 +82,20 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         {
             _cosmosDataStoreConfiguration = new CosmosDataStoreConfiguration
             {
-                Host = Environment.GetEnvironmentVariable("CosmosDb:Host") ?? CosmosDbLocalEmulator.Host,
-                Key = Environment.GetEnvironmentVariable("CosmosDb:Key") ?? CosmosDbLocalEmulator.Key,
-                DatabaseId = Environment.GetEnvironmentVariable("CosmosDb:DatabaseId") ?? "FhirTests",
-                UseManagedIdentity = bool.TryParse(Environment.GetEnvironmentVariable("CosmosDb:UseManagedIdentity"), out bool useManagedIdentity) && useManagedIdentity,
+                Host = Environment.GetEnvironmentVariable("CosmosDb__Host") ?? CosmosDbLocalEmulator.Host,
+                Key = Environment.GetEnvironmentVariable("CosmosDb__Key") ?? CosmosDbLocalEmulator.Key,
+                DatabaseId = Environment.GetEnvironmentVariable("CosmosDb__DatabaseId") ?? "FhirTests",
+                UseManagedIdentity = bool.TryParse(Environment.GetEnvironmentVariable("CosmosDb__UseManagedIdentity"), out bool useManagedIdentity) && useManagedIdentity,
                 AllowDatabaseCreation = true,
                 AllowCollectionSetup = true,
-                PreferredLocations = Environment.GetEnvironmentVariable("CosmosDb:PreferredLocations")?.Split(';', StringSplitOptions.RemoveEmptyEntries),
+                PreferredLocations = Environment.GetEnvironmentVariable("CosmosDb__PreferredLocations")?.Split(';', StringSplitOptions.RemoveEmptyEntries),
                 UseQueueClientJobs = true,
             };
 
             _cosmosCollectionConfiguration = new CosmosCollectionConfiguration
             {
                 CollectionId = Guid.NewGuid().ToString(),
-                InitialCollectionThroughput = 1000,
+                InitialCollectionThroughput = 1500,
             };
         }
 
@@ -189,6 +189,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 await dataCollectionSetup.InstallStoredProcs(CancellationToken.None);
                 await dataCollectionSetup.UpdateFhirCollectionSettingsAsync(new CollectionVersion(), CancellationToken.None);
                 _container = documentClientInitializer.CreateFhirContainer(_cosmosClient, _cosmosDataStoreConfiguration.DatabaseId, _cosmosCollectionConfiguration.CollectionId);
+                await dataCollectionUpdater.ExecuteAsync(_container, CancellationToken.None);
             }
             finally
             {


### PR DESCRIPTION
## Description
PR and CI pipelines should use MI for Integration Tests

## Related issues
Addresses [AB#126615](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/126615)

## Testing
Existing tests should pass, using new MI credentials for Cosmos

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
