### PR TITLE
Update VS Code launch.json to use net9.0

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "buildR4",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/Microsoft.Health.Fhir.R4.Web/bin/Debug/net6.0/Microsoft.Health.Fhir.R4.Web.dll",
+            "program": "${workspaceFolder}/src/Microsoft.Health.Fhir.R4.Web/bin/Debug/net9.0/Microsoft.Health.Fhir.R4.Web.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/Microsoft.Health.Fhir.R4.Web",
             "stopAtEntry": false,
@@ -33,7 +33,7 @@
             "request": "launch",
             "preLaunchTask": "buildR4",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/Microsoft.Health.Fhir.R4.Web/bin/Debug/net6.0/Microsoft.Health.Fhir.R4.Web.dll",
+            "program": "${workspaceFolder}/src/Microsoft.Health.Fhir.R4.Web/bin/Debug/net9.0/Microsoft.Health.Fhir.R4.Web.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/Microsoft.Health.Fhir.R4.Web",
             "stopAtEntry": false,
@@ -57,7 +57,7 @@
             "request": "launch",
             "preLaunchTask": "buildSTU3",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/Microsoft.Health.Fhir.Stu3.Web/bin/Debug/net6.0/Microsoft.Health.Fhir.Stu3.Web.dll",
+            "program": "${workspaceFolder}/src/Microsoft.Health.Fhir.Stu3.Web/bin/Debug/net9.0/Microsoft.Health.Fhir.Stu3.Web.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/Microsoft.Health.Fhir.Stu3.Web",
             "stopAtEntry": false,
@@ -80,7 +80,7 @@
             "request": "launch",
             "preLaunchTask": "buildSTU3",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/Microsoft.Health.Fhir.Stu3.Web/bin/Debug/net6.0/Microsoft.Health.Fhir.Stu3.Web.dll",
+            "program": "${workspaceFolder}/src/Microsoft.Health.Fhir.Stu3.Web/bin/Debug/net9.0/Microsoft.Health.Fhir.Stu3.Web.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/Microsoft.Health.Fhir.Stu3.Web",
             "stopAtEntry": false,
@@ -104,7 +104,7 @@
             "request": "launch",
             "preLaunchTask": "buildR5",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/Microsoft.Health.Fhir.R5.Web/bin/Debug/net6.0/Microsoft.Health.Fhir.R5.Web.dll",
+            "program": "${workspaceFolder}/src/Microsoft.Health.Fhir.R5.Web/bin/Debug/net9.0/Microsoft.Health.Fhir.R5.Web.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/Microsoft.Health.Fhir.R5.Web",
             "stopAtEntry": false,
@@ -127,7 +127,7 @@
             "request": "launch",
             "preLaunchTask": "buildR5",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/Microsoft.Health.Fhir.R5.Web/bin/Debug/net6.0/Microsoft.Health.Fhir.R5.Web.dll",
+            "program": "${workspaceFolder}/src/Microsoft.Health.Fhir.R5.Web/bin/Debug/net9.0/Microsoft.Health.Fhir.R5.Web.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/Microsoft.Health.Fhir.R5.Web",
             "stopAtEntry": false,


### PR DESCRIPTION
## Description

This PR fixes the VS Code launch tasks, to make it easier to launch projects from VS Code from within a dev container.

## Related issues
n/a

## Testing
This PR was tested by running the launch tasks.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
