### PR TITLE
Fixing ValidateTests to check expected profiles only.

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ValidateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ValidateTests.cs
@@ -229,14 +229,14 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 #else
             var supportedProfiles = response.Resource.Profile.Select(x => x.Url.ToString()).OrderBy(x => x).ToList();
 #endif
-            Assert.Equal(
+            Assert.All(
                 new[]
                 {
                     "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan",
                     "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
                     "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient",
                 },
-                supportedProfiles);
+                x => Assert.Contains(supportedProfiles, y => string.Equals(x, y, StringComparison.OrdinalIgnoreCase)));
         }
 
         private void CheckOperationOutcomeIssue(


### PR DESCRIPTION
## Description
GivenPostedProfiles_WhenCallingForMetadata_ThenMetadataHasSupportedProfiles validates the result by checking if supported profiles in the server match its expected ones. It was failing due to other tests creating additional profiles. The fix is to validate only ones that the test expects to be in supported profiles from the server. 

## Related issues
Addresses [issue #143833].

[User Story 143833](https://microsofthealth.visualstudio.com/Health/_workitems/edit/143833): Create E2E test to create at least one of each FHIR resource

## Testing
Tested by running the test and others creating additional profiles.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
