### PR TITLE
Remove resource id from hash

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/HashingSqlQueryParameterManager.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/HashingSqlQueryParameterManager.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
         public bool HasParametersToHash => _setToHash.Count > 0;
 
         /// <summary>
-        /// Add a parameter to the SQL command if it is not ResourceTypeId and not SearchParamId.
+        /// Add a parameter to the SQL command if it is not ResourceTypeId, not SearchParamId, and not ResourceId.
         /// </summary>
         /// <typeparam name="T">The CLR column type</typeparam>
         /// <param name="column">The table column the parameter is bound to.</param>
@@ -52,7 +52,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
         }
 
         /// <summary>
-        /// Add a parameter to the SQL command if it is not ResourceTypeId and not SearchParamId.
+        /// Add a parameter to the SQL command if it is not ResourceTypeId, not SearchParamId, and not ResourceId.
         /// </summary>
         /// <param name="column">The table column the parameter is bound to.</param>
         /// <param name="value">The parameter value</param>
@@ -65,7 +65,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
         {
             if (column.Metadata.Name == VLatest.Resource.ResourceTypeId.Metadata.Name // logic uses "ResourceTypeId" string value. Resource table is chosen arbitrarily.
                     || column.Metadata.Name == VLatest.ReferenceSearchParam.ReferenceResourceTypeId.Metadata.Name
-                    || column.Metadata.Name == VLatest.TokenSearchParam.SearchParamId.Metadata.Name) // logic uses "SearchParamId" string value. We don't have cross table column sharing concept yet, so to avoid hardcoding TokenSearchParam is arbitrarily chosen.
+                    || column.Metadata.Name == VLatest.TokenSearchParam.SearchParamId.Metadata.Name // logic uses "SearchParamId" string value. We don't have cross table column sharing concept yet, so to avoid hardcoding TokenSearchParam is arbitrarily chosen.
+                    || column.Metadata.Name == VLatest.Resource.ResourceId.Metadata.Name
+                    || column.Metadata.Name == VLatest.ReferenceSearchParam.ReferenceResourceId.Metadata.Name)
             {
                 return value;
             }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/HashingSqlQueryParameterManager.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/HashingSqlQueryParameterManager.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
         public bool HasParametersToHash => _setToHash.Count > 0;
 
         /// <summary>
-        /// Add a parameter to the SQL command if it is not ResourceTypeId, not SearchParamId, and not ResourceId.
+        /// Add a parameter to the SQL command if it is not ResourceTypeId and not SearchParamId. Do not add ResourceId to hash.
         /// </summary>
         /// <typeparam name="T">The CLR column type</typeparam>
         /// <param name="column">The table column the parameter is bound to.</param>
@@ -52,7 +52,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
         }
 
         /// <summary>
-        /// Add a parameter to the SQL command if it is not ResourceTypeId, not SearchParamId, and not ResourceId.
+        /// Add a parameter to the SQL command if it is not ResourceTypeId and not SearchParamId. Do not add ResourceId to hash.
         /// </summary>
         /// <param name="column">The table column the parameter is bound to.</param>
         /// <param name="value">The parameter value</param>
@@ -65,15 +65,15 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
         {
             if (column.Metadata.Name == VLatest.Resource.ResourceTypeId.Metadata.Name // logic uses "ResourceTypeId" string value. Resource table is chosen arbitrarily.
                     || column.Metadata.Name == VLatest.ReferenceSearchParam.ReferenceResourceTypeId.Metadata.Name
-                    || column.Metadata.Name == VLatest.TokenSearchParam.SearchParamId.Metadata.Name // logic uses "SearchParamId" string value. We don't have cross table column sharing concept yet, so to avoid hardcoding TokenSearchParam is arbitrarily chosen.
-                    || column.Metadata.Name == VLatest.Resource.ResourceId.Metadata.Name
-                    || column.Metadata.Name == VLatest.ReferenceSearchParam.ReferenceResourceId.Metadata.Name)
+                    || column.Metadata.Name == VLatest.TokenSearchParam.SearchParamId.Metadata.Name) // logic uses "SearchParamId" string value. We don't have cross table column sharing concept yet, so to avoid hardcoding TokenSearchParam is arbitrarily chosen.
             {
                 return value;
             }
 
             SqlParameter parameter = _inner.AddParameter(column, value);
-            if (includeInHash)
+            if (includeInHash
+                && column.Metadata.Name != VLatest.Resource.ResourceId.Metadata.Name
+                && column.Metadata.Name != VLatest.ReferenceSearchParam.ReferenceResourceId.Metadata.Name)
             {
                 _setToHash.Add(parameter);
             }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SortTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SortTests.cs
@@ -1179,7 +1179,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 using var response = await Client.CreateAsync(resource);
                 resources[i] = response;
 
-                await Task.Delay(10); // this delay prevents out of sync timestamps when loading to cosmos database
+                await Task.Delay(100); // this delay prevents out of sync timestamps when loading to cosmos database
             }
 
             return resources;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SortTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SortTests.cs
@@ -1179,7 +1179,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 using var response = await Client.CreateAsync(resource);
                 resources[i] = response;
 
-                await Task.Delay(10); // this delay prevents out of sync load to cosmos database
+                await Task.Delay(10); // this delay prevents out of sync timestamps when loading to cosmos database
             }
 
             return resources;


### PR DESCRIPTION
Removes ResourceId and ReferenceResourceId values from hash calculation. This enables reuse of SQL query plans and reduces compilations.
Removing resource identifiers from hash is more complex as it requires to evaluate combination of search param and its value when adding SQL parameter. These 2 things are currently separated in our code, and I did not find simple way to solve this problem.

https://microsofthealth.visualstudio.com/Health/_workitems/edit/135263