### PR TITLE
Add Dependabot configuration for .NET SDK updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,4 @@
-﻿# Configuration based on https://help.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
-
+# Configuration based on https://help.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
 updates:
   - package-ecosystem: "nuget"
@@ -9,7 +8,6 @@ updates:
       time: "08:00"
       timezone: "America/Los_Angeles"
     open-pull-requests-limit: 20
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -17,7 +15,6 @@ updates:
       time: "08:00"
       timezone: "America/Los_Angeles"
     open-pull-requests-limit: 20
-
   - package-ecosystem: "docker"
     directory: "/build/docker"
     schedule:
@@ -25,3 +22,13 @@ updates:
       time: "08:00"
       timezone: "America/Los_Angeles"
     open-pull-requests-limit: 20
+  - package-ecosystem: dotnet-sdk
+    directory: /
+    schedule:
+      interval: weekly
+      day: wednesday
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor


### PR DESCRIPTION
This PR adds Dependabot configuration to automatically manage .NET SDK version updates in global.json.

This configuration will:
- Monitor the global.json file for .NET SDK version updates
- Create pull requests when new SDK versions are available
- Help keep the project secure with the latest SDK patches

For more information, see: https://devblogs.microsoft.com/dotnet/using-dependabot-to-manage-dotnet-sdk-updates/

[AB#161383](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/161383)