### PR TITLE
Fixing a typo in an exception message.

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Filters/ValidateExportRequestFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Filters/ValidateExportRequestFilterAttribute.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
 
                 if (!requiredHeaderValueFound)
                 {
-                    throw new RequestNotValidException($"Missing required header value; header={PreferHeaderName},value={PreferHeaderValueOptional}.");
+                    throw new RequestNotValidException($"Missing required header value; header={PreferHeaderName},value={PreferHeaderValueRequired}.");
                 }
             }
             else


### PR DESCRIPTION
## Description
Fixing a typo in an exception message.

## Related issues
Addresses [issue #121238].

[User Story 121238](https://microsofthealth.visualstudio.com/Health/_workitems/edit/121238): Export job behavior when search criteria does not match

## Testing
By CR.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
