### PR TITLE
Split out oss versions for e2e/integration tests

### DIFF
--- a/build/docker-compose.test.yml
+++ b/build/docker-compose.test.yml
@@ -1,0 +1,55 @@
+services:
+  sql:
+    container_name: fhir-test-sql
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    environment:
+      ACCEPT_EULA: Y
+      SA_PASSWORD: ${SQL_SA_PASSWORD:-YourStrong!Passw0rd}
+      MSSQL_PID: Developer
+    ports:
+      - "1433:1433"
+    healthcheck:
+      test: /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "$${SA_PASSWORD}" -C -Q "SELECT 1" || exit 1
+      interval: 10s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
+    volumes:
+      - sql-data:/var/opt/mssql
+
+  cosmos:
+    container_name: fhir-test-cosmos
+    image: mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:latest
+    mem_limit: 3g
+    cpu_count: 2
+    environment:
+      AZURE_COSMOS_EMULATOR_PARTITION_COUNT: 2
+      AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE: "false"
+      AZURE_COSMOS_EMULATOR_IP_ADDRESS_OVERRIDE: "127.0.0.1"
+    ports:
+      - "8081:8081"
+      - "10250-10255:10250-10255"
+    healthcheck:
+      test: curl -k https://localhost:8081/_explorer/emulator.pem || exit 1
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 120s
+
+  azurite:
+    container_name: fhir-test-azurite
+    image: mcr.microsoft.com/azure-storage/azurite:latest
+    ports:
+      - "10000:10000"
+      - "10001:10001"
+      - "10002:10002"
+    command: azurite --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0 --loose
+    healthcheck:
+      test: nc -z localhost 10000 || exit 1
+      interval: 10s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
+
+volumes:
+  sql-data:

--- a/build/jobs/docker-cosmos-tests-only.yml
+++ b/build/jobs/docker-cosmos-tests-only.yml
@@ -1,0 +1,156 @@
+parameters:
+- name: version
+  type: string
+
+steps:
+  - checkout: self
+    fetchDepth: 1
+    fetchTags: false
+
+  - task: UseDotNet@2
+    inputs:
+      useGlobalJson: true
+
+  - task: DockerCompose@1
+    displayName: 'Start CosmosDB Emulator and Azurite containers'
+    inputs:
+      action: 'Run services'
+      dockerComposeFile: '$(Build.SourcesDirectory)/build/docker-compose.test.yml'
+      projectName: 'fhir-server-test-${{ lower(parameters.version) }}-cosmos'
+      dockerComposeCommand: 'up -d cosmos azurite'
+      detached: true
+
+  - script: |
+      echo "Waiting for Cosmos DB Emulator to be ready..."
+      timeout=240
+      elapsed=0
+      until docker exec fhir-test-cosmos curl -k https://localhost:8081/_explorer/emulator.pem > /dev/null 2>&1 || [ $elapsed -ge $timeout ]; do
+        echo "Waiting for Cosmos DB Emulator... ($elapsed seconds)"
+        sleep 10
+        elapsed=$((elapsed + 10))
+      done
+      echo "Cosmos DB Emulator is ready"
+    displayName: 'Verify Cosmos DB Emulator connectivity'
+
+  - script: |
+      echo "Exporting and trusting CosmosDB Emulator SSL certificate..."
+      # Extract certificate from the emulator
+      curl -k https://localhost:8081/_explorer/emulator.pem > ~/emulatorcert.crt
+
+      # Install to system certificate store (for curl/wget)
+      sudo cp ~/emulatorcert.crt /usr/local/share/ca-certificates/
+      sudo update-ca-certificates
+
+      # Also install as PEM file for .NET Core on Linux
+      # .NET on Linux uses OpenSSL and may need explicit cert configuration
+      sudo mkdir -p /etc/ssl/certs
+      sudo cp ~/emulatorcert.crt /etc/ssl/certs/cosmosdb-emulator.pem
+
+      # Create a combined bundle for .NET
+      cat /etc/ssl/certs/ca-certificates.crt ~/emulatorcert.crt > ~/combined-certs.crt
+      sudo cp ~/combined-certs.crt /etc/ssl/certs/ca-certificates-with-cosmos.crt
+
+      # Verify certificate installation
+      echo "Verifying certificate is installed..."
+      ls -la /usr/local/share/ca-certificates/
+      ls -la /etc/ssl/certs/cosmosdb-emulator.pem
+
+      echo "CosmosDB Emulator certificate trusted"
+    displayName: 'Trust CosmosDB Emulator SSL certificate'
+
+  - script: |
+      echo "Waiting for Azurite to be ready..."
+      timeout=60
+      elapsed=0
+      until curl -f http://localhost:10000/devstoreaccount1?restype=account > /dev/null 2>&1 || [ $elapsed -ge $timeout ]; do
+        echo "Waiting for Azurite... ($elapsed seconds)"
+        sleep 5
+        elapsed=$((elapsed + 5))
+      done
+      echo "Azurite is ready"
+    displayName: 'Verify Azurite connectivity'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Build ${{ parameters.version }} integration test project'
+    inputs:
+      command: build
+      projects: 'test/**/*${{ parameters.version }}.Tests.Integration.csproj'
+      arguments: '--configuration $(buildConfiguration) -f $(defaultBuildFramework)'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Run ${{ parameters.version }} CosmosDB Integration Tests'
+    inputs:
+      command: test
+      projects: 'test/**/*${{ parameters.version }}.Tests.Integration.csproj'
+      arguments: '--filter DisplayName!~SqlServer --configuration $(buildConfiguration) --collect "XPlat Code Coverage" -s "$(build.sourcesDirectory)/CodeCoverage.runsettings" -v normal --no-build -f $(defaultBuildFramework)'
+      testRunTitle: '${{ parameters.version }} Docker CosmosDB Integration Tests'
+      publishTestResults: true
+    env:
+      'CosmosDb__Host': 'https://localhost:8081'
+      'CosmosDb__Key': 'C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=='
+      'CosmosDb__DatabaseId': 'FhirTests'
+      # Linux Cosmos Emulator only supports Gateway mode (Direct mode is not supported)
+      'CosmosDb__ConnectionMode': 'Gateway'
+      'TestExportStoreUri': 'http://127.0.0.1:10000/devstoreaccount1'
+      'TestIntegrationStoreUri': 'http://127.0.0.1:10000/devstoreaccount1'
+      # SSL certificate configuration for .NET on Linux
+      'SSL_CERT_FILE': '/etc/ssl/certs/ca-certificates-with-cosmos.crt'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Build ${{ parameters.version }} E2E test project'
+    inputs:
+      command: build
+      projects: 'test/**/*${{ parameters.version }}.Tests.E2E.csproj'
+      arguments: '--configuration $(buildConfiguration) -f $(defaultBuildFramework)'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Run ${{ parameters.version }} CosmosDB E2E Tests (In-Proc)'
+    inputs:
+      command: test
+      projects: 'test/**/*${{ parameters.version }}.Tests.E2E.csproj'
+      arguments: '--filter FullyQualifiedName~CosmosDb --configuration $(buildConfiguration) --collect "XPlat Code Coverage" -s "$(build.sourcesDirectory)/CodeCoverage.runsettings" -v normal --no-build -f $(defaultBuildFramework)'
+      testRunTitle: '${{ parameters.version }} Docker CosmosDB E2E Tests'
+      publishTestResults: true
+    env:
+      'CosmosDb__Host': 'https://localhost:8081'
+      'CosmosDb__Key': 'C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=='
+      'CosmosDb__DatabaseId': 'FhirTests'
+      # Linux Cosmos Emulator only supports Gateway mode (Direct mode is not supported)
+      'CosmosDb__ConnectionMode': 'Gateway'
+      'TestExportStoreUri': 'http://127.0.0.1:10000/devstoreaccount1'
+      'TestIntegrationStoreUri': 'http://127.0.0.1:10000/devstoreaccount1'
+      # SSL certificate configuration for .NET on Linux
+      'SSL_CERT_FILE': '/etc/ssl/certs/ca-certificates-with-cosmos.crt'
+
+  - task: reportgenerator@5
+    displayName: 'Aggregate ${{ parameters.version }} CosmosDB test coverage'
+    condition: succeededOrFailed()
+    inputs:
+      reports: '$(Agent.TempDirectory)/*/coverage.cobertura.xml'
+      reporttypes: 'Cobertura'
+      targetdir: '$(Agent.TempDirectory)/coverage'
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish ${{ parameters.version }} CosmosDB test coverage'
+    condition: succeededOrFailed()
+    inputs:
+      pathToPublish: '$(Agent.TempDirectory)/coverage'
+      artifactName: 'Coverage_Docker_CosmosDB_${{ parameters.version }}'
+      artifactType: 'container'
+
+  - task: PublishCodeCoverageResults@1
+    displayName: 'Publish ${{ parameters.version }} CosmosDB code coverage results'
+    condition: always()
+    inputs:
+      codeCoverageTool: 'Cobertura'
+      summaryFileLocation: '$(Agent.TempDirectory)/coverage/Cobertura.xml'
+      reportDirectory: '$(Agent.TempDirectory)/coverage'
+
+  - task: DockerCompose@1
+    displayName: 'Stop and remove containers'
+    condition: always()
+    inputs:
+      action: 'Run a Docker Compose command'
+      dockerComposeFile: '$(Build.SourcesDirectory)/build/docker-compose.test.yml'
+      projectName: 'fhir-server-test-${{ lower(parameters.version) }}-cosmos'
+      dockerComposeCommand: 'down -v'

--- a/build/jobs/docker-datastore-tests.yml
+++ b/build/jobs/docker-datastore-tests.yml
@@ -1,0 +1,218 @@
+parameters:
+- name: version
+  type: string
+
+steps:
+  - checkout: self
+    fetchDepth: 1
+    fetchTags: false
+
+  - task: UseDotNet@2
+    inputs:
+      useGlobalJson: true
+
+  - bash: |
+      # Generate random password meeting SQL Server requirements:
+      # - At least 8 characters
+      # - Contains uppercase, lowercase, digits, and special characters
+      RANDOM_PASSWORD=$(openssl rand -base64 32 | tr -d "=+/" | cut -c1-20)
+      # Ensure it meets complexity by adding required characters
+      SQL_PASSWORD="Sql${RANDOM_PASSWORD}9!"
+      echo "Generated secure SQL password"
+      echo "##vso[task.setvariable variable=SQL_SA_PASSWORD;issecret=true]$SQL_PASSWORD"
+    displayName: 'Generate random SQL Server password'
+
+  - task: DockerCompose@0
+    displayName: 'Start SQL Server and Azurite containers'
+    inputs:
+      action: 'Run services'
+      dockerComposeFile: '$(Build.SourcesDirectory)/build/docker-compose.test.yml'
+      projectName: 'fhir-server-test'
+      dockerComposeCommand: 'up -d sql azurite'
+      detached: true
+    env:
+      SQL_SA_PASSWORD: $(SQL_SA_PASSWORD)
+
+  - script: |
+      echo "Waiting for SQL Server to be ready..."
+      timeout=60
+      elapsed=0
+      until docker exec fhir-test-sql /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "$(SQL_SA_PASSWORD)" -C -Q "SELECT @@VERSION" -b > /dev/null 2>&1 || [ $elapsed -ge $timeout ]; do
+        echo "Waiting for SQL Server... ($elapsed seconds)"
+        sleep 5
+        elapsed=$((elapsed + 5))
+      done
+      docker exec fhir-test-sql /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "$(SQL_SA_PASSWORD)" -C -Q "SELECT @@VERSION" -b
+    displayName: 'Verify SQL Server connectivity'
+
+  - script: |
+      echo "Waiting for Azurite to be ready..."
+      timeout=60
+      elapsed=0
+      until curl -f http://localhost:10000/devstoreaccount1?restype=account > /dev/null 2>&1 || [ $elapsed -ge $timeout ]; do
+        echo "Waiting for Azurite... ($elapsed seconds)"
+        sleep 5
+        elapsed=$((elapsed + 5))
+      done
+      echo "Azurite is ready"
+    displayName: 'Verify Azurite connectivity'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Build ${{ parameters.version }} integration test project'
+    inputs:
+      command: build
+      projects: 'test/**/*${{ parameters.version }}.Tests.Integration.csproj'
+      arguments: '--configuration $(buildConfiguration) -f $(defaultBuildFramework)'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Run ${{ parameters.version }} SQL Integration Tests'
+    inputs:
+      command: test
+      projects: 'test/**/*${{ parameters.version }}.Tests.Integration.csproj'
+      arguments: '--filter DisplayName!~CosmosDb --configuration $(buildConfiguration) --collect "XPlat Code Coverage" -s "$(build.sourcesDirectory)/CodeCoverage.runsettings" -v normal --no-build -f $(defaultBuildFramework)'
+      testRunTitle: '${{ parameters.version }} Docker SQL Integration Tests'
+      publishTestResults: true
+    env:
+      'SqlServer:ConnectionString': 'Server=localhost;Persist Security Info=False;User ID=sa;Password=$(SQL_SA_PASSWORD);MultipleActiveResultSets=False;Connection Timeout=30;TrustServerCertificate=true'
+      'TestExportStoreUri': 'http://127.0.0.1:10000/devstoreaccount1'
+      'TestIntegrationStoreUri': 'http://127.0.0.1:10000/devstoreaccount1'
+
+  - task: DockerCompose@0
+    displayName: 'Stop SQL Server container to free disk space'
+    inputs:
+      action: 'Run a Docker Compose command'
+      dockerComposeFile: '$(Build.SourcesDirectory)/build/docker-compose.test.yml'
+      projectName: 'fhir-server-test'
+      dockerComposeCommand: 'stop sql'
+
+  - task: DockerCompose@0
+    displayName: 'Start CosmosDB Emulator'
+    inputs:
+      action: 'Run services'
+      dockerComposeFile: '$(Build.SourcesDirectory)/build/docker-compose.test.yml'
+      projectName: 'fhir-server-test'
+      dockerComposeCommand: 'up -d cosmos'
+      detached: true
+
+  - script: |
+      echo "Waiting for Cosmos DB Emulator to be ready..."
+      timeout=240
+      elapsed=0
+      until docker exec fhir-test-cosmos curl -k https://localhost:8081/_explorer/emulator.pem > /dev/null 2>&1 || [ $elapsed -ge $timeout ]; do
+        echo "Waiting for Cosmos DB Emulator... ($elapsed seconds)"
+        sleep 10
+        elapsed=$((elapsed + 10))
+      done
+      echo "Cosmos DB Emulator is ready"
+    displayName: 'Verify Cosmos DB Emulator connectivity'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Run ${{ parameters.version }} CosmosDB Integration Tests'
+    inputs:
+      command: test
+      projects: 'test/**/*${{ parameters.version }}.Tests.Integration.csproj'
+      arguments: '--filter DisplayName!~SqlServer --configuration $(buildConfiguration) --collect "XPlat Code Coverage" -s "$(build.sourcesDirectory)/CodeCoverage.runsettings" -v normal --no-build -f $(defaultBuildFramework)'
+      testRunTitle: '${{ parameters.version }} Docker CosmosDB Integration Tests'
+      publishTestResults: true
+    env:
+      'CosmosDb__Host': 'https://localhost:8081'
+      'CosmosDb__Key': 'C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=='
+      'CosmosDb__DatabaseId': 'FhirTests'
+      'TestExportStoreUri': 'http://127.0.0.1:10000/devstoreaccount1'
+      'TestIntegrationStoreUri': 'http://127.0.0.1:10000/devstoreaccount1'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Build ${{ parameters.version }} E2E test project'
+    inputs:
+      command: build
+      projects: 'test/**/*${{ parameters.version }}.Tests.E2E.csproj'
+      arguments: '--configuration $(buildConfiguration) -f $(defaultBuildFramework)'
+
+  - task: DockerCompose@0
+    displayName: 'Restart SQL Server for E2E tests'
+    inputs:
+      action: 'Run a Docker Compose command'
+      dockerComposeFile: '$(Build.SourcesDirectory)/build/docker-compose.test.yml'
+      projectName: 'fhir-server-test'
+      dockerComposeCommand: 'start sql'
+
+  - script: |
+      echo "Waiting for SQL Server to be ready after restart..."
+      timeout=60
+      elapsed=0
+      until docker exec fhir-test-sql /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "$(SQL_SA_PASSWORD)" -C -Q "SELECT 1" -b > /dev/null 2>&1 || [ $elapsed -ge $timeout ]; do
+        echo "Waiting for SQL Server... ($elapsed seconds)"
+        sleep 5
+        elapsed=$((elapsed + 5))
+      done
+      echo "SQL Server is ready"
+    displayName: 'Verify SQL Server connectivity after restart'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Run ${{ parameters.version }} SQL E2E Tests (In-Proc)'
+    inputs:
+      command: test
+      projects: 'test/**/*${{ parameters.version }}.Tests.E2E.csproj'
+      arguments: '--filter FullyQualifiedName~SqlServer --configuration $(buildConfiguration) --collect "XPlat Code Coverage" -s "$(build.sourcesDirectory)/CodeCoverage.runsettings" -v normal --no-build -f $(defaultBuildFramework)'
+      testRunTitle: '${{ parameters.version }} Docker SQL E2E Tests'
+      publishTestResults: true
+    env:
+      'SqlServer:ConnectionString': 'Server=localhost;Persist Security Info=False;User ID=sa;Password=$(SQL_SA_PASSWORD);MultipleActiveResultSets=False;Connection Timeout=30;TrustServerCertificate=true'
+      'TestExportStoreUri': 'http://127.0.0.1:10000/devstoreaccount1'
+      'TestIntegrationStoreUri': 'http://127.0.0.1:10000/devstoreaccount1'
+
+  - task: DockerCompose@0
+    displayName: 'Stop SQL Server before CosmosDB E2E tests'
+    inputs:
+      action: 'Run a Docker Compose command'
+      dockerComposeFile: '$(Build.SourcesDirectory)/build/docker-compose.test.yml'
+      projectName: 'fhir-server-test'
+      dockerComposeCommand: 'stop sql'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Run ${{ parameters.version }} CosmosDB E2E Tests (In-Proc)'
+    inputs:
+      command: test
+      projects: 'test/**/*${{ parameters.version }}.Tests.E2E.csproj'
+      arguments: '--filter FullyQualifiedName~CosmosDb --configuration $(buildConfiguration) --collect "XPlat Code Coverage" -s "$(build.sourcesDirectory)/CodeCoverage.runsettings" -v normal --no-build -f $(defaultBuildFramework)'
+      testRunTitle: '${{ parameters.version }} Docker CosmosDB E2E Tests'
+      publishTestResults: true
+    env:
+      'CosmosDb__Host': 'https://localhost:8081'
+      'CosmosDb__Key': 'C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=='
+      'CosmosDb__DatabaseId': 'FhirTests'
+      'TestExportStoreUri': 'http://127.0.0.1:10000/devstoreaccount1'
+      'TestIntegrationStoreUri': 'http://127.0.0.1:10000/devstoreaccount1'
+
+  - task: reportgenerator@5
+    displayName: 'Aggregate ${{ parameters.version }} test coverage'
+    condition: succeededOrFailed()
+    inputs:
+      reports: '$(Agent.TempDirectory)/*/coverage.cobertura.xml'
+      reporttypes: 'Cobertura'
+      targetdir: '$(Agent.TempDirectory)/coverage'
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish ${{ parameters.version }} test coverage'
+    condition: succeededOrFailed()
+    inputs:
+      pathToPublish: '$(Agent.TempDirectory)/coverage'
+      artifactName: 'Coverage_Docker_${{ parameters.version }}'
+      artifactType: 'container'
+
+  - task: PublishCodeCoverageResults@1
+    displayName: 'Publish ${{ parameters.version }} code coverage results'
+    condition: always()
+    inputs:
+      codeCoverageTool: 'Cobertura'
+      summaryFileLocation: '$(Agent.TempDirectory)/coverage/Cobertura.xml'
+      reportDirectory: '$(Agent.TempDirectory)/coverage'
+
+  - task: DockerCompose@0
+    displayName: 'Stop and remove containers'
+    condition: always()
+    inputs:
+      action: 'Run a Docker Compose command'
+      dockerComposeFile: '$(Build.SourcesDirectory)/build/docker-compose.test.yml'
+      projectName: 'fhir-server-test'
+      dockerComposeCommand: 'down -v'

--- a/build/jobs/docker-sql-tests-only.yml
+++ b/build/jobs/docker-sql-tests-only.yml
@@ -1,0 +1,128 @@
+parameters:
+- name: version
+  type: string
+
+steps:
+  - checkout: self
+    fetchDepth: 1
+    fetchTags: false
+
+  - task: UseDotNet@2
+    inputs:
+      useGlobalJson: true
+
+  - bash: |
+      # Generate random password meeting SQL Server requirements
+      RANDOM_PASSWORD=$(openssl rand -base64 32 | tr -d "=+/" | cut -c1-20)
+      SQL_PASSWORD="Sql${RANDOM_PASSWORD}9!"
+      echo "Generated secure SQL password"
+      echo "##vso[task.setvariable variable=SQL_SA_PASSWORD;issecret=true]$SQL_PASSWORD"
+    displayName: 'Generate random SQL Server password'
+
+  - task: DockerCompose@1
+    displayName: 'Start SQL Server and Azurite containers'
+    inputs:
+      action: 'Run services'
+      dockerComposeFile: '$(Build.SourcesDirectory)/build/docker-compose.test.yml'
+      projectName: 'fhir-server-test-${{ lower(parameters.version) }}-sql'
+      dockerComposeCommand: 'up -d sql azurite'
+      detached: true
+    env:
+      SQL_SA_PASSWORD: $(SQL_SA_PASSWORD)
+
+  - script: |
+      echo "Waiting for SQL Server to be ready..."
+      timeout=60
+      elapsed=0
+      until docker exec fhir-test-sql /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "$(SQL_SA_PASSWORD)" -C -Q "SELECT @@VERSION" -b > /dev/null 2>&1 || [ $elapsed -ge $timeout ]; do
+        echo "Waiting for SQL Server... ($elapsed seconds)"
+        sleep 5
+        elapsed=$((elapsed + 5))
+      done
+      docker exec fhir-test-sql /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "$(SQL_SA_PASSWORD)" -C -Q "SELECT @@VERSION" -b
+    displayName: 'Verify SQL Server connectivity'
+
+  - script: |
+      echo "Waiting for Azurite to be ready..."
+      timeout=60
+      elapsed=0
+      until curl -f http://localhost:10000/devstoreaccount1?restype=account > /dev/null 2>&1 || [ $elapsed -ge $timeout ]; do
+        echo "Waiting for Azurite... ($elapsed seconds)"
+        sleep 5
+        elapsed=$((elapsed + 5))
+      done
+      echo "Azurite is ready"
+    displayName: 'Verify Azurite connectivity'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Build ${{ parameters.version }} integration test project'
+    inputs:
+      command: build
+      projects: 'test/**/*${{ parameters.version }}.Tests.Integration.csproj'
+      arguments: '--configuration $(buildConfiguration) -f $(defaultBuildFramework)'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Run ${{ parameters.version }} SQL Integration Tests'
+    inputs:
+      command: test
+      projects: 'test/**/*${{ parameters.version }}.Tests.Integration.csproj'
+      arguments: '--filter DisplayName!~CosmosDb --configuration $(buildConfiguration) --collect "XPlat Code Coverage" -s "$(build.sourcesDirectory)/CodeCoverage.runsettings" -v normal --no-build -f $(defaultBuildFramework)'
+      testRunTitle: '${{ parameters.version }} Docker SQL Integration Tests'
+      publishTestResults: true
+    env:
+      'SqlServer:ConnectionString': 'Server=localhost,1433;Initial Catalog=master;User Id=sa;Password=$(SQL_SA_PASSWORD);TrustServerCertificate=true;Encrypt=false'
+      'TestExportStoreUri': 'http://127.0.0.1:10000/devstoreaccount1'
+      'TestIntegrationStoreUri': 'http://127.0.0.1:10000/devstoreaccount1'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Build ${{ parameters.version }} E2E test project'
+    inputs:
+      command: build
+      projects: 'test/**/*${{ parameters.version }}.Tests.E2E.csproj'
+      arguments: '--configuration $(buildConfiguration) -f $(defaultBuildFramework)'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Run ${{ parameters.version }} SQL E2E Tests (In-Proc)'
+    inputs:
+      command: test
+      projects: 'test/**/*${{ parameters.version }}.Tests.E2E.csproj'
+      arguments: '--filter FullyQualifiedName~SqlServer --configuration $(buildConfiguration) --collect "XPlat Code Coverage" -s "$(build.sourcesDirectory)/CodeCoverage.runsettings" -v normal --no-build -f $(defaultBuildFramework)'
+      testRunTitle: '${{ parameters.version }} Docker SQL E2E Tests'
+      publishTestResults: true
+    env:
+      'SqlServer:ConnectionString': 'Server=localhost,1433;Initial Catalog=master;User Id=sa;Password=$(SQL_SA_PASSWORD);TrustServerCertificate=true;Encrypt=false'
+      'TestExportStoreUri': 'http://127.0.0.1:10000/devstoreaccount1'
+      'TestIntegrationStoreUri': 'http://127.0.0.1:10000/devstoreaccount1'
+
+  - task: reportgenerator@5
+    displayName: 'Aggregate ${{ parameters.version }} SQL test coverage'
+    condition: succeededOrFailed()
+    inputs:
+      reports: '$(Agent.TempDirectory)/*/coverage.cobertura.xml'
+      reporttypes: 'Cobertura'
+      targetdir: '$(Agent.TempDirectory)/coverage'
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish ${{ parameters.version }} SQL test coverage'
+    condition: succeededOrFailed()
+    inputs:
+      pathToPublish: '$(Agent.TempDirectory)/coverage'
+      artifactName: 'Coverage_Docker_SQL_${{ parameters.version }}'
+      artifactType: 'container'
+
+  - task: PublishCodeCoverageResults@1
+    displayName: 'Publish ${{ parameters.version }} SQL code coverage results'
+    condition: always()
+    inputs:
+      codeCoverageTool: 'Cobertura'
+      summaryFileLocation: '$(Agent.TempDirectory)/coverage/Cobertura.xml'
+      reportDirectory: '$(Agent.TempDirectory)/coverage'
+
+  - task: DockerCompose@1
+    displayName: 'Stop and remove containers'
+    condition: always()
+    inputs:
+      action: 'Run a Docker Compose command'
+      dockerComposeFile: '$(Build.SourcesDirectory)/build/docker-compose.test.yml'
+      projectName: 'fhir-server-test-${{ lower(parameters.version) }}-sql'
+      dockerComposeCommand: 'down -v'

--- a/build/jobs/docker-sql-tests.yml
+++ b/build/jobs/docker-sql-tests.yml
@@ -1,0 +1,153 @@
+parameters:
+- name: version
+  type: string
+
+steps:
+  - checkout: self
+    fetchDepth: 1
+    fetchTags: false
+
+  - task: UseDotNet@2
+    inputs:
+      useGlobalJson: true
+
+  - bash: |
+      # Generate random password meeting SQL Server requirements:
+      # - At least 8 characters
+      # - Contains uppercase, lowercase, digits, and special characters
+      RANDOM_PASSWORD=$(openssl rand -base64 32 | tr -d "=+/" | cut -c1-20)
+      # Ensure it meets complexity by adding required characters
+      SQL_PASSWORD="Sql${RANDOM_PASSWORD}9!"
+      echo "Generated secure SQL password"
+      echo "##vso[task.setvariable variable=SQL_SA_PASSWORD;issecret=true]$SQL_PASSWORD"
+    displayName: 'Generate random SQL Server password'
+
+  - task: DockerCompose@0
+    displayName: 'Start SQL Server and CosmosDB containers'
+    inputs:
+      action: 'Run services'
+      dockerComposeFile: 'docker-compose.test.yml'
+      projectName: 'fhir-server-test'
+      dockerComposeCommand: 'up -d'
+      detached: true
+    env:
+      SQL_SA_PASSWORD: $(SQL_SA_PASSWORD)
+
+  - script: |
+      echo "Waiting for SQL Server to be ready..."
+      timeout=60
+      elapsed=0
+      until docker exec fhir-test-sql /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "$(SQL_SA_PASSWORD)" -C -Q "SELECT @@VERSION" -b > /dev/null 2>&1 || [ $elapsed -ge $timeout ]; do
+        echo "Waiting for SQL Server... ($elapsed seconds)"
+        sleep 5
+        elapsed=$((elapsed + 5))
+      done
+      docker exec fhir-test-sql /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "$(SQL_SA_PASSWORD)" -C -Q "SELECT @@VERSION" -b
+    displayName: 'Verify SQL Server connectivity'
+
+  - script: |
+      echo "Waiting for Cosmos DB Emulator to be ready..."
+      timeout=180
+      elapsed=0
+      until docker exec fhir-test-cosmos curl -k https://localhost:8081/_explorer/emulator.pem > /dev/null 2>&1 || [ $elapsed -ge $timeout ]; do
+        echo "Waiting for Cosmos DB Emulator... ($elapsed seconds)"
+        sleep 10
+        elapsed=$((elapsed + 10))
+      done
+      echo "Cosmos DB Emulator is ready"
+    displayName: 'Verify Cosmos DB Emulator connectivity'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Build ${{ parameters.version }} integration test project'
+    inputs:
+      command: build
+      projects: 'test/**/*${{ parameters.version }}.Tests.Integration.csproj'
+      arguments: '--configuration $(buildConfiguration) -f $(defaultBuildFramework)'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Run ${{ parameters.version }} SQL Integration Tests'
+    inputs:
+      command: test
+      projects: 'test/**/*${{ parameters.version }}.Tests.Integration.csproj'
+      arguments: '--filter DisplayName!~CosmosDb --configuration $(buildConfiguration) --collect "XPlat Code Coverage" -s "$(build.sourcesDirectory)/CodeCoverage.runsettings" -v normal --no-build -f $(defaultBuildFramework)'
+      testRunTitle: '${{ parameters.version }} Docker SQL Integration Tests'
+      publishTestResults: true
+    env:
+      'SqlServer:ConnectionString': 'Server=localhost,1433;Initial Catalog=master;User Id=sa;Password=$(SQL_SA_PASSWORD);TrustServerCertificate=true;Encrypt=false'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Run ${{ parameters.version }} CosmosDB Integration Tests'
+    inputs:
+      command: test
+      projects: 'test/**/*${{ parameters.version }}.Tests.Integration.csproj'
+      arguments: '--filter DisplayName!~SqlServer --configuration $(buildConfiguration) --collect "XPlat Code Coverage" -s "$(build.sourcesDirectory)/CodeCoverage.runsettings" -v normal --no-build -f $(defaultBuildFramework)'
+      testRunTitle: '${{ parameters.version }} Docker CosmosDB Integration Tests'
+      publishTestResults: true
+    env:
+      'CosmosDb__Host': 'https://localhost:8081'
+      'CosmosDb__Key': 'C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=='
+      'CosmosDb__DatabaseId': 'FhirTests'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Build ${{ parameters.version }} E2E test project'
+    inputs:
+      command: build
+      projects: 'test/**/*${{ parameters.version }}.Tests.E2E.csproj'
+      arguments: '--configuration $(buildConfiguration) -f $(defaultBuildFramework)'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Run ${{ parameters.version }} SQL E2E Tests (In-Proc)'
+    inputs:
+      command: test
+      projects: 'test/**/*${{ parameters.version }}.Tests.E2E.csproj'
+      arguments: '--filter FullyQualifiedName~SqlServer --configuration $(buildConfiguration) --collect "XPlat Code Coverage" -s "$(build.sourcesDirectory)/CodeCoverage.runsettings" -v normal --no-build -f $(defaultBuildFramework)'
+      testRunTitle: '${{ parameters.version }} Docker SQL E2E Tests'
+      publishTestResults: true
+    env:
+      'SqlServer:ConnectionString': 'Server=localhost,1433;Initial Catalog=master;User Id=sa;Password=$(SQL_SA_PASSWORD);TrustServerCertificate=true;Encrypt=false'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Run ${{ parameters.version }} CosmosDB E2E Tests (In-Proc)'
+    inputs:
+      command: test
+      projects: 'test/**/*${{ parameters.version }}.Tests.E2E.csproj'
+      arguments: '--filter FullyQualifiedName~CosmosDb --configuration $(buildConfiguration) --collect "XPlat Code Coverage" -s "$(build.sourcesDirectory)/CodeCoverage.runsettings" -v normal --no-build -f $(defaultBuildFramework)'
+      testRunTitle: '${{ parameters.version }} Docker CosmosDB E2E Tests'
+      publishTestResults: true
+    env:
+      'CosmosDb__Host': 'https://localhost:8081'
+      'CosmosDb__Key': 'C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=='
+      'CosmosDb__DatabaseId': 'FhirTests'
+
+  - task: reportgenerator@5
+    displayName: 'Aggregate ${{ parameters.version }} test coverage'
+    condition: succeededOrFailed()
+    inputs:
+      reports: '$(Agent.TempDirectory)/*/coverage.cobertura.xml'
+      reporttypes: 'Cobertura'
+      targetdir: '$(Agent.TempDirectory)/coverage'
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish ${{ parameters.version }} test coverage'
+    condition: succeededOrFailed()
+    inputs:
+      pathToPublish: '$(Agent.TempDirectory)/coverage'
+      artifactName: 'Coverage_DockerSql_${{ parameters.version }}'
+      artifactType: 'container'
+
+  - task: PublishCodeCoverageResults@1
+    displayName: 'Publish ${{ parameters.version }} code coverage results'
+    condition: always()
+    inputs:
+      codeCoverageTool: 'Cobertura'
+      summaryFileLocation: '$(Agent.TempDirectory)/coverage/Cobertura.xml'
+      reportDirectory: '$(Agent.TempDirectory)/coverage'
+
+  - task: DockerCompose@0
+    displayName: 'Stop and remove SQL Server container'
+    condition: always()
+    inputs:
+      action: 'Run a Docker Compose command'
+      dockerComposeFile: 'docker-compose.test.yml'
+      projectName: 'fhir-server-test'
+      dockerComposeCommand: 'down -v'

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -282,89 +282,46 @@ stages:
       sqlComputeTier: 'Standard'
       reindexEnabled: true
 
-- stage: deployR4B
-  displayName: 'Deploy R4B CosmosDB Site'
-  dependsOn:
-  - DockerBuild
-  - setupEnvironment
-  - createNsp
+- stage: testOssVersionsDocker
+  displayName: 'Test OSS Versions (R4B, R5) with Docker'
+  dependsOn: []
   jobs:
-  - template: ./jobs/provision-deploy.yml
-    parameters: 
-      version: R4B
-      webAppName: $(DeploymentEnvironmentNameR4B)
-      appServicePlanName: '$(appServicePlanName)-cosmos'
-      appServicePlanResourceGroup: $(appServicePlanResourceGroup)
-      subscription: $(ConnectedServiceName)
-      resourceGroup: $(ResourceGroupName)
-      testEnvironmentUrl: $(TestApplicationResource)
-      imageTag: $(ImageTag)
-      reindexEnabled: true
-
-- stage: deployR4BSql
-  displayName: 'Deploy R4B SQL Site'
-  dependsOn:
-  - DockerBuild
-  - setupEnvironment
-  - deploySqlServer
-  jobs:
-  - template: ./jobs/provision-deploy.yml
-    parameters: 
-      version: R4B
-      sql: true
-      webAppName: $(DeploymentEnvironmentNameR4BSql)
-      appServicePlanName: '$(appServicePlanName)-sql'
-      appServicePlanResourceGroup: $(appServicePlanResourceGroup)
-      subscription: $(ConnectedServiceName)
-      resourceGroup: $(ResourceGroupName)
-      testEnvironmentUrl: $(TestApplicationResource)
-      imageTag: $(ImageTag)
-      schemaAutomaticUpdatesEnabled: 'auto'
-      sqlServerName: $(DeploymentEnvironmentName)
-      sqlComputeTier: 'Standard'
-      reindexEnabled: true
-
-- stage: deployR5
-  displayName: 'Deploy R5 CosmosDB Site'
-  dependsOn:
-  - DockerBuild
-  - setupEnvironment
-  - createNsp
-  jobs:
-  - template: ./jobs/provision-deploy.yml
-    parameters: 
-      version: R5
-      webAppName: $(DeploymentEnvironmentNameR5)
-      appServicePlanName: '$(appServicePlanName)-cosmos'
-      appServicePlanResourceGroup: $(appServicePlanResourceGroup)
-      subscription: $(ConnectedServiceName)
-      resourceGroup: $(ResourceGroupName)
-      testEnvironmentUrl: $(TestApplicationResource)
-      imageTag: $(ImageTag)
-      reindexEnabled: true
-
-- stage: deployR5Sql
-  displayName: 'Deploy R5 SQL Site'
-  dependsOn:
-  - DockerBuild
-  - setupEnvironment
-  - deploySqlServer
-  jobs:
-  - template: ./jobs/provision-deploy.yml
-    parameters: 
-      version: R5
-      sql: true
-      webAppName: $(DeploymentEnvironmentNameR5Sql)
-      appServicePlanName: '$(appServicePlanName)-sql'
-      appServicePlanResourceGroup: $(appServicePlanResourceGroup)
-      subscription: $(ConnectedServiceName)
-      resourceGroup: $(ResourceGroupName)
-      testEnvironmentUrl: $(TestApplicationResource)
-      imageTag: $(ImageTag)
-      schemaAutomaticUpdatesEnabled: 'auto'
-      sqlServerName: $(DeploymentEnvironmentName)
-      sqlComputeTier: 'Standard'
-      reindexEnabled: true
+  - job: R4B_SqlTests
+    displayName: 'R4B SQL Tests'
+    pool:
+      name: '$(DefaultLinuxPool)'
+      vmImage: '$(LinuxVmImage)'
+    steps:
+    - template: ./jobs/docker-sql-tests-only.yml
+      parameters:
+        version: R4B
+  - job: R4B_CosmosTests
+    displayName: 'R4B CosmosDB Tests'
+    pool:
+      name: '$(DefaultLinuxPool)'
+      vmImage: '$(LinuxVmImage)'
+    steps:
+    - template: ./jobs/docker-cosmos-tests-only.yml
+      parameters:
+        version: R4B
+  - job: R5_SqlTests
+    displayName: 'R5 SQL Tests'
+    pool:
+      name: '$(DefaultLinuxPool)'
+      vmImage: '$(LinuxVmImage)'
+    steps:
+    - template: ./jobs/docker-sql-tests-only.yml
+      parameters:
+        version: R5
+  - job: R5_CosmosTests
+    displayName: 'R5 CosmosDB Tests'
+    pool:
+      name: '$(DefaultLinuxPool)'
+      vmImage: '$(LinuxVmImage)'
+    steps:
+    - template: ./jobs/docker-cosmos-tests-only.yml
+      parameters:
+        version: R5
 
 - stage: testStu3
   displayName: 'Run Stu3 Tests'
@@ -396,35 +353,6 @@ stages:
       appServiceName: $(DeploymentEnvironmentNameR4)
       integrationSqlServerName: $(DeploymentEnvironmentName)inttest
 
-- stage: testR4B
-  displayName: 'Run R4B Tests'
-  dependsOn:
-  - BuildArtifacts
-  - setupEnvironment
-  - deployR4B
-  - deployR4BSql
-  jobs:
-  - template: ./jobs/run-tests.yml
-    parameters:
-      version: R4B
-      keyVaultName: $(DeploymentEnvironmentNameR4B)
-      appServiceName: $(DeploymentEnvironmentNameR4B)
-      integrationSqlServerName: $(DeploymentEnvironmentName)inttest
-
-- stage: testR5
-  displayName: 'Run R5 Tests'
-  dependsOn:
-  - BuildArtifacts
-  - setupEnvironment
-  - deployR5
-  - deployR5Sql
-  jobs:
-  - template: ./jobs/run-tests.yml
-    parameters:
-      version: R5
-      keyVaultName: $(DeploymentEnvironmentNameR5)
-      appServiceName: $(DeploymentEnvironmentNameR5)
-      integrationSqlServerName: $(DeploymentEnvironmentName)inttest
 
 - stage: aggregateCoverage
   displayName: 'Aggregate All Coverage Reports'
@@ -432,8 +360,7 @@ stages:
   - BuildUnitTests
   - testStu3
   - testR4
-  - testR4B
-  - testR5
+  - testOssVersionsDocker
   condition: succeeded()
   jobs:
   - job: AggregateCoverage

--- a/build/pr-variables.yml
+++ b/build/pr-variables.yml
@@ -1,7 +1,7 @@
 variables:
     ResourceGroupRegion: 'westus2'
     resourceGroupRoot: 'msh-fhir-pr'
-    appServicePlanName: '$(resourceGroupRoot)-$(prName)-asp'    
+    appServicePlanName: '$(resourceGroupRoot)-$(prName)-asp'
     ResourceGroupName: '$(resourceGroupRoot)-$(prName)'
     DeploymentEnvironmentName: 'f$(build.BuildNumber)'
     TestEnvironmentName: 'OSS PR$(prName)'

--- a/src/Microsoft.Health.Fhir.Tests.Common/KnownEnvironmentVariableNames.cs
+++ b/src/Microsoft.Health.Fhir.Tests.Common/KnownEnvironmentVariableNames.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Health.Fhir.Tests.Common
         public const string AzureSubscriptionClientId = "AZURESUBSCRIPTION_CLIENT_ID";
         public const string AzureSubscriptionServiceConnectionId = "AZURESUBSCRIPTION_SERVICE_CONNECTION_ID";
         public const string AzureSubscriptionTenantId = "AZURESUBSCRIPTION_TENANT_ID";
+        public const string CosmosDbConnectionMode = "CosmosDb__ConnectionMode";
         public const string CosmosDbDatabaseId = "CosmosDb__DatabaseId";
         public const string CosmosDbHost = "CosmosDb__Host";
         public const string CosmosDbKey = "CosmosDb__Key";

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
@@ -82,6 +82,14 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
         public CosmosDbFhirStorageTestsFixture()
         {
+            // Parse connection mode from environment variable (default to Direct if not specified)
+            var connectionModeString = EnvironmentVariables.GetEnvironmentVariable(KnownEnvironmentVariableNames.CosmosDbConnectionMode);
+            var connectionMode = ConnectionMode.Direct;
+            if (!string.IsNullOrEmpty(connectionModeString) && Enum.TryParse<ConnectionMode>(connectionModeString, ignoreCase: true, out var parsedMode))
+            {
+                connectionMode = parsedMode;
+            }
+
             _cosmosDataStoreConfiguration = new CosmosDataStoreConfiguration
             {
                 Host = EnvironmentVariables.GetEnvironmentVariable(KnownEnvironmentVariableNames.CosmosDbHost),
@@ -91,6 +99,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
                 AllowDatabaseCreation = true,
                 AllowCollectionSetup = true,
                 PreferredLocations = EnvironmentVariables.GetEnvironmentVariable(KnownEnvironmentVariableNames.CosmosDbPreferredLocations)?.Split(';', StringSplitOptions.RemoveEmptyEntries),
+                ConnectionMode = connectionMode,
             };
 
             _cosmosCollectionConfiguration = new CosmosCollectionConfiguration


### PR DESCRIPTION
## Description
This pull request refactors the CI pipeline to run integration and end-to-end tests for the R4B and R5 OSS versions using Dockerized SQL Server and CosmosDB containers, rather than deploying and testing against live Azure environments. It introduces a new job template for running these tests in Docker and removes several deployment and test stages for R4B and R5 CosmosDB/SQL sites, streamlining the pipeline and improving test isolation and reproducibility.

**Pipeline restructuring and test execution changes:**

* Added a new job template `docker-sql-tests.yml` to automate building, running, and testing R4B and R5 projects against Dockerized SQL Server and CosmosDB containers, including secure password generation and code coverage reporting.
* Replaced the previous Azure deployment and test stages (`deployR4B`, `deployR4BSql`, `deployR5`, `deployR5Sql`, `testR4B`, `testR5`) with a single `testOssVersionsDockerSql` stage that runs Docker-based integration and E2E tests for both R4B and R5. [[1]](diffhunk://#diff-c2e99165f026540a53d8dc27816d7e2b9dccbd9612f1832974adee41f8c620a9L285-L367) [[2]](diffhunk://#diff-c2e99165f026540a53d8dc27816d7e2b9dccbd9612f1832974adee41f8c620a9L399-R346)

**Coverage aggregation update:**

* Updated the coverage aggregation stage to depend on the new Docker SQL test stage instead of the removed R4B/R5 test stages, ensuring coverage reports include results from the new test jobs.

## Related issues
Addresses [issue #].

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
