### PR TITLE
Add REST examples for patching security tag

### DIFF
--- a/docs/rest/FhirPatchRequests.http
+++ b/docs/rest/FhirPatchRequests.http
@@ -338,3 +338,64 @@ Authorization: Bearer {{bearer.response.body.access_token}}
         }
     ]
 }
+
+### Add a security tag. This will always add the elements to the end of the array if the array exists or not.
+PATCH https://{{hostname}}/Patient/{{patient.response.body.id}}
+content-type: application/fhir+json
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+{
+  "resourceType": "Parameters",
+  "parameter": [
+    {
+      "name": "operation",
+      "part": [
+        {
+          "name": "type",
+          "valueCode": "add"
+        },
+        {
+          "name": "path",
+          "valueString": "Patient.meta"
+        },
+        {
+          "name": "name",
+          "valueString": "security"
+        },
+        {
+          "name": "value",
+          "valueCoding": {
+            "system": "http://example.org/security-system",
+            "code": "SECURITY_TAG_CODE",
+            "display": "New Security Tag Display"
+          }
+        }
+      ]
+    },
+    {
+      "name": "operation",
+      "part": [
+        {
+          "name": "type",
+          "valueCode": "add"
+        },
+        {
+          "name": "path",
+          "valueString": "Patient.meta"
+        },
+        {
+          "name": "name",
+          "valueString": "security"
+        },
+        {
+          "name": "value",
+          "valueCoding": {
+            "system": "http://example.org/security-system",
+            "code": "NEW_SECURITY_TAG_CODE",
+            "display": "New Security Tag Display"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/docs/rest/JsonPatchRequests.http
+++ b/docs/rest/JsonPatchRequests.http
@@ -186,7 +186,7 @@ Authorization: Bearer {{bearer.response.body.access_token}}
 }
 
 ### Conditional Patch
-PATCH {{fhirurl}}/Patient?identifier=1032704
+PATCH {{hostname}}/Patient?identifier=1032704
 content-type: application/json-patch+json
 Authorization: Bearer {{bearer.response.body.access_token}}
 
@@ -201,4 +201,41 @@ Authorization: Bearer {{bearer.response.body.access_token}}
                 ]
         }
     }
+]
+
+### Add a security tag. Replaces entire array if it exists
+PATCH https://{{hostname}}/Patient/{{patient.response.body.id}}
+content-type: application/json-patch+json
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+[
+  {
+    "op": "add",
+    "path": "/meta/security",
+    "value": [
+      {
+        "system": "http://example.org/security-system",
+        "code": "SECURITY_TAG_CODE",
+        "display": "Security Tag Display"
+      }
+    ]
+  }
+]
+
+### Add a security tag. Array must already exist. 
+# You cannot use JSON patch to add when you don't know if the array exists. Use FHIR Patch in this scenario.
+PATCH https://{{hostname}}/Patient/{{patient.response.body.id}}
+content-type: application/json-patch+json
+Authorization: Bearer {{bearer.response.body.access_token}}
+
+[
+  {
+    "op": "add",
+    "path": "/meta/security/-",
+    "value": {
+      "system": "http://example.org/security-system",
+      "code": "NEW_SECURITY_TAG_CODE",
+      "display": "New Security Tag Display"
+    }
+  }
 ]


### PR DESCRIPTION
## Description
Adds examples created during investigation of patching to security tag

## Related issues
[AB#129850](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/129850)

## Testing
Local rest client

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
