### PR TITLE
Disable local auth for the cosmos db (S360 item)

### DIFF
--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -169,7 +169,7 @@ jobs:
             # Ensure Cosmos DB account exists
             $existingAccount = Get-AzCosmosDBAccount -ResourceGroupName $resourceGroupName -Name $cosmosDbAccountName -ErrorAction SilentlyContinue
             if ($null -eq $existingAccount) {
-                Write-Host "Cosmos DB account '$cosmosDbAccountName' does not exist. Creating with local auth disabled..."
+                Write-Host "Cosmos DB account '$cosmosDbAccountName' does not exist. Creating..."
                 Invoke-WithRetry -OperationName "Create Cosmos DB Account" -ScriptBlock {
                     New-AzCosmosDBAccount `
                         -ResourceGroupName $resourceGroupName `
@@ -177,23 +177,33 @@ jobs:
                         -Location (Get-AzResourceGroup -Name $resourceGroupName).Location `
                         -ApiKind "Sql" `
                         -DefaultConsistencyLevel "Strong" `
-                        -DisableLocalAuth $true `
                         -ErrorAction Stop
                 }
                 Write-Host "Cosmos DB account '$cosmosDbAccountName' created successfully."
             } else {
                 Write-Host "Cosmos DB account '$cosmosDbAccountName' already exists."
-                if (-not $existingAccount.DisableLocalAuth) {
-                    Write-Host "Local auth is enabled on existing account. Updating to disable local auth..."
-                    Invoke-WithRetry -OperationName "Update Cosmos DB Account - Disable Local Auth" -ScriptBlock {
-                        Update-AzCosmosDBAccount `
-                            -ResourceGroupName $resourceGroupName `
-                            -Name $cosmosDbAccountName `
-                            -DisableLocalAuth $true `
-                            -ErrorAction Stop
+            }
+
+            # Disable local auth on the Cosmos DB account via REST API
+            $subscriptionId = (Get-AzContext).Subscription.Id
+            $cosmosResourceId = "/subscriptions/$subscriptionId/resourceGroups/$resourceGroupName/providers/Microsoft.DocumentDB/databaseAccounts/$cosmosDbAccountName"
+            $existingAccount = Get-AzCosmosDBAccount -ResourceGroupName $resourceGroupName -Name $cosmosDbAccountName -ErrorAction Stop
+            if (-not $existingAccount.DisableLocalAuth) {
+                Write-Host "Disabling local auth on Cosmos DB account '$cosmosDbAccountName'..."
+                $patchBody = @{ properties = @{ disableLocalAuth = $true } } | ConvertTo-Json -Depth 5
+                Invoke-WithRetry -OperationName "Disable Local Auth on Cosmos DB" -ScriptBlock {
+                    $response = Invoke-AzRestMethod `
+                        -Path "$cosmosResourceId`?api-version=2024-05-15" `
+                        -Method PATCH `
+                        -Payload $patchBody `
+                        -ErrorAction Stop
+                    if ($response.StatusCode -ge 400) {
+                        throw "Failed to disable local auth. Status: $($response.StatusCode), Body: $($response.Content)"
                     }
-                    Write-Host "Local auth disabled on Cosmos DB account '$cosmosDbAccountName'."
                 }
+                Write-Host "Local auth disabled on Cosmos DB account '$cosmosDbAccountName'."
+            } else {
+                Write-Host "Local auth is already disabled on Cosmos DB account '$cosmosDbAccountName'."
             }
 
             # Ensure Cosmos DB database exists

--- a/build/jobs/provision-deploy.yml
+++ b/build/jobs/provision-deploy.yml
@@ -169,7 +169,7 @@ jobs:
             # Ensure Cosmos DB account exists
             $existingAccount = Get-AzCosmosDBAccount -ResourceGroupName $resourceGroupName -Name $cosmosDbAccountName -ErrorAction SilentlyContinue
             if ($null -eq $existingAccount) {
-                Write-Host "Cosmos DB account '$cosmosDbAccountName' does not exist. Creating..."
+                Write-Host "Cosmos DB account '$cosmosDbAccountName' does not exist. Creating with local auth disabled..."
                 Invoke-WithRetry -OperationName "Create Cosmos DB Account" -ScriptBlock {
                     New-AzCosmosDBAccount `
                         -ResourceGroupName $resourceGroupName `
@@ -177,11 +177,23 @@ jobs:
                         -Location (Get-AzResourceGroup -Name $resourceGroupName).Location `
                         -ApiKind "Sql" `
                         -DefaultConsistencyLevel "Strong" `
+                        -DisableLocalAuth $true `
                         -ErrorAction Stop
                 }
                 Write-Host "Cosmos DB account '$cosmosDbAccountName' created successfully."
             } else {
                 Write-Host "Cosmos DB account '$cosmosDbAccountName' already exists."
+                if (-not $existingAccount.DisableLocalAuth) {
+                    Write-Host "Local auth is enabled on existing account. Updating to disable local auth..."
+                    Invoke-WithRetry -OperationName "Update Cosmos DB Account - Disable Local Auth" -ScriptBlock {
+                        Update-AzCosmosDBAccount `
+                            -ResourceGroupName $resourceGroupName `
+                            -Name $cosmosDbAccountName `
+                            -DisableLocalAuth $true `
+                            -ErrorAction Stop
+                    }
+                    Write-Host "Local auth disabled on Cosmos DB account '$cosmosDbAccountName'."
+                }
             }
 
             # Ensure Cosmos DB database exists


### PR DESCRIPTION
## Description
In provision-deploy.yml, the New-AzCosmosDBAccount call does not include the -DisableKeyBasedMetadataWriteAccess or a way to disable local auth. The ARM template at default-azuredeploy-docker.json has "disableLocalAuth": true hardcoded, but this template is not used by the PR provisioning pipeline — the PR pipeline uses the PowerShell New-AzCosmosDBAccount cmdlet directly, which defaults to local auth enabled.

## Related issues
Addresses [User Story 190850](https://dev.azure.com/microsofthealth/Health/_workitems/edit/190850)

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
