### PR TITLE
Added ManagedIdentityCredentialOptions to AzureAccessTokenProvider

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/AzureAccessTokenProvider.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/AzureAccessTokenProvider.cs
@@ -23,6 +23,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations
         {
             EnsureArg.IsNotNull(logger, nameof(logger));
 
+            ManagedIdentityCredentialOptions managedIdentityCredentialOptions = new ManagedIdentityCredentialOptions
+            {
+                AuthorityHost = GetAuthorityHost(),
+            };
             _azureServiceTokenProvider = new ManagedIdentityCredential();
             _logger = logger;
         }
@@ -60,6 +64,17 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations
             }
 
             return accessToken.Token;
+        }
+
+        private static Uri GetAuthorityHost()
+        {
+            string cloudEnvironment = Environment.GetEnvironmentVariable("cloudEnvironment");
+
+            return cloudEnvironment switch
+            {
+                "AzureUsGovernment" => AzureAuthorityHosts.AzureGovernment,
+                "AzureCloud" or _ => AzureAuthorityHosts.AzurePublicCloud,
+            };
         }
     }
 }


### PR DESCRIPTION
## Description
ManagedIdentityCredentialOptions was added to the AzureAccessTokenProvider so that the AuthorityHost can be set depending on what cloudEnvironment environment variable is set to. Defaults to AzurePublicCloud.

## Related issues
Addresses [issue #AB143654].

## Testing
Tested locally

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
