### PR TITLE
Adds critical build flag

### DIFF
--- a/build/ci-pipeline.yml
+++ b/build/ci-pipeline.yml
@@ -1,12 +1,20 @@
-# DESCRIPTION: 	
-# Builds, tests, and packages the solution for the main branch.	
+# DESCRIPTION:
+# Builds, tests, and packages the solution for the main branch.
 
 name: $(SourceBranchName)-$(Date:yyyyMMdd)$(Rev:-r)
 trigger: none
 
+parameters:
+- name: buildCriticalOnly
+  displayName: 'Build Critical Versions Only (skip R4B/R5)'
+  type: boolean
+  default: false
+
 variables:
 - template: ci-variables.yml
 - template: build-variables.yml
+- name: buildCriticalOnly
+  value: ${{ parameters.buildCriticalOnly }}
 
 stages:
 # *********************** Setup ***********************
@@ -124,7 +132,7 @@ stages:
     steps:
     - template: ./jobs/analyze.yml
 
-- stage: DockerBuild  
+- stage: DockerBuild
   displayName: 'Build images'
   dependsOn:
   - UpdateVersion
@@ -132,9 +140,10 @@ stages:
     assemblySemFileVer: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.assemblySemFileVer']]
   jobs:
   - template: ./jobs/docker-build-all.yml
-    parameters: 
+    parameters:
       tag: $(ImageTag)
       buildPlatform: $(publicDockerImagePlatforms)
+      buildCriticalOnly: ${{ parameters.buildCriticalOnly }}
 
 # *********************** Stu3 ***********************
 - stage: redeployStu3
@@ -217,11 +226,12 @@ stages:
 # *********************** R4B ***********************
 - stage: redeployR4B
   displayName: 'Redeploy R4B CosmosDB Site'
+  condition: eq(variables.buildCriticalOnly, false)
   dependsOn:
   - DockerBuild
   jobs:
   - template: ./jobs/redeploy-webapp.yml
-    parameters: 
+    parameters:
       version: R4B
       webAppName: $(DeploymentEnvironmentNameR4B)
       subscription: $(ConnectedServiceName)
@@ -229,11 +239,12 @@ stages:
 
 - stage: redeployR4BSql
   displayName: 'Redeploy R4B SQL Site'
+  condition: eq(variables.buildCriticalOnly, false)
   dependsOn:
   - DockerBuild
   jobs:
   - template: ./jobs/redeploy-webapp.yml
-    parameters: 
+    parameters:
       version: R4B
       webAppName: $(DeploymentEnvironmentNameR4BSql)
       subscription: $(ConnectedServiceName)
@@ -241,6 +252,7 @@ stages:
 
 - stage: testR4B
   displayName: 'Run R4B Tests'
+  condition: eq(variables.buildCriticalOnly, false)
   dependsOn:
   - BuildArtifacts
   - redeployR4B
@@ -256,11 +268,12 @@ stages:
 # *********************** R5 ***********************
 - stage: redeployR5
   displayName: 'Redeploy R5 CosmosDB Site'
+  condition: eq(variables.buildCriticalOnly, false)
   dependsOn:
   - DockerBuild
   jobs:
   - template: ./jobs/redeploy-webapp.yml
-    parameters: 
+    parameters:
       version: R5
       webAppName: $(DeploymentEnvironmentNameR5)
       subscription: $(ConnectedServiceName)
@@ -268,11 +281,12 @@ stages:
 
 - stage: redeployR5Sql
   displayName: 'Redeploy R5 SQL Site'
+  condition: eq(variables.buildCriticalOnly, false)
   dependsOn:
   - DockerBuild
   jobs:
   - template: ./jobs/redeploy-webapp.yml
-    parameters: 
+    parameters:
       version: R5
       webAppName: $(DeploymentEnvironmentNameR5Sql)
       subscription: $(ConnectedServiceName)
@@ -280,6 +294,7 @@ stages:
 
 - stage: testR5
   displayName: 'Run R5 Tests'
+  condition: eq(variables.buildCriticalOnly, false)
   dependsOn:
   - BuildArtifacts
   - redeployR5
@@ -313,6 +328,15 @@ stages:
 # *********************** Finalize ***********************
 - stage: DockerAddTag
   displayName: 'Docker add main tag'
+  # Run only if all required tests succeed (all 4 when buildCriticalOnly=false, only Stu3/R4 when buildCriticalOnly=true)
+  condition: |
+    and(
+      succeeded(),
+      or(
+        and(eq(variables.buildCriticalOnly, false), succeeded('testStu3'), succeeded('testR4'), succeeded('testR4B'), succeeded('testR5')),
+        and(eq(variables.buildCriticalOnly, true), succeeded('testStu3'), succeeded('testR4'))
+      )
+    )
   dependsOn:
   - testStu3
   - testR4

--- a/build/jobs/docker-build-all.yml
+++ b/build/jobs/docker-build-all.yml
@@ -1,4 +1,4 @@
-# DESCRIPTION: 
+# DESCRIPTION:
 # Builds and pushes images for all supported FHIR versions
 
 parameters:
@@ -6,28 +6,33 @@ parameters:
   type: string
 - name: buildPlatform
   type: string
+- name: buildCriticalOnly
+  type: boolean
+  default: false
 
 jobs:
 - template: docker-build-push.yml
-  parameters: 
+  parameters:
     version: "R4"
     tag: ${{parameters.tag}}
     buildPlatform: ${{parameters.buildPlatform}}
 
-- template: docker-build-push.yml
-  parameters: 
-    version: "R4B"
-    tag: ${{parameters.tag}}
-    buildPlatform: ${{parameters.buildPlatform}}
+- ${{ if eq(parameters.buildCriticalOnly, false) }}:
+  - template: docker-build-push.yml
+    parameters:
+      version: "R4B"
+      tag: ${{parameters.tag}}
+      buildPlatform: ${{parameters.buildPlatform}}
 
 - template: docker-build-push.yml
-  parameters: 
+  parameters:
     version: "Stu3"
     tag: ${{parameters.tag}}
     buildPlatform: ${{parameters.buildPlatform}}
 
-- template: docker-build-push.yml
-  parameters: 
-    version: "R5"
-    tag: ${{parameters.tag}}
-    buildPlatform: ${{parameters.buildPlatform}}
+- ${{ if eq(parameters.buildCriticalOnly, false) }}:
+  - template: docker-build-push.yml
+    parameters:
+      version: "R5"
+      tag: ${{parameters.tag}}
+      buildPlatform: ${{parameters.buildPlatform}}

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -1,11 +1,19 @@
-# DESCRIPTION: 	
-# Builds, tests, and packages the solution for all PR requests.	
+# DESCRIPTION:
+# Builds, tests, and packages the solution for all PR requests.
 
 trigger: none
+
+parameters:
+- name: buildCriticalOnly
+  displayName: 'Build Critical Versions Only (skip R4B/R5)'
+  type: boolean
+  default: false
 
 variables:
 - template: pr-variables.yml
 - template: build-variables.yml
+- name: buildCriticalOnly
+  value: ${{ parameters.buildCriticalOnly }}
 
 stages:
 - stage: UpdateVersion
@@ -95,7 +103,7 @@ stages:
     steps:
     - template: ./jobs/analyze.yml
 
-- stage: DockerBuild  
+- stage: DockerBuild
   displayName: 'Build images'
   dependsOn:
   - UpdateVersion
@@ -103,9 +111,10 @@ stages:
     assemblySemFileVer: $[stageDependencies.UpdateVersion.Semver.outputs['SetVariablesFromGitVersion.assemblySemFileVer']]
   jobs:
   - template: ./jobs/docker-build-all.yml
-    parameters: 
+    parameters:
       tag: $(ImageTag)
       buildPlatform: $(testDockerImagePlatforms)
+      buildCriticalOnly: ${{ parameters.buildCriticalOnly }}
 
 - stage: provisionEnvironment
   displayName: Provision Environment
@@ -284,13 +293,14 @@ stages:
 
 - stage: deployR4B
   displayName: 'Deploy R4B CosmosDB Site'
+  condition: eq(variables.buildCriticalOnly, false)
   dependsOn:
   - DockerBuild
   - setupEnvironment
   - createNsp
   jobs:
   - template: ./jobs/provision-deploy.yml
-    parameters: 
+    parameters:
       version: R4B
       webAppName: $(DeploymentEnvironmentNameR4B)
       appServicePlanName: '$(appServicePlanName)-cosmos'
@@ -303,13 +313,14 @@ stages:
 
 - stage: deployR4BSql
   displayName: 'Deploy R4B SQL Site'
+  condition: eq(variables.buildCriticalOnly, false)
   dependsOn:
   - DockerBuild
   - setupEnvironment
   - deploySqlServer
   jobs:
   - template: ./jobs/provision-deploy.yml
-    parameters: 
+    parameters:
       version: R4B
       sql: true
       webAppName: $(DeploymentEnvironmentNameR4BSql)
@@ -326,13 +337,14 @@ stages:
 
 - stage: deployR5
   displayName: 'Deploy R5 CosmosDB Site'
+  condition: eq(variables.buildCriticalOnly, false)
   dependsOn:
   - DockerBuild
   - setupEnvironment
   - createNsp
   jobs:
   - template: ./jobs/provision-deploy.yml
-    parameters: 
+    parameters:
       version: R5
       webAppName: $(DeploymentEnvironmentNameR5)
       appServicePlanName: '$(appServicePlanName)-cosmos'
@@ -345,13 +357,14 @@ stages:
 
 - stage: deployR5Sql
   displayName: 'Deploy R5 SQL Site'
+  condition: eq(variables.buildCriticalOnly, false)
   dependsOn:
   - DockerBuild
   - setupEnvironment
   - deploySqlServer
   jobs:
   - template: ./jobs/provision-deploy.yml
-    parameters: 
+    parameters:
       version: R5
       sql: true
       webAppName: $(DeploymentEnvironmentNameR5Sql)
@@ -398,6 +411,7 @@ stages:
 
 - stage: testR4B
   displayName: 'Run R4B Tests'
+  condition: eq(variables.buildCriticalOnly, false)
   dependsOn:
   - BuildArtifacts
   - setupEnvironment
@@ -413,6 +427,7 @@ stages:
 
 - stage: testR5
   displayName: 'Run R5 Tests'
+  condition: eq(variables.buildCriticalOnly, false)
   dependsOn:
   - BuildArtifacts
   - setupEnvironment
@@ -446,12 +461,20 @@ stages:
 
 - stage: cleanup
   displayName: 'Cleanup Azure Environment'
+  # Run only if all required tests succeed (all 4 when buildCriticalOnly=false, only Stu3/R4 when buildCriticalOnly=true)
+  condition: |
+    and(
+      succeeded(),
+      or(
+        and(eq(variables.buildCriticalOnly, false), eq(dependencies.testStu3.result, 'Succeeded'), eq(dependencies.testR4.result, 'Succeeded'), eq(dependencies.testR4B.result, 'Succeeded'), eq(dependencies.testR5.result, 'Succeeded')),
+        and(eq(variables.buildCriticalOnly, true), eq(dependencies.testStu3.result, 'Succeeded'), eq(dependencies.testR4.result, 'Succeeded'))
+      )
+    )
   dependsOn:
   - testStu3
   - testR4
   - testR4B
   - testR5
-  condition: succeeded()
   jobs:
   - template: ./jobs/cleanup.yml
 

--- a/docs/arch/adr-2510-critical-build-flag.md
+++ b/docs/arch/adr-2510-critical-build-flag.md
@@ -1,0 +1,70 @@
+# ADR 2510: Critical-Only Build Flag for CI/PR Pipelines
+Labels: [CI/CD](https://github.com/microsoft/fhir-server/labels/Area-CI-CD)
+
+## Context
+The FHIR server supports four FHIR specification versions: STU3, R4, R4B, and R5. In production environments, the majority of deployments use STU3 and R4, which are mature and widely adopted specifications. R4B and R5 are newer versions with limited production usage.
+
+The current CI and PR pipelines build, deploy, and test all four versions for every commit. Each version requires:
+- Docker image builds (multi-platform for CI)
+- Deployment to test environments (CosmosDB + SQL variants)
+- Integration tests (CosmosDB + SQL)
+- End-to-end tests (CosmosDB + SQL)
+
+This comprehensive validation is essential for ensuring quality across all supported versions. However, when shipping critical hotfixes or iterating rapidly on production issues affecting only R4 or STU3, the time spent deploying and testing R4B and R5 represents significant overhead. A typical full CI build takes substantial time, with R4B and R5 stages accounting for approximately 40% of deployment and test time.
+
+We need a mechanism to accelerate builds when working exclusively on R4 and STU3 production issues, while maintaining the default behavior of comprehensive multi-version validation.
+
+## Decision
+We will add a `buildCriticalOnly` parameter to both the CI and PR pipeline definitions. When set to `true`, this parameter will:
+
+1. **Skip deployment and test stages** for R4B and R5 versions:
+   - Deployment stages (CosmosDB + SQL)
+   - Integration test jobs
+   - End-to-end test jobs
+
+2. **Skip Docker image builds** for R4B and R5 versions in the `docker-build-all.yml` job template
+
+3. **Continue to build all code** in the solution, including R4B and R5 projects, during the build stages. This ensures that changes to shared code (e.g., Core libraries) do not introduce compilation errors in non-critical versions.
+
+The parameter will default to `false`, ensuring that the standard behavior remains comprehensive validation across all versions. Developers and release engineers can opt into the fast path explicitly when appropriate.
+
+### Implementation Approach
+- Add `buildCriticalOnly` parameter (type: boolean, default: false) to pipeline definitions
+- Use Azure Pipelines conditional syntax (`condition: eq(variables.buildCriticalOnly, false)`) on R4B and R5 stages
+- Update stage dependencies to handle conditionally skipped stages
+- Use template conditionals (`${{ if }}`) to skip R4B/R5 Docker builds
+
+### Usage Guidelines
+**When to use `buildCriticalOnly: true`:**
+- Hotfixes for production R4 or STU3 issues
+- Rapid iteration during R4/STU3 feature development
+- Cost-sensitive CI runs when R4B/R5 validation is not required
+
+**When NOT to use it:**
+- Before merging to main branch (full validation recommended)
+- When changes affect shared Core libraries (cross-version validation needed)
+- Release builds
+- When explicitly developing or fixing R4B/R5 functionality
+
+## Status
+Accepted
+
+## Consequences
+### Benefits:
+- **Reduced build time**: 20-30% time savings by skipping ~40% of deployment and test stages
+- **Faster hotfix delivery**: Critical R4/STU3 fixes can be validated and shipped more quickly
+- **Lower build costs**: Reduced Azure DevOps agent minutes and Azure resource usage for test environments
+- **Preserved safety**: Default behavior remains unchanged; full validation is opt-out, not opt-in
+
+### Adverse Effects:
+- **Maintenance overhead**: New parameter must be propagated when adding future FHIR versions
+- **Risk of misuse**: Developers might use the flag inappropriately, skipping validation when it's needed
+- **Incomplete time savings**: All code still compiles, so savings are less than a full solution filter approach would provide
+
+### Neutral Effects:
+- **No impact on default behavior**: Existing builds and processes remain unchanged
+
+## References
+- CI Pipeline: `build/ci-pipeline.yml`
+- PR Pipeline: `build/pr-pipeline.yml`
+- Docker Build Template: `build/jobs/docker-build-all.yml`


### PR DESCRIPTION
## Description
This pull request introduces a new `buildCriticalOnly` flag to both CI and PR pipelines, allowing the build, deployment, and test stages for R4B and R5 FHIR versions to be skipped when only critical (STU3/R4) validation is needed. This change accelerates hotfix and rapid iteration workflows while preserving the default comprehensive validation. The implementation includes pipeline parameterization, conditional stage execution, and documentation of the approach.

<img width="450" height="388" alt="image" src="https://github.com/user-attachments/assets/53c35e7f-9072-42e7-b28e-5a1537383a2a" />


Key changes:

**Pipeline Parameterization and Logic:**
- Added a `buildCriticalOnly` boolean parameter (default: false) to `build/ci-pipeline.yml`, `build/pr-pipeline.yml`, and the `docker-build-all.yml` template, enabling selective execution of pipeline stages. [[1]](diffhunk://#diff-2d945034ea8bc333996fb2caeaf7c5ccf67fc96c76a34fdc147dd0277827bb98R7-R17) [[2]](diffhunk://#diff-c2e99165f026540a53d8dc27816d7e2b9dccbd9612f1832974adee41f8c620a9R6-R16) [[3]](diffhunk://#diff-64655332ae1f5deb41a192fe0eb4517c20b560f76932738e44ce7c8606a43ffbR9-R11)
- Applied Azure Pipeline conditions to skip R4B and R5 deployment and test stages when `buildCriticalOnly` is true in both CI and PR pipelines. [[1]](diffhunk://#diff-2d945034ea8bc333996fb2caeaf7c5ccf67fc96c76a34fdc147dd0277827bb98R229) [[2]](diffhunk://#diff-2d945034ea8bc333996fb2caeaf7c5ccf67fc96c76a34fdc147dd0277827bb98R242) [[3]](diffhunk://#diff-2d945034ea8bc333996fb2caeaf7c5ccf67fc96c76a34fdc147dd0277827bb98R255) [[4]](diffhunk://#diff-2d945034ea8bc333996fb2caeaf7c5ccf67fc96c76a34fdc147dd0277827bb98R271) [[5]](diffhunk://#diff-2d945034ea8bc333996fb2caeaf7c5ccf67fc96c76a34fdc147dd0277827bb98R284) [[6]](diffhunk://#diff-2d945034ea8bc333996fb2caeaf7c5ccf67fc96c76a34fdc147dd0277827bb98R297) [[7]](diffhunk://#diff-c2e99165f026540a53d8dc27816d7e2b9dccbd9612f1832974adee41f8c620a9R283) [[8]](diffhunk://#diff-c2e99165f026540a53d8dc27816d7e2b9dccbd9612f1832974adee41f8c620a9R303) [[9]](diffhunk://#diff-c2e99165f026540a53d8dc27816d7e2b9dccbd9612f1832974adee41f8c620a9R327) [[10]](diffhunk://#diff-c2e99165f026540a53d8dc27816d7e2b9dccbd9612f1832974adee41f8c620a9R347) [[11]](diffhunk://#diff-c2e99165f026540a53d8dc27816d7e2b9dccbd9612f1832974adee41f8c620a9R401) [[12]](diffhunk://#diff-c2e99165f026540a53d8dc27816d7e2b9dccbd9612f1832974adee41f8c620a9R417)
- Updated Docker build jobs to skip R4B and R5 image builds when `buildCriticalOnly` is enabled. [[1]](diffhunk://#diff-64655332ae1f5deb41a192fe0eb4517c20b560f76932738e44ce7c8606a43ffbR20) [[2]](diffhunk://#diff-64655332ae1f5deb41a192fe0eb4517c20b560f76932738e44ce7c8606a43ffbR33)

**Stage Dependencies and Finalization:**
- Adjusted dependencies and finalization logic in both pipelines to ensure the correct stages are required for success when running in critical-only mode (e.g., only require STU3/R4 tests to pass when skipping R4B/R5). [[1]](diffhunk://#diff-2d945034ea8bc333996fb2caeaf7c5ccf67fc96c76a34fdc147dd0277827bb98R313-R321) [[2]](diffhunk://#diff-c2e99165f026540a53d8dc27816d7e2b9dccbd9612f1832974adee41f8c620a9R433-R441)

**Documentation:**
- Added a new architecture decision record (`docs/arch/adr-2510-critical-build-flag.md`) detailing the rationale, implementation, usage guidelines, and consequences of the `buildCriticalOnly` flag.

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
