### PR TITLE
Enhance input validation for export parameters

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Api/Resources.Designer.cs
@@ -284,6 +284,15 @@ namespace Microsoft.Health.Fhir.Api {
                 return ResourceManager.GetString("ExpandMissingRequiredParameter", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The value &apos;{0}&apos; is not valid. Path traversal characters are not allowed..
+        /// </summary>
+        public static string ExportParameterPathTraversalNotAllowed {
+            get {
+                return ResourceManager.GetString("ExportParameterPathTraversalNotAllowed", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Failed while running health check..

--- a/src/Microsoft.Health.Fhir.Api/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Api/Resources.resx
@@ -423,6 +423,9 @@
   <data name="InvalidExportAssociatedDataParameter" xml:space="preserve">
     <value>The export parameter "includeAssociatedData" contains an invalid value. Supported values are: {0}. </value>
   </data>
+  <data name="ExportParameterPathTraversalNotAllowed" xml:space="preserve">
+    <value>The value '{0}' is not valid. Path traversal characters are not allowed.</value>
+  </data>
   <data name="OAuth2ContentTypeMustBeFormUrlEncoded" xml:space="preserve">
     <value>Content-Type must be application/x-www-form-urlencoded.</value>
   </data>

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ExportControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ExportControllerTests.cs
@@ -235,6 +235,104 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
                 typeParameter: ResourceType.Patient.ToString()));
         }
 
+        [Theory]
+        [InlineData("../secret")]
+        [InlineData("..\\secret")]
+        [InlineData("..%2fsecret")]
+        public async Task GivenAnExportRequest_WhenContainerHasPathTraversal_ThenRequestNotValidExceptionShouldBeThrown(string containerName)
+        {
+            var exportController = GetController(_exportEnabledJobConfiguration, _featureConfiguration, _artifactStoreConfig);
+
+            await Assert.ThrowsAsync<RequestNotValidException>(() => exportController.Export(
+                typeFilter: null,
+                since: null,
+                till: null,
+                resourceType: null,
+                containerName: containerName,
+                formatName: null,
+                isParallel: false,
+                maxCount: 0,
+                anonymizationConfigCollectionReference: null,
+                anonymizationConfigLocation: null,
+                anonymizationConfigFileETag: null));
+        }
+
+        [Theory]
+        [InlineData("../secret/config.json")]
+        [InlineData("..\\secret\\config.json")]
+        [InlineData("..%2fsecret%2fconfig.json")]
+        [InlineData("secret/..")]
+        [InlineData("a/../b")]
+        public async Task GivenAnAnonymizedExportRequest_WhenAnonymizationConfigHasPathTraversal_ThenRequestNotValidExceptionShouldBeThrown(string anonymizationConfigLocation)
+        {
+            var exportController = GetController(_exportEnabledJobConfiguration, _anonymizationEnabledFeatureConfiguration, _artifactStoreConfig);
+
+            await Assert.ThrowsAsync<RequestNotValidException>(() => exportController.ExportResourceType(
+                typeFilter: null,
+                since: null,
+                till: null,
+                resourceType: null,
+                containerName: _testContainer,
+                formatName: null,
+                maxCount: 0,
+                anonymizationConfigCollectionReference: null,
+                anonymizationConfigLocation: anonymizationConfigLocation,
+                anonymizationConfigFileETag: null,
+                typeParameter: ResourceType.Patient.ToString()));
+        }
+
+        [Theory]
+        [InlineData("mycontainer")]
+        [InlineData("config.json")]
+        [InlineData("folder/config.json")]
+        [InlineData("my..config.json")]
+        [InlineData("configv2..0.json")]
+        public async Task GivenAnAnonymizedExportRequest_WhenExportParametersAreValid_ThenValidationAllowsRequest(string anonymizationConfigLocation)
+        {
+            var exportController = GetController(_exportEnabledJobConfiguration, _anonymizationEnabledFeatureConfiguration, _artifactStoreConfig);
+            ConfigureControllerForSuccessfulExport(exportController);
+
+            var exception = await Record.ExceptionAsync(() => exportController.ExportResourceType(
+                typeFilter: null,
+                since: null,
+                till: null,
+                resourceType: null,
+                containerName: "mycontainer",
+                formatName: null,
+                maxCount: 0,
+                anonymizationConfigCollectionReference: null,
+                anonymizationConfigLocation: anonymizationConfigLocation,
+                anonymizationConfigFileETag: null,
+                typeParameter: ResourceType.Patient.ToString()));
+
+            Assert.Null(exception);
+        }
+
+        [Theory]
+        [InlineData("mycontainer")]
+        [InlineData("my-container-2")]
+        [InlineData("export2026")]
+        public async Task GivenAnExportRequest_WhenContainerIsValid_ThenValidationAllowsRequest(string containerName)
+        {
+            var exportController = GetController(_exportEnabledJobConfiguration, _featureConfiguration, _artifactStoreConfig);
+            ConfigureControllerForSuccessfulExport(exportController);
+
+            var exception = await Record.ExceptionAsync(() => exportController.Export(
+                typeFilter: null,
+                since: null,
+                till: null,
+                resourceType: null,
+                containerName: containerName,
+                formatName: null,
+                isParallel: false,
+                maxCount: 0,
+                anonymizationConfigCollectionReference: null,
+                anonymizationConfigLocation: null,
+                anonymizationConfigFileETag: null));
+
+            Assert.Null(exception);
+        }
+
         [Fact]
         public async Task GivenAnExportRequestWithHistoryOrDeletedIncluded_WhenHasTypeFilter_ThenRequestNotValidExceptionShouldBeThrown()
         {
@@ -526,6 +624,30 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
                 optionsArtifactStoreConfiguration,
                 optionsFeatures,
                 fhirConfig ?? Substitute.For<IFhirRuntimeConfiguration>());
+        }
+
+        // Configures mocks so the controller can dispatch through MediatR without throwing.
+        // Required for positive-path tests that verify validation allows the request through.
+        private void ConfigureControllerForSuccessfulExport(ExportController exportController)
+        {
+            exportController.ControllerContext.HttpContext = new DefaultHttpContext();
+
+            var baseUri = new Uri("https://test.com/");
+            _fhirRequestContextAccessor.RequestContext = new FhirRequestContext(
+               method: "export",
+               uriString: baseUri.OriginalString,
+               baseUriString: baseUri.OriginalString,
+               correlationId: "export",
+               requestHeaders: new Dictionary<string, StringValues>(),
+               responseHeaders: new Dictionary<string, StringValues>());
+
+            _urlResolver
+                .ResolveOperationResultUrl(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(baseUri);
+
+            _mediator
+                .Send(Arg.Any<CreateExportRequest>(), Arg.Any<CancellationToken>())
+                .Returns(new CreateExportResponse("ExportTestJobId"));
         }
 
         private async Task RunCreateExportRequestTest(

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ExportController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/ExportController.cs
@@ -109,6 +109,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             [FromQuery(Name = KnownQueryParameterNames.AnonymizationConfigurationFileEtag)] string anonymizationConfigFileETag = null)
         {
             CheckIfExportIsEnabled();
+            ValidatePathTraversalForExportParameter(containerName);
             ValidateForAnonymizedExport(containerName, anonymizationConfigCollectionReference, anonymizationConfigLocation, anonymizationConfigFileETag);
             (bool includeHistory, bool includeDeleted) = ValidateAndParseIncludeAssociatedData(includeAssociatedData, typeFilter);
 
@@ -147,6 +148,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             [FromQuery(Name = KnownQueryParameterNames.AnonymizationConfigurationFileEtag)] string anonymizationConfigFileETag = null)
         {
             CheckIfExportIsEnabled();
+            ValidatePathTraversalForExportParameter(containerName);
             ValidateForAnonymizedExport(containerName, anonymizationConfigCollectionReference, anonymizationConfigLocation, anonymizationConfigFileETag);
 
             // Export by ResourceType is supported only for Patient resource type.
@@ -189,6 +191,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             [FromQuery(Name = KnownQueryParameterNames.AnonymizationConfigurationFileEtag)] string anonymizationConfigFileETag = null)
         {
             CheckIfExportIsEnabled();
+            ValidatePathTraversalForExportParameter(containerName);
             ValidateForAnonymizedExport(containerName, anonymizationConfigCollectionReference, anonymizationConfigLocation, anonymizationConfigFileETag);
 
             // Export by ResourceTypeId is supported only for Group resource type.
@@ -330,6 +333,31 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             if (string.IsNullOrWhiteSpace(containerName))
             {
                 throw new RequestNotValidException(Resources.ContainerIsRequiredForAnonymizedExport);
+            }
+
+            ValidatePathTraversalForExportParameter(anonymizationConfigLocation);
+        }
+
+        /// <summary>
+        /// Validates that a parameter value does not contain directory traversal sequences.
+        /// Rejects values where any path segment (split on / or \, after URL-decoding) is exactly "..".
+        /// This prevents callers from escaping the intended blob container boundary.
+        /// </summary>
+        private static void ValidatePathTraversalForExportParameter(string parameterValue)
+        {
+            if (string.IsNullOrWhiteSpace(parameterValue))
+            {
+                return;
+            }
+
+            // Decode percent-encoded separators so that sequences like ..%2f are normalized before checking.
+            string decoded = Uri.UnescapeDataString(parameterValue);
+
+            // Reject the value if any path segment is ".." (directory traversal).
+            string[] segments = decoded.Split('/', '\\');
+            if (Array.Exists(segments, static segment => segment == ".."))
+            {
+                throw new RequestNotValidException(string.Format(Resources.ExportParameterPathTraversalNotAllowed, parameterValue));
             }
         }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Export/ExportTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Export/ExportTests.cs
@@ -190,6 +190,43 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Export
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         }
 
+        [Theory]
+        [InlineData("../secret")]
+        [InlineData("..\\secret")]
+        [InlineData("..%2fsecret")]
+        public async Task GivenExportIsEnabled_WhenContainerContainsPathTraversal_ThenServerShouldReturnBadRequest(string container)
+        {
+            var queryParam = new Dictionary<string, string>
+            {
+                { KnownQueryParameterNames.Container, container },
+            };
+
+            using HttpRequestMessage request = GenerateExportRequest("$export", queryParams: queryParam);
+
+            using HttpResponseMessage response = await _client.SendAsync(request);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
+        [Theory]
+        [InlineData("../secret/config.json")]
+        [InlineData("..\\secret\\config.json")]
+        [InlineData("..%2fsecret%2fconfig.json")]
+        public async Task GivenExportIsEnabled_WhenAnonymizationConfigContainsPathTraversal_ThenServerShouldReturnBadRequest(string anonymizationConfig)
+        {
+            var queryParam = new Dictionary<string, string>
+            {
+                { KnownQueryParameterNames.Container, "test-container" },
+                { KnownQueryParameterNames.AnonymizationConfigurationLocation, anonymizationConfig },
+            };
+
+            using HttpRequestMessage request = GenerateExportRequest("$export", queryParams: queryParam);
+
+            using HttpResponseMessage response = await _client.SendAsync(request);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
         private HttpRequestMessage GenerateExportRequest(
             string path = "$export",
             string acceptHeader = ContentType.JSON_CONTENT_HEADER,


### PR DESCRIPTION
## Description

Adds input validation to the `$export` endpoint to reject path traversal sequences (`../`, `..\`, and URL-encoded equivalents) in the `_container` and `_anonymizationConfig` query parameters. This ensures parameter values conform to expected blob storage path formats and prevents unexpected path resolution behavior when constructing Azure Blob Storage URLs.

Addresses [AB#190623](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/190623)

## Changes

- Added `ValidatePathTraversalForExportParameter()` private static method in `ExportController`
- Validation applied in all three export entry points (`Export`, `ExportResourceType`, `ExportResourceTypeById`) for `_container`
- Validation applied in `CheckContainerNameAndConfigLocationForAnonymizedExport()` for `_anonymizationConfig`
- Added resource string `ExportParameterPathTraversalNotAllowed` for the error message
- Added unit tests covering rejection of traversal patterns (`../`, `..\`, `..%2f`) and acceptance of valid values
- Added E2E tests confirming 400 Bad Request response for invalid inputs

## Testing

- Unit tests: 1275 passed, 0 failed (both net8.0 and net9.0)
- E2E tests added for both `_container` and `_anonymizationConfig` traversal scenarios
- Tests verify both rejection of invalid values and acceptance of legitimate values

## PR Checklist

- [x] This change does not require a SQL migration
- [x] Unit tests added
- [x] E2E tests added