### PR TITLE
Fix not referenced search

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SearchParameterQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SearchParameterQueryGenerator.cs
@@ -136,7 +136,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             var referenceTargetTableAlias = context.TableAlias + ".";
             var referenceSourceTableAlias = "refSource";
 
-            context.StringBuilder.AppendLine("NOT EXISTS").AppendLine("(");
+            context.StringBuilder.AppendLine($"{referenceTargetTableAlias}{VLatest.Resource.IsHistory} = 0");
+            context.StringBuilder.AppendLine($"AND {referenceTargetTableAlias}{VLatest.Resource.IsDeleted} = 0");
+            context.StringBuilder.AppendLine("AND NOT EXISTS").AppendLine("(");
             using (context.StringBuilder.Indent())
             {
                 context.StringBuilder.AppendLine($"SELECT {VLatest.ReferenceSearchParam.ReferenceResourceId}");
@@ -145,10 +147,10 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                 using (var nestedDelimited = context.StringBuilder.BeginDelimitedWhereClause())
                 {
                     nestedDelimited.BeginDelimitedElement();
-                    context.StringBuilder.AppendLine($"{referenceSourceTableAlias}.{VLatest.ReferenceSearchParam.ReferenceResourceId} = {referenceTargetTableAlias}{VLatest.Resource.ResourceId}");
+                    context.StringBuilder.Append($"{referenceSourceTableAlias}.{VLatest.ReferenceSearchParam.ReferenceResourceId} = {referenceTargetTableAlias}{VLatest.Resource.ResourceId}");
 
                     nestedDelimited.BeginDelimitedElement();
-                    context.StringBuilder.AppendLine($"{referenceSourceTableAlias}.{VLatest.ReferenceSearchParam.ReferenceResourceTypeId} = {referenceTargetTableAlias}{VLatest.Resource.ResourceTypeId}");
+                    context.StringBuilder.Append($"{referenceSourceTableAlias}.{VLatest.ReferenceSearchParam.ReferenceResourceTypeId} = {referenceTargetTableAlias}{VLatest.Resource.ResourceTypeId}");
                 }
             }
 


### PR DESCRIPTION
## Description
Not referenced search is counting soft deleted resources when using `_summary=count` and is not returning correct results when soft deleted resources are present in the database. This is because deleted resources were not being filtered from the search.

## Related issues
Addresses [Bug 164809](https://microsofthealth.visualstudio.com/Health/_workitems/edit/164809)

## Testing
Manual testing

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch
