### PR TITLE
Fixing slow patient export.

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -571,6 +571,31 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
                 if (_exportJobRecord.ExportType == ExportJobType.Patient || _exportJobRecord.ExportType == ExportJobType.Group)
                 {
+                    var searchResultEntries = searchResult.Results.ToList();
+                    var startSurrogateId = sharedQueryParametersList
+                        .Where(x => string.Equals(x.Item1, KnownQueryParameterNames.StartSurrogateId, StringComparison.OrdinalIgnoreCase))
+                        .Select(x => x.Item2)
+                        .FirstOrDefault();
+                    var endSurrogateId = sharedQueryParametersList
+                        .Where(x => string.Equals(x.Item1, KnownQueryParameterNames.StartSurrogateId, StringComparison.OrdinalIgnoreCase))
+                        .Select(x => x.Item2)
+                        .FirstOrDefault();
+                    if (!string.IsNullOrEmpty(startSurrogateId) && !string.IsNullOrEmpty(endSurrogateId))
+                    {
+                        _logger.LogInformation($"Processing export job for {searchResultEntries.Count} {_exportJobRecord.ExportType} resources: [{startSurrogateId}, {endSurrogateId}]");
+                    }
+                    else
+                    {
+                        _logger.LogInformation($"Processing export job for {searchResultEntries.Count} {_exportJobRecord.ExportType} resources.");
+                    }
+
+                    sharedQueryParametersList = sharedQueryParametersList
+                            .Where(x => !string.Equals(x.Item1, KnownQueryParameterNames.GlobalStartSurrogateId, StringComparison.OrdinalIgnoreCase)
+                                && !string.Equals(x.Item1, KnownQueryParameterNames.GlobalEndSurrogateId, StringComparison.OrdinalIgnoreCase)
+                                && !string.Equals(x.Item1, KnownQueryParameterNames.StartSurrogateId, StringComparison.OrdinalIgnoreCase)
+                                && !string.Equals(x.Item1, KnownQueryParameterNames.EndSurrogateId, StringComparison.OrdinalIgnoreCase))
+                            .ToList();
+
                     uint resultIndex = 0;
                     foreach (SearchResultEntry result in searchResult.Results)
                     {

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -599,7 +599,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                                 .ToList();
 
                         uint resultIndex = 0;
-                        foreach (SearchResultEntry result in searchResult.Results)
+                        foreach (SearchResultEntry result in searchResultEntries)
                         {
                             // If a job is resumed in the middle of processing patient compartment resources it will skip patients it has already exported compartment information for.
                             // This assumes the order of the search results is the same every time the same search is performed.

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -571,51 +571,58 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
                 if (_exportJobRecord.ExportType == ExportJobType.Patient || _exportJobRecord.ExportType == ExportJobType.Group)
                 {
-                    var searchResultEntries = searchResult.Results.ToList();
-                    var startSurrogateId = sharedQueryParametersList
-                        .Where(x => string.Equals(x.Item1, KnownQueryParameterNames.StartSurrogateId, StringComparison.OrdinalIgnoreCase))
-                        .Select(x => x.Item2)
-                        .FirstOrDefault();
-                    var endSurrogateId = sharedQueryParametersList
-                        .Where(x => string.Equals(x.Item1, KnownQueryParameterNames.StartSurrogateId, StringComparison.OrdinalIgnoreCase))
-                        .Select(x => x.Item2)
-                        .FirstOrDefault();
-                    if (!string.IsNullOrEmpty(startSurrogateId) && !string.IsNullOrEmpty(endSurrogateId))
+                    var searchResultEntries = searchResult?.Results?.ToList();
+                    if (searchResultEntries?.Any() ?? false)
                     {
-                        _logger.LogInformation($"Processing export job for {searchResultEntries.Count} {_exportJobRecord.ExportType} resources: [{startSurrogateId}, {endSurrogateId}]");
+                        var startSurrogateId = sharedQueryParametersList
+                            .Where(x => string.Equals(x.Item1, KnownQueryParameterNames.StartSurrogateId, StringComparison.OrdinalIgnoreCase))
+                            .Select(x => x.Item2)
+                            .FirstOrDefault();
+                        var endSurrogateId = sharedQueryParametersList
+                            .Where(x => string.Equals(x.Item1, KnownQueryParameterNames.StartSurrogateId, StringComparison.OrdinalIgnoreCase))
+                            .Select(x => x.Item2)
+                            .FirstOrDefault();
+                        if (!string.IsNullOrEmpty(startSurrogateId) && !string.IsNullOrEmpty(endSurrogateId))
+                        {
+                            _logger.LogInformation($"Processing export job for {searchResultEntries.Count} {_exportJobRecord.ExportType} resources: [{startSurrogateId}, {endSurrogateId}]");
+                        }
+                        else
+                        {
+                            _logger.LogInformation($"Processing export job for {searchResultEntries.Count} {_exportJobRecord.ExportType} resources.");
+                        }
+
+                        sharedQueryParametersList = sharedQueryParametersList
+                                .Where(x => !string.Equals(x.Item1, KnownQueryParameterNames.GlobalStartSurrogateId, StringComparison.OrdinalIgnoreCase)
+                                    && !string.Equals(x.Item1, KnownQueryParameterNames.GlobalEndSurrogateId, StringComparison.OrdinalIgnoreCase)
+                                    && !string.Equals(x.Item1, KnownQueryParameterNames.StartSurrogateId, StringComparison.OrdinalIgnoreCase)
+                                    && !string.Equals(x.Item1, KnownQueryParameterNames.EndSurrogateId, StringComparison.OrdinalIgnoreCase))
+                                .ToList();
+
+                        uint resultIndex = 0;
+                        foreach (SearchResultEntry result in searchResult.Results)
+                        {
+                            // If a job is resumed in the middle of processing patient compartment resources it will skip patients it has already exported compartment information for.
+                            // This assumes the order of the search results is the same every time the same search is performed.
+                            if (progress.SubSearch != null && result.Resource.ResourceId != progress.SubSearch.TriggeringResourceId)
+                            {
+                                resultIndex++;
+                                continue;
+                            }
+
+                            if (progress.SubSearch == null)
+                            {
+                                progress.NewSubSearch(result.Resource.ResourceId);
+                            }
+
+                            await RunExportCompartmentSearch(exportJobConfiguration, progress.SubSearch, sharedQueryParametersList, anonymizer, cancellationToken);
+                            resultIndex++;
+
+                            progress.ClearSubSearch();
+                        }
                     }
                     else
                     {
-                        _logger.LogInformation($"Processing export job for {searchResultEntries.Count} {_exportJobRecord.ExportType} resources.");
-                    }
-
-                    sharedQueryParametersList = sharedQueryParametersList
-                            .Where(x => !string.Equals(x.Item1, KnownQueryParameterNames.GlobalStartSurrogateId, StringComparison.OrdinalIgnoreCase)
-                                && !string.Equals(x.Item1, KnownQueryParameterNames.GlobalEndSurrogateId, StringComparison.OrdinalIgnoreCase)
-                                && !string.Equals(x.Item1, KnownQueryParameterNames.StartSurrogateId, StringComparison.OrdinalIgnoreCase)
-                                && !string.Equals(x.Item1, KnownQueryParameterNames.EndSurrogateId, StringComparison.OrdinalIgnoreCase))
-                            .ToList();
-
-                    uint resultIndex = 0;
-                    foreach (SearchResultEntry result in searchResult.Results)
-                    {
-                        // If a job is resumed in the middle of processing patient compartment resources it will skip patients it has already exported compartment information for.
-                        // This assumes the order of the search results is the same every time the same search is performed.
-                        if (progress.SubSearch != null && result.Resource.ResourceId != progress.SubSearch.TriggeringResourceId)
-                        {
-                            resultIndex++;
-                            continue;
-                        }
-
-                        if (progress.SubSearch == null)
-                        {
-                            progress.NewSubSearch(result.Resource.ResourceId);
-                        }
-
-                        await RunExportCompartmentSearch(exportJobConfiguration, progress.SubSearch, sharedQueryParametersList, anonymizer, cancellationToken);
-                        resultIndex++;
-
-                        progress.ClearSubSearch();
+                        _logger.LogInformation("The search result is null or empty.");
                     }
                 }
 

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ExportController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ExportController.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                 resourceType: resourceType,
                 containerName: containerName,
                 formatName: formatName,
-                isParallel: false,
+                isParallel: true,
                 maxCount: maxCount,
                 anonymizationConfigCollectionReference: anonymizationConfigCollectionReference,
                 anonymizationConfigLocation: anonymizationConfigLocation,

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Operations/Export/SqlExportOrchestratorJobTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Operations/Export/SqlExportOrchestratorJobTests.cs
@@ -38,21 +38,20 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Operations.Export
         private IOptions<ExportJobConfiguration> _exportJobConfiguration = Options.Create(new ExportJobConfiguration());
 
         [Theory]
-        [InlineData(ExportJobType.Patient)]
-        [InlineData(ExportJobType.Group)]
-        public async Task GivenANonSystemLevelExportJob_WhenRun_ThenOneProcessingJobShouldBeCreated(ExportJobType exportJobType)
+        [InlineData(ExportJobType.Patient, 100, 100)]
+        [InlineData(ExportJobType.Group, 1, 1)]
+        public async Task GivenANonSystemLevelExportJob_WhenRun_ThenOneProcessingJobShouldBeCreated(ExportJobType exportJobType, int expectedEnqueueCalls, int expectedJobCount)
         {
-            int numExpectedJobs = 1;
             long orchestratorJobId = 10000;
 
-            SetupMockQueue(numExpectedJobs, orchestratorJobId);
+            SetupMockQueue(1, orchestratorJobId);
 
             var orchestratorJob = GetJobInfoArray(0, orchestratorJobId, false, orchestratorJobId, isParallel: true, exportJobType: exportJobType)[0];
             var exportOrchestratorJob = new SqlExportOrchestratorJob(_mockQueueClient, _mockSearchService, _exportJobConfiguration, _logger);
             var result = await exportOrchestratorJob.ExecuteAsync(orchestratorJob, CancellationToken.None);
             var jobResult = JsonConvert.DeserializeObject<ExportJobRecord>(result);
 
-            CheckJobsQueued(1, numExpectedJobs);
+            CheckJobsQueued(expectedEnqueueCalls, expectedJobCount);
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Export/SqlExportOrchestratorJob.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Export/SqlExportOrchestratorJob.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Export
                         KnownResourceTypes.Patient,
                         startId,
                         globalEndId,
-                        _exportJobConfiguration.NumberOfParallelRecordRanges,
+                        surrogateIdRangeSize,
                         _exportJobConfiguration.NumberOfParallelRecordRanges,
                         true,
                         cancellationToken);

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Export/SqlExportOrchestratorJob.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Export/SqlExportOrchestratorJob.cs
@@ -133,11 +133,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Export
                 var globalStartId = since.ToId();
                 var till = record.Till.ToDateTimeOffset();
                 var globalEndId = till.ToId() - 1; // -1 is so _till value can be used as _since in the next time based export
-                var enqueued = groupJobs.Where(x => x.Id != jobInfo.Id) // exclude coord
-                                        .Select(x => JsonConvert.DeserializeObject<ExportJobRecord>(x.Definition))
-                                        .Where(x => x.EndSurrogateId != null) // This is to handle current mock tests. It is not needed but does not hurt.
-                                        .GroupBy(x => x.ResourceType)
-                                        .ToDictionary(x => x.Key, x => x.Max(r => long.Parse(r.EndSurrogateId)));
                 var surrogateIdRanges = new List<(long StartId, long EndId)>();
                 var startId = globalStartId;
                 IReadOnlyList<(long StartId, long EndId)> response = null;

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Export/SqlExportOrchestratorJob.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Export/SqlExportOrchestratorJob.cs
@@ -135,11 +135,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Export
                 var globalStartId = since.ToId();
                 var till = record.Till.ToDateTimeOffset();
                 var globalEndId = till.ToId() - 1; // -1 is so _till value can be used as _since in the next time based export
-                var enqueued = groupJobs.Where(x => x.Id != jobInfo.Id) // exclude coord
+                var enqueuedJobs = groupJobs.Where(x => x.Id != jobInfo.Id) // exclude coord
                     .Select(x => JsonConvert.DeserializeObject<ExportJobRecord>(x.Definition))
-                    .Where(x => x.EndSurrogateId != null) // This is to handle current mock tests. It is not needed but does not hurt.
-                    .Max(x => long.Parse(x.EndSurrogateId));
-                var startId = Math.Max(globalStartId, enqueued + 1);
+                    .Where(x => x.EndSurrogateId != null); // This is to handle current mock tests. It is not needed but does not hurt.
+                var enqueuedSurrogateId = (enqueuedJobs?.Any() ?? false) ? enqueuedJobs.Max(x => long.Parse(x.EndSurrogateId)) : 0;
+                var startId = Math.Max(globalStartId, enqueuedSurrogateId + 1);
 
                 IReadOnlyList<(long StartId, long EndId)> response = null;
                 do


### PR DESCRIPTION
## Description
The change will split patients to be exported into smaller groups and create an export job for each of the groups, so they will be processed in parallel.

## Related issues
Addresses [issue #131457].

[Bug 131457](https://microsofthealth.visualstudio.com/Health/_workitems/edit/131457): Patient Export Never Completes

## Testing
Tested manually and also by running existing automation tests.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
