### PR TITLE
[Bundle] Handling transaction cancellation

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Bundle/BaseFhirTransactionException.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Bundle/BaseFhirTransactionException.cs
@@ -1,0 +1,42 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net;
+using Microsoft.Health.Fhir.Core.Exceptions;
+using Microsoft.Health.Fhir.Core.Models;
+
+namespace Microsoft.Health.Fhir.Api.Features.Bundle
+{
+    public abstract class BaseFhirTransactionException : FhirException
+    {
+        protected BaseFhirTransactionException(
+            string message,
+            HttpStatusCode httpStatusCode,
+            IReadOnlyList<OperationOutcomeIssue> operationOutcomeIssues = null)
+            : base(message)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(message), "Exception message should not be empty");
+
+            ResponseStatusCode = httpStatusCode;
+
+            Issues.Add(new OperationOutcomeIssue(
+                OperationOutcomeConstants.IssueSeverity.Error,
+                OperationOutcomeConstants.IssueType.Processing,
+                message));
+
+            if (operationOutcomeIssues != null)
+            {
+                foreach (var issue in operationOutcomeIssues)
+                {
+                    Issues.Add(issue);
+                }
+            }
+        }
+
+        public HttpStatusCode ResponseStatusCode { get; }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Api/Features/Bundle/BaseFhirTransactionException.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Bundle/BaseFhirTransactionException.cs
@@ -4,8 +4,8 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Net;
+using EnsureThat;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Models;
 
@@ -19,7 +19,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Bundle
             IReadOnlyList<OperationOutcomeIssue> operationOutcomeIssues = null)
             : base(message)
         {
-            Debug.Assert(!string.IsNullOrEmpty(message), "Exception message should not be empty");
+            EnsureArg.IsNotNullOrWhiteSpace(message, nameof(message));
 
             ResponseStatusCode = httpStatusCode;
 

--- a/src/Microsoft.Health.Fhir.Api/Features/Bundle/FhirTransactionCancelledException.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Bundle/FhirTransactionCancelledException.cs
@@ -9,28 +9,22 @@ using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Api.Features.Bundle
 {
-    public sealed class FhirTransactionFailedException : BaseFhirTransactionException
+    public sealed class FhirTransactionCancelledException : BaseFhirTransactionException
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="FhirTransactionFailedException"/> class.
+        /// Initializes a new instance of the <see cref="FhirTransactionCancelledException"/> class.
         /// Exception related to the processing of a FHIR transaction bundle.
         /// </summary>
         /// <param name="message">The exception message.</param>
-        /// <param name="httpStatusCode">The status code to report to the user.</param>
         /// <param name="operationOutcomeIssues">A list of issues to include in the operation outcome.</param>
-        public FhirTransactionFailedException(
+        public FhirTransactionCancelledException(
             string message,
-            HttpStatusCode httpStatusCode,
             IReadOnlyList<OperationOutcomeIssue> operationOutcomeIssues = null)
-            : base(message, httpStatusCode, operationOutcomeIssues)
+            : base(
+                message,
+                HttpStatusCode.RequestTimeout, // Use 408 Request Timeout to indicate that the client has cancelled.
+                operationOutcomeIssues)
         {
-        }
-
-        public bool IsErrorCausedDueClientFailure()
-        {
-            // A client error is defined as a 4xx status code.
-            // It can be caused by a malformed request, invalid data, precondition failures, etc.
-            return ResponseStatusCode >= HttpStatusCode.BadRequest && ResponseStatusCode < HttpStatusCode.InternalServerError;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.Api/Features/Bundle/FhirTransactionFailedException.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Bundle/FhirTransactionFailedException.cs
@@ -20,12 +20,15 @@ namespace Microsoft.Health.Fhir.Api.Features.Bundle
         /// <param name="message">The exception message.</param>
         /// <param name="httpStatusCode">The status code to report to the user.</param>
         /// <param name="operationOutcomeIssues">A list of issues to include in the operation outcome.</param>
-        public FhirTransactionFailedException(string message, HttpStatusCode httpStatusCode, IReadOnlyList<OperationOutcomeIssue> operationOutcomeIssues = null)
+        /// <param name="cancelled">Indicates if the operation was externally cancelled or not.</param>
+        public FhirTransactionFailedException(string message, HttpStatusCode httpStatusCode, IReadOnlyList<OperationOutcomeIssue> operationOutcomeIssues = null, bool cancelled = false)
             : base(message)
         {
             Debug.Assert(!string.IsNullOrEmpty(message), "Exception message should not be empty");
 
             ResponseStatusCode = httpStatusCode;
+
+            IsCancelled = cancelled;
 
             Issues.Add(new OperationOutcomeIssue(
                 OperationOutcomeConstants.IssueSeverity.Error,
@@ -42,6 +45,8 @@ namespace Microsoft.Health.Fhir.Api.Features.Bundle
         }
 
         public HttpStatusCode ResponseStatusCode { get; }
+
+        public bool IsCancelled { get; }
 
         public bool IsErrorCausedDueClientFailure()
         {

--- a/src/Microsoft.Health.Fhir.Core/Configs/BundleConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/BundleConfiguration.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Health.Fhir.Core.Configs
     {
         public int EntryLimit { get; set; } = 500;
 
+        public int MaxTransactionExecutionTimeInSeconds { get; set; } = 100;
+
         /// <summary>
         /// Gets or sets a value indicating whether bundle orchestrator is enabled or not.
         /// </summary>

--- a/src/Microsoft.Health.Fhir.Core/Configs/BundleConfiguration.cs
+++ b/src/Microsoft.Health.Fhir.Core/Configs/BundleConfiguration.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Health.Fhir.Core.Configs
     {
         public int EntryLimit { get; set; } = 500;
 
-        public int MaxTransactionExecutionTimeInSeconds { get; set; } = 100;
+        public int MaxExecutionTimeInSeconds { get; set; } = 100;
 
         /// <summary>
         /// Gets or sets a value indicating whether bundle orchestrator is enabled or not.

--- a/src/Microsoft.Health.Fhir.Core/Features/Persistence/Orchestration/BundleOrchestrator.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Persistence/Orchestration/BundleOrchestrator.cs
@@ -22,6 +22,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence.Orchestration
 
         private readonly ILogger<BundleOrchestrator> _logger;
 
+        private readonly int _maxExecutionTimeInSeconds;
+
         /// <summary>
         /// Creates a new instance of <see cref="BundleOrchestrator"/>.
         /// </summary>
@@ -33,6 +35,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence.Orchestration
             EnsureArg.IsNotNull(logger, nameof(logger));
 
             IsEnabled = bundleConfiguration.Value.SupportsBundleOrchestrator;
+            _maxExecutionTimeInSeconds = bundleConfiguration.Value.MaxExecutionTimeInSeconds;
 
             _logger = logger;
             _operationsById = new ConcurrentDictionary<Guid, IBundleOrchestratorOperation>();
@@ -45,7 +48,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence.Orchestration
             EnsureArg.IsNotNullOrWhiteSpace(label, nameof(label));
             EnsureArg.IsGt(expectedNumberOfResources, 0, nameof(expectedNumberOfResources));
 
-            BundleOrchestratorOperation newOperation = new BundleOrchestratorOperation(type, label, expectedNumberOfResources, _logger);
+            BundleOrchestratorOperation newOperation = new BundleOrchestratorOperation(type, label, expectedNumberOfResources, _logger, maxExecutionTimeInSeconds: _maxExecutionTimeInSeconds);
 
             if (!_operationsById.TryAdd(newOperation.Id, newOperation))
             {

--- a/src/Microsoft.Health.Fhir.Core/Features/Persistence/Orchestration/BundleOrchestratorOperation.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Persistence/Orchestration/BundleOrchestratorOperation.cs
@@ -206,6 +206,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence.Orchestration
 
                 InitializeMergeTaskSafe(dataStore: null, cancellationToken);
             }
+            catch (OperationCanceledException oce)
+            {
+                SetStatusSafe(BundleOrchestratorOperationStatus.Canceled);
+
+                _logger.LogWarning(oce, "Bundle Operation {Id}. Canceled while releasing a resource from a Bundle Orchestrator Operation: {ErrorMessage}", Id, oce.Message);
+                throw;
+            }
             catch (Exception ex)
             {
                 SetStatusSafe(BundleOrchestratorOperationStatus.Failed);
@@ -334,7 +341,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence.Orchestration
             {
                 SetStatusSafe(BundleOrchestratorOperationStatus.Canceled);
 
-                _logger.LogError(oce, "Bundle Operation {Id}. Bundle Orchestrator Operation canceled: {ErrorMessage}", Id, oce.Message);
+                _logger.LogWarning(oce, "Bundle Operation {Id}. Bundle Orchestrator Operation canceled: {ErrorMessage}", Id, oce.Message);
                 throw;
             }
             catch (Exception ex)

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerRuntimeTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerRuntimeTests.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Threading;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Health.Fhir.Api.Features.Resources.Bundle;
@@ -96,6 +97,33 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
         {
             // Act & Assert
             Assert.Throws<ArgumentNullException>(() => BundleHandlerRuntime.GetBundleProcessingLogic(_bundleConfiguration, null, BundleType.Batch));
+        }
+
+        [Fact]
+        public void IsTransactionCancelledByClient_WhenTrue()
+        {
+            const int timeWhenCustomerCancelledTheOperation = 4;
+            const int maxTransactionExecutionTimeInSeconds = 5;
+
+            var result = BundleHandlerRuntime.IsTransactionCancelledByClient(
+                TimeSpan.FromSeconds(timeWhenCustomerCancelledTheOperation),
+                new BundleConfiguration { MaxTransactionExecutionTimeInSeconds = maxTransactionExecutionTimeInSeconds },
+                new CancellationToken(canceled: true));
+
+            Assert.True(result);
+        }
+
+        [Theory]
+        [InlineData(false, 10, 5)]
+        [InlineData(true, 5, 5)]
+        public void IsTransactionCancelledByClient_WhenFalse(bool isCancelled, int transactionElapsedTime, int maxTransactionExecutionTime)
+        {
+            var result = BundleHandlerRuntime.IsTransactionCancelledByClient(
+                TimeSpan.FromSeconds(transactionElapsedTime),
+                new BundleConfiguration { MaxTransactionExecutionTimeInSeconds = maxTransactionExecutionTime },
+                new CancellationToken(canceled: isCancelled));
+
+            Assert.False(result);
         }
 
         private HttpContext GetHttpContext()

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerRuntimeTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerRuntimeTests.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
 
             var result = BundleHandlerRuntime.IsTransactionCancelledByClient(
                 TimeSpan.FromSeconds(timeWhenCustomerCancelledTheOperation),
-                new BundleConfiguration { MaxTransactionExecutionTimeInSeconds = maxTransactionExecutionTimeInSeconds },
+                new BundleConfiguration { MaxExecutionTimeInSeconds = maxTransactionExecutionTimeInSeconds },
                 new CancellationToken(canceled: true));
 
             Assert.True(result);
@@ -120,7 +120,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
         {
             var result = BundleHandlerRuntime.IsTransactionCancelledByClient(
                 TimeSpan.FromSeconds(transactionElapsedTime),
-                new BundleConfiguration { MaxTransactionExecutionTimeInSeconds = maxTransactionExecutionTime },
+                new BundleConfiguration { MaxExecutionTimeInSeconds = maxTransactionExecutionTime },
                 new CancellationToken(canceled: isCancelled));
 
             Assert.False(result);

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerTests.cs
@@ -464,17 +464,17 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
                 {
                     Type = BundleType.Transaction,
                     Entry = new List<EntryComponent>
-                {
-                    new EntryComponent
                     {
-                        Request = new RequestComponent
+                        new EntryComponent
                         {
-                            Method = HTTPVerb.POST,
-                            Url = "/Observation",
+                            Request = new RequestComponent
+                            {
+                                Method = HTTPVerb.POST,
+                                Url = "/Observation",
+                            },
+                            Resource = new Observation(),
                         },
-                        Resource = new Observation(),
                     },
-                },
                 };
 
                 var localAsyncFunction = (CallInfo callInfo) =>
@@ -483,8 +483,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
                     tokenSource.Cancel();
                 };
 
-                _router.When(r => r.RouteAsync(Arg.Any<RouteContext>()))
-                    .Do(localAsyncFunction);
+                _router.When(r => r.RouteAsync(Arg.Any<RouteContext>())).Do(localAsyncFunction);
 
                 var bundleRequest = new BundleRequest(bundle.ToResourceElement());
 

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerTests.cs
@@ -478,8 +478,6 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
 
             var localAsyncFunction = (CallInfo callInfo) =>
             {
-                var routeContext = callInfo.Arg<RouteContext>();
-
                 // Forcing the cancellation of the token and stopping the entire execution.
                 tokenSource.Cancel();
             };

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerTests.cs
@@ -454,6 +454,48 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
         }
 
         [Fact]
+        public async Task GivenATransaction_WithACancellationHappens_ReturnAProperError()
+        {
+            CancellationTokenSource tokenSource = new CancellationTokenSource();
+            CancellationToken cancellationToken = tokenSource.Token;
+
+            var bundle = new Hl7.Fhir.Model.Bundle
+            {
+                Type = BundleType.Transaction,
+                Entry = new List<EntryComponent>
+                {
+                    new EntryComponent
+                    {
+                        Request = new RequestComponent
+                        {
+                            Method = HTTPVerb.POST,
+                            Url = "/Observation",
+                        },
+                        Resource = new Observation(),
+                    },
+                },
+            };
+
+            var localAsyncFunction = (CallInfo callInfo) =>
+            {
+                var routeContext = callInfo.Arg<RouteContext>();
+
+                // Forcing the cancellation of the token and stopping the entire execution.
+                tokenSource.Cancel();
+            };
+
+            _router.When(r => r.RouteAsync(Arg.Any<RouteContext>()))
+                .Do(localAsyncFunction);
+
+            var bundleRequest = new BundleRequest(bundle.ToResourceElement());
+
+            // As the cancellation is requested during the bundle execution and the before the max transaction time, a FhirTransactionCancelledException is expected.
+            // Resulting in a HTTP408 error.
+            FhirTransactionCancelledException fhirTce = await Assert.ThrowsAsync<FhirTransactionCancelledException>(async () => await _bundleHandler.Handle(bundleRequest, cancellationToken));
+            Assert.True(fhirTce.ResponseStatusCode == System.Net.HttpStatusCode.RequestTimeout);
+        }
+
+        [Fact]
         public async Task GivenATransactionBundleRequestWithNullUrl_WhenProcessing_ReturnsABadRequest()
         {
             var bundle = new Hl7.Fhir.Model.Bundle

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerTests.cs
@@ -456,13 +456,14 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
         [Fact]
         public async Task GivenATransaction_WithACancellationHappens_ReturnAProperError()
         {
-            CancellationTokenSource tokenSource = new CancellationTokenSource();
-            CancellationToken cancellationToken = tokenSource.Token;
-
-            var bundle = new Hl7.Fhir.Model.Bundle
+            using (CancellationTokenSource tokenSource = new CancellationTokenSource())
             {
-                Type = BundleType.Transaction,
-                Entry = new List<EntryComponent>
+                CancellationToken cancellationToken = tokenSource.Token;
+
+                var bundle = new Hl7.Fhir.Model.Bundle
+                {
+                    Type = BundleType.Transaction,
+                    Entry = new List<EntryComponent>
                 {
                     new EntryComponent
                     {
@@ -474,23 +475,24 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
                         Resource = new Observation(),
                     },
                 },
-            };
+                };
 
-            var localAsyncFunction = (CallInfo callInfo) =>
-            {
-                // Forcing the cancellation of the token and stopping the entire execution.
-                tokenSource.Cancel();
-            };
+                var localAsyncFunction = (CallInfo callInfo) =>
+                {
+                    // Forcing the cancellation of the token and stopping the entire execution.
+                    tokenSource.Cancel();
+                };
 
-            _router.When(r => r.RouteAsync(Arg.Any<RouteContext>()))
-                .Do(localAsyncFunction);
+                _router.When(r => r.RouteAsync(Arg.Any<RouteContext>()))
+                    .Do(localAsyncFunction);
 
-            var bundleRequest = new BundleRequest(bundle.ToResourceElement());
+                var bundleRequest = new BundleRequest(bundle.ToResourceElement());
 
-            // As the cancellation is requested during the bundle execution and the before the max transaction time, a FhirTransactionCancelledException is expected.
-            // Resulting in a HTTP408 error.
-            FhirTransactionCancelledException fhirTce = await Assert.ThrowsAsync<FhirTransactionCancelledException>(async () => await _bundleHandler.Handle(bundleRequest, cancellationToken));
-            Assert.True(fhirTce.ResponseStatusCode == System.Net.HttpStatusCode.RequestTimeout);
+                // As the cancellation is requested during the bundle execution and the before the max transaction time, a FhirTransactionCancelledException is expected.
+                // Resulting in a HTTP408 error.
+                FhirTransactionCancelledException fhirTce = await Assert.ThrowsAsync<FhirTransactionCancelledException>(async () => await _bundleHandler.Handle(bundleRequest, cancellationToken));
+                Assert.True(fhirTce.ResponseStatusCode == System.Net.HttpStatusCode.RequestTimeout);
+            }
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/TransactionExceptionHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/TransactionExceptionHandlerTests.cs
@@ -25,7 +25,28 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
             HttpStatusCode statusCode = HttpStatusCode.Processing;
             var operationOutcome = GetOperationOutcome();
 
-            Assert.Throws<FhirTransactionFailedException>(() => TransactionExceptionHandler.ThrowTransactionException(message, statusCode, operationOutcome));
+            Assert.Throws<FhirTransactionFailedException>(() => TransactionExceptionHandler.ThrowTransactionException(
+                message,
+                statusCode,
+                operationOutcome,
+                cancelled: false));
+        }
+
+        [Fact]
+        public void GivenAnOperationOutcome_WhenCancelled_ThenACorrectExceptionIsThrown()
+        {
+            string message = "Error Message";
+            HttpStatusCode statusCode = HttpStatusCode.Processing;
+            var operationOutcome = GetOperationOutcome();
+
+            FhirTransactionCancelledException tce = Assert.Throws<FhirTransactionCancelledException>(() => TransactionExceptionHandler.ThrowTransactionException(
+                message,
+                statusCode,
+                operationOutcome,
+                cancelled: true));
+
+            Assert.Equal(message, tce.Message);
+            Assert.Equal(HttpStatusCode.RequestTimeout, tce.ResponseStatusCode);
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Filters/OperationOutcomeExceptionFilterAttribute.cs
@@ -153,6 +153,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Filters
                     case FhirTransactionFailedException fhirTransactionFailedException:
                         operationOutcomeResult.StatusCode = fhirTransactionFailedException.ResponseStatusCode;
                         break;
+                    case FhirTransactionCancelledException fhirTransactionCancelledException:
+                        operationOutcomeResult.StatusCode = fhirTransactionCancelledException.ResponseStatusCode;
+                        break;
                     case AzureContainerRegistryTokenException azureContainerRegistryTokenException:
                         operationOutcomeResult.StatusCode = azureContainerRegistryTokenException.StatusCode;
                         break;

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerParallelOperations.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerParallelOperations.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                         if (ex is FhirTransactionCancelledException tce)
                         {
                             // Handles client cancelled operations.
-                            _logger.LogWarning(ex, $"BundleHandler - Failed transaction. Error caused due an external cancellation. Canceling Bundle Orchestrator Operation. HttpStatusCode: {ex.ResponseStatusCode}");
+                            _logger.LogWarning(tce, $"BundleHandler - Failed transaction. Error caused due an external cancellation. Canceling Bundle Orchestrator Operation. HttpStatusCode: {tce.ResponseStatusCode}");
                             statistics.MarkBundleAsCancelled();
                         }
                         else if (ex is FhirTransactionFailedException tfe && tfe.IsErrorCausedDueClientFailure())

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerParallelOperations.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerParallelOperations.cs
@@ -20,6 +20,7 @@ using Microsoft.Extensions.Primitives;
 using Microsoft.Health.Api.Features.Audit;
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Fhir.Api.Features.Bundle;
+using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Persistence.Orchestration;
@@ -106,6 +107,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                             fhirJsonParser,
                             statistics,
                             _logger,
+                            _bundleConfiguration,
                             ct);
 
                         DetectNeedToRefreshProfiles(resourceExecutionContext.ResourceType);
@@ -119,17 +121,19 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                         // If the exception raised is a OperationCanceledException, then either client cancelled the request or httprequest timed out.
                         _logger.LogWarning(ex, "Bundle request timed out. Elapsed time {TotalElapsedMilliseconds}ms. Error: {ErrorMessage}", watch.Elapsed.TotalMilliseconds, ex.Message);
                     }
-                    catch (FhirTransactionFailedException ex)
+                    catch (BaseFhirTransactionException ex)
                     {
-                        if (ex.IsErrorCausedDueClientFailure())
+                        if (ex is FhirTransactionCancelledException tce)
                         {
-                            _logger.LogWarning(ex, $"BundleHandler - Failed transaction. Error caused due a client failure. Cancelling Bundle Orchestrator Operation. HttpStatusCode: {ex.ResponseStatusCode}");
-                            statistics.MarkBundleAsFailedDueClientError();
-                        }
-                        else if (ex.IsCancelled)
-                        {
+                            // Handles client cancelled operations.
                             _logger.LogWarning(ex, $"BundleHandler - Failed transaction. Error caused due an external cancellation. Canceling Bundle Orchestrator Operation. HttpStatusCode: {ex.ResponseStatusCode}");
                             statistics.MarkBundleAsCancelled();
+                        }
+                        else if (ex is FhirTransactionFailedException tfe && tfe.IsErrorCausedDueClientFailure())
+                        {
+                            // Handles client failures.
+                            _logger.LogWarning(tfe, $"BundleHandler - Failed transaction. Error caused due a client failure. Cancelling Bundle Orchestrator Operation. HttpStatusCode: {tfe.ResponseStatusCode}");
+                            statistics.MarkBundleAsFailedDueClientError();
                         }
                         else
                         {
@@ -161,11 +165,11 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                 }
                 catch (AggregateException age)
                 {
-                    FhirTransactionFailedException ftfe = age.InnerExceptions.Where(e => e is FhirTransactionFailedException).FirstOrDefault() as FhirTransactionFailedException;
-                    if (ftfe != null)
+                    BaseFhirTransactionException fte = age.InnerExceptions.Where(e => e is BaseFhirTransactionException).FirstOrDefault() as BaseFhirTransactionException;
+                    if (fte != null)
                     {
                         // If one of the exceptions raised is a FhirTransactionFailedException, then keep its origin.
-                        ExceptionDispatchInfo.Capture(ftfe).Throw();
+                        ExceptionDispatchInfo.Capture(fte).Throw();
                     }
 
                     _logger.LogError(age, "Multiple failures while processing bundle in parallel. Error: {ErrorMessage}", age.Message);
@@ -173,9 +177,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                 }
                 catch (Exception ex)
                 {
-                    if (ex is FhirTransactionFailedException)
+                    if (ex is BaseFhirTransactionException)
                     {
-                        // If one the exception raised is a FhirTransactionFailedException, then keep its origin.
+                        // If one the exception raised is a FHIR Transaction Exception, then keep its origin.
                         throw;
                     }
 
@@ -259,6 +263,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
             FhirJsonParser fhirJsonParser,
             BundleHandlerStatistics statistics,
             ILogger<BundleHandler> logger,
+            BundleConfiguration bundleConfiguration,
             CancellationToken cancellationToken)
         {
             EntryComponent entryComponent;
@@ -383,7 +388,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                     errorMessage,
                     httpStatusCode,
                     (OperationOutcome)entryComponent.Response.Outcome,
-                    cancelled: cancellationToken.IsCancellationRequested && watch.Elapsed.TotalSeconds < MaxTransactionExecutionTimeInSeconds);
+                    cancelled: BundleHandlerRuntime.IsTransactionCancelledByClient(watch.Elapsed, bundleConfiguration, cancellationToken));
             }
 
             responseBundle.Entry[resourceExecutionContext.Index] = entryComponent;

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerRuntime.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerRuntime.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
+using System.Threading;
 using EnsureThat;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Health.Fhir.Api.Features.Headers;
@@ -38,6 +40,17 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
             // Reaching this part of the code means that the bundle type is not set or it's using an invalid value.
             // Returning sequential as the default processing logic for both cases.
             return BundleProcessingLogic.Sequential;
+        }
+
+        /// <summary>
+        /// Determines whether a transaction has been cancelled by the client.
+        /// Íf the cancellation is requested and the elapsed time is less than the max transaction execution time, it is assumed that the client cancelled the request.
+        /// </summary>
+        public static bool IsTransactionCancelledByClient(TimeSpan elapsedTime, BundleConfiguration bundleConfiguration, CancellationToken cancellationToken)
+        {
+            EnsureArg.IsNotNull(bundleConfiguration, nameof(bundleConfiguration));
+
+            return cancellationToken.IsCancellationRequested && elapsedTime.TotalSeconds < bundleConfiguration.MaxTransactionExecutionTimeInSeconds;
         }
 
         internal static bool IsBundleProcessingLogicValid(HttpContext outerHttpContext)

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerRuntime.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerRuntime.cs
@@ -44,13 +44,13 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
 
         /// <summary>
         /// Determines whether a transaction has been cancelled by the client.
-        /// Íf the cancellation is requested and the elapsed time is less than the max transaction execution time, it is assumed that the client cancelled the request.
+        /// Íf the cancellation is requested and the elapsed time is less than the max bundle execution time, it is assumed that the client cancelled the request.
         /// </summary>
         public static bool IsTransactionCancelledByClient(TimeSpan elapsedTime, BundleConfiguration bundleConfiguration, CancellationToken cancellationToken)
         {
             EnsureArg.IsNotNull(bundleConfiguration, nameof(bundleConfiguration));
 
-            return cancellationToken.IsCancellationRequested && elapsedTime.TotalSeconds < bundleConfiguration.MaxTransactionExecutionTimeInSeconds;
+            return cancellationToken.IsCancellationRequested && elapsedTime.TotalSeconds < bundleConfiguration.MaxExecutionTimeInSeconds;
         }
 
         internal static bool IsBundleProcessingLogicValid(HttpContext outerHttpContext)

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerStatistics.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerStatistics.cs
@@ -61,6 +61,8 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
 
         public bool FailedDueClientError { get; private set; }
 
+        public bool Cancelled { get; private set; }
+
         public override string GetLoggingCategory() => LoggingCategory;
 
         public override string GetStatisticsAsJson()
@@ -89,6 +91,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                 registeredEntries = RegisteredEntries,
                 executionTime = ElapsedMilliseconds,
                 clientError = FailedDueClientError,
+                cancelled = Cancelled,
                 success = successedRequests,
                 errors = failedRequests,
                 customerErrors = customerFailedRequests,
@@ -117,6 +120,11 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
         public void MarkBundleAsFailedDueClientError()
         {
             FailedDueClientError = true;
+        }
+
+        public void MarkBundleAsCancelled()
+        {
+            Cancelled = true;
         }
 
         private sealed class BundleHandlerStatisticEntry

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/TransactionExceptionHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/TransactionExceptionHandler.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
 {
     internal static class TransactionExceptionHandler
     {
-        public static void ThrowTransactionException(string errorMessage, HttpStatusCode statusCode, OperationOutcome operationOutcome)
+        public static void ThrowTransactionException(string errorMessage, HttpStatusCode statusCode, OperationOutcome operationOutcome, bool cancelled)
         {
             List<OperationOutcomeIssue> operationOutcomeIssues = GetOperationOutcomeIssues(operationOutcome.Issue);
 

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/TransactionExceptionHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/TransactionExceptionHandler.cs
@@ -17,6 +17,11 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
         {
             List<OperationOutcomeIssue> operationOutcomeIssues = GetOperationOutcomeIssues(operationOutcome.Issue);
 
+            if (cancelled)
+            {
+                throw new FhirTransactionCancelledException(errorMessage, operationOutcomeIssues);
+            }
+
             throw new FhirTransactionFailedException(errorMessage, statusCode, operationOutcomeIssues);
         }
 


### PR DESCRIPTION
## Description
Improving Transactional bundles and returning HTTP408 in case of client cancellation, instead of HTTP500. 

Changes in this PR: 
* Identify client-side cancellations and handle those cancellations properly in transactional bundles.
* Return HTTP408 for client-side cancellations. 
* Centralizing the 100 seconds max execution time of bundles in BundleConfiguration. 
* Adding to BundleHandlerRuntime a logic to identify client-side cancellations. 
* Adding new exception type called FhirTransactionCancelledException. 
* Handling FhirTransactionCancelledException on OperationOutcomeExceptionFilterAttribute.

Here is an example of a cancelled request returning HTTP408 and logging the bundle as cancelled. 

<img width="821" height="875" alt="image" src="https://github.com/user-attachments/assets/829acce5-1ced-4811-aedc-0695ea4d7ba0" />

## Related issues
Addresses [AB#151668](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/151668)

## Testing
- Tested through existing tests. 
- New tests. 
- Local manual validations. 

## FHIR Team Checklist
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
