### PR TITLE
DefaultAzureCredential to ManagedIdentityCredential

### DIFF
--- a/src/Microsoft.Health.Fhir.Azure/ExportDestinationClient/AzureAccessTokenClientInitializer.cs
+++ b/src/Microsoft.Health.Fhir.Azure/ExportDestinationClient/AzureAccessTokenClientInitializer.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Health.Fhir.Azure.ExportDestinationClient
 
             try
             {
-                return new BlobServiceClient(storageAccountUri, new DefaultAzureCredential());
+                return new BlobServiceClient(storageAccountUri, new ManagedIdentityCredential());
             }
             catch (AccessTokenProviderException atp)
             {

--- a/src/Microsoft.Health.Fhir.Azure/IntegrationDataStore/AzureAccessTokenClientInitializerV2.cs
+++ b/src/Microsoft.Health.Fhir.Azure/IntegrationDataStore/AzureAccessTokenClientInitializerV2.cs
@@ -37,25 +37,25 @@ namespace Microsoft.Health.Fhir.Azure.IntegrationDataStore
         public Task<BlobClient> GetAuthorizedBlobClientAsync(Uri blobUri)
         {
             EnsureArg.IsNotNull(blobUri, nameof(blobUri));
-            return Task.FromResult(new BlobClient(blobUri, CreateDefaultTokenCredential()));
+            return Task.FromResult(new BlobClient(blobUri, CreateManagedIdentityCredential()));
         }
 
         public Task<BlobClient> GetAuthorizedBlobClientAsync(Uri blobUri, IntegrationDataStoreConfiguration integrationDataStoreConfiguration)
         {
             EnsureArg.IsNotNull(blobUri, nameof(blobUri));
-            return Task.FromResult(new BlobClient(blobUri, CreateDefaultTokenCredential()));
+            return Task.FromResult(new BlobClient(blobUri, CreateManagedIdentityCredential()));
         }
 
         public Task<BlockBlobClient> GetAuthorizedBlockBlobClientAsync(Uri blobUri)
         {
             EnsureArg.IsNotNull(blobUri, nameof(blobUri));
-            return Task.FromResult(new BlockBlobClient(blobUri, CreateDefaultTokenCredential()));
+            return Task.FromResult(new BlockBlobClient(blobUri, CreateManagedIdentityCredential()));
         }
 
         public Task<BlockBlobClient> GetAuthorizedBlockBlobClientAsync(Uri blobUri, IntegrationDataStoreConfiguration integrationDataStoreConfiguration)
         {
             EnsureArg.IsNotNull(blobUri, nameof(blobUri));
-            return Task.FromResult(new BlockBlobClient(blobUri, CreateDefaultTokenCredential()));
+            return Task.FromResult(new BlockBlobClient(blobUri, CreateManagedIdentityCredential()));
         }
 
         public async Task<BlobServiceClient> GetAuthorizedClientAsync()
@@ -77,7 +77,7 @@ namespace Microsoft.Health.Fhir.Azure.IntegrationDataStore
 
             try
             {
-                return Task.FromResult(new BlobServiceClient(storageAccountUri, CreateDefaultTokenCredential()));
+                return Task.FromResult(new BlobServiceClient(storageAccountUri, CreateManagedIdentityCredential()));
             }
             catch (AccessTokenProviderException atp)
             {
@@ -87,9 +87,9 @@ namespace Microsoft.Health.Fhir.Azure.IntegrationDataStore
             }
         }
 
-        private static DefaultAzureCredential CreateDefaultTokenCredential()
+        private static ManagedIdentityCredential CreateManagedIdentityCredential()
         {
-            return new DefaultAzureCredential();
+            return new ManagedIdentityCredential();
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/AzureAccessTokenProvider.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/AzureAccessTokenProvider.cs
@@ -16,14 +16,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations
 {
     public class AzureAccessTokenProvider : IAccessTokenProvider
     {
-        private readonly DefaultAzureCredential _azureServiceTokenProvider;
+        private readonly ManagedIdentityCredential _azureServiceTokenProvider;
         private readonly ILogger<AzureAccessTokenProvider> _logger;
 
         public AzureAccessTokenProvider(ILogger<AzureAccessTokenProvider> logger)
         {
             EnsureArg.IsNotNull(logger, nameof(logger));
 
-            _azureServiceTokenProvider = new DefaultAzureCredential();
+            _azureServiceTokenProvider = new ManagedIdentityCredential();
             _logger = logger;
         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Web/Program.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web/Program.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Health.Fhir.Web
                     var keyVaultEndpoint = builtConfig["KeyVault:Endpoint"];
                     if (!string.IsNullOrEmpty(keyVaultEndpoint))
                     {
-                        var credential = new DefaultAzureCredential();
+                        var credential = new ManagedIdentityCredential();
                         builder.AddAzureKeyVault(new System.Uri(keyVaultEndpoint), credential);
                     }
 

--- a/tools/Importer/Importer.cs
+++ b/tools/Importer/Importer.cs
@@ -598,11 +598,11 @@ namespace Microsoft.Health.Fhir.Importer
             if (!string.IsNullOrEmpty(FhirAuthCredentialOptions))
             {
                 var options = JsonConvert.DeserializeObject<DefaultAzureCredentialOptions>(FhirAuthCredentialOptions);
-                credential = new DefaultAzureCredential(options);
+                credential = new DefaultAzureCredential(options); // CodeQL [SM05137] This is non-production testing code which is not deployed to production environments.
             }
             else
             {
-                credential = new DefaultAzureCredential();
+                credential = new DefaultAzureCredential(); // CodeQL [SM05137] This is non-production testing code which is not deployed to production environments.
             }
 
             handler = new BearerTokenHandler(credential, endpoints.Select(x => new Uri(x)).ToArray(), [.. scopes]);


### PR DESCRIPTION
## Description
Updated the DefaultAzureCredential to ManagedIdentityCredential as per the CodeQL scan reports

## Related issues
[AB#154667](https://microsofthealth.visualstudio.com/Health/_workitems/edit/154667).

## Testing
Deployed the application in azure and did some functional testing.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
