### PR TITLE
Fix parallel bundle cancellation hang

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerTests.cs
@@ -955,6 +955,77 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
             Assert.True(bundleResponse.Info.ExecutionTime.TotalMilliseconds > 0, "ExecutionTime is not higher than zero.");
         }
 
+        [Fact]
+        public async Task GivenABundleRequest_WhenParallelOperationIsCanceled_ThenParallelProcessingCompletesPromptly()
+        {
+            _bundleConfiguration.BatchDefaultProcessingLogic = BundleProcessingLogic.Parallel;
+            _bundleConfiguration.SupportsBundleOrchestrator = true;
+
+            using var outerCancellationTokenSource = new CancellationTokenSource();
+
+            var bundle = new Hl7.Fhir.Model.Bundle
+            {
+                Type = BundleType.Batch,
+                Entry = new List<EntryComponent>
+                {
+                    new EntryComponent
+                    {
+                        Request = new RequestComponent
+                        {
+                            Method = HTTPVerb.POST,
+                            Url = "/Observation?mode=wait",
+                        },
+                        Resource = new Observation(),
+                    },
+                    new EntryComponent
+                    {
+                        Request = new RequestComponent
+                        {
+                            Method = HTTPVerb.POST,
+                            Url = "/Observation?mode=cancel",
+                        },
+                        Resource = new Observation(),
+                    },
+                },
+            };
+
+            var localAsyncFunction = (CallInfo callInfo) =>
+            {
+                var routeContext = callInfo.Arg<RouteContext>();
+                routeContext.Handler = async context =>
+                {
+                    string mode = context.Request.Query["mode"].ToString();
+                    if (string.Equals(mode, "cancel", StringComparison.OrdinalIgnoreCase))
+                    {
+                        throw new OperationCanceledException("Simulated parallel operation cancellation.");
+                    }
+
+                    await Task.Delay(TimeSpan.FromSeconds(30), context.RequestAborted);
+                    context.Response.StatusCode = 200;
+                };
+            };
+
+            _router.When(r => r.RouteAsync(Arg.Any<RouteContext>()))
+                .Do(localAsyncFunction);
+
+            var bundleRequest = new BundleRequest(bundle.ToResourceElement());
+            var handleTask = _bundleHandler.Handle(bundleRequest, outerCancellationTokenSource.Token);
+
+            Task completedTask = await Task.WhenAny(handleTask, Task.Delay(TimeSpan.FromSeconds(1)));
+            if (completedTask != handleTask)
+            {
+                outerCancellationTokenSource.Cancel();
+                Task cleanupTask = await Task.WhenAny(handleTask, Task.Delay(TimeSpan.FromSeconds(1)));
+                if (cleanupTask == handleTask)
+                {
+                    _ = await Record.ExceptionAsync(() => handleTask);
+                }
+            }
+
+            Assert.Same(handleTask, completedTask);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => handleTask);
+        }
+
         private void RouteAsyncFunction(CallInfo callInfo)
         {
             var routeContext = callInfo.Arg<RouteContext>();

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerParallelOperations.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerParallelOperations.cs
@@ -77,6 +77,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                 RequestContextAccessor<IFhirRequestContext> requestContext = _fhirRequestContextAccessor;
                 FhirJsonParser fhirJsonParser = _fhirJsonParser;
                 IBundleHttpContextAccessor bundleHttpContextAccessor = _bundleHttpContextAccessor;
+                int parallelCancellationSignaled = 0;
 
                 // Parallel Resource Handling Function.
                 Func<ResourceExecutionContext, CancellationToken, Task> handleRequestFunction = async (ResourceExecutionContext resourceExecutionContext, CancellationToken ct) =>
@@ -120,6 +121,16 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                     {
                         // If the exception raised is a OperationCanceledException, then either client cancelled the request or httprequest timed out.
                         _logger.LogWarning(ex, "Bundle request timed out. Elapsed time {TotalElapsedMilliseconds}ms. Error: {ErrorMessage}", watch.Elapsed.TotalMilliseconds, ex.Message);
+                        if ((cancellationToken.IsCancellationRequested || !requestCancellationToken.IsCancellationRequested)
+                            && Interlocked.Exchange(ref parallelCancellationSignaled, 1) == 0)
+                        {
+                            statistics.MarkBundleAsCancelled();
+                            bundleOperation.Cancel($"Cancelled parallel operation. Resource at position {resourceExecutionContext.Index}. Message: {ex.Message}");
+                        }
+
+                        await requestCancellationToken.CancelAsync();
+
+                        throw;
                     }
                     catch (BaseFhirTransactionException ex)
                     {
@@ -159,13 +170,17 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                 {
                     // The following Task.WhenAll should wait for all requests to finish.
 
-                    // Parallel requests are not supposed to raise exceptions, unless they are FhirTransactionFailedExceptions.
+                    // Parallel requests are not supposed to raise exceptions, unless they are cancellation or FhirTransactionFailedExceptions.
                     // FhirTransactionFailedExceptions are a special case to invalidate an entire bundle.
 
                     // Based on tests, as suggested by the following article, disposing Tasks does not bring any benefits.
                     // Ref: Do I need to dispose of Tasks? https://devblogs.microsoft.com/dotnet/do-i-need-to-dispose-of-tasks/
 
                     await Task.WhenAll(requestsPerResource);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
                 }
                 catch (AggregateException age)
                 {


### PR DESCRIPTION
## Description
Batch/transaction bundle parallel operations could hang until the max bundle execution timeout when a parallel worker observed cancellation because the worker only logged `OperationCanceledException` and did not stop the shared operation. This PR treats the first cancelled parallel worker as terminal for that bundle operation: it marks bundle statistics cancelled, cancels/releases the bundle orchestrator operation, cancels the linked request token so sibling workers observing `RequestAborted` stop promptly, and rethrows so `Task.WhenAll` propagates cancellation.

Adds focused regression coverage for a parallel batch where one operation throws `OperationCanceledException` while a sibling request waits on `RequestAborted`.

## Related issues
Addresses ADO 192125.

## Testing
- `dotnet test .\src\Microsoft.Health.Fhir.Api.UnitTests\Microsoft.Health.Fhir.R4.Api.UnitTests.csproj --filter "FullyQualifiedName~GivenABundleRequest_WhenParallelOperationIsCanceled_ThenParallelProcessingCompletesPromptly" --no-restore --verbosity minimal`
- Result: exit 0; `Test summary: total: 2594, failed: 0, succeeded: 2594, skipped: 0`

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version unchanged**. No SQL scripts or schema changes are included.
- ADR: N/A. This is a scoped runtime cancellation handling fix and does not change system design assumptions.
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main)
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch