### PR TITLE
Fix instance availability errors following schema upgrade

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
@@ -456,10 +456,15 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
         {
             ThrowIfCurrentSchemaVersionIsNull();
 
+            if (_highestInitializedVersion < _schemaInformation.MinimumSupportedVersion)
+            {
+                _logger.LogError($"The {nameof(SqlServerFhirModel)} instance has not run the initialization required for minimum supported schema version");
+                throw new ServiceUnavailableException();
+            }
+
             if (_highestInitializedVersion < _schemaInformation.Current)
             {
-                _logger.LogError($"The {nameof(SqlServerFhirModel)} instance has not run the initialization required for the current schema version");
-                throw new ServiceUnavailableException();
+                _logger.LogWarning($"The {nameof(SqlServerFhirModel)} instance has not run the initialization required for the current schema version");
             }
         }
 


### PR DESCRIPTION
## Description
We have seen that after schema upgrade, as soon as the current schema version changes for an instance, the instance since not initialized upto the current schema version returns 503 and thus it impacts the customer experience.
This PR ensures that instance should be initialized upto the min supported schema version and if there is a schema upgrade, service should continue to respond while initializing the instance in parallel.

## Related issues
Addresses [issue #].
https://microsofthealth.visualstudio.com/Health/_workitems/edit/139949

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
