### PR TITLE
Update pending delete state in sp definition manager

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs
@@ -244,6 +244,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Parameters
                 DeleteSearchParameter(searchParam.Uri.OriginalString);
             }
 
+            foreach (var searchParam in updatedSearchParameterStatus.Where(p => p.Status == SearchParameterStatus.PendingDelete))
+            {
+                _searchParameterDefinitionManager.UpdateSearchParameterStatus(searchParam.Uri.AbsolutePath, SearchParameterStatus.PendingDelete);
+            }
+
             var paramsToAdd = new List<ITypedElement>();
             foreach (var searchParam in updatedSearchParameterStatus.Where(p => p.Status == SearchParameterStatus.Enabled || p.Status == SearchParameterStatus.Supported))
             {


### PR DESCRIPTION
## Description
Update the search parameter definition manager cache for search parameters that are in PendingDelete state. 

## Related issues
Addresses [issue #154088].
[Bug 154088](https://microsofthealth.visualstudio.com/Health/_workitems/edit/154088): The cached data in SP definition manager needs to be updated before the SP validator validates an incoming SP request.

## Testing
Tested manually and also by running existing automation.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
