### PR TITLE
Fix Cosmos export duplicates due to ignoring feedRange

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchOptions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchOptions.cs
@@ -148,9 +148,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
         public bool OnlyIds { get; set; }
 
         /// <summary>
-        /// Flag for async operations that want to return a large number of results.
+        /// Flag for async operations.
         /// </summary>
-        public bool IsLargeAsyncOperation { get; internal set; }
+        public bool IsAsyncOperation { get; internal set; }
 
         /// <summary>
         /// Flag for $includes operation.

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -311,23 +311,20 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             {
                 searchOptions.MaxItemCountSpecifiedByClient = true;
 
-                if (searchParams.Count > _featureConfiguration.MaxItemCountPerSearch)
+                if (isAsyncOperation)
                 {
-                    if (isAsyncOperation)
-                    {
-                        searchOptions.IsLargeAsyncOperation = true;
-                        searchOptions.MaxItemCount = searchParams.Count.Value;
-                    }
-                    else
-                    {
-                        searchOptions.MaxItemCount = _featureConfiguration.MaxItemCountPerSearch;
+                    searchOptions.IsAsyncOperation = true;
+                    searchOptions.MaxItemCount = searchParams.Count.Value;
+                }
+                else if (searchParams.Count > _featureConfiguration.MaxItemCountPerSearch)
+                {
+                    searchOptions.MaxItemCount = _featureConfiguration.MaxItemCountPerSearch;
 
-                        _contextAccessor.RequestContext?.BundleIssues.Add(
-                            new OperationOutcomeIssue(
-                                OperationOutcomeConstants.IssueSeverity.Information,
-                                OperationOutcomeConstants.IssueType.Informational,
-                                string.Format(Core.Resources.SearchParamaterCountExceedLimit, _featureConfiguration.MaxItemCountPerSearch, searchParams.Count)));
-                    }
+                    _contextAccessor.RequestContext?.BundleIssues.Add(
+                        new OperationOutcomeIssue(
+                            OperationOutcomeConstants.IssueSeverity.Information,
+                            OperationOutcomeConstants.IssueType.Informational,
+                            string.Format(Core.Resources.SearchParamaterCountExceedLimit, _featureConfiguration.MaxItemCountPerSearch, searchParams.Count)));
                 }
                 else
                 {


### PR DESCRIPTION
## Summary
- Fixes exports to identify as async operations even with less maxCount than default FHIR query max.
- Defensively respects feed range for all cosmos queries.

## What happened
There was a bug due to an assumption in code that any export that uses _isParallel would have a maxCount > default maxCount. When this didn't happen, we parallelized by feed range but didn't apply this filter to parallelized jobs resulting in heavy duplication.

## Related issues
[AB#154189](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/154189)

## Testing
Local code path
OSS test env

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
