### PR TITLE
Fixed broken link to bulk export content in the HL7 spec. 

### DIFF
--- a/docs/BulkExport.md
+++ b/docs/BulkExport.md
@@ -1,6 +1,6 @@
 # Bulk Export
 
-This feature allows data from the FHIR server to be exported. More details can be found in the [spec](https://hl7.org/fhir/uv/bulkdata/export/index.html). The feature is currently turned on by default. To disable the feature, update the `FhirServer:Operations:Export:Enabled` setting to be false.
+This feature allows data from the FHIR server to be exported. More details can be found in the [spec](https://hl7.org/fhir/uv/bulkdata/export.html). The feature is currently turned on by default. To disable the feature, update the `FhirServer:Operations:Export:Enabled` setting to be false.
 
 ## Specifying destination
 


### PR DESCRIPTION
## Description
Fixed broken url link to bulk export content in the HL7 spec. Documentation change only.

AB#[125467](https://dev.azure.com/microsofthealth/Health/_workitems/edit/125467)

## Testing
New url works in browser. Copied and pasted to prevent typing errors.
