### PR TITLE
Cosmos connection changes

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb.Core/Configs/CosmosDataStoreConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.Core/Configs/CosmosDataStoreConfiguration.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using Microsoft.Azure.Cosmos;
 
@@ -29,6 +30,24 @@ namespace Microsoft.Health.Fhir.CosmosDb.Core.Configs
         public int? InitialDatabaseThroughput { get; set; }
 
         public ConnectionMode ConnectionMode { get; set; } = ConnectionMode.Direct;
+
+        // Default value is indefinate, recommended value is 20m - 24 hours. Setting to 1 hour.
+        public TimeSpan? IdleTcpConnectionTimeout { get; set; } = TimeSpan.FromHours(1);
+
+        // Default value is 5 seconds, recommended value is 1 second.
+        public TimeSpan? OpenTcpConnectionTimeout { get; set; } = TimeSpan.FromSeconds(1);
+
+        // Default value is 30, recommended value is 30. Leaving null to use the SDK default.
+        public int? MaxRequestsPerTcpConnection { get; set; }
+
+        // Default value is 65535, recommended value is 65535. Leaving null to use the SDK default.
+        public int? MaxTcpConnectionsPerEndpoint { get; set; }
+
+        // Default value is PortReuseMode.ReuseUnicastPort, recommended value is PortReuseMode.ReuseUnicastPort. Leaving null to use the SDK default.
+        public PortReuseMode? PortReuseMode { get; set; }
+
+        // Default value is true, recommended value is true. Leaving null to use the SDK default.
+        public bool EnableTcpConnectionEndpointRediscovery { get; set; } = true;
 
         public ConsistencyLevel? DefaultConsistencyLevel { get; set; }
 

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/FhirCosmosClientInitializer.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/FhirCosmosClientInitializer.cs
@@ -131,8 +131,22 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
                 new CosmosClientBuilder(host, _cosmosAccessTokenProviderFactory.Invoke().TokenCredential) :
                 new CosmosClientBuilder(host, key);
 
+            if (configuration.ConnectionMode == ConnectionMode.Gateway)
+            {
+                builder.WithConnectionModeGateway();
+            }
+            else
+            {
+                builder.WithConnectionModeDirect(
+                    idleTcpConnectionTimeout: configuration.IdleTcpConnectionTimeout,
+                    openTcpConnectionTimeout: configuration.OpenTcpConnectionTimeout,
+                    maxRequestsPerTcpConnection: configuration.MaxRequestsPerTcpConnection,
+                    maxTcpConnectionsPerEndpoint: configuration.MaxTcpConnectionsPerEndpoint,
+                    portReuseMode: configuration.PortReuseMode,
+                    enableTcpConnectionEndpointRediscovery: configuration.EnableTcpConnectionEndpointRediscovery);
+            }
+
             builder
-                .WithConnectionModeDirect(enableTcpConnectionEndpointRediscovery: true)
                 .WithCustomSerializer(new FhirCosmosSerializer(_logger))
                 .WithThrottlingRetryOptions(TimeSpan.FromSeconds(configuration.RetryOptions.MaxWaitTimeInSeconds), configuration.RetryOptions.MaxNumberOfRetries)
                 .AddCustomHandlers(requestHandlers.ToArray());


### PR DESCRIPTION
## Description
Cherry picking Cosmos connection related changes

## Related issues
To address 408 and 503 issues we are noticing with AKS compute

## Testing
Going to test in Canary

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
