### PR TITLE
Ignore cid-0

### DIFF
--- a/src/Microsoft.Health.Fhir.R4.Core.UnitTests/Microsoft.Health.Fhir.R4.Core.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.R4.Core.UnitTests/Microsoft.Health.Fhir.R4.Core.UnitTests.csproj
@@ -13,6 +13,8 @@
     <Compile Include="..\Microsoft.Health.Fhir.Shared.Core.UnitTests\Features\Operations\ConvertData\ConvertDataRequestHandlerTests.cs" Link="Operations\ConvertData\ConvertDataRequestHandlerTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Hl7.Fhir.Specification.Data.R4" IncludeAssets="contentFiles" />
+    <PackageReference Include="Hl7.Fhir.Validation.Legacy.R4" />
     <PackageReference Include="Microsoft.Health.Test.Utilities" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />

--- a/src/Microsoft.Health.Fhir.R4B.Core.UnitTests/Microsoft.Health.Fhir.R4B.Core.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.R4B.Core.UnitTests/Microsoft.Health.Fhir.R4B.Core.UnitTests.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Hl7.Fhir.Specification.Data.R4B" IncludeAssets="contentFiles" />
+    <PackageReference Include="Hl7.Fhir.Validation.Legacy.R4B" />
     <PackageReference Include="Microsoft.Health.Test.Utilities" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />

--- a/src/Microsoft.Health.Fhir.R5.Core.UnitTests/Microsoft.Health.Fhir.R5.Core.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.R5.Core.UnitTests/Microsoft.Health.Fhir.R5.Core.UnitTests.csproj
@@ -6,6 +6,8 @@
     <DefineConstants>R5</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Hl7.Fhir.Specification.Data.R5" IncludeAssets="contentFiles" />
+    <PackageReference Include="Hl7.Fhir.Validation.Legacy.R5" />
     <PackageReference Include="Microsoft.Health.Test.Utilities" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Microsoft.Health.Fhir.Shared.Core.UnitTests.projitems
@@ -59,6 +59,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\TypedElementSearchIndexerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Search\USCoreTestHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Security\Authorization\RoleBasedFhirAuthorizationServiceTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\Validation\ProfileValidatorTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Validation\ResourceProfileValidatorTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Models\BundleResourceContextComparerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\Persistence\ResourceWrapperFactoryTests.cs" />

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Validation/ProfileValidator.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Validation/ProfileValidator.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
             }
         }
 
-        private Validator GetValidator()
+        internal Validator GetValidator()
         {
             if (_validator != null && (DateTime.UtcNow - _lastValidatorRefresh) < _validatatorRefresh)
             {

--- a/src/Microsoft.Health.Fhir.Stu3.Core.UnitTests/Microsoft.Health.Fhir.Stu3.Core.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.Stu3.Core.UnitTests/Microsoft.Health.Fhir.Stu3.Core.UnitTests.csproj
@@ -10,6 +10,8 @@
     <Compile Include="..\Microsoft.Health.Fhir.Shared.Core.UnitTests\Features\Operations\Export\ExportAnonymizerTests.cs" Link="Features\Export\ExportAnonymizerTests.cs" />  
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Hl7.Fhir.Specification.Data.Stu3" IncludeAssets="contentFiles" />
+    <PackageReference Include="Hl7.Fhir.Validation.Legacy.Stu3" />
     <PackageReference Include="Microsoft.Health.Test.Utilities" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />


### PR DESCRIPTION
## Description
This pull request adds comprehensive unit tests for the `ProfileValidator` class and updates its implementation to correctly handle the `cid-0` constraint based on the FHIR version. The changes improve validation accuracy for different FHIR specifications and ensure that the validator's behavior is thoroughly tested.

**Unit test coverage for validation logic:**

* Added a new test class `ProfileValidatorTests` in `ProfileValidatorTests.cs` to verify that the `cid-0` constraint is ignored for FHIR R4 and later, but not for STU3, and that the constraint is preserved across validator refreshes.

**Validation logic improvements:**

* Updated the constructor of `ProfileValidator` in `ProfileValidator.cs` to accept an `IModelInfoProvider` parameter, enabling version-specific logic for FHIR validation.
* Modified the internal validator creation to append `cid-0` to the `ConstraintsToIgnore` list for FHIR R4 and later, addressing a known spec error.
* Minor code cleanup in value set expander settings initialization for clarity.

## Related issues
Addresses [Bug 175473](https://microsofthealth.visualstudio.com/Health/_workitems/edit/175473)

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
