### PR TITLE
Remove strict header requirement for export type validation

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
@@ -201,12 +201,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
         private void ValidateTypeFilters(IList<ExportJobFilter> filters)
         {
-            if (!_contextAccessor.GetIsStrictHandlingEnabled())
-            {
-                _logger.LogInformation("Validation skipped due to strict handling disabled.");
-                return;
-            }
-
             if (filters == null || filters.Count == 0)
             {
                 _logger.LogInformation("No type filters to validate.");

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Export/CreateExportRequestHandlerTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Export/CreateExportRequestHandlerTests.cs
@@ -206,7 +206,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Export
                                 }
                             },
                         },
-                        SearchParameterHandling.Lenient.ToString(),
                     },
                     new object[]
                     {
@@ -226,7 +225,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Export
                         new Dictionary<string, ISet<string>>
                         {
                         },
-                        string.Empty,
                     },
                     new object[]
                     {
@@ -271,7 +269,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Export
                                 }
                             },
                         },
-                        string.Empty,
                     },
                     new object[]
                     {
@@ -291,7 +288,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Export
                         new Dictionary<string, ISet<string>>
                         {
                         },
-                        SearchParameterHandling.Lenient.ToString(),
                     },
                 };
             }
@@ -460,10 +456,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Export
         [MemberData(nameof(ValidateTypeFilters))]
         public async Task GivenARequestWithFilters_WhenInvalidParameterFoundWithStrictHandlingEnabled_ThenABadRequestIsReturned(
             IDictionary<string, IList<KeyValuePair<string, string>>> filters,
-            IDictionary<string, ISet<string>> invalidParameters,
-#pragma warning disable xUnit1026 // Theory methods should use all of their parameters
-            string searchParameterHandling)
-#pragma warning restore xUnit1026 // Theory methods should use all of their parameters
+            IDictionary<string, ISet<string>> invalidParameters)
         {
             ExportJobRecord actualRecord = null;
             await _fhirOperationDataStore.CreateExportJobAsync(
@@ -472,14 +465,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Export
                     actualRecord = record;
                 }),
                 Arg.Any<CancellationToken>());
-
-            var fhirRequestContext = Substitute.For<IFhirRequestContext>();
-            fhirRequestContext.RequestHeaders.Returns(
-                new Dictionary<string, StringValues>
-                {
-                    { KnownHeaders.Prefer, new StringValues($"handling={SearchParameterHandling.Strict}") },
-                });
-            _requestContextAccessor.RequestContext.Returns(fhirRequestContext);
 
             var filterString = new StringBuilder();
             foreach (var kv in filters)
@@ -545,8 +530,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Export
         [MemberData(nameof(ValidateTypeFilters))]
         public async Task GivenARequestWithFilters_WhenInvalidParameterFoundWithStrictHandlingDisabled_ThenValidateTypeFiltersShouldBeSkipped(
             IDictionary<string, IList<KeyValuePair<string, string>>> filters,
-            IDictionary<string, ISet<string>> invalidParameters,
-            string searchParameterHandling)
+            IDictionary<string, ISet<string>> invalidParameters)
         {
             ExportJobRecord actualRecord = null;
             await _fhirOperationDataStore.CreateExportJobAsync(
@@ -557,10 +541,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Export
                 Arg.Any<CancellationToken>());
 
             var requestContextHeaders = new Dictionary<string, StringValues>();
-            if (!string.IsNullOrEmpty(searchParameterHandling))
-            {
-                requestContextHeaders.Add(KnownHeaders.Prefer, new StringValues($"handling={searchParameterHandling}"));
-            }
 
             var fhirRequestContext = Substitute.For<IFhirRequestContext>();
             fhirRequestContext.RequestHeaders.Returns(requestContextHeaders);


### PR DESCRIPTION
## Description
This pull request involves the removal of the strict handling logic from the `CreateExportRequestHandler` class and its associated tests. The main changes include eliminating the strict handling checks and updating the tests accordingly.

### Removal of strict handling logic:

* [`src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs`](diffhunk://#diff-d19973fc05869b86199e132a6f7cd68ac81aec7907bbebe8d4e84f8590b63cebL204-L209): Removed the strict handling validation check in the `ValidateTypeFilters` method.

### Updates to tests:

* `test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Export/CreateExportRequestHandlerTests.cs`: 
  - Removed the `SearchParameterHandling` parameter from the `ValidateTypeFilters` test data. [[1]](diffhunk://#diff-d9cfbec15c91f11a011482e2841b95b5df49c647602234db54b353c39084eaedL209) [[2]](diffhunk://#diff-d9cfbec15c91f11a011482e2841b95b5df49c647602234db54b353c39084eaedL229) [[3]](diffhunk://#diff-d9cfbec15c91f11a011482e2841b95b5df49c647602234db54b353c39084eaedL274) [[4]](diffhunk://#diff-d9cfbec15c91f11a011482e2841b95b5df49c647602234db54b353c39084eaedL294)
  - Updated the `GivenARequestWithFilters_WhenInvalidParameterFoundWithStrictHandlingEnabled_ThenABadRequestIsReturned` test method to remove the `searchParameterHandling` parameter and the related context setup. [[1]](diffhunk://#diff-d9cfbec15c91f11a011482e2841b95b5df49c647602234db54b353c39084eaedL463-R459) [[2]](diffhunk://#diff-d9cfbec15c91f11a011482e2841b95b5df49c647602234db54b353c39084eaedL476-L483)
  - Updated the `GivenARequestWithFilters_WhenInvalidParameterFoundWithStrictHandlingDisabled_ThenValidateTypeFiltersShouldBeSkipped` test method to remove the `searchParameterHandling` parameter and the related context setup. [[1]](diffhunk://#diff-d9cfbec15c91f11a011482e2841b95b5df49c647602234db54b353c39084eaedL548-R533) [[2]](diffhunk://#diff-d9cfbec15c91f11a011482e2841b95b5df49c647602234db54b353c39084eaedL560-L563)

## Related issues
Addresses AB#130227.

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
