### PR TITLE
Add tests to cover birthdate search semantics

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/DateSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/DateSearchTests.cs
@@ -262,7 +262,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             {
                 // FHIR R4 search prefixes define equality for ranges as: "the range of the search value fully contains
                 // the range of the target value." See https://hl7.org/fhir/R4/search.html#prefix.
-                // The current implementation instead matches partial birthdates using range overlap. For example,
+                // Tracked by AB#191826. The current implementation instead matches partial birthdates using range overlap. For example,
                 // birthdate=2000-03 currently returns a Patient with birthDate "2000" because the whole-year range
                 // overlaps March 2000, but that Patient should not match under the R4 equality containment rule.
                 Bundle yearBundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2000&_tag={tag}");

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/DateSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/DateSearchTests.cs
@@ -250,13 +250,21 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 p => SetPatientBirthDate(p, "1999-12-31", tag),
                 p => SetPatientBirthDate(p, "2000-04-01", tag),
                 p => SetPatientBirthDate(p, "2000-12", tag),
-                p => SetPatientBirthDate(p, "2000-03-31", tag));
+                p => SetPatientBirthDate(p, "2000-03-31", tag),
+                p => SetPatientBirthDate(p, "2001", tag),
+                p => SetPatientBirthDate(p, "2001-11-30", tag),
+                p => SetPatientBirthDate(p, "2001-12", tag),
+                p => SetPatientBirthDate(p, "2001-12-31", tag),
+                p => SetPatientBirthDate(p, "2002-01-01", tag));
             Patient patient2000 = patients[0];
             Patient patient2000March = patients[1];
             Patient patient2000March03 = patients[2];
             Patient patient2000April01 = patients[4];
             Patient patient2000December = patients[5];
             Patient patient2000March31 = patients[6];
+            Patient patient2001 = patients[7];
+            Patient patient2001December = patients[9];
+            Patient patient2001December31 = patients[10];
 
             try
             {
@@ -274,8 +282,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 Bundle dayBundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2000-03-03&_tag={tag}");
                 ValidateBundle(dayBundle, patient2000, patient2000March, patient2000March03);
 
-                Bundle decemberBundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2000-12&_tag={tag}");
-                ValidateBundle(decemberBundle, patient2000, patient2000December);
+                Bundle decemberEdgeBundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2001-12&_tag={tag}");
+                ValidateBundle(decemberEdgeBundle, patient2001, patient2001December, patient2001December31);
 
                 Bundle lastDayBundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2000-03-31&_tag={tag}");
                 ValidateBundle(lastDayBundle, patient2000, patient2000March, patient2000March31);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/DateSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/DateSearchTests.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using Hl7.Fhir.Model;
@@ -235,6 +236,85 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
             {
                 Assert.Fail($"A non-expected '{e.GetType()}' was raised. Url: {Client.HttpClient.BaseAddress}. No Activity Id present. Error: {e.Message}");
             }
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenPatientsWithDateOnlyBirthdate_WhenSearchedByEqualityAndRange_ThenCorrectPatientsAreReturned()
+        {
+            // Arrange: create three patients, two born on 2016-07-06 and one born on 2016-07-07.
+            // A unique tag scopes the search results to this test run only.
+            string tag = Guid.NewGuid().ToString();
+            Patient[] patients = await Client.CreateResourcesAsync<Patient>(
+                p => SetPatientBirthDate(p, "2016-07-06", tag),
+                p => SetPatientBirthDate(p, "2016-07-06", tag),
+                p => SetPatientBirthDate(p, "2016-07-07", tag));
+
+            try
+            {
+                // Equality: only patients born on 2016-07-06 should be returned.
+                Bundle equalityBundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2016-07-06&_tag={tag}");
+                ValidateBundle(equalityBundle, patients[0], patients[1]);
+
+                // Range: only patients born after 2016-07-06 should be returned.
+                Bundle rangeBundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=gt2016-07-06&_tag={tag}");
+                ValidateBundle(rangeBundle, patients[2]);
+            }
+            catch (FhirClientException fce)
+            {
+                Assert.Fail($"A non-expected '{nameof(FhirClientException)}' was raised. Url: {Client.HttpClient.BaseAddress}. Activity Id: {fce.Response.GetRequestId()}. Error: {fce.Message}");
+            }
+            catch (Exception e)
+            {
+                Assert.Fail($"A non-expected '{e.GetType()}' was raised. Url: {Client.HttpClient.BaseAddress}. No Activity Id present. Error: {e.Message}");
+            }
+        }
+
+        [Fact]
+        [Trait(Traits.Priority, Priority.One)]
+        public async Task GivenPatientsWithPartialBirthdates_WhenSearchedByEquality_ThenContainmentSemanticsArePreserved()
+        {
+            string tag = Guid.NewGuid().ToString();
+            Patient[] patients = await Client.CreateResourcesAsync<Patient>(
+                p => SetPatientBirthDate(p, "2000", tag),
+                p => SetPatientBirthDate(p, "2000-03", tag),
+                p => SetPatientBirthDate(p, "2000-03-03", tag),
+                p => SetPatientBirthDate(p, "1999-12-31", tag),
+                p => SetPatientBirthDate(p, "2000-04-01", tag),
+                p => SetPatientBirthDate(p, "2000-12", tag),
+                p => SetPatientBirthDate(p, "2000-03-31", tag));
+
+            try
+            {
+                Bundle yearBundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2000&_tag={tag}");
+                ValidateBundle(yearBundle, patients[0], patients[1], patients[2], patients[4], patients[5], patients[6]);
+
+                Bundle monthBundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2000-03&_tag={tag}");
+                ValidateBundle(monthBundle, patients[1], patients[2], patients[6]);
+
+                Bundle dayBundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2000-03-03&_tag={tag}");
+                ValidateBundle(dayBundle, patients[2]);
+
+                Bundle decemberBundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2000-12&_tag={tag}");
+                ValidateBundle(decemberBundle, patients[5]);
+
+                Bundle lastDayBundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2000-03-31&_tag={tag}");
+                ValidateBundle(lastDayBundle, patients[6]);
+            }
+            catch (FhirClientException fce)
+            {
+                Assert.Fail($"A non-expected '{nameof(FhirClientException)}' was raised. Url: {Client.HttpClient.BaseAddress}. Activity Id: {fce.Response.GetRequestId()}. Error: {fce.Message}");
+            }
+            catch (Exception e)
+            {
+                Assert.Fail($"A non-expected '{e.GetType()}' was raised. Url: {Client.HttpClient.BaseAddress}. No Activity Id present. Error: {e.Message}");
+            }
+        }
+
+        private static void SetPatientBirthDate(Patient patient, string birthDate, string tag)
+        {
+            patient.Meta = new Meta { Tag = new List<Coding> { new Coding(null, tag) } };
+            patient.BirthDate = birthDate;
         }
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/DateSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/DateSearchTests.cs
@@ -260,9 +260,11 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
             try
             {
-                // FHIR equality semantics require the search range to fully contain the target range, but the current
-                // implementation matches partial birthdates using range overlap. These expectations capture current
-                // system behavior so future behavior changes can be reviewed intentionally.
+                // FHIR R4 search prefixes define equality for ranges as: "the range of the search value fully contains
+                // the range of the target value." See https://hl7.org/fhir/R4/search.html#prefix.
+                // The current implementation instead matches partial birthdates using range overlap. For example,
+                // birthdate=2000-03 currently returns a Patient with birthDate "2000" because the whole-year range
+                // overlaps March 2000, but that Patient should not match under the R4 equality containment rule.
                 Bundle yearBundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2000&_tag={tag}");
                 ValidateBundle(yearBundle, patient2000, patient2000March, patient2000March03, patient2000April01, patient2000December, patient2000March31);
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/DateSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/DateSearchTests.cs
@@ -240,7 +240,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
-        public async Task GivenPatientsWithPartialBirthdates_WhenSearchedByEquality_ThenContainmentSemanticsArePreserved()
+        public async Task GivenPatientsWithPartialBirthdates_WhenSearchedByEquality_ThenCurrentOverlapBehaviorIsPreserved()
         {
             string tag = Guid.NewGuid().ToString();
             Patient[] patients = await Client.CreateResourcesAsync<Patient>(
@@ -260,20 +260,23 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
             try
             {
+                // FHIR equality semantics require the search range to fully contain the target range, but the current
+                // implementation matches partial birthdates using range overlap. These expectations capture current
+                // system behavior so future behavior changes can be reviewed intentionally.
                 Bundle yearBundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2000&_tag={tag}");
                 ValidateBundle(yearBundle, patient2000, patient2000March, patient2000March03, patient2000April01, patient2000December, patient2000March31);
 
                 Bundle monthBundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2000-03&_tag={tag}");
-                ValidateBundle(monthBundle, patient2000March, patient2000March03, patient2000March31);
+                ValidateBundle(monthBundle, patient2000, patient2000March, patient2000March03, patient2000March31);
 
                 Bundle dayBundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2000-03-03&_tag={tag}");
-                ValidateBundle(dayBundle, patient2000March03);
+                ValidateBundle(dayBundle, patient2000, patient2000March, patient2000March03);
 
                 Bundle decemberBundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2000-12&_tag={tag}");
-                ValidateBundle(decemberBundle, patient2000December);
+                ValidateBundle(decemberBundle, patient2000, patient2000December);
 
                 Bundle lastDayBundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2000-03-31&_tag={tag}");
-                ValidateBundle(lastDayBundle, patient2000March31);
+                ValidateBundle(lastDayBundle, patient2000, patient2000March, patient2000March31);
             }
             catch (FhirClientException fce)
             {

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/DateSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/DateSearchTests.cs
@@ -240,41 +240,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
 
         [Fact]
         [Trait(Traits.Priority, Priority.One)]
-        public async Task GivenPatientsWithDateOnlyBirthdate_WhenSearchedByEqualityAndRange_ThenCorrectPatientsAreReturned()
-        {
-            // Arrange: create three patients, two born on 2016-07-06 and one born on 2016-07-07.
-            // A unique tag scopes the search results to this test run only.
-            string tag = Guid.NewGuid().ToString();
-            Patient[] patients = await Client.CreateResourcesAsync<Patient>(
-                p => SetPatientBirthDate(p, "2016-07-06", tag),
-                p => SetPatientBirthDate(p, "2016-07-06", tag),
-                p => SetPatientBirthDate(p, "2016-07-07", tag));
-            Patient firstPatient20160706 = patients[0];
-            Patient secondPatient20160706 = patients[1];
-            Patient patient20160707 = patients[2];
-
-            try
-            {
-                // Equality: only patients born on 2016-07-06 should be returned.
-                Bundle equalityBundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2016-07-06&_tag={tag}");
-                ValidateBundle(equalityBundle, firstPatient20160706, secondPatient20160706);
-
-                // Range: only patients born after 2016-07-06 should be returned.
-                Bundle rangeBundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=gt2016-07-06&_tag={tag}");
-                ValidateBundle(rangeBundle, patient20160707);
-            }
-            catch (FhirClientException fce)
-            {
-                Assert.Fail($"A non-expected '{nameof(FhirClientException)}' was raised. Url: {Client.HttpClient.BaseAddress}. Activity Id: {fce.Response.GetRequestId()}. Error: {fce.Message}");
-            }
-            catch (Exception e)
-            {
-                Assert.Fail($"A non-expected '{e.GetType()}' was raised. Url: {Client.HttpClient.BaseAddress}. No Activity Id present. Error: {e.Message}");
-            }
-        }
-
-        [Fact]
-        [Trait(Traits.Priority, Priority.One)]
         public async Task GivenPatientsWithPartialBirthdates_WhenSearchedByEquality_ThenContainmentSemanticsArePreserved()
         {
             string tag = Guid.NewGuid().ToString();

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/DateSearchTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Search/DateSearchTests.cs
@@ -249,16 +249,19 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 p => SetPatientBirthDate(p, "2016-07-06", tag),
                 p => SetPatientBirthDate(p, "2016-07-06", tag),
                 p => SetPatientBirthDate(p, "2016-07-07", tag));
+            Patient firstPatient20160706 = patients[0];
+            Patient secondPatient20160706 = patients[1];
+            Patient patient20160707 = patients[2];
 
             try
             {
                 // Equality: only patients born on 2016-07-06 should be returned.
                 Bundle equalityBundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2016-07-06&_tag={tag}");
-                ValidateBundle(equalityBundle, patients[0], patients[1]);
+                ValidateBundle(equalityBundle, firstPatient20160706, secondPatient20160706);
 
                 // Range: only patients born after 2016-07-06 should be returned.
                 Bundle rangeBundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=gt2016-07-06&_tag={tag}");
-                ValidateBundle(rangeBundle, patients[2]);
+                ValidateBundle(rangeBundle, patient20160707);
             }
             catch (FhirClientException fce)
             {
@@ -283,23 +286,29 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Search
                 p => SetPatientBirthDate(p, "2000-04-01", tag),
                 p => SetPatientBirthDate(p, "2000-12", tag),
                 p => SetPatientBirthDate(p, "2000-03-31", tag));
+            Patient patient2000 = patients[0];
+            Patient patient2000March = patients[1];
+            Patient patient2000March03 = patients[2];
+            Patient patient2000April01 = patients[4];
+            Patient patient2000December = patients[5];
+            Patient patient2000March31 = patients[6];
 
             try
             {
                 Bundle yearBundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2000&_tag={tag}");
-                ValidateBundle(yearBundle, patients[0], patients[1], patients[2], patients[4], patients[5], patients[6]);
+                ValidateBundle(yearBundle, patient2000, patient2000March, patient2000March03, patient2000April01, patient2000December, patient2000March31);
 
                 Bundle monthBundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2000-03&_tag={tag}");
-                ValidateBundle(monthBundle, patients[1], patients[2], patients[6]);
+                ValidateBundle(monthBundle, patient2000March, patient2000March03, patient2000March31);
 
                 Bundle dayBundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2000-03-03&_tag={tag}");
-                ValidateBundle(dayBundle, patients[2]);
+                ValidateBundle(dayBundle, patient2000March03);
 
                 Bundle decemberBundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2000-12&_tag={tag}");
-                ValidateBundle(decemberBundle, patients[5]);
+                ValidateBundle(decemberBundle, patient2000December);
 
                 Bundle lastDayBundle = await Client.SearchAsync(ResourceType.Patient, $"birthdate=2000-03-31&_tag={tag}");
-                ValidateBundle(lastDayBundle, patients[6]);
+                ValidateBundle(lastDayBundle, patient2000March31);
             }
             catch (FhirClientException fce)
             {


### PR DESCRIPTION
## Description
Adds tests to confirm our current understanding of the patient birthdate query semantics.

## Related issues
[AB#190492](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/190492)

## Testing
This is the testing for future work.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
