### PR TITLE
Add retry to Cosmos search param operations

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/Registry/CosmosDbSearchParameterStatusDataStoreTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/Registry/CosmosDbSearchParameterStatusDataStoreTests.cs
@@ -1,0 +1,216 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Health.Core.Features.Context;
+using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Health.Fhir.Core.Features.Context;
+using Microsoft.Health.Fhir.Core.Features.Search.Registry;
+using Microsoft.Health.Fhir.CosmosDb.Core.Configs;
+using Microsoft.Health.Fhir.CosmosDb.Features.Queries;
+using Microsoft.Health.Fhir.CosmosDb.Features.Storage;
+using Microsoft.Health.Fhir.CosmosDb.Features.Storage.Registry;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Test.Utilities;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Polly;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Storage.Registry;
+
+[Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+[Trait(Traits.Category, Categories.Search)]
+public class CosmosDbSearchParameterStatusDataStoreTests
+{
+    private readonly CosmosDbSearchParameterStatusDataStore _dataStore;
+    private readonly ICosmosQueryFactory _cosmosQueryFactory;
+    private readonly IScoped<Container> _containerScope;
+    private readonly CosmosDataStoreConfiguration _cosmosDataStoreConfiguration = new CosmosDataStoreConfiguration();
+    private readonly IFhirRequestContext _fhirRequestContext;
+    private readonly RequestContextAccessor<IFhirRequestContext> _requestContextAccessor;
+    private readonly RetryExceptionPolicyFactory _retryExceptionPolicyFactory;
+
+    public CosmosDbSearchParameterStatusDataStoreTests()
+    {
+        _cosmosQueryFactory = Substitute.For<ICosmosQueryFactory>();
+        _containerScope = Substitute.For<IScoped<Container>>();
+
+        _fhirRequestContext = Substitute.For<IFhirRequestContext>();
+        _requestContextAccessor = Substitute.For<RequestContextAccessor<IFhirRequestContext>>();
+        _requestContextAccessor.RequestContext.Returns(_fhirRequestContext);
+        _retryExceptionPolicyFactory = new RetryExceptionPolicyFactory(_cosmosDataStoreConfiguration, _requestContextAccessor, NullLogger<RetryExceptionPolicyFactory>.Instance);
+
+        _dataStore = new CosmosDbSearchParameterStatusDataStore(
+            () => _containerScope,
+            new CosmosDataStoreConfiguration(),
+            _cosmosQueryFactory,
+            _retryExceptionPolicyFactory);
+    }
+
+    [Fact]
+    public async Task GivenTransientError_WhenGettingSearchParameterStatusesAsBackgroundTask_ThenRetriesShouldBeAttempted()
+    {
+        // Arrange
+        _fhirRequestContext.IsBackgroundTask.Returns(true);
+
+        var exception = new CosmosException(
+                    message: "Service Unavailable",
+                    statusCode: HttpStatusCode.ServiceUnavailable,
+                    subStatusCode: 0,
+                    activityId: Guid.NewGuid().ToString(),
+                    requestCharge: 0);
+
+        var mockQuery = Substitute.For<ICosmosQuery<SearchParameterStatusWrapper>>();
+        int runs = 0;
+
+        // Simulate failure on the first three attempts and success on fourth
+        mockQuery.ExecuteNextAsync(CancellationToken.None)
+            .ReturnsForAnyArgs(_ =>
+            {
+                runs++;
+                if (runs < 4)
+                {
+                    throw exception;
+                }
+
+                // Return a mock FeedResponse on the fourth attempt
+                return Task.FromResult(CreateMockFeedResponse(
+                [
+                    new SearchParameterStatusWrapper { Uri = new Uri("http://example.com") },
+                ]));
+            });
+
+        _cosmosQueryFactory.Create<SearchParameterStatusWrapper>(
+            Arg.Any<Container>(),
+            Arg.Any<CosmosQueryContext>()).Returns(mockQuery);
+
+        // Act
+        await _dataStore.GetSearchParameterStatuses(CancellationToken.None);
+
+        // Assert
+        await mockQuery.Received(4).ExecuteNextAsync(Arg.Any<CancellationToken>()); // 1 initial attempt + 3 retry
+    }
+
+    [Fact]
+    public async Task GivenTransientError_WhenCheckingIfSearchParameterStatusUpdateIsRequiredAsBackgroundTask_ThenRetriesShouldBeAttempted()
+    {
+        // Arrange
+        _fhirRequestContext.IsBackgroundTask.Returns(true);
+
+        var exception = new CosmosException(
+            message: "Service Unavailable",
+            statusCode: HttpStatusCode.ServiceUnavailable,
+            subStatusCode: 0,
+            activityId: Guid.NewGuid().ToString(),
+            requestCharge: 0);
+
+        var mockQuery = Substitute.For<ICosmosQuery<CosmosDbSearchParameterStatusDataStore.CacheQueryResponse>>();
+        int runs = 0;
+
+        // Simulate failure on the first three attempts and success on the fourth
+        mockQuery.ExecuteNextAsync(Arg.Any<CancellationToken>())
+            .ReturnsForAnyArgs(_ =>
+            {
+                runs++;
+                if (runs < 4)
+                {
+                    throw exception;
+                }
+
+                // Return a mock FeedResponse on the fourth attempt
+                return Task.FromResult(CreateMockFeedResponse(new List<CosmosDbSearchParameterStatusDataStore.CacheQueryResponse>
+                {
+                    new()
+                    {
+                        Count = 5,
+                        LastUpdated = DateTimeOffset.UtcNow.AddMinutes(1),
+                    },
+                }));
+            });
+
+        _cosmosQueryFactory.Create<CosmosDbSearchParameterStatusDataStore.CacheQueryResponse>(
+            Arg.Any<Container>(),
+            Arg.Any<CosmosQueryContext>()).Returns(mockQuery);
+
+        var container = Substitute.For<IScoped<Container>>();
+        container.Value.Returns(Substitute.For<Container>());
+
+        // Act
+        var result = await _dataStore.CheckIfSearchParameterStatusUpdateRequiredAsync(
+            container,
+            currentCount: 4,
+            lastRefreshed: DateTimeOffset.UtcNow,
+            CancellationToken.None);
+
+        // Assert
+        Assert.True(result); // Should return true due to mismatched count and timestamp
+        await mockQuery.Received(4).ExecuteNextAsync(Arg.Any<CancellationToken>()); // 1 initial attempt + 3 retries
+    }
+
+    [Fact]
+    public async Task GivenBatchExecutionError_WhenUpsertingStatusesAsBackgroundTask_ThenRetriesShouldBeAttempted()
+    {
+        // Arrange
+        _fhirRequestContext.IsBackgroundTask.Returns(true);
+
+        var exception = new CosmosException(
+            message: "Service Unavailable",
+            statusCode: HttpStatusCode.ServiceUnavailable,
+            subStatusCode: 0,
+            activityId: Guid.NewGuid().ToString(),
+            requestCharge: 0);
+
+        var mockContainer = Substitute.For<Container>();
+        var mockTransactionalBatch = Substitute.For<TransactionalBatch>();
+
+        int runs = 0;
+
+        // Simulate failure on the first three attempts and success on the fourth
+        mockTransactionalBatch.ExecuteAsync(Arg.Any<CancellationToken>())
+            .ReturnsForAnyArgs(_ =>
+            {
+                runs++;
+                if (runs < 4)
+                {
+                    throw exception;
+                }
+
+                // Return a mock TransactionalBatchResponse on the fourth attempt
+                return Task.FromResult(Substitute.For<TransactionalBatchResponse>());
+            });
+
+        mockContainer.CreateTransactionalBatch(Arg.Any<PartitionKey>())
+            .Returns(mockTransactionalBatch);
+
+        _containerScope.Value.Returns(mockContainer);
+
+        var statuses = new List<ResourceSearchParameterStatus>
+        {
+            new() { Uri = new Uri("http://example.com") },
+        };
+
+        // Act
+        await _dataStore.UpsertStatuses(statuses, CancellationToken.None);
+
+        // Assert
+        await mockTransactionalBatch.Received(4).ExecuteAsync(Arg.Any<CancellationToken>()); // 3 failure + 1 success
+    }
+
+    private static FeedResponse<T> CreateMockFeedResponse<T>(List<T> items)
+    {
+        var feedResponse = Substitute.For<FeedResponse<T>>();
+        feedResponse.Count.Returns(items.Count);
+        feedResponse.GetEnumerator().Returns(items.GetEnumerator());
+        return feedResponse;
+    }
+}

--- a/src/Microsoft.Health.Fhir.CosmosDb/AssemblyInfo.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/AssemblyInfo.cs
@@ -11,5 +11,5 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Microsoft.Health.Fhir.R4.Tests.Integration")]
 [assembly: InternalsVisibleTo("Microsoft.Health.Fhir.R4B.Tests.Integration")]
 [assembly: InternalsVisibleTo("Microsoft.Health.Fhir.R5.Tests.Integration")]
-[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 [assembly: NeutralResourcesLanguage("en-us")]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
@@ -207,7 +207,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             _searchParameterStatusDataStore = new CosmosDbSearchParameterStatusDataStore(
                 () => documentClient,
                 _cosmosDataStoreConfiguration,
-                cosmosDocumentQueryFactory);
+                cosmosDocumentQueryFactory,
+                new RetryExceptionPolicyFactory(_cosmosDataStoreConfiguration, _fhirRequestContextAccessor, NullLogger<RetryExceptionPolicyFactory>.Instance));
 
             var bundleConfiguration = new BundleConfiguration() { SupportsBundleOrchestrator = true };
             var bundleOptions = Substitute.For<IOptions<BundleConfiguration>>();


### PR DESCRIPTION
## Description
Adds retry to Cosmos search parameter data store operations when called by a background job.
This uses the retry policy already in place
The flag for background jobs already added in [this commit](https://github.com/microsoft/fhir-server/commit/c8f678c2b0f6202f1e02b5b33568c13a80a4dd2c#diff-7defa4243c89277e3f41b5af7d4e11aa5a6d47c4127af414086447233b72fc21)

## Related issues
[AB#136882](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/136882)

## Testing
Unit testing.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
