### PR TITLE
Continue reindex when encountering empty page

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -937,13 +937,12 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
 
             if (ranges?.Count > 0)
             {
-                var rangeId = 0;
-                while (results == null && rangeId < ranges.Count)
+                foreach (var range in ranges)
                 {
                     results = await SearchBySurrogateIdRange(
                         resourceType,
-                        ranges[rangeId].StartId,
-                        ranges[rangeId].EndId,
+                        range.StartId,
+                        range.EndId,
                         null,
                         null,
                         cancellationToken,
@@ -955,21 +954,13 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                         break;
                     }
 
-                    _logger.LogInformation("For Reindex, empty data page encountered. Resource Type={ResourceType} Iteration={IterationCount} StartId={StartId} EndId={EndId}", resourceType, rangeId, ranges[rangeId].StartId, ranges[rangeId].EndId);
-
-                    rangeId++;
-                    results = null;
-                }
-
-                if (results == null)
-                {
-                    _logger.LogWarning("For Reindex, empty result set encountered. Type={ResourceType}.", resourceType);
-                    results = new SearchResult(0, []);
+                    _logger.LogInformation("For Reindex, empty data page encountered. Resource Type={ResourceType} StartId={StartId} EndId={EndId}", resourceType, range.StartId, range.EndId);
                 }
             }
             else
             {
                 _logger.LogInformation("For Reindex, no data pages found. Resource Type={ResourceType} StartId={StartId} EndId={EndId}", resourceType, startId, endId);
+                results = new SearchResult(0, []);
             }
 
             _logger.LogInformation("For Reindex, Resource Type={ResourceType} Count={Count} MaxResourceSurrogateId={MaxResourceSurrogateId}", resourceType, results.TotalCount, results.MaxResourceSurrogateId);

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -922,7 +922,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
         protected async override Task<SearchResult> SearchForReindexInternalAsync(SearchOptions searchOptions, string searchParameterHash, CancellationToken cancellationToken)
         {
             string resourceType = GetForceReindexResourceType(searchOptions);
-
             if (searchOptions.CountOnly)
             {
                 _model.TryGetResourceTypeId(resourceType, out short resourceTypeId);
@@ -939,7 +938,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
             if (ranges?.Count > 0)
             {
                 var rangeId = 0;
-                while (results == null)
+                while (results == null && rangeId < ranges.Count)
                 {
                     results = await SearchBySurrogateIdRange(
                         resourceType,

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexSearchTests.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                 };
 
                 // Pass in a different hash value
-                SearchResult searchResult = await _searchService.Value.SearchForReindexAsync(queryParametersList, null, false, CancellationToken.None);
+                SearchResult searchResult = await _searchService.Value.SearchForReindexAsync(queryParametersList, "fakehash", false, CancellationToken.None);
 
                 Assert.Equal("5", testPatient.Version);
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexSearchTests.cs
@@ -122,11 +122,11 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
 
             try
             {
-                UpsertOutcome outcome = await UpsertPatientData();
-                outcome = await AddPatientHistorical("v2");
-                outcome = await AddPatientHistorical("v3");
-                outcome = await AddPatientHistorical("v4");
-                outcome = await AddPatientHistorical("v5");
+                UpsertOutcome outcome = await AddPatientHistorical("10");
+                outcome = await AddPatientHistorical("11");
+                outcome = await AddPatientHistorical("12");
+                outcome = await AddPatientHistorical("13");
+                outcome = await AddPatientHistorical("14");
                 testPatient = outcome.Wrapper;
 
                 var queryParametersList = new List<Tuple<string, string>>()
@@ -141,7 +141,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                 // Pass in a different hash value
                 SearchResult searchResult = await _searchService.Value.SearchForReindexAsync(queryParametersList, "fakehash", false, CancellationToken.None);
 
-                Assert.Equal("5", testPatient.Version);
+                Assert.Equal("14", testPatient.Version);
 
                 Assert.Single(searchResult.Results);
             }
@@ -198,7 +198,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                 _searchParameterDefinitionManager.GetSearchParameterHashForResourceType("Patient"));
             wrapper.SearchParameterHash = "hash";
 
-            return await _scopedDataStore.Value.UpsertAsync(new ResourceWrapperOperation(wrapper, true, true, null, false, false, bundleResourceContext: null), CancellationToken.None);
+            return await _scopedDataStore.Value.UpsertAsync(new ResourceWrapperOperation(wrapper, true, true, null, false, true, bundleResourceContext: null), CancellationToken.None);
         }
     }
 }


### PR DESCRIPTION
## Description
Changes reindex to continue when encountering empty pages for a given surrogate id range.

Since empty pages are rare, kept current behavior to only get one page range at once.

## Related issues
[AB#124883](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/124883)

## Testing
Integration Test.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
