### PR TITLE
[Bundle] In-memory operations are cleaned in case of failures

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerParallelOperations.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerParallelOperations.cs
@@ -201,7 +201,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
 
         private void CompleteOperation(IBundleOrchestratorOperation bundleOperation)
         {
-            if (_bundleOrchestrator == null)
+            if (_bundleOrchestrator == null || bundleOperation == null)
             {
                 return;
             }


### PR DESCRIPTION
## Description
Ensure in-memory operations are cleaned in case of failures.

## Related issues
[AB#175078](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/175078)

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
