### PR TITLE
HTTP method validation for the transaction bundle request.

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
@@ -340,6 +340,15 @@ namespace Microsoft.Health.Fhir.Api {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Requested operation &apos;{0}&apos; is invalid using the request method {1}..
+        /// </summary>
+        public static string InvalidBundleEntryRequest {
+            get {
+                return ResourceManager.GetString("InvalidBundleEntryRequest", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Bundle.entry.request.url is required..
         /// </summary>
         public static string InvalidBundleEntryRequestUrl {

--- a/src/Microsoft.Health.Fhir.Api/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Api/Resources.resx
@@ -426,4 +426,7 @@
   <data name="MissingInputParams" xml:space="preserve">
     <value>inputParams not found, request body must be a valid Parameters resource.</value>
   </data>
+  <data name="InvalidBundleEntryRequest" xml:space="preserve">
+    <value>Requested operation '{0}' is invalid using the request method {1}.</value>
+  </data>
 </root>

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerTests.cs
@@ -276,6 +276,33 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
         }
 
         [Fact]
+        public async Task GivenATransactionBundleRequestWithNullRequestMethod_WhenProcessing_ReturnsABadRequest()
+        {
+            var bundle = new Hl7.Fhir.Model.Bundle
+            {
+                Type = BundleType.Transaction,
+                Entry = new List<EntryComponent>
+                {
+                    new EntryComponent
+                    {
+                        Request = new RequestComponent
+                        {
+                            Method = null,
+                            Url = "/Patient",
+                        },
+                        Resource = new Basic { Id = "test"},
+                    },
+                },
+            };
+
+            _router.When(r => r.RouteAsync(Arg.Any<RouteContext>()))
+                .Do(RouteAsyncFunction);
+
+            var bundleRequest = new BundleRequest(bundle.ToResourceElement());
+            await Assert.ThrowsAsync<RequestNotValidException>(async () => await _bundleHandler.Handle(bundleRequest, default));
+        }
+
+        [Fact]
         public async Task GivenABundle_WhenProcessed_CertainResponseHeadersArePropagatedToOuterResponse()
         {
             var bundle = new Hl7.Fhir.Model.Bundle

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/TransactionBundleValidator.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/TransactionBundleValidator.cs
@@ -124,6 +124,12 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
         private static bool ShouldValidateBundleEntry(EntryComponent entry)
         {
             string requestUrl = entry.Request?.Url;
+            var requestVerb = entry.Request?.MethodElement?.ObjectValue as string;
+            if (string.IsNullOrWhiteSpace(requestVerb) || !Enum.IsDefined(typeof(HTTPVerb), requestVerb))
+            {
+                throw new RequestNotValidException(string.Format(Api.Resources.InvalidBundleEntryRequest, entry.Request.Url, requestVerb));
+            }
+
             HTTPVerb? requestMethod = entry.Request?.Method;
 
             if (string.IsNullOrWhiteSpace(requestUrl))


### PR DESCRIPTION
## Description

- Added validation to ensure the HTTP method in the Request component of the transaction bundle is a valid HTTPVerb enum value.

- If the HTTP method is invalid or null, a RequestNotValidException is thrown with a 400 Bad Request status and an error message.

## Related issues
Addresses [issue #AB 130262](https://microsofthealth.visualstudio.com/Health/_workitems/edit/130262).

## Testing
We checked the upload of the transaction bundle to the FHIR server, using the invalid request method type 'PUT''.
Result - Operation failed, and status code of 400 Bad Request is returned with error message.

We tested other HTTP operations, including the bundle containing the 'PUT'', 'GET'', 'POST'', and 'DELETE'' request methods. In all scenarios, it returned a 400 Bad Request with error message.
## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
