### PR TITLE
Remove second hash from includes

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Search/Expressions/Visitors/QueryGenerators/SqlQueryGenerator.cs
@@ -108,6 +108,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
 
             _rootExpression = expression;
 
+            var visitedInclude = false;
             if (expression.SearchParamTableExpressions.Count > 0)
             {
                 if (expression.ResourceTableExpressions.Count > 0)
@@ -135,7 +136,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                 StringBuilder.AppendLine(")");
                 StringBuilder.AppendLine("DECLARE @FilteredDataSmartV2Union AS TABLE (T1 smallint, Sid1 bigint)");
                 StringBuilder.AppendLine(";WITH");
-                var visitedInclude = false;
                 StringBuilder.AppendDelimited($"{Environment.NewLine},", expression.SearchParamTableExpressions.SortExpressionsByQueryLogic(), (sb, tableExpression) =>
                 {
                     if (tableExpression.SplitExpressions(out UnionExpression unionExpression, out SearchParamTableExpression allOtherRemainingExpressions))
@@ -183,7 +183,10 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Search.Expressions.Visitors.Q
                 StringBuilder.AppendLine();
             }
 
-            AddHash();
+            if (!visitedInclude)
+            {
+                AddHash(); // for include and rev-include we already added hash for all filtering conditions to the filter query
+            }
 
             string resourceTableAlias = "r";
             bool selectingFromResourceTable;


### PR DESCRIPTION
This fixes current bug in SQL query generator. It removes unnecessary hash from include/rev-include query part. This allows to cache query plan, so its compilation time on subsequent executions is reduced to zero. Assuming filter query is always re-compiled to guarantee best plan, for simple rev-include/include queries this leads to reduction of total compilation time on subsequent executions ~5x. For complex include queries this reduction can be >10x. 
This fix improves DDMS queries.