### PR TITLE
PUT/POST without C# transaction

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Persistence/MergeOptions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Persistence/MergeOptions.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
 {
     public sealed class MergeOptions
     {
-        public MergeOptions(bool enlistTransaction = true)
+        public MergeOptions(bool enlistTransaction = false)
         {
             EnlistInTransaction = enlistTransaction;
         }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -734,7 +734,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             }
             else
             {
-                var mergeOutcome = await MergeAsync(new[] { resource }, cancellationToken);
+                var mergeOutcome = await MergeAsync(new[] { resource }, new MergeOptions(resource.BundleResourceContext != null), cancellationToken);
                 DataStoreOperationOutcome dataStoreOperationOutcome = mergeOutcome.First().Value;
 
                 if (dataStoreOperationOutcome.IsOperationSuccessful)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -706,7 +706,7 @@ IF (SELECT count(*) FROM EventLog WHERE Process = 'MergeResources' AND Status = 
             Assert.Equal(createdId2, getResult2.Id);
         }
 
-        [Fact]
+        [Fact(Skip = "Not valid as transactions can only be set in scope of bundles")]
         [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]
         public async Task GivenATransactionHandler_WhenATransactionIsNotCommitted_ThenNothingShouldBeCreated()
         {
@@ -724,7 +724,7 @@ IF (SELECT count(*) FROM EventLog WHERE Process = 'MergeResources' AND Status = 
                 async () => { await Mediator.GetResourceAsync(new ResourceKey<Observation>(createdId)); });
         }
 
-        [Fact]
+        [Fact(Skip = "Not valid as transactions can only be set in scope of bundles")]
         [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]
         public async Task GivenATransactionHandler_WhenATransactionFailsFailedRequest_ThenNothingShouldCommit()
         {


### PR DESCRIPTION
Limits transaction enlistment to bundles only. Single resource POST/PUTs do not enlist in transaction, and thus can benefit from merge throttling. 

https://microsofthealth.visualstudio.com/Health/_workitems/edit/146794
