### PR TITLE
Fixing 500 error due to an invalid input url for import.

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ImportControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ImportControllerTests.cs
@@ -51,6 +51,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
                 GetBulkImportRequestConfigurationWithNoInputFile(),
                 GetBulkImportRequestConfigurationWithNoInputUrl(),
                 GetBulkImportRequestConfigurationWithSASToken(),
+                GetBulkImportRequestConfigurationWithRelativeInputUrl(),
             };
 
         [Theory]
@@ -284,6 +285,26 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
                 {
                     Type = "Patient",
                     Url = new Uri("https://client.example.org/patient_file_2.ndjson?sp=r&st=2022-09-30T01:39:01Z&se=2022-09-30T09:39:01Z&spr=https&sv=2021-06-08&sr=b&sig=RHIX5Xcg0Mq2rqI3OlWT"),
+                },
+            };
+
+            var bulkImportRequestConfiguration = new ImportRequest();
+            bulkImportRequestConfiguration.InputFormat = "application/fhir+ndjson";
+            bulkImportRequestConfiguration.InputSource = new Uri("https://other-server.example.org");
+            bulkImportRequestConfiguration.Input = input;
+            bulkImportRequestConfiguration.StorageDetail = new ImportRequestStorageDetail();
+
+            return bulkImportRequestConfiguration;
+        }
+
+        private static ImportRequest GetBulkImportRequestConfigurationWithRelativeInputUrl()
+        {
+            var input = new List<InputResource>
+            {
+                new InputResource
+                {
+                    Type = "Patient",
+                    Url = new Uri("/blob/patient_file_2.ndjson", UriKind.RelativeOrAbsolute),
                 },
             };
 

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ImportController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ImportController.cs
@@ -220,7 +220,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                     throw new RequestNotValidException(string.Format(Resources.UnsupportedResourceType, item.Type));
                 }
 
-                if (item.Url == null || !string.IsNullOrEmpty(item.Url.Query))
+                if (item.Url == null || !item.Url.IsAbsoluteUri || !string.IsNullOrEmpty(item.Url.Query))
                 {
                     throw new RequestNotValidException(string.Format(Resources.ImportRequestValueNotValid, "input.url"));
                 }


### PR DESCRIPTION
## Description
Fixing 500 error due to an invalid input url for import that occurs when the given input url is a relative url and we check if the url has a query string. The fix will address the issue by checking if the url is relative before checking the presence of a query string.

## Related issues
Addresses [issue #152590].

[Bug 152590](https://microsofthealth.visualstudio.com/Health/_workitems/edit/152590): Import can fail due "This operation is not supported for a relative URI."

## Testing
Tested by adding UT.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
