### PR TITLE
Reduce memory pressure during export by releasing RawResource

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportJobTaskTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Export/ExportJobTaskTests.cs
@@ -2109,6 +2109,98 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Export
             Assert.Equal(endTimestamp, _lastExportJobOutcome.JobRecord.EndTime);
         }
 
+        [Fact]
+        public async Task GivenMultipleSearchResults_WhenExecuted_ThenRawResourceIsNulledAfterWrite()
+        {
+            // Arrange
+            var exportJobRecord = CreateExportJobRecord(
+                exportJobType: ExportJobType.All,
+                maximumNumberOfResourcesPerQuery: 10);
+            SetupExportJobRecordAndOperationDataStore(exportJobRecord);
+
+            var wrappers = new List<ResourceWrapper>();
+            var entries = new SearchResultEntry[3];
+            for (int i = 0; i < 3; i++)
+            {
+                var wrapper = new ResourceWrapper(
+                    i.ToString(),
+                    "1",
+                    KnownResourceTypes.Patient,
+                    new RawResource($"data-{i}", Core.Models.FhirResourceFormat.Json, isMetaSet: true),
+                    null,
+                    DateTimeOffset.MinValue,
+                    false,
+                    null,
+                    null,
+                    null);
+                wrappers.Add(wrapper);
+                entries[i] = new SearchResultEntry(wrapper);
+            }
+
+            _searchService.SearchAsync(
+                Arg.Any<string>(),
+                Arg.Any<IReadOnlyList<Tuple<string, string>>>(),
+                _cancellationToken,
+                true)
+                .Returns(CreateSearchResult(entries));
+
+            // Act
+            await _exportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
+
+            // Assert - RawResource should be null for all wrappers after processing
+            foreach (var wrapper in wrappers)
+            {
+                Assert.Null(wrapper.RawResource);
+            }
+        }
+
+        [Fact]
+        public async Task GivenSearchResultsAsList_WhenExecuted_ThenListIsClearedAfterProcessing()
+        {
+            // Arrange
+            var exportJobRecord = CreateExportJobRecord(
+                exportJobType: ExportJobType.All,
+                maximumNumberOfResourcesPerQuery: 10);
+            SetupExportJobRecordAndOperationDataStore(exportJobRecord);
+
+            var resultList = new List<SearchResultEntry>
+            {
+                CreateSearchResultEntry("1", KnownResourceTypes.Patient),
+                CreateSearchResultEntry("2", KnownResourceTypes.Patient),
+            };
+
+            _searchService.SearchAsync(
+                Arg.Any<string>(),
+                Arg.Any<IReadOnlyList<Tuple<string, string>>>(),
+                _cancellationToken,
+                true)
+                .Returns(new SearchResult(resultList, null, null, new Tuple<string, string>[0]));
+
+            // Act
+            await _exportJobTask.ExecuteAsync(_exportJobRecord, _weakETag, _cancellationToken);
+
+            // Assert - the list passed to ProcessSearchResults should be cleared
+            Assert.Empty(resultList);
+        }
+
+        [Theory]
+        [InlineData(1u, false)]
+        [InlineData(10000u, false)]
+        [InlineData(10001u, true)]
+        public void GivenMaxCount_WhenCreatingExportJobRecord_ThenValidatesRange(uint maxCount, bool shouldThrow)
+        {
+            if (shouldThrow)
+            {
+                Assert.Throws<BadRequestException>(() => CreateExportJobRecord(
+                    maximumNumberOfResourcesPerQuery: maxCount));
+            }
+            else
+            {
+                var record = CreateExportJobRecord(maximumNumberOfResourcesPerQuery: maxCount);
+                Assert.Equal(maxCount, record.MaximumNumberOfResourcesPerQuery);
+            }
+        }
+
         private async Task RunTypeFilterTest(IList<ExportJobFilter> filters, string resourceTypes)
         {
             var exportJobRecordWithFormat = CreateExportJobRecord(

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -787,6 +787,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
         private void ProcessSearchResults(IEnumerable<SearchResultEntry> searchResults, IAnonymizer anonymizer)
         {
+            if (searchResults == null)
+            {
+                return;
+            }
+
             if (searchResults is List<SearchResultEntry> searchResultsList)
             {
                 for (int i = 0; i < searchResultsList.Count; i++)

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -629,7 +629,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
                     || string.IsNullOrWhiteSpace(_exportJobRecord.ResourceType)
                     || _exportJobRecord.ResourceType.Contains(KnownResourceTypes.Patient, StringComparison.OrdinalIgnoreCase))
                 {
-                    ProcessSearchResults(searchResult?.Results.ToList(), anonymizer);
+                    ProcessSearchResults(searchResult?.Results, anonymizer);
                 }
 
                 if (searchResult?.ContinuationToken == null)

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/ExportJobTask.cs
@@ -787,23 +787,20 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
 
         private void ProcessSearchResults(IEnumerable<SearchResultEntry> searchResults, IAnonymizer anonymizer)
         {
-            // Testing to see if the returned enumerable is a list so we can remove items from it. This helps conserve memory by not keeping entries that have already been processed.
-            // Since the search service isn't guaranteed to return a list, we need to handle both cases.
-            if (searchResults is not List<SearchResultEntry>)
+            if (searchResults is List<SearchResultEntry> searchResultsList)
+            {
+                for (int i = 0; i < searchResultsList.Count; i++)
+                {
+                    ProcessSearchResult(searchResultsList[i], anonymizer);
+                }
+
+                searchResultsList.Clear();
+            }
+            else
             {
                 foreach (var result in searchResults)
                 {
                     ProcessSearchResult(result, anonymizer);
-                }
-            }
-            else
-            {
-                var searchResultsList = searchResults as List<SearchResultEntry>;
-                while (searchResultsList.Any())
-                {
-                    var result = searchResultsList.First();
-                    ProcessSearchResult(result, anonymizer);
-                    searchResultsList.Remove(result);
                 }
             }
         }
@@ -841,6 +838,11 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export
             }
 
             _fileManager.WriteToFile(resourceWrapper.ResourceTypeName, outputData);
+
+            // Release the raw resource data to allow GC to reclaim LOH memory.
+            // The Lazy<string> inside RawResource caches the decompressed JSON string (~MBs per resource)
+            // and its closure retains the compressed byte[]. After writing to blob, neither is needed.
+            resourceWrapper.RawResource = null;
         }
 
         private async Task ProcessProgressChange(

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobRecord.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobRecord.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using EnsureThat;
 using Microsoft.Health.Core;
 using Microsoft.Health.Fhir.Core.Extensions;
+using Microsoft.Health.Fhir.Core.Features.Persistence;
 using Microsoft.Health.Fhir.Core.Models;
 using Microsoft.Health.JobManagement;
 using Newtonsoft.Json;
@@ -19,6 +20,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
     /// </summary>
     public class ExportJobRecord : JobRecord, IJobData
     {
+        public const uint MaxMaximumNumberOfResourcesPerQuery = 10000;
+        public const uint MinMaximumNumberOfResourcesPerQuery = 1;
+
         public ExportJobRecord(
             Uri requestUri,
             ExportJobType exportType,
@@ -67,6 +71,13 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
             GroupId = groupId;
             StorageAccountConnectionHash = storageAccountConnectionHash;
             StorageAccountUri = storageAccountUri;
+
+            // check for MaximumNumberOfResourcesPerQuery boundary
+            if (maximumNumberOfResourcesPerQuery < MinMaximumNumberOfResourcesPerQuery || maximumNumberOfResourcesPerQuery > MaxMaximumNumberOfResourcesPerQuery)
+            {
+                throw new BadRequestException(string.Format(Fhir.Core.Resources.InvalidExportParameterValue, nameof(MaximumNumberOfResourcesPerQuery), MinMaximumNumberOfResourcesPerQuery.ToString(), MaxMaximumNumberOfResourcesPerQuery.ToString()));
+            }
+
             MaximumNumberOfResourcesPerQuery = maximumNumberOfResourcesPerQuery;
             NumberOfPagesPerCommit = numberOfPagesPerCommit;
             RollingFileSizeInMB = rollingFileSizeInMB;

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobRecord.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Export/Models/ExportJobRecord.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Export.Models
             // check for MaximumNumberOfResourcesPerQuery boundary
             if (maximumNumberOfResourcesPerQuery < MinMaximumNumberOfResourcesPerQuery || maximumNumberOfResourcesPerQuery > MaxMaximumNumberOfResourcesPerQuery)
             {
-                throw new BadRequestException(string.Format(Fhir.Core.Resources.InvalidExportParameterValue, nameof(MaximumNumberOfResourcesPerQuery), MinMaximumNumberOfResourcesPerQuery.ToString(), MaxMaximumNumberOfResourcesPerQuery.ToString()));
+                throw new BadRequestException(string.Format(Fhir.Core.Resources.InvalidExportParameterValue, nameof(MaximumNumberOfResourcesPerQuery), MinMaximumNumberOfResourcesPerQuery, MaxMaximumNumberOfResourcesPerQuery));
             }
 
             MaximumNumberOfResourcesPerQuery = maximumNumberOfResourcesPerQuery;

--- a/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
+++ b/src/Microsoft.Health.Fhir.Core/Resources.Designer.cs
@@ -837,6 +837,15 @@ namespace Microsoft.Health.Fhir.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Export operation parameter &apos;{0}&apos; was out of the range of valid values. Please specify a different value within a range &apos;{1}&apos; - &apos;{2}&apos;..
+        /// </summary>
+        internal static string InvalidExportParameterValue {
+            get {
+                return ResourceManager.GetString("InvalidExportParameterValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The &apos;handling&apos; value &apos;{0}&apos; is invalid. The supported values are: {1}..
         /// </summary>
         internal static string InvalidHandlingValue {

--- a/src/Microsoft.Health.Fhir.Core/Resources.resx
+++ b/src/Microsoft.Health.Fhir.Core/Resources.resx
@@ -603,6 +603,9 @@
   <data name="FailedToAnonymizeResource" xml:space="preserve">
     <value>Failed to anonymize resource. The job will be marked as failed. {0}</value>
   </data>
+  <data name="InvalidExportParameterValue" xml:space="preserve">
+    <value>Export operation parameter '{0}' was out of the range of valid values. Please specify a different value within a range '{1}' - '{2}'.</value>
+  </data>
   <data name="InvalidEverythingOperationPhase" xml:space="preserve">
     <value>The phase '{0}' in $everything operation is invalid.</value>
   </data>


### PR DESCRIPTION
## Description
Export jobs on memory-constrained App Services (e.g., 8GB) hit OutOfMemoryException when exporting large resources. Each resource's RawResource contains a Lazy<string> that caches the decompressed JSON string (potentially ~24MB per resource) and its closure retains the compressed byte[]. Both stay alive in memory until the entire search result batch is fully processed, causing peak memory of N × resource_size.

Additionally, the existing while/Remove/First pattern in ProcessSearchResults was O(n²) and never actually freed memory — searchResult.Results.ToList() created a copy, so removing from the copy didn't release references from the original list.

- Null out [ResourceWrapper.RawResource] after writing each resource to blob storage, making the cached decompressed string and compressed bytes GC-eligible immediately
- Remove unnecessary `.ToList()` copy on the `SearchWithFilter` call path
- Replace O(n²) `while(Any()) { First(); Remove(); }`  with O(n) for loop + `Clear()`
- Add _maxCount <=10000 restriction for export

## Related issues
Addresses [AB187913](https://microsofthealth.visualstudio.com/Health/_workitems/edit/187913), [AB189470](https://microsofthealth.visualstudio.com/Health/_workitems/edit/189470)

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
