### PR TITLE
Add Previous Link

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/KnownHeaders.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/KnownHeaders.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Health.Fhir.Core.Features
         public const string CustomAuditHeaderPrefix = "X-MS-AZUREFHIR-AUDIT-";
         public const string FhirUserHeader = "x-ms-fhiruser";
         public const string QueryLatencyOverEfficiency = "x-ms-query-latency-over-efficiency";
+        public const string AddPreviousLink = "x-ms-add-previous-link";
 
         // #conditionalQueryParallelism - Header used to activate parallel conditional-query processing.
         public const string ConditionalQueryProcessingLogic = "x-conditionalquery-processing-logic";

--- a/src/Microsoft.Health.Fhir.Core/Features/Routing/IUrlResolver.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Routing/IUrlResolver.cs
@@ -46,8 +46,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Routing
         /// <param name="resultSortOrder">The order the results are sorted in</param>
         /// <param name="continuationToken">The continuation token.</param>
         /// <param name="removeTotalParameter">True if the _total parameter should be removed from the url, false otherwise.</param>
+        /// <param name="addPreviousLink">Whether to add the previous link</param>
         /// <returns>The URL.</returns>
-        Uri ResolveRouteUrl(IReadOnlyCollection<Tuple<string, string>> unsupportedSearchParams = null, IReadOnlyList<(SearchParameterInfo searchParameterInfo, SortOrder sortOrder)> resultSortOrder = null, string continuationToken = null, bool removeTotalParameter = false);
+        Uri ResolveRouteUrl(IReadOnlyCollection<Tuple<string, string>> unsupportedSearchParams = null, IReadOnlyList<(SearchParameterInfo searchParameterInfo, SortOrder sortOrder)> resultSortOrder = null, string continuationToken = null, bool removeTotalParameter = false, bool addPreviousLink = true);
+
+        Uri ResolvePreviousRouteUrl();
 
         /// <summary>
         /// Resolves the URL for the specified routeName.

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Operations/Everything/PatientEverythingService.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Everything
         {
             EverythingOperationContinuationToken token = string.IsNullOrEmpty(continuationToken)
                 ? new EverythingOperationContinuationToken()
-                : EverythingOperationContinuationToken.FromJson(ContinuationTokenConverter.Decode(continuationToken));
+                : EverythingOperationContinuationToken.FromJson(ContinuationTokenConverter.Decode(continuationToken.Split("||", 2)[0]));
 
             if (token == null || token.Phase < 0 || token.Phase > 3)
             {

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/BundleFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/BundleFactory.cs
@@ -156,6 +156,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                         result.UnsupportedSearchParameters,
                         result.SortOrder,
                         ContinuationTokenConverter.Encode(result.ContinuationToken),
+                        true,
                         true);
                 }
                 catch (UriFormatException)
@@ -168,6 +169,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             {
                 // Add the self link to indicate which search parameters were used.
                 bundle.SelfLink = _urlResolver.ResolveRouteUrl(result.UnsupportedSearchParameters, result.SortOrder);
+
+                // Add flag check
+                var previous = _urlResolver.ResolvePreviousRouteUrl();
+                if (previous != null)
+                {
+                    bundle.PreviousLink = previous;
+                }
             }
             catch (UriFormatException)
             {

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -133,7 +133,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                             string.Format(Core.Resources.MultipleQueryParametersNotAllowed, KnownQueryParameterNames.ContinuationToken));
                     }
 
-                    continuationToken = ContinuationTokenConverter.Decode(query.Item2);
+                    // check if previous link header is present
+                    var fullContinuationToken = query.Item2;
+
+                    continuationToken = ContinuationTokenConverter.Decode(fullContinuationToken.Split("||", 2)[0]);
                     setDefaultBundleTotal = false;
                 }
                 else if (string.Equals(query.Item1, KnownQueryParameterNames.FeedRange, StringComparison.OrdinalIgnoreCase))

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -133,9 +133,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
                             string.Format(Core.Resources.MultipleQueryParametersNotAllowed, KnownQueryParameterNames.ContinuationToken));
                     }
 
-                    // check if previous link header is present
                     var fullContinuationToken = query.Item2;
-
                     continuationToken = ContinuationTokenConverter.Decode(fullContinuationToken.Split("||", 2)[0]);
                     setDefaultBundleTotal = false;
                 }


### PR DESCRIPTION
## Description
Adds support for previous links in search bundles. This is optional behind a header "x-ms-add-previous-link". This works in both Cosmos and SQL services, but due to Cosmos continuation tokens already being rather long I wouldn't recommend using it with a Cosmos service.

## Related issues
Addresses [issue #].

## Testing
Currently just manual test, will add unit and E2E if team decides to take on the new feature.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
