### PR TITLE
Support _hardDelete and hardDelete for all delete operations.

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Models/HardDeleteModel.cs
+++ b/src/Microsoft.Health.Fhir.Api/Models/HardDeleteModel.cs
@@ -1,0 +1,21 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Health.Fhir.Core.Features;
+
+namespace Microsoft.Health.Fhir.Api.Models
+{
+    public class HardDeleteModel
+    {
+        [FromQuery(Name = KnownQueryParameterNames.BulkHardDelete)]
+        public bool? BulkHardDelete { get; set; }
+
+        [FromQuery(Name = KnownQueryParameterNames.HardDelete)]
+        public bool? HardDelete { get; set; }
+
+        public bool IsHardDelete => (BulkHardDelete ?? false) || (HardDelete ?? false);
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/KnownQueryParameterNames.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/KnownQueryParameterNames.cs
@@ -102,7 +102,9 @@ namespace Microsoft.Health.Fhir.Core.Features
         /// </summary>
         public const string Identifier = "identifier";
 
-        public const string HardDelete = "_hardDelete";
+        public const string BulkHardDelete = "_hardDelete";
+
+        public const string HardDelete = "hardDelete";
 
         public const string PurgeHistory = "_purgeHistory";
 

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/BulkDeleteController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/BulkDeleteController.cs
@@ -16,6 +16,7 @@ using Microsoft.Health.Fhir.Api.Features.ActionResults;
 using Microsoft.Health.Fhir.Api.Features.Filters;
 using Microsoft.Health.Fhir.Api.Features.Headers;
 using Microsoft.Health.Fhir.Api.Features.Routing;
+using Microsoft.Health.Fhir.Api.Models;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Features;
 using Microsoft.Health.Fhir.Core.Features.Conformance.Models;
@@ -38,6 +39,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
 
         private readonly HashSet<string> _exlcudedParameters = new(new PropertyEqualityComparer<string>(StringComparison.OrdinalIgnoreCase, s => s))
         {
+            KnownQueryParameterNames.BulkHardDelete,
             KnownQueryParameterNames.HardDelete,
             KnownQueryParameterNames.PurgeHistory,
         };
@@ -54,18 +56,18 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         [Route(KnownRoutes.BulkDelete)]
         [ServiceFilter(typeof(ValidateAsyncRequestFilterAttribute))]
         [AuditEventType(AuditEventSubType.BulkDelete)]
-        public async Task<IActionResult> BulkDelete([FromQuery(Name = KnownQueryParameterNames.HardDelete)] bool hardDelete, [FromQuery(Name = KnownQueryParameterNames.PurgeHistory)] bool purgeHistory)
+        public async Task<IActionResult> BulkDelete(HardDeleteModel hardDeleteModel, [FromQuery(Name = KnownQueryParameterNames.PurgeHistory)] bool purgeHistory)
         {
-            return await SendDeleteRequest(null, hardDelete, purgeHistory, false);
+            return await SendDeleteRequest(null, hardDeleteModel.IsHardDelete, purgeHistory, false);
         }
 
         [HttpDelete]
         [Route(KnownRoutes.BulkDeleteResourceType)]
         [ServiceFilter(typeof(ValidateAsyncRequestFilterAttribute))]
         [AuditEventType(AuditEventSubType.BulkDelete)]
-        public async Task<IActionResult> BulkDeleteByResourceType(string typeParameter, [FromQuery(Name = KnownQueryParameterNames.HardDelete)] bool hardDelete, [FromQuery(Name = KnownQueryParameterNames.PurgeHistory)] bool purgeHistory)
+        public async Task<IActionResult> BulkDeleteByResourceType(string typeParameter, HardDeleteModel hardDeleteModel, [FromQuery(Name = KnownQueryParameterNames.PurgeHistory)] bool purgeHistory)
         {
-            return await SendDeleteRequest(typeParameter, hardDelete, purgeHistory, false);
+            return await SendDeleteRequest(typeParameter, hardDeleteModel.IsHardDelete, purgeHistory, false);
         }
 
         [HttpDelete]

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/FhirController.cs
@@ -395,19 +395,19 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         /// </summary>
         /// <param name="typeParameter">The type.</param>
         /// <param name="idParameter">The identifier.</param>
-        /// <param name="hardDelete">A flag indicating whether to hard-delete the resource or not.</param>
+        /// <param name="hardDeleteModel">The model for hard-delete indicating whether to hard-delete the resource or not.</param>
         /// <param name="allowPartialSuccess">Allows for partial success of delete operation. Only applicable for hard delete on Cosmos services</param>
         [HttpDelete]
         [ValidateIdSegmentAttribute]
         [Route(KnownRoutes.ResourceTypeById)]
         [AuditEventType(AuditEventSubType.Delete)]
         [TypeFilter(typeof(CrudEndpointMetricEmitterAttribute))]
-        public async Task<IActionResult> Delete(string typeParameter, string idParameter, [FromQuery] bool hardDelete, [FromQuery] bool allowPartialSuccess)
+        public async Task<IActionResult> Delete(string typeParameter, string idParameter, HardDeleteModel hardDeleteModel, [FromQuery] bool allowPartialSuccess)
         {
             DeleteResourceResponse response = await _mediator.DeleteResourceAsync(
                 new DeleteResourceRequest(
                     new ResourceKey(typeParameter, idParameter),
-                    hardDelete ? DeleteOperation.HardDelete : DeleteOperation.SoftDelete,
+                    hardDeleteModel.IsHardDelete ? DeleteOperation.HardDelete : DeleteOperation.SoftDelete,
                     GetBundleResourceContext(),
                     allowPartialSuccess),
                 HttpContext.RequestAborted);
@@ -442,12 +442,12 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         /// Deletes the specified resource
         /// </summary>
         /// <param name="typeParameter">The type.</param>
-        /// <param name="hardDelete">A flag indicating whether to hard-delete the resource or not.</param>
+        /// <param name="hardDeleteModel">The model for hard-delete indicating whether to hard-delete the resource or not.</param>
         /// <param name="maxDeleteCount">Specifies the maximum number of resources that can be deleted.</param>
         [HttpDelete]
         [Route(KnownRoutes.ResourceType)]
         [AuditEventType(AuditEventSubType.ConditionalDelete)]
-        public async Task<IActionResult> ConditionalDelete(string typeParameter, [FromQuery] bool hardDelete, [FromQuery(Name = KnownQueryParameterNames.Count)] int? maxDeleteCount)
+        public async Task<IActionResult> ConditionalDelete(string typeParameter, HardDeleteModel hardDeleteModel, [FromQuery(Name = KnownQueryParameterNames.Count)] int? maxDeleteCount)
         {
             IReadOnlyList<Tuple<string, string>> conditionalParameters = GetQueriesForSearch();
 
@@ -457,7 +457,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                 new ConditionalDeleteResourceRequest(
                     typeParameter,
                     conditionalParameters,
-                    hardDelete ? DeleteOperation.HardDelete : DeleteOperation.SoftDelete,
+                    hardDeleteModel.IsHardDelete ? DeleteOperation.HardDelete : DeleteOperation.SoftDelete,
                     maxDeleteCount.GetValueOrDefault(1),
                     GetBundleResourceContext()),
                 HttpContext.RequestAborted);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BulkDeleteTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BulkDeleteTests.cs
@@ -109,8 +109,10 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.Equal(2, history.Resource.Entry.Count);
         }
 
-        [SkippableFact]
-        public async Task GivenHardBulkDeleteRequest_WhenCompleted_ThenHistoricalRecordsDontExist()
+        [SkippableTheory]
+        [InlineData(KnownQueryParameterNames.BulkHardDelete)]
+        [InlineData(KnownQueryParameterNames.HardDelete)]
+        public async Task GivenHardBulkDeleteRequest_WhenCompleted_ThenHistoricalRecordsDontExist(string hardDeleteKey)
         {
             CheckBulkDeleteEnabled();
 
@@ -126,7 +128,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
                 tag,
                 queryParams: new Dictionary<string, string>
                 {
-                    { "_hardDelete", "true" },
+                    { hardDeleteKey, "true" },
                 });
 
             using HttpResponseMessage response = await _httpClient.SendAsync(request);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalDeleteTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalDeleteTests.cs
@@ -59,19 +59,19 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
         }
 
-        [InlineData(true, 1)]
-        [InlineData(true, 100)]
-        [InlineData(false, 1)]
-        [InlineData(false, 100)]
+        [InlineData(KnownQueryParameterNames.BulkHardDelete, true, 1)]
+        [InlineData(KnownQueryParameterNames.HardDelete, true, 100)]
+        [InlineData(KnownQueryParameterNames.HardDelete, false, 1)]
+        [InlineData(KnownQueryParameterNames.BulkHardDelete, false, 100)]
         [Theory]
         [Trait(Traits.Priority, Priority.One)]
-        public async Task GivenOneMatchingResource_WhenDeletingConditionally_TheServerShouldDeleteSuccessfully(bool hardDelete, int deleteCount)
+        public async Task GivenOneMatchingResource_WhenDeletingConditionally_TheServerShouldDeleteSuccessfully(string hardDeleteKey, bool hardDeleteValue, int deleteCount)
         {
             var identifier = Guid.NewGuid().ToString();
             await CreateWithIdentifier(identifier);
             await ValidateResults(identifier, 1);
 
-            FhirResponse response = await _client.DeleteAsync($"{_resourceType}?identifier={identifier}&hardDelete={hardDelete}&_count={deleteCount}", CancellationToken.None);
+            FhirResponse response = await _client.DeleteAsync($"{_resourceType}?identifier={identifier}&{hardDeleteKey}={hardDeleteValue}&_count={deleteCount}", CancellationToken.None);
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
 
             await ValidateResults(identifier, 0);


### PR DESCRIPTION
## Description
Support _hardDelete and hardDelete for all delete operations including conditional-delete, delete, and bulk-delete.

## Related issues
Addresses [issue #121675].

[User Story 121675](https://microsofthealth.visualstudio.com/Health/_workitems/edit/121675): Honor both __harddelete and harddelete parameters the same way

## Testing
Tested with manual testing, adding UTs and E2E tests.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
