### PR TITLE
Fix patch history versions if only meta is updated

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Messages/Upsert/UpsertResourceRequest.cs
+++ b/src/Microsoft.Health.Fhir.Core/Messages/Upsert/UpsertResourceRequest.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Health.Fhir.Core.Messages.Upsert
 {
     public class UpsertResourceRequest : BaseBundleInnerRequest, IRequest<UpsertResourceResponse>, IRequest, IRequireCapability
     {
-        public UpsertResourceRequest(ResourceElement resource, BundleResourceContext bundleResourceContext = null, WeakETag weakETag = null, bool metaHistory = false)
+        public UpsertResourceRequest(ResourceElement resource, BundleResourceContext bundleResourceContext = null, WeakETag weakETag = null, bool metaHistory = true)
             : base(bundleResourceContext)
         {
             EnsureArg.IsNotNull(resource, nameof(resource));

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/FhirPathPatchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/FhirPathPatchTests.cs
@@ -475,5 +475,201 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             // DateTime with offset
             await Assert.ThrowsAsync<FhirClientException>(() => _client.FhirPatchAsync(response.Resource, patchRequest));
         }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenAServerThatSupportsIt_WhenPatchingOnlyMetaTag_ThenServerShouldCreateNewVersionAndPreserveHistory()
+        {
+            // Create initial patient resource
+            var poco = Samples.GetDefaultPatient().ToPoco<Patient>();
+            FhirResponse<Patient> createResponse = await _client.CreateAsync(poco);
+
+            Assert.Equal("1", createResponse.Resource.Meta.VersionId);
+            Assert.NotNull(createResponse.Resource.Id);
+
+            string patientId = createResponse.Resource.Id;
+            string initialVersionId = createResponse.Resource.Meta.VersionId;
+
+            // Create patch request to add a tag to meta.tag array
+            var patchRequest = new Parameters().AddPatchParameter(
+                "add",
+                "Patient.meta",
+                "tag",
+                new List<Parameters.ParameterComponent>()
+                {
+                    new Parameters.ParameterComponent { Name = "system", Value = new FhirUri("ORGANIZATION_ID") },
+                    new Parameters.ParameterComponent { Name = "code", Value = new Code("fhirLegalEntityId") },
+                    new Parameters.ParameterComponent { Name = "display", Value = new FhirString("fhirLegalEntityId") },
+                });
+
+            // Apply patch with If-Match header
+            using FhirResponse<Patient> patchResponse = await _client.FhirPatchAsync(
+                createResponse.Resource,
+                patchRequest,
+                ifMatchVersion: initialVersionId);
+
+            // Verify patch was successful
+            Assert.Equal(HttpStatusCode.OK, patchResponse.Response.StatusCode);
+            Assert.Equal("2", patchResponse.Resource.Meta.VersionId);
+            Assert.Equal(patientId, patchResponse.Resource.Id);
+
+            // Verify the tag was added
+            Assert.NotNull(patchResponse.Resource.Meta.Tag);
+            var addedTag = patchResponse.Resource.Meta.Tag.FirstOrDefault(t =>
+                t.System == "ORGANIZATION_ID" &&
+                t.Code == "fhirLegalEntityId");
+            Assert.NotNull(addedTag);
+            Assert.Equal("fhirLegalEntityId", addedTag.Display);
+
+            // Verify history is preserved - both versions should exist
+            FhirResponse<Bundle> historyResponse = await _client.ReadHistoryAsync(
+                ResourceType.Patient,
+                patientId);
+
+            Assert.NotNull(historyResponse.Resource);
+            Assert.True(
+                historyResponse.Resource.Entry.Count >= 2,
+                $"Expected at least 2 history entries, but found {historyResponse.Resource.Entry.Count}");
+
+            // Verify version 1 exists in history
+            var version1Entry = historyResponse.Resource.Entry.FirstOrDefault(e =>
+                e.Resource is Patient p && p.Meta.VersionId == "1");
+            Assert.NotNull(version1Entry);
+
+            // Verify version 2 exists in history
+            var version2Entry = historyResponse.Resource.Entry.FirstOrDefault(e =>
+                e.Resource is Patient p && p.Meta.VersionId == "2");
+            Assert.NotNull(version2Entry);
+
+            // Verify version 1 doesn't have the tag
+            var version1Patient = version1Entry.Resource as Patient;
+            var version1Tag = version1Patient?.Meta.Tag?.FirstOrDefault(t =>
+                t.System == "ORGANIZATION_ID" &&
+                t.Code == "fhirLegalEntityId");
+            Assert.Null(version1Tag);
+
+            // Verify version 2 has the tag
+            var version2Patient = version2Entry.Resource as Patient;
+            var version2Tag = version2Patient?.Meta.Tag?.FirstOrDefault(t =>
+                t.System == "ORGANIZATION_ID" &&
+                t.Code == "fhirLegalEntityId");
+            Assert.NotNull(version2Tag);
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenAServerThatSupportsIt_WhenPatchingMetaTagWithWrongVersion_ThenServerShouldReturnPreconditionFailed()
+        {
+            // Create initial patient resource
+            var poco = Samples.GetDefaultPatient().ToPoco<Patient>();
+            FhirResponse<Patient> createResponse = await _client.CreateAsync(poco);
+
+            Assert.Equal("1", createResponse.Resource.Meta.VersionId);
+
+            // Create patch request to add a tag
+            var patchRequest = new Parameters().AddPatchParameter(
+                "add",
+                "Patient.meta",
+                "tag",
+                new List<Parameters.ParameterComponent>()
+                {
+                    new Parameters.ParameterComponent { Name = "system", Value = new FhirUri("ORGANIZATION_ID") },
+                    new Parameters.ParameterComponent { Name = "code", Value = new Code("fhirLegalEntityId") },
+                    new Parameters.ParameterComponent { Name = "display", Value = new FhirString("fhirLegalEntityId") },
+                });
+
+            // Apply patch with incorrect If-Match header (version 3 doesn't exist)
+            var exception = await Assert.ThrowsAsync<FhirClientException>(() =>
+                _client.FhirPatchAsync(
+                    createResponse.Resource,
+                    patchRequest,
+                    ifMatchVersion: "3"));
+
+            // Verify precondition failed error
+            Assert.Equal(HttpStatusCode.PreconditionFailed, exception.Response.StatusCode);
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenAServerThatSupportsIt_WhenPatchingMetaTagMultipleTimes_ThenAllVersionsShouldBeInHistory()
+        {
+            // Create initial patient resource
+            var poco = Samples.GetDefaultPatient().ToPoco<Patient>();
+            FhirResponse<Patient> createResponse = await _client.CreateAsync(poco);
+
+            string patientId = createResponse.Resource.Id;
+
+            // First patch: Add first tag
+            var patchRequest1 = new Parameters().AddPatchParameter(
+                "add",
+                "Patient.meta",
+                "tag",
+                new List<Parameters.ParameterComponent>()
+                {
+                    new Parameters.ParameterComponent { Name = "system", Value = new FhirUri("ORGANIZATION_ID") },
+                    new Parameters.ParameterComponent { Name = "code", Value = new Code("tag1") },
+                    new Parameters.ParameterComponent { Name = "display", Value = new FhirString("First Tag") },
+                });
+
+            using FhirResponse<Patient> patchResponse1 = await _client.FhirPatchAsync(
+                createResponse.Resource,
+                patchRequest1,
+                ifMatchVersion: "1");
+
+            Assert.Equal("2", patchResponse1.Resource.Meta.VersionId);
+
+            // Second patch: Add second tag
+            var patchRequest2 = new Parameters().AddPatchParameter(
+                "add",
+                "Patient.meta",
+                "tag",
+                new List<Parameters.ParameterComponent>()
+                {
+                    new Parameters.ParameterComponent { Name = "system", Value = new FhirUri("ORGANIZATION_ID") },
+                    new Parameters.ParameterComponent { Name = "code", Value = new Code("tag2") },
+                    new Parameters.ParameterComponent { Name = "display", Value = new FhirString("Second Tag") },
+                });
+
+            using FhirResponse<Patient> patchResponse2 = await _client.FhirPatchAsync(
+                patchResponse1.Resource,
+                patchRequest2,
+                ifMatchVersion: "2");
+
+            Assert.Equal("3", patchResponse2.Resource.Meta.VersionId);
+
+            // Verify all three versions exist in history
+            FhirResponse<Bundle> historyResponse = await _client.ReadHistoryAsync(
+                ResourceType.Patient,
+                patientId);
+
+            Assert.NotNull(historyResponse.Resource);
+            Assert.True(
+                historyResponse.Resource.Entry.Count >= 3,
+                $"Expected at least 3 history entries, but found {historyResponse.Resource.Entry.Count}");
+
+            // Verify version progression
+            var version1 = historyResponse.Resource.Entry.FirstOrDefault(e =>
+                e.Resource is Patient p && p.Meta.VersionId == "1")?.Resource as Patient;
+            var version2 = historyResponse.Resource.Entry.FirstOrDefault(e =>
+                e.Resource is Patient p && p.Meta.VersionId == "2")?.Resource as Patient;
+            var version3 = historyResponse.Resource.Entry.FirstOrDefault(e =>
+                e.Resource is Patient p && p.Meta.VersionId == "3")?.Resource as Patient;
+
+            Assert.NotNull(version1);
+            Assert.NotNull(version2);
+            Assert.NotNull(version3);
+
+            // Version 1: No tags
+            Assert.True(version1.Meta.Tag == null || !version1.Meta.Tag.Any(t => t.System == "ORGANIZATION_ID"));
+
+            // Version 2: Has first tag only
+            Assert.Single(version2.Meta.Tag, t => t.System == "ORGANIZATION_ID");
+            Assert.NotNull(version2.Meta.Tag.FirstOrDefault(t => t.Code == "tag1"));
+
+            // Version 3: Has both tags
+            Assert.Equal(2, version3.Meta.Tag.Count(t => t.System == "ORGANIZATION_ID"));
+            Assert.NotNull(version3.Meta.Tag.FirstOrDefault(t => t.Code == "tag1"));
+            Assert.NotNull(version3.Meta.Tag.FirstOrDefault(t => t.Code == "tag2"));
+        }
     }
 }


### PR DESCRIPTION
## Description
Luxxotica noticed the behavior below with PATH operation when they PATCH the meta.tag attribute, other PATCH operations do not incur into this issue.
• They create a resource (POST) -> v1
• They update the resource (PUT) -> v2
• They update the resource (PATCH) -> v3
• They update the resource (PATCH) -> v4 - v3 is not present anymore
• They update the resource (PATCH) -> v5 - v3, v4 are not present anymore
• They update the resource (PATCH) -> v6 - v3, v4, v5 are not present anymore

This is to enable metadataHistory on by default

## Related issues
Addresses [[issue #].](https://microsofthealth.visualstudio.com/Health/_workitems/edit/177930)

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
