### PR TITLE
Removing throws from ValidateParams to make it more permissive

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ReindexControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ReindexControllerTests.cs
@@ -97,10 +97,18 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
 
         [Theory]
         [MemberData(nameof(InvalidBody), MemberType = typeof(ReindexControllerTests))]
-        public async Task GivenACreateReindexRequest_WhenInvalidBodySent_ThenRequestNotValidThrown(Parameters body)
+        public async Task GivenACreateReindexRequest_WhenInvalidBodySent_ThenJobIsCreatedSuccessfully(Parameters body)
         {
             _reindexEnabledController.ControllerContext.HttpContext.Request.Method = HttpMethods.Post;
-            await Assert.ThrowsAsync<RequestNotValidException>(() => _reindexEnabledController.CreateReindexJob(body));
+            _mediator.Send(Arg.Any<CreateReindexRequest>()).Returns(Task.FromResult(GetCreateReindexResponse()));
+
+            // Should NOT throw an exception - invalid parameters are now logged but don't cause failures
+            var result = await _reindexEnabledController.CreateReindexJob(body);
+
+            // Verify that the job was created successfully despite invalid parameters
+            Assert.NotNull(result);
+            var fhirResult = Assert.IsType<FhirResult>(result);
+            Assert.NotNull(fhirResult.Result);
         }
 
         [Theory]

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ReindexController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ReindexController.cs
@@ -167,11 +167,12 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             if (inputParams == null)
             {
                 _logger.LogInformation("Failed to deserialize reindex job request body as Parameters resource.");
+                return;
             }
 
             var supportedParams = _supportedParams[Request.Method];
 
-            foreach (var param in inputParams?.Parameter)
+            foreach (var param in inputParams.Parameter)
             {
                 var paramName = param.Name;
                 _logger.LogInformation(string.Format("Reindex job received parameter {0} for method {1}", paramName, Request.Method));

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ReindexController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ReindexController.cs
@@ -167,17 +167,18 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             if (inputParams == null)
             {
                 _logger.LogInformation("Failed to deserialize reindex job request body as Parameters resource.");
-                throw new RequestNotValidException(Resources.ReindexParametersNotValid);
             }
 
             var supportedParams = _supportedParams[Request.Method];
 
-            foreach (var param in inputParams.Parameter)
+            foreach (var param in inputParams?.Parameter)
             {
                 var paramName = param.Name;
+                _logger.LogInformation(string.Format("Reindex job received parameter {0} for method {1}", paramName, Request.Method));
+
                 if (!supportedParams.Contains(paramName))
                 {
-                    throw new RequestNotValidException(string.Format(Resources.ReindexParameterNotValid, paramName, Request.Method));
+                    _logger.LogInformation(string.Format(Resources.ReindexParameterNotValid, paramName, Request.Method));
                 }
             }
         }


### PR DESCRIPTION
Removing throws from ValidateParams to make it more permissive and prevent breaking change to request parameters

## Description
This PR updates the ValidateParams method in ReindexController to no longer throw an error if the parameters are not valid. This will ensure anyone using no longer supported parameters are impacted. 

## Related issues
Addresses AB#166315

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
