### PR TITLE
Adding temporary code to capture raw resource length and search param stats

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Watchdogs/CleanupEventLogWatchdog.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Watchdogs/CleanupEventLogWatchdog.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Diagnostics.Metrics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -96,7 +97,7 @@ INSERT INTO dbo.Parameters (Id,Char) SELECT 'CleanpEventLog', 'LogEvent'
 SELECT object_name = object_name(object_id)
   FROM sys.indexes I
   WHERE EXISTS (SELECT * FROM sys.partition_schemes PS WHERE PS.data_space_id = I.data_space_id AND PS.name = 'PartitionScheme_ResourceTypeId')
-    AND object_id <> object_id('Resource')
+    AND object_id NOT IN (object_id('Resource'), object_id('CompartmentAssignment'))
     AND index_id = 1
             ");
             return await sqlCommand.ExecuteReaderAsync(_sqlRetryService, reader => reader.GetString(0), _logger, cancellationToken);

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Watchdogs/CleanupEventLogWatchdog.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Watchdogs/CleanupEventLogWatchdog.cs
@@ -149,8 +149,7 @@ set nocount on
 DECLARE @SP varchar(100) = object_name(@@procid)
        ,@ResourceTypeId smallint
        ,@MaxSurrogateIdTmp bigint
-
-INSERT INTO dbo.Parameters (Id, Char) SELECT @SP, 'LogEvent'
+       ,@st datetime = getUTCdate()
 
 SET @MaxSurrogateId = 0
 
@@ -165,7 +164,7 @@ BEGIN
   DELETE FROM @Types WHERE ResourceTypeId = @ResourceTypeId
 END
 
-EXECUTE dbo.LogEvent @Process=@SP,@Status='End',@Target='@MaxSurrogateId',@Action='Select',@Text=@MaxSurrogateId
+EXECUTE dbo.LogEvent @Process=@SP,@Status='End',@Target='@MaxSurrogateId',@Action='Select',@Text=@MaxSurrogateId,@Start=@st
             ");
             await cmd.ExecuteNonQueryAsync(_sqlRetryService, _logger, cancellationToken);
 
@@ -178,8 +177,7 @@ AS
 set nocount on
 DECLARE @SP varchar(100) = object_name(@@procid)
        ,@Mode varchar(100) = 'RC='+convert(varchar,@ResourceTypeId)+' S='+convert(varchar,@SurrogateId)
-
-INSERT INTO dbo.Parameters (Id, Char) SELECT @SP, 'LogEvent'
+       ,@st datetime = getUTCdate()
 
 SELECT TOP 1000
        ResourceSurrogateId, RawResource
@@ -189,7 +187,7 @@ SELECT TOP 1000
   ORDER BY
        ResourceSurrogateId
 
-EXECUTE dbo.LogEvent @Process=@SP,@Mode=@Mode,@Status='End',@Target='Resource',@Action='Select',@Rows=@@rowcount
+EXECUTE dbo.LogEvent @Process=@SP,@Mode=@Mode,@Status='End',@Target='Resource',@Action='Select',@Rows=@@rowcount,@Start=@st
             ");
             await cmd3.ExecuteNonQueryAsync(_sqlRetryService, _logger, cancellationToken);
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Watchdogs/CleanupEventLogWatchdog.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Watchdogs/CleanupEventLogWatchdog.cs
@@ -3,12 +3,18 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
+using System.Collections.Generic;
 using System.Data;
+using System.IO;
+using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
+using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.SqlServer.Features.Storage;
 
 namespace Microsoft.Health.Fhir.SqlServer.Features.Watchdogs
@@ -16,11 +22,13 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Watchdogs
     internal sealed class CleanupEventLogWatchdog : Watchdog<CleanupEventLogWatchdog>
     {
         private readonly ISqlRetryService _sqlRetryService;
+        private readonly ICompressedRawResourceConverter _compressedRawResourceConverter;
         private readonly ILogger<CleanupEventLogWatchdog> _logger;
 
-        public CleanupEventLogWatchdog(ISqlRetryService sqlRetryService, ILogger<CleanupEventLogWatchdog> logger)
+        public CleanupEventLogWatchdog(ICompressedRawResourceConverter compressedRawResourceConverter, ISqlRetryService sqlRetryService, ILogger<CleanupEventLogWatchdog> logger)
             : base(sqlRetryService, logger)
         {
+            _compressedRawResourceConverter = EnsureArg.IsNotNull(compressedRawResourceConverter, nameof(compressedRawResourceConverter));
             _sqlRetryService = EnsureArg.IsNotNull(sqlRetryService, nameof(sqlRetryService));
             _logger = EnsureArg.IsNotNull(logger, nameof(logger));
         }
@@ -40,6 +48,53 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Watchdogs
         {
             await using var cmd = new SqlCommand("dbo.CleanupEventLog") { CommandType = CommandType.StoredProcedure, CommandTimeout = 0 };
             await cmd.ExecuteNonQueryAsync(_sqlRetryService, _logger, cancellationToken);
+
+            try
+            {
+                // TODO: This is temporary code to get some stats (including raw resource length). We should determine what pieces are needed later and find permanent home for them.
+                await CreateTmpProceduresAsync(cancellationToken);
+
+                var maxSurrogateId = await GetMaxSurrogateId(cancellationToken);
+                _logger.LogInformation($"DatabaseStats.MaxSurrogateId={maxSurrogateId}");
+
+                var types = await GetUsedResourceTypesAsync(cancellationToken);
+                _logger.LogInformation($"DatabaseStats.UsedResourceTypes.Count={types.Count}");
+
+                var totalCompressedBytes = 0L;
+                var totalDecompressedBytes = 0L;
+                var totalResources = 0L;
+                foreach (var type in types)
+                {
+                    var surrogateId = 0L;
+                    IReadOnlyList<(long SurrogateId, byte[] RawResourceBytes)> rawResources;
+                    do
+                    {
+                        rawResources = await GetRawResourcesAsync(type, surrogateId, cancellationToken);
+                        foreach (var rawResource in rawResources)
+                        {
+                            surrogateId = rawResource.SurrogateId;
+                            var rawResourceBytes = rawResource.RawResourceBytes;
+                            var isInvisible = rawResourceBytes.Length == 1 && rawResourceBytes[0] == 0xF;
+                            if (!isInvisible)
+                            {
+                                totalCompressedBytes += rawResourceBytes.Length;
+                                using var rawResourceStream = new MemoryStream(rawResourceBytes);
+                                totalDecompressedBytes += UTF8Encoding.UTF8.GetBytes(_compressedRawResourceConverter.ReadCompressedRawResource(rawResourceStream)).Length;
+                                totalResources++;
+                            }
+                        }
+                    }
+                    while (rawResources.Count > 0);
+                }
+
+                _logger.LogInformation($"DatabaseStats: resources = {totalResources}, compressed raw resource length = {totalCompressedBytes}, decompressed raw resource length = {totalDecompressedBytes}");
+
+                await DropTmpProceduresAsync(cancellationToken);
+            }
+            catch (Exception e)
+            {
+                _logger.LogWarning(e, "DatabaseStats failed.");
+            }
         }
 
         protected override async Task InitAdditionalParamsAsync()
@@ -56,6 +111,99 @@ INSERT INTO dbo.Parameters (Id,Char) SELECT 'CleanpEventLog', 'LogEvent'
             await cmd.ExecuteNonQueryAsync(_sqlRetryService, _logger, CancellationToken.None, "InitParamsAsync failed.");
 
             _logger.LogInformation("InitParamsAsync completed.");
+        }
+
+        private async Task<long> GetMaxSurrogateId(CancellationToken cancellationToken)
+        {
+            await using var cmd = new SqlCommand("dbo.tmp_GetMaxSurrogateId") { CommandType = CommandType.StoredProcedure };
+            var maxSurrogateId = cmd.Parameters.AddWithValue("@MaxSurrogateId", SqlDbType.BigInt);
+            maxSurrogateId.Direction = ParameterDirection.Output;
+            await cmd.ExecuteNonQueryAsync(_sqlRetryService, _logger, cancellationToken);
+            return (long)maxSurrogateId.Value;
+        }
+
+        private async Task<IReadOnlyList<short>> GetUsedResourceTypesAsync(CancellationToken cancellationToken)
+        {
+            using var sqlCommand = new SqlCommand("dbo.GetUsedResourceTypes") { CommandType = CommandType.StoredProcedure };
+            return await sqlCommand.ExecuteReaderAsync(_sqlRetryService, reader => reader.GetInt16(0), _logger, cancellationToken);
+        }
+
+        private async Task<IReadOnlyList<(long SurrogateId, byte[] RawResourceBytes)>> GetRawResourcesAsync(short resourceTypeId, long surrogateId, CancellationToken cancellationToken)
+        {
+            using var sqlCommand = new SqlCommand("dbo.tmp_GetRawResources") { CommandType = CommandType.StoredProcedure };
+            sqlCommand.Parameters.AddWithValue("@ResourceTypeId", resourceTypeId);
+            sqlCommand.Parameters.AddWithValue("@SurrogateId", surrogateId);
+            return await sqlCommand.ExecuteReaderAsync(_sqlRetryService, reader => (reader.GetInt64(0), reader.GetSqlBytes(1).Value), _logger, cancellationToken);
+        }
+
+        private async Task CreateTmpProceduresAsync(CancellationToken cancellationToken)
+        {
+            using var cmd = new SqlCommand(@"
+CREATE OR ALTER PROCEDURE dbo.tmp_GetMaxSurrogateId @MaxSurrogateId bigint = 0 OUT
+AS
+set nocount on
+DECLARE @SP varchar(100) = object_name(@@procid)
+       ,@ResourceTypeId smallint
+       ,@MaxSurrogateIdTmp bigint
+
+INSERT INTO dbo.Parameters (Id, Char) SELECT @SP, 'LogEvent'
+
+SET @MaxSurrogateId = 0
+
+DECLARE @Types TABLE (ResourceTypeId smallint PRIMARY KEY, Name varchar(100))
+
+INSERT INTO @Types EXECUTE dbo.GetUsedResourceTypes
+WHILE EXISTS (SELECT * FROM @Types)
+BEGIN
+  SET @ResourceTypeId = (SELECT TOP 1 ResourceTypeId FROM @Types)
+  SET @MaxSurrogateIdTmp = (SELECT max(ResourceSurrogateId) FROM Resource WHERE ResourceTypeId = @ResourceTypeId)
+  IF @MaxSurrogateIdTmp > @MaxSurrogateId SET @MaxSurrogateId = @MaxSurrogateIdTmp
+  DELETE FROM @Types WHERE ResourceTypeId = @ResourceTypeId
+END
+
+EXECUTE dbo.LogEvent @Process=@SP,@Status='End',@Target='@MaxSurrogateId',@Action='Select',@Text=@MaxSurrogateId
+            ");
+            await cmd.ExecuteNonQueryAsync(_sqlRetryService, _logger, cancellationToken);
+
+            using var cmd2 = new SqlCommand("INSERT INTO dbo.Parameters (Id, Char) SELECT 'tmp_GetMaxSurrogateId', 'LogEvent'");
+            await cmd.ExecuteNonQueryAsync(_sqlRetryService, _logger, cancellationToken);
+
+            using var cmd3 = new SqlCommand(@"
+CREATE OR ALTER PROCEDURE dbo.tmp_GetRawResources @ResourceTypeId smallint, @SurrogateId bigint
+AS
+set nocount on
+DECLARE @SP varchar(100) = object_name(@@procid)
+       ,@Mode varchar(100) = 'RC='+convert(varchar,@ResourceTypeId)+' S='+convert(varchar,@SurrogateId)
+
+INSERT INTO dbo.Parameters (Id, Char) SELECT @SP, 'LogEvent'
+
+SELECT TOP 1000
+       ResourceSurrogateId, RawResource
+  FROM dbo.Resource
+  WHERE ResourceTypeId = @ResourceTypeId
+    AND ResourceSurrogateId > @SurrogateId
+  ORDER BY
+       ResourceSurrogateId
+
+EXECUTE dbo.LogEvent @Process=@SP,@Mode=@Mode,@Status='End',@Target='Resource',@Action='Select',@Rows=@@rowcount
+            ");
+            await cmd.ExecuteNonQueryAsync(_sqlRetryService, _logger, cancellationToken);
+
+            using var cmd4 = new SqlCommand("INSERT INTO dbo.Parameters (Id, Char) SELECT 'tmp_GetRawResources', 'LogEvent'");
+            await cmd.ExecuteNonQueryAsync(_sqlRetryService, _logger, cancellationToken);
+
+            _logger.LogInformation("CreateTmpProceduresAsync completed.");
+        }
+
+        private async Task DropTmpProceduresAsync(CancellationToken cancellationToken)
+        {
+            using var cmd = new SqlCommand("DROP IF EXISTS PROCEDURE dbo.tmp_GetMaxSurrogateId");
+            await cmd.ExecuteNonQueryAsync(_sqlRetryService, _logger, cancellationToken);
+
+            using var cmd2 = new SqlCommand("DROP IF EXISTS PROCEDURE dbo.tmp_GetRawResources");
+            await cmd.ExecuteNonQueryAsync(_sqlRetryService, _logger, cancellationToken);
+
+            _logger.LogInformation("DropTmpProceduresAsync completed.");
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestHelper.cs
@@ -163,7 +163,7 @@ INSERT INTO dbo.Parameters (Id,Number) SELECT 'Defrag.MinSizeGB', 0.01
 INSERT INTO dbo.Parameters (Id,Number) SELECT @PeriodSecId, 5
 INSERT INTO dbo.Parameters (Id,Number) SELECT @LeasePeriodSecId, 2
 INSERT INTO dbo.Parameters (Id,Number) SELECT 'CleanupEventLog.DeleteBatchSize', 1000
-INSERT INTO dbo.Parameters (Id,Number) SELECT 'CleanupEventLog.AllowedRows', 1000
+INSERT INTO dbo.Parameters (Id,Number) SELECT 'CleanupEventLog.AllowedRows', 2000
 INSERT INTO dbo.Parameters (Id,Number) SELECT 'CleanupEventLog.RetentionPeriodDay', 1.0/24/3600
 INSERT INTO dbo.Parameters (Id,Number) SELECT 'CleanupEventLog.IsEnabled', 1
                 ",

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerWatchdogTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerWatchdogTests.cs
@@ -124,7 +124,7 @@ EXECUTE dbo.LogEvent @Process='Build',@Status='Warn',@Mode='',@Target='DefragTes
             ExecuteSql(@"
 TRUNCATE TABLE dbo.EventLog
 DECLARE @i int = 0
-WHILE @i < 10000
+WHILE @i < 10500
 BEGIN
   EXECUTE dbo.LogEvent @Process='Test',@Status='Warn',@Mode='Test'
   SET @i += 1

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerWatchdogTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerWatchdogTests.cs
@@ -161,13 +161,13 @@ END
             Assert.True(wd.IsLeaseHolder, "Is lease holder");
             _testOutputHelper.WriteLine($"Acquired lease in {(DateTime.UtcNow - startTime).TotalSeconds} seconds.");
 
-            while ((GetCount("EventLog") > 1000) && (DateTime.UtcNow - startTime).TotalSeconds < 120)
+            while ((GetCount("EventLog") > 2000) && (DateTime.UtcNow - startTime).TotalSeconds < 120)
             {
                 await Task.Delay(TimeSpan.FromSeconds(1), cts.Token);
             }
 
             _testOutputHelper.WriteLine($"EventLog.Count={GetCount("EventLog")}.");
-            Assert.True(GetCount("EventLog") <= 1000, "Count is high");
+            Assert.True(GetCount("EventLog") <= 2000, "Count is high");
 
             // TODO: Temp code to test database stats
             ExecuteSql("IF NOT EXISTS (SELECT * FROM dbo.EventLog WHERE Process = 'tmp_GetRawResources') RAISERROR('tmp_GetRawResources calls are not registered',18,127)");

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerWatchdogTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerWatchdogTests.cs
@@ -171,7 +171,7 @@ END
 
             // TODO: Temp code to test database stats
             ExecuteSql("IF NOT EXISTS (SELECT * FROM dbo.EventLog WHERE Process = 'tmp_GetRawResources') RAISERROR('tmp_GetRawResources calls are not registered',18,127)");
-            ExecuteSql("IF NOT EXISTS (SELECT * FROM dbo.EventLog WHERE Process = 'DatabaseStats') RAISERROR('DatabaseStats message is not registered',18,127)");
+            ExecuteSql("IF NOT EXISTS (SELECT * FROM dbo.EventLog WHERE Process = 'DatabaseStats.Totals') RAISERROR('DatabaseStats message is not registered',18,127)");
 
             await cts.CancelAsync();
             await wdTask;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerWatchdogTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerWatchdogTests.cs
@@ -145,7 +145,8 @@ END
             wrapper.ResourceSurrogateId = tran.TransactionId;
             var mergeWrapper = new MergeResourceWrapper(wrapper, true, true);
             await _fixture.SqlServerFhirDataStore.MergeResourcesWrapperAsync(tran.TransactionId, false, [mergeWrapper], false, 0, cts.Token);
-            ExecuteSql($"IF NOT EXISTS (SELECT * FROM dbo.Resource WHERE ResourceTypeId = 103 AND ResourceId = '{patient.Id}') RAISERROR('Resource is not created',18,127)");
+            var typeId = _fixture.SqlServerFhirModel.GetResourceTypeId("Patient");
+            ExecuteSql($"IF NOT EXISTS (SELECT * FROM dbo.Resource WHERE ResourceTypeId = {typeId} AND ResourceId = '{patient.Id}') RAISERROR('Resource is not created',18,127)");
 
             var wd = new CleanupEventLogWatchdog(_fixture.SqlRetryService, XUnitLogger<CleanupEventLogWatchdog>.Create(_testOutputHelper));
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerWatchdogTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerWatchdogTests.cs
@@ -171,7 +171,8 @@ END
 
             // TODO: Temp code to test database stats
             ExecuteSql("IF NOT EXISTS (SELECT * FROM dbo.EventLog WHERE Process = 'tmp_GetRawResources') RAISERROR('tmp_GetRawResources calls are not registered',18,127)");
-            ExecuteSql("IF NOT EXISTS (SELECT * FROM dbo.EventLog WHERE Process = 'DatabaseStats.Totals') RAISERROR('DatabaseStats message is not registered',18,127)");
+            ExecuteSql("IF NOT EXISTS (SELECT * FROM dbo.EventLog WHERE Process = 'DatabaseStats.ResourceTypeTotals') RAISERROR('DatabaseStats.ResourceTypeTotals message is not registered',18,127)");
+            ExecuteSql("IF NOT EXISTS (SELECT * FROM dbo.EventLog WHERE Process = 'DatabaseStats.SearchParamCount') RAISERROR('DatabaseStats.SearchParamCount message is not registered',18,127)");
 
             await cts.CancelAsync();
             await wdTask;


### PR DESCRIPTION
This is temp code to capture some database stats in the logs. Main goal was to get raw resource length (both compressed and decompressed) to help with new pricing model. I also included search param counts to help search param usage affect. Once dust settles, we can move this code in the permanent place.
 
https://microsofthealth.visualstudio.com/Health/_workitems/edit/151561
