### PR TITLE
Ensure Unique Query Parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,9 @@ ipch/
 *.vspx
 *.sap
 
+# Visual Studio Code C# Dev Kit cache files
+*.lscache
+
 # TFS 2012 Local Workspace
 $tf/
 

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchOptionsFactoryTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Search/SearchOptionsFactoryTests.cs
@@ -244,6 +244,72 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Search
             Assert.True(options.CountOnly);
         }
 
+        [Fact]
+        public void GivenDuplicateSearchParameterWithSameValue_WhenCreated_ThenSearchParameterIsParsedOnce()
+        {
+            const string parameterName = "_tag";
+            const string parameterValue = "system|code";
+
+            _expressionParser.Parse(
+                Arg.Is<string[]>(x => x.Length == 1 && x[0] == DefaultResourceType),
+                parameterName,
+                parameterValue)
+                .Returns(new StubExpression($"{parameterName}={parameterValue}"));
+
+            var queryParameters = new[]
+            {
+                Tuple.Create(parameterName, parameterValue),
+                Tuple.Create(parameterName, parameterValue),
+            };
+
+            SearchOptions options = CreateSearchOptions(queryParameters: queryParameters);
+
+            Assert.NotNull(options);
+            _expressionParser.Received(1).Parse(
+                Arg.Is<string[]>(x => x.Length == 1 && x[0] == DefaultResourceType),
+                parameterName,
+                parameterValue);
+        }
+
+        [Fact]
+        public void GivenDuplicateSearchParameterNameWithDifferentValues_WhenCreated_ThenBothSearchParametersAreParsed()
+        {
+            const string parameterName = "_tag";
+            const string firstParameterValue = "system|code1";
+            const string secondParameterValue = "system|code2";
+
+            _expressionParser.Parse(
+                Arg.Is<string[]>(x => x.Length == 1 && x[0] == DefaultResourceType),
+                parameterName,
+                firstParameterValue)
+                .Returns(new StubExpression($"{parameterName}={firstParameterValue}"));
+
+            _expressionParser.Parse(
+                Arg.Is<string[]>(x => x.Length == 1 && x[0] == DefaultResourceType),
+                parameterName,
+                secondParameterValue)
+                .Returns(new StubExpression($"{parameterName}={secondParameterValue}"));
+
+            var queryParameters = new[]
+            {
+                Tuple.Create(parameterName, firstParameterValue),
+                Tuple.Create(parameterName, secondParameterValue),
+            };
+
+            SearchOptions options = CreateSearchOptions(queryParameters: queryParameters);
+
+            Assert.NotNull(options);
+            _expressionParser.Received(1).Parse(
+                Arg.Is<string[]>(x => x.Length == 1 && x[0] == DefaultResourceType),
+                parameterName,
+                firstParameterValue);
+
+            _expressionParser.Received(1).Parse(
+                Arg.Is<string[]>(x => x.Length == 1 && x[0] == DefaultResourceType),
+                parameterName,
+                secondParameterValue);
+        }
+
         [Theory]
         [InlineData("a")]
         [InlineData("1.1")]

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -407,13 +407,9 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
 
             var validSearchParameters = new List<SearchParameterInfo>();
 
-            // Deduplicate exact (name, value) pairs before parsing. Repeated identical parameters produce
-            // redundant SQL CTEs (one per expression) without affecting query semantics. Parameters with the
-            // same name but different values are intentionally kept, as each represents a distinct AND predicate.
-            // Per FHIR R4 §3.1.1.4.17 and R5 §3.2.1.5.4, repeated parameters are AND semantics (set intersection),
-            // and AND of identical predicates is idempotent: X AND X ≡ X.
-            // R4: https://hl7.org/fhir/R4/search.html#combining
-            // R5: https://hl7.org/fhir/R5/search.html#multivalue
+            // Deduplicate exact (name, value) query parameter pairs before parsing. Repeated identical parameters produce
+            // redundant database lookups (one per expression) without affecting query semantics. Per FHIR spec, repeated
+            // parameters are AND semantics (set intersection), and AND of identical predicates is idempotent: X AND X ≡ X.
             searchExpressions.AddRange(searchParams.Parameters.Distinct().Select(
             q =>
             {

--- a/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Features/Search/SearchOptionsFactory.cs
@@ -406,7 +406,15 @@ namespace Microsoft.Health.Fhir.Core.Features.Search
             CheckFineGrainedAccessControl(searchExpressions, searchParams, requiredResourceTypes);
 
             var validSearchParameters = new List<SearchParameterInfo>();
-            searchExpressions.AddRange(searchParams.Parameters.Select(
+
+            // Deduplicate exact (name, value) pairs before parsing. Repeated identical parameters produce
+            // redundant SQL CTEs (one per expression) without affecting query semantics. Parameters with the
+            // same name but different values are intentionally kept, as each represents a distinct AND predicate.
+            // Per FHIR R4 §3.1.1.4.17 and R5 §3.2.1.5.4, repeated parameters are AND semantics (set intersection),
+            // and AND of identical predicates is idempotent: X AND X ≡ X.
+            // R4: https://hl7.org/fhir/R4/search.html#combining
+            // R5: https://hl7.org/fhir/R5/search.html#multivalue
+            searchExpressions.AddRange(searchParams.Parameters.Distinct().Select(
             q =>
             {
                 try


### PR DESCRIPTION
## Description
Deduplicate query parameters when the exact key and value are passed in. Why?
- This is creating many duplicate CTEs causing extra database load
- Query parameters are a mathmatical set in FHIR
- A set of two of the exact same item is identical to a set of 1

## Example

`GET /Patient?_tag=system%7Ccode&_tag=system%7Ccode&_total=accurate` in main generates

```sql
;WITH cte0 AS (
  SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1
  FROM dbo.TokenSearchParam
  WHERE SearchParamId = 1218
    AND SystemId = (SELECT SystemId FROM dbo.System WHERE Value = @p0)
    AND Code = @p1
    AND ResourceTypeId = 103
),
cte1 AS (
  SELECT ResourceTypeId AS T1, ResourceSurrogateId AS Sid1
  FROM dbo.TokenSearchParam
  WHERE EXISTS (SELECT * FROM cte0 WHERE ResourceTypeId = T1 AND ResourceSurrogateId = Sid1)
    AND SearchParamId = 1218
    AND SystemId = (SELECT SystemId FROM dbo.System WHERE Value = @p0)
    AND Code = @p1
    AND ResourceTypeId = 103
)
```

## FHIR spec behavior assessment

This change deduplicates only exact `(name, value)` search-filter pairs before expression parsing. I do not expect this to change FHIR result-set semantics because repeated search parameters are AND/intersection semantics, so an exact duplicate predicate is idempotent (`X AND X` is equivalent to `X`).

Spec cases considered:
- Same-name, different-value parameters are preserved, e.g. `_tag=a&_tag=b` still means AND.
- Comma-separated values are preserved, e.g. `_tag=a,b` still means OR.
- Exact duplicates with prefixes/modifiers such as `:not`, `:missing`, `ge`, and `lt` remain idempotent.
- Chains, `_has`, composite parameters, `_list`, and `_type` are also idempotent when the exact same `(name, value)` pair is repeated.
- Result-control parameters such as `_sort`, `_include`, `_revinclude`, `_count`, `_summary`, `_elements`, `_filter`, and `_query` are not affected by this `Distinct()` path.

Observable non-result changes are possible: duplicate unsupported search parameters may produce fewer duplicate warnings/errors, and logging/search expression/search parameter lists can become deduplicated. The intended semantic statement is limited to FHIR search filter criteria: exact duplicate AND predicates do not change the result set.

## Related issues
[AB#191513](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/191513)

## Testing
- Locally
- Unit/Integration/E2E