### PR TITLE
Add PATCH E2E test coverage aligned with PUT tests

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/FhirPathPatchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/FhirPathPatchTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
@@ -705,6 +706,78 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             var response = await _client.HttpClient.SendAsync(request);
 
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
+        /// <summary>
+        /// Tests that a malformed (non-weak) If-Match ETag format is rejected with 400 Bad Request, mirroring the equivalent PUT behavior.
+        /// </summary>
+        [Theory]
+        [InlineData("\"invalidVersion\"")]
+        [InlineData("\"-1\"")]
+        [InlineData("\"0\"")]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenAnInvalidETagFormat_WhenFhirPatchingAnExistingResource_ThenAnErrorShouldBeReturned(string invalidETag)
+        {
+            var poco = Samples.GetDefaultPatient().ToPoco<Patient>();
+            FhirResponse<Patient> response = await _client.CreateAsync(poco);
+
+            var patchRequest = new Parameters().AddReplacePatchParameter("Patient.gender", new Code("female"));
+            string body = new Hl7.Fhir.Serialization.FhirJsonSerializer().SerializeToString(patchRequest);
+
+            using var request = new HttpRequestMessage(HttpMethod.Patch, $"Patient/{response.Resource.Id}");
+            request.Content = new StringContent(body, Encoding.UTF8, "application/fhir+json");
+            request.Headers.TryAddWithoutValidation("If-Match", invalidETag);
+
+            using HttpResponseMessage httpResponse = await _client.HttpClient.SendAsync(request);
+
+            Assert.Equal(HttpStatusCode.BadRequest, httpResponse.StatusCode);
+        }
+
+        /// <summary>
+        /// Tests that patching a resource with no effective data change does not create a new version, mirroring the equivalent PUT behavior.
+        /// </summary>
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenTheResource_WhenFhirPatchingWithNoDataChange_ThenServerShouldNotCreateANewVersionAndReturnOk()
+        {
+            var poco = Samples.GetDefaultPatient().ToPoco<Patient>();
+            FhirResponse<Patient> createResponse = await _client.CreateAsync(poco);
+            Assert.Equal(AdministrativeGender.Male, createResponse.Resource.Gender);
+
+            string originalVersionId = createResponse.Resource.Meta.VersionId;
+            DateTimeOffset? originalLastUpdated = createResponse.Resource.Meta.LastUpdated;
+
+            // Replacing gender with the same value it already has produces no effective data change
+            var patchRequest = new Parameters().AddReplacePatchParameter("Patient.gender", new Code("male"));
+            using FhirResponse<Patient> patchResponse = await _client.FhirPatchAsync(createResponse.Resource, patchRequest);
+
+            Assert.Equal(HttpStatusCode.OK, patchResponse.Response.StatusCode);
+            Assert.Equal(originalVersionId, patchResponse.Resource.Meta.VersionId);
+            Assert.Equal(originalLastUpdated, patchResponse.Resource.Meta.LastUpdated);
+        }
+
+        /// <summary>
+        /// Tests that patching a single field does not inadvertently modify other resource fields, verifying the surgical precision of FHIR path PATCH.
+        /// </summary>
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenAnExistingPatient_WhenFhirPatchingOneField_ThenOtherFieldsShouldNotBeModified()
+        {
+            var poco = Samples.GetDefaultPatient().ToPoco<Patient>();
+            FhirResponse<Patient> createResponse = await _client.CreateAsync(poco);
+            Assert.Equal(AdministrativeGender.Male, createResponse.Resource.Gender);
+            Assert.NotEmpty(createResponse.Resource.Address);
+
+            int originalAddressCount = createResponse.Resource.Address.Count;
+
+            // Patch only gender; address and all other fields should remain unchanged
+            var patchRequest = new Parameters().AddReplacePatchParameter("Patient.gender", new Code("female"));
+            using FhirResponse<Patient> patchResponse = await _client.FhirPatchAsync(createResponse.Resource, patchRequest);
+
+            Assert.Equal(HttpStatusCode.OK, patchResponse.Response.StatusCode);
+            Assert.Equal(AdministrativeGender.Female, patchResponse.Resource.Gender);
+            Assert.Equal(originalAddressCount, patchResponse.Resource.Address.Count);
+            Assert.Equal(createResponse.Resource.Id, patchResponse.Resource.Id);
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/JsonPatchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/JsonPatchTests.cs
@@ -5,6 +5,8 @@
 
 using System;
 using System.Net;
+using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
 using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
@@ -456,6 +458,77 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             // Empty body should trigger EmptyBodyBehavior.Disallow and return BadRequest
             var exception = await Assert.ThrowsAsync<FhirClientException>(() => _client.JsonPatchAsync(response.Resource, emptyBody));
             Assert.Equal(HttpStatusCode.BadRequest, exception.Response.StatusCode);
+        }
+
+        /// <summary>
+        /// Tests that a malformed (non-weak) If-Match ETag format is rejected with 400 Bad Request, mirroring the equivalent PUT behavior.
+        /// </summary>
+        [Theory]
+        [InlineData("\"invalidVersion\"")]
+        [InlineData("\"-1\"")]
+        [InlineData("\"0\"")]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenAnInvalidETagFormat_WhenJsonPatchingAnExistingResource_ThenAnErrorShouldBeReturned(string invalidETag)
+        {
+            var poco = Samples.GetDefaultPatient().ToPoco<Patient>();
+            FhirResponse<Patient> response = await _client.CreateAsync(poco);
+
+            string patchDocument = "[{\"op\":\"replace\",\"path\":\"/gender\",\"value\":\"female\"}]";
+
+            using var request = new HttpRequestMessage(HttpMethod.Patch, $"Patient/{response.Resource.Id}");
+            request.Content = new StringContent(patchDocument, Encoding.UTF8, "application/json-patch+json");
+            request.Headers.TryAddWithoutValidation("If-Match", invalidETag);
+
+            using HttpResponseMessage httpResponse = await _client.HttpClient.SendAsync(request);
+
+            Assert.Equal(HttpStatusCode.BadRequest, httpResponse.StatusCode);
+        }
+
+        /// <summary>
+        /// Tests that patching a resource with no effective data change does not create a new version, mirroring the equivalent PUT behavior.
+        /// </summary>
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenTheResource_WhenJsonPatchingWithNoDataChange_ThenServerShouldNotCreateANewVersionAndReturnOk()
+        {
+            var poco = Samples.GetDefaultPatient().ToPoco<Patient>();
+            FhirResponse<Patient> createResponse = await _client.CreateAsync(poco);
+            Assert.Equal(AdministrativeGender.Male, createResponse.Resource.Gender);
+
+            string originalVersionId = createResponse.Resource.Meta.VersionId;
+            DateTimeOffset? originalLastUpdated = createResponse.Resource.Meta.LastUpdated;
+
+            // Replacing gender with the same value it already has produces no effective data change
+            string patchDocument = "[{\"op\":\"replace\",\"path\":\"/gender\",\"value\":\"male\"}]";
+            using FhirResponse<Patient> patchResponse = await _client.JsonPatchAsync(createResponse.Resource, patchDocument);
+
+            Assert.Equal(HttpStatusCode.OK, patchResponse.Response.StatusCode);
+            Assert.Equal(originalVersionId, patchResponse.Resource.Meta.VersionId);
+            Assert.Equal(originalLastUpdated, patchResponse.Resource.Meta.LastUpdated);
+        }
+
+        /// <summary>
+        /// Tests that patching a single field does not inadvertently modify other resource fields, verifying the surgical precision of JSON PATCH.
+        /// </summary>
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenAnExistingPatient_WhenJsonPatchingOneField_ThenOtherFieldsShouldNotBeModified()
+        {
+            var poco = Samples.GetDefaultPatient().ToPoco<Patient>();
+            FhirResponse<Patient> createResponse = await _client.CreateAsync(poco);
+            Assert.Equal(AdministrativeGender.Male, createResponse.Resource.Gender);
+            Assert.NotEmpty(createResponse.Resource.Address);
+
+            int originalAddressCount = createResponse.Resource.Address.Count;
+
+            // Patch only gender; address and all other fields should remain unchanged
+            string patchDocument = "[{\"op\":\"replace\",\"path\":\"/gender\",\"value\":\"female\"}]";
+            using FhirResponse<Patient> patchResponse = await _client.JsonPatchAsync(createResponse.Resource, patchDocument);
+
+            Assert.Equal(HttpStatusCode.OK, patchResponse.Response.StatusCode);
+            Assert.Equal(AdministrativeGender.Female, patchResponse.Resource.Gender);
+            Assert.Equal(originalAddressCount, patchResponse.Resource.Address.Count);
+            Assert.Equal(createResponse.Resource.Id, patchResponse.Resource.Id);
         }
     }
 }


### PR DESCRIPTION
## Description
PATCH operation tests are added covering the same scenarios and edge cases currently validated by PUT tests

## Related issues
Addresses https://microsofthealth.visualstudio.com/Health/_workitems/edit/178574

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
