### PR TITLE
Fix startup memory pressure

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlRetry/SqlRetryService.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlRetry/SqlRetryService.cs
@@ -338,7 +338,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
                         while (await reader.ReadAsync(cancellationToken))
                         {
-                            resultSet.Add(readerToResult(reader));
+                            var result = readerToResult(reader);
+                            if (result != null)
+                            {
+                                resultSet.Add(result);
+                            }
                         }
 
                         results.Add(resultSet);

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirModel.cs
@@ -242,6 +242,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             string commaSeparatedClaimTypes = string.Join(',', _securityConfiguration.PrincipalClaims);
             string commaSeparatedCompartmentTypes = string.Join(',', ModelInfoProvider.GetCompartmentTypeNames());
 
+            _systemToId = new FhirMemoryCache<int>("systemToId", _logger, ignoreCase: true);
+            _quantityCodeToId = new FhirMemoryCache<int>("quantityCodeToId", _logger, ignoreCase: true);
+            bool systemWarningLogged = false;
+            bool quantityCodeWarningLogged = false;
+
             using var cmd = new SqlCommand();
             cmd.CommandType = CommandType.StoredProcedure;
             cmd.CommandText = "dbo.InitializeBase";
@@ -273,11 +278,41 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                     },
                     (reader) =>
                     {
-                        return reader.ReadRow(VLatest.System.Value, VLatest.System.SystemId);
+                        // This data is processed in a streaming fashion to avoid loading the entire set of systems into memory at once, as there could be a large number of them.
+                        if (systemWarningLogged)
+                        {
+                            // If we've already logged a warning about the cache size, we can skip trying to add to the cache to save some CPU and memory.
+                            return null;
+                        }
+
+                        var (value, systemId) = reader.ReadRow(VLatest.System.Value, VLatest.System.SystemId);
+
+                        if (!_systemToId.TryAdd(value, systemId) && !systemWarningLogged)
+                        {
+                            _logger.LogWarning($"Cache '{_systemToId.Name}' reached the limit of {_systemToId.CacheMemoryLimit} bytes (with {_systemToId.Count} cached elements).");
+                            systemWarningLogged = true;
+                        }
+
+                        return null;
                     },
                     (reader) =>
                     {
-                        return reader.ReadRow(VLatest.QuantityCode.Value, VLatest.QuantityCode.QuantityCodeId);
+                        // This data is processed in a streaming fashion to avoid loading the entire set of quantity codes into memory at once, as there could be a large number of them.
+                        if (quantityCodeWarningLogged)
+                        {
+                            // If we've already logged a warning about the cache size, we can skip trying to add to the cache to save some CPU and memory.
+                            return null;
+                        }
+
+                        var (value, quantityCodeId) = reader.ReadRow(VLatest.QuantityCode.Value, VLatest.QuantityCode.QuantityCodeId);
+
+                        if (!_quantityCodeToId.TryAdd(value, quantityCodeId) && !quantityCodeWarningLogged)
+                        {
+                            _logger.LogWarning($"Cache '{_quantityCodeToId.Name}' reached the limit of {_quantityCodeToId.CacheMemoryLimit} bytes (with {_quantityCodeToId.Count} cached elements).");
+                            quantityCodeWarningLogged = true;
+                        }
+
+                        return null;
                     },
                 },
                 _logger,
@@ -322,6 +357,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                 searchParamUriToId.Add(new Uri(uri), searchParamId);
             }
 
+            _logger.LogInformation("Initialized {Count} search parameters.", searchParamUriToId.Count);
+
             // result set 3
             foreach (var result in resultsList[2])
             {
@@ -334,33 +371,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             {
                 (byte id, string compartmentName) = ((byte, string))result;
                 compartmentTypeToId.Add(compartmentName, id);
-            }
-
-            // result set 5
-            _systemToId = new FhirMemoryCache<int>("systemToId", _logger, ignoreCase: true);
-            bool systemWarningLogged = false;
-            foreach (var result in resultsList[4])
-            {
-                var (value, systemId) = ((string, int))result;
-
-                if (!_systemToId.TryAdd(value, systemId) && !systemWarningLogged)
-                {
-                    _logger.LogWarning($"Cache '{_systemToId.Name}' reached the limit of {_systemToId.CacheMemoryLimit} bytes (with {_systemToId.Count} cached elements).");
-                    systemWarningLogged = true;
-                }
-            }
-
-            // result set 6
-            _quantityCodeToId = new FhirMemoryCache<int>("quantityCodeToId", _logger, ignoreCase: true);
-            bool quantityCodeWarningLogged = false;
-            foreach (var result in resultsList[5])
-            {
-                (string value, int quantityCodeId) = ((string, int))result;
-                if (!_quantityCodeToId.TryAdd(value, quantityCodeId) && !quantityCodeWarningLogged)
-                {
-                    _logger.LogWarning($"Cache '{_quantityCodeToId.Name}' reached the limit of {_quantityCodeToId.CacheMemoryLimit} bytes (with {_quantityCodeToId.Count} cached elements).");
-                    quantityCodeWarningLogged = true;
-                }
             }
 
             _resourceTypeToId = resourceTypeToId;


### PR DESCRIPTION
## Description
Removes memory pressure on startup happening when the database has a large number of systems or quantity codes.

## Related issues
Addresses [Bug 191287](https://microsofthealth.visualstudio.com/Health/_workitems/edit/191287)

## Testing


## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
