### PR TITLE
Upsert profiles on ValidateFixture

### DIFF
--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BulkUpdateTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/BulkUpdateTests.cs
@@ -155,75 +155,94 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             expectedResults.ResourcesIgnored.Add("StructureDefinition", 4);  // Changed: use 4 StructureDefinitions instead of 2 + 2 SearchParameters
 
             var tag = new Coding(string.Empty, Guid.NewGuid().ToString());
+            var createdResources = new List<Resource>();
 
-            // Create resources of different types with the same tag
-            // Use StructureDefinition resources which are excluded from bulk update but don't have
-            // side effects like SearchParameter (which pollutes the SearchParam table and causes test conflicts)
-            var structureDefinition = Samples.GetJsonSample<StructureDefinition>("StructureDefinition-us-core-birthsex");
-            structureDefinition.Meta = new Meta();
-            structureDefinition.Meta.Tag.Add(tag);
-            await _fhirClient.CreateAsync(structureDefinition);
-
-            structureDefinition = Samples.GetJsonSample<StructureDefinition>("StructureDefinition-us-core-ethnicity");
-            structureDefinition.Meta = new Meta();
-            structureDefinition.Meta.Tag.Add(tag);
-            await _fhirClient.CreateAsync(structureDefinition);
-
-            structureDefinition = Samples.GetJsonSample<StructureDefinition>("StructureDefinition-us-core-race");
-            structureDefinition.Meta = new Meta();
-            structureDefinition.Meta.Tag.Add(tag);
-            await _fhirClient.CreateAsync(structureDefinition);
-
-            structureDefinition = Samples.GetJsonSample<StructureDefinition>("StructureDefinition-us-core-careplan");
-            structureDefinition.Meta = new Meta();
-            structureDefinition.Meta.Tag.Add(tag);
-            await _fhirClient.CreateAsync(structureDefinition);
-
-            // Create resources of different types with the same tag
-            await _fhirClient.CreateResourcesAsync<Patient>(2, tag.Code);
-            var location = new Location
+            try
             {
-                Meta = new Meta
+                // Create resources of different types with the same tag
+                // Use StructureDefinition resources which are excluded from bulk update but don't have
+                // side effects like SearchParameter (which pollutes the SearchParam table and causes test conflicts)
+                var structureDefinition = Samples.GetJsonSample<StructureDefinition>("StructureDefinition-us-core-birthsex");
+                structureDefinition.Meta = new Meta();
+                structureDefinition.Meta.Tag.Add(tag);
+                createdResources.Add(await _fhirClient.CreateAsync(structureDefinition));
+
+                structureDefinition = Samples.GetJsonSample<StructureDefinition>("StructureDefinition-us-core-ethnicity");
+                structureDefinition.Meta = new Meta();
+                structureDefinition.Meta.Tag.Add(tag);
+                createdResources.Add(await _fhirClient.CreateAsync(structureDefinition));
+
+                structureDefinition = Samples.GetJsonSample<StructureDefinition>("StructureDefinition-us-core-race");
+                structureDefinition.Meta = new Meta();
+                structureDefinition.Meta.Tag.Add(tag);
+                createdResources.Add(await _fhirClient.CreateAsync(structureDefinition));
+
+                structureDefinition = Samples.GetJsonSample<StructureDefinition>("StructureDefinition-us-core-careplan");
+                structureDefinition.Meta = new Meta();
+                structureDefinition.Meta.Tag.Add(tag);
+                createdResources.Add(await _fhirClient.CreateAsync(structureDefinition));
+
+                // Create resources of different types with the same tag
+                await _fhirClient.CreateResourcesAsync<Patient>(2, tag.Code);
+                var location = new Location
                 {
-                    Tag = new List<Coding>
+                    Meta = new Meta
                     {
-                        new Coding("testTag", tag.Code),
+                        Tag = new List<Coding>
+                        {
+                            new Coding("testTag", tag.Code),
+                        },
                     },
-                },
-            };
-            await _fhirClient.CreateAsync(location);
-
-            var organization = new Organization
-            {
-                Meta = new Meta
-                {
-                    Tag = new List<Coding>
-                    {
-                        new Coding("testTag", tag.Code),
-                    },
-                },
-                Active = true,
-            };
-            await _fhirClient.CreateAsync(organization);
-
-            // Wait to ensure resources are created before bulk update
-            await Task.Delay(2000);
-
-            var patchRequest = new Parameters()
-                .AddAddPatchParameter("Resource", "language", new Code("en"));
-
-            ChangeTypeToUpsertPatchParameter(patchRequest);
-
-            // Create the request with Observation and Location as excluded resource types
-
-            var queryParam = new Dictionary<string, string>
-                {
-                    { "_isParallel", isParallel.ToString() },
                 };
-            HttpResponseMessage response = await SendBulkUpdateRequest(tag.Code, patchRequest, "$bulk-update", queryParam);
+                await _fhirClient.CreateAsync(location);
 
-            // Monitor the job until completion
-            await MonitorBulkUpdateJob(response.Content.Headers.ContentLocation, expectedResults);
+                var organization = new Organization
+                {
+                    Meta = new Meta
+                    {
+                        Tag = new List<Coding>
+                        {
+                            new Coding("testTag", tag.Code),
+                        },
+                    },
+                    Active = true,
+                };
+                await _fhirClient.CreateAsync(organization);
+
+                // Wait to ensure resources are created before bulk update
+                await Task.Delay(2000);
+
+                var patchRequest = new Parameters()
+                    .AddAddPatchParameter("Resource", "language", new Code("en"));
+
+                ChangeTypeToUpsertPatchParameter(patchRequest);
+
+                // Create the request with Observation and Location as excluded resource types
+
+                var queryParam = new Dictionary<string, string>
+                    {
+                        { "_isParallel", isParallel.ToString() },
+                    };
+                HttpResponseMessage response = await SendBulkUpdateRequest(tag.Code, patchRequest, "$bulk-update", queryParam);
+
+                // Monitor the job until completion
+                await MonitorBulkUpdateJob(response.Content.Headers.ContentLocation, expectedResults);
+            }
+            finally
+            {
+                // Clean up created StructureDefinitions to prevent accumulation in persistent environments
+                foreach (var resource in createdResources)
+                {
+                    try
+                    {
+                        await _fhirClient.DeleteAsync(resource);
+                    }
+                    catch (Exception)
+                    {
+                        // Best-effort cleanup — don't fail the test
+                    }
+                }
+            }
         }
 
         [SkippableFact]

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ValidateTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ValidateTestFixture.cs
@@ -20,7 +20,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
         protected override async System.Threading.Tasks.Task OnInitializedAsync()
         {
-            // Delete all profile related resources before starting the test suite.
+            // Use conditional update (PUT) to upsert profile resources by canonical URL.
+            // This prevents duplicate StructureDefinitions from accumulating in persistent test environments.
             var sd = new List<string>()
             {
                 "StructureDefinition-us-core-birthsex", "StructureDefinition-us-core-ethnicity", "StructureDefinition-us-core-patient",
@@ -28,7 +29,8 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             };
             foreach (var name in sd)
             {
-                await TestFhirClient.CreateAsync(Samples.GetJsonSample<StructureDefinition>(name), $"name={name}");
+                var resource = Samples.GetJsonSample<StructureDefinition>(name);
+                await TestFhirClient.ConditionalUpdateAsync(resource, $"url={resource.Url}");
             }
 
             var valueSets = new List<string>()
@@ -38,13 +40,15 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             };
             foreach (var name in valueSets)
             {
-                await TestFhirClient.CreateAsync(Samples.GetJsonSample<ValueSet>(name), $"name={name}");
+                var resource = Samples.GetJsonSample<ValueSet>(name);
+                await TestFhirClient.ConditionalUpdateAsync(resource, $"url={resource.Url}");
             }
 
             var codeSystem = new List<string>() { "CodeSystem-careplan-category" };
             foreach (var name in codeSystem)
             {
-                await TestFhirClient.CreateAsync(Samples.GetJsonSample<CodeSystem>(name), $"name={name}");
+                var resource = Samples.GetJsonSample<CodeSystem>(name);
+                await TestFhirClient.ConditionalUpdateAsync(resource, $"url={resource.Url}");
             }
         }
     }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ValidateTestFixture.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.E2E/Rest/ValidateTestFixture.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
 
         protected override async System.Threading.Tasks.Task OnInitializedAsync()
         {
-            // Use conditional update (PUT) to upsert profile resources by canonical URL.
+            // Use PUT (UpdateAsync) with stable IDs to upsert profile resources.
             // This prevents duplicate StructureDefinitions from accumulating in persistent test environments.
             var sd = new List<string>()
             {
@@ -29,8 +29,7 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             };
             foreach (var name in sd)
             {
-                var resource = Samples.GetJsonSample<StructureDefinition>(name);
-                await TestFhirClient.ConditionalUpdateAsync(resource, $"url={resource.Url}");
+                await TestFhirClient.UpdateAsync(Samples.GetJsonSample<StructureDefinition>(name));
             }
 
             var valueSets = new List<string>()
@@ -40,15 +39,13 @@ namespace Microsoft.Health.Fhir.Tests.E2E.Rest
             };
             foreach (var name in valueSets)
             {
-                var resource = Samples.GetJsonSample<ValueSet>(name);
-                await TestFhirClient.ConditionalUpdateAsync(resource, $"url={resource.Url}");
+                await TestFhirClient.UpdateAsync(Samples.GetJsonSample<ValueSet>(name));
             }
 
             var codeSystem = new List<string>() { "CodeSystem-careplan-category" };
             foreach (var name in codeSystem)
             {
-                var resource = Samples.GetJsonSample<CodeSystem>(name);
-                await TestFhirClient.ConditionalUpdateAsync(resource, $"url={resource.Url}");
+                await TestFhirClient.UpdateAsync(Samples.GetJsonSample<CodeSystem>(name));
             }
         }
     }


### PR DESCRIPTION
## Description
Validate fixture was creating profiles and they would build up over time.  Here we update instead of create new each test run.

## Related issues
Addresses [issue [AB#192012](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/192012)].

## Testing
Tests were re-run

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
