### PR TITLE
Allow error container name to be specified

### DIFF
--- a/docs/rest/Import.http
+++ b/docs/rest/Import.http
@@ -69,6 +69,10 @@ Authorization: Bearer {{bearer.response.body.access_token}}
                     "valueUri": "{{storageUri}}/{{observationFilename}}"
                 }
             ]
+        },
+        {
+            "name": "errorContainerName",
+            "valueString": "import-error-logs"
         }
     ]
 }

--- a/src/Microsoft.Health.Fhir.Core/Extensions/ImportMediatorExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Extensions/ImportMediatorExtensions.cs
@@ -26,12 +26,13 @@ namespace Microsoft.Health.Fhir.Core.Extensions
             ImportRequestStorageDetail storageDetail,
             ImportMode importMode,
             CancellationToken cancellationToken,
-            bool allowNegativeVersions = false)
+            bool allowNegativeVersions = false,
+            string errorContainerName = null)
         {
             EnsureArg.IsNotNull(mediator, nameof(mediator));
             EnsureArg.IsNotNull(requestUri, nameof(requestUri));
 
-            var request = new CreateImportRequest(requestUri, inputFormat, inputSource, input, storageDetail, importMode, allowNegativeVersions);
+            var request = new CreateImportRequest(requestUri, inputFormat, inputSource, input, storageDetail, importMode, allowNegativeVersions, errorContainerName);
 
             CreateImportResponse response = await mediator.Send(request, cancellationToken);
             return response;

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/CreateImportRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/CreateImportRequestHandler.cs
@@ -60,6 +60,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
                 StorageDetail = request.StorageDetail,
                 ImportMode = request.ImportMode,
                 AllowNegativeVersions = request.AllowNegativeVersions,
+                ErrorContainerName = request.ErrorContainerName,
             };
 
             var jobInfo = (await _queueClient.EnqueueAsync(QueueType.Import, cancellationToken, definitions: definitionObj))[0];

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/IImportErrorStoreFactory.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/IImportErrorStoreFactory.cs
@@ -14,10 +14,18 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
     public interface IImportErrorStoreFactory
     {
         /// <summary>
-        /// Initialize error store.
+        /// Initialize error store with default container name.
         /// </summary>
         /// <param name="fileName">Error file name.</param>
         /// <param name="cancellationToken">Cancellation Token.</param>
         public Task<IImportErrorStore> InitializeAsync(string fileName, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Initialize error store with specified container name.
+        /// </summary>
+        /// <param name="containerName">Container name for storing error files.</param>
+        /// <param name="fileName">Error file name.</param>
+        /// <param name="cancellationToken">Cancellation Token.</param>
+        public Task<IImportErrorStore> InitializeAsync(string containerName, string fileName, CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportErrorStoreFactory.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportErrorStoreFactory.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
 {
     public class ImportErrorStoreFactory : IImportErrorStoreFactory
     {
-        private const string LogContainerName = "fhirlogs";
+        private const string DefaultLogContainerName = "fhirlogs";
 
         private IIntegrationDataStoreClient _integrationDataStoreClient;
         private ILoggerFactory _loggerFactory;
@@ -27,11 +27,17 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
             _loggerFactory = loggerFactory;
         }
 
-        public async Task<IImportErrorStore> InitializeAsync(string fileName, CancellationToken cancellationToken)
+        public Task<IImportErrorStore> InitializeAsync(string fileName, CancellationToken cancellationToken)
         {
+            return InitializeAsync(DefaultLogContainerName, fileName, cancellationToken);
+        }
+
+        public async Task<IImportErrorStore> InitializeAsync(string containerName, string fileName, CancellationToken cancellationToken)
+        {
+            EnsureArg.IsNotNullOrEmpty(containerName, nameof(containerName));
             EnsureArg.IsNotNullOrEmpty(fileName, nameof(fileName));
 
-            Uri fileUri = await _integrationDataStoreClient.PrepareResourceAsync(LogContainerName, fileName, cancellationToken);
+            Uri fileUri = await _integrationDataStoreClient.PrepareResourceAsync(containerName, fileName, cancellationToken);
             return new ImportErrorStore(_integrationDataStoreClient, fileUri, _loggerFactory.CreateLogger<ImportErrorStore>());
         }
     }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportOrchestratorJobDefinition.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportOrchestratorJobDefinition.cs
@@ -59,5 +59,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
         /// With this flag set to true, it can be ingested with negative version value.
         /// </summary>
         public bool AllowNegativeVersions { get; set; }
+
+        /// <summary>
+        /// Custom container name for error logs. If not specified, the default container will be used.
+        /// </summary>
+        public string ErrorContainerName { get; set; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportProcessingJobDefinition.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportProcessingJobDefinition.cs
@@ -62,5 +62,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import
         /// With this flag set to true, it can be ingested with negative version value.
         /// </summary>
         public bool AllowNegativeVersions { get; set; }
+
+        /// <summary>
+        /// Custom container name for error logs. If not specified, the default container will be used.
+        /// </summary>
+        public string ErrorContainerName { get; set; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/Models/ImportRequest.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Import/Models/ImportRequest.cs
@@ -48,5 +48,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Import.Models
         /// Force import, ignore server status and import mode check
         /// </summary>
         public bool Force { get; set; }
+
+        /// <summary>
+        /// Custom container name for error logs. If not specified, the default container will be used.
+        /// </summary>
+        public string ErrorContainerName { get; set; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Messages/BulkImport/CreateImportRequest.cs
+++ b/src/Microsoft.Health.Fhir.Core/Messages/BulkImport/CreateImportRequest.cs
@@ -21,7 +21,8 @@ namespace Microsoft.Health.Fhir.Core.Messages.Import
             IReadOnlyList<InputResource> input,
             ImportRequestStorageDetail storageDetail,
             ImportMode importMode,
-            bool allowNegativeVersions = false)
+            bool allowNegativeVersions = false,
+            string errorContainerName = null)
         {
             EnsureArg.IsNotNull(requestUri, nameof(requestUri));
 
@@ -32,6 +33,7 @@ namespace Microsoft.Health.Fhir.Core.Messages.Import
             StorageDetail = storageDetail;
             ImportMode = importMode;
             AllowNegativeVersions = allowNegativeVersions;
+            ErrorContainerName = errorContainerName;
         }
 
         /// <summary>
@@ -71,5 +73,10 @@ namespace Microsoft.Health.Fhir.Core.Messages.Import
         /// With this flag set to true, it can be ingested with negative version value.
         /// </summary>
         public bool AllowNegativeVersions { get; set; }
+
+        /// <summary>
+        /// Custom container name for error logs. If not specified, the default container will be used.
+        /// </summary>
+        public string ErrorContainerName { get; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Operations/Import/ImportRequestExtensionsTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Operations/Import/ImportRequestExtensionsTests.cs
@@ -48,5 +48,41 @@ namespace Microsoft.Health.Fhir.Shared.Api.UnitTests.Features.Operations.Import
             Assert.Equal(ImportRequestExtensions.DefaultInputFormat, output.InputFormat);
             Assert.Equal(ImportRequestExtensions.DefaultStorageDetailType, output.StorageDetail.Type);
         }
+
+        [Fact]
+        public void GivenImportRequestWithErrorContainerName_WhenConvert_ThenErrorContainerNameShouldBePreserved()
+        {
+            // Arrange
+            ImportRequest input = new ImportRequest();
+            input.InputFormat = "test";
+            input.ErrorContainerName = "custom-error-container";
+            input.InputSource = new Uri("http://dummy");
+            input.Input = new List<InputResource>() { new InputResource() { Type = "type", Url = new Uri("http://dummy/resource") } };
+            input.StorageDetail = new ImportRequestStorageDetail() { Type = "blob" };
+
+            // Act
+            ImportRequest output = input.ToParameters().ExtractImportRequest();
+
+            // Assert
+            Assert.Equal(input.ErrorContainerName, output.ErrorContainerName);
+        }
+
+        [Fact]
+        public void GivenImportRequestWithoutErrorContainerName_WhenConvert_ThenErrorContainerNameShouldBeNull()
+        {
+            // Arrange
+            ImportRequest input = new ImportRequest();
+            input.InputFormat = "test";
+            input.ErrorContainerName = null; // No error container name
+            input.InputSource = new Uri("http://dummy");
+            input.Input = new List<InputResource>() { new InputResource() { Type = "type", Url = new Uri("http://dummy/resource") } };
+            input.StorageDetail = new ImportRequestStorageDetail() { Type = "blob" };
+
+            // Act
+            ImportRequest output = input.ToParameters().ExtractImportRequest();
+
+            // Assert
+            Assert.Null(output.ErrorContainerName);
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ImportController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ImportController.cs
@@ -114,7 +114,8 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                  importRequest.StorageDetail,
                  initialLoad ? ImportMode.InitialLoad : ImportMode.IncrementalLoad, // default to incremental mode
                  HttpContext.RequestAborted,
-                 importRequest.AllowNegativeVersions);
+                 importRequest.AllowNegativeVersions,
+                 importRequest.ErrorContainerName);
 
             var bulkImportResult = ImportResult.Accepted();
             bulkImportResult.SetContentLocationHeader(_urlResolver, OperationsConstants.Import, response.TaskId);

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Operations/Import/ImportRequestExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Operations/Import/ImportRequestExtensions.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Operations.Import
         public const string ModeParameterName = "mode";
         public const string ForceParameterName = "force";
         public const string AllowNegativeVersionsParameterName = "allowNegativeVersions";
+        public const string ErrorContainerNameParameterName = "errorContainerName";
         public const string DefaultStorageDetailType = "azure-blob";
 
         public static Parameters ToParameters(this ImportRequest importRequest)
@@ -90,6 +91,11 @@ namespace Microsoft.Health.Fhir.Api.Features.Operations.Import
             if (importRequest.AllowNegativeVersions)
             {
                 parameters.Add(AllowNegativeVersionsParameterName, new FhirBoolean(true));
+            }
+
+            if (!string.IsNullOrEmpty(importRequest.ErrorContainerName))
+            {
+                parameters.Add(ErrorContainerNameParameterName, new FhirString(importRequest.ErrorContainerName));
             }
 
             return parameters;
@@ -163,6 +169,11 @@ namespace Microsoft.Health.Fhir.Api.Features.Operations.Import
             if (parameters.TryGetBooleanValue(AllowNegativeVersionsParameterName, out bool allow))
             {
                 importRequest.AllowNegativeVersions = allow;
+            }
+
+            if (parameters.TryGetStringValue(ErrorContainerNameParameterName, out string errorContainerName))
+            {
+                importRequest.ErrorContainerName = errorContainerName;
             }
 
             return importRequest;

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/ImportOrchestratorJob.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/ImportOrchestratorJob.cs
@@ -280,6 +280,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
                     GroupId = groupId,
                     ImportMode = coordDefinition.ImportMode,
                     AllowNegativeVersions = coordDefinition.AllowNegativeVersions,
+                    ErrorContainerName = coordDefinition.ErrorContainerName,
                 };
 
                 definitions.Add(importJobPayload);

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/ImportProcessingJob.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/ImportProcessingJob.cs
@@ -89,7 +89,18 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
                 cancellationToken.ThrowIfCancellationRequested();
 
                 // Design of error writes is too complex. We do not need separate init and writes. Also, it leads to adding duplicate error records on job restart.
-                IImportErrorStore importErrorStore = await _importErrorStoreFactory.InitializeAsync(GetErrorFileName(definition.ResourceType, jobInfo.GroupId, jobInfo.Id), cancellationToken);
+                IImportErrorStore importErrorStore;
+                string errorFileName = GetErrorFileName(definition.ResourceType, jobInfo.GroupId, jobInfo.Id);
+
+                if (string.IsNullOrEmpty(definition.ErrorContainerName))
+                {
+                    importErrorStore = await _importErrorStoreFactory.InitializeAsync(errorFileName, cancellationToken);
+                }
+                else
+                {
+                    importErrorStore = await _importErrorStoreFactory.InitializeAsync(definition.ErrorContainerName, errorFileName, cancellationToken);
+                }
+
                 result.ErrorLogLocation = importErrorStore.ErrorFileLocation;
 
                 // Design of resource loader is too complex. There is no need to have any channel and separate load task.

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/ImportProcessingJob.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/ImportProcessingJob.cs
@@ -178,6 +178,18 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
                 var error = new ImportJobErrorResult() { ErrorMessage = ex.Message, HttpStatusCode = HttpStatusCode.BadRequest, ErrorDetails = ex.ToString() };
                 throw new JobExecutionException(ex.Message, error, ex);
             }
+            catch (IntegrationDataStoreException ex) when (ex.Message.Contains("The specified resource name contains invalid characters", StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogJobError(ex, jobInfo, ex.Message);
+                var error = new ImportJobErrorResult() { ErrorMessage = "Error container name contains invalid characters. Only lowercase letters, numbers, and hyphens are allowed. The name must begin and end with a letter or a number. The name can't contain two consecutive hyphens.", HttpStatusCode = HttpStatusCode.BadRequest, ErrorDetails = ex.ToString() };
+                throw new JobExecutionException(error.ErrorMessage, error, ex);
+            }
+            catch (IntegrationDataStoreException ex) when (ex.Message.Contains("The specified resource name length is not within the permissible limits", StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogJobError(ex, jobInfo, ex.Message);
+                var error = new ImportJobErrorResult() { ErrorMessage = "The error container name must be between 3 and 63 characters long.", HttpStatusCode = HttpStatusCode.BadRequest, ErrorDetails = ex.ToString() };
+                throw new JobExecutionException(error.ErrorMessage, error, ex);
+            }
             catch (Exception ex)
             {
                 _logger.LogJobError(ex, jobInfo, "Critical error in import processing job.");


### PR DESCRIPTION
## Description 
This pull request introduces the capability to specify a custom container name for error logs during the FHIR import process. The changes include updates to the import request handling, job definitions, and error store initialization to support this new feature.

Key changes include:

### Import Request and Handling Updates:
* Added `errorContainerName` parameter to `ImportAsync` and `CreateImportRequest` methods, allowing the specification of a custom container name for error logs. (`src/Microsoft.Health.Fhir.Core/Extensions/ImportMediatorExtensions.cs`, `src/Microsoft.Health.Fhir.Core/Messages/BulkImport/CreateImportRequest.cs`) [[1]](diffhunk://#diff-0f8a67521d85b629872e0f0f3a60de2471845e52e086308386b87a8218aab78cL29-R35) [[2]](diffhunk://#diff-a084737bb4a9a1efb0030c5dc5b0754c5b438cd6cd9e21a3ebacd300554e618dL24-R25) [[3]](diffhunk://#diff-a084737bb4a9a1efb0030c5dc5b0754c5b438cd6cd9e21a3ebacd300554e618dR36) [[4]](diffhunk://#diff-a084737bb4a9a1efb0030c5dc5b0754c5b438cd6cd9e21a3ebacd300554e618dR76-R80)
* Updated `CreateImportRequestHandler` to handle the new `ErrorContainerName` property. (`src/Microsoft.Health.Fhir.Core/Features/Operations/Import/CreateImportRequestHandler.cs`)

### Error Store Initialization:
* Modified `IImportErrorStoreFactory` and `ImportErrorStoreFactory` to include methods for initializing the error store with a custom container name. (`src/Microsoft.Health.Fhir.Core/Features/Operations/Import/IImportErrorStoreFactory.cs`, `src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportErrorStoreFactory.cs`) [[1]](diffhunk://#diff-6136b47172715cc4e551674764d195b796e99e5e66291a8d4ae3acfa58ad563fL17-R29) [[2]](diffhunk://#diff-2c5bbca7a351339ee4594e9c2ee27f642122c35f72e55e87b06c67e827d7cea6L16-R16) [[3]](diffhunk://#diff-2c5bbca7a351339ee4594e9c2ee27f642122c35f72e55e87b06c67e827d7cea6L30-R40)

### Job Definitions:
* Added `ErrorContainerName` property to `ImportOrchestratorJobDefinition` and `ImportProcessingJobDefinition` to pass the custom container name through job definitions. (`src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportOrchestratorJobDefinition.cs`, `src/Microsoft.Health.Fhir.Core/Features/Operations/Import/ImportProcessingJobDefinition.cs`) [[1]](diffhunk://#diff-509e685d96a73d2d2d254adb3e001faf2b9893ffe644a776c2d8663076382eedR62-R66) [[2]](diffhunk://#diff-22760cd0f2804c2f6517f7e3de6046f760d84216889dc19183b95d65045c423cR65-R69)

### Unit Tests:
* Added unit tests to verify that the custom error container name is correctly handled and preserved through the import request and job execution process. (`src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Operations/Import/ImportRequestExtensionsTests.cs`, `src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Operations/Import/ImportProcessingJobTests.cs`) [[1]](diffhunk://#diff-1f1b8bc77080a7c7efca0d5fca50c5bf9701204c8e8d2f88b67579a2ef85a88fR51-R86) [[2]](diffhunk://#diff-14a6bfcd7865e720b5137d12206be51485bc602f5f5dccdce770ae25970b1125R194-R319)

These changes ensure that error logs can be directed to a specified container, providing greater flexibility in managing import errors.

![image](https://github.com/user-attachments/assets/de947553-5914-4ef9-9802-f463380eb7c3)

## Related issues
Addresses [AB#149355](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/149355).

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
