### PR TITLE
Cosmos Export - Add Retry to Next Job Queuing

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/RetryExceptionPolicyFactory.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/RetryExceptionPolicyFactory.cs
@@ -117,41 +117,25 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage
                         // Log details about each retry attempt for better visibility
                         string statusCode = "N/A";
                         string diagnostics = "N/A";
-                        bool isServiceUnavailable = false;
 
                         // Single type check for CosmosException to improve performance
                         if (e is CosmosException cosmosException)
                         {
                             statusCode = cosmosException.StatusCode.ToString();
                             diagnostics = cosmosException.Diagnostics?.ToString() ?? "empty";
-                            isServiceUnavailable = cosmosException.StatusCode == HttpStatusCode.ServiceUnavailable;
                         }
 
                         var retryType = useExponentialRetry ? "exponential" : "fixed";
                         var waitTime = timeSpan.TotalMilliseconds;
 
-                        if (isServiceUnavailable)
-                        {
-                            _logger.LogWarning(
+                        _logger.LogWarning(
                                 e,
-                                "Received a ServiceUnavailable response from Cosmos DB. Retrying attempt {RetryAttempt}/{MaxRetries}. Wait: {WaitTimeMs}ms ({RetryType}). Diagnostics: {CosmosDiagnostics}",
-                                retryAttempt,
-                                maxRetries,
-                                waitTime,
-                                retryType,
-                                diagnostics);
-                        }
-                        else
-                        {
-                            _logger.LogInformation(
-                                "Cosmos DB operation failed. Retrying attempt {RetryAttempt}/{MaxRetries}. Status: {StatusCode}. Wait: {WaitTimeMs}ms ({RetryType}). Error: {ErrorMessage}",
+                                "Cosmos DB operation failed. Retrying attempt {RetryAttempt}/{MaxRetries}. Status: {StatusCode}. Wait: {WaitTimeMs}ms ({RetryType}).",
                                 retryAttempt,
                                 maxRetries,
                                 statusCode,
                                 waitTime,
-                                retryType,
-                                e.Message);
-                        }
+                                retryType);
 
                         if (maxWaitTimeInSeconds == -1)
                         {


### PR DESCRIPTION
## Description
- Adds retry to Cosmos backend-based export when the next job in the series is queued.
- Adds additional logging to background retry provider for Cosmos.

## Related issues
[AB#153716](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/153716)

## Testing
Unit/E2E testing.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
