### PR TITLE
Fix NullReferenceException

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs
@@ -272,7 +272,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Definition
             foreach (var resourceType in allResourceTypes)
             {
                 TypeLookup[resourceType].TryRemove(searchParameterInfo.Code, out var removedParam);
-                if (removedParam.Url != searchParameterInfo.Url)
+                if (removedParam != null && removedParam.Url != searchParameterInfo.Url)
                 {
                     _logger.LogError("Error, Search Param {RemovedParam} removed from Search Param Definition manager.  It does not match deleted Search Param {Url}", removedParam.Url, url);
                 }


### PR DESCRIPTION
## Description
Fix the exception noticed in prod

env_ex_msg	env_ex_type	stackTrace
Object reference not set to an instance of an object.	System.**NullReferenceException**	   at Microsoft.Health.Fhir.Core.Features.Definition.SearchParameterDefinitionManager.DeleteSearchParameter(String url, Boolean calculateHash) in /_/src/Microsoft.Health.Fhir.Core/Features/Definition/SearchParameterDefinitionManager.cs:line 275
   at Microsoft.Health.Fhir.Core.Features.Search.Parameters.SearchParameterOperations.DeleteSearchParameter(String url) in /_/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs:line 285
   at Microsoft.Health.Fhir.Core.Features.Search.Parameters.SearchParameterOperations.GetAndApplySearchParameterUpdates(CancellationToken cancellationToken) in /_/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs:line 263
   at Microsoft.Health.Fhir.Core.Features.Search.Parameters.SearchParameterOperations.UpdateSearchParameterAsync(ITypedElement searchParam, RawResource previousSearchParam, CancellationToken cancellationToken) in /_/src/Microsoft.Health.Fhir.Core/Features/Search/Parameters/SearchParameterOperations.cs:line 174

## Related issues
[Addresses [issue #].](https://microsofthealth.visualstudio.com/Health/_workitems/edit/151667)

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
