### PR TITLE
Flips behavior, validate by default, opt out with Lenient

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Extensions/PreferHeaderExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Extensions/PreferHeaderExtensions.cs
@@ -21,7 +21,12 @@ namespace Microsoft.Health.Fhir.Core.Extensions
         {
             EnsureArg.IsNotNull(contextAccessor, nameof(contextAccessor));
 
-            bool isStrictHandlingEnabled = false;
+            return GetHandlingHeader(contextAccessor) == SearchParameterHandling.Strict;
+        }
+
+        internal static SearchParameterHandling? GetHandlingHeader(this RequestContextAccessor<IFhirRequestContext> contextAccessor)
+        {
+            EnsureArg.IsNotNull(contextAccessor, nameof(contextAccessor));
 
             if (contextAccessor.RequestContext?.RequestHeaders != null &&
                 contextAccessor.RequestContext.RequestHeaders.TryGetValue(KnownHeaders.Prefer, out StringValues values))
@@ -40,14 +45,11 @@ namespace Microsoft.Health.Fhir.Core.Extensions
                             string.Join(",", Enum.GetNames<SearchParameterHandling>())));
                     }
 
-                    if (handling == SearchParameterHandling.Strict)
-                    {
-                        isStrictHandlingEnabled = true;
-                    }
+                    return handling;
                 }
             }
 
-            return isStrictHandlingEnabled;
+            return null;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs
@@ -201,9 +201,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
         private void ValidateTypeFilters(IList<ExportJobFilter> filters)
         {
-            if (!_contextAccessor.GetIsStrictHandlingEnabled())
+            if (_contextAccessor.GetHandlingHeader() == SearchParameterHandling.Lenient)
             {
-                _logger.LogInformation("Validation skipped due to strict handling disabled.");
+                _logger.LogInformation("Validation skipped due to opting for Lenient error handling.");
                 return;
             }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Export/CreateExportRequestHandlerTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Export/CreateExportRequestHandlerTests.cs
@@ -271,7 +271,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Export
                                 }
                             },
                         },
-                        string.Empty,
+                        SearchParameterHandling.Lenient.ToString(),
                     },
                     new object[]
                     {
@@ -458,7 +458,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Export
 
         [Theory]
         [MemberData(nameof(ValidateTypeFilters))]
-        public async Task GivenARequestWithFilters_WhenInvalidParameterFoundWithStrictHandlingEnabled_ThenABadRequestIsReturned(
+        public async Task GivenARequestWithFilters_WhenInvalidParameterFound_ThenABadRequestIsReturned(
             IDictionary<string, IList<KeyValuePair<string, string>>> filters,
             IDictionary<string, ISet<string>> invalidParameters,
 #pragma warning disable xUnit1026 // Theory methods should use all of their parameters
@@ -472,14 +472,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Export
                     actualRecord = record;
                 }),
                 Arg.Any<CancellationToken>());
-
-            var fhirRequestContext = Substitute.For<IFhirRequestContext>();
-            fhirRequestContext.RequestHeaders.Returns(
-                new Dictionary<string, StringValues>
-                {
-                    { KnownHeaders.Prefer, new StringValues($"handling={SearchParameterHandling.Strict}") },
-                });
-            _requestContextAccessor.RequestContext.Returns(fhirRequestContext);
 
             var filterString = new StringBuilder();
             foreach (var kv in filters)
@@ -543,7 +535,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Export
 
         [Theory]
         [MemberData(nameof(ValidateTypeFilters))]
-        public async Task GivenARequestWithFilters_WhenInvalidParameterFoundWithStrictHandlingDisabled_ThenValidateTypeFiltersShouldBeSkipped(
+        public async Task GivenARequestWithFilters_WhenInvalidParameterFoundWithLenientHandlingSpecified_ThenValidateTypeFiltersShouldBeSkipped(
             IDictionary<string, IList<KeyValuePair<string, string>>> filters,
             IDictionary<string, ISet<string>> invalidParameters,
             string searchParameterHandling)


### PR DESCRIPTION
## Description
Take 2 on #4718. This allows the client to specify "Lenient" to opt out of validation...

This pull request includes several changes to improve the handling of search parameter validation in the FHIR server, particularly focusing on the differentiation between strict and lenient handling modes.

### Enhancements to Handling Modes:

* [`src/Microsoft.Health.Fhir.Core/Extensions/PreferHeaderExtensions.cs`](diffhunk://#diff-df21006c7fcac39ebc623d3927c1e762eda6b8054f6551fd33ba4d86f452918bL24-R29): Refactored the `GetIsStrictHandlingEnabled` method to return a boolean directly based on the `GetHandlingHeader` method, which now checks for `SearchParameterHandling.Strict`. [[1]](diffhunk://#diff-df21006c7fcac39ebc623d3927c1e762eda6b8054f6551fd33ba4d86f452918bL24-R29) [[2]](diffhunk://#diff-df21006c7fcac39ebc623d3927c1e762eda6b8054f6551fd33ba4d86f452918bL43-R52)
* [`src/Microsoft.Health.Fhir.Core/Features/Operations/Export/CreateExportRequestHandler.cs`](diffhunk://#diff-d19973fc05869b86199e132a6f7cd68ac81aec7907bbebe8d4e84f8590b63cebL204-R206): Updated the `ValidateTypeFilters` method to log and skip validation when `SearchParameterHandling.Lenient` is specified.

### Test Adjustments:

* [`test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Export/CreateExportRequestHandlerTests.cs`](diffhunk://#diff-d9cfbec15c91f11a011482e2841b95b5df49c647602234db54b353c39084eaedL274-R274): Modified test cases to reflect the changes in handling modes, including renaming test methods to specify lenient handling and removing hardcoded strict handling headers. [[1]](diffhunk://#diff-d9cfbec15c91f11a011482e2841b95b5df49c647602234db54b353c39084eaedL274-R274) [[2]](diffhunk://#diff-d9cfbec15c91f11a011482e2841b95b5df49c647602234db54b353c39084eaedL461-R461) [[3]](diffhunk://#diff-d9cfbec15c91f11a011482e2841b95b5df49c647602234db54b353c39084eaedL476-L483) [[4]](diffhunk://#diff-d9cfbec15c91f11a011482e2841b95b5df49c647602234db54b353c39084eaedL546-R538)

## Related issues
Addresses [AB#130227](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/130227)

## Testing
Unit tests.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
