### PR TITLE
Disable the ACR admin by default

### DIFF
--- a/build/jobs/e2e-tests.yml
+++ b/build/jobs/e2e-tests.yml
@@ -40,9 +40,11 @@ steps:
         $acrSettings = $appSettings | where {$_.Name -eq "FhirServer__Operations__ConvertData__ContainerRegistryServers__0"}
         $acrLoginServer = $acrSettings[0].Value
         $acrAccountName = ($acrLoginServer -split '\.')[0]
-        $acrPassword = (Get-AzContainerRegistryCredential -ResourceGroupName $(ResourceGroupName) -Name $acrAccountName).Password
-        Write-Host "##vso[task.setvariable variable=TestContainerRegistryServer]$($acrLoginServer)"
-        Write-Host "##vso[task.setvariable variable=TestContainerRegistryPassword]$($acrPassword)"
+
+        ## This needs to be moved to MI, WI #125246  
+        # $acrPassword = (Get-AzContainerRegistryCredential -ResourceGroupName $(ResourceGroupName) -Name $acrAccountName).Password
+        # Write-Host "##vso[task.setvariable variable=TestContainerRegistryServer]$($acrLoginServer)"
+        # Write-Host "##vso[task.setvariable variable=TestContainerRegistryPassword]$($acrPassword)"
 
         $exportStoreSettings = $appSettings | where {$_.Name -eq "FhirServer__Operations__Export__StorageAccountUri"}
         $exportStoreUri = $exportStoreSettings[0].Value
@@ -97,8 +99,6 @@ steps:
       'TestEnvironmentUrl_${{ parameters.version }}_Sql': $(TestEnvironmentUrl_${{ parameters.version }}_Sql)
       'Resource': $(Resource)
       'AllStorageAccounts': $(AllStorageAccounts)
-      'TestContainerRegistryServer': $(TestContainerRegistryServer)
-      'TestContainerRegistryPassword': $(TestContainerRegistryPassword)
       'TestExportStoreUri': $(TestExportStoreUri)
       'TestExportStoreKey': $(TestExportStoreKey)
       'TestIntegrationStoreUri': $(TestIntegrationStoreUri)

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -720,7 +720,7 @@
                 "tier": "Basic"
             },
             "properties": {
-                "adminUserEnabled": "true"
+                "adminUserEnabled": "false"
             }
         },
         {


### PR DESCRIPTION
## Description
This pull request includes a small but important change to the `samples/templates/default-azuredeploy-docker.json` file. The change disables the admin user by default.

* [`samples/templates/default-azuredeploy-docker.json`](diffhunk://#diff-8f12d2301c516589ac0d2aa63d5e045b1afac1caf1434ff9bae355ee8d62f494L723-R723): Changed the `adminUserEnabled` property from `"true"` to `"false"` to enhance security by disabling the admin user by default.

## Related issues
Addresses [AB#125244](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/125244)

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
