### PR TITLE
Cap retries to 8000 surrogate id errors

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -434,7 +434,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
             int GetMaxRetries(IReadOnlyList<ImportResource> resources, ImportMode importMode)
             {
-                return importMode == ImportMode.IncrementalLoad && resources.Any(_ => _.KeepLastUpdated) ? 80000 / resources.Count : 30; // 80K is id sequence rollover
+                return importMode == ImportMode.IncrementalLoad && resources.Any(_ => _.KeepLastUpdated) ? Math.Min(8000, 80000 / resources.Count) : 30; // 80K is id sequence rollover
             }
 
             List<string> GetErrors(IReadOnlyCollection<ImportResource> dups, IReadOnlyCollection<ImportResource> conflicts)


### PR DESCRIPTION
Should make 80K+1 resources import test abort less frequent.