### PR TITLE
Index all token values, regardless of casing

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/TokenSearchValue.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/TokenSearchValue.cs
@@ -107,9 +107,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.SearchValues
                 return false;
             }
 
-            return string.Equals(System, tokenSearchValueOther.System, StringComparison.OrdinalIgnoreCase) &&
-                string.Equals(Code, tokenSearchValueOther.Code, StringComparison.OrdinalIgnoreCase) &&
-                string.Equals(Text, tokenSearchValueOther.Text, StringComparison.OrdinalIgnoreCase);
+            return string.Equals(System, tokenSearchValueOther.System, StringComparison.Ordinal) &&
+                string.Equals(Code, tokenSearchValueOther.Code, StringComparison.Ordinal) &&
+                string.Equals(Text, tokenSearchValueOther.Text, StringComparison.Ordinal);
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/TokenSearchValue.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchValues/TokenSearchValue.cs
@@ -107,6 +107,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.SearchValues
                 return false;
             }
 
+            // Using case sensitive comparison to match DB colation.
+            // This allows the indexing of token values that only differ by case.
+            // As the token search is case sensitive this is needed to ensure tokens can be searched by all included values.
             return string.Equals(System, tokenSearchValueOther.System, StringComparison.Ordinal) &&
                 string.Equals(Code, tokenSearchValueOther.Code, StringComparison.Ordinal) &&
                 string.Equals(Text, tokenSearchValueOther.Text, StringComparison.Ordinal);
@@ -126,9 +129,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.SearchValues
         public override int GetHashCode()
         {
             return HashCode.Combine(
-                System != null ? System.GetHashCode(StringComparison.OrdinalIgnoreCase) : 0,
-                Code != null ? Code.GetHashCode(StringComparison.OrdinalIgnoreCase) : 0,
-                Text != null ? Text.GetHashCode(StringComparison.OrdinalIgnoreCase) : 0);
+                System != null ? System.GetHashCode(StringComparison.Ordinal) : 0,
+                Code != null ? Code.GetHashCode(StringComparison.Ordinal) : 0,
+                Text != null ? Text.GetHashCode(StringComparison.Ordinal) : 0);
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/TokenSearchTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/TokenSearchTestFixture.cs
@@ -63,6 +63,13 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                     {
                         new CodeableConcept("system", "test"),
                     };
+                },
+                o =>
+                {
+                    SetObservation(o, cc => { });
+                    o.Identifier = new List<Identifier>();
+                    o.Identifier.Add(new Identifier("test", "VALUE"));
+                    o.Identifier.Add(new Identifier("test", "value"));
                 });
 
             void SetObservation(Observation observation, Action<CodeableConcept> codeableConceptCustomizer)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/TokenSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/TokenSearchTests.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Linq;
+using System.Threading.Tasks;
 using Hl7.Fhir.Model;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
@@ -122,6 +123,18 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             Bundle bundle = await Client.SearchAsync($"?_tag={Fixture.Tag}&_type={ResourceType.Observation}&value-concept:not={queryValue}");
 
             Observation[] expected = Fixture.Observations.Where((_, i) => !excludeIndices.Contains(i)).ToArray();
+
+            ValidateBundle(bundle, expected);
+        }
+
+        [Theory]
+        [InlineData("VALUE")]
+        [InlineData("value")]
+        public async Task GivenATokenSearchParameterWithTwoValuesThatOnlyDifferInCase_WhenSearchedByEitherValue_ThenTheResourceWillBeReturned(string queryValue)
+        {
+            Bundle bundle = await Client.SearchAsync(ResourceType.Observation, $"_tag={Fixture.Tag}&identifier={queryValue}");
+
+            Observation[] expected = Fixture.Observations.Where((_, i) => _.Identifier.Any((id) => id.Value == queryValue)).ToArray();
 
             ValidateBundle(bundle, expected);
         }


### PR DESCRIPTION
## Description
If token search field has an array of values and two or more of those values differ only in casing, then only the first value in the array will be stored as a searchable parameter. This change fixes that so that all the values in the array are stored and searchable, regardless of casing.

## Related issues
Addresses [Bug 160947](https://microsofthealth.visualstudio.com/Health/_workitems/edit/160947)

## Testing
A new test was added to cover this scenario.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch
