### PR TITLE
Fixing bulk-delete on custom search parameters.

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/BulkDelete/BulkDeleteProcessingJob.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/BulkDelete/BulkDeleteProcessingJob.cs
@@ -19,6 +19,7 @@ using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Operations.BulkDelete.Messages;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Search;
+using Microsoft.Health.Fhir.Core.Features.Search.Parameters;
 using Microsoft.Health.Fhir.Core.Messages.Delete;
 using Microsoft.Health.JobManagement;
 using Newtonsoft.Json;
@@ -33,19 +34,22 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.BulkDelete
         private readonly IMediator _mediator;
         private readonly Func<IScoped<ISearchService>> _searchService;
         private readonly IQueueClient _queueClient;
+        private readonly ISearchParameterOperations _searchParameterOperations;
 
         public BulkDeleteProcessingJob(
             Func<IScoped<IDeletionService>> deleterFactory,
             RequestContextAccessor<IFhirRequestContext> contextAccessor,
             IMediator mediator,
             Func<IScoped<ISearchService>> searchService,
-            IQueueClient queueClient)
+            IQueueClient queueClient,
+            ISearchParameterOperations searchParameterOperations)
         {
             _deleterFactory = EnsureArg.IsNotNull(deleterFactory, nameof(deleterFactory));
             _contextAccessor = EnsureArg.IsNotNull(contextAccessor, nameof(contextAccessor));
             _mediator = EnsureArg.IsNotNull(mediator, nameof(mediator));
             _searchService = EnsureArg.IsNotNull(searchService, nameof(searchService));
             _queueClient = EnsureArg.IsNotNull(queueClient, nameof(queueClient));
+            _searchParameterOperations = EnsureArg.IsNotNull(searchParameterOperations, nameof(searchParameterOperations));
         }
 
         public async Task<string> ExecuteAsync(JobInfo jobInfo, CancellationToken cancellationToken)
@@ -75,6 +79,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.BulkDelete
                 using IScoped<IDeletionService> deleter = _deleterFactory.Invoke();
                 Exception exception = null;
                 List<string> types = definition.Type.SplitByOrSeparator().ToList();
+                List<ResourceWrapper> deletedSearchParameters = new List<ResourceWrapper>();
 
                 try
                 {
@@ -88,7 +93,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.BulkDelete
                             versionType: definition.VersionType,
                             allowPartialSuccess: false), // Explicitly setting to call out that this can be changed in the future if we want to. Bulk delete offers the possibility of automatically rerunning the operation until it succeeds, fully automating the process.
                         cancellationToken,
-                        definition.ExcludedResourceTypes);
+                        definition.ExcludedResourceTypes,
+                        deletedSearchParameters);
                 }
                 catch (IncompleteOperationException<IDictionary<string, long>> ex)
                 {
@@ -103,6 +109,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.BulkDelete
                     {
                         result.ResourcesDeleted[key] += value;
                     }
+                }
+
+                foreach (var sp in deletedSearchParameters)
+                {
+                    await _searchParameterOperations.DeleteSearchParameterAsync(sp.RawResource, cancellationToken);
                 }
 
                 await _mediator.Publish(new BulkDeleteMetricsNotification(jobInfo.Id, resourcesDeleted.Sum(resource => resource.Value)), cancellationToken);

--- a/src/Microsoft.Health.Fhir.Core/Features/Persistence/IDeletionService.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Persistence/IDeletionService.cs
@@ -14,6 +14,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
     {
         public Task<ResourceKey> DeleteAsync(DeleteResourceRequest request, CancellationToken cancellationToken);
 
-        public Task<IDictionary<string, long>> DeleteMultipleAsync(ConditionalDeleteResourceRequest request, CancellationToken cancellationToken, IList<string> excludedResourceTypes = null);
+        public Task<IDictionary<string, long>> DeleteMultipleAsync(ConditionalDeleteResourceRequest request, CancellationToken cancellationToken, IList<string> excludedResourceTypes = null, IList<ResourceWrapper> deletedSearchParameters = null);
     }
 }

--- a/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
+++ b/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
@@ -102,6 +102,7 @@
     <EmbeddedResource Include="TestFiles\Normative\SearchParameterBadSyntax.json" />
     <EmbeddedResource Include="TestFiles\Normative\SearchParameterMissingExpression.json" />
     <EmbeddedResource Include="TestFiles\Normative\SearchParameterMissingBase.json" />
+    <EmbeddedResource Include="TestFiles\Normative\SearchParameter-USCoreIG.json" />
     <EmbeddedResource Include="TestFiles\Normative\Specimen.json" />
     <EmbeddedResource Include="TestFiles\R4B\binary-example.json" />
     <EmbeddedResource Include="TestFiles\R4B\CommunicationAttachment.json" />
@@ -235,6 +236,7 @@
     <EmbeddedResource Include="TestFiles\R5\SearchDataBatch.json" />
     <EmbeddedResource Include="TestFiles\R5\SearchParameter-Resource-idfoo.json" />
     <EmbeddedResource Include="TestFiles\R5\SearchParameter-Patient-foo.json" />
+    <EmbeddedResource Include="TestFiles\R5\SearchParameter-USCoreIG.json" />
     <EmbeddedResource Include="TestFiles\R4\BasicExampleNarrative.json" />
     <EmbeddedResource Include="TestFiles\R4\BasicExampleNarrative.xml" />
     <EmbeddedResource Include="TestFiles\R4\Bundle-TransactionWithReferenceInResourceBody.json" />
@@ -309,6 +311,7 @@
     <EmbeddedResource Include="TestFiles\R4\ResourceWrapperNoVersion.json" />
     <EmbeddedResource Include="TestFiles\Stu3\ProvenanceHeader.json" />
     <EmbeddedResource Include="TestFiles\Stu3\Sequence.json" />
+    <EmbeddedResource Include="TestFiles\Stu3\SearchParameter-USCoreIG.json" />
     <EmbeddedResource Include="TestFiles\Stu3\StructureDefinition-us-core-birthsex.json" />
     <EmbeddedResource Include="TestFiles\Stu3\StructureDefinition-us-core-careplan.json" />
     <EmbeddedResource Include="TestFiles\Stu3\StructureDefinition-us-core-ethnicity.json" />

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/SearchParameter-USCoreIG.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/SearchParameter-USCoreIG.json
@@ -1,0 +1,631 @@
+{
+    "resourceType": "Bundle",
+    "type": "batch",
+    "entry": [
+        {
+            "resource": {
+                "resourceType": "SearchParameter",
+                "id": "us-core-race",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreRace</h2>\n\t\t\t\t<b> description</b> : <p>Returns patients with a race extension matching the specified code.</p>\n\n\t\t\t<br/> --><p><b> id</b> us-core-race</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-race</b>\n\t\t\t</p><p><b> version</b> : 4.1.0</p><p><b> name</b> : USCoreRace</p><p><b> status</b> : active</p><p><b> date</b> : 04/14/2022</p><p><b> publisher</b> : HL7 International - Cross-Group Projects</p><p><b> contact</b> : http://www.hl7.org/Special/committees/cgp</p>  <!-- <p>\n\t\t\t\t<b> useContext</b> : </p> --><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>race</code>\n\t\t\t</p><p><b> base</b> :Patient</p><p><b> type</b> : token</p><p><b> expression</b> : <code>Patient.extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race').extension.value.code</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Patient/f:extension[@url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-race']/f:extension/f:valueCoding/f:code/@value</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> multipleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> multipleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
+                },
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-wg",
+                        "valueCode": "cgp"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-race",
+                "version": "7.0.0",
+                "name": "USCoreRace",
+                "status": "active",
+                "date": "2022-04-14",
+                "publisher": "HL7 International / Cross-Group Projects",
+                "contact": [
+                    {
+                        "name": "HL7 International / Cross-Group Projects",
+                        "telecom": [
+                            {
+                                "system": "url",
+                                "value": "http://www.hl7.org/Special/committees/cgp"
+                            },
+                            {
+                                "system": "email",
+                                "value": "cgp@lists.HL7.org"
+                            }
+                        ]
+                    }
+                ],
+                "description": "Returns patients with a race extension matching the specified code.",
+                "jurisdiction": [
+                    {
+                        "coding": [
+                            {
+                                "system": "urn:iso:std:iso:3166",
+                                "code": "US"
+                            }
+                        ]
+                    }
+                ],
+                "code": "race",
+                "base": [
+                    "Patient"
+                ],
+                "type": "token",
+                "expression": "Patient.extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race').extension.value.code",
+                "xpathUsage": "normal",
+                "multipleOr": true,
+                "_multipleOr": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ]
+                },
+                "multipleAnd": true,
+                "_multipleAnd": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ]
+                }
+            },
+            "request": {
+                "method": "POST",
+                "url": "SearchParameter"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "SearchParameter",
+                "id": "us-core-ethnicity",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreEthnicity</h2>\n\t\t\t\t<b> description</b> : <p>Returns patients with an ethnicity extension matching the specified code.</p>\n\n\t\t\t<br/> --><p><b> id</b> us-core-ethnicity</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-ethnicity</b>\n\t\t\t</p><p><b> version</b> : 4.1.0</p><p><b> name</b> : USCoreEthnicity</p><p><b> status</b> : active</p><p><b> date</b> : 04/14/2022</p><p><b> publisher</b> : HL7 International - Cross-Group Projects</p><p><b> contact</b> : http://www.hl7.org/Special/committees/cgp</p>  <!-- <p>\n\t\t\t\t<b> useContext</b> : </p> --><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>ethnicity</code>\n\t\t\t</p><p><b> base</b> :Patient</p><p><b> type</b> : token</p><p><b> expression</b> : <code>Patient.extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity').extension.value.code</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Patient/f:extension[@url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity']/f:extension/f:valueCoding/f:code/@value</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> multipleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> multipleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
+                },
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-wg",
+                        "valueCode": "cgp"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-ethnicity",
+                "version": "7.0.0",
+                "name": "USCoreEthnicity",
+                "status": "active",
+                "date": "2022-04-14",
+                "publisher": "HL7 International / Cross-Group Projects",
+                "contact": [
+                    {
+                        "name": "HL7 International / Cross-Group Projects",
+                        "telecom": [
+                            {
+                                "system": "url",
+                                "value": "http://www.hl7.org/Special/committees/cgp"
+                            },
+                            {
+                                "system": "email",
+                                "value": "cgp@lists.HL7.org"
+                            }
+                        ]
+                    }
+                ],
+                "description": "Returns patients with an ethnicity extension matching the specified code.",
+                "jurisdiction": [
+                    {
+                        "coding": [
+                            {
+                                "system": "urn:iso:std:iso:3166",
+                                "code": "US"
+                            }
+                        ]
+                    }
+                ],
+                "code": "ethnicity",
+                "base": [
+                    "Patient"
+                ],
+                "type": "token",
+                "expression": "Patient.extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity').extension.value.code",
+                "xpathUsage": "normal",
+                "multipleOr": true,
+                "_multipleOr": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ]
+                },
+                "multipleAnd": true,
+                "_multipleAnd": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ]
+                }
+            },
+            "request": {
+                "method": "POST",
+                "url": "SearchParameter"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "SearchParameter",
+                "id": "us-core-patient-gender-identity",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCorePatientGenderIdentity</h2>\n\t\t\t\t<b> description</b> : <p>Returns patients with an gender-identity extension matching the specified code.</p>\n\n\t\t\t<br/> --><p><b> id</b> us-core-patient-gender-identity</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-gender-identity</b>\n\t\t\t</p><p><b> version</b> : 4.1.0</p><p><b> name</b> : USCorePatientGenderIdentity</p><p><b> status</b> : active</p><p><b> date</b> : 04/06/2023</p><p><b> publisher</b> : HL7 International - Cross-Group Projects</p><p><b> contact</b> : http://www.hl7.org/Special/committees/cgp</p>  <!-- <p>\n\t\t\t\t<b> useContext</b> : </p> --><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>gender-identity</code>\n\t\t\t</p><p><b> base</b> :Patient</p><p><b> type</b> : token</p><p><b> expression</b> : <code>Patient.extension.where(url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-genderIdentity').value.coding.code</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Patient/f:extension[@url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-genderIdentity']/f:value/f:coding/f:code/@value</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> multipleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> multipleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
+                },
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-wg",
+                        "valueCode": "cgp"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-gender-identity",
+                "version": "7.0.0",
+                "name": "USCorePatientGenderIdentity",
+                "status": "active",
+                "date": "2023-04-06",
+                "publisher": "HL7 International / Cross-Group Projects",
+                "contact": [
+                    {
+                        "name": "HL7 International / Cross-Group Projects",
+                        "telecom": [
+                            {
+                                "system": "url",
+                                "value": "http://www.hl7.org/Special/committees/cgp"
+                            },
+                            {
+                                "system": "email",
+                                "value": "cgp@lists.HL7.org"
+                            }
+                        ]
+                    }
+                ],
+                "description": "Returns patients with an gender-identity extension matching the specified code.",
+                "jurisdiction": [
+                    {
+                        "coding": [
+                            {
+                                "system": "urn:iso:std:iso:3166",
+                                "code": "US"
+                            }
+                        ]
+                    }
+                ],
+                "code": "gender-identity",
+                "base": [
+                    "Patient"
+                ],
+                "type": "token",
+                "expression": "Patient.extension.where(url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-genderIdentity').value.coding.code",
+                "xpathUsage": "normal",
+                "multipleOr": true,
+                "_multipleOr": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ]
+                },
+                "multipleAnd": true,
+                "_multipleAnd": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ]
+                }
+            },
+            "request": {
+                "method": "POST",
+                "url": "SearchParameter"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "SearchParameter",
+                "id": "us-core-careteam-role",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreCareTeamRole</h2>\n\t\t\t\t<b> description</b> : <p>Returns CareTeam resources with a participant role matching the specified code.</p>\n\n\t\t\t<br/> --><p><b> id</b> us-core-careteam-role</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-role</b>\n\t\t\t</p><p><b> version</b> : 4.1.0</p><p><b> name</b> : USCoreCareTeamRole</p><p><b> status</b> : active</p><p><b> date</b> : 04/14/2022</p><p><b> publisher</b> : HL7 International - Cross-Group Projects</p><p><b> contact</b> : http://www.hl7.org/Special/committees/cgp</p>  <!-- <p>\n\t\t\t\t<b> useContext</b> : </p> --><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>role</code>\n\t\t\t</p><p><b> base</b> :CareTeam</p><p><b> type</b> : token</p><p><b> expression</b> : <code>CareTeam.participant.role</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:CareTeam/f:participant/f:role/@value</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> multipleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> multipleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
+                },
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-wg",
+                        "valueCode": "cgp"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-role",
+                "version": "7.0.0",
+                "name": "USCoreCareTeamRole",
+                "status": "active",
+                "date": "2022-04-14",
+                "publisher": "HL7 International / Cross-Group Projects",
+                "contact": [
+                    {
+                        "name": "HL7 International / Cross-Group Projects",
+                        "telecom": [
+                            {
+                                "system": "url",
+                                "value": "http://www.hl7.org/Special/committees/cgp"
+                            },
+                            {
+                                "system": "email",
+                                "value": "cgp@lists.HL7.org"
+                            }
+                        ]
+                    }
+                ],
+                "description": "Returns CareTeam resources with a participant role matching the specified code.",
+                "jurisdiction": [
+                    {
+                        "coding": [
+                            {
+                                "system": "urn:iso:std:iso:3166",
+                                "code": "US"
+                            }
+                        ]
+                    }
+                ],
+                "code": "role",
+                "base": [
+                    "CareTeam"
+                ],
+                "type": "token",
+                "expression": "CareTeam.participant.role",
+                "xpathUsage": "normal",
+                "multipleOr": true,
+                "_multipleOr": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ]
+                },
+                "multipleAnd": true,
+                "_multipleAnd": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ]
+                }
+            },
+            "request": {
+                "method": "POST",
+                "url": "SearchParameter"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "SearchParameter",
+                "id": "us-core-condition-asserted-date",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreConditionAssertedDate</h2>\n\t\t\t\t<b> description</b> : <p>Returns conditions with an <a href=\"http://hl7.org/fhir/StructureDefinition/condition-assertedDate\">assertedDate extension</a> matching the specified date (dateTime).</p>\n\n\t\t\t<br/> --><p><b> id</b> us-core-condition-asserted-date</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-asserted-date</b>\n\t\t\t</p><p><b> name</b> : USCoreConditionAssertedDate</p><p><b> status</b> : active</p><p><b> date</b> : 04/13/2023</p><p><b> publisher</b> : HL7 International - Cross-Group Projects</p><p><b> contact</b> : http://www.hl7.org/Special/committees/cgp</p>  <!-- <p>\n\t\t\t\t<b> useContext</b> : </p> --><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>asserted-date</code>\n\t\t\t</p><p><b> base</b> :Condition</p><p><b> type</b> : date</p><p><b> expression</b> : <code>Condition.extension.where(url = 'http://hl7.org/fhir/StructureDefinition/condition-assertedDate').value</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Condition/f:extension[@url='http://hl7.org/fhir/StructureDefinition/condition-assertedDate']/f:valueDateTime/@value</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> multipleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> multipleAnd</b> : True  ( Conformance Expectation = SHOULD)</p><p><b> comparator</b> : <code>eq</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>ne</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>gt</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>ge</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>lt</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>le</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>sa</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>eb</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>ap</code> ( Conformance Expectation = MAY)</p></div>"
+                },
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-wg",
+                        "valueCode": "cgp"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-asserted-date",
+                "version": "7.0.0",
+                "name": "USCoreConditionAssertedDate",
+                "status": "active",
+                "date": "2023-04-13",
+                "publisher": "HL7 International / Cross-Group Projects",
+                "contact": [
+                    {
+                        "name": "HL7 International / Cross-Group Projects",
+                        "telecom": [
+                            {
+                                "system": "url",
+                                "value": "http://www.hl7.org/Special/committees/cgp"
+                            },
+                            {
+                                "system": "email",
+                                "value": "cgp@lists.HL7.org"
+                            }
+                        ]
+                    }
+                ],
+                "description": "Returns conditions with an [assertedDate extension](http://hl7.org/fhir/StructureDefinition/condition-assertedDate) matching the specified date (dateTime).",
+                "jurisdiction": [
+                    {
+                        "coding": [
+                            {
+                                "system": "urn:iso:std:iso:3166",
+                                "code": "US"
+                            }
+                        ]
+                    }
+                ],
+                "code": "asserted-date",
+                "base": [
+                    "Condition"
+                ],
+                "type": "date",
+                "expression": "Condition.extension.where(url = 'http://hl7.org/fhir/StructureDefinition/condition-assertedDate').value",
+                "xpathUsage": "normal",
+                "multipleOr": true,
+                "_multipleOr": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ]
+                },
+                "multipleAnd": true,
+                "_multipleAnd": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        }
+                    ]
+                },
+                "comparator": [
+                    "eq",
+                    "ne",
+                    "gt",
+                    "ge",
+                    "lt",
+                    "le",
+                    "sa",
+                    "eb",
+                    "ap"
+                ],
+                "_comparator": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                "valueCode": "MAY"
+                            }
+                        ]
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                "valueCode": "MAY"
+                            }
+                        ]
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                "valueCode": "SHALL"
+                            }
+                        ]
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                "valueCode": "SHALL"
+                            }
+                        ]
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                "valueCode": "SHALL"
+                            }
+                        ]
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                "valueCode": "SHALL"
+                            }
+                        ]
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                "valueCode": "MAY"
+                            }
+                        ]
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                "valueCode": "MAY"
+                            }
+                        ]
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                "valueCode": "MAY"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "request": {
+                "method": "POST",
+                "url": "SearchParameter"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "SearchParameter",
+                "id": "us-core-encounter-discharge-disposition",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreEncounterDischargeDisposition</h2>\n\t\t\t\t<b> description</b> : <p>Returns encounters with an discharge-disposition matching the specified code.</p>\n\n\t\t\t<br/> --><p><b> id</b> us-core-encounter-discharge-disposition</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-discharge-disposition</b>\n\t\t\t</p><p><b> version</b> : 4.1.0</p><p><b> name</b> : USCoreEncounterDischargeDisposition</p><p><b> status</b> : active</p><p><b> date</b> : 04/14/2022</p><p><b> publisher</b> : HL7 International - Cross-Group Projects</p><p><b> contact</b> : http://www.hl7.org/Special/committees/cgp</p>  <!-- <p>\n\t\t\t\t<b> useContext</b> : </p> --><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>discharge-disposition</code>\n\t\t\t</p><p><b> base</b> :Encounter</p><p><b> type</b> : token</p><p><b> expression</b> : <code>Encounter.hospitalization.dischargeDisposition</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Encounter/f:hospitalization/f:dischargeDisposition/@value</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> multipleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> multipleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
+                },
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-wg",
+                        "valueCode": "cgp"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-discharge-disposition",
+                "version": "7.0.0",
+                "name": "USCoreEncounterDischargeDisposition",
+                "status": "active",
+                "date": "2022-04-14",
+                "publisher": "HL7 International / Cross-Group Projects",
+                "contact": [
+                    {
+                        "name": "HL7 International / Cross-Group Projects",
+                        "telecom": [
+                            {
+                                "system": "url",
+                                "value": "http://www.hl7.org/Special/committees/cgp"
+                            },
+                            {
+                                "system": "email",
+                                "value": "cgp@lists.HL7.org"
+                            }
+                        ]
+                    }
+                ],
+                "description": "Returns encounters with an discharge-disposition matching the specified code.",
+                "jurisdiction": [
+                    {
+                        "coding": [
+                            {
+                                "system": "urn:iso:std:iso:3166",
+                                "code": "US"
+                            }
+                        ]
+                    }
+                ],
+                "code": "discharge-disposition",
+                "base": [
+                    "Encounter"
+                ],
+                "type": "token",
+                "expression": "Encounter.hospitalization.dischargeDisposition",
+                "xpathUsage": "normal",
+                "multipleOr": true,
+                "_multipleOr": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ]
+                },
+                "multipleAnd": true,
+                "_multipleAnd": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ]
+                }
+            },
+            "request": {
+                "method": "POST",
+                "url": "SearchParameter"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "SearchParameter",
+                "id": "us-core-goal-description",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreGoalDescription</h2>\n\t\t\t\t<b> description</b> : <p><strong>The code or text describing the goal</strong>\n<strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul>\n<li>multipleAnd</li>\n<li>multipleOr</li>\n<li>comparator</li>\n<li>modifier</li>\n<li>chain</li>\n</ul>\n\n\t\t\t<br/> --><p><b> id</b> us-core-goal-description</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-description</b>\n\t\t\t</p><p><b> version</b> : 4.1.0</p><p><b> name</b> : USCoreGoalDescription</p><p><b> status</b> : active</p><p><b> date</b> : 04/14/2022</p><p><b> publisher</b> : HL7 International - Cross-Group Projects</p><p><b> contact</b> : http://www.hl7.org/Special/committees/cgp</p>  <!-- <p>\n\t\t\t\t<b> useContext</b> : </p> --><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>description</code>\n\t\t\t</p><p><b> base</b> :Goal</p><p><b> type</b> : token</p><p><b> expression</b> : <code>Goal.description</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Goal/f:description</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> multipleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> multipleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
+                },
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-wg",
+                        "valueCode": "cgp"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-description",
+                "version": "7.0.0",
+                "name": "USCoreGoalDescription",
+                "status": "active",
+                "experimental": false,
+                "date": "2022-04-14",
+                "publisher": "HL7 International / Cross-Group Projects",
+                "contact": [
+                    {
+                        "name": "HL7 International / Cross-Group Projects",
+                        "telecom": [
+                            {
+                                "system": "url",
+                                "value": "http://www.hl7.org/Special/committees/cgp"
+                            },
+                            {
+                                "system": "email",
+                                "value": "cgp@lists.HL7.org"
+                            }
+                        ]
+                    }
+                ],
+                "description": "**The code or text describing the goal**\n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "jurisdiction": [
+                    {
+                        "coding": [
+                            {
+                                "system": "urn:iso:std:iso:3166",
+                                "code": "US"
+                            }
+                        ]
+                    }
+                ],
+                "code": "description",
+                "base": [
+                    "Goal"
+                ],
+                "type": "token",
+                "expression": "Goal.description",
+                "xpathUsage": "normal",
+                "multipleOr": true,
+                "_multipleOr": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ]
+                },
+                "multipleAnd": true,
+                "_multipleAnd": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ]
+                }
+            },
+            "request": {
+                "method": "POST",
+                "url": "SearchParameter"
+            }
+        }
+    ]
+}

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/R5/SearchParameter-USCoreIG.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/R5/SearchParameter-USCoreIG.json
@@ -1,0 +1,471 @@
+{
+    "resourceType": "Bundle",
+    "type": "batch",
+    "entry": [
+        {
+            "resource": {
+                "resourceType": "SearchParameter",
+                "id": "us-core-race",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreRace</h2>\n\t\t\t\t<b> description</b> : <p>Returns patients with a race extension matching the specified code.</p>\n\n\t\t\t<br/> --><p><b> id</b> us-core-race</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-race</b>\n\t\t\t</p><p><b> version</b> : 4.1.0</p><p><b> name</b> : USCoreRace</p><p><b> status</b> : active</p><p><b> date</b> : 04/14/2022</p><p><b> publisher</b> : HL7 International - Cross-Group Projects</p><p><b> contact</b> : http://www.hl7.org/Special/committees/cgp</p>  <!-- <p>\n\t\t\t\t<b> useContext</b> : </p> --><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>race</code>\n\t\t\t</p><p><b> base</b> :Patient</p><p><b> type</b> : token</p><p><b> expression</b> : <code>Patient.extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race').extension.value.code</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Patient/f:extension[@url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-race']/f:extension/f:valueCoding/f:code/@value</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> multipleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> multipleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
+                },
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-wg",
+                        "valueCode": "cgp"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-race",
+                "version": "7.0.0",
+                "name": "USCoreRace",
+                "status": "active",
+                "date": "2022-04-14",
+                "publisher": "HL7 International / Cross-Group Projects",
+                "contact": [
+                    {
+                        "name": "HL7 International / Cross-Group Projects",
+                        "telecom": [
+                            {
+                                "system": "url",
+                                "value": "http://www.hl7.org/Special/committees/cgp"
+                            },
+                            {
+                                "system": "email",
+                                "value": "cgp@lists.HL7.org"
+                            }
+                        ]
+                    }
+                ],
+                "description": "Returns patients with a race extension matching the specified code.",
+                "jurisdiction": [
+                    {
+                        "coding": [
+                            {
+                                "system": "urn:iso:std:iso:3166",
+                                "code": "US"
+                            }
+                        ]
+                    }
+                ],
+                "code": "race",
+                "base": [
+                    "Patient"
+                ],
+                "type": "token",
+                "expression": "Patient.extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race').extension.value.code",
+                "multipleOr": true,
+                "_multipleOr": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ]
+                },
+                "multipleAnd": true,
+                "_multipleAnd": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ]
+                }
+            },
+            "request": {
+                "method": "POST",
+                "url": "SearchParameter"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "SearchParameter",
+                "id": "us-core-ethnicity",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreEthnicity</h2>\n\t\t\t\t<b> description</b> : <p>Returns patients with an ethnicity extension matching the specified code.</p>\n\n\t\t\t<br/> --><p><b> id</b> us-core-ethnicity</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-ethnicity</b>\n\t\t\t</p><p><b> version</b> : 4.1.0</p><p><b> name</b> : USCoreEthnicity</p><p><b> status</b> : active</p><p><b> date</b> : 04/14/2022</p><p><b> publisher</b> : HL7 International - Cross-Group Projects</p><p><b> contact</b> : http://www.hl7.org/Special/committees/cgp</p>  <!-- <p>\n\t\t\t\t<b> useContext</b> : </p> --><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>ethnicity</code>\n\t\t\t</p><p><b> base</b> :Patient</p><p><b> type</b> : token</p><p><b> expression</b> : <code>Patient.extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity').extension.value.code</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Patient/f:extension[@url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity']/f:extension/f:valueCoding/f:code/@value</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> multipleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> multipleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
+                },
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-wg",
+                        "valueCode": "cgp"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-ethnicity",
+                "version": "7.0.0",
+                "name": "USCoreEthnicity",
+                "status": "active",
+                "date": "2022-04-14",
+                "publisher": "HL7 International / Cross-Group Projects",
+                "contact": [
+                    {
+                        "name": "HL7 International / Cross-Group Projects",
+                        "telecom": [
+                            {
+                                "system": "url",
+                                "value": "http://www.hl7.org/Special/committees/cgp"
+                            },
+                            {
+                                "system": "email",
+                                "value": "cgp@lists.HL7.org"
+                            }
+                        ]
+                    }
+                ],
+                "description": "Returns patients with an ethnicity extension matching the specified code.",
+                "jurisdiction": [
+                    {
+                        "coding": [
+                            {
+                                "system": "urn:iso:std:iso:3166",
+                                "code": "US"
+                            }
+                        ]
+                    }
+                ],
+                "code": "ethnicity",
+                "base": [
+                    "Patient"
+                ],
+                "type": "token",
+                "expression": "Patient.extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity').extension.value.code",
+                "multipleOr": true,
+                "_multipleOr": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ]
+                },
+                "multipleAnd": true,
+                "_multipleAnd": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ]
+                }
+            },
+            "request": {
+                "method": "POST",
+                "url": "SearchParameter"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "SearchParameter",
+                "id": "us-core-patient-gender-identity",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCorePatientGenderIdentity</h2>\n\t\t\t\t<b> description</b> : <p>Returns patients with an gender-identity extension matching the specified code.</p>\n\n\t\t\t<br/> --><p><b> id</b> us-core-patient-gender-identity</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-gender-identity</b>\n\t\t\t</p><p><b> version</b> : 4.1.0</p><p><b> name</b> : USCorePatientGenderIdentity</p><p><b> status</b> : active</p><p><b> date</b> : 04/06/2023</p><p><b> publisher</b> : HL7 International - Cross-Group Projects</p><p><b> contact</b> : http://www.hl7.org/Special/committees/cgp</p>  <!-- <p>\n\t\t\t\t<b> useContext</b> : </p> --><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>gender-identity</code>\n\t\t\t</p><p><b> base</b> :Patient</p><p><b> type</b> : token</p><p><b> expression</b> : <code>Patient.extension.where(url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-genderIdentity').value.coding.code</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Patient/f:extension[@url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-genderIdentity']/f:value/f:coding/f:code/@value</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> multipleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> multipleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
+                },
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-wg",
+                        "valueCode": "cgp"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-gender-identity",
+                "version": "7.0.0",
+                "name": "USCorePatientGenderIdentity",
+                "status": "active",
+                "date": "2023-04-06",
+                "publisher": "HL7 International / Cross-Group Projects",
+                "contact": [
+                    {
+                        "name": "HL7 International / Cross-Group Projects",
+                        "telecom": [
+                            {
+                                "system": "url",
+                                "value": "http://www.hl7.org/Special/committees/cgp"
+                            },
+                            {
+                                "system": "email",
+                                "value": "cgp@lists.HL7.org"
+                            }
+                        ]
+                    }
+                ],
+                "description": "Returns patients with an gender-identity extension matching the specified code.",
+                "jurisdiction": [
+                    {
+                        "coding": [
+                            {
+                                "system": "urn:iso:std:iso:3166",
+                                "code": "US"
+                            }
+                        ]
+                    }
+                ],
+                "code": "gender-identity",
+                "base": [
+                    "Patient"
+                ],
+                "type": "token",
+                "expression": "Patient.extension.where(url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-genderIdentity').value.coding.code",
+                "multipleOr": true,
+                "_multipleOr": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ]
+                },
+                "multipleAnd": true,
+                "_multipleAnd": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ]
+                }
+            },
+            "request": {
+                "method": "POST",
+                "url": "SearchParameter"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "SearchParameter",
+                "id": "us-core-careteam-role",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreCareTeamRole</h2>\n\t\t\t\t<b> description</b> : <p>Returns CareTeam resources with a participant role matching the specified code.</p>\n\n\t\t\t<br/> --><p><b> id</b> us-core-careteam-role</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-role</b>\n\t\t\t</p><p><b> version</b> : 4.1.0</p><p><b> name</b> : USCoreCareTeamRole</p><p><b> status</b> : active</p><p><b> date</b> : 04/14/2022</p><p><b> publisher</b> : HL7 International - Cross-Group Projects</p><p><b> contact</b> : http://www.hl7.org/Special/committees/cgp</p>  <!-- <p>\n\t\t\t\t<b> useContext</b> : </p> --><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>role</code>\n\t\t\t</p><p><b> base</b> :CareTeam</p><p><b> type</b> : token</p><p><b> expression</b> : <code>CareTeam.participant.role</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:CareTeam/f:participant/f:role/@value</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> multipleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> multipleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
+                },
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-wg",
+                        "valueCode": "cgp"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-role",
+                "version": "7.0.0",
+                "name": "USCoreCareTeamRole",
+                "status": "active",
+                "date": "2022-04-14",
+                "publisher": "HL7 International / Cross-Group Projects",
+                "contact": [
+                    {
+                        "name": "HL7 International / Cross-Group Projects",
+                        "telecom": [
+                            {
+                                "system": "url",
+                                "value": "http://www.hl7.org/Special/committees/cgp"
+                            },
+                            {
+                                "system": "email",
+                                "value": "cgp@lists.HL7.org"
+                            }
+                        ]
+                    }
+                ],
+                "description": "Returns CareTeam resources with a participant role matching the specified code.",
+                "jurisdiction": [
+                    {
+                        "coding": [
+                            {
+                                "system": "urn:iso:std:iso:3166",
+                                "code": "US"
+                            }
+                        ]
+                    }
+                ],
+                "code": "role",
+                "base": [
+                    "CareTeam"
+                ],
+                "type": "token",
+                "expression": "CareTeam.participant.role",
+                "multipleOr": true,
+                "_multipleOr": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ]
+                },
+                "multipleAnd": true,
+                "_multipleAnd": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ]
+                }
+            },
+            "request": {
+                "method": "POST",
+                "url": "SearchParameter"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "SearchParameter",
+                "id": "us-core-condition-asserted-date",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreConditionAssertedDate</h2>\n\t\t\t\t<b> description</b> : <p>Returns conditions with an <a href=\"http://hl7.org/fhir/StructureDefinition/condition-assertedDate\">assertedDate extension</a> matching the specified date (dateTime).</p>\n\n\t\t\t<br/> --><p><b> id</b> us-core-condition-asserted-date</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-asserted-date</b>\n\t\t\t</p><p><b> name</b> : USCoreConditionAssertedDate</p><p><b> status</b> : active</p><p><b> date</b> : 04/13/2023</p><p><b> publisher</b> : HL7 International - Cross-Group Projects</p><p><b> contact</b> : http://www.hl7.org/Special/committees/cgp</p>  <!-- <p>\n\t\t\t\t<b> useContext</b> : </p> --><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>asserted-date</code>\n\t\t\t</p><p><b> base</b> :Condition</p><p><b> type</b> : date</p><p><b> expression</b> : <code>Condition.extension.where(url = 'http://hl7.org/fhir/StructureDefinition/condition-assertedDate').value</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Condition/f:extension[@url='http://hl7.org/fhir/StructureDefinition/condition-assertedDate']/f:valueDateTime/@value</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> multipleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> multipleAnd</b> : True  ( Conformance Expectation = SHOULD)</p><p><b> comparator</b> : <code>eq</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>ne</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>gt</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>ge</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>lt</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>le</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>sa</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>eb</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>ap</code> ( Conformance Expectation = MAY)</p></div>"
+                },
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-wg",
+                        "valueCode": "cgp"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-asserted-date",
+                "version": "7.0.0",
+                "name": "USCoreConditionAssertedDate",
+                "status": "active",
+                "date": "2023-04-13",
+                "publisher": "HL7 International / Cross-Group Projects",
+                "contact": [
+                    {
+                        "name": "HL7 International / Cross-Group Projects",
+                        "telecom": [
+                            {
+                                "system": "url",
+                                "value": "http://www.hl7.org/Special/committees/cgp"
+                            },
+                            {
+                                "system": "email",
+                                "value": "cgp@lists.HL7.org"
+                            }
+                        ]
+                    }
+                ],
+                "description": "Returns conditions with an [assertedDate extension](http://hl7.org/fhir/StructureDefinition/condition-assertedDate) matching the specified date (dateTime).",
+                "jurisdiction": [
+                    {
+                        "coding": [
+                            {
+                                "system": "urn:iso:std:iso:3166",
+                                "code": "US"
+                            }
+                        ]
+                    }
+                ],
+                "code": "asserted-date",
+                "base": [
+                    "Condition"
+                ],
+                "type": "date",
+                "expression": "Condition.extension.where(url = 'http://hl7.org/fhir/StructureDefinition/condition-assertedDate').value",
+                "multipleOr": true,
+                "_multipleOr": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ]
+                },
+                "multipleAnd": true,
+                "_multipleAnd": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        }
+                    ]
+                },
+                "comparator": [
+                    "eq",
+                    "ne",
+                    "gt",
+                    "ge",
+                    "lt",
+                    "le",
+                    "sa",
+                    "eb",
+                    "ap"
+                ],
+                "_comparator": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                "valueCode": "MAY"
+                            }
+                        ]
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                "valueCode": "MAY"
+                            }
+                        ]
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                "valueCode": "SHALL"
+                            }
+                        ]
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                "valueCode": "SHALL"
+                            }
+                        ]
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                "valueCode": "SHALL"
+                            }
+                        ]
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                "valueCode": "SHALL"
+                            }
+                        ]
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                "valueCode": "MAY"
+                            }
+                        ]
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                "valueCode": "MAY"
+                            }
+                        ]
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                "valueCode": "MAY"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "request": {
+                "method": "POST",
+                "url": "SearchParameter"
+            }
+        }
+    ]
+}

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Stu3/SearchParameter-USCoreIG.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Stu3/SearchParameter-USCoreIG.json
@@ -1,0 +1,361 @@
+{
+    "resourceType": "Bundle",
+    "type": "batch",
+    "entry": [
+        {
+            "resource": {
+                "resourceType": "SearchParameter",
+                "id": "us-core-race",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreRace</h2>\n\t\t\t\t<b> description</b> : <p>Returns patients with a race extension matching the specified code.</p>\n\n\t\t\t<br/> --><p><b> id</b> us-core-race</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-race</b>\n\t\t\t</p><p><b> version</b> : 4.1.0</p><p><b> name</b> : USCoreRace</p><p><b> status</b> : active</p><p><b> date</b> : 04/14/2022</p><p><b> publisher</b> : HL7 International - Cross-Group Projects</p><p><b> contact</b> : http://www.hl7.org/Special/committees/cgp</p>  <!-- <p>\n\t\t\t\t<b> useContext</b> : </p> --><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>race</code>\n\t\t\t</p><p><b> base</b> :Patient</p><p><b> type</b> : token</p><p><b> expression</b> : <code>Patient.extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race').extension.value.code</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Patient/f:extension[@url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-race']/f:extension/f:valueCoding/f:code/@value</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> multipleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> multipleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
+                },
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-wg",
+                        "valueCode": "cgp"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-race",
+                "version": "7.0.0",
+                "name": "USCoreRace",
+                "status": "active",
+                "date": "2022-04-14",
+                "publisher": "HL7 International / Cross-Group Projects",
+                "contact": [
+                    {
+                        "name": "HL7 International / Cross-Group Projects",
+                        "telecom": [
+                            {
+                                "system": "url",
+                                "value": "http://www.hl7.org/Special/committees/cgp"
+                            },
+                            {
+                                "system": "email",
+                                "value": "cgp@lists.HL7.org"
+                            }
+                        ]
+                    }
+                ],
+                "description": "Returns patients with a race extension matching the specified code.",
+                "jurisdiction": [
+                    {
+                        "coding": [
+                            {
+                                "system": "urn:iso:std:iso:3166",
+                                "code": "US"
+                            }
+                        ]
+                    }
+                ],
+                "code": "race",
+                "base": [
+                    "Patient"
+                ],
+                "type": "token",
+                "expression": "Patient.extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race').extension.value.code",
+                "xpathUsage": "normal"
+            },
+            "request": {
+                "method": "POST",
+                "url": "SearchParameter"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "SearchParameter",
+                "id": "us-core-ethnicity",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreEthnicity</h2>\n\t\t\t\t<b> description</b> : <p>Returns patients with an ethnicity extension matching the specified code.</p>\n\n\t\t\t<br/> --><p><b> id</b> us-core-ethnicity</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-ethnicity</b>\n\t\t\t</p><p><b> version</b> : 4.1.0</p><p><b> name</b> : USCoreEthnicity</p><p><b> status</b> : active</p><p><b> date</b> : 04/14/2022</p><p><b> publisher</b> : HL7 International - Cross-Group Projects</p><p><b> contact</b> : http://www.hl7.org/Special/committees/cgp</p>  <!-- <p>\n\t\t\t\t<b> useContext</b> : </p> --><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>ethnicity</code>\n\t\t\t</p><p><b> base</b> :Patient</p><p><b> type</b> : token</p><p><b> expression</b> : <code>Patient.extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity').extension.value.code</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Patient/f:extension[@url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity']/f:extension/f:valueCoding/f:code/@value</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> multipleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> multipleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
+                },
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-wg",
+                        "valueCode": "cgp"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-ethnicity",
+                "version": "7.0.0",
+                "name": "USCoreEthnicity",
+                "status": "active",
+                "date": "2022-04-14",
+                "publisher": "HL7 International / Cross-Group Projects",
+                "contact": [
+                    {
+                        "name": "HL7 International / Cross-Group Projects",
+                        "telecom": [
+                            {
+                                "system": "url",
+                                "value": "http://www.hl7.org/Special/committees/cgp"
+                            },
+                            {
+                                "system": "email",
+                                "value": "cgp@lists.HL7.org"
+                            }
+                        ]
+                    }
+                ],
+                "description": "Returns patients with an ethnicity extension matching the specified code.",
+                "jurisdiction": [
+                    {
+                        "coding": [
+                            {
+                                "system": "urn:iso:std:iso:3166",
+                                "code": "US"
+                            }
+                        ]
+                    }
+                ],
+                "code": "ethnicity",
+                "base": [
+                    "Patient"
+                ],
+                "type": "token",
+                "expression": "Patient.extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity').extension.value.code",
+                "xpathUsage": "normal"
+            },
+            "request": {
+                "method": "POST",
+                "url": "SearchParameter"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "SearchParameter",
+                "id": "us-core-patient-gender-identity",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCorePatientGenderIdentity</h2>\n\t\t\t\t<b> description</b> : <p>Returns patients with an gender-identity extension matching the specified code.</p>\n\n\t\t\t<br/> --><p><b> id</b> us-core-patient-gender-identity</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-gender-identity</b>\n\t\t\t</p><p><b> version</b> : 4.1.0</p><p><b> name</b> : USCorePatientGenderIdentity</p><p><b> status</b> : active</p><p><b> date</b> : 04/06/2023</p><p><b> publisher</b> : HL7 International - Cross-Group Projects</p><p><b> contact</b> : http://www.hl7.org/Special/committees/cgp</p>  <!-- <p>\n\t\t\t\t<b> useContext</b> : </p> --><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>gender-identity</code>\n\t\t\t</p><p><b> base</b> :Patient</p><p><b> type</b> : token</p><p><b> expression</b> : <code>Patient.extension.where(url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-genderIdentity').value.coding.code</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Patient/f:extension[@url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-genderIdentity']/f:value/f:coding/f:code/@value</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> multipleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> multipleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
+                },
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-wg",
+                        "valueCode": "cgp"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-gender-identity",
+                "version": "7.0.0",
+                "name": "USCorePatientGenderIdentity",
+                "status": "active",
+                "date": "2023-04-06",
+                "publisher": "HL7 International / Cross-Group Projects",
+                "contact": [
+                    {
+                        "name": "HL7 International / Cross-Group Projects",
+                        "telecom": [
+                            {
+                                "system": "url",
+                                "value": "http://www.hl7.org/Special/committees/cgp"
+                            },
+                            {
+                                "system": "email",
+                                "value": "cgp@lists.HL7.org"
+                            }
+                        ]
+                    }
+                ],
+                "description": "Returns patients with an gender-identity extension matching the specified code.",
+                "jurisdiction": [
+                    {
+                        "coding": [
+                            {
+                                "system": "urn:iso:std:iso:3166",
+                                "code": "US"
+                            }
+                        ]
+                    }
+                ],
+                "code": "gender-identity",
+                "base": [
+                    "Patient"
+                ],
+                "type": "token",
+                "expression": "Patient.extension.where(url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-genderIdentity').value.coding.code",
+                "xpathUsage": "normal"
+            },
+            "request": {
+                "method": "POST",
+                "url": "SearchParameter"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "SearchParameter",
+                "id": "us-core-careteam-role",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreCareTeamRole</h2>\n\t\t\t\t<b> description</b> : <p>Returns CareTeam resources with a participant role matching the specified code.</p>\n\n\t\t\t<br/> --><p><b> id</b> us-core-careteam-role</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-role</b>\n\t\t\t</p><p><b> version</b> : 4.1.0</p><p><b> name</b> : USCoreCareTeamRole</p><p><b> status</b> : active</p><p><b> date</b> : 04/14/2022</p><p><b> publisher</b> : HL7 International - Cross-Group Projects</p><p><b> contact</b> : http://www.hl7.org/Special/committees/cgp</p>  <!-- <p>\n\t\t\t\t<b> useContext</b> : </p> --><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>role</code>\n\t\t\t</p><p><b> base</b> :CareTeam</p><p><b> type</b> : token</p><p><b> expression</b> : <code>CareTeam.participant.role</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:CareTeam/f:participant/f:role/@value</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> multipleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> multipleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
+                },
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-wg",
+                        "valueCode": "cgp"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-role",
+                "version": "7.0.0",
+                "name": "USCoreCareTeamRole",
+                "status": "active",
+                "date": "2022-04-14",
+                "publisher": "HL7 International / Cross-Group Projects",
+                "contact": [
+                    {
+                        "name": "HL7 International / Cross-Group Projects",
+                        "telecom": [
+                            {
+                                "system": "url",
+                                "value": "http://www.hl7.org/Special/committees/cgp"
+                            },
+                            {
+                                "system": "email",
+                                "value": "cgp@lists.HL7.org"
+                            }
+                        ]
+                    }
+                ],
+                "description": "Returns CareTeam resources with a participant role matching the specified code.",
+                "jurisdiction": [
+                    {
+                        "coding": [
+                            {
+                                "system": "urn:iso:std:iso:3166",
+                                "code": "US"
+                            }
+                        ]
+                    }
+                ],
+                "code": "role",
+                "base": [
+                    "CareTeam"
+                ],
+                "type": "token",
+                "expression": "CareTeam.participant.role",
+                "xpathUsage": "normal"
+            },
+            "request": {
+                "method": "POST",
+                "url": "SearchParameter"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "SearchParameter",
+                "id": "us-core-encounter-discharge-disposition",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreEncounterDischargeDisposition</h2>\n\t\t\t\t<b> description</b> : <p>Returns encounters with an discharge-disposition matching the specified code.</p>\n\n\t\t\t<br/> --><p><b> id</b> us-core-encounter-discharge-disposition</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-discharge-disposition</b>\n\t\t\t</p><p><b> version</b> : 4.1.0</p><p><b> name</b> : USCoreEncounterDischargeDisposition</p><p><b> status</b> : active</p><p><b> date</b> : 04/14/2022</p><p><b> publisher</b> : HL7 International - Cross-Group Projects</p><p><b> contact</b> : http://www.hl7.org/Special/committees/cgp</p>  <!-- <p>\n\t\t\t\t<b> useContext</b> : </p> --><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>discharge-disposition</code>\n\t\t\t</p><p><b> base</b> :Encounter</p><p><b> type</b> : token</p><p><b> expression</b> : <code>Encounter.hospitalization.dischargeDisposition</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Encounter/f:hospitalization/f:dischargeDisposition/@value</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> multipleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> multipleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
+                },
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-wg",
+                        "valueCode": "cgp"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-discharge-disposition",
+                "version": "7.0.0",
+                "name": "USCoreEncounterDischargeDisposition",
+                "status": "active",
+                "date": "2022-04-14",
+                "publisher": "HL7 International / Cross-Group Projects",
+                "contact": [
+                    {
+                        "name": "HL7 International / Cross-Group Projects",
+                        "telecom": [
+                            {
+                                "system": "url",
+                                "value": "http://www.hl7.org/Special/committees/cgp"
+                            },
+                            {
+                                "system": "email",
+                                "value": "cgp@lists.HL7.org"
+                            }
+                        ]
+                    }
+                ],
+                "description": "Returns encounters with an discharge-disposition matching the specified code.",
+                "jurisdiction": [
+                    {
+                        "coding": [
+                            {
+                                "system": "urn:iso:std:iso:3166",
+                                "code": "US"
+                            }
+                        ]
+                    }
+                ],
+                "code": "discharge-disposition",
+                "base": [
+                    "Encounter"
+                ],
+                "type": "token",
+                "expression": "Encounter.hospitalization.dischargeDisposition",
+                "xpathUsage": "normal"
+            },
+            "request": {
+                "method": "POST",
+                "url": "SearchParameter"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "SearchParameter",
+                "id": "us-core-goal-description",
+                "text": {
+                    "status": "generated",
+                    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreGoalDescription</h2>\n\t\t\t\t<b> description</b> : <p><strong>The code or text describing the goal</strong>\n<strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul>\n<li>multipleAnd</li>\n<li>multipleOr</li>\n<li>comparator</li>\n<li>modifier</li>\n<li>chain</li>\n</ul>\n\n\t\t\t<br/> --><p><b> id</b> us-core-goal-description</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-description</b>\n\t\t\t</p><p><b> version</b> : 4.1.0</p><p><b> name</b> : USCoreGoalDescription</p><p><b> status</b> : active</p><p><b> date</b> : 04/14/2022</p><p><b> publisher</b> : HL7 International - Cross-Group Projects</p><p><b> contact</b> : http://www.hl7.org/Special/committees/cgp</p>  <!-- <p>\n\t\t\t\t<b> useContext</b> : </p> --><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>description</code>\n\t\t\t</p><p><b> base</b> :Goal</p><p><b> type</b> : token</p><p><b> expression</b> : <code>Goal.description</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Goal/f:description</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> multipleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> multipleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
+                },
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-wg",
+                        "valueCode": "cgp"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-description",
+                "version": "7.0.0",
+                "name": "USCoreGoalDescription",
+                "status": "active",
+                "experimental": false,
+                "date": "2022-04-14",
+                "publisher": "HL7 International / Cross-Group Projects",
+                "contact": [
+                    {
+                        "name": "HL7 International / Cross-Group Projects",
+                        "telecom": [
+                            {
+                                "system": "url",
+                                "value": "http://www.hl7.org/Special/committees/cgp"
+                            },
+                            {
+                                "system": "email",
+                                "value": "cgp@lists.HL7.org"
+                            }
+                        ]
+                    }
+                ],
+                "description": "**The code or text describing the goal**\n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "jurisdiction": [
+                    {
+                        "coding": [
+                            {
+                                "system": "urn:iso:std:iso:3166",
+                                "code": "US"
+                            }
+                        ]
+                    }
+                ],
+                "code": "description",
+                "base": [
+                    "Goal"
+                ],
+                "type": "token",
+                "expression": "Goal.description",
+                "xpathUsage": "normal"
+            },
+            "request": {
+                "method": "POST",
+                "url": "SearchParameter"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
## Description
The PR will address an issue of the search parameter status going out of sync after $bulk-delete removes search parameter resources.

## Related issues
Addresses [issue #121676].
[Bug 121676](https://microsofthealth.visualstudio.com/Health/_workitems/edit/121676): Hard delete custom search parameter not cleaning up all the data

## Testing
Tested manually and also through adding E2E test.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
