### PR TITLE
Update load of search param status on initialization

### DIFF
--- a/build/jobs/analyze.yml
+++ b/build/jobs/analyze.yml
@@ -89,12 +89,14 @@ steps:
       Path: '$(Build.SourcesDirectory)'
       ToolVersion: Latest
 
-- task: Trivy@1
-  displayName: 'Run Trivy'
-  inputs:
-    Target: '$(Build.SourcesDirectory)/build/docker'
-    Severities: all
-    VulTypes: all
+## Currently removed due to too many requests issue: https://github.com/aquasecurity/trivy-action/issues/430
+## User story to address restoring this: 132160
+#- task: Trivy@1
+#  displayName: 'Run Trivy'
+#  inputs:
+#    Target: '$(Build.SourcesDirectory)/build/docker'
+#    Severities: all
+#    VulTypes: all
 
 - task: PSScriptAnalyzer@1
   displayName: 'Run PSScriptAnalyzer'

--- a/build/jobs/docker-build-push.yml
+++ b/build/jobs/docker-build-push.yml
@@ -15,8 +15,6 @@ jobs:
     name: '$(DefaultLinuxPool)'
     vmImage: '$(LinuxVmImage)'
   steps:
-  - task:  - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
   - task: AzureCLI@2
     displayName: 'Build FHIR ${{parameters.version}} Server Image'
     inputs:

--- a/build/jobs/docker-build-push.yml
+++ b/build/jobs/docker-build-push.yml
@@ -15,17 +15,22 @@ jobs:
     name: '$(DefaultLinuxPool)'
     vmImage: '$(LinuxVmImage)'
   steps:
-    - task: Docker@2
-      displayName: 'Build FHIR ${{parameters.version}} Server Image'
-      inputs:
-        containerRegistry: $(azureContainerRegistryName)
-        repository: '${{parameters.version}}_fhir-server'
-        command: 'buildAndPush'
-        Dockerfile: './build/docker/Dockerfile'
-        tags: |
-          ${{parameters.tag}}
-        buildContext: .
-        arguments: |
-          --platform ${{parameters.buildPlatform}} \
-          --build-arg FHIR_VERSION=${{parameters.version}} \
-          --build-arg ASSEMBLY_VER=$(assemblySemFileVer)
+  - task:  - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+  - task: AzureCLI@2
+    displayName: 'Build FHIR ${{parameters.version}} Server Image'
+    inputs:
+      azureSubscription: $(azureSubscriptionEndpoint)
+      scriptType: 'bash'
+      scriptLocation: 'inlineScript'
+      inlineScript: |
+        docker pull mirror.gcr.io/moby/buildkit:buildx-stable-1
+        TAG="$(azureContainerRegistry)/${{parameters.version}}_fhir-server:${{parameters.tag}}"
+        az acr login --name $(azureContainerRegistryName)
+        docker buildx create --name fhir-multi-platform --platform ${{parameters.buildPlatform}} --use --bootstrap
+        docker buildx build --tag ${TAG,,} \
+                      --file ./build/docker/Dockerfile \
+                      --platform ${{parameters.buildPlatform}} \
+                      --build-arg FHIR_VERSION=${{parameters.version}} \
+                      --build-arg ASSEMBLY_VER=$(assemblySemFileVer) \
+                      --push .

--- a/build/jobs/docker-build-push.yml
+++ b/build/jobs/docker-build-push.yml
@@ -24,6 +24,7 @@ jobs:
       inlineScript: |
         TAG="$(azureContainerRegistry)/${{parameters.version}}_fhir-server:${{parameters.tag}}"
         az acr login --name $(azureContainerRegistryName)
+        docker pull mcr.microsoft.com/moby/buildkit:latest
         docker buildx create --name fhir-multi-platform --platform ${{parameters.buildPlatform}} --use --bootstrap
         docker buildx build --tag ${TAG,,} \
                       --file ./build/docker/Dockerfile \

--- a/build/jobs/docker-build-push.yml
+++ b/build/jobs/docker-build-push.yml
@@ -15,20 +15,17 @@ jobs:
     name: '$(DefaultLinuxPool)'
     vmImage: '$(LinuxVmImage)'
   steps:
-  - task: AzureCLI@2
-    displayName: 'Build FHIR ${{parameters.version}} Server Image'
-    inputs:
-      azureSubscription: $(azureSubscriptionEndpoint)
-      scriptType: 'bash'
-      scriptLocation: 'inlineScript'
-      inlineScript: |
-        TAG="$(azureContainerRegistry)/${{parameters.version}}_fhir-server:${{parameters.tag}}"
-        az acr login --name $(azureContainerRegistryName)
-        docker pull mcr.microsoft.com/moby/buildkit:latest
-        docker buildx create --name fhir-multi-platform --platform ${{parameters.buildPlatform}} --use --bootstrap
-        docker buildx build --tag ${TAG,,} \
-                      --file ./build/docker/Dockerfile \
-                      --platform ${{parameters.buildPlatform}} \
-                      --build-arg FHIR_VERSION=${{parameters.version}} \
-                      --build-arg ASSEMBLY_VER=$(assemblySemFileVer) \
-                      --push .
+    - task: Docker@2
+      displayName: 'Build FHIR ${{parameters.version}} Server Image'
+      inputs:
+        containerRegistry: $(azureContainerRegistryName)
+        repository: '${{parameters.version}}_fhir-server'
+        command: 'buildAndPush'
+        Dockerfile: './build/docker/Dockerfile'
+        tags: |
+          ${{parameters.tag}}
+        buildContext: .
+        arguments: |
+          --platform ${{parameters.buildPlatform}} \
+          --build-arg FHIR_VERSION=${{parameters.version}} \
+          --build-arg ASSEMBLY_VER=$(assemblySemFileVer)

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/Registry/SearchParameterStatusManagerTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Search/Registry/SearchParameterStatusManagerTests.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Registry
         private static readonly string ResourceProfile = "http://hl7.org/fhir/SearchParameter/Resource-profile";
         private static readonly string ResourceSecurity = "http://hl7.org/fhir/SearchParameter/Resource-security";
         private static readonly string ResourceQuery = "http://hl7.org/fhir/SearchParameter/Resource-query";
+        private static readonly string ResourceSource = "http://hl7.org/fhir/SearchParameter/Resource-source";
 
         private readonly SearchParameterStatusManager _manager;
         private readonly ISearchParameterStatusDataStore _searchParameterStatusDataStore;
@@ -85,6 +86,12 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Registry
                         Uri = new Uri(ResourceSecurity),
                         LastUpdated = Clock.UtcNow,
                     },
+                    new ResourceSearchParameterStatus
+                    {
+                        Status = SearchParameterStatus.Disabled,
+                        Uri = new Uri(ResourceSource),
+                        LastUpdated = Clock.UtcNow,
+                    },
                 };
 
             _searchParameterStatusDataStore.GetSearchParameterStatuses(Arg.Any<CancellationToken>()).Returns(_resourceSearchParameterStatuses);
@@ -99,6 +106,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Registry
                 new SearchParameterInfo("_profile", "_profile", SearchParamType.Token, new Uri(ResourceProfile), targetResourceTypes: targetResourceTypes),
                 new SearchParameterInfo("_security", "_security", SearchParamType.Token, new Uri(ResourceSecurity), targetResourceTypes: targetResourceTypes),
                 _queryParameter,
+                new SearchParameterInfo("_source", "_source", SearchParamType.Uri, new Uri(ResourceSource), targetResourceTypes: targetResourceTypes),
             };
 
             _searchParameterDefinitionManager.GetSearchParameters("Account")
@@ -116,6 +124,10 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Registry
 
             _searchParameterSupportResolver
                 .IsSearchParameterSupported(Arg.Is(_searchParameterInfos[4]))
+                .Returns((true, false));
+
+            _searchParameterSupportResolver
+                .IsSearchParameterSupported(Arg.Is(_searchParameterInfos[5]))
                 .Returns((true, false));
         }
 
@@ -145,6 +157,11 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Registry
             Assert.False(list[4].IsSearchable);
             Assert.True(list[4].IsSupported);
             Assert.False(list[4].IsPartiallySupported);
+
+            Assert.False(list[5].IsSearchable);
+            Assert.False(list[5].IsSupported);  // Disabled Search Params show as unsupported
+            Assert.False(list[5].IsPartiallySupported);
+            Assert.Equal(SearchParameterStatus.Disabled, list[5].SearchParameterStatus);
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
@@ -81,12 +81,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
                     if (p.IsSearchable != tempStatus.IsSearchable ||
                         p.IsSupported != tempStatus.IsSupported ||
                         p.IsPartiallySupported != tempStatus.IsPartiallySupported ||
-                        p.SortStatus != result.SortStatus)
+                        p.SortStatus != result.SortStatus ||
+                        p.SearchParameterStatus != result.Status)
                     {
                         p.IsSearchable = tempStatus.IsSearchable;
                         p.IsSupported = tempStatus.IsSupported;
                         p.IsPartiallySupported = tempStatus.IsPartiallySupported;
                         p.SortStatus = result.SortStatus;
+                        p.SearchParameterStatus = result.Status;
 
                         updated.Add(p);
                     }

--- a/src/Microsoft.Health.Fhir.Core/Features/Security/DataActions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Security/DataActions.cs
@@ -30,6 +30,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Security
         Smart = 1 << 30, // Do not include Smart in the '*' case.  We only want smart for a user if explicitly added to the role or user
 
         [EnumMember(Value = "*")]
-        All = (Import << 1) - 1,
+        All = (SearchParameter << 1) - 1,
     }
 }


### PR DESCRIPTION
## Description
Sets the SearchParameterStatus property correctly upon initialization.  Also updates the DataActions to allow globalAdmin to run search parameter status changes.

## Related issues
Addresses [issue [AB#131939](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/131939)].

## Testing
Automated tests were rerun, manual testing done

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
