### PR TITLE
Add support for include to delete requests

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/BulkDelete/BulkDeleteProcessingJobTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/BulkDelete/BulkDeleteProcessingJobTests.cs
@@ -58,8 +58,11 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.BulkDelete
                 Definition = JsonConvert.SerializeObject(definition),
             };
 
+            var substituteResults = new Dictionary<string, long>();
+            substituteResults.Add("Patient", 3);
+
             _deleter.DeleteMultipleAsync(Arg.Any<ConditionalDeleteResourceRequest>(), Arg.Any<CancellationToken>())
-                .Returns(args => 3);
+                .Returns(args => substituteResults);
 
             var result = JsonConvert.DeserializeObject<BulkDeleteResult>(await _processingJob.ExecuteAsync(jobInfo, CancellationToken.None));
             Assert.Single(result.ResourcesDeleted);
@@ -80,8 +83,11 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.BulkDelete
                 Definition = JsonConvert.SerializeObject(definition),
             };
 
+            var substituteResults = new Dictionary<string, long>();
+            substituteResults.Add("Patient", 3);
+
             _deleter.DeleteMultipleAsync(Arg.Any<ConditionalDeleteResourceRequest>(), Arg.Any<CancellationToken>())
-                .Returns(args => 3);
+                .Returns(args => substituteResults);
 
             var result = JsonConvert.DeserializeObject<BulkDeleteResult>(await _processingJob.ExecuteAsync(jobInfo, CancellationToken.None));
             Assert.Single(result.ResourcesDeleted);

--- a/src/Microsoft.Health.Fhir.Core/Extensions/SearchServiceExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Extensions/SearchServiceExtensions.cs
@@ -26,8 +26,6 @@ namespace Microsoft.Health.Fhir.Core.Extensions
             KnownQueryParameterNames.Summary,
             KnownQueryParameterNames.Total,
             KnownQueryParameterNames.ContinuationToken,
-            "_include",
-            "_revinclude",
         };
 
         /// <summary>
@@ -100,7 +98,7 @@ namespace Microsoft.Health.Fhir.Core.Extensions
                     {
                         matchedResults.AddRange(
                             results?.Results
-                                .Where(x => x.SearchEntryMode == ValueSets.SearchEntryMode.Match)
+                                .Where(x => x.SearchEntryMode != ValueSets.SearchEntryMode.Outcome)
                                 .Take(Math.Max(count.HasValue ? 0 : results.Results.Count(), count.GetValueOrDefault() - matchedResults.Count)));
                     }
                 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/BulkDelete/BulkDeleteProcessingJob.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/BulkDelete/BulkDeleteProcessingJob.cs
@@ -73,14 +73,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.BulkDelete
 
                 _contextAccessor.RequestContext = fhirRequestContext;
                 var result = new BulkDeleteResult();
-                long numDeleted;
+                IDictionary<string, long> resourcesDeleted = new Dictionary<string, long>();
                 using IScoped<IDeletionService> deleter = _deleterFactory.Invoke();
                 Exception exception = null;
                 List<string> types = definition.Type.SplitByOrSeparator().ToList();
 
                 try
                 {
-                    numDeleted = await deleter.Value.DeleteMultipleAsync(
+                    resourcesDeleted = await deleter.Value.DeleteMultipleAsync(
                         new ConditionalDeleteResourceRequest(
                             types[0],
                             (IReadOnlyList<Tuple<string, string>>)definition.SearchParameters,
@@ -91,16 +91,22 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.BulkDelete
                             allowPartialSuccess: false), // Explicitly setting to call out that this can be changed in the future if we want to. Bulk delete offers the possibility of automatically rerunning the operation until it succeeds, fully automating the process.
                         cancellationToken);
                 }
-                catch (IncompleteOperationException<long> ex)
+                catch (IncompleteOperationException<IDictionary<string, long>> ex)
                 {
-                    numDeleted = ex.PartialResults;
+                    resourcesDeleted = ex.PartialResults;
                     result.Issues.Add(ex.Message);
                     exception = ex;
                 }
 
-                result.ResourcesDeleted.Add(types[0], numDeleted);
+                foreach (var (key, value) in resourcesDeleted)
+                {
+                    if (!result.ResourcesDeleted.TryAdd(key, value))
+                    {
+                        result.ResourcesDeleted[key] += value;
+                    }
+                }
 
-                await _mediator.Publish(new BulkDeleteMetricsNotification(jobInfo.Id, numDeleted), cancellationToken);
+                await _mediator.Publish(new BulkDeleteMetricsNotification(jobInfo.Id, resourcesDeleted.Sum(resource => resource.Value)), cancellationToken);
 
                 if (exception != null)
                 {

--- a/src/Microsoft.Health.Fhir.Core/Features/Persistence/IDeletionService.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Persistence/IDeletionService.cs
@@ -14,6 +14,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
     {
         public Task<ResourceKey> DeleteAsync(DeleteResourceRequest request, CancellationToken cancellationToken);
 
-        public Task<long> DeleteMultipleAsync(ConditionalDeleteResourceRequest request, CancellationToken cancellationToken);
+        public Task<IDictionary<string, long>> DeleteMultipleAsync(ConditionalDeleteResourceRequest request, CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -1592,6 +1592,15 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The number of included results exceeded the limit of {0}.
+        /// </summary>
+        internal static string TooManyIncludeResults {
+            get {
+                return ResourceManager.GetString("TooManyIncludeResults", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to There was resource contention with another process in the datastore. Please retry this transaction..
         /// </summary>
         internal static string TransactionDeadlock {

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -757,4 +757,8 @@
   <data name="OperationFailedForCustomerManagedKey" xml:space="preserve">
     <value>Error occurred during an operation that is dependent on the customer-managed key. Use https://go.microsoft.com/fwlink/?linkid=2300268 to troubleshoot the issue.</value>
   </data>
+  <data name="TooManyIncludeResults" xml:space="preserve">
+    <value>The number of included results exceeded the limit of {0}</value>
+    <comment>{0} is the limit of how many include results the service will return.</comment>
+  </data>
 </root>

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/ResourceHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/ResourceHandlerTests.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Resources
             var auditLogger = Substitute.For<IAuditLogger>();
             var logger = Substitute.For<ILogger<DeletionService>>();
 
-            var deleter = new DeletionService(_resourceWrapperFactory, lazyConformanceProvider, _fhirDataStore.CreateMockScopeProvider(), _searchService.CreateMockScopeProvider(), _resourceIdProvider, contextAccessor, auditLogger, logger);
+            var deleter = new DeletionService(_resourceWrapperFactory, lazyConformanceProvider, _fhirDataStore.CreateMockScopeProvider(), _searchService.CreateMockScopeProvider(), _resourceIdProvider, contextAccessor, auditLogger, new OptionsWrapper<CoreFeatureConfiguration>(coreFeatureConfiguration), logger);
 
             var conditionalCreateLogger = Substitute.For<ILogger<ConditionalCreateResourceHandler>>();
             var conditionalUpsertLogger = Substitute.For<ILogger<ConditionalUpsertResourceHandler>>();

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/ResourceHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/ResourceHandlerTests.cs
@@ -14,9 +14,11 @@ using Hl7.Fhir.Serialization;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Health.Core.Features.Security.Authorization;
 using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Audit;
@@ -115,6 +117,8 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Resources
             var referenceResolver = new ResourceReferenceResolver(_searchService, new TestQueryStringParser(), Substitute.For<ILogger<ResourceReferenceResolver>>());
             _resourceIdProvider = new ResourceIdProvider();
 
+            var coreFeatureConfiguration = new CoreFeatureConfiguration();
+
             var auditLogger = Substitute.For<IAuditLogger>();
             var logger = Substitute.For<ILogger<DeletionService>>();
 
@@ -129,7 +133,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Resources
             collection.Add(x => new UpsertResourceHandler(_fhirDataStore, lazyConformanceProvider, _resourceWrapperFactory, _resourceIdProvider, referenceResolver, _authorizationService, ModelInfoProvider.Instance)).Singleton().AsSelf().AsImplementedInterfaces();
             collection.Add(x => new ConditionalCreateResourceHandler(_fhirDataStore, lazyConformanceProvider, _resourceWrapperFactory, _searchService, x.GetService<IMediator>(), _resourceIdProvider, _authorizationService, conditionalCreateLogger)).Singleton().AsSelf().AsImplementedInterfaces();
             collection.Add(x => new ConditionalUpsertResourceHandler(_fhirDataStore, lazyConformanceProvider, _resourceWrapperFactory, _searchService, x.GetService<IMediator>(), _resourceIdProvider, _authorizationService, conditionalUpsertLogger)).Singleton().AsSelf().AsImplementedInterfaces();
-            collection.Add(x => new ConditionalDeleteResourceHandler(_fhirDataStore, lazyConformanceProvider, _resourceWrapperFactory, _searchService, x.GetService<IMediator>(), _resourceIdProvider, _authorizationService, deleter, contextAccessor, conditionalDeleteLogger)).Singleton().AsSelf().AsImplementedInterfaces();
+            collection.Add(x => new ConditionalDeleteResourceHandler(_fhirDataStore, lazyConformanceProvider, _resourceWrapperFactory, _searchService, x.GetService<IMediator>(), _resourceIdProvider, _authorizationService, deleter, contextAccessor, new OptionsWrapper<CoreFeatureConfiguration>(coreFeatureConfiguration), conditionalDeleteLogger)).Singleton().AsSelf().AsImplementedInterfaces();
             collection.Add(x => new GetResourceHandler(_fhirDataStore, lazyConformanceProvider, _resourceWrapperFactory, _resourceIdProvider, _dataResourceFilter, _authorizationService, contextAccessor, _searchService)).Singleton().AsSelf().AsImplementedInterfaces();
             collection.Add(x => new DeleteResourceHandler(_fhirDataStore, lazyConformanceProvider, _resourceWrapperFactory, _resourceIdProvider, _authorizationService, deleter)).Singleton().AsSelf().AsImplementedInterfaces();
 

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/ConditionalResourceHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/ConditionalResourceHandler.cs
@@ -60,7 +60,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources
                 cancellationToken,
                 logger: _logger);
 
-            int matchCount = results.Results.Where(result => result.SearchEntryMode == ValueSets.SearchEntryMode.Match).Count();
+            var matches = results.Results.Where(result => result.SearchEntryMode == ValueSets.SearchEntryMode.Match).ToList();
+            int matchCount = matches.Count;
             if (matchCount == 0)
             {
                 _logger.LogInformation("Conditional handler: Not Match. ResourceType={ResourceType}", request.ResourceType);
@@ -69,7 +70,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources
             else if (matchCount == 1)
             {
                 _logger.LogInformation("Conditional handler: One Match Found. ResourceType={ResourceType}", request.ResourceType);
-                return await HandleSingleMatch(request, results.Results.First(), cancellationToken);
+                return await HandleSingleMatch(request, matches.First(), cancellationToken);
             }
             else
             {

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/ConditionalResourceHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/ConditionalResourceHandler.cs
@@ -54,27 +54,27 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources
                 throw new UnauthorizedFhirActionException();
             }
 
-            var matchedResults = await _searchService.ConditionalSearchAsync(
+            var results = await _searchService.ConditionalSearchAsync(
                 request.ResourceType,
                 request.ConditionalParameters,
                 cancellationToken,
                 logger: _logger);
 
-            int count = matchedResults.Results.Count;
-            if (count == 0)
+            int matchCount = results.Results.Where(result => result.SearchEntryMode == ValueSets.SearchEntryMode.Match).Count();
+            if (matchCount == 0)
             {
                 _logger.LogInformation("Conditional handler: Not Match. ResourceType={ResourceType}", request.ResourceType);
                 return await HandleNoMatch(request, cancellationToken);
             }
-            else if (count == 1)
+            else if (matchCount == 1)
             {
                 _logger.LogInformation("Conditional handler: One Match Found. ResourceType={ResourceType}", request.ResourceType);
-                return await HandleSingleMatch(request, matchedResults.Results.First(), cancellationToken);
+                return await HandleSingleMatch(request, results.Results.First(), cancellationToken);
             }
             else
             {
                 // Multiple matches: The server returns a 412 Precondition Failed error indicating the client's criteria were not selective enough
-                _logger.LogInformation("PreconditionFailed: Conditional handler: Multiple Matches Found. ResourceType={ResourceType}, NumberOfMatches={NumberOfMatches}", request.ResourceType, count);
+                _logger.LogInformation("PreconditionFailed: Conditional handler: Multiple Matches Found. ResourceType={ResourceType}, NumberOfMatches={NumberOfMatches}", request.ResourceType, matchCount);
                 throw new PreconditionFailedException(string.Format(CultureInfo.InvariantCulture, Core.Resources.ConditionalOperationNotSelectiveEnough, request.ResourceType));
             }
         }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeletionService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeletionService.cs
@@ -298,13 +298,16 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
                 using var fhirDataStore = _fhirDataStoreFactory.Invoke();
 
                 // Delete includes first so that if there is a failure, the match resources are not deleted. This allows the job to restart.
-                await fhirDataStore.Value.MergeAsync(softDeleteIncludes, cancellationToken);
-                partialResults.AddRange(softDeleteIncludes.Select(item => (
-                    item.Wrapper.ResourceTypeName,
-                    item.Wrapper.ResourceId,
-                    resourcesToDelete
-                        .Where(resource => resource.Resource.ResourceId == item.Wrapper.ResourceId && resource.Resource.ResourceTypeName == item.Wrapper.ResourceTypeName)
-                        .FirstOrDefault().SearchEntryMode == ValueSets.SearchEntryMode.Include)));
+                if (softDeleteIncludes.Any())
+                {
+                    await fhirDataStore.Value.MergeAsync(softDeleteIncludes, cancellationToken);
+                    partialResults.AddRange(softDeleteIncludes.Select(item => (
+                        item.Wrapper.ResourceTypeName,
+                        item.Wrapper.ResourceId,
+                        resourcesToDelete
+                            .Where(resource => resource.Resource.ResourceId == item.Wrapper.ResourceId && resource.Resource.ResourceTypeName == item.Wrapper.ResourceTypeName)
+                            .FirstOrDefault().SearchEntryMode == ValueSets.SearchEntryMode.Include)));
+                }
 
                 await fhirDataStore.Value.MergeAsync(softDeleteMatches, cancellationToken);
             }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeletionService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeletionService.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
             var deleteTasks = new List<Task<Dictionary<string, long>>>();
             using var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
-            if (CheckFhirContextIssues())
+            if (AreIncludeResultsTruncated())
             {
                 var innerException = new BadRequestException(string.Format(CultureInfo.InvariantCulture, Core.Resources.TooManyIncludeResults, _configuration.DefaultIncludeCountPerSearch));
                 throw new IncompleteOperationException<Dictionary<string, long>>(innerException, resourceTypesDeleted);
@@ -196,7 +196,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
                                 logger: _logger);
                         }
 
-                        if (CheckFhirContextIssues())
+                        if (AreIncludeResultsTruncated())
                         {
                             tooManyIncludeResults = true;
                             break;
@@ -431,7 +431,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
             return auditTask;
         }
 
-        private bool CheckFhirContextIssues()
+        private bool AreIncludeResultsTruncated()
         {
             return _contextAccessor.RequestContext.BundleIssues.Any(x => string.Equals(x.Diagnostics, Core.Resources.TruncatedIncludeMessage, StringComparison.OrdinalIgnoreCase));
         }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeletionService.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/DeletionService.cs
@@ -50,7 +50,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
         private readonly AsyncRetryPolicy _retryPolicy;
         private readonly FhirRequestContextAccessor _contextAccessor;
         private readonly IAuditLogger _auditLogger;
-        private readonly RequestContextAccessor<IFhirRequestContext> _fhirContext;
         private readonly CoreFeatureConfiguration _configuration;
         private readonly ILogger<DeletionService> _logger;
 
@@ -65,7 +64,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
             ResourceIdProvider resourceIdProvider,
             FhirRequestContextAccessor contextAccessor,
             IAuditLogger auditLogger,
-            RequestContextAccessor<IFhirRequestContext> fhirContext,
             IOptions<CoreFeatureConfiguration> configuration,
             ILogger<DeletionService> logger)
         {
@@ -77,7 +75,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
             _contextAccessor = EnsureArg.IsNotNull(contextAccessor, nameof(contextAccessor));
             _auditLogger = EnsureArg.IsNotNull(auditLogger, nameof(auditLogger));
             _logger = EnsureArg.IsNotNull(logger, nameof(logger));
-            _fhirContext = EnsureArg.IsNotNull(fhirContext, nameof(fhirContext));
             _configuration = EnsureArg.IsNotNull(configuration.Value, nameof(configuration));
 
             _retryPolicy = Policy
@@ -385,7 +382,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
 
         private bool CheckFhirContextIssues()
         {
-            return _fhirContext.RequestContext.BundleIssues.Any(x => string.Equals(x.Diagnostics, Core.Resources.TruncatedIncludeMessage, StringComparison.OrdinalIgnoreCase));
+            return _contextAccessor.RequestContext.BundleIssues.Any(x => string.Equals(x.Diagnostics, Core.Resources.TruncatedIncludeMessage, StringComparison.OrdinalIgnoreCase));
         }
 
         private static Dictionary<string, long> AppendDeleteResults(Dictionary<string, long> results, IEnumerable<Dictionary<string, long>> newResults)

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/ResourceReferenceResolver.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/ResourceReferenceResolver.cs
@@ -70,12 +70,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources
 
                         var results = await GetExistingResourceId(requestUrl, resourceType, conditionalQueries, cancellationToken);
 
-                        if (results == null || results.Count != 1)
+                        if (results == null || results.Where(result => result.SearchEntryMode == ValueSets.SearchEntryMode.Match).Count() != 1)
                         {
                             throw new RequestNotValidException(string.Format(Core.Resources.InvalidConditionalReference, reference.Reference));
                         }
 
-                        string resourceId = results.First().Resource.ResourceId;
+                        string resourceId = results.First(result => result.SearchEntryMode == ValueSets.SearchEntryMode.Match).Resource.ResourceId;
 
                         referenceIdDictionary.Add(reference.Reference, (resourceId, resourceType));
 

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/ResourceReferenceResolver.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/ResourceReferenceResolver.cs
@@ -96,7 +96,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources
 
             var searchResourceRequest = new SearchResourceRequest(resourceType, conditionalParameters);
 
-            return (await _searchService.ConditionalSearchAsync(searchResourceRequest.ResourceType, searchResourceRequest.Queries, cancellationToken, logger: _logger)).Results;
+            var matches = (await _searchService.ConditionalSearchAsync(searchResourceRequest.ResourceType, searchResourceRequest.Queries, cancellationToken, logger: _logger))
+                .Results
+                .Where(result => result.SearchEntryMode == ValueSets.SearchEntryMode.Match)
+                .ToList();
+
+            return matches;
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BulkDeleteTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BulkDeleteTests.cs
@@ -8,7 +8,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Threading.Tasks;
 using Hl7.Fhir.Model;
+using IdentityServer4.Models;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Health.Fhir.Client;
 using Microsoft.Health.Fhir.Core.Features;
@@ -38,7 +40,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             _fhirClient = fixture.TestFhirClient;
         }
 
-        [Fact(Skip = "Fails transiently. It will be re-enabled after adding delay")]
+        [SkippableFact]
         public async Task GivenVariousResourcesOfDifferentTypes_WhenBulkDeleted_ThenAllAreDeleted()
         {
             CheckBulkDeleteEnabled();
@@ -84,7 +86,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         }
 
-        [Fact(Skip = "Fails transiently. It will be re-enabled after adding delay")]
+        [SkippableFact]
         public async Task GivenSoftBulkDeleteRequest_WhenCompleted_ThenHistoricalRecordsExist()
         {
             CheckBulkDeleteEnabled();
@@ -177,6 +179,92 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             Assert.Equal(resource.VersionId, current.Resource.VersionId);
         }
 
+        [SkippableFact]
+        public async Task GivenBulkDeleteJobWithIncludeSearch_WhenCompleted_ThenIncludedResourcesAreDeleted()
+        {
+            CheckBulkDeleteEnabled();
+
+            var resourceTypes = new Dictionary<string, long>()
+            {
+                { "Patient", 1 },
+                { "Observation", 1 },
+            };
+
+            string tag = Guid.NewGuid().ToString();
+            var patient = (await _fhirClient.CreateResourcesAsync<Patient>(1, tag)).FirstOrDefault();
+
+            var observation = Activator.CreateInstance<Observation>();
+            observation.Meta = new Meta()
+            {
+                Tag = new List<Coding>
+                {
+                    new Coding("testTag", tag),
+                },
+            };
+            observation.Subject = new ResourceReference("Patient/" + patient.Id);
+            observation.Status = ObservationStatus.Final;
+            observation.Code = new CodeableConcept("test", "test");
+
+            await _fhirClient.CreateAsync(observation);
+
+            await Task.Delay(5000); // Add delay to ensure resources are created before bulk delete
+
+            using HttpRequestMessage request = GenerateBulkDeleteRequest(
+                tag,
+                "Observation/$bulk-delete",
+                queryParams: new Dictionary<string, string>
+                {
+                    { "_include", "Observation:subject" },
+                });
+
+            using HttpResponseMessage response = await _httpClient.SendAsync(request);
+            Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+            await MonitorBulkDeleteJob(response.Content.Headers.ContentLocation, resourceTypes);
+        }
+
+        [SkippableFact]
+        public async Task GivenBulkDeleteJobWithRevincludeSearch_WhenCompleted_ThenIncludedResourcesAreDeleted()
+        {
+            CheckBulkDeleteEnabled();
+
+            var resourceTypes = new Dictionary<string, long>()
+            {
+                { "Patient", 1 },
+                { "Observation", 1 },
+            };
+
+            string tag = Guid.NewGuid().ToString();
+            var patient = (await _fhirClient.CreateResourcesAsync<Patient>(1, tag)).FirstOrDefault();
+
+            var observation = Activator.CreateInstance<Observation>();
+            observation.Meta = new Meta()
+            {
+                Tag = new List<Coding>
+                {
+                    new Coding("testTag", tag),
+                },
+            };
+            observation.Subject = new ResourceReference("Patient/" + patient.Id);
+            observation.Status = ObservationStatus.Final;
+            observation.Code = new CodeableConcept("test", "test");
+
+            await _fhirClient.CreateAsync(observation);
+
+            await Task.Delay(5000); // Add delay to ensure resources are created before bulk delete
+
+            using HttpRequestMessage request = GenerateBulkDeleteRequest(
+                tag,
+                "Patient/$bulk-delete",
+                queryParams: new Dictionary<string, string>
+                {
+                    { "_revinclude", "Observation:subject" },
+                });
+
+            using HttpResponseMessage response = await _httpClient.SendAsync(request);
+            Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+            await MonitorBulkDeleteJob(response.Content.Headers.ContentLocation, resourceTypes);
+        }
+
         private async Task RunBulkDeleteRequest(
             Dictionary<string, long> expectedResults,
             bool addUndeletedResource = false,
@@ -193,6 +281,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             {
                 await _fhirClient.CreateResourcesAsync(ModelInfoProvider.GetTypeForFhirType(key), (int)expectedResults[key], tag);
             }
+
+            await Task.Delay(5000); // Add delay to ensure resources are created before bulk delete
 
             using HttpRequestMessage request = GenerateBulkDeleteRequest(tag, path, queryParams);
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BulkDeleteTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BulkDeleteTests.cs
@@ -181,8 +181,13 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         }
 
         [SkippableFact]
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
         public async Task GivenBulkDeleteJobWithIncludeSearch_WhenCompleted_ThenIncludedResourcesAreDeleted()
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         {
+#if Stu3
+            Skip.If(true, "Referenced used isn't present in Stu3");
+#else
             CheckBulkDeleteEnabled();
 
             var resourceTypes = new Dictionary<string, long>()
@@ -203,8 +208,13 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
                     new Coding("testTag", tag),
                 },
             };
-            encounter.Status = EncounterStatus.Finished;
+            encounter.Status = EncounterStatus.Planned;
+#if !R5
             encounter.Class = new Coding("test", "test");
+#else
+            encounter.Class = new List<CodeableConcept>();
+            encounter.Class.Add(new CodeableConcept("test", "test"));
+#endif
 
             encounter = await _fhirClient.CreateAsync(encounter);
 
@@ -236,6 +246,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             using HttpResponseMessage response = await _httpClient.SendAsync(request);
             Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
             await MonitorBulkDeleteJob(response.Content.Headers.ContentLocation, resourceTypes);
+#endif
         }
 
         [SkippableFact]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BulkDeleteTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BulkDeleteTests.cs
@@ -273,8 +273,13 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
                 },
             };
             encounter.Subject = new ResourceReference("Patient/" + patient.Id);
-            encounter.Status = EncounterStatus.Finished;
+            encounter.Status = EncounterStatus.Planned;
+#if !R5
             encounter.Class = new Coding("test", "test");
+#else
+            encounter.Class = new List<CodeableConcept>();
+            encounter.Class.Add(new CodeableConcept("test", "test"));
+#endif
 
             await _fhirClient.CreateAsync(encounter);
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalDeleteTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalDeleteTests.cs
@@ -211,7 +211,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             try
             {
                 Bundle createBundle = new Bundle();
-                createBundle.Type = Bundle.BundleType.Transaction;
+                createBundle.Type = Bundle.BundleType.Batch;
                 createBundle.Entry = new System.Collections.Generic.List<Bundle.EntryComponent>();
 
                 Group group = new Group();

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalDeleteTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalDeleteTests.cs
@@ -216,7 +216,11 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
                 Group group = new Group();
                 group.Member = new System.Collections.Generic.List<Group.MemberComponent>();
+#if !R5
                 group.Actual = true;
+#else
+                group.Membership = Group.GroupMembershipBasis.Enumerated;
+#endif
                 group.Type = Group.GroupType.Person;
 
                 group.Meta = new Meta();

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalDeleteTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ConditionalDeleteTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenAnIncompleteSearchParam_WhenDeletingConditionally_TheServerRespondsWithCorrectMessage()
         {
-            FhirClientException fhirException = await Assert.ThrowsAsync<FhirClientException>(() => _client.DeleteAsync($"{_resourceType}?identifier=", CancellationToken.None));
+            FhirClientException fhirException = await Assert.ThrowsAsync<FhirClientException>(() => _client.DeleteAsync($"{_resourceType}?_tag=", CancellationToken.None));
             Assert.Equal(HttpStatusCode.PreconditionFailed, fhirException.StatusCode);
             Assert.Equal(fhirException.Response.Resource.Issue[0].Diagnostics, string.Format(Core.Resources.ConditionalOperationNotSelectiveEnough, _resourceType));
         }
@@ -52,10 +52,10 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenNoExistingResources_WhenDeletingConditionally_TheServerShouldReturnAccepted(int deleteCount)
         {
-            var identifier = Guid.NewGuid().ToString();
-            await ValidateResults(identifier, 0);
+            var tag = Guid.NewGuid().ToString();
+            await ValidateResults(tag, 0);
 
-            FhirResponse response = await _client.DeleteAsync($"{_resourceType}?identifier={identifier}&_count={deleteCount}", CancellationToken.None);
+            FhirResponse response = await _client.DeleteAsync($"{_resourceType}?_tag={tag}&_count={deleteCount}", CancellationToken.None);
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
         }
 
@@ -67,26 +67,26 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenOneMatchingResource_WhenDeletingConditionally_TheServerShouldDeleteSuccessfully(string hardDeleteKey, bool hardDeleteValue, int deleteCount)
         {
-            var identifier = Guid.NewGuid().ToString();
-            await CreateWithIdentifier(identifier);
-            await ValidateResults(identifier, 1);
+            var tag = Guid.NewGuid().ToString();
+            await CreateWithTag(tag);
+            await ValidateResults(tag, 1);
 
-            FhirResponse response = await _client.DeleteAsync($"{_resourceType}?identifier={identifier}&{hardDeleteKey}={hardDeleteValue}&_count={deleteCount}", CancellationToken.None);
+            FhirResponse response = await _client.DeleteAsync($"{_resourceType}?_tag={tag}&{hardDeleteKey}={hardDeleteValue}&_count={deleteCount}", CancellationToken.None);
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
 
-            await ValidateResults(identifier, 0);
+            await ValidateResults(tag, 0);
         }
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenMultipleMatchingResources_WhenDeletingConditionallyInSingleMode_TheServerShouldReturnError()
         {
-            var identifier = Guid.NewGuid().ToString();
-            await CreateWithIdentifier(identifier);
-            await CreateWithIdentifier(identifier);
-            await ValidateResults(identifier, 2);
+            var tag = Guid.NewGuid().ToString();
+            await CreateWithTag(tag);
+            await CreateWithTag(tag);
+            await ValidateResults(tag, 2);
 
-            await Assert.ThrowsAsync<FhirClientException>(() => _client.DeleteAsync($"{_resourceType}?identifier={identifier}", CancellationToken.None));
+            await Assert.ThrowsAsync<FhirClientException>(() => _client.DeleteAsync($"{_resourceType}?_tag={tag}", CancellationToken.None));
         }
 
         [InlineData(-1)]
@@ -96,8 +96,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenMultipleMatchingResources_WhenDeletingConditionallyWithOutOfRangeCount_TheServerShouldReturnError(int deleteCount)
         {
-            var identifier = Guid.NewGuid().ToString();
-            await Assert.ThrowsAsync<FhirClientException>(() => _client.DeleteAsync($"{_resourceType}?identifier={identifier}&_count={deleteCount}", CancellationToken.None));
+            var tag = Guid.NewGuid().ToString();
+            await Assert.ThrowsAsync<FhirClientException>(() => _client.DeleteAsync($"{_resourceType}?_tag={tag}&_count={deleteCount}", CancellationToken.None));
         }
 
         [InlineData(true)]
@@ -106,17 +106,17 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenMultipleMatchingResources_WhenDeletingConditionallyWithMultipleFlag_TheServerShouldDeleteSuccessfully(bool hardDelete)
         {
-            var identifier = Guid.NewGuid().ToString();
-            await CreateWithIdentifier(identifier);
-            await CreateWithIdentifier(identifier);
-            await CreateWithIdentifier(identifier);
-            await ValidateResults(identifier, 3);
+            var tag = Guid.NewGuid().ToString();
+            await CreateWithTag(tag);
+            await CreateWithTag(tag);
+            await CreateWithTag(tag);
+            await ValidateResults(tag, 3);
 
-            FhirResponse response = await _client.DeleteAsync($"{_resourceType}?identifier={identifier}&hardDelete={hardDelete}&_count=100", CancellationToken.None);
+            FhirResponse response = await _client.DeleteAsync($"{_resourceType}?_tag={tag}&hardDelete={hardDelete}&_count=100", CancellationToken.None);
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
             Assert.Equal(3, int.Parse(response.Headers.GetValues(KnownHeaders.ItemsDeleted).First()));
 
-            await ValidateResults(identifier, 0);
+            await ValidateResults(tag, 0);
         }
 
         [InlineData(true, 50, 50, 0)]
@@ -126,20 +126,66 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Theory]
         public async Task GivenMatchingResources_WhenDeletingConditionallyWithMultipleFlag_TheServerShouldDeleteSuccessfully(bool hardDelete, int create, int delete, int expected)
         {
-            var identifier = Guid.NewGuid().ToString();
+            var tag = Guid.NewGuid().ToString();
 
-            await Task.WhenAll(Enumerable.Range(1, create).Select(_ => CreateWithIdentifier(identifier)));
-            await ValidateResults(identifier, create);
+            await Task.WhenAll(Enumerable.Range(1, create).Select(_ => CreateWithTag(tag)));
+            await ValidateResults(tag, create);
 
-            FhirResponse response = await _client.DeleteAsync($"{_resourceType}?identifier={identifier}&hardDelete={hardDelete}&_count={delete}", CancellationToken.None);
+            FhirResponse response = await _client.DeleteAsync($"{_resourceType}?_tag={tag}&hardDelete={hardDelete}&_count={delete}", CancellationToken.None);
 
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
             Assert.Equal(delete, int.Parse(response.Headers.GetValues(KnownHeaders.ItemsDeleted).First()));
 
-            await ValidateResults(identifier, expected);
+            await ValidateResults(tag, expected);
         }
 
-        private async Task CreateWithIdentifier(string identifier)
+        [Fact]
+        public async Task GivenMatchingResources_WhenDeletingConditionallyWithInclude_ThenTheIncludedResourcesAreDeleted()
+        {
+            var tag = Guid.NewGuid().ToString();
+            await CreateGroupWithPatients(tag, 5);
+            await ValidateResults(tag, 6);
+            FhirResponse response = await _client.DeleteAsync($"Group?_tag={tag}&_count=1&_include=Group:member", CancellationToken.None);
+            Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+            Assert.Equal(6, int.Parse(response.Headers.GetValues(KnownHeaders.ItemsDeleted).First())); // currently returning 1 for some reason
+            await ValidateResults(tag, 0);
+        }
+
+        [Fact]
+        public async Task GivenMatchingResources_WhenHardDeletingConditionallyWithInclude_ThenTheIncludedResourcesAreDeleted()
+        {
+            var tag = Guid.NewGuid().ToString();
+            await CreateGroupWithPatients(tag, 5);
+            await ValidateResults(tag, 6);
+            FhirResponse response = await _client.DeleteAsync($"Group?hardDelete=true&_tag={tag}&_count=1&_include=Group:member", CancellationToken.None);
+            Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+            Assert.Equal(6, int.Parse(response.Headers.GetValues(KnownHeaders.ItemsDeleted).First())); // currently returning 1 for some reason
+            await ValidateResults(tag, 0);
+        }
+
+        [Fact]
+        public async Task GivenMultipleMatchingResources_WhenDeletingConditionallyWithInclude_ThenTheIncludedResourcesAreDeleted()
+        {
+            var tag = Guid.NewGuid().ToString();
+            await CreateGroupWithPatients(tag, 5);
+            await CreateGroupWithPatients(tag, 5);
+            await ValidateResults(tag, 12);
+            FhirResponse response = await _client.DeleteAsync($"Group?_tag={tag}&_count=2&_include=Group:member", CancellationToken.None);
+            Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+            Assert.Equal(12, int.Parse(response.Headers.GetValues(KnownHeaders.ItemsDeleted).First())); // currently returning 1 for some reason
+            await ValidateResults(tag, 0);
+        }
+
+        [Fact]
+        public async Task GivenMatchingResources_WhenDeletingConditionallyWithMoreIncludedResourcesThanTheLimit_ThenBadRequestIsRetured()
+        {
+            var tag = Guid.NewGuid().ToString();
+            await CreateGroupWithPatients(tag, 101);
+            await ValidateResults(tag, 102);
+            await Assert.ThrowsAsync<FhirClientException>(() => _client.DeleteAsync($"Group?_tag={tag}&_count=100&_include=Group:member", CancellationToken.None));
+        }
+
+        private async Task CreateWithTag(string tag)
         {
             await _createSemaphore.WaitAsync(TimeSpan.FromMinutes(1));
 
@@ -147,7 +193,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             {
                 Encounter encounter = Samples.GetJsonSample("Encounter-For-Patient-f001").ToPoco<Encounter>();
 
-                encounter.Identifier.Add(new Identifier("http://e2etests", identifier));
+                encounter.Meta = new Meta();
+                encounter.Meta.Tag = new System.Collections.Generic.List<Coding> { new Coding("http://e2etests", tag) };
                 using FhirResponse<Encounter> response = await _client.CreateAsync(encounter);
 
                 Assert.Equal(HttpStatusCode.Created, response.StatusCode);
@@ -158,17 +205,58 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             }
         }
 
-        private async Task ValidateResults(string identifier, int expected)
+        private async Task CreateGroupWithPatients(string tag, int count)
         {
-            var result = await GetResourceCount(identifier);
+            await _createSemaphore.WaitAsync(TimeSpan.FromMinutes(1));
+            try
+            {
+                Bundle createBundle = new Bundle();
+                createBundle.Type = Bundle.BundleType.Transaction;
+                createBundle.Entry = new System.Collections.Generic.List<Bundle.EntryComponent>();
+
+                Group group = new Group();
+                group.Member = new System.Collections.Generic.List<Group.MemberComponent>();
+                group.Actual = true;
+                group.Type = Group.GroupType.Person;
+
+                group.Meta = new Meta();
+                group.Meta.Tag = new System.Collections.Generic.List<Coding> { new Coding("http://e2etests", tag) };
+
+                for (int i = 0; i < count; i++)
+                {
+                    var id = Guid.NewGuid();
+                    var patient = new Patient();
+                    patient.Meta = new Meta();
+                    patient.Meta.Tag = new System.Collections.Generic.List<Coding> { new Coding("http://e2etests", tag) };
+                    patient.Id = id.ToString();
+
+                    createBundle.Entry.Add(new Bundle.EntryComponent { Resource = patient, Request = new Bundle.RequestComponent { Method = Bundle.HTTPVerb.PUT, Url = $"Patient/{id}" } });
+
+                    group.Member.Add(new Group.MemberComponent { Entity = new ResourceReference($"Patient/{id}") });
+                }
+
+                createBundle.Entry.Add(new Bundle.EntryComponent { Resource = group, Request = new Bundle.RequestComponent { Method = Bundle.HTTPVerb.POST, Url = "Group" } });
+
+                using FhirResponse<Bundle> response = await _client.PostBundleAsync(createBundle);
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            }
+            finally
+            {
+                _createSemaphore.Release();
+            }
+        }
+
+        private async Task ValidateResults(string tag, int expected)
+        {
+            var result = await GetResourceCount(tag);
             Assert.Equal(expected, result);
         }
 
-        private async Task<int?> GetResourceCount(string identifier)
+        private async Task<int?> GetResourceCount(string tag)
         {
             try
             {
-                FhirResponse<Bundle> result = await _client.SearchAsync(ResourceType.Encounter, $"identifier=http://e2etests|{identifier}&_summary=count");
+                FhirResponse<Bundle> result = await _client.SearchAsync($"?_tag=http://e2etests|{tag}&_summary=count");
 
                 return result.Resource.Total;
             }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTestsFixture.cs
@@ -19,10 +19,12 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Microsoft.Health.Abstractions.Features.Transactions;
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Fhir.Api.Features.Bundle;
 using Microsoft.Health.Fhir.Api.Features.Routing;
+using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Audit;
 using Microsoft.Health.Fhir.Core.Features.Conformance;
@@ -188,10 +190,12 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
             GetResourceHandler = new GetResourceHandler(DataStore, new Lazy<IConformanceProvider>(() => ConformanceProvider), resourceWrapperFactory, _resourceIdProvider, _dataResourceFilter, DisabledFhirAuthorizationService.Instance, FhirRequestContextAccessor, SearchService);
 
+            var coreFeatureConfiguration = new CoreFeatureConfiguration();
+
             var auditLogger = Substitute.For<IAuditLogger>();
             var logger = Substitute.For<ILogger<DeletionService>>();
 
-            var deleter = new DeletionService(resourceWrapperFactory, new Lazy<IConformanceProvider>(() => ConformanceProvider), DataStore.CreateMockScopeProvider(), SearchService.CreateMockScopeProvider(), _resourceIdProvider, new FhirRequestContextAccessor(), auditLogger, logger);
+            var deleter = new DeletionService(resourceWrapperFactory, new Lazy<IConformanceProvider>(() => ConformanceProvider), DataStore.CreateMockScopeProvider(), SearchService.CreateMockScopeProvider(), _resourceIdProvider, new FhirRequestContextAccessor(), auditLogger, new OptionsWrapper<CoreFeatureConfiguration>(coreFeatureConfiguration), logger);
 
             var collection = new ServiceCollection();
 


### PR DESCRIPTION
## Description
Adds support for `_include` and `_revinclude` to conditional and bulk delete requests. Singular deletes still do not support extra parameters.

## Related issues
Addresses [User Story 139073](https://microsofthealth.visualstudio.com/Health/_workitems/edit/139073): Phase 1: Work needed for getting cascading delete to work

## Testing
New E2E tests have been added

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/master/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/master/docs/Versioning.md))
Patch
