### PR TITLE
Fixing an IsDeleted issue on import/history.

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/BundleFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/BundleFactory.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                 if (!hasVerb && string.Equals("Import", r.Resource.Request?.Method, StringComparison.OrdinalIgnoreCase))
                 {
                     hasVerb = true;
-                    httpVerb = resource.IsDeleted() ? Bundle.HTTPVerb.DELETE : Bundle.HTTPVerb.POST;
+                    httpVerb = resource.IsDeleted() ? Bundle.HTTPVerb.DELETE : Bundle.HTTPVerb.PUT;
                 }
 
                 resource.FullUrlElement = new FhirUri(_urlResolver.ResolveResourceWrapperUrl(r.Resource));

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/BundleFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/BundleFactory.cs
@@ -71,6 +71,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                 }
 #endif
 
+                if (!hasVerb && string.Equals("Import", r.Resource.Request?.Method, StringComparison.OrdinalIgnoreCase))
+                {
+                    hasVerb = true;
+                    httpVerb = resource.IsDeleted() ? Bundle.HTTPVerb.DELETE : Bundle.HTTPVerb.POST;
+                }
+
                 resource.FullUrlElement = new FhirUri(_urlResolver.ResolveResourceWrapperUrl(r.Resource));
                 if (hasVerb)
                 {

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/RawBundleEntryComponent.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/RawBundleEntryComponent.cs
@@ -15,14 +15,14 @@ namespace Microsoft.Health.Fhir.Shared.Core.Features.Search
     [FhirType("EntryComponent")]
     public class RawBundleEntryComponent : Bundle.EntryComponent
     {
-        private readonly ResourceWrapper _resourceWrapper;
+        private readonly bool _isDeleted;
 
         public RawBundleEntryComponent(ResourceWrapper resourceWrapper)
         {
             EnsureArg.IsNotNull(resourceWrapper, nameof(resourceWrapper));
 
             ResourceElement = new RawResourceElement(resourceWrapper);
-            _resourceWrapper = resourceWrapper;
+            _isDeleted = resourceWrapper.IsDeleted;
         }
 
         public RawResourceElement ResourceElement { get; set; }
@@ -44,7 +44,7 @@ namespace Microsoft.Health.Fhir.Shared.Core.Features.Search
         /// <remarks>This instance method supersedes the extension method, Bundle.EntryComponent.IsDeleted().</remarks>
         public bool IsDeleted()
         {
-            return _resourceWrapper.IsDeleted;
+            return _isDeleted;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/RawBundleEntryComponent.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/RawBundleEntryComponent.cs
@@ -15,11 +15,14 @@ namespace Microsoft.Health.Fhir.Shared.Core.Features.Search
     [FhirType("EntryComponent")]
     public class RawBundleEntryComponent : Bundle.EntryComponent
     {
+        private readonly ResourceWrapper _resourceWrapper;
+
         public RawBundleEntryComponent(ResourceWrapper resourceWrapper)
         {
             EnsureArg.IsNotNull(resourceWrapper, nameof(resourceWrapper));
 
             ResourceElement = new RawResourceElement(resourceWrapper);
+            _resourceWrapper = resourceWrapper;
         }
 
         public RawResourceElement ResourceElement { get; set; }
@@ -32,6 +35,16 @@ namespace Microsoft.Health.Fhir.Shared.Core.Features.Search
             }
 
             throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether or not the resource has been deleted.
+        /// </summary>
+        /// <returns>True if the resource is deleted.</returns>
+        /// <remarks>This instance method supersedes the extension method, Bundle.EntryComponent.IsDeleted().</remarks>
+        public bool IsDeleted()
+        {
+            return _resourceWrapper.IsDeleted;
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTests.cs
@@ -399,7 +399,7 @@ IF (SELECT count(*) FROM EventLog WHERE Process = 'MergeResourcesCommitTransacti
 
             var history = await _client.SearchAsync($"Patient/{id}/_history");
             Assert.Equal("2", history.Resource.Entry[0].Resource.VersionId);
-            ////Assert.True(history.Resource.Entry[0].IsDeleted()); TODO: Uncomment when bug is fixed.
+            Assert.True(history.Resource.Entry[0].IsDeleted());
             Assert.Equal("1", history.Resource.Entry[1].Resource.VersionId);
             Assert.False(history.Resource.Entry[1].IsDeleted());
         }


### PR DESCRIPTION
## Description
The PR addresses two issues.
- IsDeleted() for Bundle.EntryComponent returns false on a deleted resource imported.
- A _history response doesn't have the request and response section for a deleted resource imported.

## Related issues
Addresses [issue #120287].

[Bug 120287](https://microsofthealth.visualstudio.com/Health/_workitems/edit/120287): Bundle.EntryComponent IsDeleted() method does not return TRUE for records deleted via $import

## Testing
Tested $import/_history scenarios by locally running the service.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
