### PR TITLE
Add catch for missing MI

### DIFF
--- a/src/Microsoft.Health.Fhir.Azure/ExportDestinationClient/AzureExportDestinationClient.cs
+++ b/src/Microsoft.Health.Fhir.Azure/ExportDestinationClient/AzureExportDestinationClient.cs
@@ -94,6 +94,12 @@ namespace Microsoft.Health.Fhir.Azure.ExportDestinationClient
                 _logger.LogWarning(ex, "Failed to get access token for export");
                 throw new DestinationConnectionException(Resources.CannotGetAccessToken, HttpStatusCode.Forbidden);
             }
+            catch (ArgumentNullException ex) when (ex.Message.Contains("credentialBundleName", StringComparison.OrdinalIgnoreCase))
+            {
+                // This indicates that Managed Identity isn't setup
+                _logger.LogWarning(ex, "Failed to get access token for export");
+                throw new DestinationConnectionException(Resources.CannotGetAccessToken, HttpStatusCode.Forbidden);
+            }
         }
 
         public void WriteFilePart(string fileName, string data)

--- a/src/Microsoft.Health.Fhir.Azure/IntegrationDataStore/AzureBlobIntegrationDataStoreClient.cs
+++ b/src/Microsoft.Health.Fhir.Azure/IntegrationDataStore/AzureBlobIntegrationDataStoreClient.cs
@@ -190,6 +190,12 @@ namespace Microsoft.Health.Fhir.Azure.IntegrationDataStore
 
                 throw new IntegrationDataStoreException(exception, (HttpStatusCode)se.Status);
             }
+            catch (ArgumentNullException ex) when (ex.Message.Contains("credentialBundleName", StringComparison.OrdinalIgnoreCase))
+            {
+                // This indicates that Managed Identity wasn't setup.
+                _logger.LogWarning(ex, "Failed to get access token");
+                throw new IntegrationDataStoreException(Resources.CannotGetAccessToken, HttpStatusCode.Forbidden);
+            }
         }
 
         public async Task<string> TryAcquireLeaseAsync(Uri resourceUri, string proposedLeaseId, CancellationToken cancellationToken)

--- a/src/Microsoft.Health.Fhir.Azure/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Azure/Resources.resx
@@ -130,7 +130,7 @@
     <value>Anonymization container not found on the destination storage.</value>
   </data>
   <data name="CannotGetAccessToken" xml:space="preserve">
-    <value>Unable to get access token for storage account for export.</value>
+    <value>Unable to get access token for storage account.</value>
   </data>
   <data name="CannotGetAcrAccessToken" xml:space="preserve">
     <value>Failed to get access token for Azure Container Registry. Please check your configuration.</value>


### PR DESCRIPTION
## Description
Adds a catch for missing managed identity in export and import.

## Related issues
Addresses [Bug 153984](https://microsofthealth.visualstudio.com/Health/_workitems/edit/153984)

## Testing

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
