### PR TITLE
Fix reference remover

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/Delete/ReferenceRemoverTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/Delete/ReferenceRemoverTests.cs
@@ -1,0 +1,111 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using Hl7.Fhir.Model;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Resources
+{
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.BulkDelete)]
+    public class ReferenceRemoverTests
+    {
+        [Fact]
+        public void GivenResourceWithReference_WhenReferenceIsRemoved_ThenReferenceIsRemoved()
+        {
+            var reference = KnownResourceTypes.Practitioner + "/testRef";
+            var patient = new Patient();
+            patient.GeneralPractitioner.Add(new ResourceReference(reference));
+
+            var id = "testPatient";
+            patient.Id = id;
+
+            var name = new HumanName() { Family = "Testson" };
+            patient.Name.Add(name);
+
+            ReferenceRemover.RemoveReference(patient, reference);
+
+            Assert.True(patient.GeneralPractitioner.First().Reference == null);
+            Assert.Equal("Referenced resource deleted", patient.GeneralPractitioner.First().Display);
+            Assert.Equal(id, patient.Id);
+            Assert.Equal(name, patient.Name.First());
+        }
+
+        [Fact]
+        public void GivenResourceWithoutReference_WhenReferenceIsRemoved_ThenNothingIsChanged()
+        {
+            var referenceId = "testRef";
+            var patient = new Patient();
+
+            var id = "testPatient";
+            patient.Id = id;
+
+            var name = new HumanName() { Family = "Testson" };
+            patient.Name.Add(name);
+
+            ReferenceRemover.RemoveReference(patient, referenceId);
+
+            Assert.Equal(id, patient.Id);
+            Assert.Equal(name, patient.Name.First());
+        }
+
+        [Fact]
+        public void GivenResourceWithReferenceDescription_WhenReferenceIsRemoved_ThenNothingIsChanged()
+        {
+            var referenceId = "testRef";
+            var patient = new Patient();
+
+            var reference = new ResourceReference();
+            reference.Display = referenceId;
+            patient.GeneralPractitioner.Add(reference);
+
+            var id = "testPatient";
+            patient.Id = id;
+
+            var name = new HumanName() { Family = "Testson" };
+            patient.Name.Add(name);
+
+            ReferenceRemover.RemoveReference(patient, referenceId);
+
+            Assert.True(patient.GeneralPractitioner.First().Reference == null);
+            Assert.Equal(referenceId, patient.GeneralPractitioner.First().Display);
+            Assert.Equal(id, patient.Id);
+            Assert.Equal(name, patient.Name.First());
+        }
+
+        [Fact]
+        public void GivenResourceWithTwoReferences_WhenReferenceIsRemoved_ThenOtherReferenceIsNotChanged()
+        {
+            var reference = KnownResourceTypes.Practitioner + "/testRef";
+            var otherReference = KnownResourceTypes.Practitioner + "/other";
+            var patient = new Patient();
+            patient.GeneralPractitioner.Add(new ResourceReference(reference));
+            patient.GeneralPractitioner.Add(new ResourceReference(otherReference));
+
+            var id = "testPatient";
+            patient.Id = id;
+
+            var name = new HumanName() { Family = "Testson" };
+            patient.Name.Add(name);
+
+            ReferenceRemover.RemoveReference(patient, reference);
+
+            Assert.True(patient.GeneralPractitioner[0].Reference == null);
+            Assert.Equal("Referenced resource deleted", patient.GeneralPractitioner[0].Display);
+
+            Assert.Equal(otherReference, patient.GeneralPractitioner[1].Reference);
+            Assert.True(patient.GeneralPractitioner[1].Display == null);
+
+            Assert.Equal(id, patient.Id);
+            Assert.Equal(name, patient.Name.First());
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/Delete/RemoveReferenceTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/Delete/RemoveReferenceTests.cs
@@ -1,0 +1,110 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using Hl7.Fhir.Model;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Resources
+{
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.BulkDelete)]
+    public class RemoveReferenceTests
+    {
+        [Fact]
+        public void GivenResourceWithReference_WhenReferenceIsRemoved_ThenReferenceIsRemoved()
+        {
+            var referenceId = "testRef";
+            var patient = new Patient();
+            patient.GeneralPractitioner.Add(new ResourceReference(KnownResourceTypes.Practitioner + "/" + referenceId));
+
+            var id = "testPatient";
+            patient.Id = id;
+
+            var name = new HumanName() { Family = "Testson" };
+            patient.Name.Add(name);
+
+            ReferenceRemover.RemoveReference(patient, referenceId);
+
+            Assert.True(patient.GeneralPractitioner.First().Reference == null);
+            Assert.Equal("Referenced resource deleted", patient.GeneralPractitioner.First().Display);
+            Assert.Equal(id, patient.Id);
+            Assert.Equal(name, patient.Name.First());
+        }
+
+        [Fact]
+        public void GivenResourceWithoutReference_WhenReferenceIsRemoved_ThenNothingIsChanged()
+        {
+            var referenceId = "testRef";
+            var patient = new Patient();
+
+            var id = "testPatient";
+            patient.Id = id;
+
+            var name = new HumanName() { Family = "Testson" };
+            patient.Name.Add(name);
+
+            ReferenceRemover.RemoveReference(patient, referenceId);
+
+            Assert.Equal(id, patient.Id);
+            Assert.Equal(name, patient.Name.First());
+        }
+
+        [Fact]
+        public void GivenResourceWithReferenceDescription_WhenReferenceIsRemoved_ThenNothingIsChanged()
+        {
+            var referenceId = "testRef";
+            var patient = new Patient();
+
+            var reference = new ResourceReference();
+            reference.Display = referenceId;
+            patient.GeneralPractitioner.Add(reference);
+
+            var id = "testPatient";
+            patient.Id = id;
+
+            var name = new HumanName() { Family = "Testson" };
+            patient.Name.Add(name);
+
+            ReferenceRemover.RemoveReference(patient, referenceId);
+
+            Assert.True(patient.GeneralPractitioner.First().Reference == null);
+            Assert.Equal(referenceId, patient.GeneralPractitioner.First().Display);
+            Assert.Equal(id, patient.Id);
+            Assert.Equal(name, patient.Name.First());
+        }
+
+        [Fact]
+        public void GivenResourceWithTwoReferences_WhenReferenceIsRemoved_ThenOtherReferenceIsNotChanged()
+        {
+            var referenceId = "testRef";
+            var patient = new Patient();
+            patient.GeneralPractitioner.Add(new ResourceReference(KnownResourceTypes.Practitioner + "/" + referenceId));
+            patient.GeneralPractitioner.Add(new ResourceReference(KnownResourceTypes.Practitioner + "/other"));
+
+            var id = "testPatient";
+            patient.Id = id;
+
+            var name = new HumanName() { Family = "Testson" };
+            patient.Name.Add(name);
+
+            ReferenceRemover.RemoveReference(patient, referenceId);
+
+            Assert.True(patient.GeneralPractitioner[0].Reference == null);
+            Assert.Equal("Referenced resource deleted", patient.GeneralPractitioner[0].Display);
+
+            Assert.Equal(KnownResourceTypes.Practitioner + "/other", patient.GeneralPractitioner[1].Reference);
+            Assert.True(patient.GeneralPractitioner[1].Display == null);
+
+            Assert.Equal(id, patient.Id);
+            Assert.Equal(name, patient.Name.First());
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
@@ -32,7 +32,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Persistence\Orchestration\BundleOrchestratorTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Persistence\Orchestration\BundleTestsCommonFunctions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Create\CreateResourceValidatorTests.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)features\resources\delete\RemoveReferenceTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Delete\RemoveReferenceTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\MemberMatch\MemberMatchResourceValidatorTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Patch\PatchResourceHandlerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\ResourceHandlerTests_ConditionalDelete.cs" />

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
@@ -32,6 +32,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Persistence\Orchestration\BundleOrchestratorTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Persistence\Orchestration\BundleTestsCommonFunctions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Create\CreateResourceValidatorTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)features\resources\delete\RemoveReferenceTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\MemberMatch\MemberMatchResourceValidatorTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Patch\PatchResourceHandlerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\ResourceHandlerTests_ConditionalDelete.cs" />
@@ -137,5 +138,8 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)TestFiles\USCoreMissinData-JsonCompliantSamples.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)TestFiles\USCoreMissinData-XmlNonCompliantSamples.xml" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)TestFiles\USCoreMissinData-XmlCompliantSamples.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="$(MSBuildThisFileDirectory)Features\Resources\Delete\" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
@@ -32,7 +32,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Persistence\Orchestration\BundleOrchestratorTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Persistence\Orchestration\BundleTestsCommonFunctions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Create\CreateResourceValidatorTests.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Delete\RemoveReferenceTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Delete\ReferenceRemoverTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\MemberMatch\MemberMatchResourceValidatorTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\Patch\PatchResourceHandlerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Resources\ResourceHandlerTests_ConditionalDelete.cs" />
@@ -54,7 +54,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Security\Authorization\RoleBasedFhirAuthorizationServiceTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Validation\ResourceProfileValidatorTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Models\BundleResourceContextComparerTests.cs" />
-    <Compile Include="..\Microsoft.Health.Fhir.Shared.Core.UnitTests\Features\Persistence\ResourceWrapperFactoryTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Persistence\ResourceWrapperFactoryTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\Converters\AddressToStringSearchValueConverterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\Converters\BooleanToBooleanSearchValueConverterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\Converters\CanonicalToUriSearchValueConverterTests.cs" />
@@ -91,7 +91,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchParameters\SearchParameterValidatorTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchParameters\SearchParameterSupportResolverTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\SearchParameters\SearchParameterToTypeResolverTests.cs" />
-    <Compile Include="..\Microsoft.Health.Fhir.Shared.Core.UnitTests\Features\Conformance\ProfileReferenceConverterTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Conformance\ProfileReferenceConverterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Conformance\DefaultOptionHashSetJsonConverterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Conformance\EnumLiteralJsonConverterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Definition\CompartmentDefinitionManagerTests.cs" />
@@ -138,8 +138,5 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)TestFiles\USCoreMissinData-JsonCompliantSamples.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)TestFiles\USCoreMissinData-XmlNonCompliantSamples.xml" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)TestFiles\USCoreMissinData-XmlCompliantSamples.xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="$(MSBuildThisFileDirectory)Features\Resources\Delete\" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/ReferenceRemover.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/ReferenceRemover.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
                 if (childValue.TypeName == "Reference")
                 {
                     var reference = (ResourceReference)childValue;
-                    if (reference.Reference.Contains(target, StringComparison.OrdinalIgnoreCase))
+                    if (reference.Reference != null && reference.Reference.EndsWith(target, StringComparison.OrdinalIgnoreCase))
                     {
                         reference.Reference = null;
                         reference.Display = "Referenced resource deleted";

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/ReferenceRemover.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Resources/Delete/ReferenceRemover.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
                 if (childValue.TypeName == "Reference")
                 {
                     var reference = (ResourceReference)childValue;
-                    if (reference.Reference != null && reference.Reference.EndsWith(target, StringComparison.OrdinalIgnoreCase))
+                    if (reference.Reference != null && reference.Reference.Equals(target, StringComparison.OrdinalIgnoreCase))
                     {
                         reference.Reference = null;
                         reference.Display = "Referenced resource deleted";


### PR DESCRIPTION
## Description
Fixes some bugs found in reference remover and adds tests

## Related issues
Addresses [Bug 170441](https://microsofthealth.visualstudio.com/Health/_workitems/edit/170441)

## Testing
New unit tests and manual testing.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch
