### PR TITLE
Moved cosmos job hosting to use unified retry logic

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Reindex/ReindexJobWorkerTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Reindex/ReindexJobWorkerTests.cs
@@ -9,8 +9,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Configs;
+using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Operations.Reindex;
 using Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models;
@@ -59,6 +61,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                 Options.Create(_reindexJobConfiguration),
                 _reindexJobTask.CreateMockScopeProvider(),
                 searchParameterOperations,
+                Substitute.For<RequestContextAccessor<IFhirRequestContext>>(),
                 NullLogger<ReindexJobWorker>.Instance);
 
             _reindexJobWorker.Handle(new Messages.Search.SearchParametersInitializedNotification(), CancellationToken.None);

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobWorker.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobWorker.cs
@@ -60,6 +60,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             {
                 if (_searchParametersInitialized)
                 {
+                    var originalRequestContext = _contextAccessor.RequestContext;
+
                     // Create a background task context to trigger the correct retry policy.
                     var fhirRequestContext = new FhirRequestContext(
                         method: nameof(ReindexJobWorker),
@@ -138,6 +140,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                         // The job failed.
                         _logger.LogError(ex, "Error polling Reindex jobs.");
                     }
+
+                    _contextAccessor.RequestContext = originalRequestContext;
                 }
 
                 try

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobWorker.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobWorker.cs
@@ -63,9 +63,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                     // Create a background task context to trigger the correct retry policy.
                     var fhirRequestContext = new FhirRequestContext(
                         method: nameof(ReindexJobWorker),
-                        uriString: string.Empty,
-                        baseUriString: string.Empty,
-                        correlationId: string.Empty,
+                        uriString: nameof(ReindexJobWorker),
+                        baseUriString: nameof(ReindexJobWorker),
+                        correlationId: Guid.NewGuid().ToString(),
                         requestHeaders: new Dictionary<string, StringValues>(),
                         responseHeaders: new Dictionary<string, StringValues>())
                         {

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobWorker.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobWorker.cs
@@ -12,8 +12,11 @@ using EnsureThat;
 using MediatR;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Configs;
+using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models;
 using Microsoft.Health.Fhir.Core.Features.Search.Parameters;
 using Microsoft.Health.Fhir.Core.Messages.Search;
@@ -29,6 +32,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
         private readonly ReindexJobConfiguration _reindexJobConfiguration;
         private readonly IScopeProvider<IReindexJobTask> _reindexJobTaskFactory;
         private readonly ISearchParameterOperations _searchParameterOperations;
+        private readonly RequestContextAccessor<IFhirRequestContext> _contextAccessor;
         private readonly ILogger _logger;
         private bool _searchParametersInitialized = false;
 
@@ -37,19 +41,15 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             IOptions<ReindexJobConfiguration> reindexJobConfiguration,
             IScopeProvider<IReindexJobTask> reindexJobTaskFactory,
             ISearchParameterOperations searchParameterOperations,
+            RequestContextAccessor<IFhirRequestContext> contextAccessor,
             ILogger<ReindexJobWorker> logger)
         {
-            EnsureArg.IsNotNull(fhirOperationDataStoreFactory, nameof(fhirOperationDataStoreFactory));
-            EnsureArg.IsNotNull(reindexJobConfiguration?.Value, nameof(reindexJobConfiguration));
-            EnsureArg.IsNotNull(reindexJobTaskFactory, nameof(reindexJobTaskFactory));
-            EnsureArg.IsNotNull(searchParameterOperations, nameof(searchParameterOperations));
-            EnsureArg.IsNotNull(logger, nameof(logger));
-
-            _fhirOperationDataStoreFactory = fhirOperationDataStoreFactory;
-            _reindexJobConfiguration = reindexJobConfiguration.Value;
-            _reindexJobTaskFactory = reindexJobTaskFactory;
-            _searchParameterOperations = searchParameterOperations;
-            _logger = logger;
+            _fhirOperationDataStoreFactory = EnsureArg.IsNotNull(fhirOperationDataStoreFactory, nameof(fhirOperationDataStoreFactory));
+            _reindexJobConfiguration = EnsureArg.IsNotNull(reindexJobConfiguration?.Value, nameof(reindexJobConfiguration));
+            _reindexJobTaskFactory = EnsureArg.IsNotNull(reindexJobTaskFactory, nameof(reindexJobTaskFactory));
+            _searchParameterOperations = EnsureArg.IsNotNull(searchParameterOperations, nameof(searchParameterOperations));
+            _contextAccessor = EnsureArg.IsNotNull(contextAccessor, nameof(contextAccessor));
+            _logger = EnsureArg.IsNotNull(logger, nameof(logger));
         }
 
         public async Task ExecuteAsync(CancellationToken cancellationToken)
@@ -60,6 +60,18 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             {
                 if (_searchParametersInitialized)
                 {
+                    // Create a background task context to trigger the correct retry policy.
+                    var fhirRequestContext = new FhirRequestContext(
+                        method: nameof(ReindexJobWorker),
+                        uriString: string.Empty,
+                        baseUriString: string.Empty,
+                        correlationId: string.Empty,
+                        requestHeaders: new Dictionary<string, StringValues>(),
+                        responseHeaders: new Dictionary<string, StringValues>())
+                        {
+                            IsBackgroundTask = true,
+                        };
+
                     // Check for any changes to Search Parameters
                     try
                     {

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobWorker.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobWorker.cs
@@ -72,6 +72,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                             IsBackgroundTask = true,
                         };
 
+                    _contextAccessor.RequestContext = fhirRequestContext;
+
                     // Check for any changes to Search Parameters
                     try
                     {

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/CosmosFhirDataStoreTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/CosmosFhirDataStoreTests.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Storage
                 _cosmosDataStoreConfiguration,
                 Substitute.For<IOptionsMonitor<CosmosCollectionConfiguration>>(),
                 _cosmosQueryFactory,
-                new RetryExceptionPolicyFactory(_cosmosDataStoreConfiguration, requestContextAccessor),
+                new RetryExceptionPolicyFactory(_cosmosDataStoreConfiguration, requestContextAccessor, NullLogger<RetryExceptionPolicyFactory>.Instance),
                 NullLogger<CosmosFhirDataStore>.Instance,
                 Options.Create(new CoreFeatureConfiguration()),
                 _bundleOrchestrator,

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/FhirCosmosClientInitializerTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/FhirCosmosClientInitializerTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Storage
             _initializer = new FhirCosmosClientInitializer(
                 clientTestProvider,
                 () => new[] { new TestRequestHandler() },
-                new RetryExceptionPolicyFactory(_cosmosDataStoreConfiguration, Substitute.For<RequestContextAccessor<IFhirRequestContext>>()),
+                new RetryExceptionPolicyFactory(_cosmosDataStoreConfiguration, Substitute.For<RequestContextAccessor<IFhirRequestContext>>(), NullLogger<RetryExceptionPolicyFactory>.Instance),
                 Substitute.For<CosmosAccessTokenProviderFactory>(),
                 NullLogger<FhirCosmosClientInitializer>.Instance);
 

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/Queues/CosmosQueueClientTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/Queues/CosmosQueueClientTests.cs
@@ -48,8 +48,7 @@ public class CosmosQueueClientTests
             Substitute.For<Func<IScoped<Container>>>(),
             _cosmosQueryFactory,
             _distributedLockFactory,
-            _retryPolicyFactory,
-            NullLogger<CosmosQueueClient>.Instance);
+            _retryPolicyFactory);
     }
 
     [Theory]

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/Queues/CosmosQueueClientTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/Queues/CosmosQueueClientTests.cs
@@ -1,0 +1,146 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure;
+using Hl7.Fhir.ElementModel.Types;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Health.Abstractions.Exceptions;
+using Microsoft.Health.Core.Features.Context;
+using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Health.Fhir.Core.Features.Context;
+using Microsoft.Health.Fhir.Core.UnitTests.Extensions;
+using Microsoft.Health.Fhir.CosmosDb.Core.Configs;
+using Microsoft.Health.Fhir.CosmosDb.Core.Features.Storage;
+using Microsoft.Health.Fhir.CosmosDb.Features.Queries;
+using Microsoft.Health.Fhir.CosmosDb.Features.Storage;
+using Microsoft.Health.Fhir.CosmosDb.Features.Storage.Queues;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Test.Utilities;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Storage.Queues
+{
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.DataSourceValidation)]
+    public class CosmosQueueClientTests
+    {
+        private readonly ICosmosQueryFactory _cosmosQueryFactory;
+        private readonly ICosmosDbDistributedLockFactory _distributedLockFactory;
+        private readonly CosmosDataStoreConfiguration _cosmosDataStoreConfiguration = new CosmosDataStoreConfiguration();
+        private readonly RequestContextAccessor<IFhirRequestContext> _requestContextAccessor;
+        private readonly RetryExceptionPolicyFactory _retryPolicyFactory;
+        private readonly CosmosQueueClient _cosmosQueueClient;
+
+        public CosmosQueueClientTests()
+        {
+            _cosmosQueryFactory = Substitute.For<ICosmosQueryFactory>();
+            _distributedLockFactory = Substitute.For<ICosmosDbDistributedLockFactory>();
+            _requestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
+            _retryPolicyFactory = new RetryExceptionPolicyFactory(_cosmosDataStoreConfiguration, _requestContextAccessor, NullLogger<RetryExceptionPolicyFactory>.Instance);
+
+            _cosmosQueueClient = new CosmosQueueClient(
+                Substitute.For<Func<IScoped<Container>>>(),
+                _cosmosQueryFactory,
+                _distributedLockFactory,
+                _retryPolicyFactory,
+                NullLogger<CosmosQueueClient>.Instance);
+        }
+
+        [Theory]
+        [InlineData(HttpStatusCode.ServiceUnavailable)]
+        [InlineData(HttpStatusCode.TooManyRequests)]
+        [InlineData(HttpStatusCode.Gone)]
+        [InlineData((HttpStatusCode)449)]
+        [InlineData(HttpStatusCode.RequestTimeout)]
+        public async Task GivenADequeueJobOperation_WhenExceptionOccurs_RetryWillHappen(HttpStatusCode statusCode)
+        {
+            // Arrange
+            ICosmosQuery<JobGroupWrapper> cosmosQuery = Substitute.For<ICosmosQuery<JobGroupWrapper>>();
+            _cosmosQueryFactory.Create<JobGroupWrapper>(Arg.Any<Container>(), Arg.Any<CosmosQueryContext>())
+                .ReturnsForAnyArgs(cosmosQuery);
+
+            int callCount = 0;
+            cosmosQuery.ExecuteNextAsync(Arg.Any<CancellationToken>()).ReturnsForAnyArgs(_ =>
+            {
+                if (callCount++ == 0)
+                {
+                    throw new TestCosmosException(statusCode);
+                }
+
+                return Task.FromResult(Substitute.For<FeedResponse<JobGroupWrapper>>());
+            });
+
+            // Act
+            await _cosmosQueueClient.DequeueAsync(0, "testworker", 10, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(2, callCount);
+            await cosmosQuery.ReceivedWithAnyArgs(2).ExecuteNextAsync(Arg.Any<CancellationToken>());
+        }
+
+        [Theory]
+        [InlineData(typeof(CosmosException))]
+        [InlineData(typeof(RequestRateExceededException))]
+        public async Task GivenADequeueJobOperation_WhenExceptionWithRetryAfterIsProvided_PolicyRespectsRetryAfter(Type exceptionType)
+        {
+            // Arrange
+            ICosmosQuery<JobGroupWrapper> cosmosQuery = Substitute.For<ICosmosQuery<JobGroupWrapper>>();
+            _cosmosQueryFactory.Create<JobGroupWrapper>(Arg.Any<Container>(), Arg.Any<CosmosQueryContext>())
+                .ReturnsForAnyArgs(cosmosQuery);
+            var retryAfter = TimeSpan.FromSeconds(1);
+            int callCount = 0;
+
+            cosmosQuery.ExecuteNextAsync(Arg.Any<CancellationToken>()).ReturnsForAnyArgs(_ =>
+            {
+                if (callCount++ == 0)
+                {
+                    throw exceptionType == typeof(CosmosException)
+                        ? new TestCosmosException(HttpStatusCode.TooManyRequests, retryAfter)
+                        : new RequestRateExceededException(retryAfter);
+                }
+
+                return Task.FromResult(Substitute.For<FeedResponse<JobGroupWrapper>>());
+            });
+
+            var stopwatch = Stopwatch.StartNew();
+
+            // Act
+            await _cosmosQueueClient.DequeueAsync(0, "testworker", 10, CancellationToken.None);
+
+            stopwatch.Stop();
+
+            // Assert
+            Assert.Equal(2, callCount);
+            await cosmosQuery.ReceivedWithAnyArgs(2).ExecuteNextAsync(Arg.Any<CancellationToken>());
+            Assert.True(stopwatch.Elapsed >= retryAfter, "Policy should respect the RetryAfter value.");
+        }
+
+        public class TestCosmosException : CosmosException
+        {
+            private readonly TimeSpan? _retryAfter;
+
+            public TestCosmosException(HttpStatusCode statusCode, TimeSpan? retryAfter = null)
+                : base("Test exception message", statusCode, 0, "test-activity-id", 0.0)
+            {
+                _retryAfter = retryAfter;
+            }
+
+            public override TimeSpan? RetryAfter => _retryAfter;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/Queues/CosmosQueueClientTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/Queues/CosmosQueueClientTests.cs
@@ -4,25 +4,16 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Net;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure;
-using Hl7.Fhir.ElementModel.Types;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Health.Abstractions.Exceptions;
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Features.Context;
-using Microsoft.Health.Fhir.Core.UnitTests.Extensions;
 using Microsoft.Health.Fhir.CosmosDb.Core.Configs;
 using Microsoft.Health.Fhir.CosmosDb.Core.Features.Storage;
 using Microsoft.Health.Fhir.CosmosDb.Features.Queries;
@@ -33,114 +24,107 @@ using Microsoft.Health.Test.Utilities;
 using NSubstitute;
 using Xunit;
 
-namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Storage.Queues
+namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Storage.Queues;
+
+[Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+[Trait(Traits.Category, Categories.DataSourceValidation)]
+public class CosmosQueueClientTests
 {
-    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
-    [Trait(Traits.Category, Categories.DataSourceValidation)]
-    public class CosmosQueueClientTests
+    private readonly ICosmosQueryFactory _cosmosQueryFactory;
+    private readonly ICosmosDbDistributedLockFactory _distributedLockFactory;
+    private readonly CosmosDataStoreConfiguration _cosmosDataStoreConfiguration = new CosmosDataStoreConfiguration();
+    private readonly RequestContextAccessor<IFhirRequestContext> _requestContextAccessor;
+    private readonly RetryExceptionPolicyFactory _retryPolicyFactory;
+    private readonly CosmosQueueClient _cosmosQueueClient;
+
+    public CosmosQueueClientTests()
     {
-        private readonly ICosmosQueryFactory _cosmosQueryFactory;
-        private readonly ICosmosDbDistributedLockFactory _distributedLockFactory;
-        private readonly CosmosDataStoreConfiguration _cosmosDataStoreConfiguration = new CosmosDataStoreConfiguration();
-        private readonly RequestContextAccessor<IFhirRequestContext> _requestContextAccessor;
-        private readonly RetryExceptionPolicyFactory _retryPolicyFactory;
-        private readonly CosmosQueueClient _cosmosQueueClient;
+        _cosmosQueryFactory = Substitute.For<ICosmosQueryFactory>();
+        _distributedLockFactory = Substitute.For<ICosmosDbDistributedLockFactory>();
+        _requestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
+        _retryPolicyFactory = new RetryExceptionPolicyFactory(_cosmosDataStoreConfiguration, _requestContextAccessor, NullLogger<RetryExceptionPolicyFactory>.Instance);
 
-        public CosmosQueueClientTests()
+        _cosmosQueueClient = new CosmosQueueClient(
+            Substitute.For<Func<IScoped<Container>>>(),
+            _cosmosQueryFactory,
+            _distributedLockFactory,
+            _retryPolicyFactory,
+            NullLogger<CosmosQueueClient>.Instance);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.ServiceUnavailable)]
+    [InlineData(HttpStatusCode.TooManyRequests)]
+    [InlineData(HttpStatusCode.Gone)]
+    [InlineData((HttpStatusCode)449)]
+    [InlineData(HttpStatusCode.RequestTimeout)]
+    public async Task GivenADequeueJobOperation_WhenExceptionOccurs_RetryWillHappen(HttpStatusCode statusCode)
+    {
+        // Arrange
+        ICosmosQuery<JobGroupWrapper> cosmosQuery = Substitute.For<ICosmosQuery<JobGroupWrapper>>();
+        _cosmosQueryFactory.Create<JobGroupWrapper>(Arg.Any<Container>(), Arg.Any<CosmosQueryContext>())
+            .ReturnsForAnyArgs(cosmosQuery);
+
+        int callCount = 0;
+        cosmosQuery.ExecuteNextAsync(Arg.Any<CancellationToken>()).ReturnsForAnyArgs(_ =>
         {
-            _cosmosQueryFactory = Substitute.For<ICosmosQueryFactory>();
-            _distributedLockFactory = Substitute.For<ICosmosDbDistributedLockFactory>();
-            _requestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
-            _retryPolicyFactory = new RetryExceptionPolicyFactory(_cosmosDataStoreConfiguration, _requestContextAccessor, NullLogger<RetryExceptionPolicyFactory>.Instance);
-
-            _cosmosQueueClient = new CosmosQueueClient(
-                Substitute.For<Func<IScoped<Container>>>(),
-                _cosmosQueryFactory,
-                _distributedLockFactory,
-                _retryPolicyFactory,
-                NullLogger<CosmosQueueClient>.Instance);
-        }
-
-        [Theory]
-        [InlineData(HttpStatusCode.ServiceUnavailable)]
-        [InlineData(HttpStatusCode.TooManyRequests)]
-        [InlineData(HttpStatusCode.Gone)]
-        [InlineData((HttpStatusCode)449)]
-        [InlineData(HttpStatusCode.RequestTimeout)]
-        public async Task GivenADequeueJobOperation_WhenExceptionOccurs_RetryWillHappen(HttpStatusCode statusCode)
-        {
-            // Arrange
-            ICosmosQuery<JobGroupWrapper> cosmosQuery = Substitute.For<ICosmosQuery<JobGroupWrapper>>();
-            _cosmosQueryFactory.Create<JobGroupWrapper>(Arg.Any<Container>(), Arg.Any<CosmosQueryContext>())
-                .ReturnsForAnyArgs(cosmosQuery);
-
-            int callCount = 0;
-            cosmosQuery.ExecuteNextAsync(Arg.Any<CancellationToken>()).ReturnsForAnyArgs(_ =>
+            if (callCount++ == 0)
             {
-                if (callCount++ == 0)
-                {
-                    throw new TestCosmosException(statusCode);
-                }
-
-                return Task.FromResult(Substitute.For<FeedResponse<JobGroupWrapper>>());
-            });
-
-            // Act
-            await _cosmosQueueClient.DequeueAsync(0, "testworker", 10, CancellationToken.None);
-
-            // Assert
-            Assert.Equal(2, callCount);
-            await cosmosQuery.ReceivedWithAnyArgs(2).ExecuteNextAsync(Arg.Any<CancellationToken>());
-        }
-
-        [Theory]
-        [InlineData(typeof(CosmosException))]
-        [InlineData(typeof(RequestRateExceededException))]
-        public async Task GivenADequeueJobOperation_WhenExceptionWithRetryAfterIsProvided_PolicyRespectsRetryAfter(Type exceptionType)
-        {
-            // Arrange
-            ICosmosQuery<JobGroupWrapper> cosmosQuery = Substitute.For<ICosmosQuery<JobGroupWrapper>>();
-            _cosmosQueryFactory.Create<JobGroupWrapper>(Arg.Any<Container>(), Arg.Any<CosmosQueryContext>())
-                .ReturnsForAnyArgs(cosmosQuery);
-            var retryAfter = TimeSpan.FromSeconds(1);
-            int callCount = 0;
-
-            cosmosQuery.ExecuteNextAsync(Arg.Any<CancellationToken>()).ReturnsForAnyArgs(_ =>
-            {
-                if (callCount++ == 0)
-                {
-                    throw exceptionType == typeof(CosmosException)
-                        ? new TestCosmosException(HttpStatusCode.TooManyRequests, retryAfter)
-                        : new RequestRateExceededException(retryAfter);
-                }
-
-                return Task.FromResult(Substitute.For<FeedResponse<JobGroupWrapper>>());
-            });
-
-            var stopwatch = Stopwatch.StartNew();
-
-            // Act
-            await _cosmosQueueClient.DequeueAsync(0, "testworker", 10, CancellationToken.None);
-
-            stopwatch.Stop();
-
-            // Assert
-            Assert.Equal(2, callCount);
-            await cosmosQuery.ReceivedWithAnyArgs(2).ExecuteNextAsync(Arg.Any<CancellationToken>());
-            Assert.True(stopwatch.Elapsed >= retryAfter, "Policy should respect the RetryAfter value.");
-        }
-
-        public class TestCosmosException : CosmosException
-        {
-            private readonly TimeSpan? _retryAfter;
-
-            public TestCosmosException(HttpStatusCode statusCode, TimeSpan? retryAfter = null)
-                : base("Test exception message", statusCode, 0, "test-activity-id", 0.0)
-            {
-                _retryAfter = retryAfter;
+                throw new TestCosmosException(statusCode);
             }
 
-            public override TimeSpan? RetryAfter => _retryAfter;
-        }
+            return Task.FromResult(Substitute.For<FeedResponse<JobGroupWrapper>>());
+        });
+
+        // Act
+        await _cosmosQueueClient.DequeueAsync(0, "testworker", 10, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(2, callCount);
+        await cosmosQuery.ReceivedWithAnyArgs(2).ExecuteNextAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(typeof(CosmosException))]
+    [InlineData(typeof(RequestRateExceededException))]
+    public async Task GivenADequeueJobOperation_WhenExceptionWithRetryAfterIsProvided_PolicyRespectsRetryAfter(Type exceptionType)
+    {
+        // Arrange
+        ICosmosQuery<JobGroupWrapper> cosmosQuery = Substitute.For<ICosmosQuery<JobGroupWrapper>>();
+        _cosmosQueryFactory.Create<JobGroupWrapper>(Arg.Any<Container>(), Arg.Any<CosmosQueryContext>())
+            .ReturnsForAnyArgs(cosmosQuery);
+        var retryAfter = TimeSpan.FromSeconds(1);
+        int callCount = 0;
+
+        cosmosQuery.ExecuteNextAsync(Arg.Any<CancellationToken>()).ReturnsForAnyArgs(_ =>
+        {
+            if (callCount++ == 0)
+            {
+                throw exceptionType == typeof(CosmosException)
+                    ? new TestCosmosException(HttpStatusCode.TooManyRequests, retryAfter)
+                    : new RequestRateExceededException(retryAfter);
+            }
+
+            return Task.FromResult(Substitute.For<FeedResponse<JobGroupWrapper>>());
+        });
+
+        var stopwatch = Stopwatch.StartNew();
+
+        // Act
+        await _cosmosQueueClient.DequeueAsync(0, "testworker", 10, CancellationToken.None);
+
+        stopwatch.Stop();
+
+        // Assert
+        Assert.Equal(2, callCount);
+        await cosmosQuery.ReceivedWithAnyArgs(2).ExecuteNextAsync(Arg.Any<CancellationToken>());
+        Assert.True(stopwatch.Elapsed >= retryAfter, "Policy should respect the RetryAfter value.");
+    }
+
+    public class TestCosmosException(HttpStatusCode statusCode, TimeSpan? retryAfter = null) : CosmosException("Test exception message", statusCode, 0, "test-activity-id", 0.0)
+    {
+        private readonly TimeSpan? _retryAfter = retryAfter;
+
+        public override TimeSpan? RetryAfter => _retryAfter;
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/Queues/CosmosQueueClientTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/Queues/CosmosQueueClientTests.cs
@@ -117,7 +117,7 @@ public class CosmosQueueClientTests
         // Assert
         Assert.Equal(2, callCount);
         await cosmosQuery.ReceivedWithAnyArgs(2).ExecuteNextAsync(Arg.Any<CancellationToken>());
-        Assert.True(stopwatch.Elapsed >= retryAfter, "Policy should respect the RetryAfter value.");
+        Assert.True(stopwatch.Elapsed >= retryAfter, $"Policy should respect the RetryAfter value. Stopwatch: {stopwatch.Elapsed}. Retry after: {retryAfter}.");
     }
 
     public class TestCosmosException(HttpStatusCode statusCode, TimeSpan? retryAfter = null) : CosmosException("Test exception message", statusCode, 0, "test-activity-id", 0.0)

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/Queues/CosmosQueueClientTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/Queues/CosmosQueueClientTests.cs
@@ -125,9 +125,15 @@ public class CosmosQueueClientTests
             $"Expected retry after {retryAfter.TotalSeconds} seconds, but actual elapsed time was {actualElapsedSeconds} seconds.");
     }
 
-    public class TestCosmosException(HttpStatusCode statusCode, TimeSpan? retryAfter = null) : CosmosException("Test exception message", statusCode, 0, "test-activity-id", 0.0)
+    public class TestCosmosException : CosmosException
     {
-        private readonly TimeSpan? _retryAfter = retryAfter;
+        private readonly TimeSpan? _retryAfter;
+
+        public TestCosmosException(HttpStatusCode statusCode, TimeSpan? retryAfter = null)
+            : base("Test exception message", statusCode, 0, "test-activity-id", 0.0)
+        {
+            _retryAfter = retryAfter;
+        }
 
         public override TimeSpan? RetryAfter => _retryAfter;
     }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Queues/CosmosQueueClient.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Queues/CosmosQueueClient.cs
@@ -31,21 +31,18 @@ public class CosmosQueueClient : IQueueClient
     private readonly ICosmosQueryFactory _queryFactory;
     private readonly ICosmosDbDistributedLockFactory _distributedLockFactory;
     private readonly RetryExceptionPolicyFactory _retryExceptionPolicyFactory;
-    private readonly ILogger<CosmosQueueClient> _logger;
     private readonly AsyncPolicy _retryPolicy;
 
     public CosmosQueueClient(
         Func<IScoped<Container>> containerFactory,
         ICosmosQueryFactory queryFactory,
         ICosmosDbDistributedLockFactory distributedLockFactory,
-        RetryExceptionPolicyFactory retryExceptionPolicyFactor,
-        ILogger<CosmosQueueClient> logger)
+        RetryExceptionPolicyFactory retryExceptionPolicyFactory)
     {
         _containerFactory = EnsureArg.IsNotNull(containerFactory, nameof(containerFactory));
         _queryFactory = EnsureArg.IsNotNull(queryFactory, nameof(queryFactory));
         _distributedLockFactory = EnsureArg.IsNotNull(distributedLockFactory, nameof(distributedLockFactory));
-        _retryExceptionPolicyFactory = EnsureArg.IsNotNull(retryExceptionPolicyFactor, nameof(retryExceptionPolicyFactor));
-        _logger = EnsureArg.IsNotNull(logger, nameof(logger));
+        _retryExceptionPolicyFactory = EnsureArg.IsNotNull(retryExceptionPolicyFactory, nameof(retryExceptionPolicyFactory));
 
         _retryPolicy = _retryExceptionPolicyFactory.BackgroundWorkerRetryPolicy;
     }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Queues/CosmosQueueClient.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Queues/CosmosQueueClient.cs
@@ -12,21 +12,16 @@ using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Azure.Cosmos;
-using Microsoft.Build.Framework;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Primitives;
 using Microsoft.Health.Abstractions.Exceptions;
 using Microsoft.Health.Core;
 using Microsoft.Health.Core.Extensions;
-using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Extensions;
-using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.CosmosDb.Core.Features.Storage;
 using Microsoft.Health.Fhir.CosmosDb.Features.Queries;
 using Microsoft.Health.JobManagement;
 using Polly;
-using Polly.Retry;
 
 namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Queues;
 

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/RetryExceptionPolicyFactory.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/RetryExceptionPolicyFactory.cs
@@ -4,10 +4,14 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Net;
 using System.Runtime.ExceptionServices;
+using System.Security.Cryptography;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Azure.Cosmos;
+using Microsoft.Build.Framework;
+using Microsoft.Extensions.Logging;
 using Microsoft.Health.Abstractions.Exceptions;
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Extensions;
@@ -22,15 +26,16 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
     {
         private const string RetryEndTimeContextKey = "RetryEndTime";
         private readonly RequestContextAccessor<IFhirRequestContext> _requestContextAccessor;
+        private readonly ILogger<RetryExceptionPolicyFactory> _logger;
         private readonly AsyncPolicy _sdkOnlyRetryPolicy;
         private readonly AsyncPolicy _bundleActionRetryPolicy;
         private readonly AsyncPolicy _backgroundJobRetryPolicy;
 
-        public RetryExceptionPolicyFactory(CosmosDataStoreConfiguration configuration, RequestContextAccessor<IFhirRequestContext> requestContextAccessor)
+        public RetryExceptionPolicyFactory(CosmosDataStoreConfiguration configuration, RequestContextAccessor<IFhirRequestContext> requestContextAccessor, ILogger<RetryExceptionPolicyFactory> logger)
         {
-            _requestContextAccessor = requestContextAccessor;
+            _requestContextAccessor = EnsureArg.IsNotNull(requestContextAccessor, nameof(requestContextAccessor));
             EnsureArg.IsNotNull(configuration, nameof(configuration));
-            EnsureArg.IsNotNull(requestContextAccessor, nameof(requestContextAccessor));
+            _logger = EnsureArg.IsNotNull(logger, nameof(logger));
 
             _sdkOnlyRetryPolicy = Policy.NoOpAsync();
 
@@ -38,7 +43,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
                 ? CreateExtendedRetryPolicy(configuration.IndividualBatchActionRetryOptions.MaxNumberOfRetries / configuration.RetryOptions.MaxNumberOfRetries, configuration.IndividualBatchActionRetryOptions.MaxWaitTimeInSeconds)
                 : Policy.NoOpAsync();
 
-            _backgroundJobRetryPolicy = CreateExtendedRetryPolicy(100, -1);
+            _backgroundJobRetryPolicy = CreateExtendedRetryPolicy(100, -1, true);
         }
 
         public AsyncPolicy RetryPolicy
@@ -56,16 +61,58 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
 
         public AsyncPolicy BackgroundWorkerRetryPolicy => _backgroundJobRetryPolicy;
 
-        private static AsyncRetryPolicy CreateExtendedRetryPolicy(int maxRetries, int maxWaitTimeInSeconds)
+        private AsyncRetryPolicy CreateExtendedRetryPolicy(int maxRetries, int maxWaitTimeInSeconds, bool useExponentialRetry = false)
         {
+            // Define a sleep duration provider based on the retry strategy
+            TimeSpan SleepDurationProvider(int retryAttempt, Exception exception)
+            {
+                // Respect x-ms-retry-after-ms from RequestRateExceededException
+                if (exception.AsRequestRateExceeded()?.RetryAfter is TimeSpan retryAfter)
+                {
+                    return retryAfter;
+                }
+
+                // Respect x-ms-retry-after-ms from CosmosException
+                if (exception is CosmosException cosmosException && cosmosException.StatusCode == HttpStatusCode.TooManyRequests && cosmosException.RetryAfter.HasValue)
+                {
+                    return cosmosException.RetryAfter.Value;
+                }
+
+                if (useExponentialRetry)
+                {
+                    // Exponential backoff with jitter
+                    var backoff = Math.Pow(2, retryAttempt) * 100; // Exponential backoff in milliseconds
+                    var jitter = RandomNumberGenerator.GetInt32(0, 300); // Add jitter in milliseconds
+                    return TimeSpan.FromMilliseconds(backoff + jitter);
+                }
+
+                // Default fixed wait time
+                return TimeSpan.FromSeconds(2);
+            }
+
+            // Retry recommendations for Cosmos DB: https://learn.microsoft.com/azure/cosmos-db/nosql/conceptual-resilient-sdk-applications#should-my-application-retry-on-errors
             return Policy.Handle<RequestRateExceededException>()
                 .Or<CosmosException>(e => e.IsRequestRateExceeded())
-                .Or<CosmosException>(e => (e.StatusCode == System.Net.HttpStatusCode.ServiceUnavailable || e.StatusCode == System.Net.HttpStatusCode.RequestTimeout))
+                .Or<CosmosException>(e =>
+                    e.StatusCode == System.Net.HttpStatusCode.ServiceUnavailable ||
+                    e.StatusCode == System.Net.HttpStatusCode.TooManyRequests ||
+                    e.StatusCode == System.Net.HttpStatusCode.Gone ||
+                    e.StatusCode == (HttpStatusCode)449 || // "Retry with" status code
+                    e.StatusCode == System.Net.HttpStatusCode.RequestTimeout)
                 .WaitAndRetryAsync(
                     retryCount: maxRetries,
-                    sleepDurationProvider: (_, e, _) => e.AsRequestRateExceeded()?.RetryAfter ?? TimeSpan.FromSeconds(2),
+                    sleepDurationProvider: (retryAttempt, exception, context) => SleepDurationProvider(retryAttempt, exception),
                     onRetryAsync: (e, _, _, ctx) =>
                     {
+                        if (e is CosmosException cosmosException)
+                        {
+                            if (cosmosException.StatusCode == HttpStatusCode.ServiceUnavailable)
+                            {
+                                var diagnostics = cosmosException.Diagnostics.ToString();
+                                _logger.LogWarning(cosmosException, "Received a ServiceUnavailable response from Cosmos DB. Retrying. Diagnostics: {CosmosDiagnostics}", diagnostics);
+                            }
+                        }
+
                         if (maxWaitTimeInSeconds == -1)
                         {
                             // no timeout

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/RetryExceptionPolicyFactory.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/RetryExceptionPolicyFactory.cs
@@ -100,11 +100,11 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
             return Policy.Handle<RequestRateExceededException>()
                 .Or<CosmosException>(e => e.IsRequestRateExceeded())
                 .Or<CosmosException>(e =>
-                    e.StatusCode == System.Net.HttpStatusCode.ServiceUnavailable ||
-                    e.StatusCode == System.Net.HttpStatusCode.TooManyRequests ||
-                    e.StatusCode == System.Net.HttpStatusCode.Gone ||
+                    e.StatusCode == HttpStatusCode.ServiceUnavailable ||
+                    e.StatusCode == HttpStatusCode.TooManyRequests ||
+                    e.StatusCode == HttpStatusCode.Gone ||
                     e.StatusCode == (HttpStatusCode)449 || // "Retry with" status code
-                    e.StatusCode == System.Net.HttpStatusCode.RequestTimeout)
+                    e.StatusCode == HttpStatusCode.RequestTimeout)
                 .WaitAndRetryAsync(
                     retryCount: maxRetries,
                     sleepDurationProvider: (retryAttempt, exception, context) => SleepDurationProvider(retryAttempt, exception),

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/RetryExceptionPolicyFactory.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/RetryExceptionPolicyFactory.cs
@@ -54,6 +54,8 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
             }
         }
 
+        public AsyncPolicy BackgroundWorkerRetryPolicy => _backgroundJobRetryPolicy;
+
         private static AsyncRetryPolicy CreateExtendedRetryPolicy(int maxRetries, int maxWaitTimeInSeconds)
         {
             return Policy.Handle<RequestRateExceededException>()

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/RetryExceptionPolicyFactory.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/RetryExceptionPolicyFactory.cs
@@ -103,13 +103,10 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
                     sleepDurationProvider: (retryAttempt, exception, context) => SleepDurationProvider(retryAttempt, exception),
                     onRetryAsync: (e, _, _, ctx) =>
                     {
-                        if (e is CosmosException cosmosException)
+                        if (e is CosmosException cosmosException && cosmosException.StatusCode == HttpStatusCode.ServiceUnavailable)
                         {
-                            if (cosmosException.StatusCode == HttpStatusCode.ServiceUnavailable)
-                            {
-                                var diagnostics = cosmosException.Diagnostics.ToString();
-                                _logger.LogWarning(cosmosException, "Received a ServiceUnavailable response from Cosmos DB. Retrying. Diagnostics: {CosmosDiagnostics}", diagnostics);
-                            }
+                            var diagnostics = cosmosException.Diagnostics.ToString();
+                            _logger.LogWarning(cosmosException, "Received a ServiceUnavailable response from Cosmos DB. Retrying. Diagnostics: {CosmosDiagnostics}", diagnostics);
                         }
 
                         if (maxWaitTimeInSeconds == -1)

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/RetryExceptionPolicyFactory.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/RetryExceptionPolicyFactory.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
                     {
                         if (e is CosmosException cosmosException && cosmosException.StatusCode == HttpStatusCode.ServiceUnavailable)
                         {
-                            var diagnostics = cosmosException.Diagnostics.ToString();
+                            var diagnostics = cosmosException.Diagnostics?.ToString() ?? "empty";
                             _logger.LogWarning(cosmosException, "Received a ServiceUnavailable response from Cosmos DB. Retrying. Diagnostics: {CosmosDiagnostics}", diagnostics);
                         }
 

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/RetryExceptionPolicyFactory.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/RetryExceptionPolicyFactory.cs
@@ -10,7 +10,6 @@ using System.Security.Cryptography;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Azure.Cosmos;
-using Microsoft.Build.Framework;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.Abstractions.Exceptions;
 using Microsoft.Health.Core.Features.Context;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -899,6 +899,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                 Options.Create(_jobConfiguration),
                 InitializeReindexJobTask().CreateMockScopeProvider(),
                 _searchParameterOperations,
+                Substitute.For<RequestContextAccessor<IFhirRequestContext>>(),
                 NullLogger<ReindexJobWorker>.Instance);
 
             await _reindexJobWorker.Handle(new SearchParametersInitializedNotification(), CancellationToken.None);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
             var responseProcessor = new CosmosResponseProcessor(_fhirRequestContextAccessor, mediator, Substitute.For<ICosmosQueryLogger>(), NullLogger<CosmosResponseProcessor>.Instance);
             var handler = new FhirCosmosResponseHandler(() => new NonDisposingScope(_container), _cosmosDataStoreConfiguration, _fhirRequestContextAccessor, responseProcessor);
-            var retryExceptionPolicyFactory = new RetryExceptionPolicyFactory(_cosmosDataStoreConfiguration, _fhirRequestContextAccessor);
+            var retryExceptionPolicyFactory = new RetryExceptionPolicyFactory(_cosmosDataStoreConfiguration, _fhirRequestContextAccessor, NullLogger<RetryExceptionPolicyFactory>.Instance);
             var documentClientInitializer = new FhirCosmosClientInitializer(
                 testProvider,
                 () => new[] { handler },

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
@@ -233,8 +233,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 () => _container.CreateMockScope(),
                 new CosmosQueryFactory(Substitute.For<ICosmosResponseProcessor>(), Substitute.For<ICosmosQueryLogger>()),
                 new CosmosDbDistributedLockFactory(() => _container.CreateMockScope(), NullLogger<CosmosDbDistributedLock>.Instance),
-                retryExceptionPolicyFactory,
-                NullLogger<CosmosQueueClient>.Instance);
+                retryExceptionPolicyFactory);
 
             _cosmosFhirOperationDataStore = new CosmosFhirOperationDataStore(
                 _queueClient,

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
@@ -232,7 +232,9 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             _queueClient = new CosmosQueueClient(
                 () => _container.CreateMockScope(),
                 new CosmosQueryFactory(Substitute.For<ICosmosResponseProcessor>(), Substitute.For<ICosmosQueryLogger>()),
-                new CosmosDbDistributedLockFactory(() => _container.CreateMockScope(), NullLogger<CosmosDbDistributedLock>.Instance));
+                new CosmosDbDistributedLockFactory(() => _container.CreateMockScope(), NullLogger<CosmosDbDistributedLock>.Instance),
+                retryExceptionPolicyFactory,
+                NullLogger<CosmosQueueClient>.Instance);
 
             _cosmosFhirOperationDataStore = new CosmosFhirOperationDataStore(
                 _queueClient,


### PR DESCRIPTION
## Description
Moves CosmosDB jobs to use unified exception logic. This will fix issues where 503 errors from CosmosDB are not being retried correctly in job hosting functions.

## Related issues
[AB#136882](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/136882)

## Testing
Unit tests

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
