### PR TITLE
Setting Base headers in FHIR

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Context/FhirRequestContextMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Context/FhirRequestContextMiddleware.cs
@@ -16,6 +16,14 @@ namespace Microsoft.Health.Fhir.Api.Features.Context
     public class FhirRequestContextMiddleware
     {
         private readonly RequestDelegate _next;
+        internal const string XContentTypeOptions = "X-Content-Type-Options";
+        private const string XContentTypeOptionsValue = "nosniff";
+
+        internal const string XFrameOptions = "X-Frame-Options";
+        private const string XFrameOptionsValue = "SAMEORIGIN";
+
+        internal const string ContentSecurityPolicy = "Content-Security-Policy";
+        private const string ContentSecurityPolicyValue = "frame-src 'self';";
 
         public FhirRequestContextMiddleware(RequestDelegate next)
         {
@@ -58,6 +66,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Context
                 responseHeaders: context.Response.Headers);
 
             context.Response.Headers[KnownHeaders.RequestId] = correlationId;
+            context.Response.Headers[XContentTypeOptions] = XContentTypeOptionsValue;
+            context.Response.Headers[XFrameOptions] = XFrameOptionsValue;
+            context.Response.Headers[ContentSecurityPolicy] = ContentSecurityPolicyValue;
 
             fhirRequestContextAccessor.RequestContext = fhirRequestContext;
 

--- a/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
@@ -190,8 +190,6 @@ namespace Microsoft.Extensions.DependencyInjection
                 {
                     IWebHostEnvironment env = app.ApplicationServices.GetRequiredService<IWebHostEnvironment>();
 
-                    // This middleware will add delegates to the OnStarting method of httpContext.Response for setting headers.
-                    app.UseBaseHeaders();
 
                     app.UseCors(Constants.DefaultCorsPolicy);
 

--- a/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
@@ -190,7 +190,6 @@ namespace Microsoft.Extensions.DependencyInjection
                 {
                     IWebHostEnvironment env = app.ApplicationServices.GetRequiredService<IWebHostEnvironment>();
 
-
                     app.UseCors(Constants.DefaultCorsPolicy);
 
                     // This middleware should be registered at the beginning since it generates correlation id among other things,


### PR DESCRIPTION
## Description
To address this error "Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.", we are setting base headers within FHIR code instead of using health care shared components.

## Related issues
Addresses [issue #[157475](https://microsofthealth.visualstudio.com/Health/_workitems/edit/157475)].

## Testing
Existing tests

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
