### PR TITLE
Change bulk delete to use SQL clock for filter

### DIFF
--- a/build/ci-variables.yml
+++ b/build/ci-variables.yml
@@ -1,5 +1,5 @@
 variables:
-    ResourceGroupRegion: 'southcentralus'
+    ResourceGroupRegion: 'eastus2'
     # Due to deleting a keyvault with purge protection we must use a name other than msh-fhir-ci for 90 days after 5/20/2021.
     resourceGroupRoot: 'msh-fhir-ci4'
     appServicePlanName: '$(resourceGroupRoot)-linux'

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -209,7 +209,7 @@ stages:
       imageTag: $(ImageTag)
       schemaAutomaticUpdatesEnabled: 'auto'
       sqlServerName: $(DeploymentEnvironmentName)
-      sqlComputeTier: 'Standard'
+      sqlComputeTier: 'Hyperscale'
       reindexEnabled: true
 
 - stage: deployR4
@@ -250,7 +250,7 @@ stages:
       imageTag: $(ImageTag)
       schemaAutomaticUpdatesEnabled: 'auto'
       sqlServerName: $(DeploymentEnvironmentName)
-      sqlComputeTier: 'Standard'
+      sqlComputeTier: 'Hyperscale'
       reindexEnabled: true
 
 - stage: deployR4B
@@ -291,7 +291,7 @@ stages:
       imageTag: $(ImageTag)
       schemaAutomaticUpdatesEnabled: 'auto'
       sqlServerName: $(DeploymentEnvironmentName)
-      sqlComputeTier: 'Standard'
+      sqlComputeTier: 'Hyperscale'
       reindexEnabled: true
 
 - stage: deployR5
@@ -332,7 +332,7 @@ stages:
       imageTag: $(ImageTag)
       schemaAutomaticUpdatesEnabled: 'auto'
       sqlServerName: $(DeploymentEnvironmentName)
-      sqlComputeTier: 'Standard'
+      sqlComputeTier: 'Hyperscale'
       reindexEnabled: true
 
 - stage: testStu3

--- a/build/pr-variables.yml
+++ b/build/pr-variables.yml
@@ -1,5 +1,5 @@
 variables:
-    ResourceGroupRegion: 'eastus2'
+    ResourceGroupRegion: 'eastus'
     resourceGroupRoot: 'msh-fhir-pr'
     appServicePlanName: '$(resourceGroupRoot)-$(prName)-asp'    
     ResourceGroupName: '$(resourceGroupRoot)-$(prName)'

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -285,7 +285,7 @@
         "azureContainerRegistryUri": "[if(variables('isMAG'), '.azurecr.us', '.azurecr.io')]",
         "azureContainerRegistryName": "[concat(substring(replace(variables('serviceName'), '-', ''), 0, min(11, length(replace(variables('serviceName'), '-', '')))), uniquestring(resourceGroup().id, variables('serviceName')))]",
         "isSqlHyperscaleTier": "[equals(parameters('sqlDatabaseComputeTier'),'Hyperscale')]",
-        "sqlSkuCapacity": "[if(variables('isSqlHyperscaleTier'), 2, 200)]",
+        "sqlSkuCapacity": "[if(variables('isSqlHyperscaleTier'), 4, 200)]",
         "sqlSkuFamily": "[if(variables('isSqlHyperscaleTier'), 'Gen5', '')]",
         "sqlSkuName": "[if(variables('isSqlHyperscaleTier'), 'HS_Gen5', 'Standard')]",
         "sqlSkuTier": "[if(variables('isSqlHyperscaleTier'), 'Hyperscale', 'Standard')]",

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/BulkDelete/CreateBulkDeleteHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/BulkDelete/CreateBulkDeleteHandlerTests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.BulkDelete
                 Assert.Equal(_testUrl, definition.Url);
                 Assert.Equal(_testUrl, definition.BaseUrl);
                 Assert.Equal(DeleteOperation.HardDelete, definition.DeleteOperation);
-                Assert.Equal(searchParams.Count + 1, definition.SearchParameters.Count); // Adds the max time
+                Assert.Equal(searchParams.Count, definition.SearchParameters.Count);
 
                 return new List<JobInfo>()
                     {

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/BulkDelete/BulkDeleteDefinition.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/BulkDelete/BulkDeleteDefinition.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.BulkDelete
         public string Type { get; private set; }
 
         [JsonProperty(JobRecordProperties.SearchParameters)]
-        public IList<Tuple<string, string>> SearchParameters { get; private set; }
+        public IList<Tuple<string, string>> SearchParameters { get; set; }
 
         [JsonProperty(JobRecordProperties.ExcludedResourceTypes)]
         public IList<string> ExcludedResourceTypes { get; private set; }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BulkDeleteTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BulkDeleteTests.cs
@@ -243,8 +243,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             await _fhirClient.CreateAsync(observation);
 
-            await Task.Delay(5000); // Add delay to ensure resources are created before bulk delete
-
             using HttpRequestMessage request = GenerateBulkDeleteRequest(
                 tag,
                 "Observation/$bulk-delete",
@@ -307,8 +305,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             await _fhirClient.CreateAsync(observation);
 
-            await Task.Delay(5000); // Add delay to ensure resources are created before bulk delete
-
             using HttpRequestMessage request = GenerateBulkDeleteRequest(
                 tag,
                 "Patient/$bulk-delete",
@@ -350,8 +346,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             await _fhirClient.CreateAsync(observation);
 
-            await Task.Delay(5000); // Add delay to ensure resources are created before bulk delete
-
             using HttpRequestMessage request = GenerateBulkDeleteRequest(
                 tag,
                 "Observation/$bulk-delete",
@@ -378,8 +372,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             };
             var tag = Guid.NewGuid().ToString();
             await CreateGroupWithPatients(tag, 2000);
-
-            await Task.Delay(5000); // Add delay to ensure resources are created before bulk delete
 
             using HttpRequestMessage request = GenerateBulkDeleteRequest(
                 tag,
@@ -438,9 +430,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             };
             organization.Active = true;
             await _fhirClient.CreateAsync(organization);
-
-            // Wait to ensure resources are created before bulk delete
-            await Task.Delay(2000);
 
             // Create the request with Observation and Location as excluded resource types
             var request = new HttpRequestMessage
@@ -930,8 +919,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
             await _fhirClient.CreateAsync(observation);
 
-            await Task.Delay(5000); // Add delay to ensure resources are created before bulk delete
-
             using HttpRequestMessage request = GenerateBulkDeleteRequest(
                 tag,
                 "Patient/$bulk-delete",
@@ -970,8 +957,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             {
                 await _fhirClient.CreateResourcesAsync(ModelInfoProvider.GetTypeForFhirType(key), (int)expectedResults[key], tag);
             }
-
-            await Task.Delay(2000); // Add delay to ensure resources are created before bulk delete
 
             using HttpRequestMessage request = GenerateBulkDeleteRequest(tag, path, queryParams);
 


### PR DESCRIPTION
## Description
Use the create time from the bulk job instead of the handler to prevent acting on records created after the job was queued. This avoids issues where the clocks on the instance agents doesn't match the database's clock.

## Related issues
Addresses [User Story 168257](https://microsofthealth.visualstudio.com/Health/_workitems/edit/168257)

## Testing
Manual testing. This will also make E2E tests more reliable so we can remove waits.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
