### PR TITLE
Update .NET SDK version in global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
     "sdk": {
-        "version": "9.0.102"
+        "version": "9.0.102",
+        "rollForward": "latestMinor"
     }
 }


### PR DESCRIPTION
## Description

The .NET SDK version is currently pinned to 9.0.102
The latest SDK version i 9.0.200

By setting `rollForward: latestMinor`, users with the latest 9.2.x version
(where x > 102) installed will still be able to build this project.

This makes for a better developer experience for new contributors.

## Related issues
[AB#145166](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/145166)

## Testing
This change was tested with:

```
cd ./src/Microsoft.Health.Fhir.Api
dotnet build
```

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
