### PR TITLE
Add OpenIddict validation and refine authentication setup

### DIFF
--- a/src/Microsoft.Health.Fhir.Api.OpenIddict/Extensions/DevelopmentIdentityProviderRegistrationExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Api.OpenIddict/Extensions/DevelopmentIdentityProviderRegistrationExtensions.cs
@@ -12,6 +12,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
 using EnsureThat;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -148,11 +149,26 @@ namespace Microsoft.Health.Fhir.Api.OpenIddict.Extensions
 
                                 return default;
                             }));
+                    })
+                    .AddValidation(options =>
+                    {
+                        // Import the configuration from the local OpenIddict server instance.
+                        options.UseLocalServer();
+
+                        // Register the ASP.NET Core host.
+                        options.UseAspNetCore();
                     });
 
-                services.AddAuthentication(options =>
+                // Only override the default authentication scheme - don't call AddAuthentication here
+                // Let the SecurityModule handle the authentication setup
+                services.PostConfigure<AuthenticationOptions>(options =>
                 {
-                    options.DefaultScheme = OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme;
+                    if (string.IsNullOrEmpty(options.DefaultScheme))
+                    {
+                        options.DefaultScheme = OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme;
+                        options.DefaultAuthenticateScheme = OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme;
+                        options.DefaultChallengeScheme = OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme;
+                    }
                 });
 
                 services.AddHostedService<OpenIddictApplicationCreater>();

--- a/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Web/Startup.cs
@@ -242,6 +242,22 @@ namespace Microsoft.Health.Fhir.Web
 
         private static void AddAuthenticationLibrary(IServiceCollection services, SecurityConfiguration securityConfiguration)
         {
+            // Check if OpenIddict development identity provider is enabled by reading configuration directly
+            var serviceProvider = services.BuildServiceProvider();
+            var configuration = serviceProvider.GetService<IConfiguration>();
+
+            if (configuration != null)
+            {
+                var developmentIdpEnabled = configuration.GetValue<bool>("DevelopmentIdentityProvider:Enabled");
+                var testAuthFilePath = configuration["TestAuthEnvironment:FilePath"];
+
+                // If either DevelopmentIdentityProvider is explicitly enabled OR testauthenvironment.json is configured
+                if (developmentIdpEnabled || !string.IsNullOrWhiteSpace(testAuthFilePath))
+                {
+                    return; // Don't register JWT Bearer when OpenIddict is handling authentication
+                }
+            }
+
             // Note: This method is still used to configure JWT Bearer for non–OpenIddict tokens.
             services.AddAuthentication(options =>
             {


### PR DESCRIPTION
Introduced OpenIddict validation configuration, enabling the use of a local OpenIddict server instance and ASP.NET Core host integration. Replaced `services.AddAuthentication` with `services.PostConfigure<AuthenticationOptions>` to delegate authentication setup to the `SecurityModule` and avoid overriding default schemes.

Updated `AddAuthenticationLibrary` in `Startup.cs` to conditionally skip JWT Bearer registration when OpenIddict is enabled or a test authentication environment is configured. Removed `OpenIddictAuthorizationController` registration and added necessary `using` directives for OpenIddict and options configuration.

These changes improve authentication flexibility and modularity, particularly for development environments running in containers.

## Description
Describe the changes in this PR.

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
