### PR TITLE
Associate Nsp to the storage accounts in PR builds

### DIFF
--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -82,9 +82,11 @@ jobs:
             enableReindex = if ("${{ parameters.reindexEnabled }}" -eq "true") { $true } else { $false }
             registryName = '$(azureContainerRegistry)'
             imageTag = '${{ parameters.imageTag }}'
+            enableNetworkSecurityPerimeter = $true
             networkSecurityPerimeterName = "fhirbuildsnsp"
             networkSecurityPerimeterProfileName = "defaultProfile"
-            networkSecurityPerimeterResourceGroup = "nsp"
+            networkSecurityPerimeterResourceGroup = "NSP"
+            networkSecurityPerimeterSubscriptionId = "a1766500-6fd5-4f5c-8515-607798271014"
         }
      
         if("${{ parameters.sql }}" -eq "true"){

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -252,6 +252,20 @@
             "metadata": {
                 "description": "Name of the Network Security Perimeter profile to use for storage account association."
             }
+        },
+        "enableNetworkSecurityPerimeter": {
+            "type": "bool",
+            "defaultValue": true,
+            "metadata": {
+                "description": "Enable Network Security Perimeter association for storage accounts."
+            }
+        },
+        "networkSecurityPerimeterSubscriptionId": {
+            "type": "string",
+            "defaultValue": "[subscription().subscriptionId]",
+            "metadata": {
+                "description": "Subscription ID containing the Network Security Perimeter."
+            }
         }
     },
     "variables": {
@@ -691,7 +705,7 @@
                 "[resourceId('Microsoft.KeyVault/vaults', variables('serviceName'))]"
             ],
             "properties": {
-                "roleDefinitionId": "[concat(subscription().Id, '/providers/Microsoft.Authorization/roleDefinitions/', 'b86a8fe4-44ce-4948-aee5-eccb2c155cd7')]", // Role definition ID for "Key Vault Secrets Officer"
+                "roleDefinitionId": "[concat(subscription().Id, '/providers/Microsoft.Authorization/roleDefinitions/', 'b86a8fe4-44ce-4948-aee5-eccb2c155cd7')]", // Role definition ID for "Key Vault Secrets Officer",
                 "principalId": "89e25294-a480-4657-a77d-bf69c28a836c"
             }
         },
@@ -744,18 +758,21 @@
         {
             "type": "Microsoft.Network/networkSecurityPerimeters/resourceAssociations",
             "apiVersion": "2023-07-01-preview",
-            "name": "[concat(parameters('networkSecurityPerimeterName'), '/', uniqueString(variables('storageAccountName')))]",
-            "condition": "[variables('enableIntegrationStore')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
-            ],
+            "name": "[format('{0}/{1}', parameters('networkSecurityPerimeterName'), uniqueString(variables('storageAccountName')))]",
+            "condition": "[and(variables('enableIntegrationStore'), parameters('enableNetworkSecurityPerimeter'))]",
             "properties": {
-                "resourceId": "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
-                "resourceLocation": "[resourceGroup().location]",
+                "privateLinkResource": {
+                    "id": "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+                },
                 "profile": {
-                    "id": "[resourceId(subscription().subscriptionId, parameters('networkSecurityPerimeterResourceGroup'), 'Microsoft.Network/networkSecurityPerimeters/profiles', parameters('networkSecurityPerimeterName'), parameters('networkSecurityPerimeterProfileName'))]"
+                    "id": "[resourceId(parameters('networkSecurityPerimeterSubscriptionId'), parameters('networkSecurityPerimeterResourceGroup'), 'Microsoft.Network/networkSecurityPerimeters/profiles', parameters('networkSecurityPerimeterName'), parameters('networkSecurityPerimeterProfileName'))]"
                 }
-            }
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
+                "[resourceId(parameters('networkSecurityPerimeterSubscriptionId'), parameters('networkSecurityPerimeterResourceGroup'), 'Microsoft.Network/networkSecurityPerimeters', parameters('networkSecurityPerimeterName'))]",
+                "[resourceId(parameters('networkSecurityPerimeterSubscriptionId'), parameters('networkSecurityPerimeterResourceGroup'), 'Microsoft.Network/networkSecurityPerimeters/profiles', parameters('networkSecurityPerimeterName'), parameters('networkSecurityPerimeterProfileName'))]"
+            ]
         },
         {
             "type": "Microsoft.Storage/storageAccounts/providers/roleAssignments",


### PR DESCRIPTION
## Description
Associate Nsp to the storage accounts in PR builds

## Related issues
Addresses [168466](https://microsofthealth.visualstudio.com/Health/_workitems/edit/168466)

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
