### PR TITLE
Better logging for Storage Account Not Found

### DIFF
--- a/src/Microsoft.Health.Fhir.Azure/ExportDestinationClient/AzureExportDestinationClient.cs
+++ b/src/Microsoft.Health.Fhir.Azure/ExportDestinationClient/AzureExportDestinationClient.cs
@@ -87,8 +87,16 @@ namespace Microsoft.Health.Fhir.Azure.ExportDestinationClient
             {
                 // The blob container has added a 6 attempt retry that creates an aggregate exception if it can't find the blob.
                 var innerException = (RequestFailedException)ex.InnerExceptions[0];
-                _logger.LogWarning(innerException, "{Error}", innerException.Message);
-                throw new DestinationConnectionException(innerException.Message, (HttpStatusCode)innerException.Status);
+                if (ex.InnerExceptions[0].Message.Contains("No such host is known", StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogWarning(ex, "Storage account not found");
+                    throw new DestinationConnectionException(Resources.StorageAccountNotFound, HttpStatusCode.InternalServerError);
+                }
+                else
+                {
+                    _logger.LogWarning(innerException, "{Error}", innerException.Message);
+                    throw new DestinationConnectionException(innerException.Message, (HttpStatusCode)innerException.Status);
+                }
             }
             catch (AccessTokenProviderException ex)
             {

--- a/src/Microsoft.Health.Fhir.Azure/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Azure/Resources.Designer.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Health.Fhir.Azure {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to get access token for storage account for export..
+        ///   Looks up a localized string similar to Unable to get access token for storage account..
         /// </summary>
         internal static string CannotGetAccessToken {
             get {
@@ -165,6 +165,15 @@ namespace Microsoft.Health.Fhir.Azure {
         internal static string InvalidStorageUri {
             get {
                 return ResourceManager.GetString("InvalidStorageUri", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The storage account not found..
+        /// </summary>
+        internal static string StorageAccountNotFound {
+            get {
+                return ResourceManager.GetString("StorageAccountNotFound", resourceCulture);
             }
         }
     }

--- a/src/Microsoft.Health.Fhir.Azure/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Azure/Resources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -154,5 +154,8 @@
   </data>
   <data name="InvalidStorageUri" xml:space="preserve">
     <value>The given storage uri is invalid</value>
+  </data>
+  <data name="StorageAccountNotFound" xml:space="preserve">
+    <value>The storage account not found.</value>
   </data>
 </root>

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/Models/ListedCapabilityStatement.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/Models/ListedCapabilityStatement.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance.Models
 
         public ListedCapabilityStatement()
         {
-            Id = new ResourceIdProvider().Create().ToString();
+            Id = new ResourceIdProvider().Create();
             Status = new DefaultOptionHashSet<string>("draft", StringComparer.Ordinal);
             Kind = new DefaultOptionHashSet<string>("capability", StringComparer.Ordinal);
             Rest = new HashSet<ListedRestComponent>(new PropertyEqualityComparer<ListedRestComponent>(x => x.Mode));

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/Models/ListedCapabilityStatement.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/Models/ListedCapabilityStatement.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Models;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -17,6 +18,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance.Models
 
         public ListedCapabilityStatement()
         {
+            Id = new ResourceIdProvider().Create().ToString();
             Status = new DefaultOptionHashSet<string>("draft", StringComparer.Ordinal);
             Kind = new DefaultOptionHashSet<string>("capability", StringComparer.Ordinal);
             Rest = new HashSet<ListedRestComponent>(new PropertyEqualityComparer<ListedRestComponent>(x => x.Mode));


### PR DESCRIPTION
## Description
[Better logging] Gen1 Export Returning 500 for Storage Account Not Found

## Related issues
Addresses [AB# 145777](https://microsofthealth.visualstudio.com/Health/_workitems/edit/145777)

## Testing
Tested the error witj all the fhir versions  in Gen1

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
