### PR TITLE
Increase the default include count to 1000.

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Configs/CoreFeatureConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/CoreFeatureConfiguration.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Health.Fhir.Core.Configs
         /// <summary>
         /// Gets or sets the default value for included search results.
         /// </summary>
-        public int DefaultIncludeCountPerSearch { get; set; } = 500;
+        public int DefaultIncludeCountPerSearch { get; set; } = 1000;
 
         /// <summary>
         /// Gets or sets a value whether we need to run profile validation during resource creation.

--- a/src/Microsoft.Health.Fhir.Core/Data/OperationDefinition/includes.json
+++ b/src/Microsoft.Health.Fhir.Core/Data/OperationDefinition/includes.json
@@ -25,7 +25,7 @@
             "use": "in",
             "min": 0,
             "max": "1",
-            "documentation": "The number of 'include' resources to retrieve. Defaults to 1000.",
+            "documentation": "The number of 'include' resources to retrieve.",
             "type": "integer"
         }
     ]

--- a/src/Microsoft.Health.Fhir.Core/Data/OperationDefinition/includes.json
+++ b/src/Microsoft.Health.Fhir.Core/Data/OperationDefinition/includes.json
@@ -25,7 +25,7 @@
             "use": "in",
             "min": 0,
             "max": "1",
-            "documentation": "The number of 'include' resources to retrieve. Defaults to 500.",
+            "documentation": "The number of 'include' resources to retrieve. Defaults to 1000.",
             "type": "integer"
         }
     ]

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchOptionsFactoryTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchOptionsFactoryTests.cs
@@ -594,7 +594,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
         [Theory]
         [InlineData(100, 100)]
-        [InlineData(null, 500)]
+        [InlineData(null, 1000)]
         [InlineData(int.MaxValue, 1000)]
         public void GivenAnIncludesCount_WhenCreated_ThenCorrectIncludeCountShouldBeSet(int? valueToSet, int valueExpected)
         {


### PR DESCRIPTION
## Description
Increase the default include count to 1000.

## Related issues
Addresses [issue #138967].
[User Story 138967](https://microsofthealth.visualstudio.com/Health/_workitems/edit/138967): Implement a new $include operation.

## Testing
Tested by running UT and E2E tests. 

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
