### PR TITLE
Enable merge throttling for PUT/POSTs

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -138,12 +138,12 @@ WAITFOR DELAY '00:00:01'
                 if (useDefaultMergeOptions)
                 {
                     patient.Id = Guid.NewGuid().ToString();
-                    await Mediator.UpsertResourceAsync(patient.ToResourceElement()); // thought it uses default merge options but it should not enlist in transaction anymore
+                    await Mediator.UpsertResourceAsync(patient.ToResourceElement()); // try enlist in tran w/o tran scope
                 }
                 else
                 {
                     var resOp = new ResourceWrapperOperation(CreateObservationResourceWrapper(Guid.NewGuid().ToString()), true, true, null, false, false, null);
-                    await _dataStore.MergeAsync([resOp], new MergeOptions(false), CancellationToken.None); // throttling works only w/o C# transaction, hence MergeOptions(false)
+                    await _dataStore.MergeAsync([resOp], new MergeOptions(false), CancellationToken.None); // do not enlist in tran
                 }
             });
             await _fixture.SqlHelper.ExecuteSqlCmd("DROP TRIGGER Transactions_Trigger");

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -239,6 +239,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 bundleOrchestrator,
                 SqlRetryService,
                 SqlConnectionWrapperFactory,
+                SqlTransactionHandler,
                 converter,
                 NullLogger<SqlServerFhirDataStore>.Instance,
                 SchemaInformation,


### PR DESCRIPTION
Extends throttling logic to cases with no transaction scope. 
This PR assumes that instances of SqlServerFhirDataStore and SqlConnectionWrapperFactory classes share the **same instance** of SqlTransactionHandler class.

https://microsofthealth.visualstudio.com/Health/_workitems/edit/146794/