### PR TITLE
[Generated by SRE Agent] Fix E2E test stubs to match updated interface signatures

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/AlwaysFailingSearchParameterStatusDataStore.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/AlwaysFailingSearchParameterStatusDataStore.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         public Task<IReadOnlyCollection<ResourceSearchParameterStatus>> GetSearchParameterStatuses(CancellationToken cancellationToken, DateTimeOffset? startLastUpdated = null)
             => Task.FromException<IReadOnlyCollection<ResourceSearchParameterStatus>>(new InvalidOperationException("Simulated definition-stage search parameter initialization failure."));
 
-        public Task UpsertStatuses(IReadOnlyCollection<ResourceSearchParameterStatus> statuses, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task UpsertStatuses(IReadOnlyCollection<ResourceSearchParameterStatus> statuses, CancellationToken cancellationToken, long? reindexId = null) => Task.CompletedTask;
 
         public void SyncStatuses(IReadOnlyCollection<ResourceSearchParameterStatus> statuses)
         {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/FailingSearchParameterStatusManager.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/FailingSearchParameterStatusManager.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
         public Task<IReadOnlyCollection<ResourceSearchParameterStatus>> GetAllSearchParameterStatus(CancellationToken cancellationToken)
             => Task.FromResult<IReadOnlyCollection<ResourceSearchParameterStatus>>(Array.Empty<ResourceSearchParameterStatus>());
 
-        public Task UpdateSearchParameterStatusAsync(IReadOnlyCollection<string> searchParameterUris, SearchParameterStatus status, CancellationToken cancellationToken, bool ignoreSearchParameterNotSupportedException = false) => Task.CompletedTask;
+        public Task UpdateSearchParameterStatusAsync(IReadOnlyCollection<string> searchParameterUris, SearchParameterStatus status, CancellationToken cancellationToken, bool ignoreSearchParameterNotSupportedException = false, long? reindexId = null) => Task.CompletedTask;
 
         public Task<CacheConsistencyResult> CheckCacheConsistencyAsync(DateTime updateEventsSince, DateTime activeHostsSince, CancellationToken cancellationToken) => Task.FromResult(new CacheConsistencyResult());
     }


### PR DESCRIPTION
## Summary

This PR fixes the CI Build & Deploy pipeline failure ([build 49255](https://dev.azure.com/microsofthealthoss/7621b231-1a7d-4364-935b-2f72b911c43d/_build/results?buildId=49255)) caused by CS0535 compilation errors in E2E test stubs.

## Root Cause

The interfaces `ISearchParameterStatusDataStore` and `ISearchParameterStatusManager` were updated to add a `long? reindexId` parameter to `UpsertStatuses` and `UpdateSearchParameterStatusAsync` respectively, but the E2E test stub implementations were not updated to match.

## Changes

- **AlwaysFailingSearchParameterStatusDataStore.cs**: Added `long? reindexId = null` parameter to `UpsertStatuses` method
- **FailingSearchParameterStatusManager.cs**: Added `long? reindexId = null` parameter to `UpdateSearchParameterStatusAsync` method

## Impact

- Fixes compilation errors across all FHIR version E2E test projects (R4, R4B, R5, Stu3)
- Fixes both target frameworks (net8.0 and net9.0)
- No production code changes — test stubs only

---
Created by [Azure SRE Agent](https://sre.azure.com/agents/subscriptions/11a09cd2-9add-4367-9951-bbe32d977d66/resourceGroups/sre-agent/providers/Microsoft.App/agents/olympus-sre-agent/views/thread/de1e3e01-8d9d-4ae7-a390-0bb2e1084f03)