### PR TITLE
Ensure PR pipeline runs E2E tests separately

### DIFF
--- a/build/ci-pipeline.yml
+++ b/build/ci-pipeline.yml
@@ -200,6 +200,9 @@ stages:
       keyVaultName: $(KeyVaultNameSql)
       containerAppName: $(DeploymentEnvironmentNameSql)
       integrationSqlServerName: $(DeploymentEnvironmentName)inttest
+      mainCategoryFilter: 'Category!=ExportLongRunning'
+      runReindexJob: false
+      runBulkUpdateJob: false
 
 # *********************** R4 ***********************
 - stage: redeployR4
@@ -254,6 +257,9 @@ stages:
       keyVaultName: $(KeyVaultNameR4Sql)
       containerAppName: $(DeploymentEnvironmentNameR4Sql)
       integrationSqlServerName: $(DeploymentEnvironmentName)inttest
+      mainCategoryFilter: 'Category!=ExportLongRunning'
+      runReindexJob: false
+      runBulkUpdateJob: false
 
 # *********************** R5 ***********************
 - stage: redeployR5Sql
@@ -281,6 +287,9 @@ stages:
       keyVaultName: $(KeyVaultNameR5Sql)
       containerAppName: $(DeploymentEnvironmentNameR5Sql)
       integrationSqlServerName: $(DeploymentEnvironmentName)inttest
+      mainCategoryFilter: 'Category!=ExportLongRunning'
+      runReindexJob: false
+      runBulkUpdateJob: false
 
 - stage: aggregateCoverage
   displayName: 'Aggregate All Coverage Reports'

--- a/build/jobs/run-sql-tests.yml
+++ b/build/jobs/run-sql-tests.yml
@@ -7,6 +7,15 @@ parameters:
   type: string
 - name: integrationSqlServerName
   type: string
+- name: mainCategoryFilter
+  type: string
+  default: 'Category!=ExportLongRunning&Category!=IndexAndReindex&Category!=BulkUpdate'
+- name: runReindexJob
+  type: boolean
+  default: true
+- name: runBulkUpdateJob
+  type: boolean
+  default: true
 jobs:
 
 - job: "SqlIntegrationTests"
@@ -105,4 +114,38 @@ jobs:
       version: ${{ parameters.version }}
       containerAppName: '${{ parameters.containerAppName }}'
       appServiceType: 'SqlServer'
-      categoryFilter: 'Category!=ExportLongRunning'
+      categoryFilter: '${{ parameters.mainCategoryFilter }}'
+
+- ${{ if eq(parameters.runReindexJob, true) }}:
+  - job: 'sqlE2eTests_Reindex'
+    timeoutInMinutes: 120
+    dependsOn: []
+    pool:
+      name: '$(SharedLinuxPool)'
+      vmImage: '$(LinuxVmImage)'
+    steps:
+    - template: e2e-setup.yml
+    - template: e2e-tests.yml
+      parameters:
+        version: ${{ parameters.version }}
+        containerAppName: '${{ parameters.containerAppName }}'
+        appServiceType: 'SqlServer'
+        categoryFilter: 'Category=IndexAndReindex'
+        testRunTitleSuffix: ' Reindex'
+
+- ${{ if eq(parameters.runBulkUpdateJob, true) }}:
+  - job: 'sqlE2eTests_BulkUpdate'
+    timeoutInMinutes: 120
+    dependsOn: []
+    pool:
+      name: '$(SharedLinuxPool)'
+      vmImage: '$(LinuxVmImage)'
+    steps:
+    - template: e2e-setup.yml
+    - template: e2e-tests.yml
+      parameters:
+        version: ${{ parameters.version }}
+        containerAppName: '${{ parameters.containerAppName }}'
+        appServiceType: 'SqlServer'
+        categoryFilter: 'Category=BulkUpdate'
+        testRunTitleSuffix: ' BulkUpdate'


### PR DESCRIPTION
## Description
Ensure PR pipeline runs Reindex and BulkUpdate tests as separate jobs for SQL


## Related issues
Addresses [AB#182377](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/182377).

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
