### PR TITLE
Return 404 for mis-cased FHIR resource type segments

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Routing/ResourceTypesRouteConstraint.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Routing/ResourceTypesRouteConstraint.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Routing
 
             if (values.TryGetValue(KnownActionParameterNames.ResourceType, out var resourceTypeObj) && resourceTypeObj is string resourceType && !string.IsNullOrEmpty(resourceType))
             {
-                return ModelInfoProvider.IsKnownResource(resourceType);
+                return ModelInfoProvider.IsKnownResource(resourceType, ignoreCase: false);
             }
 
             return false;

--- a/src/Microsoft.Health.Fhir.Core/Features/Conformance/ConformanceProviderBase.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Conformance/ConformanceProviderBase.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Conformance
 {
     public abstract class ConformanceProviderBase : IConformanceProvider
     {
-        private readonly ConcurrentDictionary<string, bool> _evaluatedQueries = new ConcurrentDictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+        private readonly ConcurrentDictionary<string, bool> _evaluatedQueries = new ConcurrentDictionary<string, bool>(StringComparer.Ordinal);
 
         public abstract Task<ResourceElement> GetCapabilityStatementOnStartup(CancellationToken cancellationToken = default(CancellationToken));
 

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Routing/ResourceTypesRouteConstraintTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Routing/ResourceTypesRouteConstraintTests.cs
@@ -67,6 +67,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Routing
         [InlineData("PUT")]
         [InlineData("DELETE")]
         [InlineData("POST")]
+        [InlineData("PATCH")]
         public async Task GivenAMisCasedResourceTypeForAnyVerb_WhenRouting_ThenConstraintIsNotPassed(string verb)
         {
             var data = await GetRouteData(verb, "/patient/1234");

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Routing/ResourceTypesRouteConstraintTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Routing/ResourceTypesRouteConstraintTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Routing
         [InlineData("PATCH")]
         public async Task GivenAMisCasedResourceTypeForAnyVerb_WhenRouting_ThenConstraintIsNotPassed(string verb)
         {
-            var data = await GetRouteData(verb, "/patient/1234");
+            var data = await GetRouteData(verb, "/patient");
 
             Assert.Empty(data.Routers);
             Assert.False(data.Values.ContainsKey(KnownActionParameterNames.ResourceType));

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Routing/ResourceTypesRouteConstraintTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Routing/ResourceTypesRouteConstraintTests.cs
@@ -48,6 +48,33 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Routing
             Assert.False(data.Values.ContainsKey(KnownActionParameterNames.ResourceType));
         }
 
+        [Theory]
+        [InlineData("/patient/1234")]
+        [InlineData("/PATIENT/1234")]
+        [InlineData("/oBsErVaTiOn/1234")]
+        public async Task GivenAMisCasedModelRequest_WhenRouting_ThenConstraintIsNotPassed(string path)
+        {
+            // FHIR resource type names are case-sensitive. Mis-cased types must not match
+            // the typed routes so ASP.NET routing returns a framework 404 (not 405).
+            var data = await GetRouteData(HttpMethods.Get, path);
+
+            Assert.Empty(data.Routers);
+            Assert.False(data.Values.ContainsKey(KnownActionParameterNames.ResourceType));
+        }
+
+        [Theory]
+        [InlineData("GET")]
+        [InlineData("PUT")]
+        [InlineData("DELETE")]
+        [InlineData("POST")]
+        public async Task GivenAMisCasedResourceTypeForAnyVerb_WhenRouting_ThenConstraintIsNotPassed(string verb)
+        {
+            var data = await GetRouteData(verb, "/patient/1234");
+
+            Assert.Empty(data.Routers);
+            Assert.False(data.Values.ContainsKey(KnownActionParameterNames.ResourceType));
+        }
+
         protected override void AddAdditionalServices(IServiceCollection builder)
         {
             new MvcModule().Load(builder);

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Validation/ValidateCapabilityPreProcessorTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Validation/ValidateCapabilityPreProcessorTests.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Validation
         {
             var statement = CapabilityStatementMock.GetMockedCapabilityStatement();
             CapabilityStatementMock.SetupMockResource(statement, ResourceType.Observation, interactions: new[] { TypeRestfulInteraction.Read });
+            CapabilityStatementMock.SetupMockResource(statement, ResourceType.Patient, interactions: new[] { TypeRestfulInteraction.Delete });
 
             _conformanceProvider = Substitute.For<ConformanceProviderBase>();
             _conformanceProvider.GetCapabilityStatementOnStartup().Returns(statement.ToTypedElement().ToResourceElement());
@@ -61,6 +62,21 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Validation
             var deleteResourceRequest = new DeleteResourceRequest("Observation", Guid.NewGuid().ToString(), deleteOperation, bundleResourceContext: null);
 
             await Assert.ThrowsAsync<MethodNotAllowedException>(async () => await preProcessor.Process(deleteResourceRequest, CancellationToken.None));
+        }
+
+        [Theory]
+        [InlineData(DeleteOperation.SoftDelete)]
+        [InlineData(DeleteOperation.HardDelete)]
+        public async Task GivenCaseMismatchedRequestValidatedFirst_WhenValidatingCorrectCasing_ThenCapabilityLookupShouldNotBePoisoned(DeleteOperation deleteOperation)
+        {
+            var preProcessor = new ValidateCapabilityPreProcessor<DeleteResourceRequest>(_conformanceProvider);
+
+            var invalidDeleteRequest = new DeleteResourceRequest("patient", Guid.NewGuid().ToString(), deleteOperation, bundleResourceContext: null);
+            var validDeleteRequest = new DeleteResourceRequest("Patient", Guid.NewGuid().ToString(), deleteOperation, bundleResourceContext: null);
+
+            await Assert.ThrowsAsync<MethodNotAllowedException>(async () => await preProcessor.Process(invalidDeleteRequest, CancellationToken.None));
+
+            await preProcessor.Process(validDeleteRequest, CancellationToken.None);
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ResourceTypeCaseSensitivityTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ResourceTypeCaseSensitivityTests.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
         [InlineData("PUT", "patient/123")]
         [InlineData("DELETE", "patient/123")]
         [InlineData("POST", "patient")]
+        [InlineData("PATCH", "patient/123")]
         public async Task GivenAMisCasedResourceType_WhenSendingRequest_ThenServerReturnsNotFound(string verb, string path)
         {
             using var request = new HttpRequestMessage(new HttpMethod(verb), path);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ResourceTypeCaseSensitivityTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ResourceTypeCaseSensitivityTests.cs
@@ -1,0 +1,56 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Fhir.Tests.Common.FixtureParameters;
+using Microsoft.Health.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Tests.E2E.Rest
+{
+    /// <summary>
+    /// Verifies that the FHIR server treats resource type names as case-sensitive,
+    /// per the FHIR specification. Mis-cased resource type segments must be rejected
+    /// with HTTP 404 Not Found at the routing layer (not 405 Method Not Allowed).
+    /// </summary>
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.Web)]
+    [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.Json)]
+    public class ResourceTypeCaseSensitivityTests : IClassFixture<HttpIntegrationTestFixture>
+    {
+        private readonly HttpClient _client;
+
+        public ResourceTypeCaseSensitivityTests(HttpIntegrationTestFixture fixture)
+        {
+            _client = fixture.TestFhirClient.HttpClient;
+        }
+
+        [Theory]
+        [InlineData("GET", "patient/123")]
+        [InlineData("GET", "PATIENT/123")]
+        [InlineData("GET", "patient")]
+        [InlineData("PUT", "patient/123")]
+        [InlineData("DELETE", "patient/123")]
+        [InlineData("POST", "patient")]
+        public async Task GivenAMisCasedResourceType_WhenSendingRequest_ThenServerReturnsNotFound(string verb, string path)
+        {
+            using var request = new HttpRequestMessage(new HttpMethod(verb), path);
+            using HttpResponseMessage response = await _client.SendAsync(request);
+
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task GivenACorrectlyCasedResourceType_WhenSendingRequest_ThenServerDoesNotReturnNotFoundForRouting()
+        {
+            using HttpResponseMessage response = await _client.GetAsync("Patient");
+
+            Assert.NotEqual(HttpStatusCode.NotFound, response.StatusCode);
+        }
+    }
+}


### PR DESCRIPTION
## Description

This PR fixes two related case-sensitivity bugs surfaced by requests like
`GET /patient/{id}` (lowercase resource type):

1. **405 instead of 404 for mis-cased resource types.** - not fhir spec
2. **Capability cache poisoning.**  - once you go 405, you can't run a valid query for the resource
3. 
## Reproduction

### Bug 1: mis-cased resource type returns 405
1. Start the server.
2. Issue `GET https://localhost:44348/patient/123` (lowercase) — or `PUT`, `DELETE`, `POST`.
4. Current behavior: **405**.
5. Expected behavior: **404**.

### Bug 2: lowercase request poisons later correctly-cased requests
1. Start the server.
2. Issue `DELETE https://localhost:44348/patient/123`.
3. Issue `DELETE https://localhost:44348/Patient/123`.
4. Current behavior: the second request can return **405** from
   `ValidateCapabilityPreProcessor` and continues to do so for the lifetime of the process.
6. Expected behavior: only the lowercase request should fail.


## Related Work Items

[AB#190027](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/190027)