### PR TITLE
Returning 400 on SearchParameter/$status without parameters.

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/SearchParameterControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/SearchParameterControllerTests.cs
@@ -148,6 +148,22 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
             await _mediator.Received(1).Send(Arg.Is<SearchParameterStateUpdateRequest>(x => x.SearchParameters.Any(sp => sp.Item1 == new Uri(DummyUrl) && sp.Item2 == SearchParameterStatus.Disabled)), default(CancellationToken));
         }
 
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task GivenAnInvalidSearchParameterStatusUpdateRequest_WhenParametersAreEmpty_ThenRequestNotValidExceptionShouldBeThrown(
+            bool emptyParameters)
+        {
+            var fhirRuntimeConfiguration = Substitute.For<IFhirRuntimeConfiguration>();
+            fhirRuntimeConfiguration.IsSelectiveSearchParameterSupported.Returns(true);
+            _coreFeaturesConfiguration.SupportsSelectableSearchParameters = true;
+
+            var controller = new SearchParameterController(_mediator, Options.Create(_coreFeaturesConfiguration), fhirRuntimeConfiguration);
+            var requestBody = emptyParameters ? new Parameters() : null;
+            var act = () => controller.UpdateSearchParametersStatus(requestBody, default(CancellationToken));
+            await Assert.ThrowsAsync<RequestNotValidException>(act);
+        }
+
         private Parameters CreateInvalidRequestBody()
         {
             Parameters parameters = new Parameters();

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/SearchParameterController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/SearchParameterController.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
@@ -129,6 +130,11 @@ namespace Microsoft.Health.Fhir.Api.Controllers
 
         private static SearchParameterStateUpdateRequest ParseUpdateRequestBody(Parameters inputParams)
         {
+            if (inputParams?.Parameter == null || !inputParams.Parameter.Any())
+            {
+                throw new RequestNotValidException(Core.Resources.SearchParameterRequestNotValid);
+            }
+
             List<Tuple<Uri, SearchParameterStatus>> paramsToUpdate = new List<Tuple<Uri, SearchParameterStatus>>();
 
             foreach (var parameter in inputParams.Parameter)


### PR DESCRIPTION
## Description
A fix for a null-reference exception from SearchParameterController. Returning 400 on SearchParameter/$status without parameters instead.

## Related issues
Addresses [issue #152588].

[Bug 152588](https://microsofthealth.visualstudio.com/Health/_workitems/edit/152588): Null reference from SearchParameterController.ParseUpdateRequestBody

## Testing
Tested the fix manually and also by adding some UTs.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
