### PR TITLE
Fixing includes test failures

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludesOperationTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/IncludesOperationTests.cs
@@ -10,9 +10,8 @@ using System.Net;
 using System.Text.RegularExpressions;
 using AngleSharp.Common;
 using Hl7.Fhir.Model;
-using Microsoft.Extensions.Azure;
 using Microsoft.Health.Fhir.Client;
-using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Core.Features;
 using Microsoft.Health.Fhir.Core.Features.Routing;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Tests.Common;
@@ -30,8 +29,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
     [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.Json)]
     public class IncludesOperationTests : IClassFixture<IncludesOperationTestFixture>
     {
-        private static readonly Regex ContinuationTokenRegex = new Regex("[?&]ct");
-        private static readonly Regex IncludesContinuationTokenRegex = new Regex("[?&]includesCt");
+        private static readonly Regex ContinuationTokenRegex = new Regex($"[?&]{KnownQueryParameterNames.ContinuationToken}");
+        private static readonly Regex IncludesContinuationTokenRegex = new Regex($"[?&]{KnownQueryParameterNames.IncludesContinuationToken}");
 
         private readonly IncludesOperationTestFixture _fixture;
 
@@ -224,13 +223,13 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             string query)
         {
             Assert.NotNull(response.Resource.SelfLink);
-            Assert.StartsWith($"{Server.BaseAddress}{resourceType}/{KnownRoutes.Includes}?{query}", DecodeUrl(response.Resource.SelfLink.AbsoluteUri));
+            ValidateUrl($"{Server.BaseAddress}{resourceType}/{KnownRoutes.Includes}?{query}", DecodeUrl(response.Resource.SelfLink.AbsoluteUri));
             Assert.Matches(IncludesContinuationTokenRegex, response.Resource.SelfLink.AbsoluteUri);
 
             if (response.Resource.Entry.Any(x => x.TypeName.Equals(KnownResourceTypes.OperationOutcome, StringComparison.OrdinalIgnoreCase)))
             {
                 Assert.NotNull(response.Resource.NextLink);
-                Assert.StartsWith($"{Server.BaseAddress}{resourceType}/{KnownRoutes.Includes}?{query}", DecodeUrl(response.Resource.NextLink.AbsoluteUri));
+                ValidateUrl($"{Server.BaseAddress}{resourceType}/{KnownRoutes.Includes}?{query}", DecodeUrl(response.Resource.NextLink.AbsoluteUri));
                 Assert.Matches(IncludesContinuationTokenRegex, response.Resource.NextLink.AbsoluteUri);
             }
 
@@ -247,12 +246,12 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             bool supportsIncludes)
         {
             Assert.NotNull(response.Resource.SelfLink);
-            Assert.Equal($"{Server.BaseAddress}{resourceType}?{query}", DecodeUrl(response.Resource.SelfLink.AbsoluteUri));
+            ValidateUrl($"{Server.BaseAddress}{resourceType}?{query}", DecodeUrl(response.Resource.SelfLink.AbsoluteUri));
 
             if (patientResourceCount < _fixture.PatientResources.Count)
             {
                 Assert.NotNull(response.Resource.NextLink);
-                Assert.StartsWith($"{Server.BaseAddress}{resourceType}?{query}", DecodeUrl(response.Resource.NextLink.AbsoluteUri));
+                ValidateUrl($"{Server.BaseAddress}{resourceType}?{query}", DecodeUrl(response.Resource.NextLink.AbsoluteUri));
                 Assert.Matches(ContinuationTokenRegex, response.Resource.NextLink.AbsoluteUri);
             }
 
@@ -260,9 +259,45 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             {
                 var relatedLink = response.Resource.Link?.Where(x => x.Relation.Equals("related", StringComparison.Ordinal)).FirstOrDefault();
                 Assert.NotNull(relatedLink);
-                Assert.StartsWith($"{Server.BaseAddress}{resourceType}/{KnownRoutes.Includes}?{query}", DecodeUrl(relatedLink.Url));
+                ValidateUrl($"{Server.BaseAddress}{resourceType}/{KnownRoutes.Includes}?{query}", DecodeUrl(relatedLink.Url));
                 Assert.Matches(IncludesContinuationTokenRegex, relatedLink.Url);
             }
+        }
+
+        private void ValidateUrl(string expectedUrl, string actualUrl, bool ignoreCt = true)
+        {
+            if (!Uri.TryCreate(expectedUrl, UriKind.RelativeOrAbsolute, out var expectedUri))
+            {
+                Assert.Fail($"Invalid expected url: {expectedUrl}");
+            }
+
+            if (!Uri.TryCreate(actualUrl, UriKind.RelativeOrAbsolute, out var actualUri))
+            {
+                Assert.Fail($"Invalid actual url: {actualUrl}");
+            }
+
+            Assert.Equal(expectedUri.Scheme, actualUri.Scheme);
+            Assert.Equal(expectedUri.Host, actualUri.Host);
+
+            var expectedSegments = new HashSet<string>(expectedUri.Segments);
+            var actualSegments = new HashSet<string>(actualUri.Segments);
+            Assert.Equal(expectedSegments.Count, actualSegments.Count);
+            Assert.Contains(expectedSegments, x => actualSegments.Contains(x));
+
+            var expectedQueryParams = expectedUri.Query.Split(new char[] { '&' }).Select(x => x.Trim('?'));
+            var actualQueryParams = actualUri.Query.Split(new char[] { '&' }).Select(x => x.Trim('?'));
+            if (ignoreCt)
+            {
+                expectedQueryParams = expectedQueryParams.Where(
+                    x => !x.StartsWith(KnownQueryParameterNames.ContinuationToken) && !x.StartsWith(KnownQueryParameterNames.IncludesContinuationToken));
+                actualQueryParams = actualQueryParams.Where(
+                    x => !x.StartsWith(KnownQueryParameterNames.ContinuationToken) && !x.StartsWith(KnownQueryParameterNames.IncludesContinuationToken));
+            }
+
+            var expectedQuery = new HashSet<string>(expectedQueryParams);
+            var actualQuery = new HashSet<string>(actualQueryParams);
+            Assert.Equal(expectedQuery.Count, actualQuery.Count);
+            Assert.Contains(expectedQuery, x => actualQuery.Contains(x));
         }
 
         private string TagQuery(string query)


### PR DESCRIPTION
## Description
These tests are failing in workspace-platform because of the way the self-link, next-link, and related-link are being validated. These urls will be validated by comparing url components with this change.

## Related issues
Addresses [issue #152072].
[Bug 152072](https://microsofthealth.visualstudio.com/Health/_workitems/edit/152072): Includes operation test is failing due to url validation

## Testing
Run the test with the change locally. 

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
