### PR TITLE
[Bundle] Include hardDelete and purge as part of TransactionScope

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/TransactionBundleValidatorTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/TransactionBundleValidatorTests.cs
@@ -145,6 +145,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
         public async Task GivenATransactionBundle_WhenContainsEntryWithHardDelete_ThenNoExceptionShouldBeThrown(BundleProcessingLogic processingLogic)
         {
             // TODO: When Parallel Bundles start supporting hard deletes, remove this test and update the Parallel test above.
+            // TODO: 182638 - Add support to hard deletes in parallel processing mode.
 
             // Arrange
             var bundle = new Hl7.Fhir.Model.Bundle
@@ -234,7 +235,6 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
         [InlineData(BundleProcessingLogic.Sequential, "Patient/123?_hardDelete=true")]
         [InlineData(BundleProcessingLogic.Sequential, "Observation/456?_purge=true")]
         [InlineData(BundleProcessingLogic.Sequential, "Patient/789?_hardDelete=true&_cascade=delete")]
-        [InlineData(BundleProcessingLogic.Parallel, "Observation/456?_purge=true")]
         public async Task GivenATransactionBundle_WhenContainsDeleteWithResourceIdAndQueryParams_ThenNoExceptionShouldBeThrown(BundleProcessingLogic processingLogic, string requestUrl)
         {
             // Arrange - These are hard deletes with resource IDs and query parameters
@@ -260,11 +260,13 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
         }
 
         [Theory]
+        [InlineData(BundleProcessingLogic.Parallel, "Observation/456?_purge=true")]
         [InlineData(BundleProcessingLogic.Parallel, "Patient/123?_hardDelete=true")]
         [InlineData(BundleProcessingLogic.Parallel, "Patient/789?_hardDelete=true&_cascade=delete")]
         public async Task GivenATransactionBundle_WhenContainsDeleteWithResourceIdAndQueryParams_ThenExceptionShouldBeThrownWhenInParallel(BundleProcessingLogic processingLogic, string requestUrl)
         {
             // TODO: When Parallel Bundles start supporting hard deletes, remove this test and update the Parallel test above.
+            // TODO: 182638 - Add support to hard deletes in parallel processing mode.
 
             // Arrange - These are hard deletes with resource IDs and query parameters
             var bundle = new Hl7.Fhir.Model.Bundle

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/TransactionBundleValidatorTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/TransactionBundleValidatorTests.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
         [InlineData(BundleProcessingLogic.Sequential)]
         public async Task GivenATransactionBundle_WhenContainsEntryWithHardDelete_ThenNoExceptionShouldBeThrown(BundleProcessingLogic processingLogic)
         {
-            // TODO: When Parallel Bundles start supporting hard deletes, remove this test and update the Parallel test above.
+            // TODO: When Parallel Bundles start supporting hard deletes, update this test and remove the Parallel test below.
             // TODO: 182638 - Add support to hard deletes in parallel processing mode.
 
             // Arrange
@@ -173,6 +173,9 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
         [InlineData(BundleProcessingLogic.Parallel)]
         public async Task GivenATransactionBundle_WhenContainsEntryWithHardDelete_ThenExceptionShouldBeThrownWhenExecutedInParallel(BundleProcessingLogic processingLogic)
         {
+            // TODO: When Parallel Bundles start supporting hard deletes, remove this test and update test above.
+            // TODO: 182638 - Add support to hard deletes in parallel processing mode.
+
             // Arrange
             var bundle = new Hl7.Fhir.Model.Bundle
             {
@@ -265,7 +268,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
         [InlineData(BundleProcessingLogic.Parallel, "Patient/789?_hardDelete=true&_cascade=delete")]
         public async Task GivenATransactionBundle_WhenContainsDeleteWithResourceIdAndQueryParams_ThenExceptionShouldBeThrownWhenInParallel(BundleProcessingLogic processingLogic, string requestUrl)
         {
-            // TODO: When Parallel Bundles start supporting hard deletes, remove this test and update the Parallel test above.
+            // TODO: When Parallel Bundles start supporting hard deletes, remove this test and update the test above.
             // TODO: 182638 - Add support to hard deletes in parallel processing mode.
 
             // Arrange - These are hard deletes with resource IDs and query parameters

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
@@ -225,7 +225,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                 else if (_bundleType == BundleType.Transaction)
                 {
                     // For resources within a transaction, we need to validate if they are referring to each other and throw an exception in such case.
-                    await _transactionBundleValidator.ValidateBundle(bundleResource, _referenceIdDictionary, cancellationToken);
+                    await _transactionBundleValidator.ValidateBundle(bundleResource, bundleProcessingLogic, _referenceIdDictionary, cancellationToken);
 
                     await FillRequestLists(bundleResource.Entry, cancellationToken);
 

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/TransactionBundleValidator.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/TransactionBundleValidator.cs
@@ -45,10 +45,11 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
         /// It also validates if the request operations within a entry is a valid operation.
         /// If a conditional create or update is executed and a resource exists, the value is populated in the idDictionary.
         /// </summary>
-        /// <param name="bundle"> The input bundle</param>
+        /// <param name="bundle">The input bundle</param>
+        /// <param name="processingLogic">Bundle processing logic</param>
         /// <param name="idDictionary">The id dictionary that stores fullUrl to actual ids.</param>
         /// <param name="cancellationToken"> The cancellation token</param>
-        public async Task ValidateBundle(Hl7.Fhir.Model.Bundle bundle, IDictionary<string, (string resourceId, string resourceType)> idDictionary, CancellationToken cancellationToken)
+        public async Task ValidateBundle(Hl7.Fhir.Model.Bundle bundle, BundleProcessingLogic processingLogic, IDictionary<string, (string resourceId, string resourceType)> idDictionary, CancellationToken cancellationToken)
         {
             EnsureArg.IsNotNull(bundle, nameof(bundle));
 
@@ -56,7 +57,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
 
             foreach (var entry in bundle.Entry)
             {
-                if (ShouldValidateBundleEntry(entry))
+                if (ShouldValidateBundleEntry(entry, processingLogic))
                 {
                     string resourceId = await GetResourceId(entry, idDictionary, cancellationToken);
                     string conditionalCreateQuery = entry.Request.IfNoneExist;
@@ -138,7 +139,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
             return string.Empty;
         }
 
-        private static bool ShouldValidateBundleEntry(EntryComponent entry)
+        private static bool ShouldValidateBundleEntry(EntryComponent entry, BundleProcessingLogic processingLogic)
         {
             string requestUrl = entry.Request?.Url;
             if (string.IsNullOrWhiteSpace(requestUrl))
@@ -160,8 +161,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                 throw new RequestNotValidException(string.Format(Api.Resources.InvalidBundleEntry, entry.Request.Url, requestMethod));
             }
 
-            // Conditional Delete operation is not currently supported.
-            // However, hard deletes (DELETE {type}/{id}?_hardDelete=true) are allowed.
+            // Conditional Delete operation is NOT supported.
+            // However, hard deletes (DELETE {type}/{id}?_hardDelete=true) are allowed in SEQUENTIAL BUNDLES, as they use C# Transactions.
+            // Hard deletes in PARALLEL BUNDLES are not allowed, as they are not covered by a unique SQL Transaction.
             // Conditional deletes have the pattern: DELETE {type}?{query} (no resource ID).
             if (requestMethod == HTTPVerb.DELETE && requestUrl.Contains('?', StringComparison.Ordinal))
             {
@@ -170,6 +172,11 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
 
                 // If there's no '/' in the path before '?', it's a conditional delete (not allowed)
                 if (!pathBeforeQuery.Contains('/', StringComparison.Ordinal))
+                {
+                    throw new RequestNotValidException(string.Format(Api.Resources.InvalidBundleEntry, entry.Request.Url, requestMethod));
+                }
+
+                if (processingLogic == BundleProcessingLogic.Parallel && requestUrl.Contains("_hardDelete=true", StringComparison.OrdinalIgnoreCase))
                 {
                     throw new RequestNotValidException(string.Format(Api.Resources.InvalidBundleEntry, entry.Request.Url, requestMethod));
                 }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/TransactionBundleValidator.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/TransactionBundleValidator.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
 
             // Conditional Delete operation is NOT supported.
             // However, hard deletes (DELETE {type}/{id}?_hardDelete=true) are allowed in SEQUENTIAL BUNDLES, as they use C# Transactions.
-            // Hard deletes in PARALLEL BUNDLES are not allowed, as they are not covered by a unique SQL Transaction.
+            // Hard deletes and historical purge in PARALLEL BUNDLES are not allowed, as they are not covered by a unique SQL Transaction (Work item #182638).
             // Conditional deletes have the pattern: DELETE {type}?{query} (no resource ID).
             if (requestMethod == HTTPVerb.DELETE && requestUrl.Contains('?', StringComparison.Ordinal))
             {
@@ -176,7 +176,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                     throw new RequestNotValidException(string.Format(Api.Resources.InvalidBundleEntry, entry.Request.Url, requestMethod));
                 }
 
-                if (processingLogic == BundleProcessingLogic.Parallel && requestUrl.Contains("_hardDelete=true", StringComparison.OrdinalIgnoreCase))
+                // TODO: 182638 - Add support to hard deletes in parallel processing mode.
+                if (processingLogic == BundleProcessingLogic.Parallel &&
+                    (requestUrl.Contains("_hardDelete=true", StringComparison.OrdinalIgnoreCase) || requestUrl.Contains("_purge=true", StringComparison.OrdinalIgnoreCase)))
                 {
                     throw new RequestNotValidException(string.Format(Api.Resources.InvalidBundleEntry, entry.Request.Url, requestMethod));
                 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlStoreClient.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlStoreClient.cs
@@ -45,12 +45,20 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
         public async Task HardDeleteAsync(short resourceTypeId, string resourceId, bool keepCurrentVersion, bool isResourceChangeCaptureEnabled, CancellationToken cancellationToken)
         {
-            using var cmd = new SqlCommand() { CommandText = "dbo.HardDeleteResource", CommandType = CommandType.StoredProcedure };
+            using var cmd = CreateHardDeleteSqlCommand(resourceTypeId, resourceId, keepCurrentVersion, isResourceChangeCaptureEnabled);
+            await cmd.ExecuteNonQueryAsync(_sqlRetryService, _logger, cancellationToken);
+        }
+
+        internal static SqlCommand CreateHardDeleteSqlCommand(short resourceTypeId, string resourceId, bool keepCurrentVersion, bool isResourceChangeCaptureEnabled)
+        {
+            SqlCommand cmd = new SqlCommand() { CommandText = "dbo.HardDeleteResource", CommandType = CommandType.StoredProcedure };
+
             cmd.Parameters.AddWithValue("@ResourceTypeId", resourceTypeId);
             cmd.Parameters.AddWithValue("@ResourceId", resourceId);
             cmd.Parameters.AddWithValue("@KeepCurrentVersion", keepCurrentVersion);
             cmd.Parameters.AddWithValue("@IsResourceChangeCaptureEnabled", isResourceChangeCaptureEnabled);
-            await cmd.ExecuteNonQueryAsync(_sqlRetryService, _logger, cancellationToken);
+
+            return cmd;
         }
 
         internal async Task TryLogEvent(string process, string status, string text, DateTime? startDate, CancellationToken cancellationToken)

--- a/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
+++ b/src/Microsoft.Health.Fhir.Tests.Common/Microsoft.Health.Fhir.Tests.Common.csproj
@@ -166,6 +166,7 @@
     <None Remove="TestFiles\Normative\Bundle-TransactionWithMetaHistory.json" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="TestFiles\Normative\Bundle-TransactionWithDelete.json" />
     <EmbeddedResource Include="TestFiles\Normative\Bundle-TransactionWithMetaHistory.json" />
 	  <EmbeddedResource Include="TestFiles\Normative\Bundle-BatchWithDuplicatedItems.json" />
 	  <EmbeddedResource Include="TestFiles\Normative\Bundle-BatchWithConditionalUpdateByIdentifier.json" />

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/Bundle-TransactionForRollBackWithDelete.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/Bundle-TransactionForRollBackWithDelete.json
@@ -9,9 +9,15 @@
             }
         },
         {
+            "request": {
+                "method": "DELETE",
+                "url": "Patient/patient-rollback-1"
+            }
+        },
+        {
             "resource": {
                 "resourceType": "Patient",
-                "id": "patient-rollback-1",
+                "id": "patient-rollback-2",
                 "identifier": [
                     {
                         "use": "official",

--- a/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/Bundle-TransactionWithDelete.json
+++ b/src/Microsoft.Health.Fhir.Tests.Common/TestFiles/Normative/Bundle-TransactionWithDelete.json
@@ -5,19 +5,19 @@
         {
             "request": {
                 "method": "DELETE",
-                "url": "Patient/patient-rollback-0"
+                "url": "Patient/patient-validresource-0"
             }
         },
         {
             "request": {
                 "method": "DELETE",
-                "url": "Patient/patient-rollback-1"
+                "url": "Patient/patient-validresource-1"
             }
         },
         {
             "resource": {
                 "resourceType": "Patient",
-                "id": "patient-rollback-2",
+                "id": "patient-validresource-2",
                 "identifier": [
                     {
                         "use": "official",
@@ -52,14 +52,13 @@
             },
             "request": {
                 "method": "PUT",
-                "url": "Patient/patient-rollback-2",
-                "ifMatch": "W/\"2112\""
+                "url": "Patient/patient-validresource-2"
             }
         },
         {
             "resource": {
                 "resourceType": "Observation",
-                "id": "observation-rollback-0",
+                "id": "observation-validresource-0",
                 "status": "final",
                 "code": {
                     "coding": [
@@ -81,8 +80,7 @@
             },
             "request": {
                 "method": "PUT",
-                "url": "Observation/observation-rollback-0",
-                "ifMatch": "W/\"2112\""
+                "url": "Observation/observation-validresource-0"
             }
         }
     ]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BundleTransactionTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BundleTransactionTests.cs
@@ -187,6 +187,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
                     bundle,
                     new FhirBundleOptions() { BundleProcessingLogic = processingLogic },
                     CancellationToken.None);
+
+                Assert.Fail("Transaction is supposed to fail at this point, as Parallel Bundles are expected to fail with _hardDelete/_purge operations.");
             }
             catch (FhirClientException e)
             {


### PR DESCRIPTION
## Description
In this PR I'm adding Hard Delete and Purge history operations on the same scope of the C# Transactions executed by sequential bundles.

For parallel bundles, as these operations are not using the same stored procedure and C# Transactions, then more work needs to be done. I ended up adding back the validations to block Hard Deletes and Purge History from parallel bundles. 

## Related issues
Addresses [AB#182156](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/182156)

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
