### PR TITLE
Bug(export): Adding logging for failing exports

### DIFF
--- a/src/Microsoft.Health.Fhir.Azure/ExportDestinationClient/AzureExportDestinationClient.cs
+++ b/src/Microsoft.Health.Fhir.Azure/ExportDestinationClient/AzureExportDestinationClient.cs
@@ -134,16 +134,21 @@ namespace Microsoft.Health.Fhir.Azure.ExportDestinationClient
                 {
                     uri = CommitFileRetry(fileName);
                 }
-                catch (RequestFailedException)
+                catch (RequestFailedException ex)
                 {
+                    _logger.LogError(ex, "Failed to write export file");
                     try
                     {
                         uri = CommitFileRetry(fileName);
                     }
-                    catch (RequestFailedException ex)
+                    catch (ObjectDisposedException odEx)
                     {
-                        _logger.LogError(ex, "Failed to write export file");
-                        throw new DestinationConnectionException(ex.Message, (HttpStatusCode)ex.Status);
+                        _logger.LogError(odEx, "Failed to write export file due to ObjectDisposedException");
+                    }
+                    catch (RequestFailedException ex2)
+                    {
+                        _logger.LogError(ex2, "Failed to write export file on retry");
+                        throw new DestinationConnectionException(ex2.Message, (HttpStatusCode)ex2.Status);
                     }
                 }
             }

--- a/src/Microsoft.Health.Fhir.Azure/ExportDestinationClient/AzureExportDestinationClient.cs
+++ b/src/Microsoft.Health.Fhir.Azure/ExportDestinationClient/AzureExportDestinationClient.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Health.Fhir.Azure.ExportDestinationClient
 
         public Uri CommitFile(string fileName)
         {
-            Uri uri;
+            Uri uri = null;
             if (_blobStreams.ContainsKey(fileName))
             {
                 try
@@ -144,6 +144,7 @@ namespace Microsoft.Health.Fhir.Azure.ExportDestinationClient
                     catch (ObjectDisposedException odEx)
                     {
                         _logger.LogError(odEx, "Failed to write export file due to ObjectDisposedException");
+                        throw new DestinationConnectionException(ex.Message, (HttpStatusCode)ex.Status);
                     }
                     catch (RequestFailedException ex2)
                     {


### PR DESCRIPTION
## Description
Adding logging to gather more information why export is failing

## Related issues
Addresses [issue #[124858](https://microsofthealth.visualstudio.com/Health/_workitems/edit/124858)].

## Testing


## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
