### PR TITLE
bug(logging): add full exception to logging

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Controllers/AadSmartOnFhirProxyController.cs
+++ b/src/Microsoft.Health.Fhir.Api/Controllers/AadSmartOnFhirProxyController.cs
@@ -255,7 +255,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError("Error parsing launch parameters: {Message}", ex.Message);
+                _logger.LogError(ex, "Error parsing launch parameters: {Message}", ex.Message);
                 throw new AadSmartOnFhirProxyBadRequestException(Resources.InvalidLaunchContext, ex);
             }
 
@@ -368,7 +368,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError("Error decoding compound code: {Message}", ex.Message);
+                _logger.LogError(ex, "Error decoding compound code: {Message}", ex.Message);
                 throw new AadSmartOnFhirProxyBadRequestException(Resources.InvalidCompoundCode, ex);
             }
 

--- a/src/Microsoft.Health.Fhir.Azure/IntegrationDataStore/AzureBlobIntegrationDataStoreClient.cs
+++ b/src/Microsoft.Health.Fhir.Azure/IntegrationDataStore/AzureBlobIntegrationDataStoreClient.cs
@@ -205,7 +205,7 @@ namespace Microsoft.Health.Fhir.Azure.IntegrationDataStore
             }
             catch (RequestFailedException ex) when (ex.ErrorCode == BlobErrorCode.LeaseAlreadyPresent)
             {
-                _logger.LogInformation("{Message}: {ResourceUri}", ex.Message, resourceUri);
+                _logger.LogInformation(ex, "{Message}: {ResourceUri}", ex.Message, resourceUri);
             }
             catch (RequestFailedException se)
             {

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosFhirDataStore.cs
@@ -860,7 +860,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
             }
             catch (CosmosException ex)
             {
-                _logger.LogWarning("Failed to obtain provisioned RU throughput. Error: {Message}", ex.Message);
+                _logger.LogWarning(ex, "Failed to obtain provisioned RU throughput. Error: {Message}", ex.Message);
                 return null;
             }
         }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Patch/FhirPathPatch/Operations/OperationAdd.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Patch/FhirPathPatch/Operations/OperationAdd.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Patch.FhirPathPatch.Oper
             }
             catch (InvalidOperationException ex)
             {
-                throw new InvalidOperationException($"{ex.Message} at {Operation.Path} when processing patch add operation.");
+                throw new InvalidOperationException($"{ex.Message} at {Operation.Path} when processing patch add operation. Stack Trace: {ex.StackTrace}. Inner Exception: {ex.InnerException?.Message}");
             }
 
             return ResourceElement.ToPoco<Resource>();

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Patch/FhirPathPatch/Operations/OperationAdd.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Patch/FhirPathPatch/Operations/OperationAdd.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Patch.FhirPathPatch.Oper
             }
             catch (InvalidOperationException ex)
             {
-                throw new InvalidOperationException($"{ex.Message} at {Operation.Path} when processing patch add operation. Stack Trace: {ex.StackTrace}. Inner Exception: {ex.InnerException?.Message}");
+                throw new InvalidOperationException($"{ex.Message} at {Operation.Path} when processing patch add operation.", ex);
             }
 
             return ResourceElement.ToPoco<Resource>();

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Patch/FhirPathPatch/Operations/OperationDelete.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Patch/FhirPathPatch/Operations/OperationDelete.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Patch.FhirPathPatch.Oper
             }
             catch (InvalidOperationException ex)
             {
-                throw new InvalidOperationException($"{ex.Message} for {Operation.Path} when processing patch delete operation.");
+                throw new InvalidOperationException($"{ex.Message} for {Operation.Path} when processing patch delete operation. Stack Trace: {ex.StackTrace}. Inner Exception: {ex.InnerException?.Message}");
             }
 
             if (Target is not null)

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Patch/FhirPathPatch/Operations/OperationDelete.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Patch/FhirPathPatch/Operations/OperationDelete.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Patch.FhirPathPatch.Oper
             }
             catch (InvalidOperationException ex)
             {
-                throw new InvalidOperationException($"{ex.Message} for {Operation.Path} when processing patch delete operation. Stack Trace: {ex.StackTrace}. Inner Exception: {ex.InnerException?.Message}");
+                throw new InvalidOperationException($"{ex.Message} for {Operation.Path} when processing patch delete operation.", ex);
             }
 
             if (Target is not null)

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Patch/FhirPathPatch/Operations/OperationInsert.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Patch/FhirPathPatch/Operations/OperationInsert.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Patch.FhirPathPatch.Oper
             }
             catch (InvalidOperationException ex)
             {
-                throw new InvalidOperationException($"{ex.Message} at {Operation.Path} when processing patch insert operation.");
+                throw new InvalidOperationException($"{ex.Message} at {Operation.Path} when processing patch insert operation. Stack Trace: {ex.StackTrace}. Inner Exception: {ex.InnerException?.Message}");
             }
 
             var listElements = targetParent.Children(name).ToList()

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Patch/FhirPathPatch/Operations/OperationInsert.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Patch/FhirPathPatch/Operations/OperationInsert.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Patch.FhirPathPatch.Oper
             }
             catch (InvalidOperationException ex)
             {
-                throw new InvalidOperationException($"{ex.Message} at {Operation.Path} when processing patch insert operation. Stack Trace: {ex.StackTrace}. Inner Exception: {ex.InnerException?.Message}");
+                throw new InvalidOperationException($"{ex.Message} at {Operation.Path} when processing patch insert operation.", ex);
             }
 
             var listElements = targetParent.Children(name).ToList()

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Patch/FhirPathPatch/Operations/OperationMove.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Patch/FhirPathPatch/Operations/OperationMove.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Patch.FhirPathPatch.Oper
             }
             catch (InvalidOperationException ex)
             {
-                throw new InvalidOperationException($"{ex.Message} at {Operation.Path} when processing patch move operation. Stack Trace: {ex.StackTrace}. Inner Exception: {ex.InnerException?.Message}");
+                throw new InvalidOperationException($"{ex.Message} at {Operation.Path} when processing patch move operation.", ex);
             }
 
             // Check indexes

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Patch/FhirPathPatch/Operations/OperationMove.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Patch/FhirPathPatch/Operations/OperationMove.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Patch.FhirPathPatch.Oper
             }
             catch (InvalidOperationException ex)
             {
-                throw new InvalidOperationException($"{ex.Message} at {Operation.Path} when processing patch move operation.");
+                throw new InvalidOperationException($"{ex.Message} at {Operation.Path} when processing patch move operation. Stack Trace: {ex.StackTrace}. Inner Exception: {ex.InnerException?.Message}");
             }
 
             // Check indexes

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Patch/FhirPathPatch/Operations/OperationReplace.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Patch/FhirPathPatch/Operations/OperationReplace.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Patch.FhirPathPatch.Oper
             }
             catch (InvalidOperationException ex)
             {
-                throw new InvalidOperationException($"{ex.Message} at {Operation.Path} when processing patch replace operation.");
+                throw new InvalidOperationException($"{ex.Message} at {Operation.Path} when processing patch replace operation. Stack Trace: {ex.StackTrace}. Inner Exception: {ex.InnerException?.Message}");
             }
 
             return ResourceElement.ToPoco<Resource>();

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Patch/FhirPathPatch/Operations/OperationReplace.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Patch/FhirPathPatch/Operations/OperationReplace.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Patch.FhirPathPatch.Oper
             }
             catch (InvalidOperationException ex)
             {
-                throw new InvalidOperationException($"{ex.Message} at {Operation.Path} when processing patch replace operation. Stack Trace: {ex.StackTrace}. Inner Exception: {ex.InnerException?.Message}");
+                throw new InvalidOperationException($"{ex.Message} at {Operation.Path} when processing patch replace operation.", ex);
             }
 
             return ResourceElement.ToPoco<Resource>();

--- a/src/Microsoft.Health.Fhir.Shared.Core/Operations/Export/ExportAnonymizerFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Operations/Export/ExportAnonymizerFactory.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError("Failed to fetch Anonymization configuration file: {ConfigLocation}", exportJobRecord.AnonymizationConfigurationLocation);
+                    _logger.LogError(ex, "Failed to fetch Anonymization configuration file: {ConfigLocation}", exportJobRecord.AnonymizationConfigurationLocation);
                     throw new AnonymizationConfigurationFetchException(ex.Message, ex);
                 }
 
@@ -61,7 +61,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                     }
                     catch (Exception ex)
                     {
-                        _logger.LogError("Failed to parse configuration file: {Message}", ex.Message);
+                        _logger.LogError(ex, "Failed to parse configuration file: {Message}", ex.Message);
                         throw new FailedToParseAnonymizationConfigurationException(ex.Message, ex);
                     }
                 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/CustomQueries.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/CustomQueries.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                             }
                             catch (Exception ex)
                             {
-                                logger.LogWarning("Error refreshing CustomQuery cache.  This will try again on next search execution.  Error: {ExceptionMessage}", ex.Message);
+                                logger.LogWarning(ex, "Error refreshing CustomQuery cache.  This will try again on next search execution.  Error: {ExceptionMessage}", ex.Message);
                             }
                         }
                     }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -1321,7 +1321,7 @@ SELECT isnull(min(ResourceSurrogateId), 0), isnull(max(ResourceSurrogateId), 0),
                 }
                 catch (SqlException ex)
                 {
-                    logger.LogWarning("ResourceSearchParamStats.CreateStats: Exception={Exception}", ex.Message);
+                    logger.LogWarning(ex, "ResourceSearchParamStats.CreateStats: Exception={Exception}", ex.Message);
                 }
             }
 
@@ -1340,7 +1340,7 @@ SELECT isnull(min(ResourceSurrogateId), 0), isnull(max(ResourceSurrogateId), 0),
                 }
                 catch (SqlException ex)
                 {
-                    logger.LogWarning("ResourceSearchParamStats.Init: Exception={Exception}", ex.Message);
+                    logger.LogWarning(ex, "ResourceSearchParamStats.Init: Exception={Exception}", ex.Message);
                 }
             }
         }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
@@ -231,7 +231,7 @@ INSERT INTO dbo.Parameters (Id,Number) SELECT @LeasePeriodSecId, 10
             }
             catch (Exception ex)
             {
-                Trace.TraceError("Failed to delete database: " + ex.Message);
+                Trace.TraceError($"Failed to delete database: {ex.Message}. Stack Trace: {ex.StackTrace}. Inner Exception: {ex.InnerException?.Message}");
             }
         }
 

--- a/tools/FHIRDataSynth/Program.cs
+++ b/tools/FHIRDataSynth/Program.cs
@@ -352,7 +352,7 @@ namespace FHIRDataSynth
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"ERROR! {ex.Message}");
+                Console.WriteLine($"ERROR! {ex}");
 
                 // Console.WriteLine("Press enter to close application.");
                 // Console.ReadLine();

--- a/tools/FHIRDataSynth/RDUtility.cs
+++ b/tools/FHIRDataSynth/RDUtility.cs
@@ -44,7 +44,7 @@ namespace FHIRDataSynth
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"ERROR: {ex.Message}");
+                Console.WriteLine($"ERROR: {ex}");
             }
         }
 
@@ -134,7 +134,7 @@ namespace FHIRDataSynth
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"ERROR: {ex.Message}");
+                Console.WriteLine($"ERROR: {ex}");
             }
         }
 
@@ -161,7 +161,7 @@ namespace FHIRDataSynth
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"ERROR: {ex.Message}");
+                Console.WriteLine($"ERROR: {ex}");
             }
         }
 

--- a/tools/FHIRDataSynth/ResourceProcessor.cs
+++ b/tools/FHIRDataSynth/ResourceProcessor.cs
@@ -139,7 +139,7 @@ namespace ResourceProcessorNamespace
             }
             catch (Exception ex)
             {
-                LogError($"Exception: {ex.Message}");
+                LogError($"Exception: {ex}");
             }
         }
     }


### PR DESCRIPTION
## Description
 Add full exception to logging where previously only ex.message was being logged.

## Related issues
Addresses [issue #125287](https://microsofthealth.visualstudio.com/Health/_workitems/edit/125287)

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
