### PR TITLE
[Cache] Fix FhirMemoryCache memory limits

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Storage/FhirMemoryCacheTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Storage/FhirMemoryCacheTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Storage
                 int newEntrySize = ASCIIEncoding.Unicode.GetByteCount(key) + sizeof(int);
 
                 bool ingested = cache.TryAdd(key, 2112);
-                if (ingested == true)
+                if (ingested)
                 {
                     maxNumberOfElements = cache.Count;
                 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Storage/FhirMemoryCache.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Storage/FhirMemoryCache.cs
@@ -130,14 +130,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Storage
             key = FormatKey(key);
             object cachedValue = _cache.Get(key);
 
-            if (cachedValue == null)
-            {
-                return default(T);
-            }
-            else
-            {
-                return (T)cachedValue;
-            }
+            return cachedValue == null ? default(T) : (T)cachedValue;
         }
 
         /// <summary>

--- a/src/Microsoft.Health.Fhir.Core/Features/Storage/FhirMemoryCacheItemPriority.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Storage/FhirMemoryCacheItemPriority.cs
@@ -1,0 +1,15 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Fhir.Core.Features.Storage
+{
+    public enum FhirMemoryCacheItemPriority
+    {
+        Low = 0,
+        Normal = 1,
+        High = 2,
+        NeverRemove = 3,
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Storage/IFhirMemoryCache.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Storage/IFhirMemoryCache.cs
@@ -9,13 +9,19 @@ namespace Microsoft.Health.Fhir.Core.Features.Storage
 {
     public interface IFhirMemoryCache<T>
     {
+        string Name { get; }
+
         long CacheMemoryLimit { get; }
 
         long Count { get; }
 
         T GetOrAdd(string key, T value);
 
+        T GetOrAdd(string key, T value, FhirMemoryCacheItemPriority priority);
+
         bool TryAdd(string key, T value);
+
+        bool TryAdd(string key, T value, FhirMemoryCacheItemPriority priority);
 
         T Get(string key);
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Storage/IFhirMemoryCache.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Storage/IFhirMemoryCache.cs
@@ -7,9 +7,11 @@ using System.Collections.Generic;
 
 namespace Microsoft.Health.Fhir.Core.Features.Storage
 {
-    public interface IMemoryCache<T>
+    public interface IFhirMemoryCache<T>
     {
         long CacheMemoryLimit { get; }
+
+        long Count { get; }
 
         T GetOrAdd(string key, T value);
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
@@ -42,7 +42,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
     /// many many times in the database. For more compact storage, we use IDs instead of the strings when referencing these.
     /// Also, because the number of distinct values is small, we can maintain all values in memory and avoid joins when querying.
     /// </summary>
+#pragma warning disable CA1001 // Types that own disposable fields should be disposable. Justification: SQLServerFhirModel is maintained in memory during all process execution.
     public sealed class SqlServerFhirModel : ISqlServerFhirModel
+#pragma warning restore CA1001
     {
         private readonly SchemaInformation _schemaInformation;
         private readonly ISearchParameterDefinitionManager _searchParameterDefinitionManager;

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
@@ -335,20 +335,32 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                     await reader.NextResultAsync(cancellationToken);
 
                     _systemToId = new FhirMemoryCache<int>("systemToId", _logger, ignoreCase: true);
+                    bool systemWarningLogged = false;
                     while (await reader.ReadAsync(cancellationToken))
                     {
                         var (value, systemId) = reader.ReadRow(VLatest.System.Value, VLatest.System.SystemId);
-                        _systemToId.TryAdd(value, systemId);
+
+                        if (!_systemToId.TryAdd(value, systemId) && !systemWarningLogged)
+                        {
+                            _logger.LogWarning($"Cache '{_systemToId.Name}' reached the limit of {_systemToId.CacheMemoryLimit} bytes (with {_systemToId.Count} cached elements).");
+                            systemWarningLogged = true;
+                        }
                     }
 
                     // result set 6
                     await reader.NextResultAsync(cancellationToken);
 
                     _quantityCodeToId = new FhirMemoryCache<int>("quantityCodeToId", _logger, ignoreCase: true);
+                    bool quantityCodeWarningLogged = false;
                     while (await reader.ReadAsync(cancellationToken))
                     {
                         (string value, int quantityCodeId) = reader.ReadRow(VLatest.QuantityCode.Value, VLatest.QuantityCode.QuantityCodeId);
-                        _quantityCodeToId.TryAdd(value, quantityCodeId);
+
+                        if (!_quantityCodeToId.TryAdd(value, quantityCodeId) && !quantityCodeWarningLogged)
+                        {
+                            _logger.LogWarning($"Cache '{_quantityCodeToId.Name}' reached the limit of {_quantityCodeToId.CacheMemoryLimit} bytes (with {_quantityCodeToId.Count} cached elements).");
+                            quantityCodeWarningLogged = true;
+                        }
                     }
 
                     _resourceTypeToId = resourceTypeToId;


### PR DESCRIPTION
## Description
In this PR I'm replacing the use of System.Runtime.Caching.MemoryCache with Microsoft.Extensions.Caching.MemoryCache. 

There are two main reasons for this refactoring:
1 - The "_CacheMemoryLimitMegabytes_" configuration is obsolete, and it does not work anymore since dotnet 5. And that's a problem, as we can't control the max size of the cache anymore.
2 - Microsoft.Extensions.Caching is the new recommended caching framework for ASP.NET applications. 

References:
* https://learn.microsoft.com/en-us/dotnet/core/extensions/caching
* https://learn.microsoft.com/en-us/dotnet/api/system.runtime.caching.memorycache.cachememorylimit?view=net-9.0-pp#remarks

Bug: 
[AB#157764](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/157764) 
