### PR TITLE
Catch Cosmos Job Dequeue Race Condition Exception

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/Queues/CosmosQueueClientTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Storage/Queues/CosmosQueueClientTests.cs
@@ -48,7 +48,8 @@ public class CosmosQueueClientTests
             Substitute.For<Func<IScoped<Container>>>(),
             _cosmosQueryFactory,
             _distributedLockFactory,
-            _retryPolicyFactory);
+            _retryPolicyFactory,
+            NullLogger<CosmosQueueClient>.Instance);
     }
 
     [Theory]

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Queues/CosmosQueueClient.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Queues/CosmosQueueClient.cs
@@ -32,17 +32,20 @@ public class CosmosQueueClient : IQueueClient
     private readonly ICosmosDbDistributedLockFactory _distributedLockFactory;
     private readonly RetryExceptionPolicyFactory _retryExceptionPolicyFactory;
     private readonly AsyncPolicy _retryPolicy;
+    private readonly ILogger<CosmosQueueClient> _logger;
 
     public CosmosQueueClient(
         Func<IScoped<Container>> containerFactory,
         ICosmosQueryFactory queryFactory,
         ICosmosDbDistributedLockFactory distributedLockFactory,
-        RetryExceptionPolicyFactory retryExceptionPolicyFactory)
+        RetryExceptionPolicyFactory retryExceptionPolicyFactory,
+        ILogger<CosmosQueueClient> logger)
     {
         _containerFactory = EnsureArg.IsNotNull(containerFactory, nameof(containerFactory));
         _queryFactory = EnsureArg.IsNotNull(queryFactory, nameof(queryFactory));
         _distributedLockFactory = EnsureArg.IsNotNull(distributedLockFactory, nameof(distributedLockFactory));
         _retryExceptionPolicyFactory = EnsureArg.IsNotNull(retryExceptionPolicyFactory, nameof(retryExceptionPolicyFactory));
+        _logger = EnsureArg.IsNotNull(logger, nameof(logger));
 
         _retryPolicy = _retryExceptionPolicyFactory.BackgroundWorkerRetryPolicy;
     }
@@ -256,9 +259,17 @@ public class CosmosQueueClient : IQueueClient
             }
         }
 
-        await SaveJobGroupAsync(item, cancellationToken);
-
-        return item.ToJobInfo(toReturn).ToList();
+        try
+        {
+            await SaveJobGroupAsync(item, cancellationToken);
+            return item.ToJobInfo(toReturn).ToList();
+        }
+        catch (JobConflictException)
+        {
+            // If another worker has modified this job group while we were processing it,
+            // return an empty result. The job will be re-evaluated on the next dequeue attempt.
+            return Array.Empty<JobInfo>();
+        }
     }
 
     /// <inheritdoc />
@@ -574,6 +585,18 @@ public class CosmosQueueClient : IQueueClient
         catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.RequestEntityTooLarge)
         {
             throw new JobExecutionException("Job data too large.", ex, false);
+        }
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.PreconditionFailed && !ignoreEtag)
+        {
+            // This occurs when multiple workers are attempting to dequeue the same job
+            // Instead of failing, we will just log this and return. This is handled at the caller level.
+            _logger.LogWarning(
+                ex,
+                "Job conflict detected. Another worker has modified the job group while we were processing it. Job ID: {JobId}, Group ID: {GroupId}, Queue Type: {QueueType}",
+                definition.Id,
+                definition.GroupId,
+                definition.QueueType);
+            throw new JobConflictException("Job was modified by another worker.", ex);
         }
     }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
@@ -232,7 +232,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 () => _container.CreateMockScope(),
                 new CosmosQueryFactory(Substitute.For<ICosmosResponseProcessor>(), Substitute.For<ICosmosQueryLogger>()),
                 new CosmosDbDistributedLockFactory(() => _container.CreateMockScope(), NullLogger<CosmosDbDistributedLock>.Instance),
-                retryExceptionPolicyFactory);
+                retryExceptionPolicyFactory,
+                NullLogger<CosmosQueueClient>.Instance);
 
             _cosmosFhirOperationDataStore = new CosmosFhirOperationDataStore(
                 _queueClient,


### PR DESCRIPTION
## Description
Adds catch for Cosmos 412 when multiple workers are trying to dequeue a job.

## Related issues
[AB#155368](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/155368)

## Testing
Unit/integration

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
