### PR TITLE
Use mirrored buildx for PRs Only

### DIFF
--- a/build/build-image.yml
+++ b/build/build-image.yml
@@ -32,3 +32,4 @@ stages:
     parameters: 
       tag: $(build.BuildNumber)
       buildPlatform: $(publicDockerImagePlatforms)
+      multiplePlatforms: true

--- a/build/ci-deploy.yml
+++ b/build/ci-deploy.yml
@@ -33,6 +33,7 @@ stages:
     parameters: 
       tag: $(ImageTag)
       buildPlatform: $(publicDockerImagePlatforms)
+      multiplePlatforms: true
 
 - stage: provisionEnvironment
   displayName: Provision Environment

--- a/build/ci-pipeline.yml
+++ b/build/ci-pipeline.yml
@@ -131,6 +131,7 @@ stages:
     parameters: 
       tag: $(ImageTag)
       buildPlatform: $(publicDockerImagePlatforms)
+      multiplePlatforms: true
 
 # *********************** Stu3 ***********************
 - stage: redeployStu3

--- a/build/jobs/docker-build-all.yml
+++ b/build/jobs/docker-build-all.yml
@@ -15,21 +15,25 @@ jobs:
     version: "R4"
     tag: ${{parameters.tag}}
     buildPlatform: ${{parameters.buildPlatform}}
+    multiplePlatforms: ${{parameters.multiplePlatforms}}
 
 - template: docker-build-push.yml
   parameters: 
     version: "R4B"
     tag: ${{parameters.tag}}
     buildPlatform: ${{parameters.buildPlatform}}
+    multiplePlatforms: ${{parameters.multiplePlatforms}}
 
 - template: docker-build-push.yml
   parameters: 
     version: "Stu3"
     tag: ${{parameters.tag}}
     buildPlatform: ${{parameters.buildPlatform}}
+    multiplePlatforms: ${{parameters.multiplePlatforms}}
 
 - template: docker-build-push.yml
   parameters: 
     version: "R5"
     tag: ${{parameters.tag}}
     buildPlatform: ${{parameters.buildPlatform}}
+    multiplePlatforms: ${{parameters.multiplePlatforms}}

--- a/build/jobs/docker-build-all.yml
+++ b/build/jobs/docker-build-all.yml
@@ -6,6 +6,8 @@ parameters:
   type: string
 - name: buildPlatform
   type: string
+- name: multiplePlatforms
+  type: boolean
 
 jobs:
 - template: docker-build-push.yml

--- a/build/jobs/docker-build-push.yml
+++ b/build/jobs/docker-build-push.yml
@@ -22,26 +22,6 @@ jobs:
       scriptType: 'bash'
       scriptLocation: 'inlineScript'
       inlineScript: |
-        # Temp install docker
-        apt-get -qq update
-        apt-get -qq install ca-certificates curl gnupg
-
-        install -m 0755 -d /etc/apt/keyrings
-        curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --yes --dearmor -o /etc/apt/keyrings/docker.gpg
-        chmod a+r /etc/apt/keyrings/docker.gpg
-
-        # Add the repository to apt sources:
-        echo "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-          "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
-          sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-
-        # Install the latest version
-        apt-get -qq update
-        apt-get -qq install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-
-        # Verify docker has been installed
-        docker --version
-
         TAG="$(azureContainerRegistry)/${{parameters.version}}_fhir-server:${{parameters.tag}}"
         az acr login --name $(azureContainerRegistryName)
         docker buildx create --name fhir-multi-platform --platform ${{parameters.buildPlatform}} --use --bootstrap

--- a/build/jobs/docker-build-push.yml
+++ b/build/jobs/docker-build-push.yml
@@ -8,6 +8,8 @@ parameters:
   type: string
 - name: buildPlatform
   type: string
+- name: multiplePlatforms
+  type: boolean
 
 jobs:
 - job: '${{parameters.version}}_Docker'
@@ -22,6 +24,13 @@ jobs:
       scriptType: 'bash'
       scriptLocation: 'inlineScript'
       inlineScript: |
+        if [ "${{ parameters.multiplePlatforms }}" = "true" ]; then
+          echo "Running multi-platform build. Will pull buildx from dockerhub."
+        else
+          echo "Running single-platform build, pulling buildx from mirror to avoid throttling."
+          docker pull mirror.gcr.io/moby/buildkit:buildx-stable-1
+        fi
+
         TAG="$(azureContainerRegistry)/${{parameters.version}}_fhir-server:${{parameters.tag}}"
         az acr login --name $(azureContainerRegistryName)
         docker buildx create --name fhir-multi-platform --platform ${{parameters.buildPlatform}} --use --bootstrap

--- a/build/jobs/docker-build-push.yml
+++ b/build/jobs/docker-build-push.yml
@@ -22,7 +22,26 @@ jobs:
       scriptType: 'bash'
       scriptLocation: 'inlineScript'
       inlineScript: |
-        docker pull mirror.gcr.io/moby/buildkit:buildx-stable-1
+        # Temp install docker
+        apt-get -qq update
+        apt-get -qq install ca-certificates curl gnupg
+
+        install -m 0755 -d /etc/apt/keyrings
+        curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --yes --dearmor -o /etc/apt/keyrings/docker.gpg
+        chmod a+r /etc/apt/keyrings/docker.gpg
+
+        # Add the repository to apt sources:
+        echo "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+          "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+          sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+        # Install the latest version
+        apt-get -qq update
+        apt-get -qq install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+        # Verify docker has been installed
+        docker --version
+
         TAG="$(azureContainerRegistry)/${{parameters.version}}_fhir-server:${{parameters.tag}}"
         az acr login --name $(azureContainerRegistryName)
         docker buildx create --name fhir-multi-platform --platform ${{parameters.buildPlatform}} --use --bootstrap

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -103,6 +103,7 @@ stages:
     parameters: 
       tag: $(ImageTag)
       buildPlatform: $(testDockerImagePlatforms)
+      multiplePlatforms: false
 
 - stage: provisionEnvironment
   displayName: Provision Environment


### PR DESCRIPTION
## Description
The mirrored buildx is producing invalid multi-platform images. This isn't causing issues with PRs which build for a single platform. Changing logic to only use mirror for PRs.

## Related issues
[AB#135348](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/135348)

## Testing
Running commands locally.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
