### PR TITLE
Fix versioned canonical profile resolution

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Validation/ServerProvideProfileValidationTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Validation/ServerProvideProfileValidationTests.cs
@@ -112,6 +112,38 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Validation
         }
 
         [Fact]
+        public async Task GivenVersionedStructureDefinition_WhenGettingSupportedProfiles_ThenVersionedCanonicalIsReturned()
+        {
+            // Arrange
+            var patientProfile = CreateStructureDefinition("http://example.org/fhir/StructureDefinition/custom-patient", "Patient", "3.0.0");
+            SetupSearchServiceWithResults("StructureDefinition", patientProfile);
+
+            // Act
+            var profiles = await _serverProvideProfileValidation.GetSupportedProfilesAsync("Patient", CancellationToken.None);
+
+            // Assert
+            Assert.Single(profiles);
+            Assert.Contains("http://example.org/fhir/StructureDefinition/custom-patient|3.0.0", profiles);
+        }
+
+        [Fact]
+        public async Task GivenVersionedStructureDefinition_WhenResolvingByCanonicalUriWithVersion_ThenMatchingProfileIsReturned()
+        {
+            // Arrange
+            var patientProfile = CreateStructureDefinition("http://example.org/fhir/StructureDefinition/custom-patient", "Patient", "3.0.0");
+            SetupSearchServiceWithResults("StructureDefinition", patientProfile);
+
+            // Act
+            var profile = await _serverProvideProfileValidation.ResolveByCanonicalUriAsync("http://example.org/fhir/StructureDefinition/custom-patient|3.0.0");
+
+            // Assert
+            Assert.NotNull(profile);
+            var structureDefinition = Assert.IsType<StructureDefinition>(profile);
+            Assert.Equal("http://example.org/fhir/StructureDefinition/custom-patient", structureDefinition.Url);
+            Assert.Equal("3.0.0", structureDefinition.Version);
+        }
+
+        [Fact]
         public async Task GivenANewStructureDefinition_WhenBackgroundLoopRuns_ThenSyncIsRequested()
         {
             // Arrange
@@ -353,12 +385,13 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Validation
             _serverProvideProfileValidation?.Dispose();
         }
 
-        private static StructureDefinition CreateStructureDefinition(string url, string type)
+        private static StructureDefinition CreateStructureDefinition(string url, string type, string version = null)
         {
             return new StructureDefinition
             {
                 Id = Guid.NewGuid().ToString("N").Substring(0, 16), // Generate valid FHIR ID
                 Url = url,
+                Version = version,
                 Name = $"{type}Profile",
                 Status = PublicationStatus.Active,
                 Kind = StructureDefinition.StructureDefinitionKind.Resource,

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Validation/ServerProvideProfileValidation.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Validation/ServerProvideProfileValidation.cs
@@ -138,7 +138,18 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
 
         public async Task<Resource> ResolveByCanonicalUriAsync(string uri)
         {
-            var summary = (await ListSummariesAsync(CancellationToken.None)).ResolveByCanonicalUri(uri);
+            var summaries = (await ListSummariesAsync(CancellationToken.None)).ToList();
+            var summary = summaries.ResolveByCanonicalUri(uri);
+
+            if (summary == null &&
+                TrySplitVersionedCanonicalUri(uri, out string canonicalUri, out string version))
+            {
+                summary = summaries.FirstOrDefault(x =>
+                    string.Equals(x.ResourceUri, canonicalUri, StringComparison.OrdinalIgnoreCase) &&
+                    x.TryGetValue(_structureDefinitionVersionKey, out object summaryVersion) &&
+                    string.Equals(summaryVersion?.ToString(), version, StringComparison.OrdinalIgnoreCase));
+            }
+
             return LoadBySummary(summary);
         }
 
@@ -173,6 +184,30 @@ namespace Microsoft.Health.Fhir.Core.Features.Validation
             }
 
             return url;
+        }
+
+        private static bool TrySplitVersionedCanonicalUri(string uri, out string canonicalUri, out string version)
+        {
+            canonicalUri = uri;
+            version = null;
+
+            if (string.IsNullOrWhiteSpace(uri))
+            {
+                return false;
+            }
+
+            int fragmentIndex = uri.IndexOf('#');
+            string uriWithoutFragment = fragmentIndex >= 0 ? uri.Substring(0, fragmentIndex) : uri;
+            int versionSeparatorIndex = uriWithoutFragment.LastIndexOf('|');
+
+            if (versionSeparatorIndex <= 0 || versionSeparatorIndex == uriWithoutFragment.Length - 1)
+            {
+                return false;
+            }
+
+            canonicalUri = uriWithoutFragment.Substring(0, versionSeparatorIndex);
+            version = uriWithoutFragment.Substring(versionSeparatorIndex + 1);
+            return true;
         }
 
         private static string GetHashForSupportedProfiles(IReadOnlyCollection<ArtifactSummary> summaries)


### PR DESCRIPTION
## Description
Fix versioned canonical profile resolution for validation-backed profile lookup.

This change updates `ServerProvideProfileValidation.ResolveByCanonicalUriAsync` so that when a profile is referenced using a versioned canonical URI such as `http://example.org/fhir/StructureDefinition/custom-patient|3.0.0`, the resolver can match it against the stored `StructureDefinition` by canonical URL plus version.

Without this fallback, versioned profile references could fail resolution even when the corresponding `StructureDefinition` was present on the server.

This PR also adds focused unit tests covering:
- returning versioned supported profile URLs
- resolving a versioned canonical URI to the correct `StructureDefinition`

## Related issues
Addresses #5176.

## Testing
Code changes were validated by adding targeted unit tests in `ServerProvideProfileValidationTests` for:
- `GivenVersionedStructureDefinition_WhenGettingSupportedProfiles_ThenVersionedCanonicalIsReturned`
- `GivenVersionedStructureDefinition_WhenResolvingByCanonicalUriWithVersion_ThenMatchingProfileIsReturned`

Planned test command:
```powershell
dotnet test src\Microsoft.Health.Fhir.R4.Core.UnitTests\Microsoft.Health.Fhir.R4.Core.UnitTests.csproj --filter ServerProvideProfileValidationTests