### PR TITLE
Add count limits for include

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -961,30 +961,13 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
         private void HandleTableKindIncludeLimit(SearchOptions context)
         {
-            StringBuilder.Append("SELECT DISTINCT ");
+            StringBuilder.Append("SELECT DISTINCT TOP (")
+                .Append(Parameters.AddParameter(context.IncludeCount, includeInHash: false))
+                .Append(") T1, Sid1, IsMatch, ");
 
-            // TODO - https://github.com/microsoft/fhir-server/issues/1309 (limit for _include also)
-            var isRev = _cteToLimit.Contains(_tableExpressionCounter - 1);
-            if (isRev)
-            {
-                // the related cte is a reverse include, limit the number of returned items and count to
-                // see if we are over the threshold (to produce a warning to the client)
-                StringBuilder.Append("TOP (").Append(Parameters.AddParameter(context.IncludeCount, includeInHash: false)).Append(") ");
-            }
-
-            StringBuilder.Append("T1, Sid1, IsMatch, ");
-
-            if (isRev)
-            {
-                StringBuilder.Append("CASE WHEN count_big(*) over() > ")
-                    .Append(Parameters.AddParameter(context.IncludeCount, true))
-                    .AppendLine(" THEN 1 ELSE 0 END AS IsPartial ");
-            }
-            else
-            {
-                // if forward, just mark as not partial
-                StringBuilder.AppendLine("0 AS IsPartial ");
-            }
+            StringBuilder.Append("CASE WHEN count_big(*) over() > ")
+                .Append(Parameters.AddParameter(context.IncludeCount, true))
+                .AppendLine(" THEN 1 ELSE 0 END AS IsPartial ");
 
             StringBuilder.Append("FROM ").AppendLine(TableExpressionName(_tableExpressionCounter - 1));
 


### PR DESCRIPTION
## Description
This PR adds the ability to limit the number of responses for Include statements. Previously this was limited to just revincludes.

## Related issues
Addresses [Bug 135347](https://microsofthealth.visualstudio.com/Health/_workitems/edit/135347): Fix SQL Iterative Include
#1309 

## Testing
WIP

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch 
