### PR TITLE
Fixing the content-type validation on POST search.

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Routing/SearchPostReroutingMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Routing/SearchPostReroutingMiddleware.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
                 && request.Method == "POST"
                 && request.Path.Value.EndsWith(KnownRoutes.Search, System.StringComparison.OrdinalIgnoreCase))
             {
-                if (request.ContentType is null || request.ContentType == "application/x-www-form-urlencoded")
+                if (request.ContentType is null || request.HasFormContentType)
                 {
                     if (request.HasFormContentType)
                     {

--- a/src/Microsoft.Health.Fhir.Azure.UnitTests/Api/SearchPostReroutingMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Azure.UnitTests/Api/SearchPostReroutingMiddlewareTests.cs
@@ -1,0 +1,72 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Health.Fhir.Api;
+using Microsoft.Health.Fhir.Api.Features.Routing;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Test.Utilities;
+using NSubstitute;
+using Xunit;
+using ApiResources = Microsoft.Health.Fhir.Api.Resources;
+
+namespace Microsoft.Health.Fhir.Azure.UnitTests.Api
+{
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.Search)]
+    public class SearchPostReroutingMiddlewareTests
+    {
+        private readonly SearchPostReroutingMiddleware _middleware;
+        private readonly HttpContext _httpContext;
+        private readonly RequestDelegate _requestDelegate;
+
+        public SearchPostReroutingMiddlewareTests()
+        {
+            _httpContext = new DefaultHttpContext();
+            _requestDelegate = Substitute.For<RequestDelegate>();
+            _middleware = new SearchPostReroutingMiddleware(_requestDelegate);
+        }
+
+        [Theory]
+        [InlineData(null, true)]
+        [InlineData("application/x-www-form-urlencoded", true)]
+        [InlineData("application/x-www-form-urlencoded;", true)]
+        [InlineData("application/x-www-form-urlencoded;charset=UTF-8", true)]
+        [InlineData("  application/x-www-form-urlencoded   ", true)]
+        [InlineData("text/json", false)]
+        [InlineData("application/x-www-form-urlencodedx", false)]
+        [InlineData("abc", false)]
+        [InlineData("", false)]
+        public async Task GivenSearchRequestViaPost_WhenContentTypeIsSpecified_InvalidContentTypeShouldBeRejected(string contentType, bool valid)
+        {
+            _httpContext.Request.Method = HttpMethods.Post;
+            _httpContext.Request.ContentType = contentType;
+            _httpContext.Request.Scheme = "https";
+            _httpContext.Request.Host = new HostString("localhost", 44348);
+            _httpContext.Request.Path = new PathString("/Patient/_search");
+            _httpContext.Response.Body = new MemoryStream();
+
+            await _middleware.Invoke(_httpContext);
+            if (valid)
+            {
+                await _requestDelegate.Received(1).Invoke(Arg.Any<HttpContext>());
+            }
+            else
+            {
+                await _requestDelegate.DidNotReceive().Invoke(Arg.Any<HttpContext>());
+
+                _httpContext.Response.Body.Position = 0;
+                using var reader = new StreamReader(_httpContext.Response.Body);
+                var body = reader.ReadToEnd();
+                Assert.Equal(ApiResources.ContentTypeFormUrlEncodedExpected, body);
+                Assert.Equal((int)HttpStatusCode.BadRequest, _httpContext.Response.StatusCode);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
Fixing the content-type validation on POST search.

## Related issues
Addresses [issue #130217].

[Feature 130217](https://microsofthealth.visualstudio.com/Health/_workitems/edit/130217): POST operation should consider built-in content type parsers

## Testing
Tested manually by sending various requests.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
