### PR TITLE
Moved setting default byte-to-read value to orchestrator

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Operations/Import/ImportRequestExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Operations/Import/ImportRequestExtensions.cs
@@ -29,7 +29,6 @@ namespace Microsoft.Health.Fhir.Api.Features.Operations.Import
         public const string ProcessingJobBytesToReadParameterName = "processingJobBytesToRead";
         public const string ErrorContainerNameParameterName = "errorContainerName";
         public const string DefaultStorageDetailType = "azure-blob";
-        public const int ProcessingJobBytesToReadDefault = 1000 * 10000;
 
         public static Parameters ToParameters(this ImportRequest importRequest)
         {
@@ -194,8 +193,6 @@ namespace Microsoft.Health.Fhir.Api.Features.Operations.Import
                 importRequest.ErrorContainerName = errorContainerName;
             }
 
-            // set default
-            importRequest.ProcessingJobBytesToRead = ProcessingJobBytesToReadDefault;
             if (parameters.TryGetIntValue(ProcessingJobBytesToReadParameterName, out int bytesToRead))
             {
                 importRequest.ProcessingJobBytesToRead = bytesToRead;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTests.cs
@@ -319,6 +319,11 @@ EXECUTE dbo.MergeResourcesCommitTransaction @TransactionId
             request = CreateImportRequest((await ImportTestHelper.UploadFileAsync(ndJson, _fixture.StorageAccount)).location, ImportMode.IncrementalLoad);
             result = await ImportCheckAsync(request, null, 0, true);
             Assert.Single(result.Output);
+
+            //// 0 should be ovewritten by default in orchestrator job
+            request = CreateImportRequest((await ImportTestHelper.UploadFileAsync(ndJson, _fixture.StorageAccount)).location, ImportMode.IncrementalLoad, processingJobBytesToRead: 0);
+            result = await ImportCheckAsync(request, null, 0, true);
+            Assert.Single(result.Output);
         }
 
         [Fact]


### PR DESCRIPTION
This should allow old not completed imports to finish with new code.