### PR TITLE
Add ReindexCompletion Notification

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobMetricsNotification.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexJobMetricsNotification.cs
@@ -1,0 +1,118 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Health.Fhir.Core.Features.Metrics;
+using Microsoft.Health.Fhir.ValueSets;
+
+namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
+{
+    /// <summary>
+    /// Represents the metrics notification payload for a completed reindex job.
+    /// </summary>
+    public class ReindexJobMetricsNotification : IMetricsNotification
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReindexJobMetricsNotification"/> class.
+        /// </summary>
+        /// <param name="id">The reindex job ID.</param>
+        /// <param name="status">The final reindex job status.</param>
+        /// <param name="createTime">The time the reindex job was created.</param>
+        /// <param name="endTime">The time the reindex job completed.</param>
+        /// <param name="succeededCount">The number of successfully reindexed resources.</param>
+        /// <param name="failedCount">The number of resources that failed reindexing.</param>
+        /// <param name="createdChildJobs">The number of child processing jobs created.</param>
+        /// <param name="completedChildJobs">The number of child processing jobs completed.</param>
+        /// <param name="searchParams">The search parameter URIs included in reindexing.</param>
+        /// <param name="resourceTypes">The resource types included in reindexing.</param>
+        public ReindexJobMetricsNotification(
+            string id,
+            string status,
+            DateTimeOffset createTime,
+            DateTimeOffset endTime,
+            long? succeededCount,
+            long? failedCount,
+            int createdChildJobs,
+            int completedChildJobs,
+            IReadOnlyCollection<string> searchParams,
+            IReadOnlyCollection<string> resourceTypes)
+        {
+            FhirOperation = AuditEventSubType.Reindex;
+            ResourceType = null;
+
+            Id = id;
+            Status = status;
+            CreateTime = createTime;
+            EndTime = endTime;
+            SucceededCount = succeededCount;
+            FailedCount = failedCount;
+            CreatedChildJobs = createdChildJobs;
+            CompletedChildJobs = completedChildJobs;
+            SearchParams = searchParams;
+            ResourceTypes = resourceTypes;
+        }
+
+        /// <summary>
+        /// Gets the FHIR operation name associated with this metrics notification.
+        /// </summary>
+        public string FhirOperation { get; }
+
+        /// <summary>
+        /// Gets the resource type for this metrics notification.
+        /// </summary>
+        public string ResourceType { get; }
+
+        /// <summary>
+        /// Gets the reindex job ID.
+        /// </summary>
+        public string Id { get; }
+
+        /// <summary>
+        /// Gets the final reindex job status.
+        /// </summary>
+        public string Status { get; }
+
+        /// <summary>
+        /// Gets the time the reindex job was created.
+        /// </summary>
+        public DateTimeOffset CreateTime { get; }
+
+        /// <summary>
+        /// Gets the time the reindex job completed.
+        /// </summary>
+        public DateTimeOffset EndTime { get; }
+
+        /// <summary>
+        /// Gets the number of successfully reindexed resources.
+        /// </summary>
+        public long? SucceededCount { get; }
+
+        /// <summary>
+        /// Gets the number of resources that failed reindexing.
+        /// </summary>
+        public long? FailedCount { get; }
+
+        /// <summary>
+        /// Gets the number of child processing jobs created.
+        /// </summary>
+        public int CreatedChildJobs { get; }
+
+        /// <summary>
+        /// Gets the number of child processing jobs completed.
+        /// </summary>
+        public int CompletedChildJobs { get; }
+
+        /// <summary>
+        /// Gets the search parameter URIs included in reindexing.
+        /// </summary>
+        public IReadOnlyCollection<string> SearchParams { get; }
+
+        /// <summary>
+        /// Gets the resource types included in reindexing.
+        /// </summary>
+        public IReadOnlyCollection<string> ResourceTypes { get; }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexOrchestratorJob.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexOrchestratorJob.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
 using Hl7.Fhir.Model;
+using MediatR;
 using Microsoft.AspNetCore.JsonPatch.Internal;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
@@ -42,6 +43,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
         private readonly ISearchParameterStatusManager _searchParameterStatusManager;
         private readonly IModelInfoProvider _modelInfoProvider;
         private readonly ISearchParameterOperations _searchParameterOperations;
+        private readonly IMediator _mediator;
         private readonly bool _isSurrogateIdRangingSupported;
         private readonly CoreFeatureConfiguration _coreFeatureConfiguration;
         private readonly OperationsConfiguration _operationsConfiguration;
@@ -91,6 +93,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             ISearchParameterOperations searchParameterOperations,
             IFhirRuntimeConfiguration fhirRuntimeConfiguration,
             ILoggerFactory loggerFactory,
+            IMediator mediator,
             IOptions<CoreFeatureConfiguration> coreFeatureConfiguration,
             IOptions<OperationsConfiguration> operationsConfiguration)
         {
@@ -101,6 +104,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             EnsureArg.IsNotNull(modelInfoProvider, nameof(modelInfoProvider));
             EnsureArg.IsNotNull(searchParameterStatusManager, nameof(searchParameterStatusManager));
             EnsureArg.IsNotNull(searchParameterOperations, nameof(searchParameterOperations));
+            EnsureArg.IsNotNull(mediator, nameof(mediator));
             EnsureArg.IsNotNull(coreFeatureConfiguration, nameof(coreFeatureConfiguration));
             EnsureArg.IsNotNull(coreFeatureConfiguration.Value, nameof(coreFeatureConfiguration.Value));
             EnsureArg.IsNotNull(operationsConfiguration, nameof(operationsConfiguration));
@@ -113,6 +117,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             _modelInfoProvider = modelInfoProvider;
             _searchParameterStatusManager = searchParameterStatusManager;
             _searchParameterOperations = searchParameterOperations;
+            _mediator = mediator;
             _coreFeatureConfiguration = coreFeatureConfiguration.Value;
             _operationsConfiguration = operationsConfiguration.Value;
 
@@ -179,6 +184,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             {
                 HandleException(ex);
             }
+
+            await PublishReindexMetricsNotification();
 
             return JsonConvert.SerializeObject(_currentResult);
         }
@@ -749,6 +756,34 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             LogReindexJobRecordErrorMessage();
 
             _logger.LogJobError(ex, _jobInfo, "ReindexJob Failed and didn't complete.");
+        }
+
+        /// <summary>
+        /// Publishes a metrics notification with the final reindex job results.
+        /// Wrapped in try/catch to prevent metrics failures from affecting the job outcome.
+        /// </summary>
+        private async Task PublishReindexMetricsNotification()
+        {
+            try
+            {
+                var notification = new ReindexJobMetricsNotification(
+                    _jobInfo.Id.ToString(),
+                    _reindexJobRecord.Status.ToString(),
+                    _jobInfo.CreateDate,
+                    Clock.UtcNow,
+                    _currentResult.SucceededResources,
+                    _currentResult.FailedResources,
+                    _currentResult.CreatedJobs,
+                    _currentResult.CompletedJobs,
+                    _reindexJobRecord.SearchParams?.ToList() ?? new List<string>(),
+                    _reindexJobRecord.Resources?.ToList() ?? new List<string>());
+
+                await _mediator.Publish(notification, CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogJobWarning(ex, _jobInfo, "Failed to publish reindex job metrics notification.");
+            }
         }
 
         private async Task UpdateSearchParameterStatus(List<JobInfo> completedJobs, List<string> readySearchParameters, CancellationToken cancellationToken)

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexProcessingJob.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexProcessingJob.cs
@@ -13,12 +13,15 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
+using MediatR;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using Microsoft.Health.Abstractions.Exceptions;
+using Microsoft.Health.Core;
 using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Core.Features.Operations;
 using Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models;
 using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Features.Search;
@@ -62,6 +65,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
         private readonly IResourceWrapperFactory _resourceWrapperFactory;
         private readonly Func<IScoped<IFhirDataStore>> _fhirDataStoreFactory;
         private readonly ILogger<ReindexProcessingJob> _logger;
+        private readonly IMediator _mediator;
         private readonly ISearchParameterStatusManager _searchParameterStatusManager;
         private readonly ISearchParameterOperations _searchParameterOperations;
 
@@ -87,7 +91,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             IResourceWrapperFactory resourceWrapperFactory,
             ISearchParameterOperations searchParameterOperations,
             ISearchParameterStatusManager searchParameterStatusManager,
-            ILogger<ReindexProcessingJob> logger)
+            ILogger<ReindexProcessingJob> logger,
+            IMediator mediator)
         {
             EnsureArg.IsNotNull(searchServiceFactory, nameof(searchServiceFactory));
             EnsureArg.IsNotNull(fhirDataStoreFactory, nameof(fhirDataStoreFactory));
@@ -95,6 +100,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             EnsureArg.IsNotNull(searchParameterOperations, nameof(searchParameterOperations));
             EnsureArg.IsNotNull(searchParameterStatusManager, nameof(searchParameterStatusManager));
             EnsureArg.IsNotNull(logger, nameof(logger));
+            EnsureArg.IsNotNull(mediator, nameof(mediator));
 
             _searchServiceFactory = searchServiceFactory;
             _fhirDataStoreFactory = fhirDataStoreFactory;
@@ -102,6 +108,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             _searchParameterStatusManager = searchParameterStatusManager;
             _searchParameterOperations = searchParameterOperations;
             _logger = logger;
+            _mediator = mediator;
         }
 
         public async Task<string> ExecuteAsync(JobInfo jobInfo, CancellationToken cancellationToken)
@@ -119,6 +126,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             _effectiveBatchSize = (int)_reindexProcessingJobDefinition.MaximumNumberOfResourcesPerQuery;
 
             await ProcessQueryAsync(cancellationToken);
+
+            await PublishProcessingJobMetricsNotification();
 
             return JsonConvert.SerializeObject(_reindexProcessingJobResult);
         }
@@ -694,6 +703,34 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
         {
             using IScoped<IFhirDataStore> store = _fhirDataStoreFactory();
             await store.Value.TryLogEvent(process, status, text, startDate, cancellationToken);
+        }
+
+        /// <summary>
+        /// Publishes a metrics notification with the processing job results.
+        /// Wrapped in try/catch to prevent metrics failures from affecting the job outcome.
+        /// </summary>
+        private async Task PublishProcessingJobMetricsNotification()
+        {
+            try
+            {
+                var notification = new ReindexJobMetricsNotification(
+                    _jobInfo.Id.ToString(),
+                    _reindexProcessingJobResult.Error == null ? OperationStatus.Completed.ToString() : OperationStatus.Failed.ToString(),
+                    _jobInfo.CreateDate,
+                    Clock.UtcNow,
+                    _reindexProcessingJobResult.SucceededResourceCount,
+                    _reindexProcessingJobResult.FailedResourceCount,
+                    0,
+                    0,
+                    _reindexProcessingJobDefinition.SearchParameterUrls?.ToList() ?? new List<string>(),
+                    new List<string> { _reindexProcessingJobDefinition.ResourceType });
+
+                await _mediator.Publish(notification, CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogJobWarning(ex, _jobInfo, "Failed to publish reindex processing job metrics notification.");
+            }
         }
 
         private static ReindexProcessingJobDefinition DeserializeJobDefinition(JobInfo jobInfo)

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexOrchestratorJobTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexOrchestratorJobTests.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using EnsureThat.Enforcers;
 using Hl7.Fhir.Rest;
 using Hl7.Fhir.Utility;
+using MediatR;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Extensions.DependencyInjection;
@@ -76,9 +77,10 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
             _cancellationTokenSource?.Dispose();
         }
 
-        private ReindexOrchestratorJob CreateReindexOrchestratorJob(IFhirRuntimeConfiguration runtimeConfig = null, int waitMultiplier = 0)
+        private ReindexOrchestratorJob CreateReindexOrchestratorJob(IFhirRuntimeConfiguration runtimeConfig = null, int waitMultiplier = 0, IMediator mediator = null)
         {
             runtimeConfig ??= new AzureHealthDataServicesRuntimeConfiguration();
+            mediator ??= Substitute.For<IMediator>();
 
             var coreFeatureConfig = Substitute.For<IOptions<CoreFeatureConfiguration>>();
             coreFeatureConfig.Value.Returns(new CoreFeatureConfiguration());
@@ -97,6 +99,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                 _searchParameterOperations,
                 runtimeConfig,
                 NullLoggerFactory.Instance,
+                mediator,
                 coreFeatureConfig,
                 operationsConfig);
         }
@@ -275,6 +278,49 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
             Assert.NotNull(jobResult);
             Assert.NotNull(jobResult.Error);
             Assert.Contains(jobResult.Error, e => e.Diagnostics.Contains("cancelled"));
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_WhenCompleted_PublishesMetricsNotification()
+        {
+            var mediator = Substitute.For<IMediator>();
+            _searchParameterStatusManager.GetAllSearchParameterStatus(Arg.Any<CancellationToken>())
+                .Returns(new List<ResourceSearchParameterStatus>());
+
+            var orchestrator = CreateReindexOrchestratorJob(mediator: mediator);
+            var jobInfo = await CreateReindexJobRecord();
+
+            await orchestrator.ExecuteAsync(jobInfo, _cancellationToken);
+
+            _ = mediator.Received(1).Publish(
+                Arg.Is<ReindexJobMetricsNotification>(
+                    notification => notification.Id == jobInfo.Id.ToString() &&
+                    notification.FhirOperation == "reindex" &&
+                    notification.SucceededCount == 0 &&
+                    notification.FailedCount == 0),
+                Arg.Any<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_WhenCancelled_StillPublishesMetricsNotification()
+        {
+            var mediator = Substitute.For<IMediator>();
+            var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            _searchParameterStatusManager.GetAllSearchParameterStatus(Arg.Any<CancellationToken>())
+                .Returns(new List<ResourceSearchParameterStatus>());
+
+            var orchestrator = CreateReindexOrchestratorJob(mediator: mediator);
+            var jobInfo = await CreateReindexJobRecord();
+
+            await orchestrator.ExecuteAsync(jobInfo, cts.Token);
+
+            _ = mediator.Received(1).Publish(
+                Arg.Is<ReindexJobMetricsNotification>(
+                    notification => notification.Id == jobInfo.Id.ToString() &&
+                    notification.FhirOperation == "reindex"),
+                Arg.Any<CancellationToken>());
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexProcessingJobTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexProcessingJobTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using MediatR;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Features.Operations;
@@ -42,11 +43,13 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Reinde
         private readonly Func<ReindexProcessingJob> _reindexProcessingJobTaskFactory;
         private readonly CancellationToken _cancellationToken;
         private readonly ISearchParameterStatusManager _searchParameterStatusManager = Substitute.For<ISearchParameterStatusManager>();
+        private IMediator _mediator;
 
         public ReindexProcessingJobTests()
         {
             Func<Health.Extensions.DependencyInjection.IScoped<IFhirDataStore>> fhirDataStoreScope = () => _fhirDataStore.CreateMockScope();
             _cancellationToken = _cancellationTokenSource.Token;
+            _mediator = Substitute.For<IMediator>();
             _reindexProcessingJobTaskFactory = () =>
                  new ReindexProcessingJob(
                      () => _searchService.CreateMockScope(),
@@ -54,7 +57,8 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Reinde
                      _resourceWrapperFactory,
                      _searchParameterOperations,
                      _searchParameterStatusManager,
-                     NullLogger<ReindexProcessingJob>.Instance);
+                     NullLogger<ReindexProcessingJob>.Instance,
+                     _mediator);
         }
 
         [Fact]
@@ -111,6 +115,63 @@ namespace Microsoft.Health.Fhir.Shared.Core.UnitTests.Features.Operations.Reinde
                 await _reindexProcessingJobTaskFactory().ExecuteAsync(jobInfo, _cancellationToken));
 
             Assert.Equal(_mockedSearchCount, result.SucceededResourceCount);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_WhenCompleted_PublishesMetricsNotification()
+        {
+            var mediator = Substitute.For<IMediator>();
+            _mediator = mediator;
+
+            var expectedResourceType = "Account";
+            ReindexProcessingJobDefinition job = new ReindexProcessingJobDefinition()
+            {
+                MaximumNumberOfResourcesPerQuery = 100,
+                MaximumNumberOfResourcesPerWrite = 100,
+                ResourceType = expectedResourceType,
+                ResourceCount = new SearchResultReindex()
+                {
+                    Count = 0,
+                    EndResourceSurrogateId = 0,
+                    StartResourceSurrogateId = 0,
+                    ContinuationToken = null,
+                },
+                SearchParameterHash = "accountHash",
+                SearchParameterUrls = new List<string>() { "http://hl7.org/fhir/SearchParam/Account-status" },
+                TypeId = (int)JobType.ReindexProcessing,
+            };
+
+            _searchParameterOperations.GetSearchParameterHash(Arg.Any<string>()).Returns(job.SearchParameterHash);
+
+            JobInfo jobInfo = new JobInfo()
+            {
+                Id = 1,
+                Definition = JsonConvert.SerializeObject(job),
+                QueueType = (byte)QueueType.Reindex,
+                GroupId = 1,
+                CreateDate = DateTime.UtcNow,
+                Status = JobStatus.Running,
+            };
+
+            _searchService.SearchForReindexAsync(
+                Arg.Any<IReadOnlyList<Tuple<string, string>>>(),
+                Arg.Any<string>(),
+                Arg.Any<bool>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<bool>())
+                .Returns(new SearchResult(Enumerable.Empty<SearchResultEntry>(), null, null, new List<Tuple<string, string>>()));
+
+            var processingJob = _reindexProcessingJobTaskFactory();
+            await processingJob.ExecuteAsync(jobInfo, _cancellationToken);
+
+            _ = mediator.Received(1).Publish(
+                Arg.Is<ReindexJobMetricsNotification>(
+                    notification => notification.Id == jobInfo.Id.ToString() &&
+                    notification.FhirOperation == "reindex" &&
+                    notification.SucceededCount == 0 &&
+                    notification.FailedCount == 0 &&
+                    notification.ResourceTypes.Contains(expectedResourceType)),
+                Arg.Any<CancellationToken>());
         }
 
         private SearchResultEntry CreateSearchResultEntry(string id, string type)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -239,6 +239,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                             _searchParameterOperations,
                             _fixture.FhirRuntimeConfiguration,
                             NullLoggerFactory.Instance,
+                            Substitute.For<IMediator>(),
                             _coreFeatureConfig,
                             _operationsConfig);
                     }
@@ -251,7 +252,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                             _resourceWrapperFactory,
                             _searchParameterOperations,
                             _searchParameterStatusManager,
-                            NullLogger<ReindexProcessingJob>.Instance);
+                            NullLogger<ReindexProcessingJob>.Instance,
+                            Substitute.For<IMediator>());
                     }
                     else
                     {
@@ -1109,6 +1111,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                     _searchParameterOperations,
                     runtimeConfiguration,
                     NullLoggerFactory.Instance,
+                    Substitute.For<IMediator>(),
                     _coreFeatureConfig,
                     _operationsConfig);
 
@@ -1261,7 +1264,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                 _resourceWrapperFactory,
                 _searchParameterOperations,
                 _searchParameterStatusManager,
-                NullLogger<ReindexProcessingJob>.Instance);
+                NullLogger<ReindexProcessingJob>.Instance,
+                Substitute.For<IMediator>());
 
             string resultJson = await processingJob.ExecuteAsync(jobInfo, CancellationToken.None);
             var result = JsonConvert.DeserializeObject<ReindexProcessingJobResult>(resultJson);


### PR DESCRIPTION
## Description
Adds a notification emitted after a reindex job is complete. Matches other jobs like import.

## Related issues
[AB#188199](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/188199)

## Testing
Local testing
Unit testing

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
