### PR TITLE
Fixing an argument null exception from IncludeExpression.

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/ExpressionParser.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/ExpressionParser.cs
@@ -98,6 +98,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
                 throw new InvalidSearchOperationException(Core.Resources.IncludeCannotBeAgainstBase);
             }
 
+            if (isReversed && string.IsNullOrWhiteSpace(originalType))
+            {
+                throw new InvalidSearchOperationException(Core.Resources.RevIncludeMissingType);
+            }
+
             allowedResourceTypesByScope = allowedResourceTypesByScope?.ToList();
             if (allowedResourceTypesByScope != null && !allowedResourceTypesByScope.Contains(KnownResourceTypes.All))
             {

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/ExpressionParser.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Expressions/Parsers/ExpressionParser.cs
@@ -77,6 +77,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Expressions.Parsers
             if (valueSpan.Equals("*".AsSpan(), StringComparison.InvariantCultureIgnoreCase))
             {
                 wildCard = true;
+                originalType = isReversed ? "*" : originalType;
             }
             else if (TrySplit(SearchSplitChar, ref valueSpan, out ReadOnlySpan<char> type))
             {

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/Parsers/ExpressionParserTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/Parsers/ExpressionParserTests.cs
@@ -307,6 +307,17 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
             Assert.Throws<SearchParameterNotSupportedException>(() => _expressionParser.Parse(new[] { resourceType.ToString() }, invalidParameterName, "value"));
         }
 
+        [Theory]
+        [InlineData("*")]
+        [InlineData("  :*")]
+        public void GivenARevIncludeWithoutResourceType_WhenParsing_ThenExceptionShouldBeThrown(string includeValue)
+        {
+            ResourceType sourceResourceType = ResourceType.Patient;
+
+            // Parse the expression.
+            Assert.Throws<InvalidSearchOperationException>(() => _expressionParser.ParseInclude(new[] { sourceResourceType.ToString() }, includeValue, true, false, null));
+        }
+
         private SearchParameterInfo SetupSearchParameter(ResourceType resourceType, string paramName)
         {
             SearchParameterInfo searchParameter = new SearchParameter

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/Parsers/ExpressionParserTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/Parsers/ExpressionParserTests.cs
@@ -314,10 +314,15 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
         [InlineData("  :*", true, false)]
         [InlineData("*", false, true)]
         [InlineData("*:*", false, true)]
+        [InlineData(":*", false, true)]
+        [InlineData("  :*", false, true)]
         public void GivenAnIncludeOrRevInclude_WhenParsing_ThenExceptionShouldBeThrownOnInvalidResourceType(string includeValue, bool revinclude, bool success)
         {
             try
             {
+                // Note that there is an inconsistency in handling invalid parameters for _include and _revinclude. For example,
+                // "<spaces>:*" is accepted as a valid parameter for _include whereas it is rejected for _revinclude. A parameter like
+                // that should be rejected for both (although the change for _include shouldn't be made without notifying customers).
                 _expressionParser.ParseInclude(new[] { ResourceType.Patient.ToString() }, includeValue, revinclude, false, null);
                 Assert.True(success);
             }

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/Parsers/ExpressionParserTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/Expressions/Parsers/ExpressionParserTests.cs
@@ -308,14 +308,23 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search.Expressions.Parse
         }
 
         [Theory]
-        [InlineData("*")]
-        [InlineData("  :*")]
-        public void GivenARevIncludeWithoutResourceType_WhenParsing_ThenExceptionShouldBeThrown(string includeValue)
+        [InlineData("*", true, true)]
+        [InlineData("*:*", true, true)]
+        [InlineData(":*", true, false)]
+        [InlineData("  :*", true, false)]
+        [InlineData("*", false, true)]
+        [InlineData("*:*", false, true)]
+        public void GivenAnIncludeOrRevInclude_WhenParsing_ThenExceptionShouldBeThrownOnInvalidResourceType(string includeValue, bool revinclude, bool success)
         {
-            ResourceType sourceResourceType = ResourceType.Patient;
-
-            // Parse the expression.
-            Assert.Throws<InvalidSearchOperationException>(() => _expressionParser.ParseInclude(new[] { sourceResourceType.ToString() }, includeValue, true, false, null));
+            try
+            {
+                _expressionParser.ParseInclude(new[] { ResourceType.Patient.ToString() }, includeValue, revinclude, false, null);
+                Assert.True(success);
+            }
+            catch (InvalidSearchOperationException)
+            {
+                Assert.False(success);
+            }
         }
 
         private SearchParameterInfo SetupSearchParameter(ResourceType resourceType, string paramName)


### PR DESCRIPTION
## Description
Fixing an argument null exception from IncludeExpression. The issue occurs on _revinclude without any resource type provided. The fix will add "*" as a resource type on the wildcard case and reject a request on other cases (e.g. "_revinclude=<spaces>:*"). 

## Related issues
Addresses [issue #152589].

[Bug 152589](https://microsofthealth.visualstudio.com/Health/_workitems/edit/152589): IncludeExpression raises ArgumentNullException

## Testing
Tested it manually and also by adding some UTs.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
