### PR TITLE
Add parameter and functionality to enable triggering user access for Azure resources

### DIFF
--- a/build/cleanup-aad-resources.yml
+++ b/build/cleanup-aad-resources.yml
@@ -50,11 +50,13 @@ stages:
           $AgeThresholdDays = ${{ parameters.AgeThresholdDays }}
 
           # Install and Import Microsoft Graph Modules
+          # Pin to version 2.33.0 due to bug in 2.34.0 affecting PowerShell 5.1
+          # See: https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/3479
           Write-Host "Installing Microsoft Graph modules..."
           $modules = @("Microsoft.Graph.Authentication", "Microsoft.Graph.Beta.Applications", "Microsoft.Graph.Beta.Users", "Microsoft.Graph.DirectoryObjects")
           
           foreach ($module in $modules) {
-            Install-Module -Name $module -Force -Scope CurrentUser -ErrorAction Stop
+            Install-Module -Name $module -RequiredVersion 2.33.0 -Force -Scope CurrentUser -ErrorAction Stop
             Import-Module $module
           }
 

--- a/build/jobs/add-aad-test-environment.yml
+++ b/build/jobs/add-aad-test-environment.yml
@@ -7,6 +7,7 @@ steps:
 
 - task: AzurePowerShell@5
   displayName: Setup AAD Test Environment
+  retryCountOnTaskFailure: 1
   inputs:
     azureSubscription: $(ConnectedServiceName)
     azurePowerShellVersion: latestVersion
@@ -14,10 +15,12 @@ steps:
     Inline: |
       # Install only required Microsoft Graph modules for better performance
       # Use AllowClobber to handle any version conflicts
-      Install-Module -Name Microsoft.Graph.Authentication -Force -Scope CurrentUser -AllowClobber
-      Install-Module -Name Microsoft.Graph.Applications -Force -Scope CurrentUser -AllowClobber
-      Install-Module -Name Microsoft.Graph.Users -Force -Scope CurrentUser -AllowClobber
-      Install-Module -Name Microsoft.Graph.Identity.DirectoryManagement -Force -Scope CurrentUser -AllowClobber
+      # Pin to version 2.33.0 due to bug in 2.34.0 affecting PowerShell 5.1
+      # See: https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/3479
+      Install-Module -Name Microsoft.Graph.Authentication -RequiredVersion 2.33.0 -Force -Scope CurrentUser -AllowClobber
+      Install-Module -Name Microsoft.Graph.Applications -RequiredVersion 2.33.0 -Force -Scope CurrentUser -AllowClobber
+      Install-Module -Name Microsoft.Graph.Users -RequiredVersion 2.33.0 -Force -Scope CurrentUser -AllowClobber
+      Install-Module -Name Microsoft.Graph.Identity.DirectoryManagement -RequiredVersion 2.33.0 -Force -Scope CurrentUser -AllowClobber
       Install-Module -Name Microsoft.PowerShell.SecretManagement -Force -Scope CurrentUser -AllowClobber
 
       $module = Get-Module -Name Microsoft.Graph.Authentication

--- a/build/jobs/cleanup-aad.yml
+++ b/build/jobs/cleanup-aad.yml
@@ -12,16 +12,19 @@ jobs:
 
   - task: AzurePowerShell@5
     displayName: 'Delete AAD apps'
+    retryCountOnTaskFailure: 1
     inputs:
       azureSubscription: $(ConnectedServiceName)
       azurePowerShellVersion: latestVersion
       ScriptType: InlineScript
       Inline: |
         # Install only required Microsoft Graph modules for better performance
-        Install-Module -Name Microsoft.Graph.Authentication -Force
-        Install-Module -Name Microsoft.Graph.Applications -Force
-        Install-Module -Name Microsoft.Graph.Users -Force
-        Install-Module -Name Microsoft.Graph.Identity.DirectoryManagement -Force
+        # Pin to version 2.33.0 due to bug in 2.34.0 affecting PowerShell 5.1
+        # See: https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/3479
+        Install-Module -Name Microsoft.Graph.Authentication -RequiredVersion 2.33.0 -Force
+        Install-Module -Name Microsoft.Graph.Applications -RequiredVersion 2.33.0 -Force
+        Install-Module -Name Microsoft.Graph.Users -RequiredVersion 2.33.0 -Force
+        Install-Module -Name Microsoft.Graph.Identity.DirectoryManagement -RequiredVersion 2.33.0 -Force
         
         $username = "$(tenant-admin-user-name)"
         $clientId = "$(tenant-admin-service-principal-name)"

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -33,6 +33,9 @@ parameters:
 - name: keyVaultName
   type: string
   default: ''
+- name: addTriggeringUserAccess
+  type: boolean
+  default: false
 
 jobs:
 - job: provisionEnvironment
@@ -158,6 +161,43 @@ jobs:
                   -ErrorAction Stop
             }
 
+            # Add triggering user access to CosmosDB if enabled
+            if ("${{ parameters.addTriggeringUserAccess }}" -eq "true") {
+                $triggeringUserEmail = "$(Build.RequestedForEmail)"
+                if (-not [string]::IsNullOrEmpty($triggeringUserEmail)) {
+                    Write-Host "Adding triggering user '$triggeringUserEmail' to CosmosDB..."
+                    try {
+                        $userPrincipal = Get-AzADUser -UserPrincipalName $triggeringUserEmail -ErrorAction SilentlyContinue
+                        if (-not $userPrincipal) {
+                            # Try by mail attribute for guest users
+                            $userPrincipal = Get-AzADUser -Filter "mail eq '$triggeringUserEmail'" -ErrorAction SilentlyContinue
+                        }
+                        if ($userPrincipal) {
+                            Invoke-WithRetry -OperationName "Add Triggering User CosmosDB Role" -ScriptBlock {
+                                New-AzCosmosDBSqlRoleAssignment `
+                                  -AccountName $webAppName `
+                                  -ResourceGroupName $resourceGroupName `
+                                  -Scope "/" `
+                                  -PrincipalId $userPrincipal.Id `
+                                  -RoleDefinitionId "00000000-0000-0000-0000-000000000002" `
+                                  -ErrorAction Stop
+                            }
+                            Write-Host "Successfully added triggering user to CosmosDB with Data Contributor role"
+                        } else {
+                            Write-Warning "Could not find user '$triggeringUserEmail' in Azure AD. Skipping CosmosDB user provisioning."
+                        }
+                    } catch {
+                        if ($_.Exception.Message -like "*RoleAssignmentAlreadyExists*" -or $_.Exception.Message -like "*already exists*") {
+                            Write-Host "Triggering user already has CosmosDB access. Skipping."
+                        } else {
+                            Write-Warning "Could not add triggering user to CosmosDB: $($_.Exception.Message). Continuing pipeline."
+                        }
+                    }
+                } else {
+                    Write-Host "No triggering user email available (automated trigger). Skipping CosmosDB user provisioning."
+                }
+            }
+
             # Associate CosmosDB with Network Security Perimeter using external template
             Write-Host "Associating CosmosDB with Network Security Perimeter: $nspName"
             
@@ -190,6 +230,55 @@ jobs:
                 
             Write-Host "Successfully associated CosmosDB with NSP using external ARM template"
             Write-Host "Association Resource ID: $($nspDeploymentResult.Outputs.associationResourceId.Value)"
+        }
+
+        if("${{ parameters.sql }}" -eq "true"){
+            # Add triggering user access to SQL database if enabled
+            if ("${{ parameters.addTriggeringUserAccess }}" -eq "true") {
+                $triggeringUserEmail = "$(Build.RequestedForEmail)"
+                if (-not [string]::IsNullOrEmpty($triggeringUserEmail)) {
+                    Write-Host "Adding triggering user '$triggeringUserEmail' to SQL database..."
+                    try {
+                        $sqlServerName = "${{parameters.sqlServerName}}".ToLower()
+                        $databaseName = "FHIR_${{ parameters.version }}"
+                        
+                        # Get access token for SQL using the current Azure context
+                        $accessToken = (Get-AzAccessToken -ResourceUrl "https://database.windows.net/").Token
+                        
+                        # Create SQL user for the triggering user with db_owner role
+                        # Using string concatenation to avoid YAML heredoc parsing issues
+                        $sqlQuery = "IF NOT EXISTS (SELECT * FROM sys.database_principals WHERE name = N'$triggeringUserEmail') "
+                        $sqlQuery += "BEGIN "
+                        $sqlQuery += "CREATE USER [$triggeringUserEmail] FROM EXTERNAL PROVIDER; "
+                        $sqlQuery += "ALTER ROLE db_owner ADD MEMBER [$triggeringUserEmail]; "
+                        $sqlQuery += "PRINT 'Created user and added to db_owner role'; "
+                        $sqlQuery += "END "
+                        $sqlQuery += "ELSE BEGIN "
+                        $sqlQuery += "IF NOT EXISTS (SELECT 1 FROM sys.database_role_members drm "
+                        $sqlQuery += "JOIN sys.database_principals dp ON drm.member_principal_id = dp.principal_id "
+                        $sqlQuery += "JOIN sys.database_principals r ON drm.role_principal_id = r.principal_id "
+                        $sqlQuery += "WHERE dp.name = N'$triggeringUserEmail' AND r.name = 'db_owner') "
+                        $sqlQuery += "BEGIN ALTER ROLE db_owner ADD MEMBER [$triggeringUserEmail]; PRINT 'Added existing user to db_owner role'; END "
+                        $sqlQuery += "ELSE BEGIN PRINT 'User already exists with db_owner role'; END "
+                        $sqlQuery += "END"
+                        
+                        Invoke-WithRetry -OperationName "Add Triggering User to SQL" -ScriptBlock {
+                            Invoke-Sqlcmd `
+                              -ServerInstance "$sqlServerName.database.windows.net" `
+                              -Database $databaseName `
+                              -AccessToken $accessToken `
+                              -Query $sqlQuery `
+                              -ErrorAction Stop
+                        }
+                        
+                        Write-Host "Successfully added triggering user to SQL database with db_owner role"
+                    } catch {
+                        Write-Warning "Could not add triggering user to SQL database: $($_.Exception.Message). Continuing pipeline."
+                    }
+                } else {
+                    Write-Host "No triggering user email available (automated trigger). Skipping SQL user provisioning."
+                }
+            }
         }
   - template: ./provision-healthcheck.yml
     parameters:

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -36,6 +36,9 @@ parameters:
 - name: addTriggeringUserAccess
   type: boolean
   default: false
+- name: adminUserAssignedManagedIdentityName
+  type: string
+  default: ''
 
 jobs:
 - job: provisionEnvironment
@@ -282,26 +285,52 @@ jobs:
             # Add triggering user access to SQL database if enabled
             if ("${{ parameters.addTriggeringUserAccess }}" -eq "true") {
                 $userInfo = Get-TriggeringUserInfo
+                $adminUamiName = "${{ parameters.adminUserAssignedManagedIdentityName }}"
                 
-                if ($userInfo -and -not [string]::IsNullOrEmpty($userInfo.Upn)) {
+                if ($userInfo -and -not [string]::IsNullOrEmpty($userInfo.Upn) -and -not [string]::IsNullOrEmpty($adminUamiName)) {
                     $triggeringUserUpn = $userInfo.Upn
                     Write-Host "Adding triggering user '$triggeringUserUpn' to SQL database..."
+                    
+                    # Install SqlServer module if not available
+                    if (-not (Get-Module -ListAvailable -Name SqlServer)) {
+                        Write-Host "Installing SqlServer module..."
+                        Install-Module -Name SqlServer -Force -Scope CurrentUser -AllowClobber
+                    }
+                    Import-Module SqlServer
+                    
+                    $sqlServerName = "${{parameters.sqlServerName}}".ToLower()
+                    $databaseName = "FHIR_${{ parameters.version }}"
+                    
+                    # Get service connection info
+                    $serviceConnectionAppId = (Get-AzContext).Account.Id
+                    $serviceConnectionObjectId = (Get-AzADServicePrincipal -ApplicationId $serviceConnectionAppId).Id
+                    $serviceConnectionDisplayName = "$(ConnectedServiceName) - $serviceConnectionAppId"
+                    Write-Host "Service connection ObjectId: $serviceConnectionObjectId"
+                    
+                    # Get UAMI info for restoring admin later
+                    $uami = Get-AzUserAssignedIdentity -Name $adminUamiName -ResourceGroupName $resourceGroupName
+                    $uamiObjectId = $uami.PrincipalId
+                    Write-Host "UAMI '$adminUamiName' ObjectId: $uamiObjectId"
+                    
                     try {
-                        # Install SqlServer module if not available
-                        if (-not (Get-Module -ListAvailable -Name SqlServer)) {
-                            Write-Host "Installing SqlServer module..."
-                            Install-Module -Name SqlServer -Force -Scope CurrentUser -AllowClobber
+                        # Temporarily set service connection as SQL admin
+                        Write-Host "Setting service connection as SQL admin..."
+                        Invoke-WithRetry -OperationName "Set Service Connection as SQL Admin" -ScriptBlock {
+                            Set-AzSqlServerActiveDirectoryAdministrator `
+                              -ResourceGroupName $resourceGroupName `
+                              -ServerName $sqlServerName `
+                              -DisplayName $serviceConnectionDisplayName `
+                              -ObjectId $serviceConnectionObjectId `
+                              -ErrorAction Stop
                         }
-                        Import-Module SqlServer
                         
-                        $sqlServerName = "${{parameters.sqlServerName}}".ToLower()
-                        $databaseName = "FHIR_${{ parameters.version }}"
+                        # Wait for admin change to propagate
+                        Start-Sleep -Seconds 10
                         
-                        # Get access token for SQL using the current Azure context
+                        # Get fresh access token for SQL
                         $accessToken = (Get-AzAccessToken -ResourceUrl "https://database.windows.net/").Token
                         
                         # Create SQL user for the triggering user with db_owner role
-                        # Using string concatenation to avoid YAML heredoc parsing issues
                         $sqlQuery = "IF NOT EXISTS (SELECT * FROM sys.database_principals WHERE name = N'$triggeringUserUpn') "
                         $sqlQuery += "BEGIN "
                         $sqlQuery += "CREATE USER [$triggeringUserUpn] FROM EXTERNAL PROVIDER; "
@@ -329,7 +358,25 @@ jobs:
                         Write-Host "Successfully added triggering user to SQL database with db_owner role"
                     } catch {
                         Write-Warning "Could not add triggering user to SQL database: $($_.Exception.Message). Continuing pipeline."
+                    } finally {
+                        # Always restore UAMI as SQL admin
+                        Write-Host "Restoring UAMI '$adminUamiName' as SQL admin..."
+                        try {
+                            Invoke-WithRetry -OperationName "Restore UAMI as SQL Admin" -ScriptBlock {
+                                Set-AzSqlServerActiveDirectoryAdministrator `
+                                  -ResourceGroupName $resourceGroupName `
+                                  -ServerName $sqlServerName `
+                                  -DisplayName $adminUamiName `
+                                  -ObjectId $uamiObjectId `
+                                  -ErrorAction Stop
+                            }
+                            Write-Host "Successfully restored UAMI as SQL admin"
+                        } catch {
+                            Write-Error "CRITICAL: Failed to restore UAMI as SQL admin: $($_.Exception.Message)"
+                        }
                     }
+                } elseif ([string]::IsNullOrEmpty($adminUamiName)) {
+                    Write-Host "adminUserAssignedManagedIdentityName not provided. Skipping SQL user provisioning."
                 } else {
                     Write-Host "No triggering user info resolved. Skipping SQL user provisioning."
                 }

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -61,6 +61,47 @@ jobs:
         # Import retry helper for transient error handling
         . $(System.DefaultWorkingDirectory)/release/scripts/PowerShell/Invoke-WithRetry.ps1
 
+        # Helper function to resolve triggering user email from git commit author
+        # Supports GitHub noreply emails by looking up username mapping in Key Vault
+        function Get-TriggeringUserEmail {
+            try {
+                # Get git commit author email
+                $gitEmail = git log -1 --format='%ae' 2>$null
+                if ([string]::IsNullOrEmpty($gitEmail)) {
+                    Write-Host "Could not retrieve git commit author email."
+                    return $null
+                }
+                Write-Host "Git commit author email: $gitEmail"
+                
+                # Check if this is a GitHub noreply email pattern: 12345+username@users.noreply.github.com
+                if ($gitEmail -match '^(\d+\+)?(.+)@users\.noreply\.github\.com$') {
+                    $githubUsername = $Matches[2]
+                    Write-Host "Detected GitHub noreply email. Extracted username: $githubUsername"
+                    
+                    # Look up the Azure AD email from Key Vault secret
+                    $secretName = "github-$githubUsername"
+                    Write-Host "Looking up Key Vault secret: $secretName"
+                    try {
+                        $secret = Get-AzKeyVaultSecret -VaultName 'resolute-oss-tenant-info' -Name $secretName -AsPlainText -ErrorAction Stop
+                        if (-not [string]::IsNullOrEmpty($secret)) {
+                            Write-Host "Found Azure AD email mapping in Key Vault: $secret"
+                            return $secret
+                        }
+                    } catch {
+                        Write-Warning "Key Vault secret '$secretName' not found. To enable automatic user provisioning, create a secret named '$secretName' with your Azure AD email as the value."
+                        return $null
+                    }
+                }
+                
+                # Not a noreply email - return as-is (might be a direct email)
+                Write-Host "Using git email directly: $gitEmail"
+                return $gitEmail
+            } catch {
+                Write-Warning "Error resolving triggering user email: $($_.Exception.Message)"
+                return $null
+            }
+        }
+
         $deployPath = "$(System.DefaultWorkingDirectory)/test/Configuration"
 
         $testConfig = (ConvertFrom-Json (Get-Content -Raw "$deployPath/testconfiguration.json"))
@@ -163,21 +204,7 @@ jobs:
 
             # Add triggering user access to CosmosDB if enabled
             if ("${{ parameters.addTriggeringUserAccess }}" -eq "true") {
-                $triggeringUserEmail = "$(Build.RequestedForEmail)"
-                
-                # For PR/automated triggers, email may be empty - get from git commit author
-                if ([string]::IsNullOrEmpty($triggeringUserEmail)) {
-                    Write-Host "Build.RequestedForEmail not available, getting email from git commit author..."
-                    try {
-                        $gitAuthorEmail = git log -1 --format='%ae' 2>$null
-                        if (-not [string]::IsNullOrEmpty($gitAuthorEmail)) {
-                            $triggeringUserEmail = $gitAuthorEmail
-                            Write-Host "Found git commit author email: $triggeringUserEmail"
-                        }
-                    } catch {
-                        Write-Warning "Could not get git commit author email: $($_.Exception.Message)"
-                    }
-                }
+                $triggeringUserEmail = Get-TriggeringUserEmail
                 
                 if (-not [string]::IsNullOrEmpty($triggeringUserEmail)) {
                     Write-Host "Adding triggering user '$triggeringUserEmail' to CosmosDB..."
@@ -209,7 +236,7 @@ jobs:
                         }
                     }
                 } else {
-                    Write-Host "No triggering user email available. Skipping CosmosDB user provisioning."
+                    Write-Host "No triggering user email resolved. Skipping CosmosDB user provisioning."
                 }
             }
 
@@ -250,21 +277,7 @@ jobs:
         if("${{ parameters.sql }}" -eq "true"){
             # Add triggering user access to SQL database if enabled
             if ("${{ parameters.addTriggeringUserAccess }}" -eq "true") {
-                $triggeringUserEmail = "$(Build.RequestedForEmail)"
-                
-                # For PR/automated triggers, email may be empty - get from git commit author
-                if ([string]::IsNullOrEmpty($triggeringUserEmail)) {
-                    Write-Host "Build.RequestedForEmail not available, getting email from git commit author..."
-                    try {
-                        $gitAuthorEmail = git log -1 --format='%ae' 2>$null
-                        if (-not [string]::IsNullOrEmpty($gitAuthorEmail)) {
-                            $triggeringUserEmail = $gitAuthorEmail
-                            Write-Host "Found git commit author email: $triggeringUserEmail"
-                        }
-                    } catch {
-                        Write-Warning "Could not get git commit author email: $($_.Exception.Message)"
-                    }
-                }
+                $triggeringUserEmail = Get-TriggeringUserEmail
                 
                 if (-not [string]::IsNullOrEmpty($triggeringUserEmail)) {
                     Write-Host "Adding triggering user '$triggeringUserEmail' to SQL database..."
@@ -306,7 +319,7 @@ jobs:
                         Write-Warning "Could not add triggering user to SQL database: $($_.Exception.Message). Continuing pipeline."
                     }
                 } else {
-                    Write-Host "No triggering user email available. Skipping SQL user provisioning."
+                    Write-Host "No triggering user email resolved. Skipping SQL user provisioning."
                 }
             }
         }

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -287,6 +287,13 @@ jobs:
                     $triggeringUserUpn = $userInfo.Upn
                     Write-Host "Adding triggering user '$triggeringUserUpn' to SQL database..."
                     try {
+                        # Install SqlServer module if not available
+                        if (-not (Get-Module -ListAvailable -Name SqlServer)) {
+                            Write-Host "Installing SqlServer module..."
+                            Install-Module -Name SqlServer -Force -Scope CurrentUser -AllowClobber
+                        }
+                        Import-Module SqlServer
+                        
                         $sqlServerName = "${{parameters.sqlServerName}}".ToLower()
                         $databaseName = "FHIR_${{ parameters.version }}"
                         

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -164,6 +164,21 @@ jobs:
             # Add triggering user access to CosmosDB if enabled
             if ("${{ parameters.addTriggeringUserAccess }}" -eq "true") {
                 $triggeringUserEmail = "$(Build.RequestedForEmail)"
+                
+                # For PR/automated triggers, email may be empty - get from git commit author
+                if ([string]::IsNullOrEmpty($triggeringUserEmail)) {
+                    Write-Host "Build.RequestedForEmail not available, getting email from git commit author..."
+                    try {
+                        $gitAuthorEmail = git log -1 --format='%ae' 2>$null
+                        if (-not [string]::IsNullOrEmpty($gitAuthorEmail)) {
+                            $triggeringUserEmail = $gitAuthorEmail
+                            Write-Host "Found git commit author email: $triggeringUserEmail"
+                        }
+                    } catch {
+                        Write-Warning "Could not get git commit author email: $($_.Exception.Message)"
+                    }
+                }
+                
                 if (-not [string]::IsNullOrEmpty($triggeringUserEmail)) {
                     Write-Host "Adding triggering user '$triggeringUserEmail' to CosmosDB..."
                     try {
@@ -194,7 +209,7 @@ jobs:
                         }
                     }
                 } else {
-                    Write-Host "No triggering user email available (automated trigger). Skipping CosmosDB user provisioning."
+                    Write-Host "No triggering user email available. Skipping CosmosDB user provisioning."
                 }
             }
 
@@ -236,6 +251,21 @@ jobs:
             # Add triggering user access to SQL database if enabled
             if ("${{ parameters.addTriggeringUserAccess }}" -eq "true") {
                 $triggeringUserEmail = "$(Build.RequestedForEmail)"
+                
+                # For PR/automated triggers, email may be empty - get from git commit author
+                if ([string]::IsNullOrEmpty($triggeringUserEmail)) {
+                    Write-Host "Build.RequestedForEmail not available, getting email from git commit author..."
+                    try {
+                        $gitAuthorEmail = git log -1 --format='%ae' 2>$null
+                        if (-not [string]::IsNullOrEmpty($gitAuthorEmail)) {
+                            $triggeringUserEmail = $gitAuthorEmail
+                            Write-Host "Found git commit author email: $triggeringUserEmail"
+                        }
+                    } catch {
+                        Write-Warning "Could not get git commit author email: $($_.Exception.Message)"
+                    }
+                }
+                
                 if (-not [string]::IsNullOrEmpty($triggeringUserEmail)) {
                     Write-Host "Adding triggering user '$triggeringUserEmail' to SQL database..."
                     try {
@@ -276,7 +306,7 @@ jobs:
                         Write-Warning "Could not add triggering user to SQL database: $($_.Exception.Message). Continuing pipeline."
                     }
                 } else {
-                    Write-Host "No triggering user email available (automated trigger). Skipping SQL user provisioning."
+                    Write-Host "No triggering user email available. Skipping SQL user provisioning."
                 }
             }
         }

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -334,11 +334,9 @@ jobs:
                               -ErrorAction Stop
                         }
                         
-                        # Wait for admin change to propagate
-                        Start-Sleep -Seconds 15
-                        
-                        # Get fresh access token for SQL
-                        $accessToken = (Get-AzAccessToken -ResourceUrl "https://database.windows.net/").Token
+                        # Wait for admin change to propagate (30 seconds for AAD replication)
+                        Write-Host "Waiting 30 seconds for SQL admin change to propagate..."
+                        Start-Sleep -Seconds 30
                         
                         # Create SQL user for the triggering user with db_owner role
                         $sqlQuery = "IF NOT EXISTS (SELECT * FROM sys.database_principals WHERE name = N'$triggeringUserUpn') "
@@ -356,11 +354,17 @@ jobs:
                         $sqlQuery += "ELSE BEGIN PRINT 'User already exists with db_owner role'; END "
                         $sqlQuery += "END"
                         
+                        # Get fresh access token inside retry block and execute SQL
                         Invoke-WithRetry -OperationName "Add Triggering User to SQL" -ScriptBlock {
+                            # Get fresh token with explicit tenant to avoid cache issues
+                            $freshToken = (Get-AzAccessToken -ResourceUrl "https://database.windows.net/" -TenantId $serviceConnectionTenantId).Token
+                            Write-Host "Connecting to: $sqlServerName.database.windows.net, Database: $databaseName"
+                            Write-Host "Token acquired, length: $($freshToken.Length)"
+                            
                             Invoke-Sqlcmd `
                               -ServerInstance "$sqlServerName.database.windows.net" `
                               -Database $databaseName `
-                              -AccessToken $accessToken `
+                              -AccessToken $freshToken `
                               -Query $sqlQuery `
                               -ErrorAction Stop
                         }

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -301,31 +301,41 @@ jobs:
                     $sqlServerName = "${{parameters.sqlServerName}}".ToLower()
                     $databaseName = "FHIR_${{ parameters.version }}"
                     
-                    # Get service connection info
+                    # Get service connection info (App ID and Tenant ID for ARM template)
                     $serviceConnectionAppId = (Get-AzContext).Account.Id
-                    $serviceConnectionObjectId = (Get-AzADServicePrincipal -ApplicationId $serviceConnectionAppId).Id
+                    $serviceConnectionTenantId = (Get-AzContext).Tenant.Id
                     $serviceConnectionDisplayName = "$(ConnectedServiceName) - $serviceConnectionAppId"
-                    Write-Host "Service connection ObjectId: $serviceConnectionObjectId"
+                    Write-Host "Service connection AppId: $serviceConnectionAppId, TenantId: $serviceConnectionTenantId"
                     
                     # Get UAMI info for restoring admin later
                     $uami = Get-AzUserAssignedIdentity -Name $adminUamiName -ResourceGroupName $resourceGroupName
-                    $uamiObjectId = $uami.PrincipalId
-                    Write-Host "UAMI '$adminUamiName' ObjectId: $uamiObjectId"
+                    $uamiPrincipalId = $uami.PrincipalId
+                    $uamiTenantId = $uami.TenantId
+                    Write-Host "UAMI '$adminUamiName' PrincipalId: $uamiPrincipalId, TenantId: $uamiTenantId"
                     
                     try {
-                        # Temporarily set service connection as SQL admin
-                        Write-Host "Setting service connection as SQL admin..."
+                        # Temporarily set service connection as SQL admin using ARM template
+                        # This approach works for cross-tenant service principals
+                        Write-Host "Setting service connection as SQL admin via ARM template..."
+                        $serviceConnectionAdminParams = @{
+                            sqlServerName = $sqlServerName
+                            sqlAdministratorLogin = $serviceConnectionDisplayName
+                            sqlAdministratorSid = $serviceConnectionAppId
+                            sqlAdministratorTenantId = $serviceConnectionTenantId
+                            sqlServerPrincipalType = "Application"
+                        }
+                        
                         Invoke-WithRetry -OperationName "Set Service Connection as SQL Admin" -ScriptBlock {
-                            Set-AzSqlServerActiveDirectoryAdministrator `
+                            New-AzResourceGroupDeployment `
                               -ResourceGroupName $resourceGroupName `
-                              -ServerName $sqlServerName `
-                              -DisplayName $serviceConnectionDisplayName `
-                              -ObjectId $serviceConnectionObjectId `
+                              -Name "$sqlServerName-admin-swap-to-sc" `
+                              -TemplateFile $(System.DefaultWorkingDirectory)/samples/templates/default-sqlServer.json `
+                              -TemplateParameterObject $serviceConnectionAdminParams `
                               -ErrorAction Stop
                         }
                         
                         # Wait for admin change to propagate
-                        Start-Sleep -Seconds 10
+                        Start-Sleep -Seconds 15
                         
                         # Get fresh access token for SQL
                         $accessToken = (Get-AzAccessToken -ResourceUrl "https://database.windows.net/").Token
@@ -359,15 +369,23 @@ jobs:
                     } catch {
                         Write-Warning "Could not add triggering user to SQL database: $($_.Exception.Message). Continuing pipeline."
                     } finally {
-                        # Always restore UAMI as SQL admin
-                        Write-Host "Restoring UAMI '$adminUamiName' as SQL admin..."
+                        # Always restore UAMI as SQL admin using ARM template
+                        Write-Host "Restoring UAMI '$adminUamiName' as SQL admin via ARM template..."
                         try {
+                            $uamiAdminParams = @{
+                                sqlServerName = $sqlServerName
+                                sqlAdministratorLogin = $uamiPrincipalId
+                                sqlAdministratorSid = $uamiPrincipalId
+                                sqlAdministratorTenantId = $uamiTenantId
+                                sqlServerPrincipalType = "User"
+                            }
+                            
                             Invoke-WithRetry -OperationName "Restore UAMI as SQL Admin" -ScriptBlock {
-                                Set-AzSqlServerActiveDirectoryAdministrator `
+                                New-AzResourceGroupDeployment `
                                   -ResourceGroupName $resourceGroupName `
-                                  -ServerName $sqlServerName `
-                                  -DisplayName $adminUamiName `
-                                  -ObjectId $uamiObjectId `
+                                  -Name "$sqlServerName-admin-swap-to-uami" `
+                                  -TemplateFile $(System.DefaultWorkingDirectory)/samples/templates/default-sqlServer.json `
+                                  -TemplateParameterObject $uamiAdminParams `
                                   -ErrorAction Stop
                             }
                             Write-Host "Successfully restored UAMI as SQL admin"

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -301,11 +301,19 @@ jobs:
                     $sqlServerName = "${{parameters.sqlServerName}}".ToLower()
                     $databaseName = "FHIR_${{ parameters.version }}"
                     
-                    # Get service connection info (App ID and Tenant ID for ARM template)
+                    # Get service connection info
+                    # IMPORTANT: SQL Server matches the token's 'oid' claim against the admin SID
+                    # The token contains the Service Principal's Object ID, NOT the App ID
+                    # So we must use the SP's Object ID as the admin SID
                     $serviceConnectionAppId = (Get-AzContext).Account.Id
                     $serviceConnectionTenantId = (Get-AzContext).Tenant.Id
-                    $serviceConnectionDisplayName = "$(ConnectedServiceName) - $serviceConnectionAppId"
-                    Write-Host "Service connection AppId: $serviceConnectionAppId, TenantId: $serviceConnectionTenantId"
+                    
+                    # Get the Service Principal's Object ID (required for SQL admin SID)
+                    $serviceConnectionObjectId = Invoke-WithRetry -OperationName "Get Service Connection Object ID" -ScriptBlock {
+                        (Get-AzADServicePrincipal -ApplicationId $serviceConnectionAppId -ErrorAction Stop).Id
+                    }
+                    $serviceConnectionDisplayName = "$(ConnectedServiceName)"
+                    Write-Host "Service connection AppId: $serviceConnectionAppId, ObjectId: $serviceConnectionObjectId, TenantId: $serviceConnectionTenantId"
                     
                     # Get UAMI info for restoring admin later
                     $uami = Get-AzUserAssignedIdentity -Name $adminUamiName -ResourceGroupName $resourceGroupName
@@ -315,12 +323,12 @@ jobs:
                     
                     try {
                         # Temporarily set service connection as SQL admin using ARM template
-                        # This approach works for cross-tenant service principals
+                        # Using Object ID (not App ID) as SID - this matches what the token's 'oid' claim contains
                         Write-Host "Setting service connection as SQL admin via ARM template..."
                         $serviceConnectionAdminParams = @{
                             sqlServerName = $sqlServerName
                             sqlAdministratorLogin = $serviceConnectionDisplayName
-                            sqlAdministratorSid = $serviceConnectionAppId
+                            sqlAdministratorSid = $serviceConnectionObjectId
                             sqlAdministratorTenantId = $serviceConnectionTenantId
                             sqlServerPrincipalType = "Application"
                         }

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -61,9 +61,11 @@ jobs:
         # Import retry helper for transient error handling
         . $(System.DefaultWorkingDirectory)/release/scripts/PowerShell/Invoke-WithRetry.ps1
 
-        # Helper function to resolve triggering user email from git commit author
+        # Helper function to resolve triggering user info from git commit author
         # Supports GitHub noreply emails by looking up username mapping in Key Vault
-        function Get-TriggeringUserEmail {
+        # Key Vault secret format: "objectId|upn" (e.g., "a1b2c3d4-...|joestr@microsoft.com")
+        # Returns hashtable with ObjectId and Upn properties, or $null if not found
+        function Get-TriggeringUserInfo {
             try {
                 # Get git commit author email
                 $gitEmail = git log -1 --format='%ae' 2>$null
@@ -78,26 +80,37 @@ jobs:
                     $githubUsername = $Matches[2]
                     Write-Host "Detected GitHub noreply email. Extracted username: $githubUsername"
                     
-                    # Look up the Azure AD email from Key Vault secret
+                    # Look up the Azure AD info from Key Vault secret
                     $secretName = "github-$githubUsername"
                     Write-Host "Looking up Key Vault secret: $secretName"
                     try {
                         $secret = Get-AzKeyVaultSecret -VaultName 'resolute-oss-tenant-info' -Name $secretName -AsPlainText -ErrorAction Stop
                         if (-not [string]::IsNullOrEmpty($secret)) {
-                            Write-Host "Found Azure AD email mapping in Key Vault: $secret"
-                            return $secret
+                            # Parse secret format: "objectId|upn"
+                            $parts = $secret -split '\|'
+                            if ($parts.Count -eq 2) {
+                                $result = @{
+                                    ObjectId = $parts[0].Trim()
+                                    Upn = $parts[1].Trim()
+                                }
+                                Write-Host "Found Azure AD mapping in Key Vault - ObjectId: $($result.ObjectId), UPN: $($result.Upn)"
+                                return $result
+                            } else {
+                                Write-Warning "Key Vault secret '$secretName' has invalid format. Expected 'objectId|upn'. Skipping user provisioning."
+                                return $null
+                            }
                         }
                     } catch {
-                        Write-Warning "Key Vault secret '$secretName' not found. To enable automatic user provisioning, create a secret named '$secretName' with your Azure AD email as the value."
+                        Write-Warning "Key Vault secret '$secretName' not found. To enable automatic user provisioning, create a secret named '$secretName' with format 'objectId|upn'."
                         return $null
                     }
                 }
                 
-                # Not a noreply email - return as-is (might be a direct email)
-                Write-Host "Using git email directly: $gitEmail"
-                return $gitEmail
+                # Not a noreply email - cannot resolve without Key Vault mapping
+                Write-Host "Git email '$gitEmail' is not a GitHub noreply email. Key Vault mapping required for user provisioning."
+                return $null
             } catch {
-                Write-Warning "Error resolving triggering user email: $($_.Exception.Message)"
+                Write-Warning "Error resolving triggering user info: $($_.Exception.Message)"
                 return $null
             }
         }
@@ -204,30 +217,21 @@ jobs:
 
             # Add triggering user access to CosmosDB if enabled
             if ("${{ parameters.addTriggeringUserAccess }}" -eq "true") {
-                $triggeringUserEmail = Get-TriggeringUserEmail
+                $userInfo = Get-TriggeringUserInfo
                 
-                if (-not [string]::IsNullOrEmpty($triggeringUserEmail)) {
-                    Write-Host "Adding triggering user '$triggeringUserEmail' to CosmosDB..."
+                if ($userInfo -and -not [string]::IsNullOrEmpty($userInfo.ObjectId)) {
+                    Write-Host "Adding triggering user (ObjectId: $($userInfo.ObjectId)) to CosmosDB..."
                     try {
-                        $userPrincipal = Get-AzADUser -UserPrincipalName $triggeringUserEmail -ErrorAction SilentlyContinue
-                        if (-not $userPrincipal) {
-                            # Try by mail attribute for guest users
-                            $userPrincipal = Get-AzADUser -Filter "mail eq '$triggeringUserEmail'" -ErrorAction SilentlyContinue
+                        Invoke-WithRetry -OperationName "Add Triggering User CosmosDB Role" -ScriptBlock {
+                            New-AzCosmosDBSqlRoleAssignment `
+                              -AccountName $webAppName `
+                              -ResourceGroupName $resourceGroupName `
+                              -Scope "/" `
+                              -PrincipalId $userInfo.ObjectId `
+                              -RoleDefinitionId "00000000-0000-0000-0000-000000000002" `
+                              -ErrorAction Stop
                         }
-                        if ($userPrincipal) {
-                            Invoke-WithRetry -OperationName "Add Triggering User CosmosDB Role" -ScriptBlock {
-                                New-AzCosmosDBSqlRoleAssignment `
-                                  -AccountName $webAppName `
-                                  -ResourceGroupName $resourceGroupName `
-                                  -Scope "/" `
-                                  -PrincipalId $userPrincipal.Id `
-                                  -RoleDefinitionId "00000000-0000-0000-0000-000000000002" `
-                                  -ErrorAction Stop
-                            }
-                            Write-Host "Successfully added triggering user to CosmosDB with Data Contributor role"
-                        } else {
-                            Write-Warning "Could not find user '$triggeringUserEmail' in Azure AD. Skipping CosmosDB user provisioning."
-                        }
+                        Write-Host "Successfully added triggering user to CosmosDB with Data Contributor role"
                     } catch {
                         if ($_.Exception.Message -like "*RoleAssignmentAlreadyExists*" -or $_.Exception.Message -like "*already exists*") {
                             Write-Host "Triggering user already has CosmosDB access. Skipping."
@@ -236,7 +240,7 @@ jobs:
                         }
                     }
                 } else {
-                    Write-Host "No triggering user email resolved. Skipping CosmosDB user provisioning."
+                    Write-Host "No triggering user info resolved. Skipping CosmosDB user provisioning."
                 }
             }
 
@@ -277,10 +281,11 @@ jobs:
         if("${{ parameters.sql }}" -eq "true"){
             # Add triggering user access to SQL database if enabled
             if ("${{ parameters.addTriggeringUserAccess }}" -eq "true") {
-                $triggeringUserEmail = Get-TriggeringUserEmail
+                $userInfo = Get-TriggeringUserInfo
                 
-                if (-not [string]::IsNullOrEmpty($triggeringUserEmail)) {
-                    Write-Host "Adding triggering user '$triggeringUserEmail' to SQL database..."
+                if ($userInfo -and -not [string]::IsNullOrEmpty($userInfo.Upn)) {
+                    $triggeringUserUpn = $userInfo.Upn
+                    Write-Host "Adding triggering user '$triggeringUserUpn' to SQL database..."
                     try {
                         $sqlServerName = "${{parameters.sqlServerName}}".ToLower()
                         $databaseName = "FHIR_${{ parameters.version }}"
@@ -290,18 +295,18 @@ jobs:
                         
                         # Create SQL user for the triggering user with db_owner role
                         # Using string concatenation to avoid YAML heredoc parsing issues
-                        $sqlQuery = "IF NOT EXISTS (SELECT * FROM sys.database_principals WHERE name = N'$triggeringUserEmail') "
+                        $sqlQuery = "IF NOT EXISTS (SELECT * FROM sys.database_principals WHERE name = N'$triggeringUserUpn') "
                         $sqlQuery += "BEGIN "
-                        $sqlQuery += "CREATE USER [$triggeringUserEmail] FROM EXTERNAL PROVIDER; "
-                        $sqlQuery += "ALTER ROLE db_owner ADD MEMBER [$triggeringUserEmail]; "
+                        $sqlQuery += "CREATE USER [$triggeringUserUpn] FROM EXTERNAL PROVIDER; "
+                        $sqlQuery += "ALTER ROLE db_owner ADD MEMBER [$triggeringUserUpn]; "
                         $sqlQuery += "PRINT 'Created user and added to db_owner role'; "
                         $sqlQuery += "END "
                         $sqlQuery += "ELSE BEGIN "
                         $sqlQuery += "IF NOT EXISTS (SELECT 1 FROM sys.database_role_members drm "
                         $sqlQuery += "JOIN sys.database_principals dp ON drm.member_principal_id = dp.principal_id "
                         $sqlQuery += "JOIN sys.database_principals r ON drm.role_principal_id = r.principal_id "
-                        $sqlQuery += "WHERE dp.name = N'$triggeringUserEmail' AND r.name = 'db_owner') "
-                        $sqlQuery += "BEGIN ALTER ROLE db_owner ADD MEMBER [$triggeringUserEmail]; PRINT 'Added existing user to db_owner role'; END "
+                        $sqlQuery += "WHERE dp.name = N'$triggeringUserUpn' AND r.name = 'db_owner') "
+                        $sqlQuery += "BEGIN ALTER ROLE db_owner ADD MEMBER [$triggeringUserUpn]; PRINT 'Added existing user to db_owner role'; END "
                         $sqlQuery += "ELSE BEGIN PRINT 'User already exists with db_owner role'; END "
                         $sqlQuery += "END"
                         
@@ -319,7 +324,7 @@ jobs:
                         Write-Warning "Could not add triggering user to SQL database: $($_.Exception.Message). Continuing pipeline."
                     }
                 } else {
-                    Write-Host "No triggering user email resolved. Skipping SQL user provisioning."
+                    Write-Host "No triggering user info resolved. Skipping SQL user provisioning."
                 }
             }
         }

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -272,6 +272,7 @@ stages:
       sqlComputeTier: 'Standard'
       reindexEnabled: true
       addTriggeringUserAccess: true
+      adminUserAssignedManagedIdentityName: "$(DeploymentEnvironmentName)-uami"
 
 - stage: deployR4
   displayName: 'Deploy R4 CosmosDB Site'
@@ -318,6 +319,7 @@ stages:
       sqlComputeTier: 'Standard'
       reindexEnabled: true
       addTriggeringUserAccess: true
+      adminUserAssignedManagedIdentityName: "$(DeploymentEnvironmentName)-uami"
 
 - stage: deployR4B
   displayName: 'Deploy R4B CosmosDB Site'
@@ -364,6 +366,7 @@ stages:
       sqlComputeTier: 'Standard'
       reindexEnabled: true
       addTriggeringUserAccess: true
+      adminUserAssignedManagedIdentityName: "$(DeploymentEnvironmentName)-uami"
 
 - stage: deployR5
   displayName: 'Deploy R5 CosmosDB Site'
@@ -410,6 +413,7 @@ stages:
       sqlComputeTier: 'Standard'
       reindexEnabled: true
       addTriggeringUserAccess: true
+      adminUserAssignedManagedIdentityName: "$(DeploymentEnvironmentName)-uami"
 
 - stage: testStu3
   displayName: 'Run Stu3 Tests'

--- a/build/pr-pipeline.yml
+++ b/build/pr-pipeline.yml
@@ -246,6 +246,7 @@ stages:
       testEnvironmentUrl: $(TestApplicationResource)
       imageTag: $(ImageTag)
       reindexEnabled: true
+      addTriggeringUserAccess: true
 
 - stage: deployStu3Sql
   displayName: 'Deploy STU3 SQL Site'
@@ -270,6 +271,7 @@ stages:
       sqlServerName: $(DeploymentEnvironmentName)
       sqlComputeTier: 'Standard'
       reindexEnabled: true
+      addTriggeringUserAccess: true
 
 - stage: deployR4
   displayName: 'Deploy R4 CosmosDB Site'
@@ -290,6 +292,7 @@ stages:
       testEnvironmentUrl: $(TestApplicationResource)
       imageTag: $(ImageTag)
       reindexEnabled: true
+      addTriggeringUserAccess: true
 
 - stage: deployR4Sql
   displayName: 'Deploy R4 SQL Site'
@@ -314,6 +317,7 @@ stages:
       sqlServerName: $(DeploymentEnvironmentName)
       sqlComputeTier: 'Standard'
       reindexEnabled: true
+      addTriggeringUserAccess: true
 
 - stage: deployR4B
   displayName: 'Deploy R4B CosmosDB Site'
@@ -334,6 +338,7 @@ stages:
       testEnvironmentUrl: $(TestApplicationResource)
       imageTag: $(ImageTag)
       reindexEnabled: true
+      addTriggeringUserAccess: true
 
 - stage: deployR4BSql
   displayName: 'Deploy R4B SQL Site'
@@ -358,6 +363,7 @@ stages:
       sqlServerName: $(DeploymentEnvironmentName)
       sqlComputeTier: 'Standard'
       reindexEnabled: true
+      addTriggeringUserAccess: true
 
 - stage: deployR5
   displayName: 'Deploy R5 CosmosDB Site'
@@ -378,6 +384,7 @@ stages:
       testEnvironmentUrl: $(TestApplicationResource)
       imageTag: $(ImageTag)
       reindexEnabled: true
+      addTriggeringUserAccess: true
 
 - stage: deployR5Sql
   displayName: 'Deploy R5 SQL Site'
@@ -402,6 +409,7 @@ stages:
       sqlServerName: $(DeploymentEnvironmentName)
       sqlComputeTier: 'Standard'
       reindexEnabled: true
+      addTriggeringUserAccess: true
 
 - stage: testStu3
   displayName: 'Run Stu3 Tests'


### PR DESCRIPTION
## Description
This pull request introduces a new feature to the deployment pipeline that automatically grants the triggering user's account access to CosmosDB and SQL databases during environment provisioning. This enhancement is controlled by a new parameter and is enabled across all relevant deployment stages, improving developer experience and streamlining access management for deployed environments.

**Access Management Enhancements**

* Added a new boolean parameter `addTriggeringUserAccess` to `build/jobs/provision-deploy.yml` to control whether the triggering user is granted access during provisioning.
* Implemented logic to add the triggering user as a Data Contributor in CosmosDB if the parameter is enabled, including handling for guest users and existing role assignments.
* Added logic to create or update the triggering user as a SQL database user with `db_owner` role, using Azure AD authentication and robust error handling.

**Pipeline Configuration**

* Enabled `addTriggeringUserAccess: true` for all deployment stages in `build/pr-pipeline.yml`, ensuring the feature is active for all environment types and database backends. [[1]](diffhunk://#diff-c2e99165f026540a53d8dc27816d7e2b9dccbd9612f1832974adee41f8c620a9R249) [[2]](diffhunk://#diff-c2e99165f026540a53d8dc27816d7e2b9dccbd9612f1832974adee41f8c620a9R274) [[3]](diffhunk://#diff-c2e99165f026540a53d8dc27816d7e2b9dccbd9612f1832974adee41f8c620a9R295) [[4]](diffhunk://#diff-c2e99165f026540a53d8dc27816d7e2b9dccbd9612f1832974adee41f8c620a9R320) [[5]](diffhunk://#diff-c2e99165f026540a53d8dc27816d7e2b9dccbd9612f1832974adee41f8c620a9R341) [[6]](diffhunk://#diff-c2e99165f026540a53d8dc27816d7e2b9dccbd9612f1832974adee41f8c620a9R366) [[7]](diffhunk://#diff-c2e99165f026540a53d8dc27816d7e2b9dccbd9612f1832974adee41f8c620a9R387) [[8]](diffhunk://#diff-c2e99165f026540a53d8dc27816d7e2b9dccbd9612f1832974adee41f8c620a9R412)

## Related issues
Addresses [AB#166378](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/166378).

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
