### PR TITLE
Emit protocol in bundle metric notification

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Resources/Bundle/BundleMetricsNotification.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Resources/Bundle/BundleMetricsNotification.cs
@@ -11,11 +11,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Bundle
 {
     public class BundleMetricsNotification : IMetricsNotification
     {
-        public BundleMetricsNotification(IDictionary<string, List<BundleSubCallMetricData>> apiCallResults, string bundleType)
+        public BundleMetricsNotification(IDictionary<string, List<BundleSubCallMetricData>> apiCallResults, string bundleType, string protocol = null)
         {
             FhirOperation = bundleType;
             ResourceType = KnownResourceTypes.Bundle;
             ApiCallResults = apiCallResults;
+            Protocol = protocol;
         }
 
         public string FhirOperation { get; }
@@ -23,5 +24,10 @@ namespace Microsoft.Health.Fhir.Core.Features.Resources.Bundle
         public string ResourceType { get; }
 
         public IDictionary<string, List<BundleSubCallMetricData>> ApiCallResults { get; }
+
+        /// <summary>
+        /// The protocol used to call the FHIR server.
+        /// </summary>
+        public string Protocol { get; }
     }
 }

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerTests.cs
@@ -720,6 +720,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
             await _mediator.Received().Publish(Arg.Any<BundleMetricsNotification>(), Arg.Any<CancellationToken>());
 
             Assert.Equal(type == BundleType.Batch ? AuditEventSubType.Batch : AuditEventSubType.Transaction, notification.FhirOperation);
+            Assert.Equal("https", notification.Protocol); // Verify protocol is set correctly
 
             var results = notification.ApiCallResults;
 

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
@@ -434,7 +434,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                 });
             }
 
-            await _mediator.Publish(new BundleMetricsNotification(apiCallResults, bundleType == BundleType.Batch ? AuditEventSubType.Batch : AuditEventSubType.Transaction), CancellationToken.None);
+            await _mediator.Publish(new BundleMetricsNotification(apiCallResults, bundleType == BundleType.Batch ? AuditEventSubType.Batch : AuditEventSubType.Transaction, _outerHttpContext.Request.Scheme), CancellationToken.None);
         }
 
         private async Task ExecuteTransactionForAllRequestsAsync(Hl7.Fhir.Model.Bundle responseBundle, BundleProcessingLogic processingLogic, CancellationToken cancellationToken)


### PR DESCRIPTION
## Description
BundleMetricsNotification is updated to emit protocol which will be used to set the dimension for the shoebox metrics. All the individual subcalls within the bundle inherit the same protocol from the outer HTTP context:

## Related issues
Addresses https://microsofthealth.visualstudio.com/Health/_workitems/edit/165414

## Testing
Unit test

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
