### PR TITLE
Update MediatR to 12.5.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -60,7 +60,7 @@
     <PackageVersion Include="Hl7.Fhir.Specification.R4B" Version="$(Hl7FhirVersion)" />
     <PackageVersion Include="Hl7.Fhir.Specification.R5" Version="$(Hl7FhirVersion)" />
     <PackageVersion Include="IdentityServer4" Version="4.1.2" />
-    <PackageVersion Include="MediatR" Version="12.4.1" />
+    <PackageVersion Include="MediatR" Version="12.5.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(AspNetPackageVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.JsonPatch" Version="$(AspNetPackageVersion)" />

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/CreateOrUpdateSearchParameterBehavior.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/CreateOrUpdateSearchParameterBehavior.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
             }
 
             // Allow the resource to be updated with the normal handler
-            return await next();
+            return await next(cancellationToken);
         }
 
         public async Task<UpsertResourceResponse> Handle(UpsertResourceRequest request, RequestHandlerDelegate<UpsertResourceResponse> next, CancellationToken cancellationToken)
@@ -65,7 +65,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
             }
 
             // Now allow the resource to updated per the normal behavior
-            return await next();
+            return await next(cancellationToken);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/DeleteSearchParameterBehavior.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/DeleteSearchParameterBehavior.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
                 await _searchParameterOperations.DeleteSearchParameterAsync(searchParamResource.RawResource, cancellationToken);
             }
 
-            return await next();
+            return await next(cancellationToken);
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/ProfileResourcesBehaviour.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/ProfileResourcesBehaviour.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources
                     throw new UnauthorizedFhirActionException();
                 }
 
-                var result = await next();
+                var result = await next(cancellationToken);
 
                 // If the requests is part of a bundle, as an inner request, then profiles are not refreshed.
                 // This is because the bundle can contain multiple profile changes and the refresh should only happen once, at the end of the bundle, to avoid performance degradation.
@@ -79,7 +79,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources
             }
             else
             {
-                return await next();
+                return await next(cancellationToken);
             }
         }
     }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/ProvenanceHeaderBehavior.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/ProvenanceHeaderBehavior.cs
@@ -62,12 +62,12 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources
         {
             if (_state.Intercepted)
             {
-                return await next();
+                return await next(cancellationToken);
             }
 
             _state.Intercepted = true;
             Provenance provenance = GetProvenanceFromHeader();
-            var response = await next();
+            var response = await next(cancellationToken);
 
             if (response != null && provenance != null)
             {

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Behaviors/ListSearchBehaviorTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Behaviors/ListSearchBehaviorTests.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
             SearchResourceResponse response = await behavior.Handle(
                 getResourceRequest,
-                () => { return Task.FromResult(new SearchResourceResponse(_nonEmptyBundle)); },
+                (ct) => { return Task.FromResult(new SearchResourceResponse(_nonEmptyBundle)); },
                 CancellationToken.None);
 
             Assert.Equal(_nonEmptyBundle, response.Bundle);
@@ -152,7 +152,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             var getResourceRequest = Substitute.For<SearchResourceRequest>("Patient", list, false);
             SearchResourceResponse response = await behavior.Handle(
                 getResourceRequest,
-                () =>
+                (ct) =>
                 {
                     return Task.FromResult(new SearchResourceResponse(_nonEmptyBundle));
                 },
@@ -180,7 +180,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
             SearchResourceResponse response = await behavior.Handle(
                 getResourceRequest,
-                () =>
+                (ct) =>
                 {
                     return Task.FromResult(new SearchResourceResponse(_nonEmptyBundle));
                 },
@@ -205,7 +205,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
 
             SearchResourceResponse response = await behavior.Handle(
                 getResourceRequest,
-                () =>
+                (ct) =>
                 {
                     return Task.FromResult(new SearchResourceResponse(_nonEmptyBundle));
                 },

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterBehaviorTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchParameters/SearchParameterBehaviorTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             var response = new UpsertResourceResponse(new SaveOutcome(new RawResourceElement(wrapper), SaveOutcomeType.Created));
 
             var behavior = new CreateOrUpdateSearchParameterBehavior<CreateResourceRequest, UpsertResourceResponse>(_searchParameterOperations, _fhirDataStore);
-            await behavior.Handle(request, async () => await Task.Run(() => response), CancellationToken.None);
+            await behavior.Handle(request, async (ct) => await Task.Run(() => response), CancellationToken.None);
 
             // Ensure for non-SearchParameter, that we do not call Add SearchParameter
             await _searchParameterOperations.DidNotReceive().AddSearchParameterAsync(Arg.Any<ITypedElement>(), Arg.Any<CancellationToken>());
@@ -72,7 +72,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             var response = new UpsertResourceResponse(new SaveOutcome(new RawResourceElement(wrapper), SaveOutcomeType.Created));
 
             var behavior = new CreateOrUpdateSearchParameterBehavior<CreateResourceRequest, UpsertResourceResponse>(_searchParameterOperations, _fhirDataStore);
-            await behavior.Handle(request, async () => await Task.Run(() => response), CancellationToken.None);
+            await behavior.Handle(request, async (ct) => await Task.Run(() => response), CancellationToken.None);
 
             await _searchParameterOperations.Received().AddSearchParameterAsync(Arg.Any<ITypedElement>(), Arg.Any<CancellationToken>());
         }
@@ -91,7 +91,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             var response = new DeleteResourceResponse(key);
 
             var behavior = new DeleteSearchParameterBehavior<DeleteResourceRequest, DeleteResourceResponse>(_searchParameterOperations, _fhirDataStore);
-            await behavior.Handle(request, async () => await Task.Run(() => response), CancellationToken.None);
+            await behavior.Handle(request, async (ct) => await Task.Run(() => response), CancellationToken.None);
 
             // Ensure for non-SearchParameter, that we do not call Add SearchParameter
             await _searchParameterOperations.DidNotReceive().DeleteSearchParameterAsync(Arg.Any<RawResource>(), Arg.Any<CancellationToken>());
@@ -112,7 +112,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             var response = new DeleteResourceResponse(key);
 
             var behavior = new DeleteSearchParameterBehavior<DeleteResourceRequest, DeleteResourceResponse>(_searchParameterOperations, _fhirDataStore);
-            await behavior.Handle(request, async () => await Task.Run(() => response), CancellationToken.None);
+            await behavior.Handle(request, async (ct) => await Task.Run(() => response), CancellationToken.None);
 
             await _searchParameterOperations.Received().DeleteSearchParameterAsync(Arg.Any<RawResource>(), Arg.Any<CancellationToken>());
         }
@@ -132,7 +132,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             var response = new DeleteResourceResponse(key);
 
             var behavior = new DeleteSearchParameterBehavior<DeleteResourceRequest, DeleteResourceResponse>(_searchParameterOperations, _fhirDataStore);
-            await behavior.Handle(request,  async () => await Task.Run(() => response), CancellationToken.None);
+            await behavior.Handle(request,  async (ct) => await Task.Run(() => response), CancellationToken.None);
 
             await _searchParameterOperations.DidNotReceive().DeleteSearchParameterAsync(Arg.Any<RawResource>(), Arg.Any<CancellationToken>());
         }

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Behaviors/ListSearchPipeBehavior.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/Behaviors/ListSearchPipeBehavior.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Behavior
             // if _list was not requested, or _list was requested with invalid value, continue...
             if ((listParameter == null) || string.IsNullOrWhiteSpace(listParameter.Item2))
             {
-                return await next();
+                return await next(cancellationToken);
             }
 
             ResourceWrapper listWrapper =
@@ -92,7 +92,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Behavior
 
             query = query.Concat(new[] { Tuple.Create(KnownQueryParameterNames.Id, string.Join(",", references.Select(x => x.ResourceId))) });
             request.Queries = query.ToArray();
-            return await next();
+            return await next(cancellationToken);
         }
 
         public SearchResourceResponse CreateEmptySearchResponse(SearchResourceRequest request)


### PR DESCRIPTION
## Description
Update Mediatr from 12.4.1 to 12.5.0. We are seeing errors due to mismatched versions in downstream environments.

## Related issues
[AB#151407](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/151407)

## Testing
None besides pipelines and local build.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
