### PR TITLE
Include ResourceSurrogateId in query hash for Async operations

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Search/SearchOptions.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/SearchOptions.cs
@@ -53,6 +53,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             ResourceVersionTypes = other.ResourceVersionTypes;
             IncludesContinuationToken = other.IncludesContinuationToken;
             IncludesOperationSupported = other.IncludesOperationSupported;
+            IsAsyncOperation = other.IsAsyncOperation;
         }
 
         /// <summary>

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/HashingSqlQueryParameterManagerTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/HashingSqlQueryParameterManagerTests.cs
@@ -36,9 +36,24 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
                 parameters.AddParameter(1, includeInHash: false);
                 parameters.AddParameter(VLatest.Resource.ResourceId, "abc", false);
                 parameters.AddParameter(VLatest.Resource.ResourceId, (object)"123", false);
+                parameters.AddParameter(VLatest.Resource.ResourceSurrogateId, 123, false);
             });
 
             Assert.False(parameters.HasParametersToHash);
+        }
+
+        [Fact]
+        public void GivenParameterThatShouldHashed_WhenAdded_ChangesHash()
+        {
+            using var command = new SqlCommand();
+            var parameters = new HashingSqlQueryParameterManager(new SqlQueryParameterManager(command.Parameters));
+
+            AssertChangesHash(parameters, () =>
+            {
+                parameters.AddParameter(VLatest.Resource.ResourceSurrogateId, 123, true);
+            });
+
+            Assert.True(parameters.HasParametersToHash);
         }
 
         [Theory]

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/HashingSqlQueryParameterManagerTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/HashingSqlQueryParameterManagerTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Search.Expressions
         }
 
         [Fact]
-        public void GivenParameterThatShouldHashed_WhenAdded_ChangesHash()
+        public void GivenParameterThatShouldBeHashed_WhenAdded_ChangesHash()
         {
             using var command = new SqlCommand();
             var parameters = new HashingSqlQueryParameterManager(new SqlQueryParameterManager(command.Parameters));

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/SqlQueryGeneratorTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Search/SqlQueryGeneratorTests.cs
@@ -51,6 +51,7 @@ public class SqlQueryGeneratorTests
             parameters,
             _fhirModel,
             _schemaInformation,
+            false,
             false);
     }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/ResourceSurrogateIdParameterQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/ResourceSurrogateIdParameterQueryGenerator.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
         public override SearchParameterQueryGeneratorContext VisitBinary(BinaryExpression expression, SearchParameterQueryGeneratorContext context)
         {
-            VisitSimpleBinary(expression.BinaryOperator, context, VLatest.Resource.ResourceSurrogateId, expression.ComponentIndex, expression.Value, includeInParameterHash: false);
+            VisitSimpleBinary(expression.BinaryOperator, context, VLatest.Resource.ResourceSurrogateId, expression.ComponentIndex, expression.Value, includeInParameterHash: context.IsAsyncOperation);
             return context;
         }
     }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SearchParameterQueryGeneratorContext.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SearchParameterQueryGeneratorContext.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 {
     internal readonly struct SearchParameterQueryGeneratorContext
     {
-        internal SearchParameterQueryGeneratorContext(IndentedStringBuilder stringBuilder, HashingSqlQueryParameterManager parameters, ISqlServerFhirModel model, SchemaInformation schemaInformation, string tableAlias = null)
+        internal SearchParameterQueryGeneratorContext(IndentedStringBuilder stringBuilder, HashingSqlQueryParameterManager parameters, ISqlServerFhirModel model, SchemaInformation schemaInformation, bool isAsyncOperation, string tableAlias = null)
         {
             EnsureArg.IsNotNull(stringBuilder, nameof(stringBuilder));
             EnsureArg.IsNotNull(parameters, nameof(parameters));
@@ -24,6 +24,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             Model = model;
             SchemaInformation = schemaInformation;
             TableAlias = tableAlias;
+            IsAsyncOperation = isAsyncOperation;
         }
 
         public IndentedStringBuilder StringBuilder { get; }
@@ -33,6 +34,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
         public ISqlServerFhirModel Model { get; }
 
         public SchemaInformation SchemaInformation { get; }
+
+        /// <summary>
+        /// Flag for async operations.
+        /// </summary>
+        public bool IsAsyncOperation { get; }
 
         public string TableAlias { get; }
     }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -53,6 +53,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
         private bool previousSqlQueryGeneratorFailure = false;
         private int maxTableExpressionCountLimitForExists = 5;
         private bool _reuseQueryPlans;
+        private bool _isAsyncOperation;
         private readonly HashSet<short> _searchParamIds = new();
 
         public SqlQueryGenerator(
@@ -61,6 +62,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             ISqlServerFhirModel model,
             SchemaInformation schemaInfo,
             bool reuseQueryPlans,
+            bool isAsyncOperation = false,
             SqlException sqlException = null)
         {
             EnsureArg.IsNotNull(sb, nameof(sb));
@@ -73,6 +75,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             Model = model;
             _schemaInfo = schemaInfo;
             _reuseQueryPlans = reuseQueryPlans;
+            _isAsyncOperation = isAsyncOperation;
 
             if (sqlException?.Number == SqlErrorCodes.QueryProcessorNoQueryPlan)
             {
@@ -1171,7 +1174,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
         private SearchParameterQueryGeneratorContext GetContext(string tableAlias = null)
         {
-            return new SearchParameterQueryGeneratorContext(StringBuilder, Parameters, Model, _schemaInfo, tableAlias);
+            return new SearchParameterQueryGeneratorContext(StringBuilder, Parameters, Model, _schemaInfo, isAsyncOperation: _isAsyncOperation, tableAlias);
         }
 
         private void AppendNewSetOfUnionAllTableExpressions(SearchOptions context, UnionExpression unionExpression, SearchParamTableExpressionQueryGenerator queryGenerator)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
             ISqlServerFhirModel model,
             SchemaInformation schemaInfo,
             bool reuseQueryPlans,
-            bool isAsyncOperation = false,
+            bool isAsyncOperation,
             SqlException sqlException = null)
         {
             EnsureArg.IsNotNull(sb, nameof(sb));

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/SqlServerSearchService.cs
@@ -388,6 +388,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
                                 _model,
                                 _schemaInformation,
                                 reuseQueryPlans,
+                                sqlSearchOptions.IsAsyncOperation,
                                 sqlException);
 
                             expression.AcceptVisitor(queryGenerator, clonedSearchOptions);
@@ -1347,6 +1348,7 @@ SELECT isnull(min(ResourceSurrogateId), 0), isnull(max(ResourceSurrogateId), 0),
                                 _model,
                                 _schemaInformation,
                                 _reuseQueryPlans.IsEnabled(_sqlRetryService),
+                                sqlSearchOptions.IsAsyncOperation,
                                 sqlException);
 
                             expression.AcceptVisitor(queryGenerator, clonedSearchOptions);


### PR DESCRIPTION
## Description
Include ResourceSurrogateId in query hash for Async operations

## Related issues
Addresses [AB167462](https://microsofthealth.visualstudio.com/Health/_workitems/edit/167462).

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
