### PR TITLE
Handle version 0 on racing conditions

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -511,9 +511,13 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                         if (matchedOnLastUpdated.TryGetValue(input.ResourceWrapper.ToResourceDateKey(_model.GetResourceTypeId, ignoreVersion: true), out var existing))
                         {
                             if (((input.KeepVersion && input.ResourceWrapper.Version == existing.Matched.Version) || !input.KeepVersion)
-                                && existing.Matched.RawResource != null // TODO: Remove this line after version 82 deployment
                                 && ExistingRawResourceIsEqualToInput(input.ResourceWrapper.RawResource, existing.Matched.RawResource, false))
                             {
+                                if (!input.KeepVersion)
+                                {
+                                    input.ResourceWrapper.Version = existing.Matched.Version;
+                                }
+
                                 loaded.Add(input);
                             }
                             else
@@ -660,6 +664,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                         {
                             if (ExistingRawResourceIsEqualToInput(input.ResourceWrapper.RawResource, existing.Matched.RawResource, false))
                             {
+                                input.ResourceWrapper.Version = existing.Matched.Version;
                                 loaded.Add(input);
                             }
                             else

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -513,11 +513,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                             if (((input.KeepVersion && input.ResourceWrapper.Version == existing.Matched.Version) || !input.KeepVersion)
                                 && ExistingRawResourceIsEqualToInput(input.ResourceWrapper.RawResource, existing.Matched.RawResource, false))
                             {
-                                if (!input.KeepVersion)
-                                {
-                                    input.ResourceWrapper.Version = existing.Matched.Version;
-                                }
-
                                 loaded.Add(input);
                             }
                             else
@@ -664,7 +659,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                         {
                             if (ExistingRawResourceIsEqualToInput(input.ResourceWrapper.RawResource, existing.Matched.RawResource, false))
                             {
-                                input.ResourceWrapper.Version = existing.Matched.Version;
                                 loaded.Add(input);
                             }
                             else

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -616,7 +616,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                             && ((inDb.Resource.LastModified > input.Resource.ResourceWrapper.LastModified && inDb.IntVersion < input.IntVersion)
                                 || (inDb.Resource.LastModified < input.Resource.ResourceWrapper.LastModified && inDb.IntVersion > input.IntVersion)))
                         {
-                                conflicts.Add(input.Resource); // version and last updated are not aligned
+                            conflicts.Add(input.Resource); // version and last updated are not aligned
                         }
                         else
                         {
@@ -655,13 +655,14 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                         var resourceKey = input.ResourceWrapper.ToResourceDateKey(_model.GetResourceTypeId, true);
                         versionSlots.TryGetValue(resourceKey, out var versionSlotKey);
                         input.KeepVersion = true;
-                        if (int.Parse(versionSlotKey.Key.VersionId) > 0)
+                        var versionSlotValue = int.Parse(versionSlotKey.Key.VersionId);
+                        if (versionSlotValue > 0)
                         {
                             input.ResourceWrapper.Version = versionSlotKey.Key.VersionId;
                         }
                         else
                         {
-                            if (allowNegativeVersions)
+                            if (allowNegativeVersions && versionSlotValue < 0)
                             {
                                 input.ResourceWrapper.Version = versionSlotKey.Key.VersionId;
                             }


### PR DESCRIPTION
## Description
When importing a large amount of data with the same last updated time an error can happen when two versions are created with version 0. This causes a key conflict when the resources are sent to the merge method.
The root of this is a check where if a resource is made at the same time as an existing version of the same resource it is given version 0. This should be marked as a conflict, but instead it is added to the list of resources to add if allowNegativeVersions is set. If two versions of the same resource with the same last updated are processed in the same subjob then the key conflict can happen.

## Related issues
Addresses [Bug 165395](https://microsofthealth.visualstudio.com/Health/_workitems/edit/165395)

## Testing
Manual

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch