### PR TITLE
[Import] Improving Import statistics to share ImportMode

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/ImportOrchestratorJob.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/ImportOrchestratorJob.cs
@@ -194,7 +194,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
             logger.LogJobInformation(
                 info,
                 "Import Statistics / ImportMode: {ImportMode} / SucceededResources: {SucceededResources} / FailedResources: {FailedResources}",
-                importMode.ToString(),
+                importMode == ImportMode.IncrementalLoad ? ImportMode.IncrementalLoad.ToString() : ImportMode.InitialLoad.ToString(),
                 succeeded,
                 failed);
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/ImportOrchestratorJob.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/ImportOrchestratorJob.cs
@@ -189,7 +189,14 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
 
         internal static async Task SendNotification<T>(JobStatus status, JobInfo info, long succeeded, long failed, long bytes, ImportMode importMode, FhirRequestContext context, ILogger<T> logger, IAuditLogger auditLogger, IMediator mediator)
         {
-            logger.LogJobInformation(info, "SucceededResources {SucceededResources} and FailedResources {FailedResources} in Import", succeeded, failed);
+            // This statement is used as part of telemetry to indicate how many resources were processed as part of the import job.
+            // Please do not remove without checking with the FHIR team.
+            logger.LogJobInformation(
+                info,
+                "Import Statistics / ImportMode: {ImportMode} / SucceededResources: {SucceededResources} / FailedResources: {FailedResources}",
+                importMode.ToString(),
+                succeeded,
+                failed);
 
             if (importMode == ImportMode.IncrementalLoad)
             {


### PR DESCRIPTION
Adding ImportMode as part of Import Statistics. 

## Related issues
Addresses [AB#170321](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/170321). 

- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
