### PR TITLE
Update AAD token request target resource uri for ACR access

### DIFF
--- a/src/Microsoft.Health.Fhir.Azure/ContainerRegistry/AzureContainerRegistryAccessTokenProvider.cs
+++ b/src/Microsoft.Health.Fhir.Azure/ContainerRegistry/AzureContainerRegistryAccessTokenProvider.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Health.Fhir.Azure.ContainerRegistry
         {
             EnsureArg.IsNotNullOrEmpty(registryServer, nameof(registryServer));
 
-            var aadResourceUri = new Uri(_convertDataConfiguration.AcrTargetResourceUri);
+            var aadResourceUri = _convertDataConfiguration.AcrTargetResourceUri;
             string aadToken;
             try
             {

--- a/src/Microsoft.Health.Fhir.Azure/ContainerRegistry/AzureContainerRegistryAccessTokenProvider.cs
+++ b/src/Microsoft.Health.Fhir.Azure/ContainerRegistry/AzureContainerRegistryAccessTokenProvider.cs
@@ -33,6 +33,8 @@ namespace Microsoft.Health.Fhir.Azure.ContainerRegistry
         private const string ExchangeAcrRefreshTokenUrl = "oauth2/exchange";
         private const string GetAcrAccessTokenUrl = "oauth2/token";
 
+        private static readonly Uri AcrTargetResourceUri = new Uri("https://containerregistry.azure.net/");
+
         private readonly IAccessTokenProvider _aadTokenProvider;
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly ConvertDataConfiguration _convertDataConfiguration;
@@ -59,7 +61,7 @@ namespace Microsoft.Health.Fhir.Azure.ContainerRegistry
         {
             EnsureArg.IsNotNullOrEmpty(registryServer, nameof(registryServer));
 
-            var aadResourceUri = _convertDataConfiguration.AcrTargetResourceUri;
+            var aadResourceUri = AcrTargetResourceUri;
             string aadToken;
             try
             {

--- a/src/Microsoft.Health.Fhir.Azure/ContainerRegistry/AzureContainerRegistryAccessTokenProvider.cs
+++ b/src/Microsoft.Health.Fhir.Azure/ContainerRegistry/AzureContainerRegistryAccessTokenProvider.cs
@@ -33,8 +33,6 @@ namespace Microsoft.Health.Fhir.Azure.ContainerRegistry
         private const string ExchangeAcrRefreshTokenUrl = "oauth2/exchange";
         private const string GetAcrAccessTokenUrl = "oauth2/token";
 
-        private static readonly Uri AcrTargetResourceUri = new Uri("https://containerregistry.azure.net/");
-
         private readonly IAccessTokenProvider _aadTokenProvider;
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly ConvertDataConfiguration _convertDataConfiguration;
@@ -61,10 +59,11 @@ namespace Microsoft.Health.Fhir.Azure.ContainerRegistry
         {
             EnsureArg.IsNotNullOrEmpty(registryServer, nameof(registryServer));
 
+            var aadResourceUri = _convertDataConfiguration.AcrTargetResourceUri;
             string aadToken;
             try
             {
-                aadToken = await _aadTokenProvider.GetAccessTokenForResourceAsync(AcrTargetResourceUri, cancellationToken);
+                aadToken = await _aadTokenProvider.GetAccessTokenForResourceAsync(aadResourceUri, cancellationToken);
             }
             catch (AccessTokenProviderException ex)
             {

--- a/src/Microsoft.Health.Fhir.Azure/ContainerRegistry/AzureContainerRegistryAccessTokenProvider.cs
+++ b/src/Microsoft.Health.Fhir.Azure/ContainerRegistry/AzureContainerRegistryAccessTokenProvider.cs
@@ -61,11 +61,10 @@ namespace Microsoft.Health.Fhir.Azure.ContainerRegistry
         {
             EnsureArg.IsNotNullOrEmpty(registryServer, nameof(registryServer));
 
-            var aadResourceUri = AcrTargetResourceUri;
             string aadToken;
             try
             {
-                aadToken = await _aadTokenProvider.GetAccessTokenForResourceAsync(aadResourceUri, cancellationToken);
+                aadToken = await _aadTokenProvider.GetAccessTokenForResourceAsync(AcrTargetResourceUri, cancellationToken);
             }
             catch (AccessTokenProviderException ex)
             {

--- a/src/Microsoft.Health.Fhir.Azure/ContainerRegistry/AzureContainerRegistryAccessTokenProvider.cs
+++ b/src/Microsoft.Health.Fhir.Azure/ContainerRegistry/AzureContainerRegistryAccessTokenProvider.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Health.Fhir.Azure.ContainerRegistry
         {
             EnsureArg.IsNotNullOrEmpty(registryServer, nameof(registryServer));
 
-            var aadResourceUri = new Uri(_convertDataConfiguration.ArmResourceManagerId);
+            var aadResourceUri = new Uri(_convertDataConfiguration.AcrTargetResourceUri);
             string aadToken;
             try
             {

--- a/src/Microsoft.Health.Fhir.Core/Configs/ConvertDataConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/ConvertDataConfiguration.cs
@@ -30,10 +30,11 @@ namespace Microsoft.Health.Fhir.Core.Configs
         public Uri AcrTargetResourceUri { get; set; } = new Uri("https://containerregistry.azure.net/");
 
         /// <summary>
-        /// ArmResourceManagerId to aquire AAD token for ACR access token since ACR is not an AAD resource.
+        /// ArmResourceManagerId to acquire AAD token for ACR access token since ACR is not an AAD resource.
         /// The value is "https://management.azure.com/" for AzureCloud and DogFood.
         /// Could be changed to "https://management.usgovcloudapi.net/" for Azure Government and "https://management.chinacloudapi.cn/ " for Azure China.
         /// </summary>
+        [Obsolete("Use AcrTargetResourceUri instead")]
         public string ArmResourceManagerId { get; set; } = "https://management.azure.com/";
 
         /// <summary>

--- a/src/Microsoft.Health.Fhir.Core/Configs/ConvertDataConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/ConvertDataConfiguration.cs
@@ -22,12 +22,12 @@ namespace Microsoft.Health.Fhir.Core.Configs
         public ICollection<string> ContainerRegistryServers { get; } = new List<string>();
 
         /// <summary>
-        /// AcrTargetResourceUri to acquire AAD token for ACR access token since ACR is not an AAD resource. 
+        /// AcrTargetResourceUri to acquire AAD token for ACR access token since ACR is not an AAD resource.
         /// To enable Trusted Services scenarios, we must use the ACR-specific URI rather than the more generic ARM URI.
         /// https://dev.azure.com/msazure/AzureContainerRegistry/_wiki/wikis/ACR%20Specs/480000/TrustedServicesPatterns
         /// The value is "https://containerregistry.azure.net/" for AzureCloud and DogFood.
         /// </summary>
-        public string AcrTargetResourceUri { get; set; } = "https://containerregistry.azure.net/";
+        public Uri AcrTargetResourceUri { get; set; } = new Uri("https://containerregistry.azure.net/");
 
         /// <summary>
         /// Configuration for templates.

--- a/src/Microsoft.Health.Fhir.Core/Configs/ConvertDataConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/ConvertDataConfiguration.cs
@@ -22,11 +22,19 @@ namespace Microsoft.Health.Fhir.Core.Configs
         public ICollection<string> ContainerRegistryServers { get; } = new List<string>();
 
         /// <summary>
+        /// AcrTargetResourceUri to acquire AAD token for ACR access token since ACR is not an AAD resource.
+        /// To enable Trusted Services scenarios, we must use the ACR-specific URI rather than the more generic ARM URI.
+        /// https://dev.azure.com/msazure/AzureContainerRegistry/_wiki/wikis/ACR%20Specs/480000/TrustedServicesPatterns
+        /// The value is "https://containerregistry.azure.net/" for all cloud environments.
+        /// </summary>
+        public Uri AcrTargetResourceUri { get; } = new Uri("https://containerregistry.azure.net/");
+
+        /// <summary>
         /// ArmResourceManagerId to acquire AAD token for ACR access token since ACR is not an AAD resource.
         /// The value is "https://management.azure.com/" for AzureCloud and DogFood.
         /// Could be changed to "https://management.usgovcloudapi.net/" for Azure Government and "https://management.chinacloudapi.cn/ " for Azure China.
         /// </summary>
-        [Obsolete("Non-configurable ACR target resource URI will be used instead.")]
+        [Obsolete("Use AcrTargetResourceUri instead.")]
         public string ArmResourceManagerId { get; set; } = "https://management.azure.com/";
 
         /// <summary>

--- a/src/Microsoft.Health.Fhir.Core/Configs/ConvertDataConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/ConvertDataConfiguration.cs
@@ -22,19 +22,11 @@ namespace Microsoft.Health.Fhir.Core.Configs
         public ICollection<string> ContainerRegistryServers { get; } = new List<string>();
 
         /// <summary>
-        /// AcrTargetResourceUri to acquire AAD token for ACR access token since ACR is not an AAD resource.
-        /// To enable Trusted Services scenarios, we must use the ACR-specific URI rather than the more generic ARM URI.
-        /// https://dev.azure.com/msazure/AzureContainerRegistry/_wiki/wikis/ACR%20Specs/480000/TrustedServicesPatterns
-        /// The value is "https://containerregistry.azure.net/" for all cloud environments.
-        /// </summary>
-        public Uri AcrTargetResourceUri { get; set; } = new Uri("https://containerregistry.azure.net/");
-
-        /// <summary>
         /// ArmResourceManagerId to acquire AAD token for ACR access token since ACR is not an AAD resource.
         /// The value is "https://management.azure.com/" for AzureCloud and DogFood.
         /// Could be changed to "https://management.usgovcloudapi.net/" for Azure Government and "https://management.chinacloudapi.cn/ " for Azure China.
         /// </summary>
-        [Obsolete("Use AcrTargetResourceUri instead")]
+        [Obsolete("Non-configurable ACR target resource URI will be used instead.")]
         public string ArmResourceManagerId { get; set; } = "https://management.azure.com/";
 
         /// <summary>

--- a/src/Microsoft.Health.Fhir.Core/Configs/ConvertDataConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/ConvertDataConfiguration.cs
@@ -30,6 +30,13 @@ namespace Microsoft.Health.Fhir.Core.Configs
         public Uri AcrTargetResourceUri { get; set; } = new Uri("https://containerregistry.azure.net/");
 
         /// <summary>
+        /// ArmResourceManagerId to aquire AAD token for ACR access token since ACR is not an AAD resource.
+        /// The value is "https://management.azure.com/" for AzureCloud and DogFood.
+        /// Could be changed to "https://management.usgovcloudapi.net/" for Azure Government and "https://management.chinacloudapi.cn/ " for Azure China.
+        /// </summary>
+        public string ArmResourceManagerId { get; set; } = "https://management.azure.com/";
+
+        /// <summary>
         /// Configuration for templates.
         /// </summary>
         public TemplateCollectionConfiguration TemplateCollectionOptions { get; set; } = new TemplateCollectionConfiguration();

--- a/src/Microsoft.Health.Fhir.Core/Configs/ConvertDataConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/ConvertDataConfiguration.cs
@@ -22,11 +22,12 @@ namespace Microsoft.Health.Fhir.Core.Configs
         public ICollection<string> ContainerRegistryServers { get; } = new List<string>();
 
         /// <summary>
-        /// ArmResourceManagerId to aquire AAD token for ACR access token since ACR is not an AAD resource.
-        /// The value is "https://management.azure.com/" for AzureCloud and DogFood.
-        /// Could be changed to "https://management.usgovcloudapi.net/" for Azure Government and "https://management.chinacloudapi.cn/ " for Azure China.
+        /// AcrTargetResourceUri to acquire AAD token for ACR access token since ACR is not an AAD resource. 
+        /// To enable Trusted Services scenarios, we must use the ACR-specific URI rather than the more generic ARM URI.
+        /// https://dev.azure.com/msazure/AzureContainerRegistry/_wiki/wikis/ACR%20Specs/480000/TrustedServicesPatterns
+        /// The value is "https://containerregistry.azure.net/" for AzureCloud and DogFood.
         /// </summary>
-        public string ArmResourceManagerId { get; set; } = "https://management.azure.com/";
+        public string AcrTargetResourceUri { get; set; } = "https://containerregistry.azure.net/";
 
         /// <summary>
         /// Configuration for templates.

--- a/src/Microsoft.Health.Fhir.Core/Configs/ConvertDataConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/ConvertDataConfiguration.cs
@@ -23,11 +23,11 @@ namespace Microsoft.Health.Fhir.Core.Configs
 
         /// <summary>
         /// AcrTargetResourceUri to acquire AAD token for ACR access token since ACR is not an AAD resource.
-        /// To enable Trusted Services scenarios, we must use the ACR-specific URI rather than the more generic ARM URI.
-        /// https://dev.azure.com/msazure/AzureContainerRegistry/_wiki/wikis/ACR%20Specs/480000/TrustedServicesPatterns
+        /// The value is "https://management.azure.com/" for AzureCloud and DogFood. Could be changed to "https://management.usgovcloudapi.net/" for Azure Government and "https://management.chinacloudapi.cn/ " for Azure China.
+        /// To enable Trusted Services scenarios, we must use the ACR-specific URI rather than the more generic ARM URI. https://dev.azure.com/msazure/AzureContainerRegistry/_wiki/wikis/ACR%20Specs/480000/TrustedServicesPatterns
         /// The value is "https://containerregistry.azure.net/" for all cloud environments.
         /// </summary>
-        public Uri AcrTargetResourceUri { get; } = new Uri("https://containerregistry.azure.net/");
+        public Uri AcrTargetResourceUri { get; set; } = new Uri("https://management.azure.com/");
 
         /// <summary>
         /// ArmResourceManagerId to acquire AAD token for ACR access token since ACR is not an AAD resource.

--- a/src/Microsoft.Health.Fhir.Core/Configs/ConvertDataConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/ConvertDataConfiguration.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Health.Fhir.Core.Configs
         /// AcrTargetResourceUri to acquire AAD token for ACR access token since ACR is not an AAD resource.
         /// To enable Trusted Services scenarios, we must use the ACR-specific URI rather than the more generic ARM URI.
         /// https://dev.azure.com/msazure/AzureContainerRegistry/_wiki/wikis/ACR%20Specs/480000/TrustedServicesPatterns
-        /// The value is "https://containerregistry.azure.net/" for AzureCloud and DogFood.
+        /// The value is "https://containerregistry.azure.net/" for all cloud environments.
         /// </summary>
         public Uri AcrTargetResourceUri { get; set; } = new Uri("https://containerregistry.azure.net/");
 


### PR DESCRIPTION
## Description
In alignment with [this documentation](https://dev.azure.com/msazure/AzureContainerRegistry/_wiki/wikis/ACR%20Specs/480000/TrustedServicesPatterns), we should use the ACR-specific target resource URI rather than the generic ARM URI in order to get the "xms_az_tm" claim on the token that we need to authenticate as a Trusted Service with ACR. This value is passed in and used as the scopes value for the token request in the [AuthenticationProvider](https://microsofthealth.visualstudio.com/Health/_git/health-external-mi?path=/src/Authentication/Providers/AuthenticationProvider.cs&version=GBmain&line=100&lineEnd=100&lineStartColumn=17&lineEndColumn=68&lineStyle=plain&_a=contents).

This PR effectively updates the name of the config field as "armResourceManagerId" is not descriptive of the purpose of this field, which is to determine the target resource URI for getting access tokens for the ACR. The "management.azure.com" value will still work here, so we will keep it as the default so as not to break any OSS or other scenarios. We will override this value in our PaaS code to point to the ACR-specific value which enabled Trusted Services scenarios.

## Related issues
Addresses bug [126662](https://microsofthealth.visualstudio.com/Health/_workitems/edit/126662).

## Testing
Validated this change by passing in the values of a prod Credential Bundle and the updated target resource URI into the token request in the [AuthenticationProvider](https://microsofthealth.visualstudio.com/Health/_git/health-external-mi?path=/src/Authentication/Providers/AuthenticationProvider.cs&version=GBmain&line=87&lineEnd=104&lineStartColumn=9&lineEndColumn=1&lineStyle=plain&_a=contents). With the generic ARM URI, the token comes back without the xms_az_tm claim; with the ACR-specific URI, the request comes back with the claim included.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
