### PR TITLE
[BugFix] Handle SQL Conflicts during C# transactions as HTTP412

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Storage/SqlServerFhirDataStoreUnitTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Storage/SqlServerFhirDataStoreUnitTests.cs
@@ -220,8 +220,11 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Storage
                 () => dataStore.MergeAsync(resources, new MergeOptions(enlistTransaction: true, ensureAtomicOperations: true), CancellationToken.None));
         }
 
-        [Fact]
-        public async Task MergeAsync_OnSqlConflict_WithDefaultOptions_RetriesBeforeThrowing()
+        [Theory]
+        [InlineData(false, true)] // Parallel transactions.
+        [InlineData(false, false)] // Parallel batches.
+        [InlineData(true, false)] // Regular upsert requests.
+        public async Task MergeAsync_OnSqlConflict_WithDefaultOptions_RetriesBeforeThrowing(bool enlistTransaction, bool ensureAtomicOperations)
         {
             // Arrange
             var sqlRetryService = Substitute.For<ISqlRetryService>();
@@ -251,10 +254,44 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Storage
 
             // Act & Assert
             await Assert.ThrowsAsync<TaskCanceledException>(
-                () => dataStore.MergeAsync(resources, MergeOptions.Default, cts.Token));
+                () => dataStore.MergeAsync(resources, new MergeOptions(enlistTransaction, ensureAtomicOperations), cts.Token));
 
             await sqlRetryService.Received(1)
                 .TryLogEvent("MergeAsync", "Warn", Arg.Any<string>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task MergeAsync_OnSqlConflict_WithSequentialTransactions_DoNotRetry()
+        {
+            // Arrange
+            var sqlRetryService = Substitute.For<ISqlRetryService>();
+            var sqlException = SqlExceptionFactory.GetSqlException(SqlErrorCodes.Conflict, "SQL Conflict");
+            using var cts = new CancellationTokenSource();
+
+            sqlRetryService.ExecuteReaderAsync(
+                Arg.Any<SqlCommand>(),
+                Arg.Any<Func<SqlDataReader, ResourceWrapper>>(),
+                Arg.Any<ILogger>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<bool>())
+            .Throws(sqlException);
+
+            // When trying to log events, a TaskCanceledException will be thrown.
+            sqlRetryService
+                .TryLogEvent(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+                .Returns(async callInfo =>
+                {
+                    cts.Cancel();
+                    await Task.CompletedTask;
+                });
+
+            var dataStore = CreateSqlServerFhirDataStore(sqlRetryService);
+            var resources = CreateResourceWrapperOperations();
+
+            // Act & Assert
+            await Assert.ThrowsAsync<PreconditionFailedException>(
+                () => dataStore.MergeAsync(resources, new MergeOptions(enlistTransaction: true, ensureAtomicOperations: true), cts.Token));
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -180,7 +180,13 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
                         if (sqlEx.Number == SqlErrorCodes.Conflict)
                         {
-                            if (retries++ >= maxRetries)
+                            if (mergeOptions.EnlistInTransaction && mergeOptions.EnsureAtomicOperations)
+                            {
+                                // In this scenario, a retry operation can't be safely performed as this is part of a C# transaction.
+                                _logger.LogInformation("PreconditionFailed: ResourceConcurrentUpdateConflict with C# transactions.");
+                                throw new PreconditionFailedException(Resources.ResourceConcurrentUpdateConflictWithToParallelBundles);
+                            }
+                            else if (retries++ >= maxRetries)
                             {
                                 _logger.LogInformation("PreconditionFailed: ResourceConcurrentUpdateConflict");
                                 throw new PreconditionFailedException(Resources.ResourceConcurrentUpdateConflict);

--- a/src/Microsoft.Health.Fhir.SqlServer/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Health.Fhir.SqlServer {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -151,11 +151,20 @@ namespace Microsoft.Health.Fhir.SqlServer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to One or more resources were attempted to be updated concurrently with the same version, please validate the operations running and avoid duplicated updates.
+        ///   Looks up a localized string similar to One or more resources were attempted to be updated concurrently with the same version, please validate the operations running and avoid duplicated updates..
         /// </summary>
         internal static string ResourceConcurrentUpdateConflict {
             get {
                 return ResourceManager.GetString("ResourceConcurrentUpdateConflict", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to One or more resources were attempted to be updated concurrently with the same version, please validate the operations running and avoid duplicated updates. Switch to parallel bundles to allow safe internal retries..
+        /// </summary>
+        internal static string ResourceConcurrentUpdateConflictWithToParallelBundles {
+            get {
+                return ResourceManager.GetString("ResourceConcurrentUpdateConflictWithToParallelBundles", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Health.Fhir.SqlServer/Resources.resx
+++ b/src/Microsoft.Health.Fhir.SqlServer/Resources.resx
@@ -176,4 +176,7 @@
   <data name="ResourceConcurrentUpdateConflict" xml:space="preserve">
     <value>One or more resources were attempted to be updated concurrently with the same version, please validate the operations running and avoid duplicated updates.</value>
   </data>
+  <data name="ResourceConcurrentUpdateConflictWithToParallelBundles" xml:space="preserve">
+    <value>One or more resources were attempted to be updated concurrently with the same version, please validate the operations running and avoid duplicated updates. Switch to parallel bundles to allow safe internal retries.</value>
+  </data>
 </root>


### PR DESCRIPTION
## Description
Handle SQL Conflicts during C# transactions as HTTP412.

## Related issues
Addresses [AB#188318](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/188318).

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
