### PR TITLE
Always use external buildx image

### DIFF
--- a/build/build-image.yml
+++ b/build/build-image.yml
@@ -32,4 +32,3 @@ stages:
     parameters: 
       tag: $(build.BuildNumber)
       buildPlatform: $(publicDockerImagePlatforms)
-      multiplePlatforms: true

--- a/build/ci-deploy.yml
+++ b/build/ci-deploy.yml
@@ -33,7 +33,6 @@ stages:
     parameters: 
       tag: $(ImageTag)
       buildPlatform: $(publicDockerImagePlatforms)
-      multiplePlatforms: true
 
 - stage: provisionEnvironment
   displayName: Provision Environment

--- a/build/ci-pipeline.yml
+++ b/build/ci-pipeline.yml
@@ -131,7 +131,6 @@ stages:
     parameters: 
       tag: $(ImageTag)
       buildPlatform: $(publicDockerImagePlatforms)
-      multiplePlatforms: true
 
 # *********************** Stu3 ***********************
 - stage: redeployStu3

--- a/build/jobs/docker-build-all.yml
+++ b/build/jobs/docker-build-all.yml
@@ -6,8 +6,6 @@ parameters:
   type: string
 - name: buildPlatform
   type: string
-- name: multiplePlatforms
-  type: boolean
 
 jobs:
 - template: docker-build-push.yml
@@ -15,25 +13,21 @@ jobs:
     version: "R4"
     tag: ${{parameters.tag}}
     buildPlatform: ${{parameters.buildPlatform}}
-    multiplePlatforms: ${{parameters.multiplePlatforms}}
 
 - template: docker-build-push.yml
   parameters: 
     version: "R4B"
     tag: ${{parameters.tag}}
     buildPlatform: ${{parameters.buildPlatform}}
-    multiplePlatforms: ${{parameters.multiplePlatforms}}
 
 - template: docker-build-push.yml
   parameters: 
     version: "Stu3"
     tag: ${{parameters.tag}}
     buildPlatform: ${{parameters.buildPlatform}}
-    multiplePlatforms: ${{parameters.multiplePlatforms}}
 
 - template: docker-build-push.yml
   parameters: 
     version: "R5"
     tag: ${{parameters.tag}}
     buildPlatform: ${{parameters.buildPlatform}}
-    multiplePlatforms: ${{parameters.multiplePlatforms}}

--- a/build/jobs/docker-build-push.yml
+++ b/build/jobs/docker-build-push.yml
@@ -24,17 +24,18 @@ jobs:
       inlineScript: |
         set -euo pipefail
 
-        # Create a new buildx builder instance with the specified platform and buildkit image
         # Image is defined in azdo library variable group
+        echo "Creating builder using cached buildkit mirror..."
         docker buildx create --name fhir-multi-platform --use \
             --driver docker-container --driver-opt image=$(mobyBuildkitMirror):$(mobyBuildkitVersion)
-        docker buildx inspect fhir-multi-platform --bootstrap
-
+        
         echo "Setting up QEMU for cross-platform builds..."
         docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+        
+        echo "Inspecting builder to confirm setup..."
+        docker buildx inspect fhir-multi-platform --bootstrap
 
         echo "Building FHIR ${{ parameters.version }} for platform ${{ parameters.buildPlatform }}..."
-
         TAG="$(azureContainerRegistry)/${{ parameters.version }}_fhir-server:${{ parameters.tag }}"
         az acr login --name $(azureContainerRegistryName)
         docker buildx build --tag ${TAG,,} \

--- a/build/jobs/docker-build-push.yml
+++ b/build/jobs/docker-build-push.yml
@@ -30,6 +30,9 @@ jobs:
             --driver docker-container --driver-opt image=$(mobyBuildkitMirror):$(mobyBuildkitVersion)
         docker buildx inspect fhir-multi-platform --bootstrap
 
+        echo "Setting up QEMU for cross-platform builds..."
+        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
         echo "Building FHIR ${{ parameters.version }} for platform ${{ parameters.buildPlatform }}..."
 
         TAG="$(azureContainerRegistry)/${{ parameters.version }}_fhir-server:${{ parameters.tag }}"

--- a/build/jobs/docker-build-push.yml
+++ b/build/jobs/docker-build-push.yml
@@ -26,14 +26,16 @@ jobs:
 
         # Create a new buildx builder instance with the specified platform and buildkit image
         # Image is defined in azdo library variable group
-        docker buildx create --name fhir-multi-platform --platform ${{parameters.buildPlatform}} --use --bootstrap \
+        docker buildx create --name fhir-multi-platform --use --bootstrap \
             --driver docker-container --driver-opt image=$(mobyBuildkitMirror):$(mobyBuildkitVersion)
 
-        TAG="$(azureContainerRegistry)/${{parameters.version}}_fhir-server:${{parameters.tag}}"
+        echo "Building FHIR ${{ parameters.version }} for platform ${{ parameters.buildPlatform }}..."
+
+        TAG="$(azureContainerRegistry)/${{ parameters.version} }_fhir-server:${{ parameters.tag }}"
         az acr login --name $(azureContainerRegistryName)
         docker buildx build --tag ${TAG,,} \
                       --file ./build/docker/Dockerfile \
-                      --platform ${{parameters.buildPlatform}} \
-                      --build-arg FHIR_VERSION=${{parameters.version}} \
+                      --platform ${{ parameters.buildPlatform }} \
+                      --build-arg FHIR_VERSION=${{ parameters.version }} \
                       --build-arg ASSEMBLY_VER=$(assemblySemFileVer) \
                       --push .

--- a/build/jobs/docker-build-push.yml
+++ b/build/jobs/docker-build-push.yml
@@ -31,7 +31,7 @@ jobs:
 
         echo "Building FHIR ${{ parameters.version }} for platform ${{ parameters.buildPlatform }}..."
 
-        TAG="$(azureContainerRegistry)/${{ parameters.version} }_fhir-server:${{ parameters.tag }}"
+        TAG="$(azureContainerRegistry)/${{ parameters.version }}_fhir-server:${{ parameters.tag }}"
         az acr login --name $(azureContainerRegistryName)
         docker buildx build --tag ${TAG,,} \
                       --file ./build/docker/Dockerfile \

--- a/build/jobs/docker-build-push.yml
+++ b/build/jobs/docker-build-push.yml
@@ -22,13 +22,14 @@ jobs:
       scriptType: 'bash'
       scriptLocation: 'inlineScript'
       inlineScript: |
+        set -euo pipefail
 
-        # Pull buildx from mirror to avoid throttling
-        docker pull $(mobyBuildkitMirror):$(mobyBuildkitVersion)
+        # Create a new buildx builder instance with the specified platform and buildkit image
+        docker buildx create --name fhir-multi-platform --platform ${{parameters.buildPlatform}} --use --bootstrap \
+            --driver docker-container --driver-opt image=$(mobyBuildkitMirror):$(mobyBuildkitVersion)
 
         TAG="$(azureContainerRegistry)/${{parameters.version}}_fhir-server:${{parameters.tag}}"
         az acr login --name $(azureContainerRegistryName)
-        docker buildx create --name fhir-multi-platform --platform ${{parameters.buildPlatform}} --use --bootstrap
         docker buildx build --tag ${TAG,,} \
                       --file ./build/docker/Dockerfile \
                       --platform ${{parameters.buildPlatform}} \

--- a/build/jobs/docker-build-push.yml
+++ b/build/jobs/docker-build-push.yml
@@ -28,7 +28,7 @@ jobs:
         # Image is defined in azdo library variable group
         docker buildx create --name fhir-multi-platform --use \
             --driver docker-container --driver-opt image=$(mobyBuildkitMirror):$(mobyBuildkitVersion)
-        docker builx inspect fhir-multi-platform --bootstrap
+        docker buildx inspect fhir-multi-platform --bootstrap
 
         echo "Building FHIR ${{ parameters.version }} for platform ${{ parameters.buildPlatform }}..."
 

--- a/build/jobs/docker-build-push.yml
+++ b/build/jobs/docker-build-push.yml
@@ -26,8 +26,9 @@ jobs:
 
         # Create a new buildx builder instance with the specified platform and buildkit image
         # Image is defined in azdo library variable group
-        docker buildx create --name fhir-multi-platform --use --bootstrap \
+        docker buildx create --name fhir-multi-platform --use \
             --driver docker-container --driver-opt image=$(mobyBuildkitMirror):$(mobyBuildkitVersion)
+        docker builx inspect fhir-multi-platform --bootstrap
 
         echo "Building FHIR ${{ parameters.version }} for platform ${{ parameters.buildPlatform }}..."
 
@@ -35,6 +36,7 @@ jobs:
         az acr login --name $(azureContainerRegistryName)
         docker buildx build --tag ${TAG,,} \
                       --file ./build/docker/Dockerfile \
+                      --builder fhir-multi-platform \
                       --platform ${{ parameters.buildPlatform }} \
                       --build-arg FHIR_VERSION=${{ parameters.version }} \
                       --build-arg ASSEMBLY_VER=$(assemblySemFileVer) \

--- a/build/jobs/docker-build-push.yml
+++ b/build/jobs/docker-build-push.yml
@@ -25,6 +25,7 @@ jobs:
         set -euo pipefail
 
         # Create a new buildx builder instance with the specified platform and buildkit image
+        # Image is defined in azdo library variable group
         docker buildx create --name fhir-multi-platform --platform ${{parameters.buildPlatform}} --use --bootstrap \
             --driver docker-container --driver-opt image=$(mobyBuildkitMirror):$(mobyBuildkitVersion)
 

--- a/build/jobs/docker-build-push.yml
+++ b/build/jobs/docker-build-push.yml
@@ -8,8 +8,6 @@ parameters:
   type: string
 - name: buildPlatform
   type: string
-- name: multiplePlatforms
-  type: boolean
 
 jobs:
 - job: '${{parameters.version}}_Docker'
@@ -24,13 +22,9 @@ jobs:
       scriptType: 'bash'
       scriptLocation: 'inlineScript'
       inlineScript: |
-        MULTIPLATFORM=${{ parameters.multiplePlatforms }}
-        if [ "${MULTIPLATFORM,,}" = "true" ]; then
-          echo "Running multi-platform build. Will pull buildx from dockerhub."
-        else
-          echo "Running single-platform build, pulling buildx from mirror to avoid throttling."
-          docker pull mirror.gcr.io/moby/buildkit:buildx-stable-1
-        fi
+
+        # Pull buildx from mirror to avoid throttling
+        docker pull $(mobyBuildkitMirror):$(mobyBuildkitVersion)
 
         TAG="$(azureContainerRegistry)/${{parameters.version}}_fhir-server:${{parameters.tag}}"
         az acr login --name $(azureContainerRegistryName)

--- a/build/jobs/e2e-tests.yml
+++ b/build/jobs/e2e-tests.yml
@@ -84,43 +84,6 @@ steps:
         Write-Host "##vso[task.setvariable variable=AZURESUBSCRIPTION_TENANT_ID]$env:AZURESUBSCRIPTION_TENANT_ID"
         Write-Host "##vso[task.setvariable variable=AZURESUBSCRIPTION_SERVICE_CONNECTION_ID]$env:AZURESUBSCRIPTION_SERVICE_CONNECTION_ID"
 
-  - powershell: |
-      $maxRetries = 3
-      $attempt = 0
-      $threshold = 0.05
-      do {
-        dotnet test "$(Agent.TempDirectory)/E2ETests/**/*${{ parameters.version }}.Tests.E2E*.dll" `
-          --logger "trx;LogFileName=TestResults_${attempt}.trx" `
-          --filter "FullyQualifiedName~${{parameters.appServiceType}}&Category!=ExportLongRunning"
-        $testResultFile = Join-Path -Path "$(System.DefaultWorkingDirectory)" -ChildPath "TestResults_${attempt}.trx"
-        
-        # Parse TRX to get total and failed test counts:
-        [xml]$trx = Get-Content $testResultFile
-        $total = $trx.TestRun.ResultSummary.Counters.total
-        $failed = $trx.TestRun.ResultSummary.Counters.failed
-        
-        $failureRate = $failed / $total
-        if ($failureRate -lt $threshold -and $failed -gt 0 -and $attempt -lt $maxRetries) {
-          # Generate list of failed tests
-          $failedTests = $trx.TestRun.Results.UnitTestResult |
-            Where-Object { $_.outcome -eq "Failed" } |
-            Select-Object -ExpandProperty testName |
-            ForEach-Object { "FullyQualifiedName=$_" } -join "|"
-          
-          if (-not [string]::IsNullOrWhiteSpace($failedTests)) {
-            Write-Host "Re-running failed tests... Attempt $($attempt+1)"
-            dotnet test "$(Agent.TempDirectory)/E2ETests/**/*${{ parameters.version }}.Tests.E2E*.dll" `
-              --filter $failedTests
-          }
-        }
-        $attempt++
-      } while ($failureRate -lt $threshold -and $failed -gt 0 -and $attempt -lt $maxRetries)
-
-      if ($failureRate -ge $threshold) {
-        Write-Error "Test failure rate ($([string]::Format('{0:P2}', $failureRate))) exceeded threshold."
-        exit 1
-      }
-
   - task: DotNetCoreCLI@2
     displayName: 'E2E ${{ parameters.version }} ${{parameters.appServiceType}}'
     inputs:

--- a/build/jobs/e2e-tests.yml
+++ b/build/jobs/e2e-tests.yml
@@ -84,6 +84,43 @@ steps:
         Write-Host "##vso[task.setvariable variable=AZURESUBSCRIPTION_TENANT_ID]$env:AZURESUBSCRIPTION_TENANT_ID"
         Write-Host "##vso[task.setvariable variable=AZURESUBSCRIPTION_SERVICE_CONNECTION_ID]$env:AZURESUBSCRIPTION_SERVICE_CONNECTION_ID"
 
+  - powershell: |
+      $maxRetries = 3
+      $attempt = 0
+      $threshold = 0.05
+      do {
+        dotnet test "$(Agent.TempDirectory)/E2ETests/**/*${{ parameters.version }}.Tests.E2E*.dll" `
+          --logger "trx;LogFileName=TestResults_${attempt}.trx" `
+          --filter "FullyQualifiedName~${{parameters.appServiceType}}&Category!=ExportLongRunning"
+        $testResultFile = Join-Path -Path "$(System.DefaultWorkingDirectory)" -ChildPath "TestResults_${attempt}.trx"
+        
+        # Parse TRX to get total and failed test counts:
+        [xml]$trx = Get-Content $testResultFile
+        $total = $trx.TestRun.ResultSummary.Counters.total
+        $failed = $trx.TestRun.ResultSummary.Counters.failed
+        
+        $failureRate = $failed / $total
+        if ($failureRate -lt $threshold -and $failed -gt 0 -and $attempt -lt $maxRetries) {
+          # Generate list of failed tests
+          $failedTests = $trx.TestRun.Results.UnitTestResult |
+            Where-Object { $_.outcome -eq "Failed" } |
+            Select-Object -ExpandProperty testName |
+            ForEach-Object { "FullyQualifiedName=$_" } -join "|"
+          
+          if (-not [string]::IsNullOrWhiteSpace($failedTests)) {
+            Write-Host "Re-running failed tests... Attempt $($attempt+1)"
+            dotnet test "$(Agent.TempDirectory)/E2ETests/**/*${{ parameters.version }}.Tests.E2E*.dll" `
+              --filter $failedTests
+          }
+        }
+        $attempt++
+      } while ($failureRate -lt $threshold -and $failed -gt 0 -and $attempt -lt $maxRetries)
+
+      if ($failureRate -ge $threshold) {
+        Write-Error "Test failure rate ($([string]::Format('{0:P2}', $failureRate))) exceeded threshold."
+        exit 1
+      }
+
   - task: DotNetCoreCLI@2
     displayName: 'E2E ${{ parameters.version }} ${{parameters.appServiceType}}'
     inputs:

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -102,7 +102,6 @@ stages:
     parameters: 
       tag: $(ImageTag)
       buildPlatform: $(testDockerImagePlatforms)
-      multiplePlatforms: false
 
 - stage: provisionEnvironment
   displayName: Provision Environment


### PR DESCRIPTION
## Description
Uses internally defined container for pulling buildx image to get around Dockerhub API limits. Registry isn't in code per image recommendations.

Note - the buildx version is slightly different, so we need to enable QEMU to enable cross-platform builds.

## Related issues
[AB#132159](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/132159)

## Testing
Run PR pipeline - see if image build works.
Run CI pipeline - see if image build works.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
