### PR TITLE
Fix data store key comparison

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Persistence/ResourceKeyTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Persistence/ResourceKeyTests.cs
@@ -190,13 +190,13 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Persistence
         }
 
         [Fact]
-        public void GivenResourceKeys_WhenComparisonIsCaseInsensitive_ThenCompareCorrectly()
+        public void GivenResourceKeys_WhenComparisonIsCaseSensitive_ThenCompareCorrectly()
         {
             var key1 = new ResourceKey("Patient", "abc");
             var key2 = new ResourceKey("Patient", "ABC");
 
-            // Case-insensitive comparison should treat them as equal
-            Assert.Equal(0, key1.CompareTo(key2));
+            // Case-sensitive comparison should treat them as different
+            Assert.NotEqual(0, key1.CompareTo(key2));
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Persistence/ResourceKeyTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Persistence/ResourceKeyTests.cs
@@ -1,0 +1,232 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
+using Microsoft.Health.Fhir.Core.Models;
+using Microsoft.Health.Fhir.Tests.Common;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Persistence
+{
+    public class ResourceKeyTests
+    {
+        public ResourceKeyTests()
+        {
+            ModelInfoProvider.SetProvider(MockModelInfoProviderBuilder.Create(FhirSpecification.R4).AddKnownTypes(KnownResourceTypes.Group).Build());
+        }
+
+        [Fact]
+        public void GivenTwoResourceKeys_WhenResourceTypesAreDifferent_ThenCompareByResourceType()
+        {
+            var key1 = new ResourceKey("Patient", "123");
+            var key2 = new ResourceKey("Observation", "123");
+
+            // Patient comes after Observation alphabetically
+            Assert.True(key1.CompareTo(key2) > 0);
+            Assert.True(key2.CompareTo(key1) < 0);
+        }
+
+        [Fact]
+        public void GivenTwoResourceKeys_WhenResourceTypesAreSameAndIdsAreDifferent_ThenCompareById()
+        {
+            var key1 = new ResourceKey("Patient", "123");
+            var key2 = new ResourceKey("Patient", "456");
+
+            // "123" comes before "456" alphabetically
+            Assert.True(key1.CompareTo(key2) < 0);
+            Assert.True(key2.CompareTo(key1) > 0);
+        }
+
+        [Fact]
+        public void GivenTwoResourceKeys_WhenResourceTypeAndIdAreSameButVersionsAreDifferent_ThenCompareByVersion()
+        {
+            var key1 = new ResourceKey("Patient", "123", "1");
+            var key2 = new ResourceKey("Patient", "123", "2");
+
+            // Numeric versions: 1 < 2
+            Assert.True(key1.CompareTo(key2) < 0);
+            Assert.True(key2.CompareTo(key1) > 0);
+        }
+
+        [Fact]
+        public void GivenTwoResourceKeys_WhenVersionsAreNumeric_ThenCompareNumerically()
+        {
+            var key1 = new ResourceKey("Patient", "123", "2");
+            var key2 = new ResourceKey("Patient", "123", "10");
+
+            // Numeric comparison: 2 < 10 (not string comparison where "10" < "2")
+            Assert.True(key1.CompareTo(key2) < 0);
+            Assert.True(key2.CompareTo(key1) > 0);
+        }
+
+        [Fact]
+        public void GivenTwoResourceKeys_WhenVersionsAreNotNumeric_ThenCompareAsStrings()
+        {
+            var key1 = new ResourceKey("Patient", "123", "v1");
+            var key2 = new ResourceKey("Patient", "123", "v2");
+
+            // String comparison
+            Assert.True(key1.CompareTo(key2) < 0);
+            Assert.True(key2.CompareTo(key1) > 0);
+        }
+
+        [Fact]
+        public void GivenTwoResourceKeys_WhenOneHasVersionAndOtherDoesNot_ThenAreEqual()
+        {
+            var key1 = new ResourceKey("Patient", "123", "1");
+            var key2 = new ResourceKey("Patient", "123");
+
+            // When one version is null, they should be equal
+            Assert.Equal(0, key1.CompareTo(key2));
+            Assert.Equal(0, key2.CompareTo(key1));
+        }
+
+        [Fact]
+        public void GivenTwoResourceKeys_WhenBothHaveNoVersion_ThenAreEqual()
+        {
+            var key1 = new ResourceKey("Patient", "123");
+            var key2 = new ResourceKey("Patient", "123");
+
+            Assert.Equal(0, key1.CompareTo(key2));
+        }
+
+        [Fact]
+        public void GivenTwoIdenticalResourceKeys_WhenCompared_ThenAreEqual()
+        {
+            var key1 = new ResourceKey("Patient", "123", "1");
+            var key2 = new ResourceKey("Patient", "123", "1");
+
+            Assert.Equal(0, key1.CompareTo(key2));
+        }
+
+        [Fact]
+        public void GivenTwoResourceKeys_WhenUsingLessThanOperator_ThenReturnsCorrectResult()
+        {
+            var key1 = new ResourceKey("Patient", "123", "1");
+            var key2 = new ResourceKey("Patient", "123", "2");
+
+            Assert.True(key1 < key2);
+            Assert.False(key2 < key1);
+        }
+
+        [Fact]
+        public void GivenTwoResourceKeys_WhenUsingLessThanOrEqualOperator_ThenReturnsCorrectResult()
+        {
+            var key1 = new ResourceKey("Patient", "123", "1");
+            var key2 = new ResourceKey("Patient", "123", "2");
+            var key3 = new ResourceKey("Patient", "123", "1");
+
+            Assert.True(key1 <= key2);
+            Assert.True(key1 <= key3);
+            Assert.False(key2 <= key1);
+        }
+
+        [Fact]
+        public void GivenTwoResourceKeys_WhenUsingGreaterThanOperator_ThenReturnsCorrectResult()
+        {
+            var key1 = new ResourceKey("Patient", "123", "1");
+            var key2 = new ResourceKey("Patient", "123", "2");
+
+            Assert.True(key2 > key1);
+            Assert.False(key1 > key2);
+        }
+
+        [Fact]
+        public void GivenTwoResourceKeys_WhenUsingGreaterThanOrEqualOperator_ThenReturnsCorrectResult()
+        {
+            var key1 = new ResourceKey("Patient", "123", "1");
+            var key2 = new ResourceKey("Patient", "123", "2");
+            var key3 = new ResourceKey("Patient", "123", "1");
+
+            Assert.True(key2 >= key1);
+            Assert.True(key1 >= key3);
+            Assert.False(key1 >= key2);
+        }
+
+        [Fact]
+        public void GivenNullResourceKey_WhenUsingLessThanOperator_ThenReturnsCorrectResult()
+        {
+            ResourceKey nullKey = null;
+            var key = new ResourceKey("Patient", "123");
+
+            Assert.True(nullKey < key);
+            Assert.False(key < nullKey);
+        }
+
+        [Fact]
+        public void GivenNullResourceKey_WhenUsingLessThanOrEqualOperator_ThenReturnsCorrectResult()
+        {
+            ResourceKey nullKey = null;
+            var key = new ResourceKey("Patient", "123");
+
+            Assert.True(nullKey <= key);
+            Assert.False(key <= nullKey);
+        }
+
+        [Fact]
+        public void GivenNullResourceKey_WhenUsingGreaterThanOperator_ThenReturnsCorrectResult()
+        {
+            ResourceKey nullKey = null;
+            var key = new ResourceKey("Patient", "123");
+
+            Assert.True(key > nullKey);
+            Assert.False(nullKey > key);
+        }
+
+        [Fact]
+        public void GivenNullResourceKey_WhenUsingGreaterThanOrEqualOperator_ThenReturnsCorrectResult()
+        {
+            ResourceKey nullKey = null;
+            var key = new ResourceKey("Patient", "123");
+
+            Assert.True(key >= nullKey);
+            Assert.False(nullKey >= key);
+        }
+
+        [Fact]
+        public void GivenResourceKeys_WhenComparisonIsCaseInsensitive_ThenCompareCorrectly()
+        {
+            var key1 = new ResourceKey("Patient", "abc");
+            var key2 = new ResourceKey("Patient", "ABC");
+
+            // Case-insensitive comparison should treat them as equal
+            Assert.Equal(0, key1.CompareTo(key2));
+        }
+
+        [Fact]
+        public void GivenResourceKeys_WhenSortingList_ThenSortsCorrectly()
+        {
+            var keys = new List<ResourceKey>
+            {
+                new ResourceKey("Patient", "123", "3"),
+                new ResourceKey("Observation", "456", "1"),
+                new ResourceKey("Patient", "123", "1"),
+                new ResourceKey("Patient", "456", "1"),
+                new ResourceKey("Patient", "123", "2"),
+            };
+
+            keys.Sort();
+
+            // Expected order: Observation first, then Patient sorted by Id, then by version
+            Assert.Equal("Observation", keys[0].ResourceType);
+            Assert.Equal("Patient", keys[1].ResourceType);
+            Assert.Equal("123", keys[1].Id);
+            Assert.Equal("1", keys[1].VersionId);
+            Assert.Equal("Patient", keys[2].ResourceType);
+            Assert.Equal("123", keys[2].Id);
+            Assert.Equal("2", keys[2].VersionId);
+            Assert.Equal("Patient", keys[3].ResourceType);
+            Assert.Equal("123", keys[3].Id);
+            Assert.Equal("3", keys[3].VersionId);
+            Assert.Equal("Patient", keys[4].ResourceType);
+            Assert.Equal("456", keys[4].Id);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Persistence/ResourceKeyTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Persistence/ResourceKeyTests.cs
@@ -3,18 +3,17 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Persistence
 {
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.Conformance)]
     public class ResourceKeyTests
     {
         public ResourceKeyTests()

--- a/src/Microsoft.Health.Fhir.Core/Features/Persistence/ResourceKey.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Persistence/ResourceKey.cs
@@ -129,13 +129,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
                 return 1;
             }
 
-            if (!string.Equals(ResourceType, other.ResourceType, StringComparison.OrdinalIgnoreCase))
+            if (!string.Equals(ResourceType, other.ResourceType, StringComparison.Ordinal))
             {
-                result = string.Compare(ResourceType, other.ResourceType, StringComparison.OrdinalIgnoreCase);
+                result = string.Compare(ResourceType, other.ResourceType, StringComparison.Ordinal);
             }
-            else if (!string.Equals(Id, other.Id, StringComparison.OrdinalIgnoreCase))
+            else if (!string.Equals(Id, other.Id, StringComparison.Ordinal))
             {
-                result = string.Compare(Id, other.Id, StringComparison.OrdinalIgnoreCase);
+                result = string.Compare(Id, other.Id, StringComparison.Ordinal);
             }
             else if (VersionId != null && other.VersionId != null)
             {
@@ -147,7 +147,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
                 }
                 else
                 {
-                    result = string.Compare(VersionId, other.VersionId, StringComparison.OrdinalIgnoreCase);
+                    result = string.Compare(VersionId, other.VersionId, StringComparison.Ordinal);
                 }
             }
             else

--- a/src/Microsoft.Health.Fhir.Core/Features/Persistence/ResourceKey.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Persistence/ResourceKey.cs
@@ -123,6 +123,12 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
         public int CompareTo(ResourceKey other)
         {
             int result = 0;
+
+            if (other is null)
+            {
+                return 1;
+            }
+
             if (!string.Equals(ResourceType, other.ResourceType, StringComparison.OrdinalIgnoreCase))
             {
                 result = string.Compare(ResourceType, other.ResourceType, StringComparison.OrdinalIgnoreCase);

--- a/src/Microsoft.Health.Fhir.Core/Features/Persistence/ResourceKey.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Persistence/ResourceKey.cs
@@ -10,7 +10,7 @@ using Microsoft.Health.Fhir.Core.Models;
 
 namespace Microsoft.Health.Fhir.Core.Features.Persistence
 {
-    public class ResourceKey : IEquatable<ResourceKey>
+    public class ResourceKey : IEquatable<ResourceKey>, IComparable<ResourceKey>
     {
         public ResourceKey(string resourceType, string id, string versionId = null)
         {
@@ -28,6 +28,41 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
         public string VersionId { get; }
 
         public string ResourceType { get; }
+
+        public static bool operator ==(ResourceKey left, ResourceKey right)
+        {
+            if (ReferenceEquals(left, null))
+            {
+                return ReferenceEquals(right, null);
+            }
+
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(ResourceKey left, ResourceKey right)
+        {
+            return !(left == right);
+        }
+
+        public static bool operator <(ResourceKey left, ResourceKey right)
+        {
+            return ReferenceEquals(left, null) ? !ReferenceEquals(right, null) : left.CompareTo(right) < 0;
+        }
+
+        public static bool operator <=(ResourceKey left, ResourceKey right)
+        {
+            return ReferenceEquals(left, null) || left.CompareTo(right) <= 0;
+        }
+
+        public static bool operator >(ResourceKey left, ResourceKey right)
+        {
+            return !ReferenceEquals(left, null) && left.CompareTo(right) > 0;
+        }
+
+        public static bool operator >=(ResourceKey left, ResourceKey right)
+        {
+            return ReferenceEquals(left, null) ? ReferenceEquals(right, null) : left.CompareTo(right) >= 0;
+        }
 
         public bool Equals(ResourceKey other)
         {
@@ -83,6 +118,38 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence
             }
 
             return builder.ToString();
+        }
+
+        public int CompareTo(ResourceKey other)
+        {
+            int result = 0;
+            if (!string.Equals(ResourceType, other.ResourceType, StringComparison.OrdinalIgnoreCase))
+            {
+                result = string.Compare(ResourceType, other.ResourceType, StringComparison.OrdinalIgnoreCase);
+            }
+            else if (!string.Equals(Id, other.Id, StringComparison.OrdinalIgnoreCase))
+            {
+                result = string.Compare(Id, other.Id, StringComparison.OrdinalIgnoreCase);
+            }
+            else if (VersionId != null && other.VersionId != null)
+            {
+                var versionIsNum = int.TryParse(VersionId, out int version);
+                var otherVersionIsNum = int.TryParse(other.VersionId, out int otherVersion);
+                if (versionIsNum && otherVersionIsNum)
+                {
+                    result = version.CompareTo(otherVersion);
+                }
+                else
+                {
+                    result = string.Compare(VersionId, other.VersionId, StringComparison.OrdinalIgnoreCase);
+                }
+            }
+            else
+            {
+                result = 0;
+            }
+
+            return result;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -230,19 +230,19 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
             var index = 0;
             var mergeWrappersWithVersions = new List<(MergeResourceWrapper Wrapper, bool KeepVersion, int ResourceVersion, int? ExistingVersion)>();
-            var prevResourceId = string.Empty;
+            ResourceKey prevResourceId = null;
             foreach (var resourceExt in resources) // if list contains more that one version per resource it must be sorted by id and last updated DESC.
             {
                 var metaHistory = true;
                 var resource = resourceExt.Wrapper;
-                var setAsHistory = prevResourceId == resource.ResourceId; // this assumes that first resource version is the latest one
+                var setAsHistory = prevResourceId == resource.ToResourceKey(true); // this assumes that first resource version is the latest one
                 //// negative versions are historical by definition
                 if (resourceExt.KeepVersion && int.Parse(resource.Version) < 0)
                 {
                     setAsHistory = true;
                 }
 
-                prevResourceId = resource.ResourceId;
+                prevResourceId = resource.ToResourceKey(true);
                 var weakETag = resourceExt.WeakETag;
                 int? eTag = weakETag == null
                     ? null
@@ -402,16 +402,16 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             // Resources with keepVersion=true must be in separate call, and not mixed with keepVersion=false ones.
             // Sort them in groups by resource id and order by version.
             // In each group find the smallest version higher then existing
-            prevResourceId = string.Empty;
+            prevResourceId = null;
             var notSetInResoureGroup = false;
             foreach (var mergeWrapper in mergeWrappersWithVersions.Where(x => x.KeepVersion && x.ExistingVersion != 0).OrderBy(x => x.Wrapper.ResourceWrapper.ResourceId).ThenBy(x => x.ResourceVersion))
             {
-                if (prevResourceId != mergeWrapper.Wrapper.ResourceWrapper.ResourceId) // this should reset flag on each resource id group including first.
+                if (prevResourceId != mergeWrapper.Wrapper.ResourceWrapper.ToResourceKey(true)) // this should reset flag on each resource id group including first.
                 {
                     notSetInResoureGroup = true;
                 }
 
-                prevResourceId = mergeWrapper.Wrapper.ResourceWrapper.ResourceId;
+                prevResourceId = mergeWrapper.Wrapper.ResourceWrapper.ToResourceKey(true);
 
                 if (notSetInResoureGroup && mergeWrapper.ResourceVersion > mergeWrapper.ExistingVersion)
                 {

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -230,19 +230,19 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
             var index = 0;
             var mergeWrappersWithVersions = new List<(MergeResourceWrapper Wrapper, bool KeepVersion, int ResourceVersion, int? ExistingVersion)>();
-            ResourceKey prevResourceId = null;
+            ResourceKey prevResourceKey = null;
             foreach (var resourceExt in resources) // if list contains more that one version per resource it must be sorted by id and last updated DESC.
             {
                 var metaHistory = true;
                 var resource = resourceExt.Wrapper;
-                var setAsHistory = prevResourceId == resource.ToResourceKey(true); // this assumes that first resource version is the latest one
+                var setAsHistory = prevResourceKey == resource.ToResourceKey(true); // this assumes that first resource version is the latest one
                 //// negative versions are historical by definition
                 if (resourceExt.KeepVersion && int.Parse(resource.Version) < 0)
                 {
                     setAsHistory = true;
                 }
 
-                prevResourceId = resource.ToResourceKey(true);
+                prevResourceKey = resource.ToResourceKey(true);
                 var weakETag = resourceExt.WeakETag;
                 int? eTag = weakETag == null
                     ? null
@@ -402,16 +402,16 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             // Resources with keepVersion=true must be in separate call, and not mixed with keepVersion=false ones.
             // Sort them in groups by resource id and order by version.
             // In each group find the smallest version higher then existing
-            prevResourceId = null;
+            prevResourceKey = null;
             var notSetInResoureGroup = false;
-            foreach (var mergeWrapper in mergeWrappersWithVersions.Where(x => x.KeepVersion && x.ExistingVersion != 0).OrderBy(x => x.Wrapper.ResourceWrapper.ResourceId).ThenBy(x => x.ResourceVersion))
+            foreach (var mergeWrapper in mergeWrappersWithVersions.Where(x => x.KeepVersion && x.ExistingVersion != 0).OrderBy(x => x.Wrapper.ResourceWrapper.ToResourceKey(true)).ThenBy(x => x.ResourceVersion))
             {
-                if (prevResourceId != mergeWrapper.Wrapper.ResourceWrapper.ToResourceKey(true)) // this should reset flag on each resource id group including first.
+                if (prevResourceKey != mergeWrapper.Wrapper.ResourceWrapper.ToResourceKey(true)) // this should reset flag on each resource id group including first.
                 {
                     notSetInResoureGroup = true;
                 }
 
-                prevResourceId = mergeWrapper.Wrapper.ResourceWrapper.ToResourceKey(true);
+                prevResourceKey = mergeWrapper.Wrapper.ResourceWrapper.ToResourceKey(true);
 
                 if (notSetInResoureGroup && mergeWrapper.ResourceVersion > mergeWrapper.ExistingVersion)
                 {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BundleEdgeCaseTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BundleEdgeCaseTests.cs
@@ -98,6 +98,92 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         }
 
         [Fact]
+        public async Task WhenProcessingABundle_ResourceIdIsSharedBetweenResourceTypes_AllOperationsSucceed()
+        {
+            CancellationToken cancellationToken = CancellationToken.None;
+
+            Guid globalId = Guid.NewGuid();
+
+            // 1 - Create an observation with 5 versions.
+            for (int i = 0; i < 5; i++)
+            {
+                Observation observation = new Observation()
+                {
+                    Category = new List<CodeableConcept>()
+                    {
+                        new CodeableConcept("x", "10"),
+                    },
+                    Text = new Narrative("text"),
+                    Id = globalId.ToString(),
+                    Issued = DateTime.UtcNow,
+                    Status = ObservationStatus.Amended,
+                };
+
+                FhirResponse<Observation> response = await _client.UpdateAsync<Observation>(observation, cancellationToken: cancellationToken);
+                Assert.True(response.StatusCode == HttpStatusCode.OK || response.StatusCode == HttpStatusCode.Created, "Bundle ingestion did not complete as expected.");
+            }
+
+            // 2 - Create a bundle with Patient and Observation, all with the name Resource ID.
+            Bundle bundle = new Bundle() { Type = BundleType.Transaction };
+            EntryComponent entryComponent1 = new EntryComponent()
+            {
+                Resource = new Patient()
+                {
+                    Id = globalId.ToString(),
+                    Name = new List<HumanName> { new HumanName() { Family = "Rush", Given = new List<string> { $"John" } } },
+                    Gender = AdministrativeGender.Male,
+                    BirthDate = "1974-12-21",
+                    Text = new Narrative($"<div>{DateTime.UtcNow.ToString("o")}</div>"),
+                },
+                Request = new RequestComponent()
+                {
+                    Method = HTTPVerb.GET,
+                    Url = $"Patient/{globalId}",
+                },
+            };
+            bundle.Entry.Add(entryComponent1);
+
+            EntryComponent entryComponent2 = new EntryComponent()
+            {
+                Resource = new Observation()
+                {
+                    Category = new List<CodeableConcept>()
+                    {
+                        new CodeableConcept("x", "10"),
+                    },
+                    Text = new Narrative("text"),
+                    Id = globalId.ToString(),
+                    Issued = DateTime.UtcNow,
+                    Status = ObservationStatus.Amended,
+                },
+                Request = new RequestComponent()
+                {
+                    Method = HTTPVerb.GET,
+                    Url = $"Observation/{globalId}",
+                },
+            };
+            bundle.Entry.Add(entryComponent2);
+
+            FhirResponse<Bundle> bundleResponse = await _client.PostBundleAsync(
+                bundle,
+                new FhirBundleOptions() { BundleProcessingLogic = FhirBundleProcessingLogic.Parallel },
+                cancellationToken);
+
+            Assert.True(bundleResponse.StatusCode == HttpStatusCode.OK, "Bundle ingestion did not complete as expected.");
+
+            foreach (EntryComponent item in bundleResponse.Resource.Entry)
+            {
+                Assert.True(item.Response.Status == "200" || item.Response.Status == "201");
+            }
+
+            Patient p1 = await _client.ReadAsync<Patient>($"Patient/{globalId}", cancellationToken);
+            Assert.True(p1.Meta.VersionId == "1");
+
+            Observation o1 = await _client.ReadAsync<Observation>($"Observation/{globalId}", cancellationToken);
+            Assert.True(p1.Meta.VersionId == "6");
+        }
+
+        [Fact]
         public async Task WhenProcessingABundle_IfItContainsHistoryEndpointRequests_ThenReturnTheResourcesAsExpected()
         {
             CancellationToken cancellationToken = CancellationToken.None;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BundleEdgeCaseTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BundleEdgeCaseTests.cs
@@ -100,87 +100,86 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [Fact]
         public async Task WhenProcessingABundle_ResourceIdIsSharedBetweenResourceTypes_AllOperationsSucceed()
         {
+            // In this test we validate that when multiple resources in the same bundle share the same ID, all operations complete successfully and the version of each resource is increased as expected.
+            // This is an edge case, but it can leave resources in a bad state where all available versions are set as historical.
+
             CancellationToken cancellationToken = CancellationToken.None;
 
-            Guid globalId = Guid.NewGuid();
+            // 0 - Create an unique ID to be used in all resources.
+            Guid uniqueIdToAllResource = Guid.NewGuid();
+
+            const int observationInitialVersions = 5;
 
             // 1 - Create an observation with 5 versions.
-            for (int i = 0; i < 5; i++)
+            for (int i = 0; i < observationInitialVersions; i++)
             {
-                Observation observation = new Observation()
-                {
-                    Category = new List<CodeableConcept>()
-                    {
-                        new CodeableConcept("x", "10"),
-                    },
-                    Text = new Narrative("text"),
-                    Id = globalId.ToString(),
-                    Issued = DateTime.UtcNow,
-                    Status = ObservationStatus.Amended,
-                };
+                Observation observation = CreateObservation(uniqueIdToAllResource);
 
                 FhirResponse<Observation> response = await _client.UpdateAsync<Observation>(observation, cancellationToken: cancellationToken);
                 Assert.True(response.StatusCode == HttpStatusCode.OK || response.StatusCode == HttpStatusCode.Created, "Bundle ingestion did not complete as expected.");
+                Assert.True(response.Resource.Meta.VersionId == (i + 1).ToString(), "Observation version did not match expected value.");
             }
 
-            // 2 - Create a bundle with Patient and Observation, all with the name Resource ID.
-            Bundle bundle = new Bundle() { Type = BundleType.Transaction };
-            EntryComponent entryComponent1 = new EntryComponent()
+            // 2 - Create bundles with Patient and Observation, all with the same Resource ID.
+            int patientVersionAfterUpdates = 1;
+            int observationVersionAfterUpdates = observationInitialVersions + 1;
+            for (int i = 0; i < 10; i++)
             {
-                Resource = new Patient()
-                {
-                    Id = globalId.ToString(),
-                    Name = new List<HumanName> { new HumanName() { Family = "Rush", Given = new List<string> { $"John" } } },
-                    Gender = AdministrativeGender.Male,
-                    BirthDate = "1974-12-21",
-                    Text = new Narrative($"<div>{DateTime.UtcNow.ToString("o")}</div>"),
-                },
-                Request = new RequestComponent()
-                {
-                    Method = HTTPVerb.GET,
-                    Url = $"Patient/{globalId}",
-                },
-            };
-            bundle.Entry.Add(entryComponent1);
+                Bundle bundle = new Bundle() { Type = BundleType.Batch };
 
-            EntryComponent entryComponent2 = new EntryComponent()
-            {
-                Resource = new Observation()
+                Patient patient = CreatePatient(uniqueIdToAllResource);
+                bundle.Entry.Add(CreatePutEntryComponent(patient));
+
+                Observation observation = CreateObservation(uniqueIdToAllResource);
+                bundle.Entry.Add(CreatePutEntryComponent(observation));
+
+                FhirResponse<Bundle> bundleResponse = await _client.PostBundleAsync(
+                    bundle,
+                    new FhirBundleOptions() { BundleProcessingLogic = FhirBundleProcessingLogic.Parallel },
+                    cancellationToken);
+
+                Assert.True(bundleResponse.StatusCode == HttpStatusCode.OK, "Bundle ingestion did not complete as expected.");
+
+                foreach (EntryComponent item in bundleResponse.Resource.Entry)
                 {
-                    Category = new List<CodeableConcept>()
+                    if (item.Resource is Patient)
                     {
-                        new CodeableConcept("x", "10"),
-                    },
-                    Text = new Narrative("text"),
-                    Id = globalId.ToString(),
-                    Issued = DateTime.UtcNow,
-                    Status = ObservationStatus.Amended,
-                },
-                Request = new RequestComponent()
-                {
-                    Method = HTTPVerb.GET,
-                    Url = $"Observation/{globalId}",
-                },
-            };
-            bundle.Entry.Add(entryComponent2);
+                        Assert.True(item.Resource.Meta.VersionId == patientVersionAfterUpdates.ToString(), "Patient version did not match expected value.");
+                    }
+                    else if (item.Resource is Observation)
+                    {
+                        Assert.True(item.Resource.Meta.VersionId == observationVersionAfterUpdates.ToString(), "Observation version did not match expected value.");
+                    }
 
-            FhirResponse<Bundle> bundleResponse = await _client.PostBundleAsync(
-                bundle,
-                new FhirBundleOptions() { BundleProcessingLogic = FhirBundleProcessingLogic.Parallel },
-                cancellationToken);
+                    Assert.True(item.Response.Status == "200" || item.Response.Status == "201");
+                }
 
-            Assert.True(bundleResponse.StatusCode == HttpStatusCode.OK, "Bundle ingestion did not complete as expected.");
+                Patient patientResponse = await _client.ReadAsync<Patient>($"Patient/{uniqueIdToAllResource}", cancellationToken);
+                Assert.True(patientResponse.Meta.VersionId == patientVersionAfterUpdates.ToString(), "Patient version did not match expected value.");
 
-            foreach (EntryComponent item in bundleResponse.Resource.Entry)
-            {
-                Assert.True(item.Response.Status == "200" || item.Response.Status == "201");
+                Observation observationResponse = await _client.ReadAsync<Observation>($"Observation/{uniqueIdToAllResource}", cancellationToken);
+                Assert.True(observationResponse.Meta.VersionId == observationVersionAfterUpdates.ToString(), "Observation version did not match expected value.");
+
+                patientVersionAfterUpdates++;
+                observationVersionAfterUpdates++;
             }
 
-            Patient p1 = await _client.ReadAsync<Patient>($"Patient/{globalId}", cancellationToken);
-            Assert.True(p1.Meta.VersionId == "1");
+            // 3 - Run additional updates to ensure resource is updatable after all those operations.
+            for (int i = 0; i < 5; i++)
+            {
+                Patient patient = CreatePatient(uniqueIdToAllResource);
+                FhirResponse<Patient> patientResponse = await _client.UpdateAsync(patient, cancellationToken: cancellationToken);
+                Assert.True(patientResponse.StatusCode == HttpStatusCode.OK, "Patient update did not complete as expected.");
+                Assert.True(patientResponse.Resource.Meta.VersionId == patientVersionAfterUpdates.ToString(), "Patient version did not match expected value.");
 
-            Observation o1 = await _client.ReadAsync<Observation>($"Observation/{globalId}", cancellationToken);
-            Assert.True(p1.Meta.VersionId == "6");
+                Observation observation = CreateObservation(uniqueIdToAllResource);
+                FhirResponse<Observation> observationResponse = await _client.UpdateAsync(observation, cancellationToken: cancellationToken);
+                Assert.True(observationResponse.StatusCode == HttpStatusCode.OK, "Observation update did not complete as expected.");
+                Assert.True(observationResponse.Resource.Meta.VersionId == observationVersionAfterUpdates.ToString(), "Observation version did not match expected value.");
+
+                patientVersionAfterUpdates++;
+                observationVersionAfterUpdates++;
+            }
         }
 
         [Fact]
@@ -290,7 +289,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
                     // Create Patient clones in memory.
                     Patient tempPatient = Clone(patientsUserForInitialization[j]);
 
-                    EntryComponent entryComponent = CreateEntryComponent(tempPatient);
+                    EntryComponent entryComponent = CreatePutEntryComponent(tempPatient);
 
                     bundle.Entry.Add(entryComponent);
                 }
@@ -344,6 +343,34 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
                 $"Total mumber of created patients ({numberOfPatientsPerBundle}) is different than the number ingested during the test {uniquePatientIds}.");
         }
 
+        private static Observation CreateObservation(Guid id)
+        {
+            return new Observation()
+            {
+                Category = new List<CodeableConcept>()
+                    {
+                        new CodeableConcept("x", "10"),
+                    },
+                Text = new Narrative($"<div>{DateTime.UtcNow.ToString("o")}</div>"),
+                Id = id.ToString(),
+                Issued = DateTime.UtcNow,
+                Status = ObservationStatus.Amended,
+                Code = new CodeableConcept("x", "10"),
+            };
+        }
+
+        private static Patient CreatePatient(Guid id)
+        {
+            return new Patient()
+            {
+                Id = id.ToString(),
+                Name = new List<HumanName> { new HumanName() { Family = "Rush", Given = new List<string> { $"John" } } },
+                Gender = AdministrativeGender.Male,
+                BirthDate = "1974-12-21",
+                Text = new Narrative($"<div>{DateTime.UtcNow.ToString("o")}</div>"),
+            };
+        }
+
         private static Patient Clone(Patient patient)
         {
             // Patient does not have a native Clone method.
@@ -360,15 +387,15 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             return clone;
         }
 
-        private static EntryComponent CreateEntryComponent(Patient patient)
+        private static EntryComponent CreatePutEntryComponent(Resource resource)
         {
             EntryComponent entryComponent = new EntryComponent()
             {
-                Resource = patient,
+                Resource = resource,
                 Request = new RequestComponent()
                 {
                     Method = HTTPVerb.PUT,
-                    Url = $"Patient/{patient.Id}",
+                    Url = $"{resource.TypeName}/{resource.Id}",
                 },
             };
 


### PR DESCRIPTION
## Description
SQL Data Store that can leave resources in a “full history mode” where the highest version available is set as “IsHistory: true”.

This behavior will lead to two problems:

Resources cannot be updated: as the service will try to recreate the combination of Resource Type, Resource ID and Version 1, and it’ll collide with the existing constraints.
* The resource does not have an active version, that will return HTTP404 when queried, unless the resource is queried explicitly for one of its historical versions.
* The following screenshot shows how the version system will look when this bug is present.

In this case, all versions of the record with ResourceTypeID 96 are set as “IsHistory: 1”, which indicates that those are all historical versions of the same record, not leaving an active version of the record.

The correct for this scenario would be the following, where the highest version is set as “IsHistory:0”.

Cases where this problem can happen:
* Import, when a blob has resources with different resource types sharing the same resource ID.
* Parallel bundles, when the bundle has resources with different resource types sharing the same resource ID.

---

The current plan includes:

Hotfix release to fix and stop the problem from happening with more resources.
An update to active the sleeping active version of the affected resources.

## Related issues
Addresses [AB#188729](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/188729)

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
