### PR TITLE
Fix Cancel Import Request

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Import/CancelImportRequestHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Import/CancelImportRequestHandlerTests.cs
@@ -74,7 +74,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.BulkImport
         {
             List<JobInfo> jobs = await SetupAndExecuteCancelImportAsync(jobStatus, HttpStatusCode.Accepted);
 
-            await _queueClient.Received(1).CancelJobByGroupIdAsync((byte)Core.Features.Operations.QueueType.Import, jobs[0].Id, _cancellationToken);
+            var groupJobId = jobs[0].GroupId;
+            await _queueClient.Received(1).CancelJobByGroupIdAsync((byte)Core.Features.Operations.QueueType.Import, groupJobId, _cancellationToken);
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Import/CancelImportRequestHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Import/CancelImportRequestHandlerTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.BulkImport
         [InlineData(JobStatus.Cancelled)]
         public async Task GivenAFhirMediator_WhenCancelingExistingBulkImportJobThatHasAlreadyBeenCanceled_ThenAcceptedStatusCodeShouldBeReturned(JobStatus taskStatus)
         {
-            List<JobInfo> jobs = SetupBulkImportJob(taskStatus, true);
+            SetupBulkImportJob(taskStatus, true);
             CancelImportResponse response = await _mediator.CancelImportAsync(JobId, _cancellationToken);
 
             Assert.NotNull(response);

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Import/CancelImportRequestHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Import/CancelImportRequestHandlerTests.cs
@@ -58,13 +58,23 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.BulkImport
 
         [Theory]
         [InlineData(JobStatus.Completed)]
-        [InlineData(JobStatus.Cancelled)]
         [InlineData(JobStatus.Failed)]
         public async Task GivenAFhirMediator_WhenCancelingExistingBulkImportJobThatHasAlreadyCompleted_ThenConflictStatusCodeShouldBeReturned(JobStatus taskStatus)
         {
             OperationFailedException operationFailedException = await Assert.ThrowsAsync<OperationFailedException>(async () => await SetupAndExecuteCancelImportAsync(taskStatus, HttpStatusCode.Conflict));
 
             Assert.Equal(HttpStatusCode.Conflict, operationFailedException.ResponseStatusCode);
+        }
+
+        [Theory]
+        [InlineData(JobStatus.Cancelled)]
+        public async Task GivenAFhirMediator_WhenCancelingExistingBulkImportJobThatHasAlreadyBeenCanceled_ThenAcceptedStatusCodeShouldBeReturned(JobStatus taskStatus)
+        {
+            List<JobInfo> jobs = SetupBulkImportJob(taskStatus, true);
+            CancelImportResponse response = await _mediator.CancelImportAsync(JobId, _cancellationToken);
+
+            Assert.NotNull(response);
+            Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
         }
 
         [Theory]

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/CancelImportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/CancelImportRequestHandler.cs
@@ -53,25 +53,27 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
                 throw new ResourceNotFoundException(string.Format(Core.Resources.ImportJobNotFound, request.JobId));
             }
 
-            var conflict = false;
+            var anyFailed = false;
             var allComplete = true;
 
             // Check each job status
             foreach (var job in jobs)
             {
-                if (job.Status == JobStatus.Failed || job.Status == JobStatus.Cancelled)
+                if (job.Status == JobStatus.Failed)
                 {
-                    conflict = true;
+                    anyFailed = true;
+                    break;
                 }
 
                 if (job.Status != JobStatus.Completed)
                 {
                     allComplete = false;
+                    break;
                 }
             }
 
-            // If the job is already completed, failed or cancelled, return conflict status.
-            if (conflict || allComplete)
+            // If the job is already completed or failed, return conflict status.
+            if (anyFailed || allComplete)
             {
                 throw new OperationFailedException(Core.Resources.ImportOperationCompleted, HttpStatusCode.Conflict);
             }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/CancelImportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/CancelImportRequestHandler.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
             // We need to check the status of all jobs
             IReadOnlyList<JobInfo> jobs = await _queueClient.GetJobByGroupIdAsync(QueueType.Import, request.JobId, false, cancellationToken);
 
-            if (jobs == null || jobs.Count == 0)
+            if (jobs.Count == 0)
             {
                 throw new ResourceNotFoundException(string.Format(Core.Resources.ImportJobNotFound, request.JobId));
             }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/CancelImportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/CancelImportRequestHandler.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
                 throw new UnauthorizedFhirActionException();
             }
 
-            // We need to check all Jobs status
+            // We need to check the status of all jobs
             IReadOnlyList<JobInfo> jobs = await _queueClient.GetJobByGroupIdAsync(QueueType.Import, request.JobId, false, cancellationToken);
 
             if (jobs == null || jobs.Count == 0)

--- a/src/Microsoft.Health.Fhir.Core/Messages/BulkImport/CancelImportRequest.cs
+++ b/src/Microsoft.Health.Fhir.Core/Messages/BulkImport/CancelImportRequest.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Health.Fhir.Core.Messages.Import
         }
 
         /// <summary>
-        /// Import orchestrator job id
+        /// Import orchestrator/coordinator job id this is also known as Group Id
         /// </summary>
         public long JobId { get; }
     }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTests.cs
@@ -1494,12 +1494,12 @@ EXECUTE dbo.MergeResourcesCommitTransaction @TransactionId
             };
 
             Uri checkLocation = await ImportTestHelper.CreateImportTaskAsync(_client, request);
-            var respone = await _client.CancelImport(checkLocation);
+            var response = await _client.CancelImport(checkLocation);
 
-            // wait task completed
-            while (respone.StatusCode != HttpStatusCode.Conflict)
+            // This test makes sure that if the jobs already completed, it will return Conflict but it never cancelled the task
+            while (response.StatusCode != HttpStatusCode.Conflict)
             {
-                respone = await _client.CancelImport(checkLocation);
+                response = await _client.CancelImport(checkLocation);
                 await Task.Delay(TimeSpan.FromSeconds(0.30));
             }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTests.cs
@@ -1551,7 +1551,7 @@ EXECUTE dbo.MergeResourcesCommitTransaction @TransactionId
                 }
 
                 importStatus = await _client.CheckImportAsync(checkLocation);
-                await Task.Delay(TimeSpan.FromSeconds(0.5));
+                await Task.Delay(TimeSpan.FromSeconds(5));
             }
 
             // Then we cancel import job


### PR DESCRIPTION
## Description
Currently, the Orchestrator job completes before the processing jobs are completed, it will incorrectly not allow cancel of an import because it thinks the job is done. This is incorrect as the Orchestrator is done but not the child Processing Jobs,.

This PR is fixing this issue, now we check all jobs to check the status of all jobs.

## Related issues
Addresses [issue #124093](https://microsofthealth.visualstudio.com/Health/_workitems/edit/124093/)

## Testing
Added a test to make sure it first returns Accepted status to cancel request, which means the import job has been cancelled, and then make sure we received Conflict status if we have already cancelled the job.

The existing test was making sure that the cancel operation works if all jobs have already completed (with just one patient) it was happening.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
