### PR TITLE
Change missing input params to RequestNotValid exception

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Filters/ValidateParametersResourceAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Filters/ValidateParametersResourceAttribute.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
             context.ActionArguments?.TryGetValue("inputParams", out inputResource);
             if (inputResource == null)
             {
-                throw new MissingMethodException("Controller method does not contain parameter named 'inputParams'");
+                throw new RequestNotValidException(Resources.MissingInputParams);
             }
 
             if (inputResource is not Parameters)

--- a/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
@@ -520,6 +520,15 @@ namespace Microsoft.Health.Fhir.Api {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to inputParams not found, request body must be a valid Parameters resource..
+        /// </summary>
+        public static string MissingInputParams {
+            get {
+                return ResourceManager.GetString("MissingInputParams", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Only one profile can be provided between a Parameters resource and the URL.
         /// </summary>
         public static string MultipleProfilesProvided {

--- a/src/Microsoft.Health.Fhir.Api/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Api/Resources.resx
@@ -423,4 +423,7 @@
   <data name="NotAbleToCreateTheFinalResultsOfAnOperation" xml:space="preserve">
     <value>Not able to create final result. Retry the operation.</value>
   </data>
+  <data name="MissingInputParams" xml:space="preserve">
+    <value>inputParams not found, request body must be a valid Parameters resource.</value>
+  </data>
 </root>


### PR DESCRIPTION
## Description
Currently we throw a 500 error if a customer sends an invalid request for Reindex.  This does not give a helpful error message, and indicates that our service has a problem rather than the correct response which is that the request is bad.

## Related issues
Addresses [issue [AB#124925](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/124925)].

## Testing
Manually tested invalid $reindex input to verify 500 and with this fix, a 400 response.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
