### PR TITLE
Add reference resource id back to hash

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/HashingSqlQueryParameterManager.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/HashingSqlQueryParameterManager.cs
@@ -80,8 +80,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search
 
             SqlParameter parameter = _inner.AddParameter(column, value);
             if (includeInHash
-                && column.Metadata.Name != VLatest.Resource.ResourceId.Metadata.Name
-                && column.Metadata.Name != VLatest.ReferenceSearchParam.ReferenceResourceId.Metadata.Name)
+                && column.Metadata.Name != VLatest.Resource.ResourceId.Metadata.Name)
             {
                 _setToHash.Add(parameter);
             }


### PR DESCRIPTION
There are cases when number of rows in the ReferenceSearchParam are very different for different ReferenceResourceId values. Reusing plan for different values is a problem. We should not be caching these plans.

Customer who might still benefit form plan caching can use explicit caching headers. 