### PR TITLE
Fixing SessionMessageHandler to handle multiple session tokens.

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TestFhirServer.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/TestFhirServer.cs
@@ -449,9 +449,9 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
                         }
                     });
 
-                    if (response.Headers.TryGetValues("x-ms-session-token", out var tokens))
+                    if (response.Headers.TryGetValues("x-ms-session-token", out var tokens) && tokens != null && tokens.Any())
                     {
-                        _sessionTokenContainer.SessionToken = tokens.SingleOrDefault();
+                        _sessionTokenContainer.SessionToken = string.Join(",", tokens);
                     }
 
                     return response;


### PR DESCRIPTION
## Description
We noticed that some tests recently started failing in AKS - FHIR Prod E2E test pipeline with an error, "InvalidOperationException: Sequence contains more than one element" in SessionMessageHandler. 

SessionMessageHandler code incorrectly assumes a "x-ms-session-token" response header contains only one session token. (Note: Session tokens are partition-bound and the response may contain multiple session tokens when a request spans multiple partitions according to the source below. Also, we recently increased RU for the Gen1 test services to 20k.)

The change will update SessionMessageHandler to be able to handle multiple session tokens in the response.

Source:
https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-manage-consistency?tabs=portal%2Cdotnetv2%2Capi-async#utilize-session-tokens

https://learn.microsoft.com/en-us/azure/cosmos-db/partitioning#physical-partitions

https://stackoverflow.com/questions/79335139/passing-session-token-for-querying-multiple-items-in-cosmosdb

## Related issues
Addresses [issue #189767].

[Bug 189767](https://microsofthealth.visualstudio.com/Health/_workitems/edit/189767): FHIR PaaS Gen1: More than one "x-ms-session-token" are added in the response headers.

## Testing
Tested by running existing tests (though best to test with running AKS - FHIR Prod E2E test pipeline) 

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
