### PR TITLE
Fix Auth for Local E2E Tests

### DIFF
--- a/src/Microsoft.Health.Fhir.Api.OpenIddict/Extensions/DevelopmentIdentityProviderRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Api.OpenIddict/Extensions/DevelopmentIdentityProviderRegistrationExtensions.cs
@@ -73,8 +73,6 @@ namespace Microsoft.Health.Fhir.Api.OpenIddict.Extensions
 
             if (developmentIdentityProviderConfiguration.Enabled)
             {
-                var host = configuration["ASPNETCORE_URLS"];
-
                 services.AddDbContext<ApplicationAuthDbContext>(options =>
                 {
                     options.UseInMemoryDatabase("DevAuthDb");

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/InProcTestFhirServer.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/InProcTestFhirServer.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             configuration["TestAuthEnvironment:FilePath"] = "testauthenvironment.json";
             configuration["FhirServer:Security:Enabled"] = "true";
+            configuration["DevelopmentIdentityProvider:Enabled"] = "true";
 
             string inProcEndpoint = "https://inprochost";
             configuration["FhirServer:Security:Authentication:Authority"] = inProcEndpoint;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/StartupBaseForCustomProviders.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/StartupBaseForCustomProviders.cs
@@ -6,6 +6,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Api.Controllers;
+using Microsoft.Health.Fhir.Api.OpenIddict.Controllers;
 using Microsoft.Health.Fhir.Web;
 
 namespace Microsoft.Health.Fhir.Tests.E2E
@@ -25,7 +26,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E
             // FHIR controllers from the API assemblies are not automatically registered.
             services.AddMvc()
                 .AddApplicationPart(typeof(FhirController).Assembly)
-                .AddApplicationPart(typeof(AadSmartOnFhirProxyController).Assembly);
+                .AddApplicationPart(typeof(AadSmartOnFhirProxyController).Assembly)
+                .AddApplicationPart(typeof(OpenIddictAuthorizationController).Assembly);
         }
     }
 }


### PR DESCRIPTION
## Description
Adds OpenIdDict controller for local E2E tests.

## Related issues
[AB#157537](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/157537)

## Testing
- Running tests locally
- PR pipeline

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
