### PR TITLE
Deployment template can specify registryName

### DIFF
--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -81,6 +81,7 @@ jobs:
             enableImport = $true
             backgroundTaskCount = 5
             enableReindex = if ("${{ parameters.reindexEnabled }}" -eq "true") { $true } else { $false }
+            registryName = '$(azureContainerRegistry)'
             imageTag = '${{ parameters.imageTag }}'
         }
      

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -114,17 +114,6 @@
                 "description": "An object representing the default consistency policy for the Cosmos DB account. See https://docs.microsoft.com/en-us/azure/templates/microsoft.documentdb/databaseaccounts#ConsistencyPolicy"
             }
         },
-        "cosmosDbFreeTier": {
-            "type": "string",
-            "allowedValues": [
-                "Yes",
-                "No"
-            ],
-            "defaultValue": "No",
-            "metadata": {
-                "description": "Use Cosmos DB free tier."
-            }
-        },
         "cosmosDbCmkUrl": {
             "type": "string",
             "defaultValue": "",
@@ -182,9 +171,16 @@
                 "description": "Version of the FHIR specification to deploy."
             }
         },
+        "registryName": {
+            "type": "string",
+            "defaultValue": "mcr.microsoft.com/healthcareapis",
+            "metadata": {
+                "description": "Docker registry containing images to deploy."
+            }
+        },
         "imageTag": {
             "type": "string",
-            "defaultValue": "release",
+            "defaultValue": "latest",
             "metadata": {
                 "description": "Tag of the docker image to deploy."
             }
@@ -239,7 +235,6 @@
     },
     "variables": {
         "isMAG": "[or(contains(resourceGroup().location,'usgov'),contains(resourceGroup().location,'usdod'))]",
-        "isCosmosDbFreeTier": "[equals(parameters('cosmosDbFreeTier'),'Yes')]",
         "serviceName": "[toLower(parameters('serviceName'))]",
         "keyvaultEndpoint": "[if(variables('isMAG'), concat('https://', variables('serviceName'), '.vault.usgovcloudapi.net/'), concat('https://', variables('serviceName'), '.vault.azure.net/'))]",
         "appServicePlanResourceGroup": "[if(empty(parameters('appServicePlanResourceGroup')), resourceGroup().name, parameters('appServicePlanResourceGroup'))]",
@@ -286,7 +281,6 @@
         "sqlDatabaseName": "[concat('FHIR', parameters('fhirVersion'))]",
         "computedSqlServerReference": "[concat('Microsoft.Sql/servers/', variables('sqlServerDerivedName'))]",
         "storageAccountName": "[concat(substring(replace(variables('serviceName'), '-', ''), 0, min(11, length(replace(variables('serviceName'), '-', '')))), uniquestring(resourceGroup().id, variables('serviceName')))]",
-        "registryName": "healthplatformregistry.azurecr.io",
         "azureContainerRegistryUri": "[if(variables('isMAG'), '.azurecr.us', '.azurecr.io')]",
         "azureContainerRegistryName": "[concat(substring(replace(variables('serviceName'), '-', ''), 0, min(11, length(replace(variables('serviceName'), '-', '')))), uniquestring(resourceGroup().id, variables('serviceName')))]",
         "isSqlHyperscaleTier": "[equals(parameters('sqlDatabaseComputeTier'),'Hyperscale')]",
@@ -343,7 +337,7 @@
                     "appSettings": [
                         {
                             "name": "DOCKER_REGISTRY_SERVER_URL",
-                            "value": "[concat('https://', variables('registryName'))]"
+                            "value": "[concat('https://', parameters('registryName'))]"
                         },
                         {
                             "name": "DOCKER_REGISTRY_SERVER_USERNAME",
@@ -392,7 +386,7 @@
                         "[if(variables('deployAppInsights'),concat('Microsoft.Insights/components/', variables('appInsightsName')),resourceId('Microsoft.KeyVault/vaults', variables('serviceName')))]"
                     ],
                     "properties": {
-                        "linuxFxVersion": "[concat('DOCKER|', variables('registryName'), '/', toLower(parameters('fhirVersion')), '_fhir-server',':', parameters('imageTag'))]",
+                        "linuxFxVersion": "[concat('DOCKER|', parameters('registryName'), '/', toLower(parameters('fhirVersion')), '-fhir-server',':', parameters('imageTag'))]",
                         "appCommandLine": "azure-fhir-api",
                         "alwaysOn": true,
                         "healthCheckPath": "/health/check"

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -288,7 +288,8 @@
         "sqlSkuFamily": "[if(variables('isSqlHyperscaleTier'), 'Gen5', '')]",
         "sqlSkuName": "[if(variables('isSqlHyperscaleTier'), 'HS_Gen5', 'Standard')]",
         "sqlSkuTier": "[if(variables('isSqlHyperscaleTier'), 'Hyperscale', 'Standard')]",
-        "keyVaultRoleName": "[concat('Key Vault Secrets Officer-', variables('serviceName'))]"
+        "keyVaultRoleName": "[concat('Key Vault Secrets Officer-', variables('serviceName'))]",
+        "imageRepositoryName": "[if(contains(parameters('registryName'),'mcr.'), concat(toLower(parameters('fhirVersion')), '-fhir-server'), concat(toLower(parameters('fhirVersion')), '_fhir-server'))]"
     },
     "resources": [
         {
@@ -386,7 +387,7 @@
                         "[if(variables('deployAppInsights'),concat('Microsoft.Insights/components/', variables('appInsightsName')),resourceId('Microsoft.KeyVault/vaults', variables('serviceName')))]"
                     ],
                     "properties": {
-                        "linuxFxVersion": "[concat('DOCKER|', parameters('registryName'), '/', toLower(parameters('fhirVersion')), '-fhir-server',':', parameters('imageTag'))]",
+                        "linuxFxVersion": "[concat('DOCKER|', parameters('registryName'), '/', variables('imageRepositoryName'),':', parameters('imageTag'))]",
                         "appCommandLine": "azure-fhir-api",
                         "alwaysOn": true,
                         "healthCheckPath": "/health/check"


### PR DESCRIPTION
## Description
This pull request includes changes to the deployment configuration files to enhance consistency and flexibility. The most significant changes involve the introduction of a new `registryName` parameter.

Enhancements to deployment configuration:

* [`samples/templates/default-azuredeploy-docker.json`](diffhunk://#diff-8f12d2301c516589ac0d2aa63d5e045b1afac1caf1434ff9bae355ee8d62f494R174-R183): Added a new `registryName` parameter to specify the Docker registry containing images to deploy.
* [`samples/templates/default-azuredeploy-docker.json`](diffhunk://#diff-8f12d2301c516589ac0d2aa63d5e045b1afac1caf1434ff9bae355ee8d62f494L346-R340): Modified the `linuxFxVersion` and `DOCKER_REGISTRY_SERVER_URL` properties to use the new `registryName` parameter instead of a hardcoded value. [[1]](diffhunk://#diff-8f12d2301c516589ac0d2aa63d5e045b1afac1caf1434ff9bae355ee8d62f494L346-R340) [[2]](diffhunk://#diff-8f12d2301c516589ac0d2aa63d5e045b1afac1caf1434ff9bae355ee8d62f494L395-R389)

Removal of obsolete parameters:

* [`samples/templates/default-azuredeploy-docker.json`](diffhunk://#diff-8f12d2301c516589ac0d2aa63d5e045b1afac1caf1434ff9bae355ee8d62f494L117-L127): Removed the `cosmosDbFreeTier` parameter and its associated logic. [[1]](diffhunk://#diff-8f12d2301c516589ac0d2aa63d5e045b1afac1caf1434ff9bae355ee8d62f494L117-L127) [[2]](diffhunk://#diff-8f12d2301c516589ac0d2aa63d5e045b1afac1caf1434ff9bae355ee8d62f494L242)

Other improvements:

* [`build/jobs/provision-deploy.yml`](diffhunk://#diff-96e510a6dff7e5dadab5de4fd09bd73429703125d6bf40296f7aeb4ccc75052cR84): Added a new `registryName` variable to the provisioning script.
* [`samples/templates/default-azuredeploy-docker.json`](diffhunk://#diff-8f12d2301c516589ac0d2aa63d5e045b1afac1caf1434ff9bae355ee8d62f494R174-R183): Updated the default value for the `imageTag` parameter to "latest".

## Related issues
Addresses #4806, [AB#144203](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/144203)

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
