### PR TITLE
Reverted unnecessary reindex test changes

### DIFF
--- a/build/ci-variables.yml
+++ b/build/ci-variables.yml
@@ -14,7 +14,7 @@ variables:
     # Shared ACA scaling/sizing values consumed by build/jobs/provision-deploy.yml.
     # Centralized here so all CI provision-deploy invocations stay consistent.
     minReplicas: 3
-    maxReplicas: 24
+    maxReplicas: 8
     containerCpu: '2.0'
     containerMemory: '4Gi'
     cosmosAutoscaleMaxThroughput: 5000

--- a/build/ci-variables.yml
+++ b/build/ci-variables.yml
@@ -20,8 +20,8 @@ variables:
     cosmosAutoscaleMaxThroughput: 5000
 
     # Shared FHIR runtime tuning values consumed by build/jobs/provision-deploy.yml.
-    taskHostingPollingFrequencyInSeconds: 30
+    taskHostingPollingFrequencyInSeconds: 1
     taskHostingMaxRunningTaskCount: 4
-    searchParameterCacheRefreshIntervalSeconds: 20
-    systemConformanceProviderRefreshIntervalSeconds: 60
+    searchParameterCacheRefreshIntervalSeconds: 2
+    systemConformanceProviderRefreshIntervalSeconds: 5
     reindexCacheRefreshWaitMultiplier: 6

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
@@ -1192,9 +1192,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
                     _output.WriteLine($"Failed to delete SearchParameter/{param?.Id}: {ex.Message}");
                 }
             }
-
-            // Allow time for soft deletes to be processed
-            await Task.Delay(500);
         }
 
         private async Task<OperationStatus> WaitForJobCompletionAsync(Uri jobUri, TimeSpan timeout)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
@@ -396,6 +396,9 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
                 ],
             };
 
+            // This test is count sensitive.
+            // It will work only if there is expected number of persons and there are no other resource types to reindex.
+            // Hence - delete and reindex.
             await DeleteResourcesAsync("Person");
             value = await _fixture.TestFhirClient.PostReindexJobAsync(parameters);
             await WaitForJobCompletionAsync(value.jobUri, TimeSpan.FromSeconds(300));

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
@@ -1219,10 +1219,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
 
             // Allow time for soft deletes to be processed
             await Task.Delay(500);
-
-            // Note: Final reindex is handled by ReindexTestFixture.OnDisposedAsync() which runs
-            // once at the very end after all tests complete. This eliminates the need to reindex
-            // after each individual test cleanup.
         }
 
         private async Task<OperationStatus> WaitForJobCompletionAsync(Uri jobUri, TimeSpan timeout)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
@@ -48,16 +48,20 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
 
         public async Task InitializeAsync()
         {
-            // Delete leftover resources from previous test runs
-            _output.WriteLine("Initializing ReindexTests - cleaning up leftover resources...");
+            // delete leftover resources from previous test runs
+            // this guarantees that we start from clean state even on previous hard failures when we cannot rely on finally
+            // we can consider removing finally altogether
+            var sw = Stopwatch.StartNew();
+            _output.WriteLine("ReindexTests.InitializeAsync: Starting...");
 
+            await CancelAnyRunningReindexJobsAsync();
             await DeleteResourcesAsync("SearchParameter", false); // hard delete does not work right
             await DeleteResourcesAsync("Person", true);
             await DeleteResourcesAsync("Specimen", true);
             await DeleteResourcesAsync("SupplyDelivery", true);
             await DeleteResourcesAsync("Immunization", true);
 
-            _output.WriteLine("ReindexTests initialization completed.");
+            _output.WriteLine($"ReindexTests.InitializeAsync: Completed. Elapsed={(int)sw.Elapsed.TotalMilliseconds} msec.");
         }
 
         public Task DisposeAsync()
@@ -68,8 +72,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
         [Fact]
         public async Task Given500SearchParams_WhenReindexCompletes_ThenSearchParamsAreEnabled()
         {
-            await CancelAnyRunningReindexJobsAsync();
-
             const int numberOfSearchParams = 10; // increase to 500 when cache is not updated by API calls and status is saved with resources in a single SQL transaction
             const string urlPrefix = "http://my.org/";
             var codes = new List<string>();
@@ -153,7 +155,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
         [Fact]
         public async Task GivenTwoSearchParamsWithCodeConflictOnDerived_ThenBadRequestIsReturned()
         {
-            await CancelAnyRunningReindexJobsAsync();
 #if R5
             var personTypes = new List<VersionIndependentResourceTypesAll?>() { VersionIndependentResourceTypesAll.Person };
             var resourceTypes = new List<VersionIndependentResourceTypesAll?>() { VersionIndependentResourceTypesAll.Resource };
@@ -217,7 +218,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
         [Fact]
         public async Task GivenTwoSearchParamsForDifferentResourceTypesUsingSameCode_ThenBothCreated()
         {
-            await CancelAnyRunningReindexJobsAsync();
 #if R5
             var personTypes = new List<VersionIndependentResourceTypesAll?>() { VersionIndependentResourceTypesAll.Person };
             var supplyDeliveryTypes = new List<VersionIndependentResourceTypesAll?>() { VersionIndependentResourceTypesAll.SupplyDelivery };
@@ -293,8 +293,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
             {
                 return;
             }
-
-            await CancelAnyRunningReindexJobsAsync();
 
             const string urlPrefix = "http://my.org/";
             var codes = new List<string>();
@@ -401,8 +399,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
         [Fact]
         public async Task GivenReindexJobWithConcurrentUpdates_ThenReportedCountsAreLessThanOriginal()
         {
-            await CancelAnyRunningReindexJobsAsync();
-
             var searchParam = new SearchParameter();
             var testResources = new List<(string resourceType, string resourceId)>();
             (FhirResponse<Parameters> response, Uri jobUri) value = default;
@@ -453,9 +449,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
         public async Task GivenReindexJobWithMixedZeroAndNonZeroCountResources_WhenReindexCompletes_ThenSearchParametersShouldWork()
         {
             var storageMultiplier = (_isSql || _fixture.IsUsingInProcTestServer) ? 1 : 50; // allows to keep settings for cosmos and optimize sql
-
-            // Cancel any running reindex jobs before starting this test
-            await CancelAnyRunningReindexJobsAsync();
 
             // Scenario 1: Test that search parameter status is only updated when ALL jobs complete successfully
             // This tests both zero-count and non-zero-count resource scenarios with multiple resource types
@@ -568,9 +561,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
         [Fact]
         public async Task GivenReindexJobWithResourceAndAddedAfterSingleCustomSearchParameterAndBeforeReindex_WhenReindexCompletes_ThenSearchParameterShouldWork()
         {
-            // Cancel any running reindex jobs before starting this test
-            await CancelAnyRunningReindexJobsAsync();
-
             // Scenario 2: Test that search parameter with invalid expression fails indexing
             // This validates that indexing failures prevent status updates
             var randomSuffix = Guid.NewGuid().ToString("N").Substring(0, 8);
@@ -639,9 +629,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
         [Fact]
         public async Task GivenReindexJobWithResourceAndAddedAfterMultiCustomSearchParameterAndBeforeReindex_WhenReindexCompletes_ThenSearchParametersShouldWork()
         {
-            // Cancel any running reindex jobs before starting this test
-            await CancelAnyRunningReindexJobsAsync();
-
             // Scenario 2: Test that search parameter with invalid expression fails indexing
             // This validates that indexing failures prevent status updates
             var randomSuffix = Guid.NewGuid().ToString("N").Substring(0, 8);
@@ -711,9 +698,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
         [Fact]
         public async Task GivenReindexWithCaseVariantSearchParameterUrls_WhenBothHaveSameStatus_ThenBothShouldBeProcessedCorrectly()
         {
-            // Cancel any running reindex jobs before starting this test
-            await CancelAnyRunningReindexJobsAsync();
-
             // Scenario 3a: Case variant search parameter URLs with same status (Supported, Supported)
             // Both should be treated as separate entries and processed correctly
             var randomSuffix = Guid.NewGuid().ToString("N").Substring(0, 8);
@@ -783,9 +767,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
         [Fact]
         public async Task GivenReindexWithCaseVariantSearchParameterUrls_WhenHavingDifferentStatuses_ThenBothSearchParametersShouldWork()
         {
-            // Cancel any running reindex jobs before starting this test
-            await CancelAnyRunningReindexJobsAsync();
-
             // Scenario 3b: Case variant search parameter URLs with different statuses
             // Verify both are set to the correct status when all jobs complete
             var randomSuffix = Guid.NewGuid().ToString("N").Substring(0, 8);
@@ -855,9 +836,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
         [Fact]
         public async Task GivenSearchParameterAddedAndReindexed_WhenSearchParameterIsDeleted_ThenAfterReindexSearchParameterShouldNotBeSupported()
         {
-            // Cancel any running reindex jobs before starting this test
-            await CancelAnyRunningReindexJobsAsync();
-
             // Comprehensive lifecycle test:
             // 1. Create a Specimen record with specific data
             // 2. Add a custom search parameter
@@ -1008,27 +986,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
             {
                 _output.WriteLine($"Failed to create resource {id}: {ex.Message}");
                 return (false, null, id);
-            }
-        }
-
-        /// <summary>
-        /// Helper method to create and post a resource in a single operation
-        /// </summary>
-        private async Task<T> CreateAndPostResourceAsync<T>(string id, string name, Func<string, string, Task<T>> createResourceFunc)
-            where T : Resource
-        {
-            var resource = await createResourceFunc(id, name);
-
-            try
-            {
-                // Post the resource using the client's CreateAsync method
-                var response = await _fixture.TestFhirClient.CreateAsync(resource);
-                return response;
-            }
-            catch (Exception ex)
-            {
-                _output.WriteLine($"Failed to create resource {id}: {ex.Message}");
-                return resource; // Return the original resource even on failure so ID can be tracked
             }
         }
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
@@ -1174,7 +1174,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
         {
             try
             {
-                await _fixture.TestFhirClient.DeleteAsync($"{resourceType}/{resourceId}?hardDelete=true", false);
+                await _fixture.TestFhirClient.DeleteAsync($"{resourceType}/{resourceId}?hardDelete=true", true);
                 _output.WriteLine($"Deleted {resourceType}/{resourceId}");
             }
             catch (Exception ex)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
@@ -403,7 +403,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
             try
             {
                 var randomSuffix = Guid.NewGuid().ToString("N").Substring(0, 8);
-                var resources = await SetupTestDataAsync("Person", 40, randomSuffix, CreatePersonResourceAsync);
+                var resources = await SetupTestDataAsync("Person", 100, randomSuffix, CreatePersonResourceAsync);
                 testResources.AddRange(resources);
                 searchParam = await CreateCustomSearchParameterAsync($"custom-person-name-{randomSuffix}", ["Person"], "Person.name.given", SearchParamType.String);
                 Assert.NotNull(searchParam);

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
@@ -35,12 +35,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
     [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.Json)]
     public class ReindexTests : IClassFixture<HttpIntegrationTestFixture>
     {
-        // Maximum time to wait for a reindex job to reach a terminal state. Set high enough to accommodate
-        // multi-replica search-parameter cache convergence in CI (poll interval up to 30s, conformance refresh
-        // up to 60s, plus reindex worker queue scheduling and retry backoffs).
-        private static readonly TimeSpan ReindexJobCompletionTimeout = TimeSpan.FromMinutes(20);
-        private const string TestSearchParameterUrlPrefix = "http://my.org/";
-
         private readonly HttpIntegrationTestFixture _fixture;
         private readonly bool _isSql;
         private readonly ITestOutputHelper _output;
@@ -91,20 +85,20 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
             }
             finally
             {
-                await DeleteSearchParamsAsync(codes.Select(c => new SearchParameter { Id = c, Url = $"{urlPrefix}{c}" }));
+                await DeleteSearchParamsAsync(codes);
             }
 
             async Task<Bundle> CreatePersonSearchParamsAsync()
             {
                 var bundle = new Bundle { Type = Bundle.BundleType.Batch, Entry = new List<EntryComponent>() };
 
-                #if R5
+#if R5
                 var resourceTypes = new List<VersionIndependentResourceTypesAll?>();
                 resourceTypes.Add(Enum.Parse<VersionIndependentResourceTypesAll>("Person"));
-                #else
+#else
                 var resourceTypes = new List<ResourceType?>();
                 resourceTypes.Add(Enum.Parse<ResourceType>("Person"));
-                #endif
+#endif
 
                 foreach (var code in codes)
                 {
@@ -145,13 +139,12 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
             var personTypes = new List<VersionIndependentResourceTypesAll?>() { VersionIndependentResourceTypesAll.Person };
             var resourceTypes = new List<VersionIndependentResourceTypesAll?>() { VersionIndependentResourceTypesAll.Resource };
 #else
-            var personTypes = new List<ResourceType?>() { ResourceType.Person};
+            var personTypes = new List<ResourceType?>() { ResourceType.Person };
             var resourceTypes = new List<ResourceType?>() { ResourceType.Resource };
 #endif
-            var uniqueSuffix = CreateUniqueSearchParameterSuffix();
-            var searchParams = new List<SearchParameter>();
-            var ids = new List<string> { $"c-id-1-{uniqueSuffix}", $"c-id-2-{uniqueSuffix}" };
-            var code = $"same-code-{uniqueSuffix}";
+            const string urlPrefix = "http://my.org/";
+            var ids = new List<string> { "c-id-1", "c-id-2" };
+            var code = "same-code";
             try
             {
                 var bundle = new Bundle { Type = Bundle.BundleType.Batch, Entry = [] };
@@ -160,7 +153,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
                 var searchParam = new SearchParameter
                 {
                     Id = id,
-                    Url = BuildTestSearchParameterUrl($"c-1-{uniqueSuffix}"),
+                    Url = $"{urlPrefix}c-1",
                     Name = code,
                     Code = code,
                     Status = PublicationStatus.Active,
@@ -169,7 +162,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
                     Description = "any",
                     Base = personTypes,
                 };
-                searchParams.Add(searchParam);
 
                 bundle.Entry.Add(new EntryComponent { Request = new RequestComponent { Method = Bundle.HTTPVerb.PUT, Url = $"SearchParameter/{id}" }, Resource = searchParam });
 
@@ -177,7 +169,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
                 searchParam = new SearchParameter
                 {
                     Id = id,
-                    Url = BuildTestSearchParameterUrl($"c-2-{uniqueSuffix}"),
+                    Url = $"{urlPrefix}c-2",
                     Name = code,
                     Code = code,
                     Status = PublicationStatus.Active,
@@ -186,7 +178,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
                     Description = "any",
                     Base = resourceTypes,
                 };
-                searchParams.Add(searchParam);
 
                 bundle.Entry.Add(new EntryComponent { Request = new RequestComponent { Method = Bundle.HTTPVerb.PUT, Url = $"SearchParameter/{id}" }, Resource = searchParam });
 
@@ -200,7 +191,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
             }
             finally
             {
-                await DeleteSearchParamsAsync(searchParams);
+                await DeleteSearchParamsAsync(ids);
             }
         }
 
@@ -215,19 +206,18 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
             var personTypes = new List<ResourceType?>() { ResourceType.Person };
             var supplyDeliveryTypes = new List<ResourceType?>() { ResourceType.SupplyDelivery };
 #endif
-            var uniqueSuffix = CreateUniqueSearchParameterSuffix();
-            var searchParams = new List<SearchParameter>();
-            var ids = new List<string> { $"c-id-1-{uniqueSuffix}", $"c-id-2-{uniqueSuffix}" };
+            const string urlPrefix = "http://my.org/";
+            var ids = new List<string> { "c-id-1", "c-id-2" };
             try
             {
                 var bundle = new Bundle { Type = Bundle.BundleType.Batch, Entry = [] };
 
-                var code = $"same-code-{uniqueSuffix}";
+                var code = "same-code";
                 var id = ids[0];
                 var searchParam = new SearchParameter
                 {
                     Id = id,
-                    Url = BuildTestSearchParameterUrl($"c-1-{uniqueSuffix}"),
+                    Url = $"{urlPrefix}c-1",
                     Name = code,
                     Code = code,
                     Status = PublicationStatus.Active,
@@ -236,7 +226,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
                     Description = "any",
                     Base = personTypes,
                 };
-                searchParams.Add(searchParam);
 
                 bundle.Entry.Add(new EntryComponent { Request = new RequestComponent { Method = Bundle.HTTPVerb.PUT, Url = $"SearchParameter/{id}" }, Resource = searchParam });
 
@@ -244,7 +233,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
                 searchParam = new SearchParameter
                 {
                     Id = id,
-                    Url = BuildTestSearchParameterUrl($"c-2-{uniqueSuffix}"),
+                    Url = $"{urlPrefix}c-2",
                     Name = code,
                     Code = code,
                     Status = PublicationStatus.Active,
@@ -253,7 +242,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
                     Description = "any",
                     Base = supplyDeliveryTypes,
                 };
-                searchParams.Add(searchParam);
 
                 bundle.Entry.Add(new EntryComponent { Request = new RequestComponent { Method = Bundle.HTTPVerb.PUT, Url = $"SearchParameter/{id}" }, Resource = searchParam });
 
@@ -263,7 +251,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
             }
             finally
             {
-                await DeleteSearchParamsAsync(searchParams);
+                await DeleteSearchParamsAsync(ids);
             }
         }
 
@@ -289,32 +277,31 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
 
             await CancelAnyRunningReindexJobsAsync();
 
-            var uniqueSuffix = CreateUniqueSearchParameterSuffix();
+            const string urlPrefix = "http://my.org/";
             var codes = new List<string>();
             var urls = new List<string>();
             var ids = new List<string>();
-            var searchParams = new List<SearchParameter>();
             try
             {
-                ids.Add($"c-id-x-{uniqueSuffix}");
-                codes.Add($"c-code-x-{uniqueSuffix}");
-                urls.Add(BuildTestSearchParameterUrl($"c-code-x-{uniqueSuffix}"));
+                ids.Add("c-id-x");
+                codes.Add("c-code-x");
+                urls.Add($"{urlPrefix}c-code-x");
 
-                ids.Add($"c-id-y-{uniqueSuffix}");
+                ids.Add("c-id-y");
                 if (dupCodes && dupUrls)
                 {
-                    codes.Add(codes[0]);
-                    urls.Add(urls[0]);
+                    codes.Add("c-code-x");
+                    urls.Add($"{urlPrefix}c-code-x");
                 }
                 else if (dupCodes)
                 {
-                    codes.Add(codes[0]);
-                    urls.Add(BuildTestSearchParameterUrl($"c-code-y-{uniqueSuffix}"));
+                    codes.Add("c-code-x");
+                    urls.Add($"{urlPrefix}c-code-y");
                 }
                 else if (dupUrls)
                 {
-                    codes.Add($"c-code-y-{uniqueSuffix}");
-                    urls.Add(urls[0]);
+                    codes.Add("c-code-y");
+                    urls.Add($"{urlPrefix}c-code-x");
                 }
 
                 var response = await CreatePersonSearchParamsAsync();
@@ -346,7 +333,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
             }
             finally
             {
-                await DeleteSearchParamsAsync(searchParams);
+                await DeleteSearchParamsAsync(ids);
             }
 
             async Task<Bundle> CreatePersonSearchParamsAsync()
@@ -373,7 +360,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
                         Description = "any",
                         Base = resourceTypes,
                     };
-                    searchParams.Add(searchParam);
 
                     bundle.Entry.Add(new EntryComponent { Request = new RequestComponent { Method = Bundle.HTTPVerb.PUT, Url = $"SearchParameter/{id}" }, Resource = searchParam });
                 }
@@ -383,9 +369,14 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
             }
         }
 
-        private async Task DeleteSearchParamsAsync(IEnumerable<SearchParameter> searchParameters)
+        private async Task DeleteSearchParamsAsync(List<string> ids)
         {
-            await CleanupSearchParametersAsync(searchParameters?.ToArray());
+            foreach (var id in ids)
+            {
+                var bundle = new Bundle { Type = Bundle.BundleType.Batch, Entry = new List<EntryComponent>() };
+                bundle.Entry.Add(new EntryComponent { Request = new RequestComponent { Method = Bundle.HTTPVerb.DELETE, Url = $"SearchParameter/{id}" } });
+                await _fixture.TestFhirClient.PostBundleAsync(bundle, new FhirBundleOptions { BundleProcessingLogic = FhirBundleProcessingLogic.Parallel });
+            }
         }
 
         [Fact]
@@ -400,7 +391,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
             try
             {
                 var randomSuffix = Guid.NewGuid().ToString("N").Substring(0, 8);
-                var resources = await SetupTestDataAsync("Person", 20, randomSuffix, CreatePersonResourceAsync);
+                var resources = await SetupTestDataAsync("Person", 40, randomSuffix, CreatePersonResourceAsync);
                 testResources.AddRange(resources);
                 searchParam = await CreateCustomSearchParameterAsync($"custom-person-name-{randomSuffix}", ["Person"], "Person.name.given", SearchParamType.String);
                 Assert.NotNull(searchParam);
@@ -414,51 +405,18 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
                     ],
                 };
 
-                await Task.Delay(5000);
-
-                // Snapshot the actual Person row count just before posting the reindex job. The reindex job for a
-                // brand-new SearchParameter targeting Person re-scans every Person row in the database, not only the
-                // 20 we just created — and the shared CI environment typically has Person resources left over from
-                // other tests. Comparing against a hard-coded count of 20 is wrong in that environment; we need the
-                // real "universe" of rows reindex will see so that "lessThan" is meaningful.
-                var personCountBeforeReindex = (long)((await _fixture.TestFhirClient.SearchAsync("Person?_summary=count")).Resource.Total ?? 0);
-                _output.WriteLine($"Person count snapshot before reindex: {personCountBeforeReindex}");
-
                 value = await _fixture.TestFhirClient.PostReindexJobAsync(parameters);
                 Assert.Equal(HttpStatusCode.Created, value.response.Response.StatusCode);
 
-                // Drive concurrent updates as a continuous loop instead of a single one-shot batch. With the
-                // orchestrator's SearchParameter cache convergence wait set to several seconds (and longer in CI),
-                // a one-shot batch of 6 PUTs completes well before reindex starts scanning, so the updated rows'
-                // new surrogate IDs are still inside the reindex snapshot's upper-bound and nothing gets skipped.
-                // The loop guarantees at least some updates land while the scan is active.
-                using var updatesCts = new CancellationTokenSource();
-                var updateLoop = RandomPersonUpdateLoop(testResources.Take(6).ToList(), updatesCts.Token);
+                var tasks = new[]
+                {
+                    WaitForJobCompletionAsync(value.jobUri, TimeSpan.FromSeconds(300)),
+                    RandomPersonUpdate(testResources),
+                };
+                await Task.WhenAll(tasks);
 
-                try
-                {
-                    await WaitForJobCompletionAsync(value.jobUri, ReindexJobCompletionTimeout);
-                }
-                catch (Exception ex)
-                {
-                    _output.WriteLine($"Unexpected exception while waiting for reindex job completion: {ex}");
-                    throw;
-                }
-                finally
-                {
-                    updatesCts.Cancel();
-                    try
-                    {
-                        await updateLoop;
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        // expected on cancellation
-                    }
-                }
-
-                // reported in reindex counts should be less than total resources visible at reindex start
-                await CheckReportedCounts(value.jobUri, personCountBeforeReindex, true);
+                // reported in reindex counts should be less than total resources created
+                await CheckReportedCounts(value.jobUri, testResources.Count, true);
             }
             finally
             {
@@ -537,7 +495,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
                 Assert.NotNull(value.jobUri);
 
                 // Wait for job to complete (this will wait for all sub-jobs to complete)
-                var jobStatus = await WaitForJobCompletionAsync(value.jobUri, ReindexJobCompletionTimeout);
+                var jobStatus = await WaitForJobCompletionAsync(value.jobUri, TimeSpan.FromSeconds(300));
                 Assert.True(
                     jobStatus == OperationStatus.Completed,
                     $"Expected Completed, got {jobStatus}");
@@ -632,7 +590,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
                 Assert.NotNull(value.jobUri);
 
                 // Wait for job to complete
-                var jobStatus = await WaitForJobCompletionAsync(value.jobUri, ReindexJobCompletionTimeout);
+                var jobStatus = await WaitForJobCompletionAsync(value.jobUri, TimeSpan.FromSeconds(300));
                 Assert.True(
                     jobStatus == OperationStatus.Completed,
                     $"Expected Completed, got {jobStatus}");
@@ -704,7 +662,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
                 Assert.NotNull(value.jobUri);
 
                 // Wait for job to complete
-                var jobStatus = await WaitForJobCompletionAsync(value.jobUri, ReindexJobCompletionTimeout);
+                var jobStatus = await WaitForJobCompletionAsync(value.jobUri, TimeSpan.FromSeconds(300));
                 Assert.True(
                     jobStatus == OperationStatus.Completed,
                     $"Expected Completed, got {jobStatus}");
@@ -775,7 +733,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
                 Assert.NotNull(value.jobUri);
 
                 // Wait for job completion
-                var jobStatus = await WaitForJobCompletionAsync(value.jobUri, ReindexJobCompletionTimeout);
+                var jobStatus = await WaitForJobCompletionAsync(value.jobUri, TimeSpan.FromSeconds(300));
                 Assert.True(
                     jobStatus == OperationStatus.Completed,
                     $"Expected Completed, got {jobStatus}");
@@ -847,7 +805,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
                 Assert.NotNull(value.jobUri);
 
                 // Wait for job completion
-                var jobStatus = await WaitForJobCompletionAsync(value.jobUri, ReindexJobCompletionTimeout);
+                var jobStatus = await WaitForJobCompletionAsync(value.jobUri, TimeSpan.FromSeconds(300));
                 Assert.True(
                     jobStatus == OperationStatus.Completed,
                     $"Expected Completed, got {jobStatus}");
@@ -935,7 +893,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
                 Assert.NotNull(reindexRequest1.jobUri);
                 _output.WriteLine("Started first reindex job to index the new search parameter");
 
-                var jobStatus1 = await WaitForJobCompletionAsync(reindexRequest1.jobUri, ReindexJobCompletionTimeout);
+                var jobStatus1 = await WaitForJobCompletionAsync(reindexRequest1.jobUri, TimeSpan.FromSeconds(240));
                 Assert.True(
                     jobStatus1 == OperationStatus.Completed,
                     $"First reindex job should complete successfully, but got {jobStatus1}");
@@ -961,7 +919,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
                 Assert.NotNull(reindexRequest2.jobUri);
                 _output.WriteLine("Started second reindex job to remove the deleted search parameter");
 
-                var jobStatus2 = await WaitForJobCompletionAsync(reindexRequest2.jobUri, ReindexJobCompletionTimeout);
+                var jobStatus2 = await WaitForJobCompletionAsync(reindexRequest2.jobUri, TimeSpan.FromSeconds(240));
                 Assert.True(
                     jobStatus2 == OperationStatus.Completed,
                     $"Second reindex job should complete successfully, but got {jobStatus2}");
@@ -1226,16 +1184,13 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
                     _output.WriteLine($"Failed to delete SearchParameter/{param?.Id}: {ex.Message}");
                 }
             }
-        }
 
-        private static string CreateUniqueSearchParameterSuffix()
-        {
-            return Guid.NewGuid().ToString("N").Substring(0, 8);
-        }
+            // Allow time for soft deletes to be processed
+            await Task.Delay(500);
 
-        private static string BuildTestSearchParameterUrl(string suffix)
-        {
-            return $"{TestSearchParameterUrlPrefix}{suffix}";
+            // Note: Final reindex is handled by ReindexTestFixture.OnDisposedAsync() which runs
+            // once at the very end after all tests complete. This eliminates the need to reindex
+            // after each individual test cleanup.
         }
 
         private async Task<OperationStatus> WaitForJobCompletionAsync(Uri jobUri, TimeSpan timeout)
@@ -1601,45 +1556,16 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
 
         private async Task RandomPersonUpdate(IList<(string resourceType, string resourceId)> resources)
         {
-            var tasks = resources
-                .OrderBy(_ => RandomNumberGenerator.GetInt32((int)1e6))
-                .Select(resource => _fixture.TestFhirClient.UpdateAsync(CreatePersonResource(resource.resourceId, Guid.NewGuid().ToString())));
-
-            await Task.WhenAll(tasks);
-        }
-
-        /// <summary>
-        /// Continuously updates the supplied Person resources until <paramref name="cancellationToken"/> is signaled.
-        /// Used by reindex concurrency tests to guarantee at least some updates land while the reindex job is
-        /// actively scanning, regardless of how long the orchestrator's pre-scan SearchParameter cache convergence
-        /// wait is. A single one-shot batch of updates can complete before reindex starts, leaving no rows whose
-        /// surrogate IDs sit past the reindex snapshot upper-bound and therefore no skips, which makes
-        /// "ReportedCountsAreLessThanOriginal" trivially false.
-        /// </summary>
-        private async Task RandomPersonUpdateLoop(IList<(string resourceType, string resourceId)> resources, CancellationToken cancellationToken)
-        {
-            while (!cancellationToken.IsCancellationRequested)
+            foreach (var resource in resources.OrderBy(_ => RandomNumberGenerator.GetInt32((int)1e6)))
             {
+                await Task.Delay(30); // spread updates over more time
                 try
                 {
-                    await RandomPersonUpdate(resources);
+                    await _fixture.TestFhirClient.UpdateAsync(CreatePersonResource(resource.resourceId, Guid.NewGuid().ToString()));
                 }
-                catch (OperationCanceledException)
+                catch
                 {
-                    break;
-                }
-                catch (Exception ex)
-                {
-                    _output.WriteLine($"RandomPersonUpdateLoop iteration failed (continuing): {ex.Message}");
-                }
-
-                try
-                {
-                    await Task.Delay(TimeSpan.FromMilliseconds(500), cancellationToken);
-                }
-                catch (OperationCanceledException)
-                {
-                    break;
+                    // do nothing
                 }
             }
         }
@@ -1766,7 +1692,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
                 if (cancelResponse.IsSuccessStatusCode)
                 {
                     _output.WriteLine($"Waiting for job {jobId} to reach terminal state...");
-                    var finalStatus = await WaitForJobCompletionAsync(jobUri, ReindexJobCompletionTimeout);
+                    var finalStatus = await WaitForJobCompletionAsync(jobUri, TimeSpan.FromSeconds(120));
                     _output.WriteLine($"Job {jobId} reached final status: {finalStatus}");
 
                     // Add a small delay to ensure system is ready

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
@@ -1585,7 +1585,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
         {
             foreach (var resource in resources.OrderBy(_ => RandomNumberGenerator.GetInt32((int)1e6)))
             {
-                await Task.Delay(30); // spread updates over more time
+                await Task.Delay(100); // spread updates over more time
                 try
                 {
                     await _fixture.TestFhirClient.UpdateAsync(CreatePersonResource(resource.resourceId, Guid.NewGuid().ToString()));

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
     [Trait(Traits.Category, Categories.IndexAndReindex)]
     [Trait(Traits.Category, Categories.ReindexOperation)]
     [HttpIntegrationFixtureArgumentSets(DataStore.All, Format.Json)]
-    public class ReindexTests : IClassFixture<HttpIntegrationTestFixture>
+    public class ReindexTests : IClassFixture<HttpIntegrationTestFixture>, IAsyncLifetime
     {
         private readonly HttpIntegrationTestFixture _fixture;
         private readonly bool _isSql;
@@ -44,6 +44,25 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
             _fixture = fixture;
             _isSql = _fixture.DataStore == DataStore.SqlServer;
             _output = output;
+        }
+
+        public async Task InitializeAsync()
+        {
+            // Delete leftover resources from previous test runs
+            _output.WriteLine("Initializing ReindexTests - cleaning up leftover resources...");
+
+            await DeleteResourcesAsync("SearchParameter", false); // hard delete does not work right
+            await DeleteResourcesAsync("Person", true);
+            await DeleteResourcesAsync("Specimen", true);
+            await DeleteResourcesAsync("SupplyDelivery", true);
+            await DeleteResourcesAsync("Immunization", true);
+
+            _output.WriteLine("ReindexTests initialization completed.");
+        }
+
+        public Task DisposeAsync()
+        {
+            return Task.CompletedTask;
         }
 
         [Fact]
@@ -399,7 +418,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
             // This test is count sensitive.
             // It will work only if there is expected number of persons and there are no other resource types to reindex.
             // Hence - delete and reindex.
-            await DeleteResourcesAsync("Person");
+            await DeleteResourcesAsync("Person", true);
             value = await _fixture.TestFhirClient.PostReindexJobAsync(parameters);
             await WaitForJobCompletionAsync(value.jobUri, TimeSpan.FromSeconds(300));
 
@@ -1089,7 +1108,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
             return await Task.FromResult(supplyDelivery);
         }
 
-        private async Task DeleteResourcesAsync(string resourceType)
+        private async Task DeleteResourcesAsync(string resourceType, bool hardDelete)
         {
             try
             {
@@ -1104,7 +1123,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
                     _output.WriteLine($"Found {searchResponse.Resource.Entry.Count} {resourceType} resources.");
                     foreach (var entry in searchResponse.Resource.Entry)
                     {
-                        await DeleteResourceAsync(resourceType, entry.Resource.Id);
+                        await DeleteResourceAsync(resourceType, entry.Resource.Id, hardDelete);
                     }
                 }
                 while (true);
@@ -1175,11 +1194,11 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
         /// <summary>
         /// Helper method to delete a single resource with error handling
         /// </summary>
-        private async Task DeleteResourceAsync(string resourceType, string resourceId)
+        private async Task DeleteResourceAsync(string resourceType, string resourceId, bool hardDelete = false)
         {
             try
             {
-                await _fixture.TestFhirClient.DeleteAsync($"{resourceType}/{resourceId}?hardDelete=true", true);
+                await _fixture.TestFhirClient.DeleteAsync($"{resourceType}/{resourceId}?hardDelete={hardDelete}", true);
                 _output.WriteLine($"Deleted {resourceType}/{resourceId}");
             }
             catch (Exception ex)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
@@ -383,6 +383,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
         public async Task GivenReindexJobWithConcurrentUpdates_ThenReportedCountsAreLessThanOriginal()
         {
             await CancelAnyRunningReindexJobsAsync();
+            await DeleteResourcesAsync("Person");
 
             var searchParam = new SearchParameter();
             var testResources = new List<(string resourceType, string resourceId)>();
@@ -1083,6 +1084,32 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
             return await Task.FromResult(supplyDelivery);
         }
 
+        private async Task DeleteResourcesAsync(string resourceType)
+        {
+            try
+            {
+                do
+                {
+                    var searchResponse = await _fixture.TestFhirClient.SearchAsync(resourceType);
+                    if (searchResponse?.Resource?.Entry == null || searchResponse.Resource.Entry.Count == 0)
+                    {
+                        break;
+                    }
+
+                    _output.WriteLine($"Found {searchResponse.Resource.Entry.Count} {resourceType} resources.");
+                    foreach (var entry in searchResponse.Resource.Entry)
+                    {
+                        await DeleteResourceAsync(resourceType, entry.Resource.Id);
+                    }
+                }
+                while (true);
+            }
+            catch (Exception ex)
+            {
+                _output.WriteLine($"Failed to delete Person resources: {ex.Message}");
+            }
+        }
+
         /// <summary>
         /// Cleanup method that handles both test data resources (Person, Observation, etc.) and search parameters.
         /// Ensures all created resources are properly deleted using parallel batch processing for improved performance.
@@ -1147,7 +1174,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
         {
             try
             {
-                await _fixture.TestFhirClient.DeleteAsync($"{resourceType}/{resourceId}");
+                await _fixture.TestFhirClient.DeleteAsync($"{resourceType}/{resourceId}?hardDelete=true", false);
                 _output.WriteLine($"Deleted {resourceType}/{resourceId}");
             }
             catch (Exception ex)

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/Reindex/ReindexTests.cs
@@ -383,11 +383,22 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
         public async Task GivenReindexJobWithConcurrentUpdates_ThenReportedCountsAreLessThanOriginal()
         {
             await CancelAnyRunningReindexJobsAsync();
-            await DeleteResourcesAsync("Person");
 
             var searchParam = new SearchParameter();
             var testResources = new List<(string resourceType, string resourceId)>();
             (FhirResponse<Parameters> response, Uri jobUri) value = default;
+            var parameters = new Parameters
+            {
+                Parameter =
+                [
+                    new Parameters.ParameterComponent { Name = "maximumNumberOfResourcesPerQuery", Value = new Integer(2) },
+                    new Parameters.ParameterComponent { Name = "maximumNumberOfResourcesPerWrite", Value = new Integer(1) },
+                ],
+            };
+
+            await DeleteResourcesAsync("Person");
+            value = await _fixture.TestFhirClient.PostReindexJobAsync(parameters);
+            await WaitForJobCompletionAsync(value.jobUri, TimeSpan.FromSeconds(300));
 
             try
             {
@@ -396,15 +407,6 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest.Reindex
                 testResources.AddRange(resources);
                 searchParam = await CreateCustomSearchParameterAsync($"custom-person-name-{randomSuffix}", ["Person"], "Person.name.given", SearchParamType.String);
                 Assert.NotNull(searchParam);
-
-                var parameters = new Parameters
-                {
-                    Parameter =
-                    [
-                        new Parameters.ParameterComponent { Name = "maximumNumberOfResourcesPerQuery", Value = new Integer(2) },
-                        new Parameters.ParameterComponent { Name = "maximumNumberOfResourcesPerWrite", Value = new Integer(1) },
-                    ],
-                };
 
                 value = await _fixture.TestFhirClient.PostReindexJobAsync(parameters);
                 Assert.Equal(HttpStatusCode.Created, value.response.Response.StatusCode);


### PR DESCRIPTION
Reverts back all recent changes related to CI pipeline not working in the e2e ReindexTests class.
Reverts back parallel update test in e2e ReindexTests class to spread the update load.  
Add deletes of resources before reindex for count sensitive test.
Changes resource deletes on cleanup to hard deletes.
Adjusted CI settings to match PR ones (exception CPU and RAM on replicas)