### PR TITLE
Adding id in capability statement

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/Models/ListedCapabilityStatement.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/Models/ListedCapabilityStatement.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance.Models
 
         public ListedCapabilityStatement()
         {
-            Id = new ResourceIdProvider().Create().ToString();
+            Id = new ResourceIdProvider().Create();
             Status = new DefaultOptionHashSet<string>("draft", StringComparer.Ordinal);
             Kind = new DefaultOptionHashSet<string>("capability", StringComparer.Ordinal);
             Rest = new HashSet<ListedRestComponent>(new PropertyEqualityComparer<ListedRestComponent>(x => x.Mode));

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/Models/ListedCapabilityStatement.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/Models/ListedCapabilityStatement.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Models;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -17,6 +18,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance.Models
 
         public ListedCapabilityStatement()
         {
+            Id = new ResourceIdProvider().Create().ToString();
             Status = new DefaultOptionHashSet<string>("draft", StringComparer.Ordinal);
             Kind = new DefaultOptionHashSet<string>("capability", StringComparer.Ordinal);
             Rest = new HashSet<ListedRestComponent>(new PropertyEqualityComparer<ListedRestComponent>(x => x.Mode));


### PR DESCRIPTION
## Description
Adding Id element in the Capability Statement

## Related issues
Addresses [AB# 101216](https://microsofthealth.visualstudio.com/Health/_workitems/edit/101216)

## Testing
Tested with SQL Server  and Cosmos db for all FHIR versions(R4,R4B,R5,STU3)

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
