### PR TITLE
Refactor BulkDeleteController to simplify search parameter checks

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/BulkDeleteControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/BulkDeleteControllerTests.cs
@@ -16,7 +16,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Api.Controllers;
 using Microsoft.Health.Fhir.Api.Features.ActionResults;
 using Microsoft.Health.Fhir.Api.Models;
@@ -24,7 +23,6 @@ using Microsoft.Health.Fhir.Core.Exceptions;
 using Microsoft.Health.Fhir.Core.Features;
 using Microsoft.Health.Fhir.Core.Features.Operations.BulkDelete.Messages;
 using Microsoft.Health.Fhir.Core.Features.Routing;
-using Microsoft.Health.Fhir.Core.Features.Search;
 using Microsoft.Health.Fhir.Core.Features.Search.Parameters;
 using Microsoft.Health.Fhir.Core.Messages.Delete;
 using Microsoft.Health.Fhir.Core.Models;
@@ -81,16 +79,9 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
                 Arg.Any<string>())
                 .Returns(new Uri(OperationResultUrl));
 
-            var searchService = Substitute.For<ISearchService>();
-            searchService.GetUsedResourceTypes(Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult<IReadOnlyList<string>>(new List<string> { KnownResourceTypes.Patient }));
-            var scopedSearchService = Substitute.For<IScoped<ISearchService>>();
-            scopedSearchService.Value.Returns(searchService);
-
             _controller = new BulkDeleteController(
                 _mediator,
                 _searchParameterOperations,
-                () => scopedSearchService,
                 urlResolver);
             _controller.ControllerContext = new ControllerContext(
                 new ActionContext(
@@ -223,6 +214,25 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
 
             Assert.IsType<JobResult>(response);
             await _searchParameterOperations.DidNotReceive().EnsureNoActiveReindexJobAsync(Arg.Any<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task GivenSystemWideBulkDeleteWithoutResourceType_WhenReindexIsRunning_ThenRequestSucceedsAndReindexCheckIsDeferred()
+        {
+            // The controller should not preemptively block system-wide bulk delete requests when a
+            // reindex job is running. The orchestrator/processing job applies the precise check
+            // against the user's search filters, so the controller must not produce false-positive
+            // conflicts (e.g. when the request is filtered by _tag and won't actually touch any
+            // SearchParameter resources).
+            _searchParameterOperations
+                .When(x => x.EnsureNoActiveReindexJobAsync(Arg.Any<CancellationToken>()))
+                .Do(_ => throw new FhirJobConflictException("reindex running"));
+
+            var response = await _controller.BulkDelete(new HardDeleteModel(), false, false);
+
+            Assert.IsType<JobResult>(response);
+            await _searchParameterOperations.DidNotReceive().EnsureNoActiveReindexJobAsync(Arg.Any<CancellationToken>());
+            await _mediator.ReceivedWithAnyArgs(1).Send<CreateBulkDeleteResponse>(default, default);
         }
 
         [Theory]

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/BulkDeleteControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/BulkDeleteControllerTests.cs
@@ -216,23 +216,33 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
             await _searchParameterOperations.DidNotReceive().EnsureNoActiveReindexJobAsync(Arg.Any<CancellationToken>());
         }
 
-        [Fact]
-        public async Task GivenSystemWideBulkDeleteWithoutResourceType_WhenReindexIsRunning_ThenRequestSucceedsAndReindexCheckIsDeferred()
+        // The controller must not preemptively block system-wide bulk delete requests when a
+        // reindex job is running. The orchestrator/processing job applies the precise check
+        // against the user's actual search filters, so the controller cannot produce false-positive
+        // conflicts. Mocking EnsureNoActiveReindexJobAsync to throw guarantees that any reliance
+        // on it from this layer would fail this test.
+        [Theory]
+        [InlineData("")]
+        [InlineData("?_tag=abc-123")]
+        [InlineData("?_lastUpdated=lt2021-12-12")]
+        [InlineData("?_tag=abc-123&_lastUpdated=lt2021-12-12")]
+        [InlineData("?identifier=urn:test|value")]
+        public async Task GivenSystemWideBulkDelete_WhenReindexIsRunning_ThenRequestSucceedsWithoutControllerLevelReindexCheck(string query)
         {
-            // The controller should not preemptively block system-wide bulk delete requests when a
-            // reindex job is running. The orchestrator/processing job applies the precise check
-            // against the user's search filters, so the controller must not produce false-positive
-            // conflicts (e.g. when the request is filtered by _tag and won't actually touch any
-            // SearchParameter resources).
+            _httpRequest.QueryString.Returns(new QueryString(query));
+
             _searchParameterOperations
                 .When(x => x.EnsureNoActiveReindexJobAsync(Arg.Any<CancellationToken>()))
                 .Do(_ => throw new FhirJobConflictException("reindex running"));
 
-            var response = await _controller.BulkDelete(new HardDeleteModel(), false, false);
+            // System-wide variants: BulkDelete (no Type) and BulkDeleteSoftDeleted (no Type, soft-delete-cleanup).
+            var softDeleteResponse = await _controller.BulkDelete(new HardDeleteModel(), purgeHistory: false, removeReferences: false);
+            var hardDeleteResponse = await _controller.BulkDelete(new HardDeleteModel { HardDelete = true }, purgeHistory: false, removeReferences: false);
 
-            Assert.IsType<JobResult>(response);
-            await _searchParameterOperations.DidNotReceive().EnsureNoActiveReindexJobAsync(Arg.Any<CancellationToken>());
-            await _mediator.ReceivedWithAnyArgs(1).Send<CreateBulkDeleteResponse>(default, default);
+            Assert.IsType<JobResult>(softDeleteResponse);
+            Assert.IsType<JobResult>(hardDeleteResponse);
+            await _searchParameterOperations.DidNotReceiveWithAnyArgs().EnsureNoActiveReindexJobAsync(Arg.Any<CancellationToken>());
+            await _mediator.ReceivedWithAnyArgs(2).Send<CreateBulkDeleteResponse>(default, default);
         }
 
         [Theory]

--- a/src/Microsoft.Health.Fhir.Shared.Api/Controllers/BulkDeleteController.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Controllers/BulkDeleteController.cs
@@ -11,7 +11,6 @@ using EnsureThat;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Health.Api.Features.Audit;
-using Microsoft.Health.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Api.Extensions;
 using Microsoft.Health.Fhir.Api.Features.ActionResults;
 using Microsoft.Health.Fhir.Api.Features.Filters;
@@ -41,7 +40,6 @@ namespace Microsoft.Health.Fhir.Api.Controllers
     {
         private readonly IMediator _mediator;
         private readonly ISearchParameterOperations _searchParameterOperations;
-        private readonly Func<IScoped<ISearchService>> _searchService;
         private readonly IUrlResolver _urlResolver;
 
         private readonly HashSet<string> _excludedParameters = new(new PropertyEqualityComparer<string>(StringComparison.OrdinalIgnoreCase, s => s))
@@ -56,12 +54,10 @@ namespace Microsoft.Health.Fhir.Api.Controllers
         public BulkDeleteController(
             IMediator mediator,
             ISearchParameterOperations searchParameterOperations,
-            Func<IScoped<ISearchService>> searchService,
             IUrlResolver urlResolver)
         {
             _mediator = EnsureArg.IsNotNull(mediator, nameof(mediator));
             _searchParameterOperations = EnsureArg.IsNotNull(searchParameterOperations, nameof(searchParameterOperations));
-            _searchService = EnsureArg.IsNotNull(searchService, nameof(searchService));
             _urlResolver = EnsureArg.IsNotNull(urlResolver, nameof(urlResolver));
         }
 
@@ -158,7 +154,7 @@ namespace Microsoft.Health.Fhir.Api.Controllers
                 excludedResourceTypesList = excludedResourceTypes.Split(',').ToList();
             }
 
-            if (await CanAffectSearchParametersAsync(typeParameter, excludedResourceTypesList))
+            if (WillAffectSearchParameters(typeParameter, excludedResourceTypesList))
             {
                 await _searchParameterOperations.EnsureNoActiveReindexJobAsync(HttpContext.RequestAborted);
             }
@@ -170,21 +166,25 @@ namespace Microsoft.Health.Fhir.Api.Controllers
             return response;
         }
 
-        private async Task<bool> CanAffectSearchParametersAsync(string resourceType, IList<string> excludedResourceTypes)
+        // Determines whether the request will deterministically affect SearchParameter resources.
+        // Only the explicit-type case is checked here (e.g. _type=SearchParameter); for system-wide
+        // requests the precise check is deferred to the orchestrator/processing job, which evaluates
+        // the user's search filters against actual record counts. This avoids false-positive
+        // conflicts on system-wide deletes that are filtered (e.g. by _tag) and would not actually
+        // touch any SearchParameter resources.
+        private static bool WillAffectSearchParameters(string resourceType, IList<string> excludedResourceTypes)
         {
             if (excludedResourceTypes?.Any(x => string.Equals(x, KnownResourceTypes.SearchParameter, StringComparison.OrdinalIgnoreCase)) == true)
             {
                 return false;
             }
 
-            if (!string.IsNullOrWhiteSpace(resourceType))
+            if (string.IsNullOrWhiteSpace(resourceType))
             {
-                return resourceType.SplitByOrSeparator().Any(x => string.Equals(x, KnownResourceTypes.SearchParameter, StringComparison.OrdinalIgnoreCase));
+                return false;
             }
 
-            using IScoped<ISearchService> searchService = _searchService.Invoke();
-            IReadOnlyList<string> usedResourceTypes = await searchService.Value.GetUsedResourceTypes(HttpContext.RequestAborted);
-            return usedResourceTypes.Any(x => string.Equals(x, KnownResourceTypes.SearchParameter, StringComparison.OrdinalIgnoreCase));
+            return resourceType.SplitByOrSeparator().Any(x => string.Equals(x, KnownResourceTypes.SearchParameter, StringComparison.OrdinalIgnoreCase));
         }
     }
 }


### PR DESCRIPTION
## Description
This pull request refactors the logic in `BulkDeleteController` to avoid false-positive conflicts when handling system-wide bulk delete requests during a running reindex job. It removes unnecessary dependencies and simplifies the check for whether a delete request can affect `SearchParameter` resources. Additionally, a new unit test is added to ensure correct behavior.

## Related issues
Addresses [AB#191051](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/191051).

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
