### PR TITLE
Prepare for concurrency based on max last updated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -296,6 +296,10 @@ install-aso/
 *.Generated.cs
 *.Generated.*.cs
 
+# Exclude auto-generated SQL schema snapshot files, keep the .diff.sql
+src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/*.sql
+!src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/*.diff.sql
+
 # Azurite temporary files
 __*
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexOrchestratorJob.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/ReindexOrchestratorJob.cs
@@ -840,7 +840,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             {
                 _logger.LogJobInformation(_jobInfo, "Reindex job updating the status of the fully indexed search parameter, parameters: '{ParamUris}' to Disabled.", string.Join("', '", disabledParamUris));
                 await _searchParameterStatusRetries.ExecuteAsync(
-                    async () => await _searchParameterStatusManager.UpdateSearchParameterStatusAsync(disabledParamUris, SearchParameterStatus.Disabled, cancellationToken));
+                    async () => await _searchParameterStatusManager.UpdateSearchParameterStatusAsync(disabledParamUris, SearchParameterStatus.Disabled, cancellationToken, reindexId: _jobInfo.Id));
                 _processedSearchParameters.UnionWith(disabledParamUris);
             }
 
@@ -848,7 +848,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             {
                 _logger.LogJobInformation(_jobInfo, "Reindex job updating the status of the fully indexed search parameter, parameters: '{ParamUris}' to Deleted.", string.Join("', '", deletedParamUris));
                 await _searchParameterStatusRetries.ExecuteAsync(
-                    async () => await _searchParameterStatusManager.UpdateSearchParameterStatusAsync(deletedParamUris, SearchParameterStatus.Deleted, cancellationToken));
+                    async () => await _searchParameterStatusManager.UpdateSearchParameterStatusAsync(deletedParamUris, SearchParameterStatus.Deleted, cancellationToken, reindexId: _jobInfo.Id));
                 _processedSearchParameters.UnionWith(deletedParamUris);
             }
 
@@ -856,7 +856,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
             {
                 _logger.LogJobInformation(_jobInfo, "Reindex job updating the status of the fully indexed search parameter, parameters: '{ParamUris} to Enabled.'", string.Join("', '", fullyIndexedParamUris));
                 await _searchParameterStatusRetries.ExecuteAsync(
-                    async () => await _searchParameterStatusManager.UpdateSearchParameterStatusAsync(fullyIndexedParamUris, SearchParameterStatus.Enabled, _cancellationToken));
+                    async () => await _searchParameterStatusManager.UpdateSearchParameterStatusAsync(fullyIndexedParamUris, SearchParameterStatus.Enabled, _cancellationToken, reindexId: _jobInfo.Id));
                 _processedSearchParameters.UnionWith(fullyIndexedParamUris);
             }
         }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/FilebasedSearchParameterStatusDataStore.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/FilebasedSearchParameterStatusDataStore.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
             return _statusResults;
         }
 
-        public Task UpsertStatuses(IReadOnlyCollection<ResourceSearchParameterStatus> statuses, CancellationToken cancellationToken)
+        public Task UpsertStatuses(IReadOnlyCollection<ResourceSearchParameterStatus> statuses, CancellationToken cancellationToken, long? reindexId = null)
         {
             // File based registry does not persist runtime updates
             return Task.CompletedTask;

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/ISearchParameterStatusDataStore.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/ISearchParameterStatusDataStore.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
 
         Task<IReadOnlyCollection<ResourceSearchParameterStatus>> GetSearchParameterStatuses(CancellationToken cancellationToken, DateTimeOffset? startLastUpdated = null);
 
-        Task UpsertStatuses(IReadOnlyCollection<ResourceSearchParameterStatus> statuses, CancellationToken cancellationToken);
+        Task UpsertStatuses(IReadOnlyCollection<ResourceSearchParameterStatus> statuses, CancellationToken cancellationToken, long? reindexId = null);
 
         void SyncStatuses(IReadOnlyCollection<ResourceSearchParameterStatus> statuses);
 

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/ISearchParameterStatusManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/ISearchParameterStatusManager.cs
@@ -13,8 +13,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
 {
     public interface ISearchParameterStatusManager
     {
-        Task AddSearchParameterStatusAsync(IReadOnlyCollection<string> searchParamUris, CancellationToken cancellationToken);
-
         Task ApplySearchParameterStatus(IReadOnlyCollection<ResourceSearchParameterStatus> updatedSearchParameterStatus, CancellationToken cancellationToken);
 
         Task DeleteSearchParameterStatusAsync(string url, CancellationToken cancellationToken);
@@ -23,7 +21,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
 
         Task Handle(SearchParameterDefinitionManagerInitialized notification, CancellationToken cancellationToken);
 
-        Task UpdateSearchParameterStatusAsync(IReadOnlyCollection<string> searchParameterUris, SearchParameterStatus status, CancellationToken cancellationToken, bool ignoreSearchParameterNotSupportedException = false);
+        Task UpdateSearchParameterStatusAsync(IReadOnlyCollection<string> searchParameterUris, SearchParameterStatus status, CancellationToken cancellationToken, bool ignoreSearchParameterNotSupportedException = false, long? reindexId = null);
 
         Task<CacheConsistencyResult> CheckCacheConsistencyAsync(DateTime updateEventsSince, DateTime activeHostsSince, CancellationToken cancellationToken);
     }

--- a/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Search/Registry/SearchParameterStatusManager.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
             await EnsureInitializedAsync(cancellationToken);
         }
 
-        public async Task UpdateSearchParameterStatusAsync(IReadOnlyCollection<string> searchParameterUris, SearchParameterStatus status, CancellationToken cancellationToken, bool ignoreSearchParameterNotSupportedException = false)
+        public async Task UpdateSearchParameterStatusAsync(IReadOnlyCollection<string> searchParameterUris, SearchParameterStatus status, CancellationToken cancellationToken, bool ignoreSearchParameterNotSupportedException = false, long? reindexId = null)
         {
             EnsureArg.IsNotNull(searchParameterUris);
 
@@ -171,14 +171,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Search.Registry
                 }
             }
 
-            await _searchParameterStatusDataStore.UpsertStatuses(searchParameterStatusList, cancellationToken);
-        }
-
-        public async Task AddSearchParameterStatusAsync(IReadOnlyCollection<string> searchParamUris, CancellationToken cancellationToken)
-        {
-            // new search parameters are added as supported, until reindexing occurs, when
-            // they will be fully enabled
-            await UpdateSearchParameterStatusAsync(searchParamUris, SearchParameterStatus.Supported, cancellationToken);
+            await _searchParameterStatusDataStore.UpsertStatuses(searchParameterStatusList, cancellationToken, reindexId);
         }
 
         public async Task DeleteSearchParameterStatusAsync(string url, CancellationToken cancellationToken)

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Registry/CosmosDbSearchParameterStatusDataStore.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Storage/Registry/CosmosDbSearchParameterStatusDataStore.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Storage.Registry
             }
         }
 
-        public async Task UpsertStatuses(IReadOnlyCollection<ResourceSearchParameterStatus> statuses, CancellationToken cancellationToken)
+        public async Task UpsertStatuses(IReadOnlyCollection<ResourceSearchParameterStatus> statuses, CancellationToken cancellationToken, long? reindexId = null)
         {
             EnsureArg.IsNotNull(statuses, nameof(statuses));
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexOrchestratorJobTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexOrchestratorJobTests.cs
@@ -798,9 +798,11 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
             // Assert
             Assert.NotNull(jobResult);
             await _searchParameterStatusManager.Received().UpdateSearchParameterStatusAsync(
-                Arg.Is<List<string>>(l => l.Contains(searchParam.Url.ToString())),
-                SearchParameterStatus.Disabled,
-                Arg.Any<CancellationToken>());
+                        Arg.Is<List<string>>(l => l.Contains(searchParam.Url.ToString())),
+                        SearchParameterStatus.Disabled,
+                        Arg.Any<CancellationToken>(),
+                        Arg.Any<bool>(),
+                        Arg.Any<long?>());
         }
 
         [Fact]
@@ -849,7 +851,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
             await _searchParameterStatusManager.Received().UpdateSearchParameterStatusAsync(
                 Arg.Is<List<string>>(l => l.Contains(searchParam.Url.ToString())),
                 SearchParameterStatus.Deleted,
-                Arg.Any<CancellationToken>());
+                Arg.Any<CancellationToken>(),
+                Arg.Any<bool>(),
+                Arg.Any<long?>());
         }
 
         [Fact]
@@ -1564,7 +1568,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
                             l.Contains(patientNameParam.Url.ToString()) ||
                             l.Contains(patientBirthdateParam.Url.ToString())),
                         SearchParameterStatus.Enabled,
-                        Arg.Any<CancellationToken>());
+                        Arg.Any<CancellationToken>(),
+                        Arg.Any<bool>(),
+                        Arg.Any<long?>());
 
                     receivedCall = true;
                 }
@@ -1780,7 +1786,9 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
             await _searchParameterStatusManager.Received().UpdateSearchParameterStatusAsync(
                 Arg.Any<List<string>>(),
                 SearchParameterStatus.Enabled,
-                Arg.Any<CancellationToken>());
+                Arg.Any<CancellationToken>(),
+                Arg.Any<bool>(),
+                Arg.Any<long?>());
         }
 
         [Fact]
@@ -1940,12 +1948,16 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
             await _searchParameterStatusManager.Received().UpdateSearchParameterStatusAsync(
                         Arg.Is<List<string>>(l => l.Contains(searchParamLowercase.Url.ToString())),
                         SearchParameterStatus.Enabled,
-                        Arg.Any<CancellationToken>());
+                        Arg.Any<CancellationToken>(),
+                        Arg.Any<bool>(),
+                        Arg.Any<long?>());
 
             await _searchParameterStatusManager.Received().UpdateSearchParameterStatusAsync(
                         Arg.Is<List<string>>(l => l.Contains(searchParamMixedCase.Url.ToString())),
                         SearchParameterStatus.Deleted,
-                        Arg.Any<CancellationToken>());
+                        Arg.Any<CancellationToken>(),
+                        Arg.Any<bool>(),
+                        Arg.Any<long?>());
         }
 
         [Fact]
@@ -2006,14 +2018,18 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
             // Assert
             Assert.NotNull(jobResult);
             await _searchParameterStatusManager.Received().UpdateSearchParameterStatusAsync(
-                Arg.Is<List<string>>(l => l.Contains(searchParam1.Url.ToString())),
-                SearchParameterStatus.Disabled,
-                Arg.Any<CancellationToken>());
+                        Arg.Is<List<string>>(l => l.Contains(searchParam1.Url.ToString())),
+                        SearchParameterStatus.Disabled,
+                        Arg.Any<CancellationToken>(),
+                        Arg.Any<bool>(),
+                        Arg.Any<long?>());
 
             await _searchParameterStatusManager.Received().UpdateSearchParameterStatusAsync(
-                    Arg.Is<List<string>>(l => l.Contains(searchParam2.Url.ToString())),
-                    SearchParameterStatus.Disabled,
-                    Arg.Any<CancellationToken>());
+                        Arg.Is<List<string>>(l => l.Contains(searchParam2.Url.ToString())),
+                        SearchParameterStatus.Disabled,
+                        Arg.Any<CancellationToken>(),
+                        Arg.Any<bool>(),
+                        Arg.Any<long?>());
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/112.diff.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/112.diff.sql
@@ -1,8 +1,8 @@
-ALTER PROCEDURE dbo.MergeSearchParams @SearchParams dbo.SearchParamList READONLY, @InputLastUpdated datetimeoffset(7) = NULL, @ReindexId bigint = NULL
+ALTER PROCEDURE dbo.MergeSearchParams @SearchParams dbo.SearchParamList READONLY, @InputLastUpdated datetimeoffset(7) = NULL, @ReindexId bigint = -1
 AS
 set nocount on
 DECLARE @SP varchar(100) = object_name(@@procid)
-       ,@Mode varchar(200) = 'Cnt='+convert(varchar,(SELECT count(*) FROM @SearchParams))+' L='+isnull(convert(varchar(23),@InputLastUpdated,126),'NULL')+' R='+isnull(convert(varchar,@ReindexId),'NULL')
+       ,@Mode varchar(200) = 'Cnt='+convert(varchar,(SELECT count(*) FROM @SearchParams))+' L='+isnull(convert(varchar(23),@InputLastUpdated,126),'NULL')+' R='+convert(varchar,@ReindexId)
        ,@st datetime = getUTCdate()
        ,@LastUpdated datetimeoffset(7) = convert(datetimeoffset(7), sysUTCdatetime())
        ,@MaxLastUpdated datetimeoffset(7)
@@ -32,7 +32,7 @@ BEGIN TRY
   END
 
   SET @RunningReindexId = (SELECT TOP 1 GroupId FROM dbo.JobQueue WHERE QueueType = 6 AND Status IN (0,1))
-  IF @RunningReindexId IS NOT NULL AND @RunningReindexId <> isnull(@ReindexId,0)
+  IF @ReindexId <> -1 AND @RunningReindexId IS NOT NULL AND @RunningReindexId <> @ReindexId -- @ReindexId = -1 old code
   BEGIN
     SET @msg = 'Reindex job is in progress. ReindexId='+isnull(convert(varchar,@RunningReindexId),'NULL')
     ROLLBACK TRANSACTION;

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/112.diff.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/112.diff.sql
@@ -1,10 +1,11 @@
-ALTER PROCEDURE dbo.GetActiveJobs @QueueType tinyint, @GroupId bigint = NULL, @ReturnParentOnly bit = 0, @ReturnCountOnly bit = 0, @ActiveJobs int = NULL OUT
+ALTER PROCEDURE dbo.GetActiveJobs @QueueType tinyint, @GroupId bigint = NULL OUT, @ReturnParentOnly bit = 0, @IsExistsCheck bit = 0
 AS
 set nocount on
 DECLARE @SP varchar(100) = 'GetActiveJobs'
        ,@Mode varchar(100) = 'Q='+isnull(convert(varchar,@QueueType),'NULL')
                            +' G='+isnull(convert(varchar,@GroupId),'NULL')
-                           + ' R='+CONVERT(VARCHAR, @ReturnParentOnly)
+                           + ' R='+convert(varchar, @ReturnParentOnly)
+                           + ' E='+convert(varchar, @IsExistsCheck)
        ,@st datetime = getUTCdate()
        ,@PartitionId tinyint
        ,@MaxPartitions tinyint = 16 -- !!! hardcoded
@@ -16,7 +17,8 @@ DECLARE @JobIds TABLE (Id bigint PRIMARY KEY, GroupId bigint)
 BEGIN TRY
   SET @PartitionId = @MaxPartitions * rand()
 
-  WHILE @LookedAtPartitions < @MaxPartitions
+  -- gfor exists check exit immediately when any row found
+  WHILE @LookedAtPartitions < @MaxPartitions AND (@IsExistsCheck = 0 OR @IsExistsCheck = 1 AND @Rows = 0)
   BEGIN
     IF @GroupId IS NULL
       INSERT INTO @JobIds SELECT JobId, GroupId FROM dbo.JobQueue WHERE PartitionId = @PartitionId AND QueueType = @QueueType AND Status IN (0,1)
@@ -29,9 +31,9 @@ BEGIN TRY
     SET @LookedAtPartitions += 1 
   END
 
-  IF @ReturnCountOnly = 1
+  IF @IsExistsCheck = 1
   BEGIN
-    SET @ActiveJobs = @Rows
+    SET @GroupId = (SELECT TOP 1 GroupId FROM @JobIds ORDER BY GroupId DESC)
     RETURN
   END
 
@@ -39,6 +41,8 @@ BEGIN TRY
   BEGIN
     IF @ReturnParentOnly = 1
       DELETE FROM @JobIds WHERE Id <> (SELECT TOP 1 GroupId FROM @JobIds ORDER BY GroupId DESC)
+    
+    SET @GroupId = (SELECT TOP 1 GroupId FROM @JobIds ORDER BY GroupId DESC)
 
     EXECUTE dbo.GetJobs @QueueType = @QueueType, @JobIds = @JobIds
   END
@@ -65,7 +69,7 @@ DECLARE @SP varchar(100) = object_name(@@procid)
        ,@Uri varchar(4000)
        ,@Status varchar(20)
        ,@InputTrancount int = @@trancount
-       ,@ActiveReindexJobs int
+       ,@ActiveJobId bigint
        ,@ExpectedLastUpdated datetimeoffset(7) = (SELECT max(LastUpdated) FROM @SearchParams)
 
 SET @Mode = @Mode +' L='+isnull(convert(varchar(23),@ExpectedLastUpdated,126),'NULL')
@@ -95,15 +99,37 @@ BEGIN TRY
      AND NOT EXISTS (SELECT 1 FROM dbo.JobQueue WHERE PartitionId = @ReindexId % 16 AND QueueType = 6 AND JobId = @ReindexId AND Status = 1)
     RAISERROR('Reindex job is not running', 18, 127)
 
-  IF @ReindexId = 0
+  IF @ReindexId < 0 -- this can be ivoked for new and old code.
   BEGIN
-    EXECUTE dbo.GetActiveJobs @QueueType = 6, @ReturnCountOnly = 1, @ActiveJobs = @ActiveReindexJobs OUT
-    IF @ActiveReindexJobs > 0 THROW 50002, 'Reindex job is in progress.', 1
-    
+    EXECUTE dbo.GetActiveJobs @QueueType = 6, @IsExistsCheck = 1, @GroupId = @ActiveJobId OUT
+    SET @msg = 'Reindex job is in progress. Job Id='+convert(varchar,@ActiveJobId)
+    IF @ActiveJobId IS NOT NULL THROW 50002, @msg, 1
+  END
+
+  -- Check for concurrency conflicts using LastUpdated
+  -- Ignore any checks for reindex, as it owns statuses when it runs.
+  IF @ReindexId = 0 -- max(LastUpdated) logic
+  BEGIN
     SET @MaxLastUpdated = (SELECT max(LastUpdated) FROM dbo.SearchParam)
     IF @MaxLastUpdated <> @ExpectedLastUpdated
     BEGIN
       SET @msg = 'Optimistic concurrency conflict detected : expected last updated = '+convert(varchar(23),@ExpectedLastUpdated,126)+' max last updated = '+convert(varchar(23),@MaxLastUpdated,126);
+      THROW 50001, @msg, 1
+    END
+  END
+
+  -- Remove this old logic when code starts using max last updated
+  IF @ReindexId = -1
+  BEGIN
+    -- Only the top 60 are included in the message to avoid hitting the 8000 character limit, but all conflicts will cause the transaction to roll back
+    SELECT @msg = string_agg(S.Uri, ', ') 
+      FROM (
+        SELECT TOP 60 S.Uri
+          FROM @SearchParams I JOIN dbo.SearchParam S ON S.Uri = I.Uri
+          WHERE I.LastUpdated != S.LastUpdated) S
+    IF @msg IS NOT NULL
+    BEGIN
+      SET @msg = concat('Optimistic concurrency conflict detected for search parameters: ', @msg);
       THROW 50001, @msg, 1
     END
   END
@@ -118,8 +144,9 @@ BEGIN TRY
     WHEN NOT MATCHED BY TARGET THEN 
       INSERT   (  Uri,   Status,  LastUpdated,   IsPartiallySupported) 
         VALUES (I.Uri, I.Status, @LastUpdated, I.IsPartiallySupported);
-
-  SET @msg = 'LastUpdated='+convert(varchar(23),@LastUpdated,126)+' Merged='+convert(varchar,@@rowcount)
+  SET @Rows = @@rowcount
+  
+  SET @msg = 'LastUpdated='+convert(varchar(23),@LastUpdated,126)
 
   IF @InputTrancount = 0 COMMIT TRANSACTION
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/112.diff.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/112.diff.sql
@@ -56,7 +56,7 @@ BEGIN CATCH
 END CATCH
 GO
 ALTER PROCEDURE dbo.MergeSearchParams @SearchParams dbo.SearchParamList READONLY, @ReindexId bigint = -1
--- @ReindexId = -1 old code, @ReindexId = 0 - new codebut not reindex. @ReindexId > 0 - new code and reindex.
+-- @ReindexId = -1 old code, @ReindexId = 0 - new code but not reindex. @ReindexId > 0 - new code and reindex.
 AS
 set nocount on
 DECLARE @SP varchar(100) = object_name(@@procid)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/112.diff.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/112.diff.sql
@@ -1,0 +1,164 @@
+ALTER PROCEDURE dbo.MergeSearchParams @SearchParams dbo.SearchParamList READONLY, @InputLastUpdated datetimeoffset(7) = NULL, @ReindexId bigint = NULL
+AS
+set nocount on
+DECLARE @SP varchar(100) = object_name(@@procid)
+       ,@Mode varchar(200) = 'Cnt='+convert(varchar,(SELECT count(*) FROM @SearchParams))+' L='+isnull(convert(varchar(23),@InputLastUpdated,126),'NULL')+' R='+isnull(convert(varchar,@ReindexId),'NULL')
+       ,@st datetime = getUTCdate()
+       ,@LastUpdated datetimeoffset(7) = convert(datetimeoffset(7), sysUTCdatetime())
+       ,@MaxLastUpdated datetimeoffset(7)
+       ,@msg varchar(4000)
+       ,@Rows int
+       ,@Uri varchar(4000)
+       ,@Status varchar(20)
+       ,@InputTrancount int = @@trancount
+       ,@RunningReindexId bigint
+
+DECLARE @SearchParamsCopy dbo.SearchParamList
+INSERT INTO @SearchParamsCopy SELECT * FROM @SearchParams
+WHILE EXISTS (SELECT * FROM @SearchParamsCopy)
+BEGIN
+  SELECT TOP 1 @Uri = Uri, @Status = Status FROM @SearchParamsCopy
+  SET @msg = 'Status='+@Status+' Uri='+@Uri
+  EXECUTE dbo.LogEvent @Process=@SP,@Mode=@Mode,@Status='Start',@Text=@msg
+  DELETE FROM @SearchParamsCopy WHERE Uri = @Uri
+END
+
+BEGIN TRY
+  IF @InputTrancount = 0 -- transaction can start in MergeResourcesAndSearchParams
+  BEGIN 
+    SET TRANSACTION ISOLATION LEVEL SERIALIZABLE
+
+    BEGIN TRANSACTION
+  END
+
+  SET @RunningReindexId = (SELECT TOP 1 GroupId FROM dbo.JobQueue WHERE QueueType = 6 AND Status IN (0,1))
+  IF @RunningReindexId IS NOT NULL AND @RunningReindexId <> isnull(@ReindexId,0)
+  BEGIN
+    SET @msg = 'Reindex job is in progress. ReindexId='+isnull(convert(varchar,@RunningReindexId),'NULL')
+    ROLLBACK TRANSACTION;
+    THROW 50002, @msg, 1
+  END
+  
+  IF @InputLastUpdated IS NOT NULL -- check concurrency based on max(LastUpdated)
+  BEGIN
+    SET @MaxLastUpdated = (SELECT max(LastUpdated) FROM dbo.SearchParam)
+    IF @MaxLastUpdated <> @InputLastUpdated AND @ReindexId IS NULL
+    BEGIN
+      SET @msg = 'Optimistic concurrency conflict detected : input last updated = '+convert(varchar(23),@InputLastUpdated,126)+' max last updated = '+convert(varchar(23),@MaxLastUpdated,126)
+      ROLLBACK TRANSACTION;
+      THROW 50001, @msg, 1
+    END
+  END
+  ELSE
+  BEGIN
+    -- remove below block once all callers are updated to pass LastUpdated
+    -- Check for concurrency conflicts first using LastUpdated
+    -- Only the top 60 are included in the message to avoid hitting the 8000 character limit, but all conflicts will cause the transaction to roll back
+    SELECT @msg = string_agg(S.Uri, ', ') 
+      FROM (
+        SELECT TOP 60 S.Uri
+          FROM @SearchParams I JOIN dbo.SearchParam S ON S.Uri = I.Uri
+          WHERE I.LastUpdated != S.LastUpdated) S
+    IF @msg IS NOT NULL
+    BEGIN
+      SET @msg = concat('Optimistic concurrency conflict detected for search parameters: ', @msg) 
+      ROLLBACK TRANSACTION;
+      THROW 50001, @msg, 1
+    END
+  END
+
+  MERGE INTO dbo.SearchParam S
+    USING @SearchParams I ON I.Uri = S.Uri
+    WHEN MATCHED THEN 
+      UPDATE 
+        SET Status = I.Status
+           ,LastUpdated = @LastUpdated
+           ,IsPartiallySupported = I.IsPartiallySupported
+    WHEN NOT MATCHED BY TARGET THEN 
+      INSERT   (  Uri,   Status,  LastUpdated,   IsPartiallySupported) 
+        VALUES (I.Uri, I.Status, @LastUpdated, I.IsPartiallySupported);
+
+  SET @msg = 'LastUpdated='+convert(varchar(23),@LastUpdated,126)+' Merged='+convert(varchar,@@rowcount)
+
+  IF @InputTrancount = 0 COMMIT TRANSACTION
+
+  EXECUTE dbo.LogEvent @Process=@SP,@Mode=@Mode,@Status='End',@Start=@st,@Action='Merge',@Rows=@Rows,@Text=@msg
+END TRY
+BEGIN CATCH
+  IF @@trancount > 0 ROLLBACK TRANSACTION
+  EXECUTE dbo.LogEvent @Process=@SP,@Mode=@Mode,@Status='Error',@Start=@st;
+  THROW
+END CATCH
+GO
+ALTER PROCEDURE dbo.MergeResourcesAndSearchParams 
+     @SearchParams dbo.SearchParamList READONLY
+    ,@InputLastUpdated datetimeoffset(7) = NULL
+    ,@ReindexId bigint = NULL
+    ,@IsResourceChangeCaptureEnabled bit = 0
+    ,@TransactionId bigint = NULL
+    ,@Resources dbo.ResourceList READONLY
+    ,@ResourceWriteClaims dbo.ResourceWriteClaimList READONLY
+    ,@ReferenceSearchParams dbo.ReferenceSearchParamList READONLY
+    ,@TokenSearchParams dbo.TokenSearchParamList READONLY
+    ,@TokenTexts dbo.TokenTextList READONLY
+    ,@StringSearchParams dbo.StringSearchParamList READONLY
+    ,@UriSearchParams dbo.UriSearchParamList READONLY
+    ,@NumberSearchParams dbo.NumberSearchParamList READONLY
+    ,@QuantitySearchParams dbo.QuantitySearchParamList READONLY
+    ,@DateTimeSearchParms dbo.DateTimeSearchParamList READONLY
+    ,@ReferenceTokenCompositeSearchParams dbo.ReferenceTokenCompositeSearchParamList READONLY
+    ,@TokenTokenCompositeSearchParams dbo.TokenTokenCompositeSearchParamList READONLY
+    ,@TokenDateTimeCompositeSearchParams dbo.TokenDateTimeCompositeSearchParamList READONLY
+    ,@TokenQuantityCompositeSearchParams dbo.TokenQuantityCompositeSearchParamList READONLY
+    ,@TokenStringCompositeSearchParams dbo.TokenStringCompositeSearchParamList READONLY
+    ,@TokenNumberNumberCompositeSearchParams dbo.TokenNumberNumberCompositeSearchParamList READONLY
+AS
+set nocount on
+DECLARE @SP varchar(100) = object_name(@@procid)
+       ,@Mode varchar(200) = 'R='+convert(varchar,(SELECT count(*) FROM @Resources))+' SP='+convert(varchar,(SELECT count(*) FROM @SearchParams))
+       ,@st datetime = getUTCdate()
+       ,@Rows int = 0
+
+BEGIN TRY
+  SET TRANSACTION ISOLATION LEVEL SERIALIZABLE
+
+  BEGIN TRANSACTION
+  
+  EXECUTE dbo.MergeSearchParams @SearchParams, @InputLastUpdated, @ReindexId
+
+  IF EXISTS (SELECT * FROM @Resources)
+    EXECUTE dbo.MergeResources
+             @AffectedRows = @Rows OUTPUT
+            ,@RaiseExceptionOnConflict = 1
+            ,@IsResourceChangeCaptureEnabled = @IsResourceChangeCaptureEnabled
+            ,@TransactionId = @TransactionId
+            ,@SingleTransaction = 1
+            ,@Resources = @Resources
+            ,@ResourceWriteClaims = @ResourceWriteClaims
+            ,@ReferenceSearchParams = @ReferenceSearchParams
+            ,@TokenSearchParams = @TokenSearchParams
+            ,@TokenTexts = @TokenTexts
+            ,@StringSearchParams = @StringSearchParams
+            ,@UriSearchParams = @UriSearchParams
+            ,@NumberSearchParams = @NumberSearchParams
+            ,@QuantitySearchParams = @QuantitySearchParams
+            ,@DateTimeSearchParms = @DateTimeSearchParms
+            ,@ReferenceTokenCompositeSearchParams = @ReferenceTokenCompositeSearchParams
+            ,@TokenTokenCompositeSearchParams = @TokenTokenCompositeSearchParams
+            ,@TokenDateTimeCompositeSearchParams = @TokenDateTimeCompositeSearchParams
+            ,@TokenQuantityCompositeSearchParams = @TokenQuantityCompositeSearchParams
+            ,@TokenStringCompositeSearchParams = @TokenStringCompositeSearchParams
+            ,@TokenNumberNumberCompositeSearchParams = @TokenNumberNumberCompositeSearchParams;
+
+  COMMIT TRANSACTION
+
+  EXECUTE dbo.LogEvent @Process=@SP,@Mode=@Mode,@Status='End',@Start=@st,@Action='Merge',@Rows=@Rows
+END TRY
+BEGIN CATCH
+  IF @@trancount > 0 ROLLBACK TRANSACTION;
+  EXECUTE dbo.LogEvent @Process=@SP,@Mode=@Mode,@Status='Error',@Start=@st;
+  THROW
+END CATCH
+GO
+INSERT INTO Parameters (Id,Char) SELECT 'MergeResourcesAndSearchParams','LogEvent'
+GO

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/112.diff.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/112.diff.sql
@@ -7,23 +7,24 @@ DECLARE @SP varchar(100) = 'GetActiveJobs'
                            + ' R='+convert(varchar, @ReturnParentOnly)
                            + ' E='+convert(varchar, @IsExistsCheck)
        ,@st datetime = getUTCdate()
+       ,@JobIds BigintList
        ,@PartitionId tinyint
        ,@MaxPartitions tinyint = 16 -- !!! hardcoded
        ,@LookedAtPartitions tinyint = 0
        ,@Rows int = 0
 
-DECLARE @JobIds TABLE (Id bigint PRIMARY KEY, GroupId bigint)
+DECLARE @JobRecords TABLE (Id bigint PRIMARY KEY, GroupId bigint)
 
 BEGIN TRY
   SET @PartitionId = @MaxPartitions * rand()
 
-  -- gfor exists check exit immediately when any row found
+  -- for exists check exit immediately when any row found
   WHILE @LookedAtPartitions < @MaxPartitions AND (@IsExistsCheck = 0 OR @IsExistsCheck = 1 AND @Rows = 0)
   BEGIN
     IF @GroupId IS NULL
-      INSERT INTO @JobIds SELECT JobId, GroupId FROM dbo.JobQueue WHERE PartitionId = @PartitionId AND QueueType = @QueueType AND Status IN (0,1)
+      INSERT INTO @JobRecords SELECT JobId, GroupId FROM dbo.JobQueue WHERE PartitionId = @PartitionId AND QueueType = @QueueType AND Status IN (0,1)
     ELSE
-      INSERT INTO @JobIds SELECT JobId, GroupId FROM dbo.JobQueue WHERE PartitionId = @PartitionId AND QueueType = @QueueType AND GroupId = @GroupId AND Status IN (0,1)
+      INSERT INTO @JobRecords SELECT JobId, GroupId FROM dbo.JobQueue WHERE PartitionId = @PartitionId AND QueueType = @QueueType AND GroupId = @GroupId AND Status IN (0,1)
 
     SET @Rows += @@rowcount
 
@@ -31,18 +32,17 @@ BEGIN TRY
     SET @LookedAtPartitions += 1 
   END
 
+  SET @GroupId = (SELECT TOP 1 GroupId FROM @JobRecords ORDER BY GroupId DESC)
+
   IF @IsExistsCheck = 1
-  BEGIN
-    SET @GroupId = (SELECT TOP 1 GroupId FROM @JobIds ORDER BY GroupId DESC)
     RETURN
-  END
 
   IF @Rows > 0
   BEGIN
     IF @ReturnParentOnly = 1
-      DELETE FROM @JobIds WHERE Id <> (SELECT TOP 1 GroupId FROM @JobIds ORDER BY GroupId DESC)
-    
-    SET @GroupId = (SELECT TOP 1 GroupId FROM @JobIds ORDER BY GroupId DESC)
+      DELETE FROM @JobRecords WHERE Id <> @GroupId
+
+    INSERT INTO @JobIds SELECT Id FROM @JobRecords
 
     EXECUTE dbo.GetJobs @QueueType = @QueueType, @JobIds = @JobIds
   END

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/112.diff.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/112.diff.sql
@@ -1,8 +1,62 @@
-ALTER PROCEDURE dbo.MergeSearchParams @SearchParams dbo.SearchParamList READONLY, @InputLastUpdated datetimeoffset(7) = NULL, @ReindexId bigint = -1
+ALTER PROCEDURE dbo.GetActiveJobs @QueueType tinyint, @GroupId bigint = NULL, @ReturnParentOnly bit = 0, @ReturnCountOnly bit = 0, @ActiveJobs int = NULL OUT
+AS
+set nocount on
+DECLARE @SP varchar(100) = 'GetActiveJobs'
+       ,@Mode varchar(100) = 'Q='+isnull(convert(varchar,@QueueType),'NULL')
+                           +' G='+isnull(convert(varchar,@GroupId),'NULL')
+                           + ' R='+CONVERT(VARCHAR, @ReturnParentOnly)
+       ,@st datetime = getUTCdate()
+       ,@PartitionId tinyint
+       ,@MaxPartitions tinyint = 16 -- !!! hardcoded
+       ,@LookedAtPartitions tinyint = 0
+       ,@Rows int = 0
+
+DECLARE @JobIds TABLE (Id bigint PRIMARY KEY, GroupId bigint)
+
+BEGIN TRY
+  SET @PartitionId = @MaxPartitions * rand()
+
+  WHILE @LookedAtPartitions < @MaxPartitions
+  BEGIN
+    IF @GroupId IS NULL
+      INSERT INTO @JobIds SELECT JobId, GroupId FROM dbo.JobQueue WHERE PartitionId = @PartitionId AND QueueType = @QueueType AND Status IN (0,1)
+    ELSE
+      INSERT INTO @JobIds SELECT JobId, GroupId FROM dbo.JobQueue WHERE PartitionId = @PartitionId AND QueueType = @QueueType AND GroupId = @GroupId AND Status IN (0,1)
+
+    SET @Rows += @@rowcount
+
+    SET @PartitionId = CASE WHEN @PartitionId = 15 THEN 0 ELSE @PartitionId + 1 END
+    SET @LookedAtPartitions += 1 
+  END
+
+  IF @ReturnCountOnly = 1
+  BEGIN
+    SET @ActiveJobs = @Rows
+    RETURN
+  END
+
+  IF @Rows > 0
+  BEGIN
+    IF @ReturnParentOnly = 1
+      DELETE FROM @JobIds WHERE Id <> (SELECT TOP 1 GroupId FROM @JobIds ORDER BY GroupId DESC)
+
+    EXECUTE dbo.GetJobs @QueueType = @QueueType, @JobIds = @JobIds
+  END
+
+  EXECUTE dbo.LogEvent @Process=@SP,@Mode=@Mode,@Status='End',@Start=@st,@Rows=@Rows
+END TRY
+BEGIN CATCH
+  IF error_number() = 1750 THROW -- Real error is before 1750, cannot trap in SQL.
+  EXECUTE dbo.LogEvent @Process=@SP,@Mode=@Mode,@Status='Error';
+  THROW
+END CATCH
+GO
+ALTER PROCEDURE dbo.MergeSearchParams @SearchParams dbo.SearchParamList READONLY, @ReindexId bigint = -1
+-- @ReindexId = -1 old code, @ReindexId = 0 - new codebut not reindex. @ReindexId > 0 - new code and reindex.
 AS
 set nocount on
 DECLARE @SP varchar(100) = object_name(@@procid)
-       ,@Mode varchar(200) = 'Cnt='+convert(varchar,(SELECT count(*) FROM @SearchParams))+' L='+isnull(convert(varchar(23),@InputLastUpdated,126),'NULL')+' R='+convert(varchar,@ReindexId)
+       ,@Mode varchar(200) = 'Cnt='+convert(varchar,(SELECT count(*) FROM @SearchParams))+' R='+convert(varchar,@ReindexId)
        ,@st datetime = getUTCdate()
        ,@LastUpdated datetimeoffset(7) = convert(datetimeoffset(7), sysUTCdatetime())
        ,@MaxLastUpdated datetimeoffset(7)
@@ -11,19 +65,24 @@ DECLARE @SP varchar(100) = object_name(@@procid)
        ,@Uri varchar(4000)
        ,@Status varchar(20)
        ,@InputTrancount int = @@trancount
-       ,@RunningReindexId bigint
+       ,@ActiveReindexJobs int
+       ,@ExpectedLastUpdated datetimeoffset(7) = (SELECT max(LastUpdated) FROM @SearchParams)
 
-DECLARE @SearchParamsCopy dbo.SearchParamList
-INSERT INTO @SearchParamsCopy SELECT * FROM @SearchParams
-WHILE EXISTS (SELECT * FROM @SearchParamsCopy)
-BEGIN
-  SELECT TOP 1 @Uri = Uri, @Status = Status FROM @SearchParamsCopy
-  SET @msg = 'Status='+@Status+' Uri='+@Uri
-  EXECUTE dbo.LogEvent @Process=@SP,@Mode=@Mode,@Status='Start',@Text=@msg
-  DELETE FROM @SearchParamsCopy WHERE Uri = @Uri
-END
+SET @Mode = @Mode +' L='+isnull(convert(varchar(23),@ExpectedLastUpdated,126),'NULL')
 
 BEGIN TRY
+  IF @ReindexId IS NULL RAISERROR('@ReindexId cannot be null', 18, 127)
+
+  DECLARE @SearchParamsCopy dbo.SearchParamList
+  INSERT INTO @SearchParamsCopy SELECT * FROM @SearchParams
+  WHILE EXISTS (SELECT * FROM @SearchParamsCopy)
+  BEGIN
+    SELECT TOP 1 @Uri = Uri, @Status = Status FROM @SearchParamsCopy
+    SET @msg = 'Status='+@Status+' Uri='+@Uri
+    EXECUTE dbo.LogEvent @Process=@SP,@Mode=@Mode,@Status='Start',@Text=@msg
+    DELETE FROM @SearchParamsCopy WHERE Uri = @Uri
+  END
+
   IF @InputTrancount = 0 -- transaction can start in MergeResourcesAndSearchParams
   BEGIN 
     SET TRANSACTION ISOLATION LEVEL SERIALIZABLE
@@ -31,38 +90,20 @@ BEGIN TRY
     BEGIN TRANSACTION
   END
 
-  SET @RunningReindexId = (SELECT TOP 1 GroupId FROM dbo.JobQueue WHERE QueueType = 6 AND Status IN (0,1))
-  IF @ReindexId <> -1 AND @RunningReindexId IS NOT NULL AND @RunningReindexId <> @ReindexId -- @ReindexId = -1 old code
+  -- check if job id is valid
+  IF @ReindexId > 0
+     AND NOT EXISTS (SELECT 1 FROM dbo.JobQueue WHERE PartitionId = @ReindexId % 16 AND QueueType = 6 AND JobId = @ReindexId AND Status = 1)
+    RAISERROR('Reindex job is not running', 18, 127)
+
+  IF @ReindexId = 0
   BEGIN
-    SET @msg = 'Reindex job is in progress. ReindexId='+isnull(convert(varchar,@RunningReindexId),'NULL')
-    ROLLBACK TRANSACTION;
-    THROW 50002, @msg, 1
-  END
-  
-  IF @InputLastUpdated IS NOT NULL -- check concurrency based on max(LastUpdated)
-  BEGIN
+    EXECUTE dbo.GetActiveJobs @QueueType = 6, @ReturnCountOnly = 1, @ActiveJobs = @ActiveReindexJobs OUT
+    IF @ActiveReindexJobs > 0 THROW 50002, 'Reindex job is in progress.', 1
+    
     SET @MaxLastUpdated = (SELECT max(LastUpdated) FROM dbo.SearchParam)
-    IF @MaxLastUpdated <> @InputLastUpdated AND @ReindexId IS NULL
+    IF @MaxLastUpdated <> @ExpectedLastUpdated
     BEGIN
-      SET @msg = 'Optimistic concurrency conflict detected : input last updated = '+convert(varchar(23),@InputLastUpdated,126)+' max last updated = '+convert(varchar(23),@MaxLastUpdated,126)
-      ROLLBACK TRANSACTION;
-      THROW 50001, @msg, 1
-    END
-  END
-  ELSE
-  BEGIN
-    -- remove below block once all callers are updated to pass LastUpdated
-    -- Check for concurrency conflicts first using LastUpdated
-    -- Only the top 60 are included in the message to avoid hitting the 8000 character limit, but all conflicts will cause the transaction to roll back
-    SELECT @msg = string_agg(S.Uri, ', ') 
-      FROM (
-        SELECT TOP 60 S.Uri
-          FROM @SearchParams I JOIN dbo.SearchParam S ON S.Uri = I.Uri
-          WHERE I.LastUpdated != S.LastUpdated) S
-    IF @msg IS NOT NULL
-    BEGIN
-      SET @msg = concat('Optimistic concurrency conflict detected for search parameters: ', @msg) 
-      ROLLBACK TRANSACTION;
+      SET @msg = 'Optimistic concurrency conflict detected : expected last updated = '+convert(varchar(23),@ExpectedLastUpdated,126)+' max last updated = '+convert(varchar(23),@MaxLastUpdated,126);
       THROW 50001, @msg, 1
     END
   END
@@ -92,8 +133,7 @@ END CATCH
 GO
 ALTER PROCEDURE dbo.MergeResourcesAndSearchParams 
      @SearchParams dbo.SearchParamList READONLY
-    ,@InputLastUpdated datetimeoffset(7) = NULL
-    ,@ReindexId bigint = NULL
+    ,@ReindexId bigint = -1
     ,@IsResourceChangeCaptureEnabled bit = 0
     ,@TransactionId bigint = NULL
     ,@Resources dbo.ResourceList READONLY
@@ -124,7 +164,7 @@ BEGIN TRY
 
   BEGIN TRANSACTION
   
-  EXECUTE dbo.MergeSearchParams @SearchParams, @InputLastUpdated, @ReindexId
+  EXECUTE dbo.MergeSearchParams @SearchParams, @ReindexId
 
   IF EXISTS (SELECT * FROM @Resources)
     EXECUTE dbo.MergeResources
@@ -159,6 +199,4 @@ BEGIN CATCH
   EXECUTE dbo.LogEvent @Process=@SP,@Mode=@Mode,@Status='Error',@Start=@st;
   THROW
 END CATCH
-GO
-INSERT INTO Parameters (Id,Char) SELECT 'MergeResourcesAndSearchParams','LogEvent'
 GO

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaVersion.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaVersion.cs
@@ -121,5 +121,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema
         V109 = 109,
         V110 = 110,
         V111 = 111,
+        V112 = 112,
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaVersionConstants.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaVersionConstants.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema
     public static class SchemaVersionConstants
     {
         public const int Min = (int)SchemaVersion.V103;
-        public const int Max = (int)SchemaVersion.V111;
+        public const int Max = (int)SchemaVersion.V112;
         public const int MinForUpgrade = (int)SchemaVersion.V103; // this is used for upgrade tests only
         public const int SearchParameterStatusSchemaVersion = (int)SchemaVersion.V6;
         public const int SupportForReferencesWithMissingTypeVersion = (int)SchemaVersion.V7;

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Sql/Sprocs/GetActiveJobs.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Sql/Sprocs/GetActiveJobs.sql
@@ -9,23 +9,24 @@ DECLARE @SP varchar(100) = 'GetActiveJobs'
                            + ' R='+convert(varchar, @ReturnParentOnly)
                            + ' E='+convert(varchar, @IsExistsCheck)
        ,@st datetime = getUTCdate()
+       ,@JobIds BigintList
        ,@PartitionId tinyint
        ,@MaxPartitions tinyint = 16 -- !!! hardcoded
        ,@LookedAtPartitions tinyint = 0
        ,@Rows int = 0
 
-DECLARE @JobIds TABLE (Id bigint PRIMARY KEY, GroupId bigint)
+DECLARE @JobRecords TABLE (Id bigint PRIMARY KEY, GroupId bigint)
 
 BEGIN TRY
   SET @PartitionId = @MaxPartitions * rand()
 
-  -- gfor exists check exit immediately when any row found
+  -- for exists check exit immediately when any row found
   WHILE @LookedAtPartitions < @MaxPartitions AND (@IsExistsCheck = 0 OR @IsExistsCheck = 1 AND @Rows = 0)
   BEGIN
     IF @GroupId IS NULL
-      INSERT INTO @JobIds SELECT JobId, GroupId FROM dbo.JobQueue WHERE PartitionId = @PartitionId AND QueueType = @QueueType AND Status IN (0,1)
+      INSERT INTO @JobRecords SELECT JobId, GroupId FROM dbo.JobQueue WHERE PartitionId = @PartitionId AND QueueType = @QueueType AND Status IN (0,1)
     ELSE
-      INSERT INTO @JobIds SELECT JobId, GroupId FROM dbo.JobQueue WHERE PartitionId = @PartitionId AND QueueType = @QueueType AND GroupId = @GroupId AND Status IN (0,1)
+      INSERT INTO @JobRecords SELECT JobId, GroupId FROM dbo.JobQueue WHERE PartitionId = @PartitionId AND QueueType = @QueueType AND GroupId = @GroupId AND Status IN (0,1)
 
     SET @Rows += @@rowcount
 
@@ -33,18 +34,17 @@ BEGIN TRY
     SET @LookedAtPartitions += 1 
   END
 
+  SET @GroupId = (SELECT TOP 1 GroupId FROM @JobRecords ORDER BY GroupId DESC)
+
   IF @IsExistsCheck = 1
-  BEGIN
-    SET @GroupId = (SELECT TOP 1 GroupId FROM @JobIds ORDER BY GroupId DESC)
     RETURN
-  END
 
   IF @Rows > 0
   BEGIN
     IF @ReturnParentOnly = 1
-      DELETE FROM @JobIds WHERE Id <> (SELECT TOP 1 GroupId FROM @JobIds ORDER BY GroupId DESC)
+      DELETE FROM @JobRecords WHERE Id <> @GroupId
 
-    SET @GroupId = (SELECT TOP 1 GroupId FROM @JobIds ORDER BY GroupId DESC)
+    INSERT INTO @JobIds SELECT Id FROM @JobRecords
 
     EXECUTE dbo.GetJobs @QueueType = @QueueType, @JobIds = @JobIds
   END

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Sql/Sprocs/GetActiveJobs.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Sql/Sprocs/GetActiveJobs.sql
@@ -1,12 +1,13 @@
 ﻿--DROP PROCEDURE dbo.GetActiveJobs
 GO
-CREATE PROCEDURE dbo.GetActiveJobs @QueueType tinyint, @GroupId bigint = NULL, @ReturnParentOnly bit = 0, @ReturnCountOnly bit = 0, @ActiveJobs int = NULL OUT
+CREATE PROCEDURE dbo.GetActiveJobs @QueueType tinyint, @GroupId bigint = NULL OUT, @ReturnParentOnly bit = 0, @IsExistsCheck bit = 0
 AS
 set nocount on
 DECLARE @SP varchar(100) = 'GetActiveJobs'
        ,@Mode varchar(100) = 'Q='+isnull(convert(varchar,@QueueType),'NULL')
                            +' G='+isnull(convert(varchar,@GroupId),'NULL')
-                           + ' R='+CONVERT(VARCHAR, @ReturnParentOnly)
+                           + ' R='+convert(varchar, @ReturnParentOnly)
+                           + ' E='+convert(varchar, @IsExistsCheck)
        ,@st datetime = getUTCdate()
        ,@PartitionId tinyint
        ,@MaxPartitions tinyint = 16 -- !!! hardcoded
@@ -18,7 +19,8 @@ DECLARE @JobIds TABLE (Id bigint PRIMARY KEY, GroupId bigint)
 BEGIN TRY
   SET @PartitionId = @MaxPartitions * rand()
 
-  WHILE @LookedAtPartitions < @MaxPartitions
+  -- gfor exists check exit immediately when any row found
+  WHILE @LookedAtPartitions < @MaxPartitions AND (@IsExistsCheck = 0 OR @IsExistsCheck = 1 AND @Rows = 0)
   BEGIN
     IF @GroupId IS NULL
       INSERT INTO @JobIds SELECT JobId, GroupId FROM dbo.JobQueue WHERE PartitionId = @PartitionId AND QueueType = @QueueType AND Status IN (0,1)
@@ -31,9 +33,9 @@ BEGIN TRY
     SET @LookedAtPartitions += 1 
   END
 
-  IF @ReturnCountOnly = 1
+  IF @IsExistsCheck = 1
   BEGIN
-    SET @ActiveJobs = @Rows
+    SET @GroupId = (SELECT TOP 1 GroupId FROM @JobIds ORDER BY GroupId DESC)
     RETURN
   END
 
@@ -41,6 +43,8 @@ BEGIN TRY
   BEGIN
     IF @ReturnParentOnly = 1
       DELETE FROM @JobIds WHERE Id <> (SELECT TOP 1 GroupId FROM @JobIds ORDER BY GroupId DESC)
+
+    SET @GroupId = (SELECT TOP 1 GroupId FROM @JobIds ORDER BY GroupId DESC)
 
     EXECUTE dbo.GetJobs @QueueType = @QueueType, @JobIds = @JobIds
   END

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Sql/Sprocs/GetActiveJobs.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Sql/Sprocs/GetActiveJobs.sql
@@ -1,6 +1,6 @@
 ﻿--DROP PROCEDURE dbo.GetActiveJobs
 GO
-CREATE PROCEDURE dbo.GetActiveJobs @QueueType tinyint, @GroupId bigint = NULL, @ReturnParentOnly BIT = 0
+CREATE PROCEDURE dbo.GetActiveJobs @QueueType tinyint, @GroupId bigint = NULL, @ReturnParentOnly bit = 0, @ReturnCountOnly bit = 0, @ActiveJobs int = NULL OUT
 AS
 set nocount on
 DECLARE @SP varchar(100) = 'GetActiveJobs'
@@ -8,11 +8,12 @@ DECLARE @SP varchar(100) = 'GetActiveJobs'
                            +' G='+isnull(convert(varchar,@GroupId),'NULL')
                            + ' R='+CONVERT(VARCHAR, @ReturnParentOnly)
        ,@st datetime = getUTCdate()
-       ,@JobIds BigintList
        ,@PartitionId tinyint
        ,@MaxPartitions tinyint = 16 -- !!! hardcoded
        ,@LookedAtPartitions tinyint = 0
        ,@Rows int = 0
+
+DECLARE @JobIds TABLE (Id bigint PRIMARY KEY, GroupId bigint)
 
 BEGIN TRY
   SET @PartitionId = @MaxPartitions * rand()
@@ -20,9 +21,9 @@ BEGIN TRY
   WHILE @LookedAtPartitions < @MaxPartitions
   BEGIN
     IF @GroupId IS NULL
-      INSERT INTO @JobIds SELECT JobId FROM dbo.JobQueue WHERE PartitionId = @PartitionId AND QueueType = @QueueType AND Status IN (0,1)
+      INSERT INTO @JobIds SELECT JobId, GroupId FROM dbo.JobQueue WHERE PartitionId = @PartitionId AND QueueType = @QueueType AND Status IN (0,1)
     ELSE
-      INSERT INTO @JobIds SELECT JobId FROM dbo.JobQueue WHERE PartitionId = @PartitionId AND QueueType = @QueueType AND GroupId = @GroupId AND Status IN (0,1)
+      INSERT INTO @JobIds SELECT JobId, GroupId FROM dbo.JobQueue WHERE PartitionId = @PartitionId AND QueueType = @QueueType AND GroupId = @GroupId AND Status IN (0,1)
 
     SET @Rows += @@rowcount
 
@@ -30,18 +31,20 @@ BEGIN TRY
     SET @LookedAtPartitions += 1 
   END
 
+  IF @ReturnCountOnly = 1
+  BEGIN
+    SET @ActiveJobs = @Rows
+    RETURN
+  END
+
   IF @Rows > 0
-    BEGIN
-      IF @ReturnParentOnly = 1
-      BEGIN
-        DECLARE @TopGroupId BIGINT;
+  BEGIN
+    IF @ReturnParentOnly = 1
+      DELETE FROM @JobIds WHERE Id <> (SELECT TOP 1 GroupId FROM @JobIds ORDER BY GroupId DESC)
 
-        SELECT TOP 1 @TopGroupId = GroupId FROM dbo.JobQueue WHERE JobId IN (SELECT Id FROM @JobIds) ORDER BY GroupId DESC;
+    EXECUTE dbo.GetJobs @QueueType = @QueueType, @JobIds = @JobIds
+  END
 
-        DELETE FROM @JobIds	WHERE Id NOT IN (SELECT JobId FROM dbo.JobQueue	WHERE JobId = @TopGroupId);
-      END
-      EXECUTE dbo.GetJobs @QueueType = @QueueType, @JobIds = @JobIds
-    END
   EXECUTE dbo.LogEvent @Process=@SP,@Mode=@Mode,@Status='End',@Start=@st,@Rows=@Rows
 END TRY
 BEGIN CATCH

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Sql/Sprocs/MergeResourcesAndSearchParams.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Sql/Sprocs/MergeResourcesAndSearchParams.sql
@@ -1,7 +1,6 @@
 ﻿CREATE PROCEDURE dbo.MergeResourcesAndSearchParams 
      @SearchParams dbo.SearchParamList READONLY
-    ,@InputLastUpdated datetimeoffset(7) = NULL
-    ,@ReindexId bigint = NULL
+    ,@ReindexId bigint = -1
     ,@IsResourceChangeCaptureEnabled bit = 0
     ,@TransactionId bigint = NULL
     ,@Resources dbo.ResourceList READONLY
@@ -32,7 +31,7 @@ BEGIN TRY
 
   BEGIN TRANSACTION
   
-  EXECUTE dbo.MergeSearchParams @SearchParams, @InputLastUpdated, @ReindexId
+  EXECUTE dbo.MergeSearchParams @SearchParams, @ReindexId
 
   IF EXISTS (SELECT * FROM @Resources)
     EXECUTE dbo.MergeResources

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Sql/Sprocs/MergeResourcesAndSearchParams.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Sql/Sprocs/MergeResourcesAndSearchParams.sql
@@ -1,5 +1,7 @@
 ﻿CREATE PROCEDURE dbo.MergeResourcesAndSearchParams 
      @SearchParams dbo.SearchParamList READONLY
+    ,@InputLastUpdated datetimeoffset(7) = NULL
+    ,@ReindexId bigint = NULL
     ,@IsResourceChangeCaptureEnabled bit = 0
     ,@TransactionId bigint = NULL
     ,@Resources dbo.ResourceList READONLY
@@ -21,48 +23,20 @@
 AS
 set nocount on
 DECLARE @SP varchar(100) = object_name(@@procid)
-       ,@Mode varchar(200) = 'Cnt='+convert(varchar,(SELECT count(*) FROM @SearchParams))
+       ,@Mode varchar(200) = 'R='+convert(varchar,(SELECT count(*) FROM @Resources))+' SP='+convert(varchar,(SELECT count(*) FROM @SearchParams))
        ,@st datetime = getUTCdate()
-       ,@LastUpdated datetimeoffset(7) = convert(datetimeoffset(7), sysUTCdatetime())
-       ,@msg varchar(4000)
-       ,@Rows int
-       ,@AffectedRows int = 0
-       ,@Uri varchar(4000)
-       ,@Status varchar(20)
-
-DECLARE @SearchParamsCopy dbo.SearchParamList
-INSERT INTO @SearchParamsCopy SELECT * FROM @SearchParams
-WHILE EXISTS (SELECT * FROM @SearchParamsCopy)
-BEGIN
-  SELECT TOP 1 @Uri = Uri, @Status = Status FROM @SearchParamsCopy
-  SET @msg = 'Status='+@Status+' Uri='+@Uri
-  EXECUTE dbo.LogEvent @Process=@SP,@Mode=@Mode,@Status='Start',@Text=@msg
-  DELETE FROM @SearchParamsCopy WHERE Uri = @Uri
-END
+       ,@Rows int = 0
 
 BEGIN TRY
   SET TRANSACTION ISOLATION LEVEL SERIALIZABLE
 
   BEGIN TRANSACTION
   
-  -- Check for concurrency conflicts first using LastUpdated
-  -- Only the top 60 are included in the message to avoid hitting the 8000 character limit, but all conflicts will cause the transaction to roll back
-  SELECT @msg = string_agg(S.Uri, ', ') 
-    FROM (
-      SELECT TOP 60 S.Uri
-        FROM @SearchParams I JOIN dbo.SearchParam S ON S.Uri = I.Uri
-        WHERE I.LastUpdated != S.LastUpdated) S
-  IF @msg IS NOT NULL
-  BEGIN
-    SET @msg = concat('Optimistic concurrency conflict detected for search parameters: ', @msg) 
-    ROLLBACK TRANSACTION;
-    THROW 50001, @msg, 1
-  END
+  EXECUTE dbo.MergeSearchParams @SearchParams, @InputLastUpdated, @ReindexId
 
   IF EXISTS (SELECT * FROM @Resources)
-  BEGIN
     EXECUTE dbo.MergeResources
-             @AffectedRows = @AffectedRows OUTPUT
+             @AffectedRows = @Rows OUTPUT
             ,@RaiseExceptionOnConflict = 1
             ,@IsResourceChangeCaptureEnabled = @IsResourceChangeCaptureEnabled
             ,@TransactionId = @TransactionId
@@ -84,25 +58,9 @@ BEGIN TRY
             ,@TokenStringCompositeSearchParams = @TokenStringCompositeSearchParams
             ,@TokenNumberNumberCompositeSearchParams = @TokenNumberNumberCompositeSearchParams;
 
-    SET @Rows = @Rows + @AffectedRows;
-  END
-
-  MERGE INTO dbo.SearchParam S
-    USING @SearchParams I ON I.Uri = S.Uri
-    WHEN MATCHED THEN 
-      UPDATE 
-        SET Status = I.Status
-           ,LastUpdated = @LastUpdated
-           ,IsPartiallySupported = I.IsPartiallySupported
-    WHEN NOT MATCHED BY TARGET THEN 
-      INSERT   (  Uri,   Status,  LastUpdated,   IsPartiallySupported) 
-        VALUES (I.Uri, I.Status, @LastUpdated, I.IsPartiallySupported);
-
-  SET @msg = 'LastUpdated='+convert(varchar(23),@LastUpdated,126)+' Merged='+convert(varchar,@@rowcount)
-
   COMMIT TRANSACTION
 
-  EXECUTE dbo.LogEvent @Process=@SP,@Mode=@Mode,@Status='End',@Start=@st,@Action='Merge',@Rows=@Rows,@Text=@msg
+  EXECUTE dbo.LogEvent @Process=@SP,@Mode=@Mode,@Status='End',@Start=@st,@Action='Merge',@Rows=@Rows
 END TRY
 BEGIN CATCH
   IF @@trancount > 0 ROLLBACK TRANSACTION;

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Sql/Sprocs/MergeSearchParams.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Sql/Sprocs/MergeSearchParams.sql
@@ -1,44 +1,70 @@
-﻿CREATE PROCEDURE dbo.MergeSearchParams @SearchParams dbo.SearchParamList READONLY
+﻿CREATE PROCEDURE dbo.MergeSearchParams @SearchParams dbo.SearchParamList READONLY, @InputLastUpdated datetimeoffset(7) = NULL, @ReindexId bigint = NULL
 AS
 set nocount on
 DECLARE @SP varchar(100) = object_name(@@procid)
-       ,@Mode varchar(200) = 'Cnt='+convert(varchar,(SELECT count(*) FROM @SearchParams))
+       ,@Mode varchar(200) = 'Cnt='+convert(varchar,(SELECT count(*) FROM @SearchParams))+' L='+isnull(convert(varchar(23),@InputLastUpdated,126),'NULL')+' R='+isnull(convert(varchar,@ReindexId),'NULL')
        ,@st datetime = getUTCdate()
-       ,@LastUpdated datetimeoffset(7) = sysdatetimeoffset()
+       ,@LastUpdated datetimeoffset(7) = convert(datetimeoffset(7), sysUTCdatetime())
+       ,@MaxLastUpdated datetimeoffset(7)
        ,@msg varchar(4000)
        ,@Rows int
        ,@Uri varchar(4000)
        ,@Status varchar(20)
+       ,@InputTrancount int = @@trancount
+       ,@RunningReindexId bigint
 
 DECLARE @SearchParamsCopy dbo.SearchParamList
 INSERT INTO @SearchParamsCopy SELECT * FROM @SearchParams
 WHILE EXISTS (SELECT * FROM @SearchParamsCopy)
 BEGIN
   SELECT TOP 1 @Uri = Uri, @Status = Status FROM @SearchParamsCopy
-  SET @msg = 'Uri='+@Uri+' Status='+@Status
+  SET @msg = 'Status='+@Status+' Uri='+@Uri
   EXECUTE dbo.LogEvent @Process=@SP,@Mode=@Mode,@Status='Start',@Text=@msg
   DELETE FROM @SearchParamsCopy WHERE Uri = @Uri
 END
 
-DECLARE @SummaryOfChanges TABLE (Uri varchar(128) COLLATE Latin1_General_100_CS_AS NOT NULL, Operation varchar(20) NOT NULL)
-
 BEGIN TRY
-  SET TRANSACTION ISOLATION LEVEL SERIALIZABLE
+  IF @InputTrancount = 0 -- transaction can start in MergeResourcesAndSearchParams
+  BEGIN 
+    SET TRANSACTION ISOLATION LEVEL SERIALIZABLE
 
-  BEGIN TRANSACTION
-  
-  -- Check for concurrency conflicts first using LastUpdated
-  -- Only the top 60 are included in the message to avoid hitting the 8000 character limit, but all conflicts will cause the transaction to roll back
-  SELECT @msg = string_agg(S.Uri, ', ') 
-    FROM (
-      SELECT TOP 60 S.Uri
-        FROM @SearchParams I JOIN dbo.SearchParam S ON S.Uri = I.Uri
-        WHERE I.LastUpdated != S.LastUpdated) S
-  IF @msg IS NOT NULL
+    BEGIN TRANSACTION
+  END
+
+  SET @RunningReindexId = (SELECT TOP 1 GroupId FROM dbo.JobQueue WHERE QueueType = 6 AND Status IN (0,1))
+  IF @RunningReindexId IS NOT NULL AND @RunningReindexId <> isnull(@ReindexId,0)
   BEGIN
-    SET @msg = concat('Optimistic concurrency conflict detected for search parameters: ', @msg) 
+    SET @msg = 'Reindex job is in progress. ReindexId='+isnull(convert(varchar,@RunningReindexId),'NULL')
     ROLLBACK TRANSACTION;
-    THROW 50001, @msg, 1
+    THROW 50002, @msg, 1
+  END
+  
+  IF @InputLastUpdated IS NOT NULL -- check concurrency based on max(LastUpdated)
+  BEGIN
+    SET @MaxLastUpdated = (SELECT max(LastUpdated) FROM dbo.SearchParam)
+    IF @MaxLastUpdated <> @InputLastUpdated AND @ReindexId IS NULL
+    BEGIN
+      SET @msg = 'Optimistic concurrency conflict detected : input last updated = '+convert(varchar(23),@InputLastUpdated,126)+' max last updated = '+convert(varchar(23),@MaxLastUpdated,126)
+      ROLLBACK TRANSACTION;
+      THROW 50001, @msg, 1
+    END
+  END
+  ELSE
+  BEGIN
+    -- remove below block once all callers are updated to pass LastUpdated
+    -- Check for concurrency conflicts first using LastUpdated
+    -- Only the top 60 are included in the message to avoid hitting the 8000 character limit, but all conflicts will cause the transaction to roll back
+    SELECT @msg = string_agg(S.Uri, ', ') 
+      FROM (
+        SELECT TOP 60 S.Uri
+          FROM @SearchParams I JOIN dbo.SearchParam S ON S.Uri = I.Uri
+          WHERE I.LastUpdated != S.LastUpdated) S
+    IF @msg IS NOT NULL
+    BEGIN
+      SET @msg = concat('Optimistic concurrency conflict detected for search parameters: ', @msg) 
+      ROLLBACK TRANSACTION;
+      THROW 50001, @msg, 1
+    END
   END
 
   MERGE INTO dbo.SearchParam S
@@ -50,23 +76,16 @@ BEGIN TRY
            ,IsPartiallySupported = I.IsPartiallySupported
     WHEN NOT MATCHED BY TARGET THEN 
       INSERT   (  Uri,   Status,  LastUpdated,   IsPartiallySupported) 
-        VALUES (I.Uri, I.Status, @LastUpdated, I.IsPartiallySupported)
-    OUTPUT I.Uri, $action INTO @SummaryOfChanges;
-  SET @Rows = @@rowcount
+        VALUES (I.Uri, I.Status, @LastUpdated, I.IsPartiallySupported);
 
-  SELECT S.SearchParamId
-        ,S.Uri
-        ,S.LastUpdated
-    FROM dbo.SearchParam S JOIN @SummaryOfChanges C ON C.Uri = S.Uri
-    WHERE C.Operation = 'INSERT'
-  SET @msg = 'LastUpdated='+substring(convert(varchar,@LastUpdated),1,23)+' INSERT='+convert(varchar,@@rowcount)
+  SET @msg = 'LastUpdated='+convert(varchar(23),@LastUpdated,126)+' Merged='+convert(varchar,@@rowcount)
 
-  COMMIT TRANSACTION
+  IF @InputTrancount = 0 COMMIT TRANSACTION
 
   EXECUTE dbo.LogEvent @Process=@SP,@Mode=@Mode,@Status='End',@Start=@st,@Action='Merge',@Rows=@Rows,@Text=@msg
 END TRY
 BEGIN CATCH
-  IF @@trancount > 0 ROLLBACK TRANSACTION;
+  IF @@trancount > 0 ROLLBACK TRANSACTION
   EXECUTE dbo.LogEvent @Process=@SP,@Mode=@Mode,@Status='Error',@Start=@st;
   THROW
 END CATCH

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Sql/Sprocs/MergeSearchParams.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Sql/Sprocs/MergeSearchParams.sql
@@ -1,5 +1,5 @@
 ﻿CREATE PROCEDURE dbo.MergeSearchParams @SearchParams dbo.SearchParamList READONLY, @ReindexId bigint = -1
--- @ReindexId = -1 old code, @ReindexId = 0 - new codebut not reindex. @ReindexId > 0 - new code and reindex.
+-- @ReindexId = -1 old code, @ReindexId = 0 - new code but not reindex. @ReindexId > 0 - new code and reindex.
 AS
 set nocount on
 DECLARE @SP varchar(100) = object_name(@@procid)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Sql/Sprocs/MergeSearchParams.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Sql/Sprocs/MergeSearchParams.sql
@@ -12,7 +12,7 @@ DECLARE @SP varchar(100) = object_name(@@procid)
        ,@Uri varchar(4000)
        ,@Status varchar(20)
        ,@InputTrancount int = @@trancount
-       ,@ActiveReindexJobs int
+       ,@ActiveJobId bigint
        ,@ExpectedLastUpdated datetimeoffset(7) = (SELECT max(LastUpdated) FROM @SearchParams)
 
 SET @Mode = @Mode +' L='+isnull(convert(varchar(23),@ExpectedLastUpdated,126),'NULL')
@@ -42,15 +42,37 @@ BEGIN TRY
      AND NOT EXISTS (SELECT 1 FROM dbo.JobQueue WHERE PartitionId = @ReindexId % 16 AND QueueType = 6 AND JobId = @ReindexId AND Status = 1)
     RAISERROR('Reindex job is not running', 18, 127)
 
-  IF @ReindexId = 0
+  IF @ReindexId < 0 -- this can be ivoked for new and old code.
   BEGIN
-    EXECUTE dbo.GetActiveJobs @QueueType = 6, @ReturnCountOnly = 1, @ActiveJobs = @ActiveReindexJobs OUT
-    IF @ActiveReindexJobs > 0 THROW 50002, 'Reindex job is in progress.', 1
-    
+    EXECUTE dbo.GetActiveJobs @QueueType = 6, @IsExistsCheck = 1, @GroupId = @ActiveJobId OUT
+    SET @msg = 'Reindex job is in progress. Job Id='+convert(varchar,@ActiveJobId)
+    IF @ActiveJobId IS NOT NULL THROW 50002, @msg, 1
+  END
+
+  -- Check for concurrency conflicts using LastUpdated
+  -- Ignore any checks for reindex, as it owns statuses when it runs.
+  IF @ReindexId = 0 -- max(LastUpdated) logic
+  BEGIN
     SET @MaxLastUpdated = (SELECT max(LastUpdated) FROM dbo.SearchParam)
     IF @MaxLastUpdated <> @ExpectedLastUpdated
     BEGIN
       SET @msg = 'Optimistic concurrency conflict detected : expected last updated = '+convert(varchar(23),@ExpectedLastUpdated,126)+' max last updated = '+convert(varchar(23),@MaxLastUpdated,126);
+      THROW 50001, @msg, 1
+    END
+  END
+
+  -- Remove this old logic when code starts using max last updated
+  IF @ReindexId = -1
+  BEGIN
+    -- Only the top 60 are included in the message to avoid hitting the 8000 character limit, but all conflicts will cause the transaction to roll back
+    SELECT @msg = string_agg(S.Uri, ', ') 
+      FROM (
+        SELECT TOP 60 S.Uri
+          FROM @SearchParams I JOIN dbo.SearchParam S ON S.Uri = I.Uri
+          WHERE I.LastUpdated != S.LastUpdated) S
+    IF @msg IS NOT NULL
+    BEGIN
+      SET @msg = concat('Optimistic concurrency conflict detected for search parameters: ', @msg);
       THROW 50001, @msg, 1
     END
   END
@@ -65,8 +87,9 @@ BEGIN TRY
     WHEN NOT MATCHED BY TARGET THEN 
       INSERT   (  Uri,   Status,  LastUpdated,   IsPartiallySupported) 
         VALUES (I.Uri, I.Status, @LastUpdated, I.IsPartiallySupported);
-
-  SET @msg = 'LastUpdated='+convert(varchar(23),@LastUpdated,126)+' Merged='+convert(varchar,@@rowcount)
+  SET @Rows = @@rowcount
+  
+  SET @msg = 'LastUpdated='+convert(varchar(23),@LastUpdated,126)
 
   IF @InputTrancount = 0 COMMIT TRANSACTION
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Sql/Sprocs/MergeSearchParams.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Sql/Sprocs/MergeSearchParams.sql
@@ -1,8 +1,8 @@
-﻿CREATE PROCEDURE dbo.MergeSearchParams @SearchParams dbo.SearchParamList READONLY, @InputLastUpdated datetimeoffset(7) = NULL, @ReindexId bigint = NULL
+﻿CREATE PROCEDURE dbo.MergeSearchParams @SearchParams dbo.SearchParamList READONLY, @InputLastUpdated datetimeoffset(7) = NULL, @ReindexId bigint = -1
 AS
 set nocount on
 DECLARE @SP varchar(100) = object_name(@@procid)
-       ,@Mode varchar(200) = 'Cnt='+convert(varchar,(SELECT count(*) FROM @SearchParams))+' L='+isnull(convert(varchar(23),@InputLastUpdated,126),'NULL')+' R='+isnull(convert(varchar,@ReindexId),'NULL')
+       ,@Mode varchar(200) = 'Cnt='+convert(varchar,(SELECT count(*) FROM @SearchParams))+' L='+isnull(convert(varchar(23),@InputLastUpdated,126),'NULL')+' R='+convert(varchar,@ReindexId)
        ,@st datetime = getUTCdate()
        ,@LastUpdated datetimeoffset(7) = convert(datetimeoffset(7), sysUTCdatetime())
        ,@MaxLastUpdated datetimeoffset(7)
@@ -32,7 +32,7 @@ BEGIN TRY
   END
 
   SET @RunningReindexId = (SELECT TOP 1 GroupId FROM dbo.JobQueue WHERE QueueType = 6 AND Status IN (0,1))
-  IF @RunningReindexId IS NOT NULL AND @RunningReindexId <> isnull(@ReindexId,0)
+  IF @ReindexId <> -1 AND @RunningReindexId IS NOT NULL AND @RunningReindexId <> @ReindexId -- @ReindexId = -1 old code
   BEGIN
     SET @msg = 'Reindex job is in progress. ReindexId='+isnull(convert(varchar,@RunningReindexId),'NULL')
     ROLLBACK TRANSACTION;

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Sql/Sprocs/MergeSearchParams.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Sql/Sprocs/MergeSearchParams.sql
@@ -1,8 +1,9 @@
-﻿CREATE PROCEDURE dbo.MergeSearchParams @SearchParams dbo.SearchParamList READONLY, @InputLastUpdated datetimeoffset(7) = NULL, @ReindexId bigint = -1
+﻿CREATE PROCEDURE dbo.MergeSearchParams @SearchParams dbo.SearchParamList READONLY, @ReindexId bigint = -1
+-- @ReindexId = -1 old code, @ReindexId = 0 - new codebut not reindex. @ReindexId > 0 - new code and reindex.
 AS
 set nocount on
 DECLARE @SP varchar(100) = object_name(@@procid)
-       ,@Mode varchar(200) = 'Cnt='+convert(varchar,(SELECT count(*) FROM @SearchParams))+' L='+isnull(convert(varchar(23),@InputLastUpdated,126),'NULL')+' R='+convert(varchar,@ReindexId)
+       ,@Mode varchar(200) = 'Cnt='+convert(varchar,(SELECT count(*) FROM @SearchParams))+' R='+convert(varchar,@ReindexId)
        ,@st datetime = getUTCdate()
        ,@LastUpdated datetimeoffset(7) = convert(datetimeoffset(7), sysUTCdatetime())
        ,@MaxLastUpdated datetimeoffset(7)
@@ -11,19 +12,24 @@ DECLARE @SP varchar(100) = object_name(@@procid)
        ,@Uri varchar(4000)
        ,@Status varchar(20)
        ,@InputTrancount int = @@trancount
-       ,@RunningReindexId bigint
+       ,@ActiveReindexJobs int
+       ,@ExpectedLastUpdated datetimeoffset(7) = (SELECT max(LastUpdated) FROM @SearchParams)
 
-DECLARE @SearchParamsCopy dbo.SearchParamList
-INSERT INTO @SearchParamsCopy SELECT * FROM @SearchParams
-WHILE EXISTS (SELECT * FROM @SearchParamsCopy)
-BEGIN
-  SELECT TOP 1 @Uri = Uri, @Status = Status FROM @SearchParamsCopy
-  SET @msg = 'Status='+@Status+' Uri='+@Uri
-  EXECUTE dbo.LogEvent @Process=@SP,@Mode=@Mode,@Status='Start',@Text=@msg
-  DELETE FROM @SearchParamsCopy WHERE Uri = @Uri
-END
+SET @Mode = @Mode +' L='+isnull(convert(varchar(23),@ExpectedLastUpdated,126),'NULL')
 
 BEGIN TRY
+  IF @ReindexId IS NULL RAISERROR('@ReindexId cannot be null', 18, 127)
+
+  DECLARE @SearchParamsCopy dbo.SearchParamList
+  INSERT INTO @SearchParamsCopy SELECT * FROM @SearchParams
+  WHILE EXISTS (SELECT * FROM @SearchParamsCopy)
+  BEGIN
+    SELECT TOP 1 @Uri = Uri, @Status = Status FROM @SearchParamsCopy
+    SET @msg = 'Status='+@Status+' Uri='+@Uri
+    EXECUTE dbo.LogEvent @Process=@SP,@Mode=@Mode,@Status='Start',@Text=@msg
+    DELETE FROM @SearchParamsCopy WHERE Uri = @Uri
+  END
+
   IF @InputTrancount = 0 -- transaction can start in MergeResourcesAndSearchParams
   BEGIN 
     SET TRANSACTION ISOLATION LEVEL SERIALIZABLE
@@ -31,38 +37,20 @@ BEGIN TRY
     BEGIN TRANSACTION
   END
 
-  SET @RunningReindexId = (SELECT TOP 1 GroupId FROM dbo.JobQueue WHERE QueueType = 6 AND Status IN (0,1))
-  IF @ReindexId <> -1 AND @RunningReindexId IS NOT NULL AND @RunningReindexId <> @ReindexId -- @ReindexId = -1 old code
+  -- check if job id is valid
+  IF @ReindexId > 0
+     AND NOT EXISTS (SELECT 1 FROM dbo.JobQueue WHERE PartitionId = @ReindexId % 16 AND QueueType = 6 AND JobId = @ReindexId AND Status = 1)
+    RAISERROR('Reindex job is not running', 18, 127)
+
+  IF @ReindexId = 0
   BEGIN
-    SET @msg = 'Reindex job is in progress. ReindexId='+isnull(convert(varchar,@RunningReindexId),'NULL')
-    ROLLBACK TRANSACTION;
-    THROW 50002, @msg, 1
-  END
-  
-  IF @InputLastUpdated IS NOT NULL -- check concurrency based on max(LastUpdated)
-  BEGIN
+    EXECUTE dbo.GetActiveJobs @QueueType = 6, @ReturnCountOnly = 1, @ActiveJobs = @ActiveReindexJobs OUT
+    IF @ActiveReindexJobs > 0 THROW 50002, 'Reindex job is in progress.', 1
+    
     SET @MaxLastUpdated = (SELECT max(LastUpdated) FROM dbo.SearchParam)
-    IF @MaxLastUpdated <> @InputLastUpdated AND @ReindexId IS NULL
+    IF @MaxLastUpdated <> @ExpectedLastUpdated
     BEGIN
-      SET @msg = 'Optimistic concurrency conflict detected : input last updated = '+convert(varchar(23),@InputLastUpdated,126)+' max last updated = '+convert(varchar(23),@MaxLastUpdated,126)
-      ROLLBACK TRANSACTION;
-      THROW 50001, @msg, 1
-    END
-  END
-  ELSE
-  BEGIN
-    -- remove below block once all callers are updated to pass LastUpdated
-    -- Check for concurrency conflicts first using LastUpdated
-    -- Only the top 60 are included in the message to avoid hitting the 8000 character limit, but all conflicts will cause the transaction to roll back
-    SELECT @msg = string_agg(S.Uri, ', ') 
-      FROM (
-        SELECT TOP 60 S.Uri
-          FROM @SearchParams I JOIN dbo.SearchParam S ON S.Uri = I.Uri
-          WHERE I.LastUpdated != S.LastUpdated) S
-    IF @msg IS NOT NULL
-    BEGIN
-      SET @msg = concat('Optimistic concurrency conflict detected for search parameters: ', @msg) 
-      ROLLBACK TRANSACTION;
+      SET @msg = 'Optimistic concurrency conflict detected : expected last updated = '+convert(varchar(23),@ExpectedLastUpdated,126)+' max last updated = '+convert(varchar(23),@MaxLastUpdated,126);
       THROW 50001, @msg, 1
     END
   END

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerSearchParameterStatusDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerSearchParameterStatusDataStore.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry
                 return;
             }
 
-            await UpsertStatusesWithRetry(statuses, 3, cancellationToken); // add reindexId when reindex job tests start using true queue client.
+            await UpsertStatusesWithRetry(statuses, 3, cancellationToken, reindexId); // add reindexId when reindex job tests start using true queue client.
         }
 
         private async Task UpsertStatusesWithRetry(IReadOnlyCollection<ResourceSearchParameterStatus> statuses, int maxRetries, CancellationToken cancellationToken, long? reindexId = null)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerSearchParameterStatusDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerSearchParameterStatusDataStore.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry
                 return;
             }
 
-            await UpsertStatusesWithRetry(statuses, 3, cancellationToken, reindexId);
+            await UpsertStatusesWithRetry(statuses, 3, cancellationToken); // add reindexId when reindex job tests start using true queue client.
         }
 
         private async Task UpsertStatusesWithRetry(IReadOnlyCollection<ResourceSearchParameterStatus> statuses, int maxRetries, CancellationToken cancellationToken, long? reindexId = null)
@@ -189,7 +189,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry
             using var cmd = new SqlCommand();
             cmd.CommandType = CommandType.StoredProcedure;
             cmd.CommandText = "dbo.MergeSearchParams";
-            if (_schemaInformation.Current >= 112)
+            if (_schemaInformation.Current >= 112 && reindexId.HasValue) // remove value check to invoke new max(LastUpdated) logic
             {
                 cmd.Parameters.AddWithValue("@ReindexId", reindexId ?? 0);
             }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerSearchParameterStatusDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/Registry/SqlServerSearchParameterStatusDataStore.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry
             return parameterStatuses;
         }
 
-        public async Task UpsertStatuses(IReadOnlyCollection<ResourceSearchParameterStatus> statuses, CancellationToken cancellationToken)
+        public async Task UpsertStatuses(IReadOnlyCollection<ResourceSearchParameterStatus> statuses, CancellationToken cancellationToken, long? reindexId = null)
         {
             EnsureArg.IsNotNull(statuses, nameof(statuses));
 
@@ -139,10 +139,10 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry
                 return;
             }
 
-            await UpsertStatusesWithRetry(statuses, 3, cancellationToken);
+            await UpsertStatusesWithRetry(statuses, 3, cancellationToken, reindexId);
         }
 
-        private async Task UpsertStatusesWithRetry(IReadOnlyCollection<ResourceSearchParameterStatus> statuses, int maxRetries, CancellationToken cancellationToken)
+        private async Task UpsertStatusesWithRetry(IReadOnlyCollection<ResourceSearchParameterStatus> statuses, int maxRetries, CancellationToken cancellationToken, long? reindexId = null)
         {
             var currentStatuses = statuses.ToList();
             int retryCount = 0;
@@ -151,7 +151,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry
             {
                 try
                 {
-                    await UpsertStatusesInternal(currentStatuses, cancellationToken);
+                    await UpsertStatusesInternal(currentStatuses, cancellationToken, reindexId);
                     return; // Success
                 }
                 catch (SqlException sqlEx) when (sqlEx.Number == 50001 && retryCount < maxRetries) // Our custom concurrency error
@@ -184,17 +184,14 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage.Registry
             }
         }
 
-        private async Task UpsertStatusesInternal(IReadOnlyCollection<ResourceSearchParameterStatus> statuses, CancellationToken cancellationToken)
+        private async Task UpsertStatusesInternal(IReadOnlyCollection<ResourceSearchParameterStatus> statuses, CancellationToken cancellationToken, long? reindexId = null)
         {
             using var cmd = new SqlCommand();
             cmd.CommandType = CommandType.StoredProcedure;
-            if (_schemaInformation.Current >= 111)
+            cmd.CommandText = "dbo.MergeSearchParams";
+            if (_schemaInformation.Current >= 112)
             {
-                cmd.CommandText = "dbo.MergeResourcesAndSearchParams";
-            }
-            else
-            {
-                cmd.CommandText = "dbo.MergeSearchParams";
+                cmd.Parameters.AddWithValue("@ReindexId", reindexId ?? 0);
             }
 
             new SearchParamListTableValuedParameterDefinition("@SearchParams").AddParameter(cmd.Parameters, new SearchParamListRowGenerator().GenerateRows(statuses.ToList()));

--- a/src/Microsoft.Health.Fhir.SqlServer/Microsoft.Health.Fhir.SqlServer.csproj
+++ b/src/Microsoft.Health.Fhir.SqlServer/Microsoft.Health.Fhir.SqlServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <!-- Properties used by sql task to generate full script -->
   <PropertyGroup>
-    <LatestSchemaVersion>111</LatestSchemaVersion>
+    <LatestSchemaVersion>112</LatestSchemaVersion>
     <GeneratedFullScriptPath>Features\Schema\Migrations\$(LatestSchemaVersion).sql</GeneratedFullScriptPath>
     <PackageTags>LatestSchemaVersion-$(LatestSchemaVersion)</PackageTags>
   </PropertyGroup>

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Import/ImportTests.cs
@@ -18,6 +18,7 @@ using EnsureThat;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using MediatR;
+using Microsoft.Azure.Cosmos.Linq;
 using Microsoft.Data.SqlClient;
 using Microsoft.Health.Fhir.Api.Features.Operations.Import;
 using Microsoft.Health.Fhir.Client;
@@ -574,7 +575,7 @@ EXECUTE dbo.MergeResourcesCommitTransaction @TransactionId
             Assert.Equal(2, history.Resource.Entry.Count);
             //// same order
             Assert.True(int.Parse(history.Resource.Entry[0].Resource.VersionId) > int.Parse(history.Resource.Entry[1].Resource.VersionId));
-            Assert.True(history.Resource.Entry[0].Resource.Meta.LastUpdated > history.Resource.Entry[1].Resource.Meta.LastUpdated);
+            Assert.True(history.Resource.Entry[0].Resource.Meta.LastUpdated > history.Resource.Entry[1].Resource.Meta.LastUpdated, $"Expected {history.Resource.Entry[0].Resource.Meta.LastUpdated.Value.ToString("yyyy-MM-dd HH:mm:ss.fffffff")} > {history.Resource.Entry[1].Resource.Meta.LastUpdated.Value.ToString("yyyy-MM-dd HH:mm:ss.fffffff")}");
         }
 
         [Fact]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/CustomSearchParamTests.cs
@@ -31,17 +31,12 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
     [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.Json)]
     public class CustomSearchParamTests : SearchTestsBase<HttpIntegrationTestFixture>
     {
-        private readonly HttpIntegrationTestFixture _fixture;
-        private readonly ITestOutputHelper _output;
         private const int MaxAllowedUrlLength = 128;
-        private const int MaxRetryCount = 10;
         private const string UrlLengthValidationMessage = "exceeds the maximum length limit of 128";
 
         public CustomSearchParamTests(HttpIntegrationTestFixture fixture, ITestOutputHelper output)
             : base(fixture)
         {
-            _fixture = fixture;
-            _output = output;
         }
 
         [RetryTheory]
@@ -104,12 +99,12 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 #if R5
             var baseResourceTypes = new List<VersionIndependentResourceTypesAll?>
             {
-                VersionIndependentResourceTypesAll.Patient,
+                VersionIndependentResourceTypesAll.Person,
             };
 #else
             var baseResourceTypes = new List<ResourceType?>
             {
-                ResourceType.Patient,
+                ResourceType.Person,
             };
 #endif
 
@@ -123,7 +118,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 Code = $"customparam{suffix[..8]}",
                 Base = baseResourceTypes,
                 Type = SearchParamType.String,
-                Expression = "Patient.name",
+                Expression = "Person.name",
             };
         }
     }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -669,7 +669,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
             // Confirm that "foo" is dropped from the query string and all patients are returned
             Assert.Equal(4, searchResults.Results.Count());
 
-            var createReindexRequest = new CreateReindexRequest(new List<string>(), new List<string>(), 2, 2);
+            var createReindexRequest = new CreateReindexRequest(new List<string>(), new List<string>(), 2, 2); // 1 does not work yet
             CreateReindexResponse response = await SetUpForReindexing(createReindexRequest);
 
             using var cancellationTokenSource = new CancellationTokenSource();

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -669,7 +669,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
             // Confirm that "foo" is dropped from the query string and all patients are returned
             Assert.Equal(4, searchResults.Results.Count());
 
-            var createReindexRequest = new CreateReindexRequest(new List<string>(), new List<string>(), 1, 1);
+            var createReindexRequest = new CreateReindexRequest(new List<string>(), new List<string>(), 2, 2);
             CreateReindexResponse response = await SetUpForReindexing(createReindexRequest);
 
             using var cancellationTokenSource = new CancellationTokenSource();

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -637,29 +637,20 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
             var searchParamCode = randomName + "Code";
             var searchParam = await CreateSearchParam(searchParamName, SearchParamType.String, KnownResourceTypes.Patient, "Patient.name", searchParamCode);
 
-            var createReindexRequest = new CreateReindexRequest(new List<string>(), new List<string>(), 2, 1); // 1 does not work yet
-            var response = await SetUpForReindexing(createReindexRequest);
+            var response = await SetUpForReindexing(new CreateReindexRequest([], [], 2, 1)); // 1 does not work yet);
 
             using var cancellationTokenSource = new CancellationTokenSource();
 
             try
             {
+                var cancelReindexHandler = new CancelReindexRequestHandler(_fhirOperationDataStore, DisabledFhirAuthorizationService.Instance);
+                await cancelReindexHandler.Handle(new CancelReindexRequest(response.Job.JobRecord.Id), CancellationToken.None);
+                ReindexJobWrapper coord = null;
                 var sw = Stopwatch.StartNew();
-                ReindexJobWrapper reindexJobWorker = null;
-                while (sw.Elapsed < TimeSpan.FromSeconds(300))
+                while (sw.Elapsed.TotalSeconds < 300)
                 {
-                    try
-                    {
-                        var cancelReindexHandler = new CancelReindexRequestHandler(_fhirOperationDataStore, DisabledFhirAuthorizationService.Instance);
-                        await cancelReindexHandler.Handle(new CancelReindexRequest(response.Job.JobRecord.Id), CancellationToken.None);
-                    }
-                    catch (Exception)
-                    {
-                        // do nothing.
-                    }
-
-                    reindexJobWorker = await _fhirOperationDataStore.GetReindexJobByIdAsync(response.Job.JobRecord.Id, cancellationTokenSource.Token);
-                    if (reindexJobWorker.JobRecord.Status == OperationStatus.Canceled)
+                    coord = await _fhirOperationDataStore.GetReindexJobByIdAsync(response.Job.JobRecord.Id, cancellationTokenSource.Token);
+                    if (coord.JobRecord.Status == OperationStatus.Canceled)
                     {
                         break;
                     }
@@ -667,7 +658,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                     await Task.Delay(500);
                 }
 
-                Assert.True(reindexJobWorker.JobRecord.Status == OperationStatus.Canceled, JsonConvert.SerializeObject(reindexJobWorker.JobRecord));
+                Assert.True(coord.JobRecord.Status == OperationStatus.Canceled, JsonConvert.SerializeObject(coord.JobRecord));
             }
             catch (RequestNotValidException ex)
             {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -676,12 +676,20 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
 
             try
             {
-                var cancelReindexHandler = new CancelReindexRequestHandler(_fhirOperationDataStore, DisabledFhirAuthorizationService.Instance);
-                await cancelReindexHandler.Handle(new CancelReindexRequest(response.Job.JobRecord.Id), CancellationToken.None);
                 var sw = Stopwatch.StartNew();
                 ReindexJobWrapper reindexJobWorker = null;
                 while (sw.Elapsed < TimeSpan.FromSeconds(300))
                 {
+                    try
+                    {
+                        var cancelReindexHandler = new CancelReindexRequestHandler(_fhirOperationDataStore, DisabledFhirAuthorizationService.Instance);
+                        await cancelReindexHandler.Handle(new CancelReindexRequest(response.Job.JobRecord.Id), CancellationToken.None);
+                    }
+                    catch (Exception)
+                    {
+                        // do nothing.
+                    }
+
                     reindexJobWorker = await _fhirOperationDataStore.GetReindexJobByIdAsync(response.Job.JobRecord.Id, cancellationTokenSource.Token);
                     if (reindexJobWorker.JobRecord.Status == OperationStatus.Canceled)
                     {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -624,8 +624,10 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
             }
         }
 
-        [Fact]
-        public async Task GivenReindexJobRunning_WhenReindexJobCancelRequest_ThenReindexJobStopsAndMarkedCanceled()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task GivenReindexJobRunning_WhenReindexJobCancelRequest_ThenReindexJobStopsAndMarkedCanceled(bool isCancel)
         {
             var sample1 = await CreatePatientResource("patient1", Guid.NewGuid().ToString());
             var sample2 = await CreatePatientResource("patient2", Guid.NewGuid().ToString());
@@ -641,14 +643,18 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
 
             try
             {
-                var cancelReindexHandler = new CancelReindexRequestHandler(_fhirOperationDataStore, DisabledFhirAuthorizationService.Instance);
-                await cancelReindexHandler.Handle(new CancelReindexRequest(response.Job.JobRecord.Id), CancellationToken.None);
+                if (isCancel)
+                {
+                    var cancelReindexHandler = new CancelReindexRequestHandler(_fhirOperationDataStore, DisabledFhirAuthorizationService.Instance);
+                    await cancelReindexHandler.Handle(new CancelReindexRequest(response.Job.JobRecord.Id), CancellationToken.None);
+                }
+
                 ReindexJobWrapper coord = null;
                 var sw = Stopwatch.StartNew();
                 while (sw.Elapsed.TotalSeconds < 300)
                 {
                     coord = await _fhirOperationDataStore.GetReindexJobByIdAsync(response.Job.JobRecord.Id, CancellationToken.None);
-                    if (coord.JobRecord.Status == OperationStatus.Canceled)
+                    if (coord.JobRecord.Status == (isCancel ? OperationStatus.Canceled : OperationStatus.Completed))
                     {
                         break;
                     }
@@ -656,7 +662,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                     await Task.Delay(500);
                 }
 
-                Assert.True(coord.JobRecord.Status == OperationStatus.Canceled, JsonConvert.SerializeObject(coord.JobRecord));
+                Assert.True(coord.JobRecord.Status == (isCancel ? OperationStatus.Canceled : OperationStatus.Completed), JsonConvert.SerializeObject(coord.JobRecord));
             }
             catch (RequestNotValidException ex)
             {
@@ -667,51 +673,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                 {
                     throw;
                 }
-            }
-            finally
-            {
-                _searchParameterDefinitionManager.DeleteSearchParameter(searchParam.ToTypedElement());
-                await _testHelper.DeleteSearchParameterStatusAsync(searchParam.Url, CancellationToken.None);
-
-                await _fixture.DataStore.HardDeleteAsync(sample1.Wrapper.ToResourceKey(), false, false, CancellationToken.None);
-                await _fixture.DataStore.HardDeleteAsync(sample2.Wrapper.ToResourceKey(), false, false, CancellationToken.None);
-                await _fixture.DataStore.HardDeleteAsync(sample3.Wrapper.ToResourceKey(), false, false, CancellationToken.None);
-                await _fixture.DataStore.HardDeleteAsync(sample4.Wrapper.ToResourceKey(), false, false, CancellationToken.None);
-            }
-        }
-
-        [Fact]
-        public async Task CheckSetup_GivenReindexJobRunning_WhenReindexJobCancelRequest_ThenReindexJobStopsAndMarkedCanceled()
-        {
-            // this is identical to the above test
-            var sample1 = await CreatePatientResource("patient1", Guid.NewGuid().ToString());
-            var sample2 = await CreatePatientResource("patient2", Guid.NewGuid().ToString());
-            var sample3 = await CreatePatientResource("patient3", Guid.NewGuid().ToString());
-            var sample4 = await CreatePatientResource("patient4", Guid.NewGuid().ToString());
-
-            var randomName = Guid.NewGuid().ToString().ComputeHash().Substring(0, 14).ToLower();
-            var searchParamName = randomName;
-            var searchParamCode = randomName + "Code";
-            var searchParam = await CreateSearchParam(searchParamName, SearchParamType.String, KnownResourceTypes.Patient, "Patient.name", searchParamCode);
-
-            var response = await SetUpForReindexing(new CreateReindexRequest([], [], 2, 1)); // 1 does not work yet);
-
-            try
-            {
-                ReindexJobWrapper coord = null;
-                var sw = Stopwatch.StartNew();
-                while (sw.Elapsed.TotalSeconds < 300)
-                {
-                    coord = await _fhirOperationDataStore.GetReindexJobByIdAsync(response.Job.JobRecord.Id, CancellationToken.None);
-                    if (coord.JobRecord.Status == OperationStatus.Completed)
-                    {
-                        break;
-                    }
-
-                    await Task.Delay(500);
-                }
-
-                Assert.True(coord.JobRecord.Status == OperationStatus.Completed, JsonConvert.SerializeObject(coord.JobRecord));
             }
             finally
             {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -678,9 +678,20 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
             {
                 var cancelReindexHandler = new CancelReindexRequestHandler(_fhirOperationDataStore, DisabledFhirAuthorizationService.Instance);
                 await cancelReindexHandler.Handle(new CancelReindexRequest(response.Job.JobRecord.Id), CancellationToken.None);
-                var reindexWrapper = await _fhirOperationDataStore.GetReindexJobByIdAsync(response.Job.JobRecord.Id, cancellationTokenSource.Token);
+                var sw = Stopwatch.StartNew();
+                ReindexJobWrapper reindexJobWorker = null;
+                while (sw.Elapsed < TimeSpan.FromSeconds(300))
+                {
+                    reindexJobWorker = await _fhirOperationDataStore.GetReindexJobByIdAsync(response.Job.JobRecord.Id, cancellationTokenSource.Token);
+                    if (reindexJobWorker.JobRecord.Status == OperationStatus.Canceled)
+                    {
+                        break;
+                    }
 
-                Assert.Equal(OperationStatus.Canceled, reindexWrapper.JobRecord.Status);
+                    await Task.Delay(500);
+                }
+
+                Assert.True(reindexJobWorker.JobRecord.Status == OperationStatus.Canceled, JsonConvert.SerializeObject(reindexJobWorker.JobRecord));
             }
             catch (RequestNotValidException ex)
             {
@@ -1324,7 +1335,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                 await Task.Delay(1000);
             }
 
-            Assert.Equal(OperationStatus.Completed, orchestrator.JobRecord.Status);
+            Assert.True(orchestrator.JobRecord.Status == OperationStatus.Completed, JsonConvert.SerializeObject(orchestrator.JobRecord));
 
             var serializer = new FhirJsonSerializer();
             _output.WriteLine(serializer.SerializeToString(orchestrator.ToParametersResourceElement().ToPoco<Parameters>()));

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -639,8 +639,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
 
             var response = await SetUpForReindexing(new CreateReindexRequest([], [], 2, 1)); // 1 does not work yet);
 
-            using var cancellationTokenSource = new CancellationTokenSource();
-
             try
             {
                 var cancelReindexHandler = new CancelReindexRequestHandler(_fhirOperationDataStore, DisabledFhirAuthorizationService.Instance);
@@ -649,7 +647,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                 var sw = Stopwatch.StartNew();
                 while (sw.Elapsed.TotalSeconds < 300)
                 {
-                    coord = await _fhirOperationDataStore.GetReindexJobByIdAsync(response.Job.JobRecord.Id, cancellationTokenSource.Token);
+                    coord = await _fhirOperationDataStore.GetReindexJobByIdAsync(response.Job.JobRecord.Id, CancellationToken.None);
                     if (coord.JobRecord.Status == OperationStatus.Canceled)
                     {
                         break;
@@ -672,8 +670,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
             }
             finally
             {
-                cancellationTokenSource.Cancel();
-
                 _searchParameterDefinitionManager.DeleteSearchParameter(searchParam.ToTypedElement());
                 await _testHelper.DeleteSearchParameterStatusAsync(searchParam.Url, CancellationToken.None);
 
@@ -700,15 +696,13 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
 
             var response = await SetUpForReindexing(new CreateReindexRequest([], [], 2, 1)); // 1 does not work yet);
 
-            using var cancellationTokenSource = new CancellationTokenSource();
-
             try
             {
                 ReindexJobWrapper coord = null;
                 var sw = Stopwatch.StartNew();
                 while (sw.Elapsed.TotalSeconds < 300)
                 {
-                    coord = await _fhirOperationDataStore.GetReindexJobByIdAsync(response.Job.JobRecord.Id, cancellationTokenSource.Token);
+                    coord = await _fhirOperationDataStore.GetReindexJobByIdAsync(response.Job.JobRecord.Id, CancellationToken.None);
                     if (coord.JobRecord.Status == OperationStatus.Completed)
                     {
                         break;
@@ -721,8 +715,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
             }
             finally
             {
-                cancellationTokenSource.Cancel();
-
                 _searchParameterDefinitionManager.DeleteSearchParameter(searchParam.ToTypedElement());
                 await _testHelper.DeleteSearchParameterStatusAsync(searchParam.Url, CancellationToken.None);
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -627,50 +627,18 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
         [Fact]
         public async Task GivenReindexJobRunning_WhenReindexJobCancelRequest_ThenReindexJobStopsAndMarkedCanceled()
         {
+            var sample1 = await CreatePatientResource("patient1", Guid.NewGuid().ToString());
+            var sample2 = await CreatePatientResource("patient2", Guid.NewGuid().ToString());
+            var sample3 = await CreatePatientResource("patient3", Guid.NewGuid().ToString());
+            var sample4 = await CreatePatientResource("patient4", Guid.NewGuid().ToString());
+
             var randomName = Guid.NewGuid().ToString().ComputeHash().Substring(0, 14).ToLower();
-            string searchParamName = randomName;
-            string searchParamCode = randomName + "Code";
-            SearchParameter searchParam = await CreateSearchParam(searchParamName, SearchParamType.String, KnownResourceTypes.Patient, "Patient.name", searchParamCode);
+            var searchParamName = randomName;
+            var searchParamCode = randomName + "Code";
+            var searchParam = await CreateSearchParam(searchParamName, SearchParamType.String, KnownResourceTypes.Patient, "Patient.name", searchParamCode);
 
-            const string sampleName1 = "searchIndicesPatient1";
-            const string sampleName2 = "searchIndicesPatient2";
-            const string sampleName3 = "searchIndicesPatient3";
-            const string sampleName4 = "searchIndicesPatient4";
-
-            string sampleId1 = Guid.NewGuid().ToString();
-            string sampleId2 = Guid.NewGuid().ToString();
-            string sampleId3 = Guid.NewGuid().ToString();
-            string sampleId4 = Guid.NewGuid().ToString();
-
-            // Set up the values that the search index extraction should return during reindexing
-            var searchValues = new List<(string, ISearchValue)>
-            {
-                (sampleId1, new StringSearchValue(sampleName1)),
-                (sampleId2, new StringSearchValue(sampleName2)),
-                (sampleId3, new StringSearchValue(sampleName3)),
-                (sampleId4, new StringSearchValue(sampleName4)),
-            };
-
-            MockSearchIndexExtraction(searchValues, searchParam);
-
-            UpsertOutcome sample1 = await CreatePatientResource(sampleName1, sampleId1);
-            UpsertOutcome sample2 = await CreatePatientResource(sampleName2, sampleId2);
-            UpsertOutcome sample3 = await CreatePatientResource(sampleName3, sampleId3);
-            UpsertOutcome sample4 = await CreatePatientResource(sampleName4, sampleId4);
-
-            // Create the query <fhirserver>/Patient?foo=searchIndicesPatient1
-            var queryParams = new List<Tuple<string, string>> { new(searchParamCode, sampleName1) };
-            SearchResult searchResults = await _searchService.Value.SearchAsync("Patient", queryParams, CancellationToken.None);
-
-            // Confirm that the search parameter "foo" is marked as unsupported
-            Assert.Equal(searchParamCode, searchResults.UnsupportedSearchParameters.FirstOrDefault()?.Item1);
-
-            // When search parameters aren't recognized, they are ignored
-            // Confirm that "foo" is dropped from the query string and all patients are returned
-            Assert.Equal(4, searchResults.Results.Count());
-
-            var createReindexRequest = new CreateReindexRequest(new List<string>(), new List<string>(), 2, 2); // 1 does not work yet
-            CreateReindexResponse response = await SetUpForReindexing(createReindexRequest);
+            var createReindexRequest = new CreateReindexRequest(new List<string>(), new List<string>(), 2, 1); // 1 does not work yet
+            var response = await SetUpForReindexing(createReindexRequest);
 
             using var cancellationTokenSource = new CancellationTokenSource();
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -685,6 +685,55 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
         }
 
         [Fact]
+        public async Task CheckSetup_GivenReindexJobRunning_WhenReindexJobCancelRequest_ThenReindexJobStopsAndMarkedCanceled()
+        {
+            // this is identical to the above test
+            var sample1 = await CreatePatientResource("patient1", Guid.NewGuid().ToString());
+            var sample2 = await CreatePatientResource("patient2", Guid.NewGuid().ToString());
+            var sample3 = await CreatePatientResource("patient3", Guid.NewGuid().ToString());
+            var sample4 = await CreatePatientResource("patient4", Guid.NewGuid().ToString());
+
+            var randomName = Guid.NewGuid().ToString().ComputeHash().Substring(0, 14).ToLower();
+            var searchParamName = randomName;
+            var searchParamCode = randomName + "Code";
+            var searchParam = await CreateSearchParam(searchParamName, SearchParamType.String, KnownResourceTypes.Patient, "Patient.name", searchParamCode);
+
+            var response = await SetUpForReindexing(new CreateReindexRequest([], [], 2, 1)); // 1 does not work yet);
+
+            using var cancellationTokenSource = new CancellationTokenSource();
+
+            try
+            {
+                ReindexJobWrapper coord = null;
+                var sw = Stopwatch.StartNew();
+                while (sw.Elapsed.TotalSeconds < 300)
+                {
+                    coord = await _fhirOperationDataStore.GetReindexJobByIdAsync(response.Job.JobRecord.Id, cancellationTokenSource.Token);
+                    if (coord.JobRecord.Status == OperationStatus.Completed)
+                    {
+                        break;
+                    }
+
+                    await Task.Delay(500);
+                }
+
+                Assert.True(coord.JobRecord.Status == OperationStatus.Completed, JsonConvert.SerializeObject(coord.JobRecord));
+            }
+            finally
+            {
+                cancellationTokenSource.Cancel();
+
+                _searchParameterDefinitionManager.DeleteSearchParameter(searchParam.ToTypedElement());
+                await _testHelper.DeleteSearchParameterStatusAsync(searchParam.Url, CancellationToken.None);
+
+                await _fixture.DataStore.HardDeleteAsync(sample1.Wrapper.ToResourceKey(), false, false, CancellationToken.None);
+                await _fixture.DataStore.HardDeleteAsync(sample2.Wrapper.ToResourceKey(), false, false, CancellationToken.None);
+                await _fixture.DataStore.HardDeleteAsync(sample3.Wrapper.ToResourceKey(), false, false, CancellationToken.None);
+                await _fixture.DataStore.HardDeleteAsync(sample4.Wrapper.ToResourceKey(), false, false, CancellationToken.None);
+            }
+        }
+
+        [Fact]
         public async Task GivenNewSearchParamCreatedAfterResourcesToBeIndexed_WhenReindexJobCompleted_ThenResourcesAreIndexedAndParamIsSearchable()
         {
             var randomName = Guid.NewGuid().ToString().ComputeHash().Substring(0, 14).ToLower();

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -110,8 +110,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
             _operationsConfig.Value.Returns(new OperationsConfiguration());
             _coreFeatureConfig.Value.Returns(new CoreFeatureConfiguration { SearchParameterCacheRefreshIntervalSeconds = 1 });
 
-            // Initialize critical fields first before cleanup
-            _fhirOperationDataStore = _fixture.OperationDataStore;
+            // initialize operations data store to use true queue clients
+            _fhirOperationDataStore = _fixture.SqlServerOperationDataStore ?? _fixture.CosmosOperationDataStore;
             _fhirStorageTestHelper = _fixture.TestHelper;
             _scopedDataStore = _fixture.DataStore.CreateMockScope();
             _searchService = _fixture.SearchService.CreateMockScope();
@@ -197,20 +197,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
 
         private void InitializeJobHosting()
         {
-            // Get the actual queue client from the operation datastore implementation
-            var operationDataStoreBase = _fhirOperationDataStore as FhirOperationDataStoreBase;
-            if (operationDataStoreBase != null)
-            {
-                // We need to access the _queueClient field using reflection since it's private
-                var field = typeof(FhirOperationDataStoreBase).GetField("_queueClient", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-                _queueClient = field?.GetValue(operationDataStoreBase) as IQueueClient;
-            }
-
-            // If we couldn't get the actual queue client, use the one from the fixture
-            if (_queueClient == null)
-            {
-                _queueClient = _fixture.QueueClient;
-            }
+            _queueClient = _fixture.QueueClient;
 
             if (_jobFactory == null)
             {
@@ -1292,7 +1279,9 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
         private async Task<JobInfo> SeedOrchestratorJobAsync(ReindexJobRecord jobRecord)
         {
             var definition = JsonConvert.SerializeObject(jobRecord);
-            return await _queueClient.EnqueueWithStatusAsync((byte)QueueType.Reindex, null, definition, JobStatus.Running, null, null, CancellationToken.None);
+            var jobInfo = await _queueClient.EnqueueWithStatusAsync((byte)QueueType.Reindex, null, definition, JobStatus.Running, null, null, CancellationToken.None);
+            jobInfo.QueueType = (byte)QueueType.Reindex;
+            return jobInfo;
         }
 
         private async Task SeedProcessingJobAsync(long groupId, ReindexProcessingJobDefinition jobDefinition, ReindexProcessingJobResult jobResult, JobStatus status, int? data)
@@ -1311,6 +1300,7 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                 : JsonConvert.SerializeObject(jobResult);
 
             var job = await _queueClient.EnqueueWithStatusAsync((byte)QueueType.Reindex, groupId, definition, JobStatus.Running, null, null, CancellationToken.None);
+            job.QueueType = (byte)QueueType.Reindex;
             job.Status = status;
             job.Data = data;
             job.Result = result;

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/CosmosDbFhirStorageTestsFixture.cs
@@ -100,6 +100,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
             };
         }
 
+        internal CosmosFhirOperationDataStore CosmosOperationDataStore => _cosmosFhirOperationDataStore;
+
         public Container Container => _container;
 
         public virtual async Task InitializeAsync()

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/FhirStorageTestsFixture.cs
@@ -52,6 +52,8 @@ using Microsoft.Health.Fhir.Core.Messages.Upsert;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.Fhir.Core.Registration;
 using Microsoft.Health.Fhir.Core.UnitTests.Extensions;
+using Microsoft.Health.Fhir.CosmosDb.Features.Storage.Operations;
+using Microsoft.Health.Fhir.SqlServer.Features.Storage;
 using Microsoft.Health.Fhir.Tests.Common;
 using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
 using Microsoft.Health.Fhir.Tests.Common.Mocks;
@@ -150,6 +152,32 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         public TestSqlHashCalculator SqlQueryHashCalculator => _fixture.GetRequiredService<TestSqlHashCalculator>();
 
         public GetResourceHandler GetResourceHandler { get; set; }
+
+        internal IFhirOperationDataStore CosmosOperationDataStore
+        {
+            get
+            {
+                if (_fixture is CosmosDbFhirStorageTestsFixture cosmosFixture)
+                {
+                    return cosmosFixture.CosmosOperationDataStore;
+                }
+
+                return null;
+            }
+        }
+
+        internal IFhirOperationDataStore SqlServerOperationDataStore
+        {
+            get
+            {
+                if (_fixture is SqlServerFhirStorageTestsFixture sqlFixture)
+                {
+                    return sqlFixture.SqlServerOperationDataStore;
+                }
+
+                return null;
+            }
+        }
 
         public IQueueClient QueueClient => _fixture.GetRequiredService<IQueueClient>();
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/SqlServerFhirStorageTestsFixture.cs
@@ -107,6 +107,8 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
 
         public string TestConnectionString { get; private set; }
 
+        internal SqlServerFhirOperationDataStore SqlServerOperationDataStore => _sqlServerFhirOperationDataStore;
+
         internal SqlTransactionHandler SqlTransactionHandler { get; private set; }
 
         internal SqlConnectionWrapperFactory SqlConnectionWrapperFactory { get; private set; }


### PR DESCRIPTION
Fixes:
https://microsofthealth.visualstudio.com/Health/_workitems/edit/190779
https://dev.azure.com/microsofthealth/Health/_workitems/edit/190931
https://dev.azure.com/microsofthealth/Health/_workitems/edit/190979

It also changes git ignore to exclude full SQL from check ins.

1. Eliminates code duplication between MergeSearchParams and MergeResourcesAndSearchParams by calling MergeSearchParams from MergeResourcesAndSearchParams
2. Adds ability to use max(LastUpdated) logic in the database when code is ready
3. Adds extra check for running reindex directly in SQL transaction in MergeSearchParams, thus ensuring absence of racing search param updates.
4. Fixes access in GetActiveJobs
5. Adds ability to check existence of active jobs without checking all JobQueue partitions.
6. Changes search param create tests to use Person instead of Patient.