### PR TITLE
Changes to log Cosmos SDK Diagnostics from response

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb.Core/Configs/CosmosDataStoreConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.Core/Configs/CosmosDataStoreConfiguration.cs
@@ -92,13 +92,13 @@ namespace Microsoft.Health.Fhir.CosmosDb.Core.Configs
         /// <summary>
         /// Option to print Diagnostics returned from Cosmos SDK for each response
         /// </summary>
-        public bool LogSDKDiagnostics { get; set; } = false;
+        public bool LogSdkDiagnostics { get; set; } = false;
 
         /// <summary>
-        ///     This represent the end to end elapsed time of the request. If the request is
-        ///     still in progress it will return the current elapsed time since the start of
-        ///     the request.
+        /// This represent the end to end elapsed time of the request. If the request is
+        /// still in progress it will return the current elapsed time since the start of
+        /// the request.
         /// </summary>
-        public bool LogSDKClientElapsedTime { get; set; } = false;
+        public bool LogSdkClientElapsedTime { get; set; } = false;
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb.Core/Configs/CosmosDataStoreConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.Core/Configs/CosmosDataStoreConfiguration.cs
@@ -88,5 +88,17 @@ namespace Microsoft.Health.Fhir.CosmosDb.Core.Configs
         /// Options to determine if the parallel query execution is needed across physical partitions to speed up the selective queries
         /// </summary>
         public CosmosDataStoreParallelQueryOptions ParallelQueryOptions { get; } = new CosmosDataStoreParallelQueryOptions { MaxQueryConcurrency = 500 };
+
+        /// <summary>
+        /// Option to print Diagnostics returned from Cosmos SDK for each response
+        /// </summary>
+        public bool LogSDKDiagnostics { get; set; } = false;
+
+        /// <summary>
+        ///     This represent the end to end elapsed time of the request. If the request is
+        ///     still in progress it will return the current elapsed time since the start of
+        ///     the request.
+        /// </summary>
+        public bool LogSDKClientElapsedTime { get; set; } = false;
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/CosmosResponseProcessorTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/CosmosResponseProcessorTests.cs
@@ -17,6 +17,7 @@ using Microsoft.Health.Abstractions.Exceptions;
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Features.Context;
+using Microsoft.Health.Fhir.CosmosDb.Core.Configs;
 using Microsoft.Health.Fhir.CosmosDb.Features.Metrics;
 using Microsoft.Health.Fhir.CosmosDb.Features.Queries;
 using Microsoft.Health.Fhir.CosmosDb.Features.Storage;
@@ -36,6 +37,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Storage
         private readonly CosmosResponseProcessor _cosmosResponseProcessor;
         private readonly IMediator _mediator;
         private readonly RequestContextAccessor<IFhirRequestContext> _fhirRequestContextAccessor;
+        private CosmosDataStoreConfiguration _cosmosDataStoreConfiguration;
 
         public CosmosResponseProcessorTests()
         {
@@ -44,10 +46,11 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Storage
             _fhirRequestContextAccessor.RequestContext.ResponseHeaders.Returns(_responseHeaders);
             _fhirRequestContextAccessor.RequestContext.ResourceType.Returns("resource");
             _fhirRequestContextAccessor.RequestContext.AuditEventType.Returns("operation");
+            _cosmosDataStoreConfiguration = new CosmosDataStoreConfiguration();
 
             _mediator = Substitute.For<IMediator>();
             var nullLogger = NullLogger<CosmosResponseProcessor>.Instance;
-            _cosmosResponseProcessor = new CosmosResponseProcessor(_fhirRequestContextAccessor, _mediator, Substitute.For<ICosmosQueryLogger>(), nullLogger);
+            _cosmosResponseProcessor = new CosmosResponseProcessor(_fhirRequestContextAccessor, _mediator, _cosmosDataStoreConfiguration, Substitute.For<ICosmosQueryLogger>(), nullLogger);
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/CosmosResponseProcessorTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/CosmosResponseProcessorTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Storage
         private readonly CosmosResponseProcessor _cosmosResponseProcessor;
         private readonly IMediator _mediator;
         private readonly RequestContextAccessor<IFhirRequestContext> _fhirRequestContextAccessor;
-        private CosmosDataStoreConfiguration _cosmosDataStoreConfiguration;
+        private readonly CosmosDataStoreConfiguration _cosmosDataStoreConfiguration;
 
         public CosmosResponseProcessorTests()
         {

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Queries/ICosmosQueryLogger.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Queries/ICosmosQueryLogger.cs
@@ -41,5 +41,27 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Queries
             double durationMs,
             string partitionKeyRangeId,
             Exception exception = null);
+
+        /// <summary>
+        /// Logs the diagnostics.
+        /// </summary>
+        /// <param name="activityId">The activity id returned by the Cosmos DB.</param>
+        /// <param name="diagnostics">The diagnostics if any.</param>
+        /// <param name="exception">The exception if any.</param>
+        void LogQueryDiagnostics(
+            string activityId,
+            CosmosDiagnostics diagnostics = null,
+            Exception exception = null);
+
+        /// <summary>
+        /// Logs end to end elapsed time of the request
+        /// </summary>
+        /// <param name="activityId">The activity id returned by the Cosmos DB.</param>
+        /// <param name="clientElapsedTime">end to end elapsed time of the request.</param>
+        /// <param name="exception">The exception if any.</param>
+        void LogQueryClientElapsedTime(
+            string activityId,
+            string clientElapsedTime = null,
+            Exception exception = null);
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosResponseMessage.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosResponseMessage.cs
@@ -3,20 +3,23 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Diagnostics;
 using System.Net;
 using Microsoft.Azure.Cosmos;
+using Microsoft.CodeAnalysis;
 
 namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
 {
     public sealed class CosmosResponseMessage
     {
-        public CosmosResponseMessage(HttpStatusCode statusCode, bool isSuccessStatusCode, Headers headers, string errorMessage, string continuationToken)
+        public CosmosResponseMessage(HttpStatusCode statusCode, bool isSuccessStatusCode, Headers headers, string errorMessage, string continuationToken, CosmosDiagnostics diagnostics)
         {
             StatusCode = statusCode;
             IsSuccessStatusCode = isSuccessStatusCode;
             Headers = headers;
             ErrorMessage = errorMessage;
             ContinuationToken = continuationToken;
+            Diagnostics = diagnostics;
         }
 
         public HttpStatusCode StatusCode { get; private set; }
@@ -29,9 +32,11 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
 
         public string ContinuationToken { get; private set; }
 
+        public CosmosDiagnostics Diagnostics { get; private set; }
+
         public static CosmosResponseMessage Create(ResponseMessage response)
         {
-            return new CosmosResponseMessage(response.StatusCode, response.IsSuccessStatusCode, response.Headers, response.ErrorMessage, response.ContinuationToken);
+            return new CosmosResponseMessage(response.StatusCode, response.IsSuccessStatusCode, response.Headers, response.ErrorMessage, response.ContinuationToken, response.Diagnostics);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosResponseProcessor.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosResponseProcessor.cs
@@ -118,14 +118,14 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
                 double.TryParse(responseMessage.Headers["x-ms-request-duration-ms"], out var duration) ? duration : 0,
                 responseMessage.Headers["x-ms-documentdb-partitionkeyrangeid"]);
 
-            if (_cosmosDataStoreConfiguration.LogSDKDiagnostics)
+            if (_cosmosDataStoreConfiguration.LogSdkDiagnostics)
             {
                 _queryLogger.LogQueryDiagnostics(responseMessage.Headers.ActivityId, responseMessage.Diagnostics);
             }
 
-            if (_cosmosDataStoreConfiguration.LogSDKClientElapsedTime)
+            if (_cosmosDataStoreConfiguration.LogSdkClientElapsedTime && responseMessage.Diagnostics != null)
             {
-                _queryLogger.LogQueryClientElapsedTime(responseMessage.Headers.ActivityId, responseMessage.Diagnostics?.GetClientElapsedTime().ToString());
+                _queryLogger.LogQueryClientElapsedTime(responseMessage.Headers.ActivityId, responseMessage.Diagnostics.GetClientElapsedTime().ToString());
             }
 
             IFhirRequestContext fhirRequestContext = _fhirRequestContextAccessor.RequestContext;

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosResponseProcessor.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/CosmosResponseProcessor.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using EnsureThat;
 using MediatR;
 using Microsoft.Azure.Cosmos;
+using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Health.Abstractions.Exceptions;
@@ -19,6 +20,7 @@ using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Fhir.Api.Features.ExceptionNotifications;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Context;
+using Microsoft.Health.Fhir.CosmosDb.Core.Configs;
 using Microsoft.Health.Fhir.CosmosDb.Features.Metrics;
 using Microsoft.Health.Fhir.CosmosDb.Features.Queries;
 
@@ -27,20 +29,23 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
     public class CosmosResponseProcessor : ICosmosResponseProcessor
     {
         private readonly RequestContextAccessor<IFhirRequestContext> _fhirRequestContextAccessor;
+        private readonly CosmosDataStoreConfiguration _cosmosDataStoreConfiguration;
         private readonly IMediator _mediator;
         private readonly ICosmosQueryLogger _queryLogger;
         private readonly ILogger<CosmosResponseProcessor> _logger;
 
-        public CosmosResponseProcessor(RequestContextAccessor<IFhirRequestContext> fhirRequestContextAccessor, IMediator mediator, ICosmosQueryLogger queryLogger, ILogger<CosmosResponseProcessor> logger)
+        public CosmosResponseProcessor(RequestContextAccessor<IFhirRequestContext> fhirRequestContextAccessor, IMediator mediator, CosmosDataStoreConfiguration cosmosDataStoreConfiguration, ICosmosQueryLogger queryLogger, ILogger<CosmosResponseProcessor> logger)
         {
             EnsureArg.IsNotNull(fhirRequestContextAccessor, nameof(fhirRequestContextAccessor));
             EnsureArg.IsNotNull(mediator, nameof(mediator));
             EnsureArg.IsNotNull(queryLogger, nameof(queryLogger));
+            EnsureArg.IsNotNull(cosmosDataStoreConfiguration, nameof(cosmosDataStoreConfiguration));
             EnsureArg.IsNotNull(logger, nameof(logger));
 
             _fhirRequestContextAccessor = fhirRequestContextAccessor;
             _mediator = mediator;
             _queryLogger = queryLogger;
+            _cosmosDataStoreConfiguration = cosmosDataStoreConfiguration;
             _logger = logger;
         }
 
@@ -112,6 +117,16 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
                 int.TryParse(responseMessage.Headers["x-ms-item-count"], out var count) ? count : 0,
                 double.TryParse(responseMessage.Headers["x-ms-request-duration-ms"], out var duration) ? duration : 0,
                 responseMessage.Headers["x-ms-documentdb-partitionkeyrangeid"]);
+
+            if (_cosmosDataStoreConfiguration.LogSDKDiagnostics)
+            {
+                _queryLogger.LogQueryDiagnostics(responseMessage.Headers.ActivityId, responseMessage.Diagnostics);
+            }
+
+            if (_cosmosDataStoreConfiguration.LogSDKClientElapsedTime)
+            {
+                _queryLogger.LogQueryClientElapsedTime(responseMessage.Headers.ActivityId, responseMessage.Diagnostics?.GetClientElapsedTime().ToString());
+            }
 
             IFhirRequestContext fhirRequestContext = _fhirRequestContextAccessor.RequestContext;
             if (fhirRequestContext == null)

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -182,7 +182,9 @@
         "ParallelQueryOptions": {
             "MaxQueryConcurrency": 500,
             "EnableConcurrencyIfQueryExceedsTimeLimit": true
-        }
+        },
+        "LogSDKDiagnostics": false,
+        "LogSDKClientElapsedTime": false
     },
     "DataStore": "CosmosDb",
     "SqlServer": {

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -183,8 +183,8 @@
             "MaxQueryConcurrency": 500,
             "EnableConcurrencyIfQueryExceedsTimeLimit": true
         },
-        "LogSDKDiagnostics": false,
-        "LogSDKClientElapsedTime": false
+        "LogSdkDiagnostics": false,
+        "LogSdkClientElapsedTime": false
     },
     "DataStore": "CosmosDb",
     "SqlServer": {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             ICollectionDataUpdater dataCollectionUpdater = new CosmosDbSearchParameterStatusInitializer(
                 () => _filebasedSearchParameterStatusDataStore,
                 new CosmosQueryFactory(
-                    new CosmosResponseProcessor(_fhirRequestContextAccessor, mediator, Substitute.For<ICosmosQueryLogger>(), NullLogger<CosmosResponseProcessor>.Instance),
+                    new CosmosResponseProcessor(_fhirRequestContextAccessor, mediator, _cosmosDataStoreConfiguration, Substitute.For<ICosmosQueryLogger>(), NullLogger<CosmosResponseProcessor>.Instance),
                     NullFhirCosmosQueryLogger.Instance),
                 _cosmosDataStoreConfiguration);
 
@@ -144,7 +144,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             var cosmosAccessor = Substitute.For<IAccessTokenProvider>();
             cosmosAccessor.TokenCredential.Returns(GetTokenCredential());
 
-            var responseProcessor = new CosmosResponseProcessor(_fhirRequestContextAccessor, mediator, Substitute.For<ICosmosQueryLogger>(), NullLogger<CosmosResponseProcessor>.Instance);
+            var responseProcessor = new CosmosResponseProcessor(_fhirRequestContextAccessor, mediator, _cosmosDataStoreConfiguration, Substitute.For<ICosmosQueryLogger>(), NullLogger<CosmosResponseProcessor>.Instance);
             var handler = new FhirCosmosResponseHandler(() => new NonDisposingScope(_container), _cosmosDataStoreConfiguration, _fhirRequestContextAccessor, responseProcessor);
             var retryExceptionPolicyFactory = new RetryExceptionPolicyFactory(_cosmosDataStoreConfiguration, _fhirRequestContextAccessor, NullLogger<RetryExceptionPolicyFactory>.Instance);
             var documentClientInitializer = new FhirCosmosClientInitializer(

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/NullFhirCosmosQueryLogger.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/NullFhirCosmosQueryLogger.cs
@@ -20,5 +20,13 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         public void LogQueryExecutionResult(string activityId, double requestCharge, string continuationToken, int count, double durationMs, string partitionKeyRangeId, Exception exception = null)
         {
         }
+
+        public void LogQueryDiagnostics(string activityId, CosmosDiagnostics diagnostics = null, Exception exception = null)
+        {
+        }
+
+        public void LogQueryClientElapsedTime(string activityId, string clientElapsedTime = null, Exception exception = null)
+        {
+        }
     }
 }


### PR DESCRIPTION
## Description
Code added to log diagnostic string and client elapsed time based on Cosmos data store configuration for each response.

## Related issues
Addresses [issue [#](https://microsofthealth.visualstudio.com/Health/_workitems/edit/147661)].

## Testing
Tested locally with Azure Cosmos DB Emulator turning settings on and off

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
