### PR TITLE
Increase max valueset size to 20,000

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Validation/ProfileValidator.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Validation/ProfileValidator.cs
@@ -9,6 +9,7 @@ using EnsureThat;
 using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Specification.Source;
+using Hl7.Fhir.Specification.Terminology;
 using Hl7.Fhir.Validation;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Core.Configs;
@@ -38,12 +39,20 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
 
         private Validator GetValidator()
         {
+            var expanderSettings = new ValueSetExpanderSettings
+            {
+                MaxExpansionSize = 20000, // Set your desired max expansion size here
+            };
+
+            var terminologyService = new LocalTerminologyService(_resolver.AsAsync(), expanderSettings);
+
             var ctx = new ValidationSettings()
             {
                 ResourceResolver = _resolver,
                 GenerateSnapshot = true,
                 Trace = false,
                 ResolveExternalReferences = false,
+                TerminologyService = terminologyService,
             };
 
             var validator = new Validator(ctx);


### PR DESCRIPTION
## Description
This increases the maximum expansion for a valueset from 500 to 20,000 codes.  This is needed for a customer in production which uses a large in memory valuest.

## Related issues
Addresses [issue [AB#145937](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/145937)].

## Testing
Manual testing

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
