### PR TITLE
$import - Retry in case of in case of Surrogate ID collision

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Storage/SqlServerFhirDataStoreUnitTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Storage/SqlServerFhirDataStoreUnitTests.cs
@@ -261,7 +261,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Storage
         {
             // Arrange
             var sqlRetryService = Substitute.For<ISqlRetryService>();
-            var sqlException = SqlExceptionFactory.GetSqlException(FhirSqlErrorCodes.FailedDependency, "Duplicated keys.");
+            var sqlException = SqlExceptionFactory.GetSqlException(FhirSqlErrorCodes.DuplicateKeyConflict, "Duplicated keys.");
             using var cts = new CancellationTokenSource();
 
             sqlRetryService.ExecuteReaderAsync(

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Storage/SqlServerFhirDataStoreUnitTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Storage/SqlServerFhirDataStoreUnitTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -257,7 +258,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Storage
         }
 
         [Fact]
-        public async Task MergeAsync_OnSqlFailedDependency_RetriesBeforeThrowing()
+        public async Task MergeAsync_OnSqlDuplicateKeyConflict_DoNotRetryBeforeThrowing()
         {
             // Arrange
             var sqlRetryService = Substitute.For<ISqlRetryService>();
@@ -273,23 +274,14 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Storage
                 Arg.Any<bool>())
             .Throws(sqlException);
 
-            sqlRetryService
-                .TryLogEvent(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
-                .Returns(async callInfo =>
-                {
-                    cts.Cancel();
-                    await Task.CompletedTask;
-                });
-
             var dataStore = CreateSqlServerFhirDataStore(sqlRetryService);
             var resources = CreateResourceWrapperOperations();
 
-            // Act & Assert
-            await Assert.ThrowsAsync<TaskCanceledException>(
+            // Act & Assert.
+            SqlException sqlExceptionAsFinalResult = await Assert.ThrowsAsync<SqlException>(
                 () => dataStore.MergeAsync(resources, MergeOptions.Default, cts.Token));
 
-            await sqlRetryService.Received(1)
-                .TryLogEvent("MergeAsync", "Warn", Arg.Any<string>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>());
+            Assert.True(sqlExceptionAsFinalResult.Errors.Cast<SqlError>().Any(e => e.Number == FhirSqlErrorCodes.DuplicateKeyConflict), "Expected a DuplicateKeyConflict error.");
         }
 
         private static SqlServerFhirDataStore CreateSqlServerFhirDataStore(ISqlRetryService sqlRetryService)

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Storage/SqlServerFhirDataStoreUnitTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Storage/SqlServerFhirDataStoreUnitTests.cs
@@ -258,11 +258,11 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Storage
         }
 
         [Fact]
-        public async Task MergeAsync_OnSqlDuplicateKeyConflict_RetryBeforeThrowing()
+        public async Task MergeAsync_OnSqlSurrogateIdCollision_RetryBeforeThrowing()
         {
             // Arrange
             var sqlRetryService = Substitute.For<ISqlRetryService>();
-            var sqlException = SqlExceptionFactory.GetSqlException(FhirSqlErrorCodes.DuplicateKeyConflict, "Duplicated keys.");
+            var sqlException = SqlExceptionFactory.GetSqlException(FhirSqlErrorCodes.SurrogateIdCollision, "Surrogate Id Collision.");
             using var cts = new CancellationTokenSource();
 
             sqlRetryService.ExecuteReaderAsync(

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Storage/SqlServerFhirDataStoreUnitTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Storage/SqlServerFhirDataStoreUnitTests.cs
@@ -258,7 +258,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Storage
         }
 
         [Fact]
-        public async Task MergeAsync_OnSqlDuplicateKeyConflict_DoNotRetryBeforeThrowing()
+        public async Task MergeAsync_OnSqlDuplicateKeyConflict_RetryBeforeThrowing()
         {
             // Arrange
             var sqlRetryService = Substitute.For<ISqlRetryService>();
@@ -274,14 +274,23 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Storage
                 Arg.Any<bool>())
             .Throws(sqlException);
 
+            sqlRetryService
+                .TryLogEvent(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+                .Returns(async callInfo =>
+                {
+                    cts.Cancel();
+                    await Task.CompletedTask;
+                });
+
             var dataStore = CreateSqlServerFhirDataStore(sqlRetryService);
             var resources = CreateResourceWrapperOperations();
 
-            // Act & Assert.
-            SqlException sqlExceptionAsFinalResult = await Assert.ThrowsAsync<SqlException>(
+            // Act & Assert
+            await Assert.ThrowsAsync<TaskCanceledException>(
                 () => dataStore.MergeAsync(resources, MergeOptions.Default, cts.Token));
 
-            Assert.True(sqlExceptionAsFinalResult.Errors.Cast<SqlError>().Any(e => e.Number == FhirSqlErrorCodes.DuplicateKeyConflict), "Expected a DuplicateKeyConflict error.");
+            await sqlRetryService.Received(1)
+                .TryLogEvent("MergeAsync", "Warn", Arg.Any<string>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>());
         }
 
         private static SqlServerFhirDataStore CreateSqlServerFhirDataStore(ISqlRetryService sqlRetryService)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/ImportProcessingJob.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/ImportProcessingJob.cs
@@ -165,9 +165,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
                 var error = new ImportJobErrorResult() { ErrorMessage = CancelledErrorMessage };
                 throw new JobExecutionException(canceledEx.Message, error, canceledEx, false);
             }
-            catch (SqlException ex) when (ex.Number == FhirSqlErrorCodes.DuplicateKeyConflict)
+            catch (SqlException ex) when (ex.Number == FhirSqlErrorCodes.SurrogateIdCollision)
             {
-                _logger.LogJobInformation(ex, jobInfo, "Exceeded retries on key conflicts. Most likely reason - too many input resources with the same last updated.");
+                _logger.LogJobInformation(ex, jobInfo, "Exceeded retries on Surrogate Id Collision. Most likely reason - too many input resources with the same last updated.");
                 var error = new ImportJobErrorResult() { ErrorMessage = SurrogateIdsErrorMessage, HttpStatusCode = HttpStatusCode.BadRequest, ErrorDetails = ex.ToString() };
                 throw new JobExecutionException(ex.Message, error, ex, false);
             }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/ImportProcessingJob.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Operations/Import/ImportProcessingJob.cs
@@ -165,9 +165,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Operations.Import
                 var error = new ImportJobErrorResult() { ErrorMessage = CancelledErrorMessage };
                 throw new JobExecutionException(canceledEx.Message, error, canceledEx, false);
             }
-            catch (SqlException ex) when (ex.Number == FhirSqlErrorCodes.FailedDependency)
+            catch (SqlException ex) when (ex.Number == FhirSqlErrorCodes.DuplicateKeyConflict)
             {
-                _logger.LogJobInformation(ex, jobInfo, "Exceeded retries on conflicts. Most likely reason - too many input resources with the same last updated.");
+                _logger.LogJobInformation(ex, jobInfo, "Exceeded retries on key conflicts. Most likely reason - too many input resources with the same last updated.");
                 var error = new ImportJobErrorResult() { ErrorMessage = SurrogateIdsErrorMessage, HttpStatusCode = HttpStatusCode.BadRequest, ErrorDetails = ex.ToString() };
                 throw new JobExecutionException(ex.Message, error, ex, false);
             }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/FhirSqlErrorCodes.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/FhirSqlErrorCodes.cs
@@ -18,9 +18,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
         public const int MergeResourcesConcurrentCallsIsAboveOptimal = 50410;
 
         /// <summary>
-        /// Failed dependency. Not enough resources to perform the operation: limit on surrogate IDs per second reached.
+        /// Duplicate Key conflicts. Not enough resources to perform the operation: limit on surrogate IDs per second reached.
         /// This is a transient error and retrying the operation may succeed.
         /// </summary>
-        public const int FailedDependency = 50424;
+        public const int DuplicateKeyConflict = 50424;
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/FhirSqlErrorCodes.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/FhirSqlErrorCodes.cs
@@ -18,9 +18,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
         public const int MergeResourcesConcurrentCallsIsAboveOptimal = 50410;
 
         /// <summary>
-        /// Duplicate Key conflicts. Not enough resources to perform the operation: limit on surrogate IDs per second reached.
+        /// Surrogate ID collision. Not enough resources to perform the operation: limit on surrogate IDs per second reached.
         /// This is a transient error and retrying the operation may succeed.
         /// </summary>
-        public const int DuplicateKeyConflict = 50424;
+        public const int SurrogateIdCollision = 50424;
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -192,13 +192,13 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                                 continue;
                             }
                         }
-                        else if (sqlEx.Number == FhirSqlErrorCodes.DuplicateKeyConflict)
+                        else if (sqlEx.Number == FhirSqlErrorCodes.DuplicateKeyConflict && retries++ < maxRetries)
                         {
                             _logger.LogWarning(e, $"Error from SQL database on {nameof(MergeAsync)} retries={{Retries}} (DuplicateKeyConflict)", retries);
                             await _sqlRetryService.TryLogEvent(nameof(MergeAsync), "Warn", $"retries={retries}, error={e}, ", null, cancellationToken);
 
-                            // Do not retry immediately as it is likely that the surrogate ID generation is the root cause.
-                            // Regular requests should fail, but background operations (like import) can retry.
+                            await Task.Delay(defaultRetryDelayInMilliseconds, cancellationToken);
+                            continue;
                         }
                     }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -192,9 +192,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                                 continue;
                             }
                         }
-                        else if (sqlEx.Number == FhirSqlErrorCodes.FailedDependency && retries++ < maxRetries)
+                        else if (sqlEx.Number == FhirSqlErrorCodes.DuplicateKeyConflict && retries++ < maxRetries)
                         {
-                            _logger.LogWarning(e, $"Error from SQL database on {nameof(MergeAsync)} retries={{Retries}} (FailedDependency)", retries);
+                            _logger.LogWarning(e, $"Error from SQL database on {nameof(MergeAsync)} retries={{Retries}} (DuplicateKeyConflict)", retries);
                             await _sqlRetryService.TryLogEvent(nameof(MergeAsync), "Warn", $"retries={retries}, error={e}, ", null, cancellationToken);
                             await Task.Delay(defaultRetryDelayInMilliseconds, cancellationToken);
                             continue;
@@ -492,9 +492,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                         continue;
                     }
 
-                    if (sqlEx != null && sqlEx.Number == SqlErrorCodes.Conflict && retries++ < maxRetries)
+                    if (sqlEx != null && (sqlEx.Number == SqlErrorCodes.Conflict || sqlEx.Number == FhirSqlErrorCodes.DuplicateKeyConflict) && retries++ < maxRetries)
                     {
-                        _logger.LogWarning(e, $"Error on {nameof(ImportResourcesInternalAsync)} retries={{Retries}} resources={{Resources}}", retries, resources.Count);
+                        _logger.LogWarning(e, $"Error on {nameof(ImportResourcesInternalAsync)} retries={{Retries}} resources={{Resources}} error={{SqlErrorCode}}", retries, resources.Count, sqlEx.Number);
                         await Task.Delay(retries > 3 ? 10 : 1000, cancellationToken); // if >3 assume that it is id generation problem
                         continue;
                     }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -192,7 +192,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                                 continue;
                             }
                         }
-                        else if (sqlEx.Number == FhirSqlErrorCodes.DuplicateKeyConflict && retries++ < maxRetries)
+                        else if (sqlEx.Number == FhirSqlErrorCodes.DuplicateKeyConflict)
                         {
                             _logger.LogWarning(e, $"Error from SQL database on {nameof(MergeAsync)} retries={{Retries}} (DuplicateKeyConflict)", retries);
                             await _sqlRetryService.TryLogEvent(nameof(MergeAsync), "Warn", $"retries={retries}, error={e}, ", null, cancellationToken);

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                     if (sqlEx != null)
                     {
                         // SQL Conflict (50409) - It indicates a conflict with another concurrent operation, which could be resolved by retrying.
-                        // SQL Failed Dependency (50424) - Rare scenario. It indicates an issue with the surrogate ID generation, which could be resolved by retrying.
+                        // SQL Duplicated Key Conflict (50424) - Rare scenario. It indicates an issue with the surrogate ID generation. Regular API calls should not retry.
 
                         if (sqlEx.Number == SqlErrorCodes.Conflict)
                         {
@@ -196,8 +196,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                         {
                             _logger.LogWarning(e, $"Error from SQL database on {nameof(MergeAsync)} retries={{Retries}} (DuplicateKeyConflict)", retries);
                             await _sqlRetryService.TryLogEvent(nameof(MergeAsync), "Warn", $"retries={retries}, error={e}, ", null, cancellationToken);
-                            await Task.Delay(defaultRetryDelayInMilliseconds, cancellationToken);
-                            continue;
+
+                            // Do not retry immediately as it is likely that the surrogate ID generation is the root cause.
+                            // Regular requests should fail, but background operations (like import) can retry.
                         }
                     }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -192,9 +192,9 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                                 continue;
                             }
                         }
-                        else if (sqlEx.Number == FhirSqlErrorCodes.DuplicateKeyConflict && retries++ < maxRetries)
+                        else if (sqlEx.Number == FhirSqlErrorCodes.SurrogateIdCollision && retries++ < maxRetries)
                         {
-                            _logger.LogWarning(e, $"Error from SQL database on {nameof(MergeAsync)} retries={{Retries}} (DuplicateKeyConflict)", retries);
+                            _logger.LogWarning(e, $"Error from SQL database on {nameof(MergeAsync)} retries={{Retries}} (SurrogateIdCollision)", retries);
                             await _sqlRetryService.TryLogEvent(nameof(MergeAsync), "Warn", $"retries={retries}, error={e}, ", null, cancellationToken);
 
                             await Task.Delay(defaultRetryDelayInMilliseconds, cancellationToken);
@@ -493,7 +493,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                         continue;
                     }
 
-                    if (sqlEx != null && (sqlEx.Number == SqlErrorCodes.Conflict || sqlEx.Number == FhirSqlErrorCodes.DuplicateKeyConflict) && retries++ < maxRetries)
+                    if (sqlEx != null && (sqlEx.Number == SqlErrorCodes.Conflict || sqlEx.Number == FhirSqlErrorCodes.SurrogateIdCollision) && retries++ < maxRetries)
                     {
                         _logger.LogWarning(e, $"Error on {nameof(ImportResourcesInternalAsync)} retries={{Retries}} resources={{Resources}} error={{SqlErrorCode}}", retries, resources.Count, sqlEx.Number);
                         await Task.Delay(retries > 3 ? 10 : 1000, cancellationToken); // if >3 assume that it is id generation problem


### PR DESCRIPTION
## Description
In this PR, we are adding back to $import the ability to retry when Duplicate Key errors happen. 

## Related issues
Addresses [AB#189643](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/189643).

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
