### PR TITLE
Updates to improve PR infrastructure deployment stability

### DIFF
--- a/build/build-variables.yml
+++ b/build/build-variables.yml
@@ -16,6 +16,14 @@ variables:
   DeploymentEnvironmentNameR4BSql: '$(DeploymentEnvironmentNameR4B)-sql'
   DeploymentEnvironmentNameR5: '$(DeploymentEnvironmentName)-r5'
   DeploymentEnvironmentNameR5Sql: '$(DeploymentEnvironmentNameR5)-sql'
+  # Key Vault names (shorter due to 24 character limit)
+  KeyVaultNameSql: '$(KeyVaultBaseName)-sql'
+  KeyVaultNameR4: '$(KeyVaultBaseName)-r4'
+  KeyVaultNameR4Sql: '$(KeyVaultNameR4)-sql'
+  KeyVaultNameR4B: '$(KeyVaultBaseName)-r4b'
+  KeyVaultNameR4BSql: '$(KeyVaultNameR4B)-sql'
+  KeyVaultNameR5: '$(KeyVaultBaseName)-r5'
+  KeyVaultNameR5Sql: '$(KeyVaultNameR5)-sql'
   TestEnvironmentUrl: 'https://$(DeploymentEnvironmentName).azurewebsites.net'
   # These variables are not used in the deployment scripts, but are used in the E2E tests files.
   TestEnvironmentUrl_Sql: 'https://$(DeploymentEnvironmentName)-sql.azurewebsites.net'

--- a/build/ci-variables.yml
+++ b/build/ci-variables.yml
@@ -4,6 +4,8 @@ variables:
     resourceGroupRoot: 'msh-fhir-ci4'
     appServicePlanName: '$(resourceGroupRoot)-linux'
     DeploymentEnvironmentName: '$(resourceGroupRoot)'
+    # CI uses the same name for Key Vaults as the deployment environment (no BuildId suffix needed)
+    KeyVaultBaseName: '$(DeploymentEnvironmentName)'
     ResourceGroupName: '$(resourceGroupRoot)'
     CrucibleEnvironmentUrl: 'https://crucible.mshapis.com/'
     TestEnvironmentName: 'OSS CI'

--- a/build/jobs/add-aad-test-environment.yml
+++ b/build/jobs/add-aad-test-environment.yml
@@ -32,21 +32,9 @@ steps:
       $password =  ConvertTo-SecureString -AsPlainText $password_raw -Force
       $clientSecretCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $clientId, $password
 
-      # If a deleted keyvault with purge protection exists, try to restore it.
       $environmentName = "$(DeploymentEnvironmentName)".ToLower() -replace "\.", "" 
+      $keyVaultName = "$(KeyVaultBaseName)-ts".ToLower() -replace "\.", ""
       Write-Host "Installed module and set variables"
-
-      $vaultName = "${environmentName}-ts"
-      $vaultLocation = "westus"
-      $vaultResourceGroupName = "$(ResourceGroupName)"
-      if (Get-AzKeyVault -VaultName $vaultName -Location $vaultLocation -InRemovedState)
-      {
-          Write-Host "Attempting to restore vault ${vaultName}"
-
-          Undo-AzKeyVaultRemoval -VaultName $vaultName -ResourceGroupName $vaultResourceGroupName -Location $vaultLocation
-          Write-Host "KeyVault $vaultName is restored"
-      }
-      Write-Host "Restored keyvaults"
 
       # Connect to Microsoft Graph using client credentials
       Write-Host "Connecting to Microsoft Graph"
@@ -57,4 +45,4 @@ steps:
       Import-Module $(System.DefaultWorkingDirectory)/release/scripts/PowerShell/FhirServerRelease/FhirServerRelease.psd1
 
       Write-Host "Imported modules"
-      $output = Add-AadTestAuthEnvironment -TestAuthEnvironmentPath $(System.DefaultWorkingDirectory)/testauthenvironment.json -EnvironmentName $environmentName -ResourceGroupName $(ResourceGroupName) -TenantAdminCredential $clientSecretCredential -TenantId $tenantId -ClientId $clientId -ClientSecret $password
+      $output = Add-AadTestAuthEnvironment -TestAuthEnvironmentPath $(System.DefaultWorkingDirectory)/testauthenvironment.json -EnvironmentName $environmentName -KeyVaultName $keyVaultName -ResourceGroupName $(UniqueResourceGroupName) -EnvironmentLocation $(ResourceGroupRegion) -TenantAdminCredential $clientSecretCredential -TenantId $tenantId -ClientId $clientId -ClientSecret $password

--- a/build/jobs/cleanup.yml
+++ b/build/jobs/cleanup.yml
@@ -12,12 +12,71 @@ jobs:
       azurePowerShellVersion: latestVersion
       ScriptType: InlineScript
       Inline: |
-        Get-AzResourceGroup -Name $(ResourceGroupName) -ErrorVariable notPresent -ErrorAction SilentlyContinue 
+        $deploymentEnvName = "$(DeploymentEnvironmentName)"
+        $keyVaultBaseName = "$(KeyVaultBaseName)"
+        
+        Get-AzResourceGroup -Name $(UniqueResourceGroupName) -ErrorVariable notPresent -ErrorAction SilentlyContinue 
         if ($notPresent) {
-          Write-Host "Resource group $(ResourceGroupName) not found"
+          Write-Host "Resource group $(UniqueResourceGroupName) not found"
         } else {
-          Write-Host "Deleting resource group $(ResourceGroupName)"
-          Remove-AzResourceGroup -Name $(ResourceGroupName) -Force -Verbose
+          Write-Host "Deleting resource group $(UniqueResourceGroupName)"
+          $maxRetries = 3
+          $retryCount = 0
+          $deleted = $false
+          
+          while (-not $deleted -and $retryCount -lt $maxRetries) {
+            try {
+              Remove-AzResourceGroup -Name $(UniqueResourceGroupName) -Force -Verbose -ErrorAction Stop
+              $deleted = $true
+              Write-Host "Successfully deleted resource group $(UniqueResourceGroupName)"
+            }
+            catch {
+              $retryCount++
+              if ($retryCount -lt $maxRetries) {
+                Write-Warning "Failed to delete resource group (attempt $retryCount of $maxRetries). Retrying in 30 seconds... Error: $($_.Exception.Message)"
+                Start-Sleep -Seconds 30
+              } else {
+                Write-Warning "Failed to delete resource group after $maxRetries attempts. Error: $($_.Exception.Message)"
+              }
+            }
+          }
+        }
+        
+        # Purge any soft-deleted Key Vaults from this build
+        # Vault names use KeyVaultBaseName (e.g., f20585pr5240-ts, f20585pr5240-r4, etc.)
+        $vaultPattern = "$keyVaultBaseName*"
+        Write-Host "Checking for soft-deleted Key Vaults matching pattern: $vaultPattern"
+        $softDeletedVaults = Get-AzKeyVault -InRemovedState -ErrorAction SilentlyContinue | Where-Object {
+          $_.VaultName -like $vaultPattern
+        }
+        
+        if ($softDeletedVaults.Count -eq 0) {
+          Write-Host "No soft-deleted vaults found to purge"
+        } else {
+          Write-Host "Found $($softDeletedVaults.Count) soft-deleted vault(s) to purge"
+          
+          $results = $softDeletedVaults | ForEach-Object -Parallel {
+            $vaultName = $_.VaultName
+            $vaultLocation = $_.Location
+            try {
+              Remove-AzKeyVault -VaultName $vaultName -Location $vaultLocation -InRemovedState -Force -ErrorAction Stop
+              [PSCustomObject]@{ Vault = $vaultName; Status = "Success" }
+            }
+            catch {
+              [PSCustomObject]@{ Vault = $vaultName; Status = "Failed: $($_.Exception.Message)" }
+            }
+          } -ThrottleLimit 10
+          
+          $results | ForEach-Object {
+            if ($_.Status -eq "Success") {
+              Write-Host "Successfully purged vault: $($_.Vault)"
+            } else {
+              Write-Warning "Failed to purge vault $($_.Vault). $($_.Status)"
+            }
+          }
+          
+          $successCount = ($results | Where-Object { $_.Status -eq "Success" }).Count
+          Write-Host "Completed purging: $successCount of $($softDeletedVaults.Count) vaults"
         }
       
 

--- a/build/jobs/e2e-setup.yml
+++ b/build/jobs/e2e-setup.yml
@@ -17,7 +17,7 @@ steps:
       KeyVaultName: 'resolute-oss-tenant-info'
 
   - task: AzureKeyVault@1
-    displayName: 'Azure Key Vault: $(DeploymentEnvironmentName)-ts'
+    displayName: 'Azure Key Vault: $(KeyVaultBaseName)-ts'
     inputs:
       azureSubscription: $(ConnectedServiceName)
-      KeyVaultName: '$(DeploymentEnvironmentName)-ts'
+      KeyVaultName: '$(KeyVaultBaseName)-ts'

--- a/build/jobs/e2e-tests.yml
+++ b/build/jobs/e2e-tests.yml
@@ -5,92 +5,29 @@ parameters:
   type: string
 - name: appServiceType
   type: string
+- name: categoryFilter
+  type: string
+  default: 'Category!=ExportLongRunning'
+- name: testRunTitleSuffix
+  type: string
+  default: ''
 
 steps:
   - template: e2e-tests-extract.yml
     parameters:
       version: ${{parameters.version}}
 
-  - task: AzurePowerShell@5
-    displayName: 'Set Variables'
-    inputs:
-      azureSubscription: $(ConnectedServiceName)
-      azurePowerShellVersion: latestVersion
-      ScriptType: inlineScript
-      Inline: |
-        $keyVault = "$(DeploymentEnvironmentName)-ts"
-        $secrets = Get-AzKeyVaultSecret -VaultName $keyVault
-
-        foreach($secret in $secrets)
-        {
-            $environmentVariableName = $secret.Name.Replace("--","_")
-
-            $secretValue = Get-AzKeyVaultSecret -VaultName $keyVault -Name $secret.Name
-            # Replace with -AsPlainText flag when v5.3 of the Az Module is supported
-            $plainValue = ([System.Net.NetworkCredential]::new("", $secretValue.SecretValue).Password).ToString()
-            if([string]::IsNullOrEmpty($plainValue))
-            {
-                throw "$($secret.Name) is empty"
-            }
-            Write-Host "##vso[task.setvariable variable=$($environmentVariableName)]$($plainValue)"
-        }
-
-        $appServiceName = "${{ parameters.appServiceName }}"
-        $appSettings = (Get-AzWebApp -ResourceGroupName $(ResourceGroupName) -Name $appServiceName).SiteConfig.AppSettings
-        $acrSettings = $appSettings | where {$_.Name -eq "FhirServer__Operations__ConvertData__ContainerRegistryServers__0"}
-        $acrLoginServer = $acrSettings[0].Value
-        $acrAccountName = ($acrLoginServer -split '\.')[0]
-
-        ## This needs to be moved to MI, WI #125246  
-        # $acrPassword = (Get-AzContainerRegistryCredential -ResourceGroupName $(ResourceGroupName) -Name $acrAccountName).Password
-        # Write-Host "##vso[task.setvariable variable=TestContainerRegistryServer]$($acrLoginServer)"
-        # Write-Host "##vso[task.setvariable variable=TestContainerRegistryPassword]$($acrPassword)"
-
-        $exportStoreSettings = $appSettings | where {$_.Name -eq "FhirServer__Operations__Export__StorageAccountUri"}
-        $exportStoreUri = $exportStoreSettings[0].Value
-        Write-Host "$exportStoreUri"
-        $exportStoreAccountName = [System.Uri]::new("$exportStoreUri").Host.Split('.')[0]
-        $exportStoreKey = Get-AzStorageAccountKey -ResourceGroupName $(ResourceGroupName) -Name "$exportStoreAccountName" | Where-Object {$_.KeyName -eq "key1"}
-        
-        Write-Host "##vso[task.setvariable variable=TestExportStoreUri]$($exportStoreUri)"
-
-        $integrationStoreSettings = $appSettings | where {$_.Name -eq "FhirServer__Operations__IntegrationDataStore__StorageAccountUri"}
-        $integrationStoreUri = $integrationStoreSettings[0].Value
-        Write-Host "$integrationStoreUri"
-        $integrationStoreAccountName = [System.Uri]::new("$integrationStoreUri").Host.Split('.')[0]
-        Write-Host "##vso[task.setvariable variable=TestIntegrationStoreUri]$($integrationStoreUri)"
-
-        Write-Host "##vso[task.setvariable variable=Resource]$(TestApplicationResource)"
-        
-        $secrets = Get-AzKeyVaultSecret -VaultName resolute-oss-tenant-info
-        foreach($secret in $secrets)
-        {
-            $environmentVariableName = $secret.Name.Replace("--","_")
-
-            $secretValue = Get-AzKeyVaultSecret -VaultName resolute-oss-tenant-info -Name $secret.Name
-            # Replace with -AsPlainText flag when v5.3 of the Az Module is supported
-            $plainValue = ([System.Net.NetworkCredential]::new("", $secretValue.SecretValue).Password).ToString()
-            if([string]::IsNullOrEmpty($plainValue))
-            {
-                throw "$($secret.Name) is empty"
-            }
-            Write-Host "##vso[task.setvariable variable=$($environmentVariableName)]$($plainValue)"
-        }
-        # ----------------------------------------
-
-        dotnet dev-certs https
-
-        Write-Host "##vso[task.setvariable variable=AZURESUBSCRIPTION_CLIENT_ID]$env:AZURESUBSCRIPTION_CLIENT_ID"
-        Write-Host "##vso[task.setvariable variable=AZURESUBSCRIPTION_TENANT_ID]$env:AZURESUBSCRIPTION_TENANT_ID"
-        Write-Host "##vso[task.setvariable variable=AZURESUBSCRIPTION_SERVICE_CONNECTION_ID]$env:AZURESUBSCRIPTION_SERVICE_CONNECTION_ID"
+  - template: ../tasks/e2e-set-variables.yml
+    parameters:
+      appServiceName: ${{ parameters.appServiceName }}
 
   - task: DotNetCoreCLI@2
-    displayName: 'E2E ${{ parameters.version }} ${{parameters.appServiceType}}'
+    displayName: 'E2E ${{ parameters.version }} ${{parameters.appServiceType}}${{ parameters.testRunTitleSuffix }}'
     inputs:
       command: test
-      arguments: '"$(Agent.TempDirectory)/E2ETests/**/*${{ parameters.version }}.Tests.E2E*.dll" --blame-hang-timeout 7m --filter "FullyQualifiedName~${{parameters.appServiceType}}&Category!=ExportLongRunning"'
+      arguments: '"$(Agent.TempDirectory)/E2ETests/**/*${{ parameters.version }}.Tests.E2E*.dll" --blame-hang-timeout 15m --filter "FullyQualifiedName~${{parameters.appServiceType}}&${{ parameters.categoryFilter }}"'
       workingDirectory: "$(System.ArtifactsDirectory)"
-      testRunTitle: '${{ parameters.version }} ${{parameters.appServiceType}}'
+      testRunTitle: '${{ parameters.version }} ${{parameters.appServiceType}}${{ parameters.testRunTitleSuffix }}'
     env:
       'TestEnvironmentUrl': $(TestEnvironmentUrl)
       'TestEnvironmentUrl_${{ parameters.version }}': $(TestEnvironmentUrl_${{ parameters.version }})

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -30,6 +30,9 @@ parameters:
 - name: reindexEnabled
   type: boolean
   default: true
+- name: keyVaultName
+  type: string
+  default: ''
 
 jobs:
 - job: provisionEnvironment
@@ -73,6 +76,7 @@ jobs:
             appServicePlanSku = "P2V3"
             numberOfInstances = 2
             serviceName = $webAppName
+            keyVaultName = "${{ parameters.keyVaultName }}".ToLower()
             securityAuthenticationAuthority = "https://login.microsoftonline.com/$(tenant-id)"
             securityAuthenticationAudience = "${{ parameters.testEnvironmentUrl }}"
             additionalFhirServerConfigProperties = $additionalProperties
@@ -98,13 +102,6 @@ jobs:
 
         $deploymentName = $webAppName
         $resourceGroupName = "${{ parameters.resourceGroup }}"
-
-        Write-Host "Check for keyvaults in removed state..."
-        if (Get-AzKeyVault -VaultName $webAppName -Location $(ResourceGroupRegion) -InRemovedState)
-        {
-            Undo-AzKeyVaultRemoval -VaultName $webAppName -ResourceGroupName $resourceGroupName -Location $(ResourceGroupRegion)
-            Write-Host "KeyVault $webAppName is restored"
-        }
 
         Write-Host "Provisioning Resource Group"
         Write-Host "ResourceGroupName: ${{ parameters.resourceGroup }}"

--- a/build/jobs/provision-sqlServer.yml
+++ b/build/jobs/provision-sqlServer.yml
@@ -114,13 +114,34 @@ jobs:
               'nspProfile' = 'default'
           }
             
-          # Deploy using external template
-          $nspDeploymentResult = New-AzResourceGroupDeployment `
-            -ResourceGroupName $resourceGroup `
-            -Name "$sqlServerName-nsp-association" `
-            -TemplateFile $(System.DefaultWorkingDirectory)/samples/templates/nsp-resource-association.json `
-            -TemplateParameterObject $templateParameters `
-            -Verbose
+          # Deploy using external template with retry logic for transient conflicts
+          $maxRetries = 3
+          $retryDelaySeconds = 15
+          $attempt = 0
+          $success = $false
+          
+          do {
+            try {
+              $attempt++
+              Write-Host "Attempt $attempt of $maxRetries to create NSP association..."
+              
+              $nspDeploymentResult = New-AzResourceGroupDeployment `
+                -ResourceGroupName $resourceGroup `
+                -Name "$sqlServerName-nsp-association" `
+                -TemplateFile $(System.DefaultWorkingDirectory)/samples/templates/nsp-resource-association.json `
+                -TemplateParameterObject $templateParameters `
+                -Verbose
+              
+              $success = $true
+            } catch {
+              if ($_.Exception.Message -like "*Conflict*" -and $attempt -lt $maxRetries) {
+                Write-Host "Conflict detected. Retrying in $retryDelaySeconds seconds..."
+                Start-Sleep -Seconds $retryDelaySeconds
+              } else {
+                throw
+              }
+            }
+          } while (-not $success -and $attempt -lt $maxRetries)
             
           Write-Host "Successfully associated SQL Server with NSP using external ARM template"
           Write-Host "Association Resource ID: $($nspDeploymentResult.Outputs.associationResourceId.Value)"

--- a/build/jobs/run-export-tests.yml
+++ b/build/jobs/run-export-tests.yml
@@ -23,7 +23,7 @@ jobs:
       azurePowerShellVersion: latestVersion
       ScriptType: inlineScript
       Inline: |
-        $keyVault = "$(DeploymentEnvironmentName)-ts"
+        $keyVault = "$(KeyVaultBaseName)-ts"
         $secrets = Get-AzKeyVaultSecret -VaultName $keyVault
         
         foreach($secret in $secrets)
@@ -116,7 +116,7 @@ jobs:
       azurePowerShellVersion: latestVersion
       ScriptType: inlineScript
       Inline: |
-        $keyVault = "$(DeploymentEnvironmentName)-ts"
+        $keyVault = "$(KeyVaultBaseName)-ts"
         $secrets = Get-AzKeyVaultSecret -VaultName $keyVault
         
         foreach($secret in $secrets)

--- a/build/jobs/run-tests.yml
+++ b/build/jobs/run-tests.yml
@@ -40,7 +40,7 @@ jobs:
         Write-Host "##vso[task.setvariable variable=AZURESUBSCRIPTION_SERVICE_CONNECTION_ID]$env:AZURESUBSCRIPTION_SERVICE_CONNECTION_ID"
 
         $appServiceName = '${{ parameters.appServiceName }}'
-        $appSettings = (Get-AzWebApp -ResourceGroupName $(ResourceGroupName) -Name $appServiceName).SiteConfig.AppSettings
+        $appSettings = (Get-AzWebApp -ResourceGroupName $(UniqueResourceGroupName) -Name $appServiceName).SiteConfig.AppSettings
         $dataStoreResourceId = $appSettings | where {$_.Name -eq "FhirServer__ResourceManager__DataStoreResourceId"}
         $dataStoreResourceId = $dataStoreResourceId[0].Value
         Write-Host "$dataStoreResourceId"
@@ -180,6 +180,22 @@ jobs:
       version: ${{ parameters.version }}
       appServiceName: ${{ parameters.appServiceName }}
       appServiceType: 'CosmosDb'
+      categoryFilter: 'Category!=ExportLongRunning&Category!=IndexAndReindex'
+
+- job: 'cosmosE2eTests_Reindex'
+  dependsOn: []
+  pool:
+    name: '$(SharedLinuxPool)'
+    vmImage: '$(LinuxVmImage)'
+  steps:
+  - template: e2e-setup.yml
+  - template: e2e-tests.yml
+    parameters:
+      version: ${{ parameters.version }}
+      appServiceName: ${{ parameters.appServiceName }}
+      appServiceType: 'CosmosDb'
+      categoryFilter: 'Category=IndexAndReindex'
+      testRunTitleSuffix: ' Reindex'
 
 - job: 'sqlE2eTests'
   dependsOn: []
@@ -193,3 +209,34 @@ jobs:
       version: ${{ parameters.version }}
       appServiceName: '${{ parameters.appServiceName }}-sql'
       appServiceType: 'SqlServer'
+      categoryFilter: 'Category!=ExportLongRunning&Category!=IndexAndReindex&Category!=BulkUpdate'
+
+- job: 'sqlE2eTests_Reindex'
+  dependsOn: []
+  pool:
+    name: '$(SharedLinuxPool)'
+    vmImage: '$(LinuxVmImage)'
+  steps:
+  - template: e2e-setup.yml
+  - template: e2e-tests.yml
+    parameters:
+      version: ${{ parameters.version }}
+      appServiceName: '${{ parameters.appServiceName }}-sql'
+      appServiceType: 'SqlServer'
+      categoryFilter: 'Category=IndexAndReindex'
+      testRunTitleSuffix: ' Reindex'
+
+- job: 'sqlE2eTests_BulkUpdate'
+  dependsOn: []
+  pool:
+    name: '$(SharedLinuxPool)'
+    vmImage: '$(LinuxVmImage)'
+  steps:
+  - template: e2e-setup.yml
+  - template: e2e-tests.yml
+    parameters:
+      version: ${{ parameters.version }}
+      appServiceName: '${{ parameters.appServiceName }}-sql'
+      appServiceType: 'SqlServer'
+      categoryFilter: 'Category=BulkUpdate'
+      testRunTitleSuffix: ' BulkUpdate'

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -107,6 +107,19 @@ stages:
       tag: $(ImageTag)
       buildPlatform: $(testDockerImagePlatforms)
 
+- stage: cleanupOldResources
+  displayName: 'Cleanup Old PR Resources'
+  dependsOn: 
+  - setupEnvironment
+  jobs:
+  - job: deleteOldResourceGroups
+    displayName: 'Delete Old Resource Groups'
+    pool:
+      name: '$(DefaultLinuxPool)'
+      vmImage: '$(LinuxVmImage)'
+    steps:
+    - template: ./tasks/delete-resource-groups.yml
+
 - stage: provisionEnvironment
   displayName: Provision Environment
   dependsOn: []
@@ -124,17 +137,20 @@ stages:
         azurePowerShellVersion: latestVersion
         ScriptType: inlineScript
         Inline: |
+          # Handle re-run scenario: remove existing RG for this build if it exists
           try
           {
-            Get-AzResourceGroup -Name $(ResourceGroupName) | Remove-AzResourceGroup -Verbose -Force
+            Get-AzResourceGroup -Name $(UniqueResourceGroupName) | Remove-AzResourceGroup -Verbose -Force
           }
           catch
           {}
-          New-AzResourceGroup -Name "$(ResourceGroupName)" -Location "$(ResourceGroupRegion)" -Force
+          # Create new resource group with unique name
+          New-AzResourceGroup -Name "$(UniqueResourceGroupName)" -Location "$(ResourceGroupRegion)" -Force
+          Write-Host "Created resource group: $(UniqueResourceGroupName)"
     - template: ./jobs/add-resource-group-role-assignments.yml
       parameters:
         azureSubscription: $(ConnectedServiceName)
-        resourceGroupName: $(ResourceGroupName)
+        resourceGroupName: $(UniqueResourceGroupName)
 
 - stage: setupEnvironment
   displayName: Setup Test Environment
@@ -143,10 +159,18 @@ stages:
   - provisionEnvironment
   jobs:
   - template: ./jobs/cleanup-aad.yml
+  - job: deleteKeyVaults
+    displayName: 'Delete and Purge Key Vaults'
+    pool:
+      name: '$(DefaultLinuxPool)'
+      vmImage: '$(LinuxVmImage)'
+    steps:
+    - template: ./tasks/delete-keyvaults.yml
   - job: setup
     displayName: 'Setup AAD'
     dependsOn:
     - cleanupAad
+    - deleteKeyVaults
     pool:
       vmImage: '$(WindowsVmImage)'
     steps:
@@ -159,8 +183,8 @@ stages:
   jobs:
   - template: ./jobs/provision-nsp.yml
     parameters:
-      resourceGroup: $(ResourceGroupName)
-      nspName: 'nsp-$(ResourceGroupName)'
+      resourceGroup: $(UniqueResourceGroupName)
+      nspName: 'nsp-$(UniqueResourceGroupName)'
       nspProfile: 'default'
 
 - stage: associateKeyVaultNsp
@@ -171,9 +195,9 @@ stages:
   jobs:
   - template: ./jobs/associate-keyvault-nsp.yml
     parameters:
-      resourceGroup: $(ResourceGroupName)
-      keyVaultName: '$(DeploymentEnvironmentName)-ts'
-      nspName: 'nsp-$(ResourceGroupName)'
+      resourceGroup: $(UniqueResourceGroupName)
+      keyVaultName: '$(KeyVaultBaseName)-ts'
+      nspName: 'nsp-$(UniqueResourceGroupName)'
       nspProfile: 'default'
 
 - stage: deploySqlServer
@@ -184,19 +208,19 @@ stages:
   jobs:
   - template: ./jobs/provision-sqlServer.yml
     parameters:
-      resourceGroup: $(ResourceGroupName)
+      resourceGroup: $(UniqueResourceGroupName)
       sqlServerName: $(DeploymentEnvironmentName)
       adminType: 'userAssignedManagedIdentity'
       adminUserAssignedManagedIdentityName: "$(DeploymentEnvironmentName)-uami"
       deploymentName: "AppServer"
-      nspName: 'nsp-$(ResourceGroupName)'
+      nspName: 'nsp-$(UniqueResourceGroupName)'
   - template: ./jobs/provision-sqlServer.yml
     parameters:
-      resourceGroup: $(ResourceGroupName)
+      resourceGroup: $(UniqueResourceGroupName)
       sqlServerName: $(DeploymentEnvironmentName)inttest
       adminType: 'federatedServiceConnection'
       deploymentName: "IntegrationTests"
-      nspName: 'nsp-$(ResourceGroupName)'
+      nspName: 'nsp-$(UniqueResourceGroupName)'
 
 - stage: deployStu3
   displayName: 'Deploy STU3 CosmosDB Site'
@@ -209,10 +233,11 @@ stages:
     parameters: 
       version: Stu3
       webAppName: $(DeploymentEnvironmentName)
+      keyVaultName: $(KeyVaultBaseName)
       appServicePlanName: '$(appServicePlanName)-cosmos'
       appServicePlanResourceGroup: $(appServicePlanResourceGroup)
       subscription: $(ConnectedServiceName)
-      resourceGroup: $(ResourceGroupName)
+      resourceGroup: $(UniqueResourceGroupName)
       testEnvironmentUrl: $(TestApplicationResource)
       imageTag: $(ImageTag)
       reindexEnabled: true
@@ -229,10 +254,11 @@ stages:
       version: Stu3
       sql: true
       webAppName: $(DeploymentEnvironmentNameSql)
+      keyVaultName: $(KeyVaultNameSql)
       appServicePlanName: '$(appServicePlanName)-sql'
       appServicePlanResourceGroup: $(appServicePlanResourceGroup)
       subscription: $(ConnectedServiceName)
-      resourceGroup: $(ResourceGroupName)
+      resourceGroup: $(UniqueResourceGroupName)
       testEnvironmentUrl: $(TestApplicationResource)
       imageTag: $(ImageTag)
       schemaAutomaticUpdatesEnabled: 'auto'
@@ -251,10 +277,11 @@ stages:
     parameters: 
       version: R4
       webAppName: $(DeploymentEnvironmentNameR4)
+      keyVaultName: $(KeyVaultNameR4)
       appServicePlanName: '$(appServicePlanName)-cosmos'
       appServicePlanResourceGroup: $(appServicePlanResourceGroup)
       subscription: $(ConnectedServiceName)
-      resourceGroup: $(ResourceGroupName)
+      resourceGroup: $(UniqueResourceGroupName)
       testEnvironmentUrl: $(TestApplicationResource)
       imageTag: $(ImageTag)
       reindexEnabled: true
@@ -271,10 +298,11 @@ stages:
       version: R4
       sql: true
       webAppName: $(DeploymentEnvironmentNameR4Sql)
+      keyVaultName: $(KeyVaultNameR4Sql)
       appServicePlanName: '$(appServicePlanName)-sql'
       appServicePlanResourceGroup: $(appServicePlanResourceGroup)
       subscription: $(ConnectedServiceName)
-      resourceGroup: $(ResourceGroupName)
+      resourceGroup: $(UniqueResourceGroupName)
       testEnvironmentUrl: $(TestApplicationResource)
       imageTag: $(ImageTag)
       schemaAutomaticUpdatesEnabled: 'auto'
@@ -293,10 +321,11 @@ stages:
     parameters: 
       version: R4B
       webAppName: $(DeploymentEnvironmentNameR4B)
+      keyVaultName: $(KeyVaultNameR4B)
       appServicePlanName: '$(appServicePlanName)-cosmos'
       appServicePlanResourceGroup: $(appServicePlanResourceGroup)
       subscription: $(ConnectedServiceName)
-      resourceGroup: $(ResourceGroupName)
+      resourceGroup: $(UniqueResourceGroupName)
       testEnvironmentUrl: $(TestApplicationResource)
       imageTag: $(ImageTag)
       reindexEnabled: true
@@ -313,10 +342,11 @@ stages:
       version: R4B
       sql: true
       webAppName: $(DeploymentEnvironmentNameR4BSql)
+      keyVaultName: $(KeyVaultNameR4BSql)
       appServicePlanName: '$(appServicePlanName)-sql'
       appServicePlanResourceGroup: $(appServicePlanResourceGroup)
       subscription: $(ConnectedServiceName)
-      resourceGroup: $(ResourceGroupName)
+      resourceGroup: $(UniqueResourceGroupName)
       testEnvironmentUrl: $(TestApplicationResource)
       imageTag: $(ImageTag)
       schemaAutomaticUpdatesEnabled: 'auto'
@@ -335,10 +365,11 @@ stages:
     parameters: 
       version: R5
       webAppName: $(DeploymentEnvironmentNameR5)
+      keyVaultName: $(KeyVaultNameR5)
       appServicePlanName: '$(appServicePlanName)-cosmos'
       appServicePlanResourceGroup: $(appServicePlanResourceGroup)
       subscription: $(ConnectedServiceName)
-      resourceGroup: $(ResourceGroupName)
+      resourceGroup: $(UniqueResourceGroupName)
       testEnvironmentUrl: $(TestApplicationResource)
       imageTag: $(ImageTag)
       reindexEnabled: true
@@ -355,10 +386,11 @@ stages:
       version: R5
       sql: true
       webAppName: $(DeploymentEnvironmentNameR5Sql)
+      keyVaultName: $(KeyVaultNameR5Sql)
       appServicePlanName: '$(appServicePlanName)-sql'
       appServicePlanResourceGroup: $(appServicePlanResourceGroup)
       subscription: $(ConnectedServiceName)
-      resourceGroup: $(ResourceGroupName)
+      resourceGroup: $(UniqueResourceGroupName)
       testEnvironmentUrl: $(TestApplicationResource)
       imageTag: $(ImageTag)
       schemaAutomaticUpdatesEnabled: 'auto'
@@ -377,7 +409,7 @@ stages:
   - template: ./jobs/run-tests.yml
     parameters:
       version: Stu3
-      keyVaultName: $(DeploymentEnvironmentName)
+      keyVaultName: $(KeyVaultBaseName)
       appServiceName: $(DeploymentEnvironmentName)
       integrationSqlServerName: $(DeploymentEnvironmentName)inttest
 
@@ -392,7 +424,7 @@ stages:
   - template: ./jobs/run-tests.yml
     parameters:
       version: R4
-      keyVaultName: $(DeploymentEnvironmentNameR4)
+      keyVaultName: $(KeyVaultNameR4)
       appServiceName: $(DeploymentEnvironmentNameR4)
       integrationSqlServerName: $(DeploymentEnvironmentName)inttest
 
@@ -407,7 +439,7 @@ stages:
   - template: ./jobs/run-tests.yml
     parameters:
       version: R4B
-      keyVaultName: $(DeploymentEnvironmentNameR4B)
+      keyVaultName: $(KeyVaultNameR4B)
       appServiceName: $(DeploymentEnvironmentNameR4B)
       integrationSqlServerName: $(DeploymentEnvironmentName)inttest
 
@@ -422,7 +454,7 @@ stages:
   - template: ./jobs/run-tests.yml
     parameters:
       version: R5
-      keyVaultName: $(DeploymentEnvironmentNameR5)
+      keyVaultName: $(KeyVaultNameR5)
       appServiceName: $(DeploymentEnvironmentNameR5)
       integrationSqlServerName: $(DeploymentEnvironmentName)inttest
 

--- a/build/pr-variables.yml
+++ b/build/pr-variables.yml
@@ -3,7 +3,12 @@ variables:
     resourceGroupRoot: 'msh-fhir-pr'
     appServicePlanName: '$(resourceGroupRoot)-$(prName)-asp'    
     ResourceGroupName: '$(resourceGroupRoot)-$(prName)'
-    DeploymentEnvironmentName: 'f$(build.BuildNumber)'
+    # Unique resource group name with Build.BuildId suffix to avoid waiting for deletion of existing RG
+    UniqueResourceGroupName: '$(resourceGroupRoot)-$(prName)-$(Build.BuildId)'
+    # Base name for Key Vaults (kept short due to 24 char limit)
+    KeyVaultBaseName: 'f$(build.BuildNumber)'
+    # Deployment environment name includes BuildId for uniqueness across builds
+    DeploymentEnvironmentName: 'f$(build.BuildNumber)-$(Build.BuildId)'
     TestEnvironmentName: 'OSS PR$(prName)'
     ImageTag: '$(build.BuildNumber)'
 

--- a/build/tasks/delete-keyvaults.yml
+++ b/build/tasks/delete-keyvaults.yml
@@ -1,0 +1,97 @@
+# Task template to delete Key Vaults from old resource groups and purge them
+# This prevents soft-delete conflicts when deploying new vaults with the same name
+
+steps:
+- task: AzurePowerShell@5
+  displayName: 'Delete and Purge Key Vaults'
+  inputs:
+    azureSubscription: $(ConnectedServiceName)
+    azurePowerShellVersion: latestVersion
+    ScriptType: inlineScript
+    Inline: |
+      $keyVaultBaseName = "$(KeyVaultBaseName)"
+      $currentRgName = "$(UniqueResourceGroupName)"
+      $region = "$(ResourceGroupRegion)"
+      $pattern = "$keyVaultBaseName*"
+      
+      Write-Host "Looking for Key Vaults matching pattern: $pattern in region: $region"
+      Write-Host "Current resource group (excluded): $currentRgName"
+      
+      # Get all key vaults matching the pattern that are NOT in the current RG
+      $vaults = Get-AzKeyVault | Where-Object { 
+        $_.VaultName -like $pattern -and 
+        $_.Location -eq $region -and
+        $_.ResourceGroupName -ne $currentRgName
+      }
+      
+      if ($null -eq $vaults -or $vaults.Count -eq 0) {
+        Write-Host "No Key Vaults found to delete"
+      } else {
+        Write-Host "Found $($vaults.Count) Key Vault(s) to delete"
+        
+        # Filter out vaults with resource locks
+        $vaultsToDelete = $vaults | Where-Object {
+          $locks = Get-AzResourceLock -ResourceGroupName $_.ResourceGroupName -ResourceName $_.VaultName -ResourceType "Microsoft.KeyVault/vaults" -ErrorAction SilentlyContinue
+          if ($locks) {
+            Write-Warning "Vault '$($_.VaultName)' has resource locks - skipping"
+            return $false
+          }
+          return $true
+        }
+        
+        if ($vaultsToDelete.Count -eq 0) {
+          Write-Host "No vaults eligible for deletion after lock check"
+        } else {
+          Write-Host "Deleting $($vaultsToDelete.Count) vault(s) in parallel..."
+          
+          # Step 1: Delete vaults (moves them to soft-deleted state)
+          $deleteResults = $vaultsToDelete | ForEach-Object -Parallel {
+            $vaultName = $_.VaultName
+            $sourceRg = $_.ResourceGroupName
+            try {
+              Remove-AzKeyVault -VaultName $vaultName -ResourceGroupName $sourceRg -Force -ErrorAction Stop
+              [PSCustomObject]@{ Vault = $vaultName; Location = $_.Location; Status = "Deleted" }
+            }
+            catch {
+              [PSCustomObject]@{ Vault = $vaultName; Location = $_.Location; Status = "DeleteFailed: $($_.Exception.Message)" }
+            }
+          } -ThrottleLimit 10
+          
+          $deleteResults | ForEach-Object {
+            if ($_.Status -eq "Deleted") {
+              Write-Host "Deleted vault: $($_.Vault)"
+            } else {
+              Write-Warning "$($_.Vault): $($_.Status)"
+            }
+          }
+          
+          # Step 2: Purge the deleted vaults
+          $deletedVaults = $deleteResults | Where-Object { $_.Status -eq "Deleted" }
+          if ($deletedVaults.Count -gt 0) {
+            Write-Host "Purging $($deletedVaults.Count) soft-deleted vault(s)..."
+            
+            $purgeResults = $deletedVaults | ForEach-Object -Parallel {
+              $vaultName = $_.Vault
+              $location = $_.Location
+              try {
+                Remove-AzKeyVault -VaultName $vaultName -Location $location -InRemovedState -Force -ErrorAction Stop
+                [PSCustomObject]@{ Vault = $vaultName; Status = "Purged" }
+              }
+              catch {
+                [PSCustomObject]@{ Vault = $vaultName; Status = "PurgeFailed: $($_.Exception.Message)" }
+              }
+            } -ThrottleLimit 10
+            
+            $purgeResults | ForEach-Object {
+              if ($_.Status -eq "Purged") {
+                Write-Host "Purged vault: $($_.Vault)"
+              } else {
+                Write-Warning "$($_.Vault): $($_.Status)"
+              }
+            }
+            
+            $purgedCount = ($purgeResults | Where-Object { $_.Status -eq "Purged" }).Count
+            Write-Host "Completed: $purgedCount of $($deletedVaults.Count) vaults purged"
+          }
+        }
+      }

--- a/build/tasks/delete-resource-groups.yml
+++ b/build/tasks/delete-resource-groups.yml
@@ -1,0 +1,64 @@
+# Task template to delete old resource groups for a PR
+# Runs after Key Vaults have been moved out to prevent soft-delete conflicts
+
+steps:
+- task: AzurePowerShell@5
+  displayName: 'Delete Old Resource Groups'
+  inputs:
+    azureSubscription: $(ConnectedServiceName)
+    azurePowerShellVersion: latestVersion
+    ScriptType: inlineScript
+    Inline: |
+      $prNumber = "$(prName)"
+      $resourceGroupRoot = "$(resourceGroupRoot)"
+      $currentRgName = "$(UniqueResourceGroupName)"
+      $pattern = "$resourceGroupRoot-$prNumber*"
+      
+      Write-Host "Looking for old resource groups matching pattern: $pattern"
+      Write-Host "Excluding current RG: $currentRgName"
+      
+      $oldRGs = Get-AzResourceGroup | Where-Object { 
+        $_.ResourceGroupName -like $pattern -and 
+        $_.ResourceGroupName -ne $currentRgName
+      }
+      
+      if ($oldRGs.Count -eq 0) {
+        Write-Host "No old resource groups found to cleanup"
+      } else {
+        Write-Host "Found $($oldRGs.Count) old resource group(s) to cleanup"
+        
+        # Delete all RGs in parallel with retry logic
+        $results = $oldRGs | ForEach-Object -Parallel {
+          $rgName = $_.ResourceGroupName
+          $maxRetries = 3
+          $retryCount = 0
+          $deleted = $false
+          
+          while (-not $deleted -and $retryCount -lt $maxRetries) {
+            try {
+              Remove-AzResourceGroup -Name $rgName -Force -ErrorAction Stop
+              $deleted = $true
+              [PSCustomObject]@{ RG = $rgName; Status = "Success" }
+            }
+            catch {
+              $retryCount++
+              if ($retryCount -lt $maxRetries) {
+                Start-Sleep -Seconds 30
+              } else {
+                [PSCustomObject]@{ RG = $rgName; Status = "Failed: $($_.Exception.Message)" }
+              }
+            }
+          }
+        } -ThrottleLimit 10
+        
+        $results | ForEach-Object {
+          if ($_.Status -eq "Success") {
+            Write-Host "Successfully removed resource group: $($_.RG)"
+          } else {
+            Write-Warning "Failed to remove resource group $($_.RG). $($_.Status)"
+          }
+        }
+        
+        $successCount = ($results | Where-Object { $_.Status -eq "Success" }).Count
+        Write-Host "Completed removal: $successCount of $($oldRGs.Count) resource group(s)"
+      }

--- a/build/tasks/e2e-set-variables.yml
+++ b/build/tasks/e2e-set-variables.yml
@@ -1,0 +1,77 @@
+parameters:
+- name: appServiceName
+  type: string
+
+steps:
+- task: AzurePowerShell@5
+  displayName: 'Set Variables'
+  inputs:
+    azureSubscription: $(ConnectedServiceName)
+    azurePowerShellVersion: LatestVersion
+    ScriptType: InlineScript
+    Inline: |
+        $keyVault = "$(KeyVaultBaseName)-ts"
+        $secrets = Get-AzKeyVaultSecret -VaultName $keyVault
+
+        foreach($secret in $secrets)
+        {
+            $environmentVariableName = $secret.Name.Replace("--","_")
+
+            $secretValue = Get-AzKeyVaultSecret -VaultName $keyVault -Name $secret.Name
+            # Replace with -AsPlainText flag when v5.3 of the Az Module is supported
+            $plainValue = ([System.Net.NetworkCredential]::new("", $secretValue.SecretValue).Password).ToString()
+            if([string]::IsNullOrEmpty($plainValue))
+            {
+                throw "$($secret.Name) is empty"
+            }
+            Write-Host "##vso[task.setvariable variable=$($environmentVariableName)]$($plainValue)"
+        }
+
+        $appServiceName = "${{ parameters.appServiceName }}"
+        $appSettings = (Get-AzWebApp -ResourceGroupName $(UniqueResourceGroupName) -Name $appServiceName).SiteConfig.AppSettings
+        $acrSettings = $appSettings | where {$_.Name -eq "FhirServer__Operations__ConvertData__ContainerRegistryServers__0"}
+        $acrLoginServer = $acrSettings[0].Value
+        $acrAccountName = ($acrLoginServer -split '\.')[0]
+
+        ## This needs to be moved to MI, WI #125246  
+        # $acrPassword = (Get-AzContainerRegistryCredential -ResourceGroupName $(ResourceGroupName) -Name $acrAccountName).Password
+        # Write-Host "##vso[task.setvariable variable=TestContainerRegistryServer]$($acrLoginServer)"
+        # Write-Host "##vso[task.setvariable variable=TestContainerRegistryPassword]$($acrPassword)"
+
+        $exportStoreSettings = $appSettings | where {$_.Name -eq "FhirServer__Operations__Export__StorageAccountUri"}
+        $exportStoreUri = $exportStoreSettings[0].Value
+        Write-Host "$exportStoreUri"
+        $exportStoreAccountName = [System.Uri]::new("$exportStoreUri").Host.Split('.')[0]
+        $exportStoreKey = Get-AzStorageAccountKey -ResourceGroupName $(UniqueResourceGroupName) -Name "$exportStoreAccountName" | Where-Object {$_.KeyName -eq "key1"}
+        
+        Write-Host "##vso[task.setvariable variable=TestExportStoreUri]$($exportStoreUri)"
+
+        $integrationStoreSettings = $appSettings | where {$_.Name -eq "FhirServer__Operations__IntegrationDataStore__StorageAccountUri"}
+        $integrationStoreUri = $integrationStoreSettings[0].Value
+        Write-Host "$integrationStoreUri"
+        $integrationStoreAccountName = [System.Uri]::new("$integrationStoreUri").Host.Split('.')[0]
+        Write-Host "##vso[task.setvariable variable=TestIntegrationStoreUri]$($integrationStoreUri)"
+
+        Write-Host "##vso[task.setvariable variable=Resource]$(TestApplicationResource)"
+        
+        $secrets = Get-AzKeyVaultSecret -VaultName resolute-oss-tenant-info
+        foreach($secret in $secrets)
+        {
+            $environmentVariableName = $secret.Name.Replace("--","_")
+
+            $secretValue = Get-AzKeyVaultSecret -VaultName resolute-oss-tenant-info -Name $secret.Name
+            # Replace with -AsPlainText flag when v5.3 of the Az Module is supported
+            $plainValue = ([System.Net.NetworkCredential]::new("", $secretValue.SecretValue).Password).ToString()
+            if([string]::IsNullOrEmpty($plainValue))
+            {
+                throw "$($secret.Name) is empty"
+            }
+            Write-Host "##vso[task.setvariable variable=$($environmentVariableName)]$($plainValue)"
+        }
+        # ----------------------------------------
+
+        dotnet dev-certs https
+
+        Write-Host "##vso[task.setvariable variable=AZURESUBSCRIPTION_CLIENT_ID]$env:AZURESUBSCRIPTION_CLIENT_ID"
+        Write-Host "##vso[task.setvariable variable=AZURESUBSCRIPTION_TENANT_ID]$env:AZURESUBSCRIPTION_TENANT_ID"
+        Write-Host "##vso[task.setvariable variable=AZURESUBSCRIPTION_SERVICE_CONNECTION_ID]$env:AZURESUBSCRIPTION_SERVICE_CONNECTION_ID"

--- a/samples/templates/default-azuredeploy-docker.json
+++ b/samples/templates/default-azuredeploy-docker.json
@@ -5,9 +5,16 @@
         "serviceName": {
             "type": "string",
             "minLength": 3,
-            "maxLength": 24,
             "metadata": {
                 "description": "Name of the FHIR service Web App."
+            }
+        },
+        "keyVaultName": {
+            "type": "string",
+            "defaultValue": "",
+            "maxLength": 24,
+            "metadata": {
+                "description": "Name of the Key Vault. If empty, serviceName is used. Must be 24 characters or less."
             }
         },
         "appServicePlanResourceGroup": {
@@ -258,7 +265,8 @@
     "variables": {
         "isMAG": "[or(contains(resourceGroup().location,'usgov'),contains(resourceGroup().location,'usdod'))]",
         "serviceName": "[toLower(parameters('serviceName'))]",
-        "keyvaultEndpoint": "[if(variables('isMAG'), concat('https://', variables('serviceName'), '.vault.usgovcloudapi.net/'), concat('https://', variables('serviceName'), '.vault.azure.net/'))]",
+        "keyVaultName": "[if(empty(parameters('keyVaultName')), variables('serviceName'), toLower(parameters('keyVaultName')))]",
+        "keyvaultEndpoint": "[if(variables('isMAG'), concat('https://', variables('keyVaultName'), '.vault.usgovcloudapi.net/'), concat('https://', variables('keyVaultName'), '.vault.azure.net/'))]",
         "appServicePlanResourceGroup": "[if(empty(parameters('appServicePlanResourceGroup')), resourceGroup().name, parameters('appServicePlanResourceGroup'))]",
         "appServicePlanName": "[if(empty(parameters('appServicePlanName')),concat(variables('serviceName'),'-asp'),parameters('appServicePlanName'))]",
         "appServiceResourceId": "[resourceId('Microsoft.Web/sites', variables('serviceName'))]",
@@ -310,7 +318,7 @@
         "sqlSkuFamily": "[if(variables('isSqlHyperscaleTier'), 'Gen5', '')]",
         "sqlSkuName": "[if(variables('isSqlHyperscaleTier'), 'HS_Gen5', 'Standard')]",
         "sqlSkuTier": "[if(variables('isSqlHyperscaleTier'), 'Hyperscale', 'Standard')]",
-        "keyVaultRoleName": "[concat('Key Vault Secrets Officer-', variables('serviceName'))]",
+        "keyVaultRoleName": "[concat('Key Vault Secrets Officer-', variables('keyVaultName'))]",
         "imageRepositoryName": "[if(contains(parameters('registryName'),'mcr.'), concat(toLower(parameters('fhirVersion')), '-fhir-server'), concat(toLower(parameters('fhirVersion')), '_fhir-server'))]",
         "networkSecurityPerimeterName": "[parameters('networkSecurityPerimeterName')]"
     },
@@ -386,7 +394,7 @@
             "dependsOn": [
                 "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]",
                 "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('managedIdentityName'))]",
-                "[if(variables('deployAppInsights'),concat('Microsoft.Insights/components/', variables('appInsightsName')),resourceId('Microsoft.KeyVault/vaults', variables('serviceName')))]"
+                "[if(variables('deployAppInsights'),concat('Microsoft.Insights/components/', variables('appInsightsName')),resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName')))]"
             ],
             "resources": [
                 {
@@ -395,8 +403,8 @@
                     "type": "config",
                     "dependsOn": [
                         "[variables('appServiceResourceId')]",
-                        "[if(variables('deployAppInsights'),concat('Microsoft.Insights/components/', variables('appInsightsName')),resourceId('Microsoft.KeyVault/vaults', variables('serviceName')))]",
-                        "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), resourceId('Microsoft.KeyVault/vaults/secrets', variables('serviceName'), 'CosmosDb--Host'), resourceId('Microsoft.KeyVault/vaults/secrets', variables('serviceName'), 'SqlServer--ConnectionString'))]"
+                        "[if(variables('deployAppInsights'),concat('Microsoft.Insights/components/', variables('appInsightsName')),resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName')))]",
+                        "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), resourceId('Microsoft.KeyVault/vaults/secrets', variables('keyVaultName'), 'CosmosDb--Host'), resourceId('Microsoft.KeyVault/vaults/secrets', variables('keyVaultName'), 'SqlServer--ConnectionString'))]"
                     ],
                     "properties": "[union(variables('combinedFhirServerConfigProperties'), json(concat('{ \"FhirServer__ResourceManager__DataStoreResourceId\": \"', if(equals(parameters('solutionType'),'FhirServerCosmosDB'), resourceId('Microsoft.DocumentDb/databaseAccounts', variables('serviceName')), resourceId('Microsoft.Sql/servers/', variables('sqlServerDerivedName'))), '\", ', if(variables('deployAppInsights'), concat('\"Telemetry__Provider\": \"', parameters('telemetryProviderType'), '\",', '\"Telemetry__InstrumentationKey\": \"', reference(resourceId('Microsoft.Insights/components', variables('appInsightsName'))).InstrumentationKey, '\",', '\"Telemetry__ConnectionString\": \"', reference(resourceId('Microsoft.Insights/components', variables('appInsightsName'))).ConnectionString, '\"'), ''), '}')))]"
                 },
@@ -407,7 +415,7 @@
                     "dependsOn": [
                         "appsettings",
                         "[variables('appServiceResourceId')]",
-                        "[if(variables('deployAppInsights'),concat('Microsoft.Insights/components/', variables('appInsightsName')),resourceId('Microsoft.KeyVault/vaults', variables('serviceName')))]"
+                        "[if(variables('deployAppInsights'),concat('Microsoft.Insights/components/', variables('appInsightsName')),resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName')))]"
                     ],
                     "properties": {
                         "linuxFxVersion": "[concat('DOCKER|', parameters('registryName'), '/', variables('imageRepositoryName'),':', parameters('imageTag'))]",
@@ -641,7 +649,7 @@
         },
         {
             "type": "Microsoft.KeyVault/vaults",
-            "name": "[variables('serviceName')]",
+            "name": "[variables('keyVaultName')]",
             "apiVersion": "2022-07-01",
             "location": "[resourceGroup().location]",
             "tags": {
@@ -676,9 +684,9 @@
         {
             "type": "Microsoft.KeyVault/vaults/providers/roleAssignments",
             "apiVersion": "2022-04-01",
-            "name": "[concat(variables('serviceName'), '/Microsoft.Authorization/', guid(uniqueString(variables('keyVaultRoleName'), parameters('fhirVersion'), variables('serviceName'))))]",
+            "name": "[concat(variables('keyVaultName'), '/Microsoft.Authorization/', guid(uniqueString(variables('keyVaultRoleName'), parameters('fhirVersion'), variables('keyVaultName'))))]",
             "dependsOn": [
-                "[resourceId('Microsoft.KeyVault/vaults', variables('serviceName'))]"
+                "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
             ],
             "properties": {
                 "roleDefinitionId": "[concat(subscription().Id, '/providers/Microsoft.Authorization/roleDefinitions/', 'b86a8fe4-44ce-4948-aee5-eccb2c155cd7')]", // Role definition ID for "Key Vault Secrets Officer"
@@ -688,9 +696,9 @@
         {
             "type": "Microsoft.KeyVault/vaults/providers/roleAssignments",
             "apiVersion": "2022-04-01",
-            "name": "[concat(variables('serviceName'), '/Microsoft.Authorization/', guid(uniqueString('Reader', parameters('fhirVersion'), variables('serviceName'))))]",
+            "name": "[concat(variables('keyVaultName'), '/Microsoft.Authorization/', guid(uniqueString('Reader', parameters('fhirVersion'), variables('keyVaultName'))))]",
             "dependsOn": [
-                "[resourceId('Microsoft.KeyVault/vaults', variables('serviceName'))]"
+                "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
             ],
             "properties": {
                 "roleDefinitionId": "[concat(subscription().Id, '/providers/Microsoft.Authorization/roleDefinitions/', 'b86a8fe4-44ce-4948-aee5-eccb2c155cd7')]", // Role definition ID for "Key Vault Secrets Officer"
@@ -700,28 +708,28 @@
         {
             "condition": "[equals(parameters('solutionType'),'FhirServerCosmosDB')]",
             "type": "Microsoft.KeyVault/vaults/secrets",
-            "name": "[concat(variables('serviceName'), '/CosmosDb--Host')]",
+            "name": "[concat(variables('keyVaultName'), '/CosmosDb--Host')]",
             "apiVersion": "2015-06-01",
             "properties": {
                 "contentType": "text/plain",
                 "value": "[if(equals(parameters('solutionType'),'FhirServerCosmosDB'), reference(concat('Microsoft.DocumentDb/databaseAccounts/', variables('serviceName'))).documentEndpoint, '')]"
             },
             "dependsOn": [
-                "[resourceId('Microsoft.KeyVault/vaults', variables('serviceName'))]",
+                "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
                 "[resourceId('Microsoft.DocumentDb/databaseAccounts', variables('serviceName'))]"
             ]
         },
         {
             "condition": "[equals(parameters('solutionType'),'FhirServerSqlServer')]",
             "type": "Microsoft.KeyVault/vaults/secrets",
-            "name": "[concat(variables('serviceName'), '/SqlServer--ConnectionString')]",
+            "name": "[concat(variables('keyVaultName'), '/SqlServer--ConnectionString')]",
             "apiVersion": "2015-06-01",
             "properties": {
                 "contentType": "text/plain",
                 "value": "[concat('Server=tcp:', if(equals(parameters('solutionType'),'FhirServerSqlServer'), reference(variables('computedSqlServerReference'), '2015-05-01-preview').fullyQualifiedDomainName, ''),',1433;Initial Catalog=',variables('sqlDatabaseName'),';Persist Security Info=False;Authentication=ActiveDirectoryMSI;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;User Id=', reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('managedIdentityName')), '2018-11-30').clientId, ';')]"
             },
             "dependsOn": [
-                "[resourceId('Microsoft.KeyVault/vaults', variables('serviceName'))]",
+                "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
                 "[resourceId('Microsoft.Sql/servers', variables('sqlServerDerivedName'))]"
             ]
         },
@@ -817,15 +825,15 @@
         {
             "type": "Microsoft.Network/networkSecurityPerimeters/resourceAssociations",
             "apiVersion": "2023-07-01-preview",
-            "name": "[concat(variables('networkSecurityPerimeterName'), '/keyvault-', uniqueString(variables('serviceName')))]",
+            "name": "[concat(variables('networkSecurityPerimeterName'), '/keyvault-', uniqueString(variables('keyVaultName')))]",
             "dependsOn": [
-                "[resourceId('Microsoft.KeyVault/vaults', variables('serviceName'))]",
+                "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
                 "[resourceId('Microsoft.Network/networkSecurityPerimeters', variables('networkSecurityPerimeterName'))]",
                 "[resourceId('Microsoft.Network/networkSecurityPerimeters/profiles', variables('networkSecurityPerimeterName'), parameters('networkSecurityPerimeterProfileName'))]"
             ],
             "properties": {
                 "privateLinkResource": {
-                    "id": "[resourceId('Microsoft.KeyVault/vaults', variables('serviceName'))]"
+                    "id": "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
                 },
                 "profile": {
                     "id": "[resourceId('Microsoft.Network/networkSecurityPerimeters/profiles', variables('networkSecurityPerimeterName'), parameters('networkSecurityPerimeterProfileName'))]"


### PR DESCRIPTION
## Description
This pull request introduces several improvements and refactors to the PR pipeline, focusing on better handling of Azure Key Vault naming, resource cleanup, and enhanced test job configuration. The changes increase reliability, allow for more granular test execution, and improve resource management, especially around soft-deleted Key Vaults and resource groups.

**Key Vault and Resource Management:**

* Standardized Key Vault naming by introducing the `KeyVaultBaseName` variable and updating references throughout the pipeline, ensuring compliance with Azure's character limits and simplifying resource identification. [[1]](diffhunk://#diff-c8bfb92d4e7e1c6f5860c93b34f1bc1a0e39e1f1b7e963ca1399ec4fc98e3ec0R7-R8) [[2]](diffhunk://#diff-bfc12f69c641e547dbbe0305583c1928f4649eacb49da33c96b0aa7d979080d3R19-R26) [[3]](diffhunk://#diff-6d6b6f8eb00c634065385fc0368fa77d23d8ddcc1382a84648cc6666c2b92290L20-R23) [[4]](diffhunk://#diff-a62ff4b7c3b307f9abdcc79a7c0c55dc1801bf5bcf945f306be8e81bf44dff1bL26-R26) [[5]](diffhunk://#diff-a62ff4b7c3b307f9abdcc79a7c0c55dc1801bf5bcf945f306be8e81bf44dff1bL119-R119)
* Enhanced resource cleanup in `cleanup.yml` by adding retry logic for resource group deletion and parallel purging of soft-deleted Key Vaults, improving reliability and preventing resource leaks.
* Removed legacy logic for restoring soft-deleted Key Vaults in provisioning and test environment setup jobs, relying instead on improved cleanup and naming conventions. [[1]](diffhunk://#diff-4b1d377c692c6c38650f83f50a7347de4275bbba9e6b23c1c9609ff916c098a5L35-L50) [[2]](diffhunk://#diff-96e510a6dff7e5dadab5de4fd09bd73429703125d6bf40296f7aeb4ccc75052cL102-L108)

**Test Job Configuration and Flexibility:**

* Refactored E2E and test job templates to support configurable test category filtering and run title suffixes, enabling targeted execution of specific test groups such as reindexing and bulk update tests. [[1]](diffhunk://#diff-5c8fc62a83124f3ab8b982c24aa547ad5873553f5d27c40b86fb65477f779180R8-R30) [[2]](diffhunk://#diff-13d8d0c0eb241c4458935a761202ea80c00bd1484d66759933ff89ba189580e0R183-R198) [[3]](diffhunk://#diff-13d8d0c0eb241c4458935a761202ea80c00bd1484d66759933ff89ba189580e0R212-R242)
* Split E2E test jobs into multiple jobs (`Reindex`, `BulkUpdate`, etc.) for both CosmosDb and SqlServer, allowing for more granular test reporting and isolation. [[1]](diffhunk://#diff-13d8d0c0eb241c4458935a761202ea80c00bd1484d66759933ff89ba189580e0R183-R198) [[2]](diffhunk://#diff-13d8d0c0eb241c4458935a761202ea80c00bd1484d66759933ff89ba189580e0R212-R242)

**Resource Provisioning Reliability:**

* Added retry logic for SQL Server NSP resource association deployments to handle transient conflicts, increasing robustness of infrastructure provisioning.

**Pipeline Structure and Maintenance:**

* Introduced a new pipeline stage `cleanupOldResources` in `pr-pipeline.yml` to proactively remove old PR resources, reducing Azure resource sprawl and potential cost.

**Miscellaneous Improvements:**

* Updated references to use `UniqueResourceGroupName` where appropriate, ensuring resource group operations target the correct, isolated environment. [[1]](diffhunk://#diff-b8c199fb528cd3d18fbe22ec9b0b0b2973fdd047cb8f5b8986d3a3756b4fde95L15-R79) [[2]](diffhunk://#diff-13d8d0c0eb241c4458935a761202ea80c00bd1484d66759933ff89ba189580e0L43-R43)
* Updated Key Vault references in E2E setup and export test jobs to use the new naming convention. [[1]](diffhunk://#diff-6d6b6f8eb00c634065385fc0368fa77d23d8ddcc1382a84648cc6666c2b92290L20-R23) [[2]](diffhunk://#diff-a62ff4b7c3b307f9abdcc79a7c0c55dc1801bf5bcf945f306be8e81bf44dff1bL26-R26) [[3]](diffhunk://#diff-a62ff4b7c3b307f9abdcc79a7c0c55dc1801bf5bcf945f306be8e81bf44dff1bL119-R119)

## Related issues
Addresses [AB#166378](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/166378).

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
