### PR TITLE
[Bundle] Change default bundle processing logic for transactions

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Headers/HttpContextExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Headers/HttpContextExtensions.cs
@@ -79,12 +79,13 @@ namespace Microsoft.Health.Fhir.Api.Features.Headers
         /// Retrieves from the HTTP header information about the bundle processing logic to be adopted.
         /// </summary>
         /// <param name="outerHttpContext">HTTP context</param>
-        public static BundleProcessingLogic GetBundleProcessingLogic(this HttpContext outerHttpContext)
+        /// <param name="defaultBundleProcessingLogic">Default bundle processing logic to use if not specified in the header</param>
+        public static BundleProcessingLogic GetBundleProcessingLogic(this HttpContext outerHttpContext, BundleProcessingLogic defaultBundleProcessingLogic)
         {
             return ExtractEnumerationFlagFromHttpHeader(
                 outerHttpContext,
                 httpHeaderName: BundleOrchestratorNamingConventions.HttpHeaderBundleProcessingLogic,
-                defaultValue: BundleProcessingLogic.Sequential);
+                defaultValue: defaultBundleProcessingLogic);
         }
 
         public static TEnum ExtractEnumerationFlagFromHttpHeader<TEnum>(HttpContext outerHttpContext, string httpHeaderName, TEnum defaultValue)

--- a/src/Microsoft.Health.Fhir.Api/Features/Headers/HttpContextExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Headers/HttpContextExtensions.cs
@@ -100,12 +100,15 @@ namespace Microsoft.Health.Fhir.Api.Features.Headers
                 string processingLogicAsString = headerValues.FirstOrDefault();
                 if (string.IsNullOrWhiteSpace(processingLogicAsString))
                 {
+                    // If the bundle processing header is present but empty, we consider it invalid.
                     return false;
                 }
 
-                return Enum.TryParse<BundleProcessingLogic>(processingLogicAsString.Trim(), ignoreCase: true, out _);
+                // Check if the value can be parsed as a valid BundleProcessingLogic enum value.
+                return Enum.TryParse<BundleProcessingLogic>(processingLogicAsString.Trim(), ignoreCase: true, out BundleProcessingLogic result) && Enum.IsDefined(result);
             }
 
+            // If the bundle processing header is not present, we consider it valid by default.
             return true;
         }
 

--- a/src/Microsoft.Health.Fhir.Api/Features/Headers/HttpContextExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Headers/HttpContextExtensions.cs
@@ -88,6 +88,27 @@ namespace Microsoft.Health.Fhir.Api.Features.Headers
                 defaultValue: defaultBundleProcessingLogic);
         }
 
+        public static bool IsBundleProcessingLogicValid(this HttpContext outerHttpContext)
+        {
+            if (outerHttpContext == null)
+            {
+                return false;
+            }
+
+            if (outerHttpContext.Request.Headers.TryGetValue(BundleOrchestratorNamingConventions.HttpHeaderBundleProcessingLogic, out StringValues headerValues))
+            {
+                string processingLogicAsString = headerValues.FirstOrDefault();
+                if (string.IsNullOrWhiteSpace(processingLogicAsString))
+                {
+                    return false;
+                }
+
+                return Enum.TryParse<BundleProcessingLogic>(processingLogicAsString.Trim(), ignoreCase: true, out _);
+            }
+
+            return true;
+        }
+
         public static TEnum ExtractEnumerationFlagFromHttpHeader<TEnum>(HttpContext outerHttpContext, string httpHeaderName, TEnum defaultValue)
             where TEnum : struct, Enum
         {

--- a/src/Microsoft.Health.Fhir.Core/Configs/BundleConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/BundleConfiguration.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Microsoft.Health.Fhir.Core.Models;
+
 namespace Microsoft.Health.Fhir.Core.Configs
 {
     public class BundleConfiguration
@@ -13,5 +15,13 @@ namespace Microsoft.Health.Fhir.Core.Configs
         /// Gets or sets a value indicating whether bundle orchestrator is enabled or not.
         /// </summary>
         public bool SupportsBundleOrchestrator { get; set; }
+
+        // The default bundle processing logic for Transactions is set to Parallel, as by the FHIR specification, a transactional bundle
+        // cannot contain duplicated operations under the same bundle.
+        public BundleProcessingLogic TransactionDefaultProcessingLogic { get; set; } = BundleProcessingLogic.Parallel;
+
+        // The default bundle processing logic for Batches is set to Sequential, as current customer can have resource identities overlaps
+        // (including resolved identities from conditional update/delete, which are not allowed in a transaction bundle).
+        public BundleProcessingLogic BatchDefaultProcessingLogic { get; set; } = BundleProcessingLogic.Sequential;
     }
 }

--- a/src/Microsoft.Health.Fhir.Core/Features/Persistence/Orchestration/BundleOrchestratorOperation.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Persistence/Orchestration/BundleOrchestratorOperation.cs
@@ -307,6 +307,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence.Orchestration
                     }
                     else if (_knownHttpVerbsInOperation.Count > 1)
                     {
+                        // If multiple HTTP Verbs are used, then resources must be sorted by BundleResourceContext.
+                        // This is required to ensure that resources are processed in the correct order following the FHIR specification.
+                        // This logic is documented on "BundleResourceContextComparer" and applicable to Bundle Transactions.
                         resources = _resources.Values.OrderBy(x => x.BundleResourceContext, _contextComparer).ToList();
                     }
                     else

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Bundle/FhirTransactionFailedExceptionTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Bundle/FhirTransactionFailedExceptionTests.cs
@@ -15,7 +15,7 @@ using Xunit;
 namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Bundle
 {
     [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
-    [Trait(Traits.Category, Categories.Transaction)]
+    [Trait(Traits.Category, Categories.BundleTransaction)]
     public class FhirTransactionFailedExceptionTests
     {
         [Fact]

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Headers/HttpContextExtensionsTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Headers/HttpContextExtensionsTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
 using Microsoft.Health.Fhir.Api.Features.Headers;
 using Microsoft.Health.Fhir.Api.Features.Resources;
 using Microsoft.Health.Fhir.Core.Features;
@@ -28,14 +29,20 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Headers
         [InlineData(BundleProcessingLogic.Parallel)]
         public void WhenHttpContextDoesNotHaveCustomHeaders_ReturnDefaultValues(BundleProcessingLogic defaultAndExpectBundleProcessingLogic)
         {
+            // Empty HttpContext simulates the case where no custom headers are set.
             HttpContext httpContext = GetFakeHttpContext();
 
             bool isLatencyOverEfficiencyEnabled = httpContext.IsLatencyOverEfficiencyEnabled();
             Assert.False(isLatencyOverEfficiencyEnabled);
 
+            // Given different default values for the bundle processing logic, we expect the same value to be returned.
             BundleProcessingLogic bundleProcessingLogic = httpContext.GetBundleProcessingLogic(
                 defaultBundleProcessingLogic: defaultAndExpectBundleProcessingLogic);
             Assert.Equal(defaultAndExpectBundleProcessingLogic, bundleProcessingLogic);
+
+            // Empty header is expected to be assumed as valid.
+            bool isBundleProcessingLogicValid = httpContext.IsBundleProcessingLogicValid();
+            Assert.True(isBundleProcessingLogicValid);
 
             // #conditionalQueryParallelism
             ConditionalQueryProcessingLogic conditionalQueryProcessingLogic = httpContext.GetConditionalQueryProcessingLogic();
@@ -89,6 +96,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Headers
             Assert.Equal(processingLogic, conditionalQueryProcessingLogic);
         }
 
+        [Trait(Traits.Category, Categories.Bundle)]
         [Theory]
         [InlineData("", BundleProcessingLogic.Sequential)]
         [InlineData(null, BundleProcessingLogic.Sequential)]
@@ -111,6 +119,19 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Headers
                 defaultBundleProcessingLogic: BundleProcessingLogic.Sequential);
 
             Assert.Equal(processingLogic, bundleProcessingLogic);
+        }
+
+        [Trait(Traits.Category, Categories.Bundle)]
+        [Theory]
+        [InlineData("2112")]
+        [InlineData("red barchetta")]
+        public void WhenHttpContextHasCustomHeaders_WithInvalidValues_ThatShouldBeIdentified(string value)
+        {
+            var httpHeaders = new Dictionary<string, string>() { { BundleOrchestratorNamingConventions.HttpHeaderBundleProcessingLogic, value } };
+            HttpContext httpContext = GetFakeHttpContext(httpHeaders);
+
+            bool isBundleProcessingLogicValid = httpContext.IsBundleProcessingLogicValid();
+            Assert.False(isBundleProcessingLogicValid);
         }
 
         [Fact]
@@ -148,7 +169,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Headers
             {
                 foreach (var header in optionalHttpHeaders)
                 {
-                    httpContext.Request.Headers.Append(header.Key, header.Value);
+                    httpContext.Request.Headers.Append(header.Key, new StringValues(header.Value));
                 }
             }
 

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Headers/HttpContextExtensionsTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Headers/HttpContextExtensionsTests.cs
@@ -22,16 +22,20 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Headers
     [Trait(Traits.Category, Categories.Web)]
     public sealed class HttpContextExtensionsTests
     {
-        [Fact]
-        public void WhenHttpContextDoesNotHaveCustomHeaders_ReturnDefaultValues()
+        [Trait(Traits.Category, Categories.Bundle)]
+        [Theory]
+        [InlineData(BundleProcessingLogic.Sequential)]
+        [InlineData(BundleProcessingLogic.Parallel)]
+        public void WhenHttpContextDoesNotHaveCustomHeaders_ReturnDefaultValues(BundleProcessingLogic defaultAndExpectBundleProcessingLogic)
         {
             HttpContext httpContext = GetFakeHttpContext();
 
             bool isLatencyOverEfficiencyEnabled = httpContext.IsLatencyOverEfficiencyEnabled();
             Assert.False(isLatencyOverEfficiencyEnabled);
 
-            BundleProcessingLogic bundleProcessingLogic = httpContext.GetBundleProcessingLogic();
-            Assert.Equal(BundleProcessingLogic.Sequential, bundleProcessingLogic);
+            BundleProcessingLogic bundleProcessingLogic = httpContext.GetBundleProcessingLogic(
+                defaultBundleProcessingLogic: defaultAndExpectBundleProcessingLogic);
+            Assert.Equal(defaultAndExpectBundleProcessingLogic, bundleProcessingLogic);
 
             // #conditionalQueryParallelism
             ConditionalQueryProcessingLogic conditionalQueryProcessingLogic = httpContext.GetConditionalQueryProcessingLogic();
@@ -103,7 +107,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Headers
             var httpHeaders = new Dictionary<string, string>() { { BundleOrchestratorNamingConventions.HttpHeaderBundleProcessingLogic, value } };
             HttpContext httpContext = GetFakeHttpContext(httpHeaders);
 
-            BundleProcessingLogic bundleProcessingLogic = httpContext.GetBundleProcessingLogic();
+            BundleProcessingLogic bundleProcessingLogic = httpContext.GetBundleProcessingLogic(
+                defaultBundleProcessingLogic: BundleProcessingLogic.Sequential);
 
             Assert.Equal(processingLogic, bundleProcessingLogic);
         }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerRuntimeTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerRuntimeTests.cs
@@ -1,0 +1,113 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+using Microsoft.Health.Fhir.Api.Features.Resources.Bundle;
+using Microsoft.Health.Fhir.Core.Features.Persistence.Orchestration;
+using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Test.Utilities;
+using Xunit;
+using static Hl7.Fhir.Model.Bundle;
+
+namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
+{
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.Bundle)]
+    public class BundleHandlerRuntimeTests
+    {
+        [Theory]
+        [InlineData(BundleType.Transaction, BundleProcessingLogic.Parallel)]
+        [InlineData(BundleType.Batch, BundleProcessingLogic.Sequential)]
+        public void GetDefaultBundleProcessingLogic_BatchAndTransaction_ReturnsExpectedProcessingLogic(
+            BundleType bundleType,
+            BundleProcessingLogic expectedDefaultProcessingLogic)
+        {
+            // Arrange an empty HttpContext
+            var httpContext = GetHttpContext();
+
+            // Act
+            var result = BundleHandlerRuntime.GetBundleProcessingLogic(httpContext, bundleType);
+
+            // Assert
+            Assert.Equal(expectedDefaultProcessingLogic, result);
+        }
+
+        [Fact]
+        public void GetBundleProcessingLogic_NullBundleType_ReturnsSequential()
+        {
+            // Arrange
+            var httpContext = GetHttpContext();
+
+            // Act
+            var result = BundleHandlerRuntime.GetBundleProcessingLogic(httpContext, null);
+
+            // Assert
+            Assert.Equal(BundleProcessingLogic.Sequential, result);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        [InlineData("parallel")]
+        [InlineData("sequential")]
+        [InlineData("   PaRaLlEl   ")]
+        [InlineData("   SeQuentiAl   ")]
+        public void IsBundleProcessingLogicSetValid_DelegatesToHttpContext(string input)
+        {
+            // Arrange
+            var httpContext = GetHttpContext();
+            httpContext.Request.Headers.Append(BundleOrchestratorNamingConventions.HttpHeaderBundleProcessingLogic, new StringValues(input));
+
+            // Act
+            var result = BundleHandlerRuntime.IsBundleProcessingLogicValid(httpContext);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Theory]
+        [InlineData("para llel")]
+        [InlineData("sequential.")]
+        [InlineData("   x   ")]
+        [InlineData("test")]
+        public void IsBundleProcessingLogicSetValid_DelegatesToHttpContext_HandleInvalid(string input)
+        {
+            // Arrange
+            var httpContext = GetHttpContext();
+            httpContext.Request.Headers.Append(BundleOrchestratorNamingConventions.HttpHeaderBundleProcessingLogic, new StringValues(input));
+
+            // Act
+            var result = BundleHandlerRuntime.IsBundleProcessingLogicValid(httpContext);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void GetBundleProcessingLogic_NullHttpContext_Throws()
+        {
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => BundleHandlerRuntime.GetBundleProcessingLogic(null, BundleType.Batch));
+        }
+
+        private HttpContext GetHttpContext()
+        {
+            var httpContext = new DefaultHttpContext()
+            {
+                Request =
+                {
+                    Scheme = "https",
+                    Host = new HostString("localhost"),
+                    PathBase = new PathString("/"),
+                },
+            };
+
+            return httpContext;
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerRuntimeTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerRuntimeTests.cs
@@ -7,6 +7,7 @@ using System;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Health.Fhir.Api.Features.Resources.Bundle;
+using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features.Persistence.Orchestration;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Tests.Common;
@@ -20,6 +21,8 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
     [Trait(Traits.Category, Categories.Bundle)]
     public class BundleHandlerRuntimeTests
     {
+        private readonly BundleConfiguration _bundleConfiguration = new BundleConfiguration();
+
         [Theory]
         [InlineData(BundleType.Transaction, BundleProcessingLogic.Parallel)]
         [InlineData(BundleType.Batch, BundleProcessingLogic.Sequential)]
@@ -31,7 +34,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
             var httpContext = GetHttpContext();
 
             // Act
-            var result = BundleHandlerRuntime.GetBundleProcessingLogic(httpContext, bundleType);
+            var result = BundleHandlerRuntime.GetBundleProcessingLogic(_bundleConfiguration, httpContext, bundleType);
 
             // Assert
             Assert.Equal(expectedDefaultProcessingLogic, result);
@@ -44,7 +47,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
             var httpContext = GetHttpContext();
 
             // Act
-            var result = BundleHandlerRuntime.GetBundleProcessingLogic(httpContext, null);
+            var result = BundleHandlerRuntime.GetBundleProcessingLogic(_bundleConfiguration, httpContext, null);
 
             // Assert
             Assert.Equal(BundleProcessingLogic.Sequential, result);
@@ -92,7 +95,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
         public void GetBundleProcessingLogic_NullHttpContext_Throws()
         {
             // Act & Assert
-            Assert.Throws<ArgumentNullException>(() => BundleHandlerRuntime.GetBundleProcessingLogic(null, BundleType.Batch));
+            Assert.Throws<ArgumentNullException>(() => BundleHandlerRuntime.GetBundleProcessingLogic(_bundleConfiguration, null, BundleType.Batch));
         }
 
         private HttpContext GetHttpContext()

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Microsoft.Health.Fhir.Shared.Api.UnitTests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Microsoft.Health.Fhir.Shared.Api.UnitTests.projitems
@@ -64,6 +64,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\Import\InitialImportLockMiddlewareTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\OperationsCapabilityProviderTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Bundle\BundleHandlerEdgeCaseTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Bundle\BundleHandlerRuntimeTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Bundle\BundleHandlerStatisticsTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Bundle\BundleSerializerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Bundle\TransactionExceptionHandlerTests.cs" />

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
             // Set optimized-query processing logic.
             _optimizedQuerySet = SetRequestContextWithOptimizedQuerying(_outerHttpContext, fhirRequestContextAccessor.RequestContext, _logger);
 
-            _isBundleProcessingLogicValid = BundleHandlerRuntime.IsBundleProcessingLogicValid(_outerHttpContext);
+            _isBundleProcessingLogicValid = _bundleOrchestrator.IsEnabled ? BundleHandlerRuntime.IsBundleProcessingLogicValid(_outerHttpContext) : true;
         }
 
         public async Task<BundleResponse> Handle(BundleRequest request, CancellationToken cancellationToken)
@@ -198,7 +198,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                 _bundleType = bundleResource.Type;
 
                 // Retrieve bundle processing logic.
-                BundleProcessingLogic bundleProcessingLogic = BundleHandlerRuntime.GetBundleProcessingLogic(_outerHttpContext, _bundleType);
+                BundleProcessingLogic bundleProcessingLogic = _bundleOrchestrator.IsEnabled ? BundleHandlerRuntime.GetBundleProcessingLogic(_outerHttpContext, _bundleType) : BundleProcessingLogic.Sequential;
 
                 if (_bundleType == BundleType.Batch)
                 {

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                 _bundleType = bundleResource.Type;
 
                 // Retrieve bundle processing logic.
-                BundleProcessingLogic bundleProcessingLogic = _bundleOrchestrator.IsEnabled ? BundleHandlerRuntime.GetBundleProcessingLogic(_outerHttpContext, _bundleType) : BundleProcessingLogic.Sequential;
+                BundleProcessingLogic bundleProcessingLogic = _bundleOrchestrator.IsEnabled ? BundleHandlerRuntime.GetBundleProcessingLogic(_bundleConfiguration, _outerHttpContext, _bundleType) : BundleProcessingLogic.Sequential;
 
                 if (_bundleType == BundleType.Batch)
                 {

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerRuntime.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerRuntime.cs
@@ -17,9 +17,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
     public static class BundleHandlerRuntime
     {
         // The default bundle processing logic for Transactions is set to Parallel, as by the FHIR specification, a transactional bundle
-        // cannot contain any resources that refer to each other, and therefore can be processed in parallel.
-        // The default bundle processing logic for Batches is set to Sequential, as by the FHIR specification, a batch can contain resources
-        // that refer to each other, and therefore must be processed sequentially.
+        // cannot contain duplicated operations under the same bundle.
+        // The default bundle processing logic for Batches is set to Sequential, as current customer can haver esource identities overlaps
+        // (including resolved identities from conditional update/delete, which are not allowed in a transaction bundle).
         private const BundleProcessingLogic BatchDefaultBundleProcessingLogic = BundleProcessingLogic.Sequential;
         private const BundleProcessingLogic TransactionDefaultBundleProcessingLogic = BundleProcessingLogic.Parallel;
 

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerRuntime.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerRuntime.cs
@@ -6,6 +6,7 @@
 using EnsureThat;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Health.Fhir.Api.Features.Headers;
+using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Models;
 using static Hl7.Fhir.Model.Bundle;
 
@@ -16,14 +17,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
     /// </summary>
     public static class BundleHandlerRuntime
     {
-        // The default bundle processing logic for Transactions is set to Parallel, as by the FHIR specification, a transactional bundle
-        // cannot contain duplicated operations under the same bundle.
-        // The default bundle processing logic for Batches is set to Sequential, as current customer can haver esource identities overlaps
-        // (including resolved identities from conditional update/delete, which are not allowed in a transaction bundle).
-        private const BundleProcessingLogic BatchDefaultBundleProcessingLogic = BundleProcessingLogic.Sequential;
-        private const BundleProcessingLogic TransactionDefaultBundleProcessingLogic = BundleProcessingLogic.Parallel;
-
-        public static BundleProcessingLogic GetBundleProcessingLogic(HttpContext outerHttpContext, BundleType? bundleType)
+        public static BundleProcessingLogic GetBundleProcessingLogic(BundleConfiguration bundleConfiguration, HttpContext outerHttpContext, BundleType? bundleType)
         {
             EnsureArg.IsNotNull(outerHttpContext, nameof(outerHttpContext));
 
@@ -32,12 +26,12 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                 if (bundleType.Value == BundleType.Transaction)
                 {
                     // For transactions, the default processing logic is parallel.
-                    return outerHttpContext.GetBundleProcessingLogic(TransactionDefaultBundleProcessingLogic);
+                    return outerHttpContext.GetBundleProcessingLogic(bundleConfiguration.TransactionDefaultProcessingLogic);
                 }
                 else if (bundleType.Value == BundleType.Batch)
                 {
                     // For batch, the default processing logic is parallel.
-                    return outerHttpContext.GetBundleProcessingLogic(BatchDefaultBundleProcessingLogic);
+                    return outerHttpContext.GetBundleProcessingLogic(bundleConfiguration.BatchDefaultProcessingLogic);
                 }
             }
 

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerRuntime.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerRuntime.cs
@@ -1,0 +1,53 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using EnsureThat;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Health.Fhir.Api.Features.Headers;
+using Microsoft.Health.Fhir.Core.Models;
+using static Hl7.Fhir.Model.Bundle;
+
+namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
+{
+    public static class BundleHandlerRuntime
+    {
+        // The default bundle processing logic for Transactions is set to Parallel, as by the FHIR specification, a transactional bundle
+        // cannot contain any resources that refer to each other, and therefore can be processed in parallel.
+        // The default bundle processing logic for Batches is set to Sequential, as by the FHIR specification, a batch can contain resources
+        // that refer to each other, and therefore must be processed sequentially.
+        private const BundleProcessingLogic BatchDefaultBundleProcessingLogic = BundleProcessingLogic.Sequential;
+        private const BundleProcessingLogic TransactionDefaultBundleProcessingLogic = BundleProcessingLogic.Parallel;
+
+        public static BundleProcessingLogic GetBundleProcessingLogic(HttpContext outerHttpContext, BundleType? bundleType)
+        {
+            EnsureArg.IsNotNull(outerHttpContext, nameof(outerHttpContext));
+
+            if (bundleType.HasValue)
+            {
+                if (bundleType.Value == BundleType.Transaction)
+                {
+                    // For transactions, the default processing logic is parallel.
+                    return outerHttpContext.GetBundleProcessingLogic(TransactionDefaultBundleProcessingLogic);
+                }
+                else if (bundleType.Value == BundleType.Batch)
+                {
+                    // For batch, the default processing logic is parallel.
+                    return outerHttpContext.GetBundleProcessingLogic(BatchDefaultBundleProcessingLogic);
+                }
+            }
+
+            // Reaching this part of the code means that the bundle type is not set or it's using an invalid value.
+            // Returning sequential as the default processing logic for both cases.
+            return BundleProcessingLogic.Sequential;
+        }
+
+        internal static bool IsBundleProcessingLogicValid(HttpContext outerHttpContext)
+        {
+            EnsureArg.IsNotNull(outerHttpContext, nameof(outerHttpContext));
+
+            return outerHttpContext.IsBundleProcessingLogicValid();
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerRuntime.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerRuntime.cs
@@ -11,6 +11,9 @@ using static Hl7.Fhir.Model.Bundle;
 
 namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
 {
+    /// <summary>
+    /// Set of static methods used as part of the bundle handling logic.
+    /// </summary>
     public static class BundleHandlerRuntime
     {
         // The default bundle processing logic for Transactions is set to Parallel, as by the FHIR specification, a transactional bundle

--- a/src/Microsoft.Health.Fhir.Shared.Api/Microsoft.Health.Fhir.Shared.Api.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Microsoft.Health.Fhir.Shared.Api.projitems
@@ -41,6 +41,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\OperationsCapabilityProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Operations\ParametersExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Bundle\BundleHandlerParallelOperations.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Bundle\BundleHandlerRuntime.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Bundle\BundleHandlerStatistics.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Bundle\BundleRouter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Bundle\BundleSerializer.cs" />

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Models/BundleResourceContextComparerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Models/BundleResourceContextComparerTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Models
 {
     [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
     [Trait(Traits.Category, Categories.Bundle)]
-    [Trait(Traits.Category, Categories.Transaction)]
+    [Trait(Traits.Category, Categories.BundleTransaction)]
     public sealed class BundleResourceContextComparerTests
     {
         private readonly Guid _bundleOperationId = Guid.NewGuid();

--- a/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
+++ b/src/Microsoft.Health.Fhir.Shared.Web/appsettings.json
@@ -105,7 +105,9 @@
         },
         "Bundle": {
             "EntryLimit": 500,
-            "SupportsBundleOrchestrator": true
+            "SupportsBundleOrchestrator": true,
+            "BatchDefaultProcessingLogic": "sequential",
+            "TransactionDefaultProcessingLogic": "parallel"
         },
         "Throttling": {
             "Enabled": false,

--- a/src/Microsoft.Health.Fhir.Tests.Common/Categories.cs
+++ b/src/Microsoft.Health.Fhir.Tests.Common/Categories.cs
@@ -19,6 +19,8 @@ namespace Microsoft.Health.Fhir.Tests.Common
 
         public const string Bundle = nameof(Bundle);
 
+        public const string BundleTransaction = nameof(BundleTransaction);
+
         public const string BundleOrchestrator = nameof(BundleOrchestrator);
 
         public const string CompartmentSearch = nameof(CompartmentSearch);
@@ -89,8 +91,6 @@ namespace Microsoft.Health.Fhir.Tests.Common
         public const string SmartOnFhir = nameof(SmartOnFhir);
 
         public const string Sort = nameof(Sort);
-
-        public const string Transaction = nameof(Transaction);
 
         public const string Throttling = nameof(Throttling);
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/AuditTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Audit/AuditTests.cs
@@ -513,7 +513,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit
 
         [SkippableFact]
         [HttpIntegrationFixtureArgumentSets(dataStores: DataStore.SqlServer)]
-        [Trait(Traits.Category, Categories.Transaction)]
+        [Trait(Traits.Category, Categories.BundleTransaction)]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenATransactionBundleWithValidEntries_WhenSuccessfulPost_ThenAuditLogEntriesShouldBeCreated()
         {
@@ -540,7 +540,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Audit
 
         [SkippableFact]
         [HttpIntegrationFixtureArgumentSets(dataStores: DataStore.SqlServer)]
-        [Trait(Traits.Category, Categories.Transaction)]
+        [Trait(Traits.Category, Categories.BundleTransaction)]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenATransactionBundle_WhenAnUnsuccessfulPost_ThenTransactionShouldRollBackAndAuditLogEntriesShouldBeCreated()
         {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BundleTransactionTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BundleTransactionTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 {
     [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
     [Trait(Traits.Category, Categories.Search)]
-    [Trait(Traits.Category, Categories.Transaction)]
+    [Trait(Traits.Category, Categories.BundleTransaction)]
     [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer, Format.All)]
     public class BundleTransactionTests : IClassFixture<HttpIntegrationTestFixture>
     {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Metric/MetricTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Metric/MetricTests.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Metric
         }
 
         [HttpIntegrationFixtureArgumentSets(dataStores: DataStore.SqlServer)]
-        [Trait(Traits.Category, Categories.Transaction)]
+        [Trait(Traits.Category, Categories.BundleTransaction)]
         [Trait(Traits.Priority, Priority.One)]
         [Fact]
         public async Task GivenATransaction_WhenInvoked_MetricNotificationsShouldBeEmitted()


### PR DESCRIPTION
## Description
Switch the default bundle processing logic for transactions. 

The default bundle processing logic for Transactions is set to Parallel, as by the FHIR specification, a transactional bundle cannot contain any resources that refer to each other and therefore can be processed in parallel.

The default bundle processing logic for Batches is set to Sequential, as by the FHIR specification, a batch can contain resources that refer to each other and therefore must be processed sequentially.

## Related issues
[AB#147954](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/147954)

## Testing
Describe how this change was tested.

- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
