### PR TITLE
Add architectural doc for duplicated clinical notes

### DIFF
--- a/docs/arch/adr-fhir-resource-duplication-design.md
+++ b/docs/arch/adr-fhir-resource-duplication-design.md
@@ -131,10 +131,42 @@ This approach intercepts search operations and dynamically generates resources o
 
 #### Flow
 1. **Search Interception**: When searching for DocumentReference or DiagnosticReport:
-   - Execute the original search query
-   - Execute a parallel search for the other resource type with attachment URLs
-   - Transform found resources of the other type into the requested type
-   - Merge results and return unified response
+   - When a search query comes in, it will be analyzed for any DiagnosticReport or DocumentReference resource type to be included in the results.  If only one of those types is being queried, the other type will be added
+    - When the other type is added it will be added with the same search criteria, and in addition, if not already present the new type will also have two more search criteria
+      - Must have a patient reference
+      - Must have a reference to a url
+    - Once the search results come back, the resources in the results will be examined.  Any items in the result set which are of the "other" type will be removed from the search results, and replaced with a dynamically generated resource of the primary type.
+      - This dynamically generated resource will not have an ID
+      - This dynamically generated resource will have a source property populated with a link to resource that was used to generate it.
+
+#### Example:
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant FHIR_Service
+    participant Storage
+
+    Note over Client,Storage: Search Interception Flow for DocumentReference Query
+
+    Client->>FHIR_Service: GET DocumentReference?patient=123
+    
+    Note over FHIR_Service: Analyze search query
+    Note over FHIR_Service: Rewrite query to include both DocumentReference<br/>and DiagnosticReport with patient reference<br/>and url constraints
+    
+    FHIR_Service->>Storage: Query (DocumentReference?patient=123) OR<br/>(DiagnosticReport?patient=123&presentedForm.url:exists=true)
+    Storage-->>FHIR_Service: Combined result set with both resource types
+    
+    loop For each DiagnosticReport in results
+        Note over FHIR_Service: Remove DiagnosticReport from result set
+        Note over FHIR_Service: Generate DocumentReference from DiagnosticReport
+        Note over FHIR_Service: Add generated DocumentReference to result set
+    end
+    
+    Note over FHIR_Service: Apply paging and count limits to final result set
+    
+    FHIR_Service-->>Client: Bundle with DocumentReference resources<br/>(original + generated from DiagnosticReport)
+```
 
 2. **Resource Operations**: Normal create/update/delete operations (no special logic)
 
@@ -175,6 +207,39 @@ Generated resources need clear identification:
 - Handle cases where resource generation fails
 - Graceful degradation when duplication is temporarily unavailable
 - Logging and monitoring for duplication-related issues
+
+### Testing Considerations
+
+#### Paging Scenarios
+The search interception approach requires careful testing of pagination scenarios to ensure correct behavior across multiple pages:
+
+1. **Basic Paging**:
+   - Test with `_count` parameter to limit results per page
+   - Verify `Bundle.total` reflects the correct count after resource transformation
+   - Ensure `Bundle.link` navigation URLs work correctly for next/previous pages
+
+2. **Cross-Page Resource Distribution**:
+   - Test scenarios where DiagnosticReport resources span multiple pages
+   - Verify generated DocumentReference resources appear in correct pages
+   - Test edge cases where transformation changes the total page count
+
+3. **Mixed Resource Types**:
+   - Test pages containing both original DocumentReference and DiagnosticReport resources
+   - Verify transformation maintains proper sort order across pages
+   - Test scenarios where all resources on a page are transformed
+
+4. **Large Result Sets**:
+   - Test performance with large numbers of resources requiring transformation
+   - Verify memory usage remains acceptable during bulk transformations
+   - Test timeout scenarios for large result sets
+
+#### Test Cases
+- **Empty Results**: Search returning no resources of either type
+- **Single Type Results**: Search returning only DocumentReference or only DiagnosticReport
+- **Mixed Results**: Search returning both resource types in various combinations
+- **Boundary Conditions**: First page, last page, single-item pages
+- **Error Scenarios**: Transformation failures, storage errors during cross-type queries
+- **Configuration Testing**: Feature enabled/disabled states
 
 ## Monitoring
 - Metric for everytime a "duplicate" is created/updated


### PR DESCRIPTION
## Description
Add architectural notes/design doc for duplicated clinical notes feature.

## Related issues
Addresses [issue [AB#158013](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/158013)].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
