### PR TITLE
Add Retry to Export on Connection Exception

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Configs/ExportJobConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/ExportJobConfiguration.cs
@@ -77,5 +77,15 @@ namespace Microsoft.Health.Fhir.Core.Configs
         /// The maximum number of times a job can be restarted before it is considered failed.
         /// </summary>
         public uint MaxJobRestartCount { get; set; } = 64;
+
+        /// <summary>
+        /// Gets or sets the maximum number of retry attempts for transient errors.
+        /// </summary>
+        public int MaxRetryCount { get; set; } = 3;
+
+        /// <summary>
+        /// Gets or sets the delay in milliseconds between retry attempts.
+        /// </summary>
+        public int RetryDelayMilliseconds { get; set; } = 5000;
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
         private ExportJobRecord _exportJobRecord;
         private WeakETag _weakETag;
         private ExportFileManager _fileManager;
-        private readonly AsyncRetryPolicy _exportJobRetryPolicy;
+        private readonly AsyncRetryPolicy _exportSearchRetryPolicy;
 
         public ExportJobTask(
             Func<IScoped<IFhirOperationDataStore>> fhirOperationDataStoreFactory,
@@ -92,7 +92,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
             UpdateExportJob = UpdateExportJobAsync;
 
-            _exportJobRetryPolicy = Policy
+            // Retry policy for the actual export job action.
+            _exportSearchRetryPolicy = Policy
                 .Handle<DestinationConnectionException>()
                 .WaitAndRetryAsync(
                     _exportJobConfiguration.MaxRetryCount,
@@ -228,7 +229,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
                 ExportJobProgress progress = _exportJobRecord.Progress;
 
-                await _retryPolicy.ExecuteAsync(async () =>
+                await _exportSearchRetryPolicy.ExecuteAsync(async () =>
                 {
                     await RunExportSearch(exportJobConfiguration, progress, queryParametersList, exportResourceVersionTypes, cancellationToken);
                 });

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -29,6 +29,8 @@ using Microsoft.Health.Fhir.Core.Features.Operations.Export.Models;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Models;
+using Polly;
+using Polly.Retry;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
@@ -50,6 +52,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
         private ExportJobRecord _exportJobRecord;
         private WeakETag _weakETag;
         private ExportFileManager _fileManager;
+        private readonly AsyncRetryPolicy _exportJobRetryPolicy;
 
         public ExportJobTask(
             Func<IScoped<IFhirOperationDataStore>> fhirOperationDataStoreFactory,
@@ -88,6 +91,21 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
             _logger = logger;
 
             UpdateExportJob = UpdateExportJobAsync;
+
+            _exportJobRetryPolicy = Policy
+                .Handle<DestinationConnectionException>()
+                .WaitAndRetryAsync(
+                    _exportJobConfiguration.MaxRetryCount,
+                    retryAttempt => TimeSpan.FromMilliseconds(_exportJobConfiguration.RetryDelayMilliseconds),
+                    (exception, timeSpan, retryCount, context) =>
+                    {
+                        _logger.LogWarning(
+                            exception,
+                            "[JobId:{JobId}] Retry {RetryCount} for DestinationConnectionException. Waiting {TimeSpan} before next retry.",
+                            _exportJobRecord?.Id,
+                            retryCount,
+                            timeSpan);
+                    });
         }
 
         public Func<ExportJobRecord, WeakETag, CancellationToken, Task<ExportJobOutcome>> UpdateExportJob
@@ -210,7 +228,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
                 ExportJobProgress progress = _exportJobRecord.Progress;
 
-                await RunExportSearch(exportJobConfiguration, progress, queryParametersList, exportResourceVersionTypes, cancellationToken);
+                await _retryPolicy.ExecuteAsync(async () =>
+                {
+                    await RunExportSearch(exportJobConfiguration, progress, queryParametersList, exportResourceVersionTypes, cancellationToken);
+                });
 
                 await CompleteJobAsync(OperationStatus.Completed, cancellationToken);
 


### PR DESCRIPTION
## Description
 - Adds retry to export execution on destination connection exception
   - Will help with 412 errors from Azure Storage
 - Adds small delay on AzureExportDestinationClient write
   - Helps with potential library concurrency issues

## Related issues
[AB#153716](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/153716)

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
