### PR TITLE
P2V3 S4 2sec 4tasks no waits

### DIFF
--- a/build/ci-deploy.yml
+++ b/build/ci-deploy.yml
@@ -123,6 +123,7 @@ stages:
       imageTag: $(ImageTag)
       schemaAutomaticUpdatesEnabled: 'auto'
       sqlServerName: $(DeploymentEnvironmentName)
+      sqlComputeTier: 'Hyperscale'
       reindexEnabled: true
 
 - stage: deployR4
@@ -163,6 +164,7 @@ stages:
       imageTag: $(ImageTag)
       schemaAutomaticUpdatesEnabled: 'auto'
       sqlServerName: $(DeploymentEnvironmentName)
+      sqlComputeTier: 'Hyperscale'
       reindexEnabled: true
 
 - stage: deployR4B
@@ -201,6 +203,7 @@ stages:
       resourceGroup: $(DeploymentEnvironmentName)
       testEnvironmentUrl: $(TestApplicationResource)
       sqlServerName: $(DeploymentEnvironmentName)
+      sqlComputeTier: 'Hyperscale'
       imageTag: $(ImageTag)
       schemaAutomaticUpdatesEnabled: 'auto'
 
@@ -242,4 +245,5 @@ stages:
       imageTag: $(ImageTag)
       schemaAutomaticUpdatesEnabled: 'auto'
       sqlServerName: $(DeploymentEnvironmentName)
+      sqlComputeTier: 'Hyperscale'
       reindexEnabled: true

--- a/build/jobs/e2e-tests.yml
+++ b/build/jobs/e2e-tests.yml
@@ -88,7 +88,7 @@ steps:
     displayName: 'E2E ${{ parameters.version }} ${{parameters.appServiceType}}'
     inputs:
       command: test
-      arguments: '"$(Agent.TempDirectory)/E2ETests/**/*${{ parameters.version }}.Tests.E2E*.dll" --blame-hang-timeout 10m --filter "FullyQualifiedName~${{parameters.appServiceType}}&Category!=ExportLongRunning"'
+      arguments: '"$(Agent.TempDirectory)/E2ETests/**/*${{ parameters.version }}.Tests.E2E*.dll" --blame-hang-timeout 7m --filter "FullyQualifiedName~${{parameters.appServiceType}}&Category!=ExportLongRunning"'
       workingDirectory: "$(System.ArtifactsDirectory)"
       testRunTitle: '${{ parameters.version }} ${{parameters.appServiceType}}'
     env:

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -69,7 +69,7 @@ jobs:
         $templateParameters = @{
             fhirVersion = "${{ parameters.version }}"
             appServicePlanName = "${{ parameters.appServicePlanName }}"
-            appServicePlanSku = "B3"
+            appServicePlanSku = "P2V3"
             numberOfInstances = 2
             serviceName = $webAppName
             securityAuthenticationAuthority = "https://login.microsoftonline.com/$(tenant-id)"

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -63,7 +63,7 @@ jobs:
         $additionalProperties["SqlServer__DeleteAllDataOnStartup"] = "false"
         $additionalProperties["SqlServer__AllowDatabaseCreation"] = "true"
         $additionalProperties["CosmosDb__InitialDatabaseThroughput"] = 1500
-        $additionalProperties["TaskHosting__PollingFrequencyInSeconds"] = 1
+        $additionalProperties["TaskHosting__PollingFrequencyInSeconds"] = 4
         $additionalProperties["ASPNETCORE_FORWARDEDHEADERS_ENABLED"] = "true"
 
         $webAppName = "${{ parameters.webAppName }}".ToLower()
@@ -71,7 +71,7 @@ jobs:
         $templateParameters = @{
             fhirVersion = "${{ parameters.version }}"
             appServicePlanName = "${{ parameters.appServicePlanName }}"
-            appServicePlanSku = "P1V3"
+            appServicePlanSku = "P2V3"
             numberOfInstances = 2
             serviceName = $webAppName
             securityAuthenticationAuthority = "https://login.microsoftonline.com/$(tenant-id)"

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -63,7 +63,7 @@ jobs:
         $additionalProperties["SqlServer__DeleteAllDataOnStartup"] = "false"
         $additionalProperties["SqlServer__AllowDatabaseCreation"] = "true"
         $additionalProperties["CosmosDb__InitialDatabaseThroughput"] = 1500
-        $additionalProperties["TaskHosting__PollingFrequencyInSeconds"] = 4
+        $additionalProperties["TaskHosting__PollingFrequencyInSeconds"] = 2
         $additionalProperties["ASPNETCORE_FORWARDEDHEADERS_ENABLED"] = "true"
 
         $webAppName = "${{ parameters.webAppName }}".ToLower()

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -69,7 +69,7 @@ jobs:
         $templateParameters = @{
             fhirVersion = "${{ parameters.version }}"
             appServicePlanName = "${{ parameters.appServicePlanName }}"
-            appServicePlanSku = "P2V3"
+            appServicePlanSku = "P1V3"
             numberOfInstances = 2
             serviceName = $webAppName
             securityAuthenticationAuthority = "https://login.microsoftonline.com/$(tenant-id)"

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -63,7 +63,7 @@ jobs:
         $additionalProperties["SqlServer__DeleteAllDataOnStartup"] = "false"
         $additionalProperties["SqlServer__AllowDatabaseCreation"] = "true"
         $additionalProperties["CosmosDb__InitialDatabaseThroughput"] = 1500
-        $additionalProperties["TaskHosting__PollingFrequencyInSeconds"] = 2
+        $additionalProperties["TaskHosting__PollingFrequencyInSeconds"] = 1
         $additionalProperties["ASPNETCORE_FORWARDEDHEADERS_ENABLED"] = "true"
 
         $webAppName = "${{ parameters.webAppName }}".ToLower()

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -63,7 +63,7 @@ jobs:
         $additionalProperties["SqlServer__DeleteAllDataOnStartup"] = "false"
         $additionalProperties["SqlServer__AllowDatabaseCreation"] = "true"
         $additionalProperties["CosmosDb__InitialDatabaseThroughput"] = 1500
-        $additionalProperties["TaskHosting__PollingFrequencyInSeconds"] = 1
+        $additionalProperties["TaskHosting__PollingFrequencyInSeconds"] = 2
         $additionalProperties["ASPNETCORE_FORWARDEDHEADERS_ENABLED"] = "true"
 
         $webAppName = "${{ parameters.webAppName }}".ToLower()

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -25,6 +25,9 @@ parameters:
 - name: sqlServerName
   type: string
   default: ''
+- name: sqlComputeTier
+  type: string
+  default: 'Standard'
 - name: reindexEnabled
   type: boolean
   default: true
@@ -60,8 +63,7 @@ jobs:
         $additionalProperties["SqlServer__DeleteAllDataOnStartup"] = "false"
         $additionalProperties["SqlServer__AllowDatabaseCreation"] = "true"
         $additionalProperties["CosmosDb__InitialDatabaseThroughput"] = 1500
-        $additionalProperties["FhirServer__Operations__Import__PollingFrequencyInSeconds"] = 1
-        $additionalProperties["FhirServer__Operations__Export__PollingFrequencyInSeconds"] = 1
+        $additionalProperties["TaskHosting__PollingFrequencyInSeconds"] = 1
         $additionalProperties["ASPNETCORE_FORWARDEDHEADERS_ENABLED"] = "true"
 
         $webAppName = "${{ parameters.webAppName }}".ToLower()
@@ -91,6 +93,7 @@ jobs:
             $templateParameters["sqlServerName"] = "${{parameters.sqlServerName}}".ToLower()
             $templateParameters["sqlServerNewOrExisting"] = "existing"
             $templateParameters["sqlSchemaAutomaticUpdatesEnabled"] = "${{parameters.schemaAutomaticUpdatesEnabled}}"
+            $templateParameters["sqlDatabaseComputeTier"] = "${{parameters.sqlComputeTier}}"
         }
 
         $deploymentName = $webAppName

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -69,7 +69,7 @@ jobs:
         $templateParameters = @{
             fhirVersion = "${{ parameters.version }}"
             appServicePlanName = "${{ parameters.appServicePlanName }}"
-            appServicePlanSku = "P1V3"
+            appServicePlanSku = "P2V3"
             numberOfInstances = 2
             serviceName = $webAppName
             securityAuthenticationAuthority = "https://login.microsoftonline.com/$(tenant-id)"

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -71,7 +71,7 @@ jobs:
         $templateParameters = @{
             fhirVersion = "${{ parameters.version }}"
             appServicePlanName = "${{ parameters.appServicePlanName }}"
-            appServicePlanSku = "P2V3"
+            appServicePlanSku = "P1V3"
             numberOfInstances = 2
             serviceName = $webAppName
             securityAuthenticationAuthority = "https://login.microsoftonline.com/$(tenant-id)"
@@ -81,7 +81,7 @@ jobs:
             enableExport = $true
             enableConvertData = $true
             enableImport = $true
-            backgroundTaskCount = 5
+            backgroundTaskCount = 4
             enableReindex = if ("${{ parameters.reindexEnabled }}" -eq "true") { $true } else { $false }
             registryName = '$(azureContainerRegistry)'
             imageTag = '${{ parameters.imageTag }}'

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -209,6 +209,7 @@ stages:
       imageTag: $(ImageTag)
       schemaAutomaticUpdatesEnabled: 'auto'
       sqlServerName: $(DeploymentEnvironmentName)
+      sqlComputeTier: 'Standard'
       reindexEnabled: true
 
 - stage: deployR4
@@ -249,6 +250,7 @@ stages:
       imageTag: $(ImageTag)
       schemaAutomaticUpdatesEnabled: 'auto'
       sqlServerName: $(DeploymentEnvironmentName)
+      sqlComputeTier: 'Standard'
       reindexEnabled: true
 
 - stage: deployR4B
@@ -289,6 +291,7 @@ stages:
       imageTag: $(ImageTag)
       schemaAutomaticUpdatesEnabled: 'auto'
       sqlServerName: $(DeploymentEnvironmentName)
+      sqlComputeTier: 'Standard'
       reindexEnabled: true
 
 - stage: deployR5
@@ -329,6 +332,7 @@ stages:
       imageTag: $(ImageTag)
       schemaAutomaticUpdatesEnabled: 'auto'
       sqlServerName: $(DeploymentEnvironmentName)
+      sqlComputeTier: 'Standard'
       reindexEnabled: true
 
 - stage: testStu3

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -27,7 +27,6 @@
         "appServicePlanSku": {
             "type": "string",
             "allowedValues": [
-                "P1V3",
                 "P2V3",
                 "B3",
                 "S1",

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -27,6 +27,7 @@
         "appServicePlanSku": {
             "type": "string",
             "allowedValues": [
+                "P2V3",
                 "B3",
                 "S1",
                 "S2",

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -286,7 +286,7 @@
         "azureContainerRegistryUri": "[if(variables('isMAG'), '.azurecr.us', '.azurecr.io')]",
         "azureContainerRegistryName": "[concat(substring(replace(variables('serviceName'), '-', ''), 0, min(11, length(replace(variables('serviceName'), '-', '')))), uniquestring(resourceGroup().id, variables('serviceName')))]",
         "isSqlHyperscaleTier": "[equals(parameters('sqlDatabaseComputeTier'),'Hyperscale')]",
-        "sqlSkuCapacity": "[if(variables('isSqlHyperscaleTier'), 2, 50)]",
+        "sqlSkuCapacity": "[if(variables('isSqlHyperscaleTier'), 2, 200)]",
         "sqlSkuFamily": "[if(variables('isSqlHyperscaleTier'), 'Gen5', '')]",
         "sqlSkuName": "[if(variables('isSqlHyperscaleTier'), 'HS_Gen5', 'Standard')]",
         "sqlSkuTier": "[if(variables('isSqlHyperscaleTier'), 'Hyperscale', 'Standard')]",

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -27,6 +27,7 @@
         "appServicePlanSku": {
             "type": "string",
             "allowedValues": [
+                "P1V3",
                 "P2V3",
                 "B3",
                 "S1",

--- a/src/Microsoft.Health.Fhir.Shared.Client/FhirClient.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Client/FhirClient.cs
@@ -572,33 +572,23 @@ namespace Microsoft.Health.Fhir.Client
 
         public async Task<FhirResponse<Parameters>> WaitForReindexStatus(Uri reindexJobUri, params string[] desiredStatus)
         {
-            int checkReindexCount = 0;
-            int maxCount = 30;
-            var delay = TimeSpan.FromSeconds(10);
-            var sw = new Stopwatch();
+            const int maxSeconds = 300;
+            var sw = Stopwatch.StartNew();
             string currentStatus;
             FhirResponse<Parameters> reindexJobResult;
-            sw.Start();
-
             do
             {
-                if (checkReindexCount > 0)
-                {
-                    await Task.Delay(delay);
-                }
-
+                await Task.Delay(TimeSpan.FromSeconds(1));
                 reindexJobResult = await CheckJobAsync(reindexJobUri);
                 currentStatus = reindexJobResult.Resource.Parameter.FirstOrDefault(p => p.Name == ReindexParametersStatus)?.Value.ToString();
-                checkReindexCount++;
             }
-            while (!desiredStatus.Contains(currentStatus) && checkReindexCount < maxCount);
-
+            while (!desiredStatus.Contains(currentStatus) && sw.Elapsed.TotalSeconds < maxSeconds);
             sw.Stop();
 
-            if (checkReindexCount >= maxCount)
+            if (sw.Elapsed.TotalSeconds >= maxSeconds && !desiredStatus.Contains(currentStatus))
             {
 #pragma warning disable CA2201 // Do not raise reserved exception types. This is used in a test and has a specific message.
-                throw new Exception($"ReindexJob did not complete within {checkReindexCount} attempts and a duration of {sw.Elapsed.Duration()}. This may cause other tests using Reindex to fail.");
+                throw new Exception($"ReindexJob did not complete within {maxSeconds} seconds. This may cause other tests using Reindex to fail.");
 #pragma warning restore CA2201 // Do not raise reserved exception types
             }
 
@@ -607,31 +597,21 @@ namespace Microsoft.Health.Fhir.Client
 
         public async Task<FhirResponse<Parameters>> WaitForBulkJobStatus(string jobType, Uri bulkJobUri)
         {
-            int checkCount = 0;
-            int maxCount = 30;
-            var delay = TimeSpan.FromSeconds(10);
-            var sw = new Stopwatch();
+            const int maxSeconds = 300;
+            var sw = Stopwatch.StartNew();
             FhirResponse<Parameters> jobResult;
-            sw.Start();
-
             do
             {
-                if (checkCount > 0)
-                {
-                    await Task.Delay(delay);
-                }
-
+                await Task.Delay(TimeSpan.FromSeconds(1));
                 jobResult = await CheckJobAsync(bulkJobUri);
-                checkCount++;
             }
-            while (jobResult.Response.StatusCode == System.Net.HttpStatusCode.Accepted && checkCount < maxCount);
-
+            while (jobResult.Response.StatusCode == System.Net.HttpStatusCode.Accepted && sw.Elapsed.TotalSeconds < maxSeconds);
             sw.Stop();
 
-            if (checkCount >= maxCount)
+            if (sw.Elapsed.TotalSeconds >= maxSeconds && jobResult.Response.StatusCode == System.Net.HttpStatusCode.Accepted)
             {
 #pragma warning disable CA2201 // Do not raise reserved exception types. This is used in a test and has a specific message.
-                throw new Exception($"${jobType} at ${bulkJobUri} did not complete within {checkCount} attempts and a duration of {sw.Elapsed.Duration()}");
+                throw new Exception($"${jobType} at ${bulkJobUri} did not complete within {maxSeconds} seconds.");
 #pragma warning restore CA2201 // Do not raise reserved exception types
             }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BulkDeleteTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BulkDeleteTests.cs
@@ -243,8 +243,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             await _fhirClient.CreateAsync(observation);
 
-            await Task.Delay(5000); // Add delay to ensure resources are created before bulk delete
-
             using HttpRequestMessage request = GenerateBulkDeleteRequest(
                 tag,
                 "Observation/$bulk-delete",
@@ -307,8 +305,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             await _fhirClient.CreateAsync(observation);
 
-            await Task.Delay(5000); // Add delay to ensure resources are created before bulk delete
-
             using HttpRequestMessage request = GenerateBulkDeleteRequest(
                 tag,
                 "Patient/$bulk-delete",
@@ -350,8 +346,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             await _fhirClient.CreateAsync(observation);
 
-            await Task.Delay(5000); // Add delay to ensure resources are created before bulk delete
-
             using HttpRequestMessage request = GenerateBulkDeleteRequest(
                 tag,
                 "Observation/$bulk-delete",
@@ -378,8 +372,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             };
             var tag = Guid.NewGuid().ToString();
             await CreateGroupWithPatients(tag, 2000);
-
-            await Task.Delay(5000); // Add delay to ensure resources are created before bulk delete
 
             using HttpRequestMessage request = GenerateBulkDeleteRequest(
                 tag,
@@ -930,8 +922,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             await _fhirClient.CreateAsync(observation);
 
-            await Task.Delay(5000); // Add delay to ensure resources are created before bulk delete
-
             using HttpRequestMessage request = GenerateBulkDeleteRequest(
                 tag,
                 "Patient/$bulk-delete",
@@ -970,8 +960,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             {
                 await _fhirClient.CreateResourcesAsync(ModelInfoProvider.GetTypeForFhirType(key), (int)expectedResults[key], tag);
             }
-
-            await Task.Delay(2000); // Add delay to ensure resources are created before bulk delete
 
             using HttpRequestMessage request = GenerateBulkDeleteRequest(tag, path, queryParams);
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BulkDeleteTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BulkDeleteTests.cs
@@ -28,6 +28,7 @@ using Newtonsoft.Json;
 using Polly;
 using Xunit;
 using Xunit.Abstractions;
+using Xunit.Sdk;
 using static Hl7.Fhir.Model.Encounter;
 using Task = System.Threading.Tasks.Task;
 
@@ -110,6 +111,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             string tag = Guid.NewGuid().ToString();
             var resource = (await _fhirClient.CreateResourcesAsync<Patient>(1, tag)).FirstOrDefault();
 
+            await Task.Delay(2000); // Add delay to ensure resources are created before bulk delete
+
             using HttpRequestMessage request = GenerateBulkDeleteRequest(tag);
 
             using HttpResponseMessage response = await _httpClient.SendAsync(request);
@@ -136,6 +139,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             string tag = Guid.NewGuid().ToString();
             var resource = (await _fhirClient.CreateResourcesAsync<Patient>(1, tag)).FirstOrDefault();
+
+            await Task.Delay(2000); // Add delay to ensure resources are created before bulk delete
 
             using HttpRequestMessage request = GenerateBulkDeleteRequest(
                 tag,
@@ -169,6 +174,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             // Add a second version
             resource.Active = true;
             resource = await _fhirClient.UpdateAsync(resource);
+
+            await Task.Delay(2000); // Add delay to ensure resources are created before bulk delete
 
             using HttpRequestMessage request = GenerateBulkDeleteRequest(
                 tag,
@@ -1026,13 +1033,30 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
                 }
                 else if (parameter.Name == "ResourceDeletedCount")
                 {
+                    var exceptions = new List<EqualException>();
+                    var aggregateMessage = "Resource count mismatch.\r\n";
+
                     foreach (var part in parameter.Part)
                     {
                         var resourceName = part.Name;
                         var numberDeleted = (long)((Integer64)part.Value).Value;
 
-                        Assert.Equal(expectedResults[resourceName], numberDeleted);
+                        try
+                        {
+                            Assert.Equal(expectedResults[resourceName], numberDeleted);
+                        }
+                        catch (EqualException ex)
+                        {
+                            exceptions.Add(ex);
+                            aggregateMessage += $"{resourceName} amount didn't match. Deleted {numberDeleted}, expected {expectedResults[resourceName]}\r\n";
+                        }
+
                         resultsChecked++;
+                    }
+
+                    if (exceptions.Any())
+                    {
+                        throw new AggregateException(aggregateMessage, exceptions);
                     }
                 }
                 else

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTests.cs
@@ -552,7 +552,7 @@ EXECUTE dbo.MergeResourcesCommitTransaction @TransactionId
         public async Task GivenIncrementalLoad_LastUpdatedOnResourceCannotBeInTheFuture()
         {
             var id = Guid.NewGuid().ToString("N");
-            var ndJson = CreateTestPatient(id, DateTimeOffset.UtcNow.AddSeconds(20)); // set value higher than 10 seconds tolerance
+            var ndJson = CreateTestPatient(id, DateTimeOffset.UtcNow.AddSeconds(60)); // set value higher than 10 seconds tolerance
             var location = (await ImportTestHelper.UploadFileAsync(ndJson, _fixture.StorageAccount)).location;
             var request = CreateImportRequest(location, ImportMode.IncrementalLoad, false, true);
             var result = await ImportCheckAsync(request, null, 1);
@@ -1961,7 +1961,7 @@ EXECUTE dbo.MergeResourcesCommitTransaction @TransactionId
             Assert.NotEmpty(result.Output);
             if (errorCount != null && errorCount != 0)
             {
-                Assert.Equal(errorCount.Value, result.Error.First().Count);
+                Assert.Equal(errorCount.Value, result.Error.Count > 0 ? result.Error.First().Count : 0);
             }
             else
             {


### PR DESCRIPTION
1. B3 app compute is changed to premium P2V3. This speeds up compute >2x. 
2. Merged RB's PR that sets SQL DBs back to standard and provides true ability to adjust task polling interval.
3. Sets DBs to S4 (~2 v-cores).
4. Adjusts # of hosting tasks and polling interval
5. Increases future time diff to 60 secs on one import test to make it more reliable. 
6. Sets blame hang back to 7 mins
7. Reduces sleep time in waiting for background jobs status to 1 sec,
8. Removes waits in bulk delete tests.

Results:
1. SQL E2E tests execution time dropped from ~50 minutes to <24 minutes.
2. SQL site provision reduced by ~8 minutes.