### PR TITLE
Add more logging to search parameters

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
@@ -87,13 +87,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
                     throw new SearchParameterNotSupportedException(errorMessage);
                 }
 
-                _logger.LogTrace("Adding the search parameter '{Url}'", searchParameterWrapper.Url);
+                _logger.LogInformation("Adding the search parameter '{Url}'", searchParameterWrapper.Url);
                 _searchParameterDefinitionManager.AddNewSearchParameters(new List<ITypedElement> { searchParam });
 
                 await _searchParameterStatusManager.AddSearchParameterStatusAsync(new List<string> { searchParameterWrapper.Url }, cancellationToken);
             }
             catch (FhirException fex)
             {
+                _logger.LogError(fex, "Error adding search parameter.");
                 fex.Issues.Add(new OperationOutcomeIssue(
                     OperationOutcomeConstants.IssueSeverity.Error,
                     OperationOutcomeConstants.IssueType.Exception,
@@ -103,6 +104,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
             }
             catch (Exception ex)
             {
+                _logger.LogError(ex, "Error adding search parameter.");
                 var customSearchException = new ConfigureCustomSearchException(Core.Resources.CustomSearchCreateError);
                 customSearchException.Issues.Add(new OperationOutcomeIssue(
                     OperationOutcomeConstants.IssueSeverity.Error,
@@ -133,7 +135,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
                 // First we delete the status metadata from the data store as this function depends on
                 // the in memory definition manager.  Once complete we remove the SearchParameter from
                 // the definition manager.
-                _logger.LogTrace("Deleting the search parameter '{Url}'", searchParameterUrl);
+                _logger.LogInformation("Deleting the search parameter '{Url}'", searchParameterUrl);
                 await _searchParameterStatusManager.UpdateSearchParameterStatusAsync(new List<string>() { searchParameterUrl }, SearchParameterStatus.PendingDelete, cancellationToken);
 
                 // Update the status of the search parameter in the definition manager once the status is updated in the store.
@@ -141,6 +143,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
             }
             catch (FhirException fex)
             {
+                _logger.LogError(fex, "Error deleting search parameter.");
                 fex.Issues.Add(new OperationOutcomeIssue(
                     OperationOutcomeConstants.IssueSeverity.Error,
                     OperationOutcomeConstants.IssueType.Exception,
@@ -150,6 +153,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
             }
             catch (Exception ex)
             {
+                _logger.LogError(ex, "Error deleting search parameter.");
                 var customSearchException = new ConfigureCustomSearchException(Core.Resources.CustomSearchDeleteError);
                 customSearchException.Issues.Add(new OperationOutcomeIssue(
                     OperationOutcomeConstants.IssueSeverity.Error,
@@ -190,16 +194,17 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
                 // As any part of the SearchParameter may have been changed, including the URL
                 // the most reliable method of updating the SearchParameter is to delete the previous
                 // data and insert the updated version
-                _logger.LogTrace("Deleting the search parameter '{Url}' (update step 1/2)", prevSearchParamUrl);
+                _logger.LogInformation("Deleting the search parameter '{Url}' (update step 1/2)", prevSearchParamUrl);
                 await _searchParameterStatusManager.DeleteSearchParameterStatusAsync(prevSearchParamUrl, cancellationToken);
                 _searchParameterDefinitionManager.DeleteSearchParameter(prevSearchParam);
 
-                _logger.LogTrace("Adding the search parameter '{Url}' (update step 2/2)", searchParameterWrapper.Url);
+                _logger.LogInformation("Adding the search parameter '{Url}' (update step 2/2)", searchParameterWrapper.Url);
                 _searchParameterDefinitionManager.AddNewSearchParameters(new List<ITypedElement>() { searchParam });
                 await _searchParameterStatusManager.AddSearchParameterStatusAsync(new List<string>() { searchParameterWrapper.Url }, cancellationToken);
             }
             catch (FhirException fex)
             {
+                _logger.LogError(fex, "Error updating search parameter.");
                 fex.Issues.Add(new OperationOutcomeIssue(
                     OperationOutcomeConstants.IssueSeverity.Error,
                     OperationOutcomeConstants.IssueType.Exception,
@@ -209,6 +214,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
             }
             catch (Exception ex)
             {
+                _logger.LogError(ex, "Error updating search parameter.");
                 var customSearchException = new ConfigureCustomSearchException(Core.Resources.CustomSearchUpdateError);
                 customSearchException.Issues.Add(new OperationOutcomeIssue(
                     OperationOutcomeConstants.IssueSeverity.Error,

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
 
             foreach (string uri in searchParameterUris)
             {
-                _logger.LogTrace("Setting the search parameter status of '{Uri}' to '{NewStatus}'", uri, status.ToString());
+                _logger.LogInformation("Setting the search parameter status of '{Uri}' to '{NewStatus}'", uri, status.ToString());
 
                 SearchParameterInfo paramInfo = _searchParameterDefinitionManager.GetSearchParameter(uri);
                 updated.Add(paramInfo);


### PR DESCRIPTION
## Description
Adding more logging to help diagnose issues with custom search parameters.

## Related issues
Addresses [User Story 150607](https://microsofthealth.visualstudio.com/Health/_workitems/edit/150607)

## Testing
N/A

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch