### PR TITLE
Add Retry functionality to xUnit

### DIFF
--- a/src/Microsoft.Health.Extensions.Xunit/RetryFactAttribute.cs
+++ b/src/Microsoft.Health.Extensions.Xunit/RetryFactAttribute.cs
@@ -1,0 +1,37 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Microsoft.Health.Extensions.Xunit
+{
+    /// <summary>
+    /// Attribute that marks a test method to be retried a specified number of times if it fails.
+    /// Useful for handling transient failures in integration and end-to-end tests.
+    /// </summary>
+    [XunitTestCaseDiscoverer("Microsoft.Health.Extensions.Xunit.RetryFactDiscoverer", "Microsoft.Health.Extensions.Xunit")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public sealed class RetryFactAttribute : FactAttribute
+    {
+        /// <summary>
+        /// Gets or sets the maximum number of retry attempts (default is 3).
+        /// </summary>
+        public int MaxRetries { get; set; } = 3;
+
+        /// <summary>
+        /// Gets or sets the delay in milliseconds between retry attempts (default is 5000ms).
+        /// </summary>
+        public int DelayBetweenRetriesMs { get; set; } = 5000;
+
+        /// <summary>
+        /// Gets or sets whether to retry on assertion failures (XunitException).
+        /// Default is false - assertion failures usually indicate test bugs, not transient issues.
+        /// Set to true for tests that validate eventually-consistent systems (e.g., cache refresh, reindex operations).
+        /// </summary>
+        public bool RetryOnAssertionFailure { get; set; } = false;
+    }
+}

--- a/src/Microsoft.Health.Extensions.Xunit/RetryFactDiscoverer.cs
+++ b/src/Microsoft.Health.Extensions.Xunit/RetryFactDiscoverer.cs
@@ -1,0 +1,54 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.Health.Extensions.Xunit
+{
+    /// <summary>
+    /// Test case discoverer for <see cref="RetryFactAttribute"/>.
+    /// </summary>
+    public class RetryFactDiscoverer : IXunitTestCaseDiscoverer
+    {
+        private readonly IMessageSink _diagnosticMessageSink;
+
+        public RetryFactDiscoverer(IMessageSink diagnosticMessageSink)
+        {
+            _diagnosticMessageSink = diagnosticMessageSink;
+        }
+
+        public IEnumerable<IXunitTestCase> Discover(
+            ITestFrameworkDiscoveryOptions discoveryOptions,
+            ITestMethod testMethod,
+            IAttributeInfo factAttribute)
+        {
+            var maxRetries = factAttribute.GetNamedArgument<int>(nameof(RetryFactAttribute.MaxRetries));
+            var delayMs = factAttribute.GetNamedArgument<int>(nameof(RetryFactAttribute.DelayBetweenRetriesMs));
+            var retryOnAssertionFailure = factAttribute.GetNamedArgument<bool>(nameof(RetryFactAttribute.RetryOnAssertionFailure));
+
+            // Use default values if not specified
+            if (maxRetries == 0)
+            {
+                maxRetries = 3;
+            }
+
+            if (delayMs == 0)
+            {
+                delayMs = 5000;
+            }
+
+            yield return new RetryTestCase(
+                _diagnosticMessageSink,
+                discoveryOptions.MethodDisplayOrDefault(),
+                discoveryOptions.MethodDisplayOptionsOrDefault(),
+                testMethod,
+                maxRetries,
+                delayMs,
+                retryOnAssertionFailure);
+        }
+    }
+}

--- a/src/Microsoft.Health.Extensions.Xunit/RetryTestCase.cs
+++ b/src/Microsoft.Health.Extensions.Xunit/RetryTestCase.cs
@@ -1,0 +1,316 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.Health.Extensions.Xunit
+{
+    /// <summary>
+    /// Test case that implements retry logic.
+    /// </summary>
+    public class RetryTestCase : XunitTestCase
+    {
+        private int _maxRetries;
+        private int _delayMs;
+        private bool _retryOnAssertionFailure;
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+        public RetryTestCase()
+        {
+        }
+
+        public RetryTestCase(
+            IMessageSink diagnosticMessageSink,
+            TestMethodDisplay defaultMethodDisplay,
+            TestMethodDisplayOptions defaultMethodDisplayOptions,
+            ITestMethod testMethod,
+            int maxRetries,
+            int delayMs,
+            bool retryOnAssertionFailure = false,
+            object[] testMethodArguments = null)
+            : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, testMethodArguments)
+        {
+            _maxRetries = maxRetries;
+            _delayMs = delayMs;
+            _retryOnAssertionFailure = retryOnAssertionFailure;
+        }
+
+        public override async Task<RunSummary> RunAsync(
+            IMessageSink diagnosticMessageSink,
+            IMessageBus messageBus,
+            object[] constructorArguments,
+            ExceptionAggregator aggregator,
+            CancellationTokenSource cancellationTokenSource)
+        {
+            // Use System.Diagnostics.Trace for ADO visibility
+            Trace.WriteLine($"##vso[task.logdetail]RetryFact starting test '{TestMethod.TestClass.Class.Name}.{TestMethod.Method.Name}' with MaxRetries={_maxRetries}, DelayMs={_delayMs}, RetryOnAssertionFailure={_retryOnAssertionFailure}");
+
+            var runSummary = new RunSummary { Total = 1 };
+            Exception lastException = null;
+
+            for (int attempt = 1; attempt <= _maxRetries; attempt++)
+            {
+                var isLastAttempt = attempt == _maxRetries;
+
+                Trace.WriteLine($"##vso[task.logdetail]RetryFact attempt {attempt}/{_maxRetries} for test '{TestMethod.Method.Name}'");
+
+                // Create a fresh aggregator for each attempt
+                var attemptAggregator = new ExceptionAggregator();
+
+                // Only intercept failure messages on non-final attempts
+                // On the final attempt, let everything go through (both success and failure)
+                IMessageBus busToUse;
+                FailureInterceptingMessageBus interceptingBus = null;
+
+                if (isLastAttempt)
+                {
+                    busToUse = messageBus;
+                }
+                else
+                {
+                    interceptingBus = new FailureInterceptingMessageBus(messageBus);
+                    busToUse = interceptingBus;
+                }
+
+                try
+                {
+                    var summary = await base.RunAsync(
+                        diagnosticMessageSink,
+                        busToUse,
+                        constructorArguments,
+                        attemptAggregator,
+                        cancellationTokenSource);
+
+                    runSummary.Time = summary.Time;
+
+                    if (summary.Failed == 0)
+                    {
+                        // Test passed - success message already went through to Test Explorer
+                        Trace.WriteLine($"##vso[task.logdetail]RetryFact test '{TestMethod.TestClass.Class.Name}.{TestMethod.Method.Name}' passed on attempt {attempt}/{_maxRetries}");
+                        diagnosticMessageSink.OnMessage(
+                            new DiagnosticMessage($"[RetryFact] Test '{TestMethod.TestClass.Class.Name}.{TestMethod.Method.Name}' passed on attempt {attempt}/{_maxRetries}"));
+
+                        runSummary.Failed = 0;
+                        return runSummary;
+                    }
+
+                    // Test failed on this attempt
+                    lastException = attemptAggregator.ToException();
+
+                    // If no exception was captured but test failed, create an exception using captured failure details
+                    if (lastException == null && summary.Failed > 0)
+                    {
+                        string failureMsg = interceptingBus?.LastFailureMessage ?? "Test failed but no exception was captured.";
+                        string stackTrace = interceptingBus?.LastFailureStackTrace;
+                        bool isAssertionFailure = interceptingBus?.IsAssertionFailure ?? false;
+
+                        string fullMessage = failureMsg +
+                            (stackTrace != null ? Environment.NewLine + "Stack Trace:" + Environment.NewLine + stackTrace : string.Empty);
+
+                        // If this is an assertion failure (based on exception types), create an XunitException
+                        // so that RetryOnAssertionFailure logic works correctly
+                        if (isAssertionFailure)
+                        {
+                            lastException = new XunitException(fullMessage);
+                        }
+                        else
+                        {
+                            lastException = new InvalidOperationException(fullMessage);
+                        }
+
+                        Trace.WriteLine($"##vso[task.logdetail]RetryFact: Test failed but exception is null, created placeholder exception (IsAssertion={isAssertionFailure})");
+                    }
+
+                    Trace.WriteLine($"##vso[task.logdetail]RetryFact test failed on attempt {attempt} with exception type: {lastException?.GetType().FullName ?? "null"}, Message: {lastException?.Message ?? "null"}");
+
+                    if (!isLastAttempt)
+                    {
+                        // Check if we should retry this exception (now handles null)
+                        var shouldRetry = ShouldRetry(lastException);
+                        Trace.WriteLine($"##vso[task.logdetail]RetryFact ShouldRetry={shouldRetry} for exception type {lastException?.GetType().FullName ?? "null"}");
+
+                        if (!shouldRetry)
+                        {
+                            Trace.WriteLine($"##vso[task.logissue type=warning]Test '{TestMethod.Method.Name}' failed with non-retriable exception. Skipping retries.");
+                            diagnosticMessageSink.OnMessage(
+                                new DiagnosticMessage($"[RetryFact] Test '{TestMethod.Method.Name}' failed with non-retriable exception. Skipping retries."));
+
+                            if (lastException != null)
+                            {
+                                aggregator.Add(lastException);
+                            }
+
+                            runSummary.Failed = 1;
+                            return runSummary;
+                        }
+
+                        // Not the last attempt - the failure was intercepted, so retry
+                        Trace.WriteLine($"##vso[task.logissue type=warning]Test '{TestMethod.Method.Name}' failed on attempt {attempt}/{_maxRetries}, will retry after {_delayMs}ms");
+                        diagnosticMessageSink.OnMessage(
+                            new DiagnosticMessage($"[RetryFact] Test '{TestMethod.TestClass.Class.Name}.{TestMethod.Method.Name}' failed on attempt {attempt}/{_maxRetries}. Retrying after {_delayMs}ms delay. Error: {lastException?.Message ?? "No exception message"}"));
+
+                        await Task.Delay(_delayMs);
+                    }
+                    else
+                    {
+                        // Last attempt - failure message already went through to Test Explorer
+                        Trace.WriteLine($"##vso[task.logissue type=error]Test '{TestMethod.TestClass.Class.Name}.{TestMethod.Method.Name}' failed after {_maxRetries} attempts. Final error: {lastException?.Message ?? "No exception captured"}");
+                        diagnosticMessageSink.OnMessage(
+                            new DiagnosticMessage($"[RetryFact] Test '{TestMethod.TestClass.Class.Name}.{TestMethod.Method.Name}' failed after {_maxRetries} attempts. Last exception: {lastException?.Message ?? "No exception message"}"));
+
+                        if (lastException != null)
+                        {
+                            aggregator.Add(lastException);
+                        }
+                        else if (summary.Failed > 0)
+                        {
+                            // Add an exception with captured failure details if test failed but no exception was captured
+                            aggregator.Add(new InvalidOperationException($"Test failed after {_maxRetries} attempts but no exception was captured"));
+                        }
+
+                        runSummary.Failed = 1;
+                        return runSummary;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Trace.WriteLine($"##vso[task.logissue type=error]RetryFact unexpected exception: {ex.GetType().FullName}: {ex.Message}");
+                    throw;
+                }
+                finally
+                {
+                    // Dispose the intercepting bus if we created one
+                    interceptingBus?.Dispose();
+                }
+            }
+
+            // Should never reach here
+            Trace.WriteLine($"##vso[task.logissue type=error]RetryFact WARNING: Reached end of retry loop unexpectedly");
+            runSummary.Failed = 1;
+            return runSummary;
+        }
+
+        public override void Serialize(IXunitSerializationInfo data)
+        {
+            base.Serialize(data);
+            data.AddValue(nameof(_maxRetries), _maxRetries);
+            data.AddValue(nameof(_delayMs), _delayMs);
+            data.AddValue(nameof(_retryOnAssertionFailure), _retryOnAssertionFailure);
+        }
+
+        public override void Deserialize(IXunitSerializationInfo data)
+        {
+            base.Deserialize(data);
+            _maxRetries = data.GetValue<int>(nameof(_maxRetries));
+            _delayMs = data.GetValue<int>(nameof(_delayMs));
+            _retryOnAssertionFailure = data.GetValue<bool>(nameof(_retryOnAssertionFailure));
+        }
+
+        /// <summary>
+        /// Determines if an exception should trigger a retry.
+        /// </summary>
+        private bool ShouldRetry(Exception ex)
+        {
+            // If exception is null, we should retry (something went wrong with exception capture)
+            if (ex == null)
+            {
+                Trace.WriteLine($"##vso[task.logdetail]RetryFact: Exception is null, will retry");
+                return true; // Retry when we can't determine the exception type
+            }
+
+            // Unwrap aggregate exceptions
+            while (ex is AggregateException aggEx && aggEx.InnerExceptions.Count == 1)
+            {
+                ex = aggEx.InnerException;
+            }
+
+            // Don't retry assertion failures unless explicitly configured
+            if (ex is XunitException)
+            {
+                if (!_retryOnAssertionFailure)
+                {
+                    Trace.WriteLine($"##vso[task.logdetail]RetryFact: Not retrying XunitException because _retryOnAssertionFailure is false");
+                    return false;
+                }
+                else
+                {
+                    Trace.WriteLine($"##vso[task.logdetail]RetryFact: Retrying XunitException because _retryOnAssertionFailure is true");
+                    return true;
+                }
+            }
+
+            // Retry everything else (network, timeout, SQL transient, etc.)
+            Trace.WriteLine($"##vso[task.logdetail]RetryFact: Retrying non-assertion exception of type {ex.GetType().FullName}");
+            return true;
+        }
+
+        /// <summary>
+        /// Message bus that intercepts ONLY failure messages (ITestFailed).
+        /// Used on non-final retry attempts to suppress intermediate failures.
+        /// Success messages and all other messages always pass through.
+        /// Also captures failure details (messages and stack traces) for diagnostic purposes.
+        /// </summary>
+        private class FailureInterceptingMessageBus : IMessageBus
+        {
+            private readonly IMessageBus _innerBus;
+
+            public FailureInterceptingMessageBus(IMessageBus innerBus)
+            {
+                _innerBus = innerBus;
+            }
+
+            public string LastFailureMessage { get; private set; }
+
+            public string LastFailureStackTrace { get; private set; }
+
+            public bool IsAssertionFailure { get; private set; }
+
+            public bool QueueMessage(IMessageSinkMessage message)
+            {
+                // Intercept ONLY failure messages - suppress them for non-final attempts
+                if (message is ITestFailed failed)
+                {
+                    // Capture failure details for diagnostics
+                    LastFailureMessage = failed.Messages != null && failed.Messages.Length > 0
+                        ? string.Join(Environment.NewLine, failed.Messages)
+                        : failed.ExceptionTypes != null && failed.ExceptionTypes.Length > 0
+                            ? string.Join(", ", failed.ExceptionTypes)
+                            : "Unknown failure";
+
+                    LastFailureStackTrace = failed.StackTraces != null && failed.StackTraces.Length > 0
+                        ? string.Join(Environment.NewLine, failed.StackTraces)
+                        : null;
+
+                    // Detect if this is an assertion failure by checking exception types
+                    // XUnit assertion exceptions typically have types containing "Xunit" or "Assert"
+                    IsAssertionFailure = failed.ExceptionTypes != null &&
+                        failed.ExceptionTypes.Length > 0 &&
+                        (failed.ExceptionTypes[0].Contains("Xunit", StringComparison.Ordinal) ||
+                         failed.ExceptionTypes[0].Contains("Assert", StringComparison.Ordinal) ||
+                         failed.ExceptionTypes[0].Contains("EqualException", StringComparison.Ordinal) ||
+                         failed.ExceptionTypes[0].Contains("TrueException", StringComparison.Ordinal) ||
+                         failed.ExceptionTypes[0].Contains("FalseException", StringComparison.Ordinal));
+
+                    return true; // Swallow the failure - we're going to retry
+                }
+
+                // All other messages (ITestPassed, ITestStarting, ITestFinished, etc.) pass through
+                return _innerBus.QueueMessage(message);
+            }
+
+            public void Dispose()
+            {
+                // Don't dispose the inner bus - it's owned by the caller
+            }
+        }
+    }
+}

--- a/src/Microsoft.Health.Extensions.Xunit/RetryTheoryAttribute.cs
+++ b/src/Microsoft.Health.Extensions.Xunit/RetryTheoryAttribute.cs
@@ -1,0 +1,37 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Microsoft.Health.Extensions.Xunit
+{
+    /// <summary>
+    /// Attribute that marks a theory method to be retried a specified number of times if it fails.
+    /// Useful for handling transient failures in integration and end-to-end tests with parameterized data.
+    /// </summary>
+    [XunitTestCaseDiscoverer("Microsoft.Health.Extensions.Xunit.RetryTheoryDiscoverer", "Microsoft.Health.Extensions.Xunit")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public sealed class RetryTheoryAttribute : TheoryAttribute
+    {
+        /// <summary>
+        /// Gets or sets the maximum number of retry attempts (default is 3).
+        /// </summary>
+        public int MaxRetries { get; set; } = 3;
+
+        /// <summary>
+        /// Gets or sets the delay in milliseconds between retry attempts (default is 5000ms).
+        /// </summary>
+        public int DelayBetweenRetriesMs { get; set; } = 5000;
+
+        /// <summary>
+        /// Gets or sets whether to retry on assertion failures (XunitException).
+        /// Default is false - assertion failures usually indicate test bugs, not transient issues.
+        /// Set to true for tests that validate eventually-consistent systems (e.g., cache refresh, reindex operations).
+        /// </summary>
+        public bool RetryOnAssertionFailure { get; set; } = false;
+    }
+}

--- a/src/Microsoft.Health.Extensions.Xunit/RetryTheoryDiscoverer.cs
+++ b/src/Microsoft.Health.Extensions.Xunit/RetryTheoryDiscoverer.cs
@@ -1,0 +1,91 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.Health.Extensions.Xunit
+{
+    /// <summary>
+    /// Test case discoverer for <see cref="RetryTheoryAttribute"/>.
+    /// For Theory tests, we need to let xUnit discover the data-driven test cases first,
+    /// then wrap each one with retry logic.
+    /// </summary>
+    public class RetryTheoryDiscoverer : TheoryDiscoverer
+    {
+        public RetryTheoryDiscoverer(IMessageSink diagnosticMessageSink)
+            : base(diagnosticMessageSink)
+        {
+        }
+
+        protected override IEnumerable<IXunitTestCase> CreateTestCasesForDataRow(
+            ITestFrameworkDiscoveryOptions discoveryOptions,
+            ITestMethod testMethod,
+            IAttributeInfo theoryAttribute,
+            object[] dataRow)
+        {
+            var maxRetries = theoryAttribute.GetNamedArgument<int>(nameof(RetryTheoryAttribute.MaxRetries));
+            var delayMs = theoryAttribute.GetNamedArgument<int>(nameof(RetryTheoryAttribute.DelayBetweenRetriesMs));
+            var retryOnAssertionFailure = theoryAttribute.GetNamedArgument<bool>(nameof(RetryTheoryAttribute.RetryOnAssertionFailure));
+
+            // Use default values if not specified
+            if (maxRetries == 0)
+            {
+                maxRetries = 3;
+            }
+
+            if (delayMs == 0)
+            {
+                delayMs = 5000;
+            }
+
+            // Create a RetryTestCase for each data row
+            yield return new RetryTestCase(
+                DiagnosticMessageSink,
+                discoveryOptions.MethodDisplayOrDefault(),
+                discoveryOptions.MethodDisplayOptionsOrDefault(),
+                testMethod,
+                maxRetries,
+                delayMs,
+                retryOnAssertionFailure,
+                dataRow);
+        }
+
+        protected override IEnumerable<IXunitTestCase> CreateTestCasesForTheory(
+            ITestFrameworkDiscoveryOptions discoveryOptions,
+            ITestMethod testMethod,
+            IAttributeInfo theoryAttribute)
+        {
+            var maxRetries = theoryAttribute.GetNamedArgument<int>(nameof(RetryTheoryAttribute.MaxRetries));
+            var delayMs = theoryAttribute.GetNamedArgument<int>(nameof(RetryTheoryAttribute.DelayBetweenRetriesMs));
+            var retryOnAssertionFailure = theoryAttribute.GetNamedArgument<bool>(nameof(RetryTheoryAttribute.RetryOnAssertionFailure));
+
+            // Use default values if not specified
+            if (maxRetries == 0)
+            {
+                maxRetries = 3;
+            }
+
+            if (delayMs == 0)
+            {
+                delayMs = 5000;
+            }
+
+            // For theories without data (will be skipped), wrap in retry
+            return base.CreateTestCasesForTheory(discoveryOptions, testMethod, theoryAttribute)
+                .Select(testCase => new RetryTestCase(
+                    DiagnosticMessageSink,
+                    discoveryOptions.MethodDisplayOrDefault(),
+                    discoveryOptions.MethodDisplayOptionsOrDefault(),
+                    testMethod,
+                    maxRetries,
+                    delayMs,
+                    retryOnAssertionFailure,
+                    testCase.TestMethodArguments));
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/ConvertData/ConvertDataRequestHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/ConvertData/ConvertDataRequestHandlerTests.cs
@@ -10,6 +10,7 @@ using Hl7.Fhir.Serialization;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Core.Features.Security.Authorization;
+using Microsoft.Health.Extensions.Xunit;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features.Operations.ConvertData;
 using Microsoft.Health.Fhir.Core.Features.Security;
@@ -29,7 +30,7 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Conver
     [Trait(Traits.Category, Categories.Operations)]
     public class ConvertDataRequestHandlerTests
     {
-        [Fact]
+        [RetryFact(MaxRetries = 3, DelayBetweenRetriesMs = 5000)]
         public async Task GivenAHl7v2ConvertRequest_WhenConvertData_CorrectResponseShouldReturn()
         {
             var convertDataRequestHandler = GetRequestHandler();

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Import/ImportResourceParserTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Import/ImportResourceParserTests.cs
@@ -8,6 +8,7 @@ using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Core.Features.Security;
+using Microsoft.Health.Extensions.Xunit;
 using Microsoft.Health.Fhir.Core.Features.Compartment;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Definition;
@@ -54,7 +55,7 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Import
             _importResourceParser = new(_jsonParser, _wrapperFactory);
         }
 
-        [Fact]
+        [RetryFact(MaxRetries = 3, DelayBetweenRetriesMs = 5000)]
         public void GivenImportWithSoftDeletedFile_WhenParsed_DeletedExtensionShouldBeRemoved()
         {
             Patient patient = new Patient();

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/Upsert/BulkUpdateServiceTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Resources/Upsert/BulkUpdateServiceTests.cs
@@ -19,6 +19,7 @@ using Microsoft.Health.Core.Features.Audit;
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Core.Features.Security;
 using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Health.Extensions.Xunit;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Extensions;
@@ -386,7 +387,7 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Resources.Upsert
             Assert.True(result.ResourcesIgnored["Observation"] == 1); // Observations ignored as no applicable patch request
         }
 
-        [Theory]
+        [RetryTheory(MaxRetries = 3)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task UpdateMultipleAsync_WhenSingleMatchAndMoreThanMaxParallelThreadsIncludePagesWithGivenReadNextPage_ResourcesAreUpdated(bool readNextPage)
@@ -614,7 +615,7 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Resources.Upsert
             }
         }
 
-        [Theory]
+        [RetryTheory]
         [InlineData(true)]
         [InlineData(false)]
         public async Task UpdateMultipleAsync__WhenMoreThanMaxParallelThreadsMatchAndIncludePagesWithGivenReadNextPage_ResourcesAreUpdated(bool readNextPage)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BundleTransactionTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BundleTransactionTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Net;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Utility;
+using Microsoft.Health.Extensions.Xunit;
 using Microsoft.Health.Fhir.Client;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Core.Features.Resources;
@@ -102,7 +103,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             ValidateOperationOutcome(expectedDiagnostics, expectedCodeType, fhirException.OperationOutcome);
         }
 
-        [Theory]
+        [RetryTheory]
         [Trait(Traits.Priority, Priority.One)]
         [InlineData(FhirBundleProcessingLogic.Parallel)]
         [InlineData(FhirBundleProcessingLogic.Sequential)]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HistoryTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/HistoryTests.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using System.Web;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
+using Microsoft.Health.Extensions.Xunit;
 using Microsoft.Health.Fhir.Client;
 using Microsoft.Health.Fhir.Core.Extensions;
 using Microsoft.Health.Fhir.Tests.Common;
@@ -93,7 +94,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
                 userMessage: $"Record 0's latest update ({readResponse[0].Resource.Meta.LastUpdated}) is not greater or equal than Record's 1 latest update ({readResponse[1].Resource.Meta.LastUpdated}).");
         }
 
-        [Fact]
+        [RetryFact]
         [Trait(Traits.Priority, Priority.One)]
         public async Task GivenTestResourcesWithUpdatesAndDeletes_WhenGettingResourceHistoryCount_TheServerShouldReturnCorrectCount()
         {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using Microsoft.Health.Core.Extensions;
+using Microsoft.Health.Extensions.Xunit;
 using Microsoft.Health.Fhir.Client;
 using Microsoft.Health.Fhir.Core.Features;
 using Microsoft.Health.Fhir.Core.Features.Operations;
@@ -23,13 +24,13 @@ using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 {
-    [CollectionDefinition(Categories.CustomSearch, DisableParallelization = true)]
-    [Collection(Categories.CustomSearch)]
+    [CollectionDefinition(Categories.IndexAndReindex, DisableParallelization = true)]
+    [Collection(Categories.IndexAndReindex)]
     [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
     [Trait(Traits.Category, Categories.Search)]
-    [Trait(Traits.Category, Categories.CustomSearch)]
+    [Trait(Traits.Category, Categories.IndexAndReindex)]
     [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.Json)]
-    public class CustomSearchParamTests : SearchTestsBase<HttpIntegrationTestFixture>, IAsyncLifetime
+    public class CustomSearchParamTests : SearchTestsBase<HttpIntegrationTestFixture>
     {
         private readonly HttpIntegrationTestFixture _fixture;
         private readonly ITestOutputHelper _output;
@@ -42,188 +43,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             _output = output;
         }
 
-        public async Task InitializeAsync()
-        {
-            await Client.DeleteAllResources(ResourceType.Specimen, null);
-            await Client.DeleteAllResources(ResourceType.Immunization, null);
-        }
-
-        [SkippableFact]
-        public async Task GivenANewSearchParam_WhenReindexingComplete_ThenResourcesSearchedWithNewParamReturned()
-        {
-            Skip.If(!_fixture.IsUsingInProcTestServer, "Reindex is not enabled on this server.");
-
-            var randomName = Guid.NewGuid().ToString().ComputeHash()[..14].ToLower();
-            SearchParameter searchParam = Samples.GetJsonSample<SearchParameter>("SearchParameter-SpecimenStatus");
-            searchParam.Name = randomName;
-            searchParam.Url = searchParam.Url.Replace("foo", randomName);
-            searchParam.Code = randomName + "Code";
-
-            // POST a new Specimen
-            Specimen specimen = Samples.GetJsonSample<Specimen>("Specimen");
-            specimen.Status = Specimen.SpecimenStatus.Available;
-            var tag = new Coding(null, randomName);
-            specimen.Meta = new Meta();
-            specimen.Meta.Tag.Add(tag);
-            FhirResponse<Specimen> expectedSpecimen = await Client.CreateAsync(specimen);
-
-            // POST a second Specimen to show it is filtered and not returned when using the new search parameter
-            Specimen specimen2 = Samples.GetJsonSample<Specimen>("Specimen");
-            specimen2.Status = Specimen.SpecimenStatus.EnteredInError;
-            specimen2.Meta = new Meta();
-            specimen2.Meta.Tag.Add(tag);
-            await Client.CreateAsync(specimen2);
-
-            // POST a new Search parameter
-            FhirResponse<SearchParameter> searchParamPosted = null;
-            int retryCount = 0;
-            bool success = true;
-            try
-            {
-                searchParamPosted = await Client.CreateAsync(searchParam);
-                _output.WriteLine($"SearchParameter is posted {searchParam.Url}");
-
-                // Start a reindex job
-                Uri reindexJobUri;
-                FhirResponse<Parameters> reindexJobResult;
-                (reindexJobResult, reindexJobUri) = await RunReindexToCompletion(new Parameters());
-
-                Parameters.ParameterComponent param = reindexJobResult.Resource.Parameter.FirstOrDefault(p => p.Name == JobRecordProperties.SearchParams);
-                Assert.Contains(searchParamPosted.Resource.Url, param?.Value?.ToString());
-
-                do
-                {
-                    success = true;
-                    retryCount++;
-                    try
-                    {
-                        await ExecuteAndValidateBundle(
-                            $"Specimen?{searchParam.Code}={Specimen.SpecimenStatus.Available.ToString().ToLower()}&_tag={tag.Code}",
-                            expectedSpecimen.Resource);
-
-                        _output.WriteLine($"Success on attempt {retryCount} of {MaxRetryCount}");
-                    }
-                    catch (Exception ex)
-                    {
-                        string error = $"Attempt {retryCount} of {MaxRetryCount}: Failed to validate bundle: {ex}";
-                        _output.WriteLine(error);
-                        success = false;
-                        await Task.Delay(TimeSpan.FromSeconds(10));
-                    }
-                }
-                while (!success && retryCount < MaxRetryCount);
-
-                Assert.True(success);
-            }
-            catch (FhirClientException ex) when (ex.StatusCode == HttpStatusCode.BadRequest && ex.Message.Contains("not enabled"))
-            {
-                _output.WriteLine($"Skipping because reindex is disabled.");
-                return;
-            }
-            catch (Exception e)
-            {
-                _output.WriteLine($"Exception: {e.Message}");
-                _output.WriteLine($"Stack Trace: {e.StackTrace}");
-                throw;
-            }
-            finally
-            {
-                // Clean up new SearchParameter
-                await DeleteSearchParameterAndVerify(searchParamPosted?.Resource);
-            }
-        }
-
-        [SkippableFact]
-        public async Task GivenASearchParam_WhenUpdatingParam_ThenResourcesIndexedWithUpdatedParam()
-        {
-            Skip.If(!_fixture.IsUsingInProcTestServer, "Reindex is not enabled on this server.");
-
-            var randomName = Guid.NewGuid().ToString().ComputeHash()[28..].ToLower();
-            var patient = new Patient { Name = new List<HumanName> { new HumanName { Family = randomName } } };
-            SearchParameter searchParam = Samples.GetJsonSample<SearchParameter>("SearchParameter-Patient-foo");
-            searchParam.Name = randomName;
-            searchParam.Url = searchParam.Url.Replace("foo", randomName);
-            searchParam.Code = randomName;
-            searchParam.Id = randomName;
-
-            // POST a new patient
-            FhirResponse<Patient> expectedPatient = await Client.CreateAsync(patient);
-
-            // POST a new Search parameter
-            FhirResponse<SearchParameter> searchParamPosted = null;
-            int retryCount = 0;
-            bool success = true;
-            try
-            {
-                searchParamPosted = await Client.CreateAsync(searchParam);
-
-                // now update the new search parameter
-                var randomNameUpdated = randomName + "U";
-                searchParamPosted.Resource.Name = randomNameUpdated;
-                searchParamPosted.Resource.Url = "http://hl7.org/fhir/SearchParameter/Patient-" + randomNameUpdated;
-                searchParamPosted.Resource.Code = randomNameUpdated;
-                searchParamPosted = await Client.UpdateAsync(searchParamPosted.Resource);
-
-                Uri reindexJobUri;
-                FhirResponse<Parameters> reindexJobResult;
-
-                // Reindex just a single patient, so we can try searching with a partially indexed search param
-                (reindexJobResult, reindexJobUri) = await RunReindexToCompletion(new Parameters(), $"Patient/{expectedPatient.Resource.Id}/");
-
-                Parameters.ParameterComponent param = reindexJobResult.Resource.Parameter.FirstOrDefault(p => p.Name == randomNameUpdated);
-                if (param == null)
-                {
-                    _output.WriteLine($"Parameter with name equal to randomly generated name of this test case: {randomNameUpdated} not found in reindex result.");
-                }
-
-                Assert.NotNull(param);
-                Assert.Equal(randomName, param.Value.ToString());
-
-                do
-                {
-                    success = true;
-                    retryCount++;
-                    try
-                    {
-                        // When reindex job complete, search for resources using new parameter
-                        await ExecuteAndValidateBundle(
-                                    $"Patient?{searchParamPosted.Resource.Code}:exact={randomName}",
-                                    Tuple.Create(KnownHeaders.PartiallyIndexedParamsHeaderName, "true"),
-                                    expectedPatient.Resource);
-
-                        _output.WriteLine($"Success on attempt {retryCount} of {MaxRetryCount}");
-                    }
-                    catch (Exception ex)
-                    {
-                        string error = $"Attempt {retryCount} of {MaxRetryCount}: Failed to validate bundle: {ex}";
-                        _output.WriteLine(error);
-                        success = false;
-                        await Task.Delay(TimeSpan.FromSeconds(10));
-                    }
-                }
-                while (!success && retryCount < MaxRetryCount);
-
-                Assert.True(success);
-            }
-            catch (FhirClientException ex) when (ex.StatusCode == HttpStatusCode.BadRequest && ex.Message.Contains("not enabled"))
-            {
-                _output.WriteLine($"Skipping because reindex is disabled.");
-                return;
-            }
-            catch (Exception e)
-            {
-                _output.WriteLine($"Exception: {e.Message}");
-                _output.WriteLine($"Stack Trace: {e.StackTrace}");
-                throw;
-            }
-            finally
-            {
-                // Clean up new SearchParameter
-                await DeleteSearchParameterAndVerify(searchParamPosted?.Resource);
-            }
-        }
-
-        [Theory]
+        [RetryTheory]
         [InlineData("SearchParameterBadSyntax", "The search parameter definition contains one or more invalid entries.")]
 #if Stu3 || R4 || R4B
         [InlineData("SearchParameterInvalidBase", "Literal 'foo' is not a valid value for enumeration 'ResourceType'")]
@@ -249,91 +69,5 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 Assert.Contains(ex.OperationOutcome.Issue, i => i.Diagnostics.Contains(errorMessage));
             }
         }
-
-        [Fact]
-        public async Task GivenNonParametersRequestBody_WhenReindexSent_ThenBadRequest()
-        {
-            string body = Samples.GetJson("PatientWithMinimalData");
-            FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(async () => await Client.PostAsync("$reindex", body));
-            Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
-        }
-
-        private async Task<(FhirResponse<Parameters> response, Uri uri)> RunReindexToCompletion(Parameters reindexParameters, string uniqueResource = null)
-        {
-            Uri reindexJobUri;
-            FhirResponse<Parameters> response;
-            (response, reindexJobUri) = await Client.PostReindexJobAsync(reindexParameters, uniqueResource);
-
-            // this becomes null when the uniqueResource gets passed in
-            if (reindexJobUri != null)
-            {
-                response = await Client.WaitForReindexStatus(reindexJobUri, "Completed");
-
-                _output.WriteLine("ReindexJobDocument:");
-                var serializer = new FhirJsonSerializer();
-                serializer.Settings.Pretty = true;
-                _output.WriteLine(serializer.SerializeToString(response.Resource));
-
-                var floatParse = float.TryParse(
-                    response.Resource.Parameter.FirstOrDefault(p => p.Name == JobRecordProperties.ResourcesSuccessfullyReindexed).Value.ToString(),
-                    out float resourcesReindexed);
-
-                Assert.True(floatParse);
-                Assert.True(resourcesReindexed > 0.0);
-            }
-            else
-            {
-                _output.WriteLine("response.Resource.Parameter output:");
-                foreach (Parameters.ParameterComponent paramComponent in response.Resource.Parameter)
-                {
-                    _output.WriteLine($"  {paramComponent.Name}: {paramComponent.Value}");
-                }
-            }
-
-            return (response, reindexJobUri);
-        }
-
-        private async Task DeleteSearchParameterAndVerify(SearchParameter searchParam)
-        {
-            if (searchParam != null)
-            {
-                // Clean up new SearchParameter
-                // When there are multiple instances of the fhir-server running, it could take some time
-                // for the search parameter/reindex updates to propagate to all instances. Hence we are
-                // adding some retries below to account for that delay.
-                int retryCount = 0;
-                bool success = true;
-                do
-                {
-                    success = true;
-                    retryCount++;
-                    try
-                    {
-                        await Client.DeleteAsync(searchParam);
-                    }
-                    catch (Exception exp)
-                    {
-                        _output.WriteLine($"Attempt {retryCount} of {MaxRetryCount}: CustomSearchParameter test experienced issue attempted to clean up SearchParameter {searchParam.Url}.  The exception is {exp}");
-                        if (exp is FhirClientException fhirException && fhirException.OperationOutcome?.Issue != null)
-                        {
-                            foreach (OperationOutcome.IssueComponent issueComponent in fhirException.OperationOutcome.Issue)
-                            {
-                                _output.WriteLine("FhirException OperationOutome message from trying to delete SearchParameter is CustomSearchParam test: {0}", issueComponent.Diagnostics);
-                            }
-                        }
-
-                        success = false;
-                        await Task.Delay(TimeSpan.FromSeconds(10));
-                    }
-                }
-                while (!success && retryCount < MaxRetryCount);
-
-                Assert.True(success);
-                FhirClientException ex = await Assert.ThrowsAsync<FhirClientException>(() => Client.ReadAsync<SearchParameter>(ResourceType.SearchParameter, searchParam.Id));
-                Assert.Contains("Gone", ex.Message);
-            }
-        }
-
-        public Task DisposeAsync() => Task.CompletedTask;
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SearchProxyTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SearchProxyTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             _proxyClient.HttpClient.DefaultRequestHeaders.Add(XForwardedPrefix, Prefix);
         }
 
-        [Fact]
+        [RetryFact]
         public async Task GivenSearch_WhenIncludingForwardedHeaders_ThenModifyResponseUrls()
         {
             // Ensure at least one patient exists
@@ -74,7 +74,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             AssertSingletonPatientBundle(searchset);
         }
 
-        [Fact]
+        [RetryFact]
         public async Task GivenSearchBundle_WhenIncludingForwardedHeaders_ThenModifyResponseUrls()
         {
             // Ensure at least one patient exists

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SortTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/SortTests.cs
@@ -489,7 +489,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 observations.Add(obs.First());
             }
 
-            resources.AddRange(patients.Reverse());
+            resources.AddRange(patients.AsEnumerable().Reverse());
             resources.AddRange(observations);
 
             // Ask to get all patient with specific tag order by birthdate (timestamp)
@@ -561,7 +561,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 observations.Add(obs.First());
             }
 
-            resources.AddRange(patients.Reverse());
+            resources.AddRange(patients.AsEnumerable().Reverse());
             observations.Reverse();
             resources.AddRange(observations);
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTests.cs
@@ -17,6 +17,7 @@ using MediatR;
 using Microsoft.Data.SqlClient;
 using Microsoft.Health.Abstractions.Exceptions;
 using Microsoft.Health.Abstractions.Features.Transactions;
+using Microsoft.Health.Extensions.Xunit;
 using Microsoft.Health.Fhir.Core;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Extensions;
@@ -69,7 +70,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
         protected Mediator Mediator { get; }
 
-        [Theory]
+        [RetryTheory(MaxRetries = 3, DelayBetweenRetriesMs = 5000)]
         [InlineData(5)] // should succeed
         [InlineData(35)] // shoul fail
         [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]
@@ -113,7 +114,7 @@ IF (SELECT count(*) FROM EventLog WHERE Process = 'MergeResources' AND Status = 
             }
         }
 
-        [Theory]
+        [RetryTheory(MaxRetries = 3, DelayBetweenRetriesMs = 5000)]
         [InlineData(true)]
         [InlineData(false)]
         [FhirStorageTestsFixtureArgumentSets(DataStore.SqlServer)]
@@ -259,7 +260,7 @@ IF (SELECT count(*) FROM EventLog WHERE Process = 'MergeResources' AND Status = 
             await _fixture.SqlHelper.ExecuteSqlCmd($"UPDATE dbo.Resource SET ResourceId = '{oldId}', Version = 3 WHERE ResourceId = '{newId}' AND Version = 1");
         }
 
-        [Fact]
+        [RetryFact]
         public async Task GivenAResource_WhenSaving_ThenTheMetaIsUpdated_AndLastUpdatedIsWithin1sec()
         {
             var saveResult = await Mediator.UpsertResourceAsync(Samples.GetJsonSample("Weight"));
@@ -1189,7 +1190,7 @@ IF (SELECT count(*) FROM EventLog WHERE Process = 'MergeResources' AND Status = 
         {
             var searchParam = new SearchParameter
             {
-                Url = $"http://hl7.org/fhir/SearchParameter/Patient-{searchParamName}",
+                Url = $"http://hl7.org/fhir/SearchParameter/Patient-{searchParamName}-Integration-FhirStorageTests",
                 Type = type,
 #if Stu3 || R4 || R4B
                 Base = new List<ResourceType?>() { ResourceType.Patient },

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerSchemaUpgradeTests.cs
@@ -17,6 +17,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Extensions.DependencyInjection;
+using Microsoft.Health.Extensions.Xunit;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Features.Definition;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
@@ -92,7 +93,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             }
         }
 
-        [Fact]
+        [RetryFact]
         public void GivenASchemaVersion_WhenApplyingDiffTwice_ShouldSucceed()
         {
             var versions = Enum.GetValues(typeof(SchemaVersion)).OfType<object>().ToList().Select(x => Convert.ToInt32(x)).ToList();

--- a/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/Rest/VersionSpecificTests.cs
+++ b/test/Microsoft.Health.Fhir.Stu3.Tests.E2E/Rest/VersionSpecificTests.cs
@@ -5,6 +5,7 @@
 
 using System.Net;
 using Hl7.Fhir.Model;
+using Microsoft.Health.Extensions.Xunit;
 using Microsoft.Health.Fhir.Client;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
@@ -21,13 +22,13 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
     [Trait(Traits.Category, Categories.DomainLogicValidation)]
     public partial class VersionSpecificTests : IClassFixture<HttpIntegrationTestFixture>
     {
-        [Fact]
+        [RetryFact]
         public async Task GivenStu3Server_WhenCapabilityStatementIsRetrieved_ThenCorrectVersionShouldBeReturned()
         {
             await TestCapabilityStatementFhirVersion("3.0.2");
         }
 
-        [Fact]
+        [RetryFact]
         [HttpIntegrationFixtureArgumentSets(DataStore.SqlServer)]
         public async Task GivenAnObservation_WithInvalidDecimalSpecification_ThenBadRequestShouldBeReturned()
         {


### PR DESCRIPTION
## Description
This pull request introduces a set of custom xUnit attributes and supporting classes to enable automatic retry logic for flaky or transiently failing tests, both for standard tests and data-driven theories. The new functionality allows tests to be retried a configurable number of times with a delay between attempts, and provides an option to retry on assertion failures if desired. This is especially useful for integration and end-to-end tests that may encounter intermittent issues.

**New retry test infrastructure:**

* Added `RetryFactAttribute` and `RetryTheoryAttribute`, which can be applied to test methods to enable automatic retries on failure, with configurable maximum retries, delay between attempts, and retry-on-assertion options. [[1]](diffhunk://#diff-02e7a0f66d9fcd2215433eef252d14473e213dfe9d3ce17d613bcfe49aab2d47R1-R37) [[2]](diffhunk://#diff-9e3b0fc8c2b5d8a999a1583b1fa4b07ec8e4c2549c37621898e75cc81ddbe7e8R1-R37)
* Implemented `RetryFactDiscoverer` and `RetryTheoryDiscoverer`, which integrate with xUnit's test discovery to wrap test cases and theory data rows with retry logic. [[1]](diffhunk://#diff-3dd8777531a992111d6704cafb3d466c0489721db8f28574669b16243454fd5bR1-R54) [[2]](diffhunk://#diff-404e220c504e9a311a16134c5c1f20c02774da1d19d11c366792d57842dfbd0dR1-R91)
* Added `RetryTestCase`, a custom test case that encapsulates the retry loop, manages diagnostic output, and determines whether to retry based on exception type and configuration. It also includes a message bus to intercept and suppress failure messages for non-final attempts.

**Integration:**

* Updated test files to use the new retry infrastructure by referencing `Microsoft.Health.Extensions.Xunit`.

## Related issues
Addresses [[AB#178906](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/178906)].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
