### PR TITLE
Fix transaction heartbeat watchdog correlation

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Storage/SqlServerFhirDataStoreUnitTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Storage/SqlServerFhirDataStoreUnitTests.cs
@@ -14,6 +14,7 @@ using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
 using Microsoft.Health.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Exceptions;
@@ -315,7 +316,70 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Storage
             Assert.Contains("is not a known resource type", exception.Message, StringComparison.Ordinal);
         }
 
-        private static SqlServerFhirDataStore CreateSqlServerFhirDataStore(ISqlRetryService sqlRetryService)
+        [Fact]
+        public async Task GivenCancelledRequestToken_WhenPuttingTransactionHeartbeat_ThenHeartbeatUsesNonRequestCancellationToken()
+        {
+            var sqlRetryService = Substitute.For<ISqlRetryService>();
+            var schemaInfo = new SchemaInformation(SchemaVersionConstants.Min, SchemaVersionConstants.Max)
+            {
+                Current = SchemaVersionConstants.Max,
+            };
+            var storeClient = new TestSqlStoreClient(sqlRetryService, schemaInfo);
+            var dataStore = CreateSqlServerFhirDataStore(sqlRetryService, storeClient);
+
+            await dataStore.PutTransactionHeartbeatAsync(123);
+
+            Assert.Equal(1, storeClient.HeartbeatCallCount);
+            Assert.Equal(123, storeClient.HeartbeatTransactionId);
+            Assert.Equal(SqlServerFhirDataStore.MergeResourcesTransactionHeartbeatPeriod, storeClient.HeartbeatPeriod);
+            Assert.False(storeClient.HeartbeatCancellationToken.CanBeCanceled);
+            Assert.False(storeClient.HeartbeatCancellationToken.IsCancellationRequested);
+        }
+
+        [Fact]
+        public void GivenRequestContext_WhenBuildingTransactionDefinition_ThenCorrelationFieldsAreCapturedWithoutFullUri()
+        {
+            var requestContext = new FhirRequestContext(
+                "POST",
+                "https://localhost/Bundle?patient=secret",
+                "https://localhost/",
+                "correlation-123",
+                new Dictionary<string, StringValues>(),
+                new Dictionary<string, StringValues>())
+            {
+                ExecutingBatchOrTransaction = true,
+                ResourceType = KnownResourceTypes.Bundle,
+                RouteName = "BatchOrTransaction",
+            };
+
+            string definition = SqlServerFhirDataStore.BuildMergeResourcesTransactionDefinition(requestContext);
+
+            Assert.Contains("correlationId=correlation-123", definition, StringComparison.Ordinal);
+            Assert.Contains("method=POST", definition, StringComparison.Ordinal);
+            Assert.Contains("routeName=BatchOrTransaction", definition, StringComparison.Ordinal);
+            Assert.Contains("resourceType=Bundle", definition, StringComparison.Ordinal);
+            Assert.Contains("executingBatchOrTransaction=True", definition, StringComparison.Ordinal);
+            Assert.DoesNotContain("patient=secret", definition, StringComparison.Ordinal);
+            Assert.DoesNotContain("https://localhost/Bundle", definition, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void GivenLongRequestContext_WhenBuildingTransactionDefinition_ThenDefinitionIsCappedAtSqlColumnLength()
+        {
+            var requestContext = new FhirRequestContext(
+                "POST",
+                "https://localhost/Bundle",
+                "https://localhost/",
+                new string('a', 3000),
+                new Dictionary<string, StringValues>(),
+                new Dictionary<string, StringValues>());
+
+            string definition = SqlServerFhirDataStore.BuildMergeResourcesTransactionDefinition(requestContext);
+
+            Assert.Equal(SqlStoreClient.MergeResourcesTransactionDefinitionMaxLength, definition.Length);
+        }
+
+        private static SqlServerFhirDataStore CreateSqlServerFhirDataStore(ISqlRetryService sqlRetryService, SqlStoreClient storeClient = null)
         {
             ModelInfoProvider.SetProvider(MockModelInfoProviderBuilder.Create(FhirSpecification.R4).AddKnownTypes(KnownResourceTypes.Group).Build());
 
@@ -358,7 +422,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Storage
                 .GetField("_highestInitializedVersion", BindingFlags.NonPublic | BindingFlags.Instance)
                 .SetValue(model, schemaInfo.Current);
 
-            var storeClient = new SqlStoreClient(sqlRetryService, NullLogger<SqlStoreClient>.Instance, schemaInfo);
+            storeClient ??= new SqlStoreClient(sqlRetryService, NullLogger<SqlStoreClient>.Instance, schemaInfo);
 
             CoreFeatureConfiguration coreFeatureConfiguration = new CoreFeatureConfiguration();
             BundleConfiguration bundleConfiguration = new BundleConfiguration();
@@ -412,6 +476,31 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Storage
             {
                 new ResourceWrapperOperation(wrapper, allowCreate: true, keepHistory: false, weakETag: null, requireETagOnUpdate: false, keepVersion: false, bundleResourceContext: null),
             };
+        }
+
+        private sealed class TestSqlStoreClient : SqlStoreClient
+        {
+            public TestSqlStoreClient(ISqlRetryService sqlRetryService, SchemaInformation schemaInformation)
+                : base(sqlRetryService, NullLogger<SqlStoreClient>.Instance, schemaInformation)
+            {
+            }
+
+            public int HeartbeatCallCount { get; private set; }
+
+            public long HeartbeatTransactionId { get; private set; }
+
+            public TimeSpan HeartbeatPeriod { get; private set; }
+
+            public CancellationToken HeartbeatCancellationToken { get; private set; }
+
+            internal override Task MergeResourcesPutTransactionHeartbeatAsync(long transactionId, TimeSpan heartbeatPeriod, CancellationToken cancellationToken)
+            {
+                HeartbeatCallCount++;
+                HeartbeatTransactionId = transactionId;
+                HeartbeatPeriod = heartbeatPeriod;
+                HeartbeatCancellationToken = cancellationToken;
+                return Task.CompletedTask;
+            }
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Storage/SqlStoreClientTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Storage/SqlStoreClientTests.cs
@@ -1,0 +1,97 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Health.Fhir.SqlServer.Features.Schema;
+using Microsoft.Health.Fhir.SqlServer.Features.Storage;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.SqlServer.Features.Schema;
+using Microsoft.Health.Test.Utilities;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Storage
+{
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.DataSourceValidation)]
+    public class SqlStoreClientTests
+    {
+        [Fact]
+        public async Task GivenTransactionDefinitionAndSupportedSchema_WhenBeginningTransaction_ThenDefinitionIsSentToSql()
+        {
+            var sqlRetryService = Substitute.For<ISqlRetryService>();
+            SqlCommand capturedCommand = null;
+            sqlRetryService
+                .ExecuteSql(
+                    Arg.Do<SqlCommand>(command =>
+                    {
+                        capturedCommand = command;
+                        command.Parameters["@TransactionId"].Value = 123L;
+                        command.Parameters["@SequenceRangeFirstValue"].Value = 1;
+                    }),
+                    Arg.Any<Func<SqlCommand, CancellationToken, Task>>(),
+                    Arg.Any<ILogger>(),
+                    Arg.Any<string>(),
+                    Arg.Any<CancellationToken>(),
+                    Arg.Any<bool>(),
+                    Arg.Any<bool>(),
+                    Arg.Any<string>())
+                .Returns(Task.CompletedTask);
+
+            var client = CreateClient(sqlRetryService, SchemaVersionConstants.TransactionRequestContext);
+
+            await client.MergeResourcesBeginTransactionAsync(1, CancellationToken.None, definition: "correlationId=correlation-123");
+
+            Assert.NotNull(capturedCommand);
+            Assert.Equal("dbo.MergeResourcesBeginTransaction", capturedCommand.CommandText);
+            Assert.Equal("correlationId=correlation-123", capturedCommand.Parameters["@Definition"].Value);
+        }
+
+        [Fact]
+        public async Task GivenTransactionDefinitionAndOlderSchema_WhenBeginningTransaction_ThenDefinitionIsNotSentToSql()
+        {
+            var sqlRetryService = Substitute.For<ISqlRetryService>();
+            SqlCommand capturedCommand = null;
+            sqlRetryService
+                .ExecuteSql(
+                    Arg.Do<SqlCommand>(command =>
+                    {
+                        capturedCommand = command;
+                        command.Parameters["@TransactionId"].Value = 123L;
+                        command.Parameters["@SequenceRangeFirstValue"].Value = 1;
+                    }),
+                    Arg.Any<Func<SqlCommand, CancellationToken, Task>>(),
+                    Arg.Any<ILogger>(),
+                    Arg.Any<string>(),
+                    Arg.Any<CancellationToken>(),
+                    Arg.Any<bool>(),
+                    Arg.Any<bool>(),
+                    Arg.Any<string>())
+                .Returns(Task.CompletedTask);
+
+            var client = CreateClient(sqlRetryService, SchemaVersionConstants.TransactionRequestContext - 1);
+
+            await client.MergeResourcesBeginTransactionAsync(1, CancellationToken.None, definition: "correlationId=correlation-123");
+
+            Assert.NotNull(capturedCommand);
+            Assert.False(capturedCommand.Parameters.Contains("@Definition"));
+        }
+
+        private static SqlStoreClient CreateClient(ISqlRetryService sqlRetryService, int currentSchemaVersion)
+        {
+            var schemaInformation = new SchemaInformation(SchemaVersionConstants.Min, SchemaVersionConstants.Max)
+            {
+                Current = currentSchemaVersion,
+            };
+
+            return new SqlStoreClient(sqlRetryService, NullLogger<SqlStoreClient>.Instance, schemaInformation);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Watchdogs/TransactionWatchdogTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Watchdogs/TransactionWatchdogTests.cs
@@ -1,0 +1,43 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Health.Fhir.SqlServer.Features.Storage;
+using Microsoft.Health.Fhir.SqlServer.Features.Watchdogs;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Watchdogs
+{
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.DataSourceValidation)]
+    public class TransactionWatchdogTests
+    {
+        [Fact]
+        public void GivenTimedOutTransactionContext_WhenFormattingWatchdogEvent_ThenRequestCorrelationIsIncluded()
+        {
+            var transaction = new SqlStoreClient.MergeResourcesTransaction(
+                123,
+                "correlationId=correlation-123;method=POST;routeName=BatchOrTransaction");
+
+            string message = TransactionWatchdog.FormatTransactionEventText("committed", transaction, resources: 2);
+
+            Assert.Contains("committed transaction=123", message, System.StringComparison.Ordinal);
+            Assert.Contains("resources=2", message, System.StringComparison.Ordinal);
+            Assert.Contains("correlationId=correlation-123", message, System.StringComparison.Ordinal);
+            Assert.Contains("routeName=BatchOrTransaction", message, System.StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void GivenTimedOutTransactionWithoutContext_WhenFormattingWatchdogEvent_ThenMessageStillContainsTransaction()
+        {
+            var transaction = new SqlStoreClient.MergeResourcesTransaction(123, null);
+
+            string message = TransactionWatchdog.FormatTransactionEventText("found timed out", transaction);
+
+            Assert.Equal("found timed out transaction=123", message);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/114.diff.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Migrations/114.diff.sql
@@ -1,6 +1,6 @@
-﻿--DROP PROCEDURE dbo.MergeResourcesBeginTransaction
+--DROP PROCEDURE dbo.MergeResourcesBeginTransaction
 GO
-CREATE PROCEDURE dbo.MergeResourcesBeginTransaction @Count int, @TransactionId bigint OUT, @SequenceRangeFirstValue int = NULL OUT, @HeartbeatDate datetime = NULL, @EnableThrottling bit = 0, @Definition varchar(2000) = NULL
+CREATE OR ALTER PROCEDURE dbo.MergeResourcesBeginTransaction @Count int, @TransactionId bigint OUT, @SequenceRangeFirstValue int = NULL OUT, @HeartbeatDate datetime = NULL, @EnableThrottling bit = 0, @Definition varchar(2000) = NULL
 AS
 set nocount on
 DECLARE @SP varchar(100) = 'MergeResourcesBeginTransaction'
@@ -52,8 +52,31 @@ BEGIN CATCH
   THROW
 END CATCH
 GO
---DECLARE @TransactionId bigint
---EXECUTE dbo.MergeResourcesBeginTransaction @Count = 100, @TransactionId = @TransactionId OUT
---SELECT @TransactionId
---SELECT TOP 10 * FROM Transactions ORDER BY SurrogateIdRangeFirstValue DESC
---SELECT TOP 100 * FROM EventLog WHERE EventDate > dateadd(minute,-60,getUTCdate()) AND Process = 'MergeResourcesBeginTransaction' ORDER BY EventDate DESC, EventId DESC
+
+--DROP PROCEDURE MergeResourcesGetTimeoutTransactions
+GO
+CREATE OR ALTER PROCEDURE dbo.MergeResourcesGetTimeoutTransactions @TimeoutSec int
+AS
+set nocount on
+DECLARE @SP varchar(100) = object_name(@@procid)
+       ,@Mode varchar(100) = 'T='+convert(varchar,@TimeoutSec)
+       ,@st datetime = getUTCdate()
+       ,@MinTransactionId bigint
+
+BEGIN TRY
+  EXECUTE dbo.MergeResourcesGetTransactionVisibility @MinTransactionId OUT
+
+  SELECT SurrogateIdRangeFirstValue, Definition
+    FROM dbo.Transactions 
+    WHERE SurrogateIdRangeFirstValue > @MinTransactionId
+      AND IsCompleted = 0
+      AND datediff(second, HeartbeatDate, getUTCdate()) > @TimeoutSec
+    ORDER BY SurrogateIdRangeFirstValue
+
+  EXECUTE dbo.LogEvent @Process=@SP,@Mode=@Mode,@Status='End',@Start=@st,@Rows=@@rowcount
+END TRY
+BEGIN CATCH
+  EXECUTE dbo.LogEvent @Process=@SP,@Mode=@Mode,@Status='Error';
+  THROW
+END CATCH
+GO

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaVersion.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaVersion.cs
@@ -123,5 +123,6 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema
         V111 = 111,
         V112 = 112,
         V113 = 113,
+        V114 = 114,
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaVersionConstants.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/SchemaVersionConstants.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema
     public static class SchemaVersionConstants
     {
         public const int Min = (int)SchemaVersion.V103;
-        public const int Max = (int)SchemaVersion.V113;
+        public const int Max = (int)SchemaVersion.V114;
         public const int MinForUpgrade = (int)SchemaVersion.V103; // this is used for upgrade tests only
         public const int SearchParameterStatusSchemaVersion = (int)SchemaVersion.V6;
         public const int SupportForReferencesWithMissingTypeVersion = (int)SchemaVersion.V7;
@@ -38,6 +38,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Schema
         public const int SearchParameterMaxLastUpdatedStoredProcedure = (int)SchemaVersion.V96;
         public const int SearchParameterLastUpdatedIndex = (int)SchemaVersion.V98;
         public const int FhirModelInitialization = (int)SchemaVersion.V107;
+        public const int TransactionRequestContext = (int)SchemaVersion.V114;
 
         // It is currently used in Azure Healthcare APIs.
         public const int ParameterizedRemovePartitionFromResourceChangesVersion = (int)SchemaVersion.V21;

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Sql/Sprocs/MergeResourcesGetTimeoutTransactions.sql
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Sql/Sprocs/MergeResourcesGetTimeoutTransactions.sql
@@ -11,7 +11,7 @@ DECLARE @SP varchar(100) = object_name(@@procid)
 BEGIN TRY
   EXECUTE dbo.MergeResourcesGetTransactionVisibility @MinTransactionId OUT
 
-  SELECT SurrogateIdRangeFirstValue
+  SELECT SurrogateIdRangeFirstValue, Definition
     FROM dbo.Transactions 
     WHERE SurrogateIdRangeFirstValue > @MinTransactionId
       AND IsCompleted = 0

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Security.Cryptography;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using EnsureThat;
@@ -229,7 +230,8 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             // Assume that most likely case is that all resources should be updated.
             // TODO: MergeResourcesBeginTransaction accepts new parameter allowing to throw exception on overload.
             // TODO: Set this parameter to true when 429 instead of intenal waits is desired. Make sure that exception is NOT thrown only for API calls.
-            (var transactionId, var minSequenceId) = await StoreClient.MergeResourcesBeginTransactionAsync(resources.Count, cancellationToken);
+            string transactionDefinition = BuildMergeResourcesTransactionDefinition(_requestContextAccessor?.RequestContext);
+            (var transactionId, var minSequenceId) = await StoreClient.MergeResourcesBeginTransactionAsync(resources.Count, cancellationToken, definition: transactionDefinition);
 
             var index = 0;
             var mergeWrappersWithVersions = new List<(MergeResourceWrapper Wrapper, bool KeepVersion, int ResourceVersion, int? ExistingVersion)>();
@@ -433,7 +435,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
             if (mergeWrappersWithVersions.Count > 0) // Do not call DB with empty input
             {
-                await using (new Timer(async _ => await _sqlStoreClient.MergeResourcesPutTransactionHeartbeatAsync(transactionId, MergeResourcesTransactionHeartbeatPeriod, cancellationToken), null, TimeSpan.FromSeconds(RandomNumberGenerator.GetInt32(100) / 100.0 * MergeResourcesTransactionHeartbeatPeriod.TotalSeconds), MergeResourcesTransactionHeartbeatPeriod))
+                await using (new Timer(async _ => await PutTransactionHeartbeatAsync(transactionId), null, TimeSpan.FromSeconds(RandomNumberGenerator.GetInt32(100) / 100.0 * MergeResourcesTransactionHeartbeatPeriod.TotalSeconds), MergeResourcesTransactionHeartbeatPeriod))
                 {
                     var retries = 0;
                     var timeoutRetries = 0;
@@ -473,6 +475,49 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             // If this is not an atomic operations, even if there are unsuccessful results, the operation state will be set as 'Completed'.
             // For atomic operations, reaching this level means that all results are successful.
             return new MergeOutcome(MergeOutcomeFinalState.Completed, results);
+        }
+
+        internal static string BuildMergeResourcesTransactionDefinition(IFhirRequestContext context)
+        {
+            if (context == null)
+            {
+                return null;
+            }
+
+            var builder = new StringBuilder();
+            AppendTransactionDefinitionValue(builder, "correlationId", context.CorrelationId);
+            AppendTransactionDefinitionValue(builder, "method", context.Method);
+            AppendTransactionDefinitionValue(builder, "routeName", context.RouteName);
+            AppendTransactionDefinitionValue(builder, "resourceType", context.ResourceType);
+            AppendTransactionDefinitionValue(builder, "executingBatchOrTransaction", context.ExecutingBatchOrTransaction.ToString());
+            AppendTransactionDefinitionValue(builder, "host", context.BaseUri?.Host);
+
+            string definition = builder.ToString();
+            return definition.Length == 0
+                ? null
+                : definition.Substring(0, Math.Min(definition.Length, SqlStoreClient.MergeResourcesTransactionDefinitionMaxLength));
+        }
+
+        internal Task PutTransactionHeartbeatAsync(long transactionId)
+        {
+            return _sqlStoreClient.MergeResourcesPutTransactionHeartbeatAsync(transactionId, MergeResourcesTransactionHeartbeatPeriod, CancellationToken.None);
+        }
+
+        private static void AppendTransactionDefinitionValue(StringBuilder builder, string key, string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return;
+            }
+
+            if (builder.Length > 0)
+            {
+                builder.Append(';');
+            }
+
+            builder.Append(key);
+            builder.Append('=');
+            builder.Append(value.Trim().Replace(';', ',').Replace('=', ':').Replace('\r', ' ').Replace('\n', ' '));
         }
 
         internal async Task<IReadOnlyList<string>> ImportResourcesAsync(IReadOnlyList<ImportResource> resources, ImportMode importMode, bool allowNegativeVersions, bool eventualConsistency, CancellationToken cancellationToken)

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlStoreClient.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlStoreClient.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
         private readonly ILogger _logger;
         private readonly SchemaInformation _schemaInformation;
         private const string _invisibleResource = " ";
+        internal const int MergeResourcesTransactionDefinitionMaxLength = 2000;
 
         public SqlStoreClient(ISqlRetryService sqlRetryService, ILogger<SqlStoreClient> logger, SchemaInformation schemaInformation)
         {
@@ -42,6 +43,10 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             _logger = EnsureArg.IsNotNull(logger, nameof(logger));
             _schemaInformation = schemaInformation;
         }
+
+        private bool SupportsTransactionRequestContext => _schemaInformation != null &&
+            _schemaInformation.Current.HasValue &&
+            _schemaInformation.Current.Value >= SchemaVersionConstants.TransactionRequestContext;
 
         public async Task HardDeleteAsync(short resourceTypeId, string resourceId, bool keepCurrentVersion, bool isResourceChangeCaptureEnabled, CancellationToken cancellationToken)
         {
@@ -188,7 +193,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             };
         }
 
-        internal async Task MergeResourcesPutTransactionHeartbeatAsync(long transactionId, TimeSpan heartbeatPeriod, CancellationToken cancellationToken)
+        internal virtual async Task MergeResourcesPutTransactionHeartbeatAsync(long transactionId, TimeSpan heartbeatPeriod, CancellationToken cancellationToken)
         {
             try
             {
@@ -222,7 +227,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             return (long)transactionIdParam.Value;
         }
 
-        internal async Task<(long TransactionId, int Sequence)> MergeResourcesBeginTransactionAsync(int resourceVersionCount, CancellationToken cancellationToken, DateTime? heartbeatDate = null)
+        internal async Task<(long TransactionId, int Sequence)> MergeResourcesBeginTransactionAsync(int resourceVersionCount, CancellationToken cancellationToken, DateTime? heartbeatDate = null, string definition = null)
         {
             await using var cmd = new SqlCommand() { CommandText = "dbo.MergeResourcesBeginTransaction", CommandType = CommandType.StoredProcedure };
             cmd.Parameters.AddWithValue("@Count", resourceVersionCount);
@@ -234,6 +239,11 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             if (heartbeatDate.HasValue)
             {
                 cmd.Parameters.AddWithValue("@HeartbeatDate", heartbeatDate.Value);
+            }
+
+            if (SupportsTransactionRequestContext && !string.IsNullOrWhiteSpace(definition))
+            {
+                cmd.Parameters.Add("@Definition", SqlDbType.VarChar, MergeResourcesTransactionDefinitionMaxLength).Value = TruncateTransactionDefinition(definition);
             }
 
             if (_schemaInformation != null && _schemaInformation.Current.HasValue && _schemaInformation.Current.Value >= SchemaVersionConstants.MergeThrottling)
@@ -313,11 +323,20 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             return affectedRows;
         }
 
-        internal async Task<IReadOnlyList<long>> MergeResourcesGetTimeoutTransactionsAsync(int timeoutSec, CancellationToken cancellationToken)
+        internal async Task<IReadOnlyList<MergeResourcesTransaction>> MergeResourcesGetTimeoutTransactionsAsync(int timeoutSec, CancellationToken cancellationToken)
         {
             await using var cmd = new SqlCommand { CommandText = "dbo.MergeResourcesGetTimeoutTransactions", CommandType = CommandType.StoredProcedure };
             cmd.Parameters.AddWithValue("@TimeoutSec", timeoutSec);
-            return await cmd.ExecuteReaderAsync(_sqlRetryService, reader => reader.GetInt64(0), _logger, cancellationToken);
+            bool readDefinition = SupportsTransactionRequestContext;
+            return await cmd.ExecuteReaderAsync(
+                _sqlRetryService,
+                reader =>
+                {
+                    string definition = readDefinition && reader.FieldCount > 1 && !reader.IsDBNull(1) ? reader.GetString(1) : null;
+                    return new MergeResourcesTransaction(reader.GetInt64(0), definition);
+                },
+                _logger,
+                cancellationToken);
         }
 
         internal async Task<IReadOnlyList<(long TransactionId, DateTime? VisibleDate, DateTime? InvisibleHistoryRemovedDate)>> GetTransactionsAsync(long startNotInclusiveTranId, long endInclusiveTranId, CancellationToken cancellationToken, DateTime? endDate = null)
@@ -342,6 +361,13 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                 cancellationToken);
         }
 
+        private static string TruncateTransactionDefinition(string definition)
+        {
+            return definition.Length <= MergeResourcesTransactionDefinitionMaxLength
+                ? definition
+                : definition.Substring(0, MergeResourcesTransactionDefinitionMaxLength);
+        }
+
         internal async Task<IReadOnlyList<ResourceDateKey>> GetResourceDateKeysByTransactionIdAsync(long transactionId, CancellationToken cancellationToken)
         {
             await using var cmd = new SqlCommand { CommandText = "dbo.GetResourcesByTransactionId", CommandType = CommandType.StoredProcedure, CommandTimeout = 600 };
@@ -349,6 +375,19 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
             cmd.Parameters.AddWithValue("@IncludeHistory", true);
             cmd.Parameters.AddWithValue("@ReturnResourceKeysOnly", true);
             return await cmd.ExecuteReaderAsync(_sqlRetryService, ReadResourceDateKeyWrapper, _logger, cancellationToken);
+        }
+
+        internal readonly struct MergeResourcesTransaction
+        {
+            public MergeResourcesTransaction(long transactionId, string definition)
+            {
+                TransactionId = transactionId;
+                Definition = definition;
+            }
+
+            public long TransactionId { get; }
+
+            public string Definition { get; }
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Watchdogs/TransactionWatchdog.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Watchdogs/TransactionWatchdog.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Watchdogs
                 return;
             }
 
-            IReadOnlyList<long> timeoutTransactions = await _store.StoreClient.MergeResourcesGetTimeoutTransactionsAsync((int)SqlServerFhirDataStore.MergeResourcesTransactionHeartbeatPeriod.TotalSeconds * 6, cancellationToken);
+            IReadOnlyList<SqlStoreClient.MergeResourcesTransaction> timeoutTransactions = await _store.StoreClient.MergeResourcesGetTimeoutTransactionsAsync((int)SqlServerFhirDataStore.MergeResourcesTransactionHeartbeatPeriod.TotalSeconds * 6, cancellationToken);
             if (timeoutTransactions.Count > 0)
             {
                 _logger.LogWarning(FoundTemplate, timeoutTransactions.Count);
@@ -65,16 +65,17 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Watchdogs
                 _logger.LogDebug(FoundTemplate, timeoutTransactions.Count);
             }
 
-            await Parallel.ForEachAsync(timeoutTransactions, new ParallelOptions { MaxDegreeOfParallelism = 2 }, async (tranId, cancel) =>
+            await Parallel.ForEachAsync(timeoutTransactions, new ParallelOptions { MaxDegreeOfParallelism = 2 }, async (transaction, cancel) =>
             {
+                long tranId = transaction.TransactionId;
                 var st = DateTime.UtcNow;
-                _logger.LogInformation("TransactionWatchdog found timed out transaction={Transaction}, attempting to roll forward...", tranId);
+                _logger.LogInformation("TransactionWatchdog {TransactionWatchdogEvent}, attempting to roll forward...", FormatTransactionEventText("found timed out", transaction));
                 var resources = await _store.GetResourcesByTransactionIdAsync(tranId, cancellationToken);
                 if (resources.Count == 0)
                 {
                     await _store.StoreClient.MergeResourcesCommitTransactionAsync(tranId, "WD: 0 resources", cancellationToken);
                     _logger.LogWarning("TransactionWatchdog committed transaction={Transaction}, resources=0", tranId);
-                    await _store.StoreClient.TryLogEvent("TransactionWatchdog", "Warn", $"committed transaction={tranId}, resources=0", st, cancellationToken);
+                    await _store.StoreClient.TryLogEvent("TransactionWatchdog", "Warn", FormatTransactionEventText("committed", transaction, 0), st, cancellationToken);
                     return;
                 }
 
@@ -86,11 +87,27 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Watchdogs
                 await _store.MergeResourcesWrapperAsync(tranId, false, resources.Select(x => new MergeResourceWrapper(x, true, true)).ToList(), false, 0, null, cancellationToken);
                 await _store.StoreClient.MergeResourcesCommitTransactionAsync(tranId, null, cancellationToken);
                 _logger.LogWarning("TransactionWatchdog committed transaction={Transaction}, resources={Resources}", tranId, resources.Count);
-                await _store.StoreClient.TryLogEvent("TransactionWatchdog", "Warn", $"committed transaction={tranId}, resources={resources.Count}", st, cancellationToken);
+                await _store.StoreClient.TryLogEvent("TransactionWatchdog", "Warn", FormatTransactionEventText("committed", transaction, resources.Count), st, cancellationToken);
 
                 affectedRows = await _store.StoreClient.MergeResourcesAdvanceTransactionVisibilityAsync(cancellationToken);
                 _logger.LogInformation("TransactionWatchdog advanced visibility on {Transactions} transactions.", affectedRows);
             });
+        }
+
+        internal static string FormatTransactionEventText(string action, SqlStoreClient.MergeResourcesTransaction transaction, int? resources = null)
+        {
+            string text = $"{action} transaction={transaction.TransactionId}";
+            if (resources.HasValue)
+            {
+                text += $", resources={resources.Value}";
+            }
+
+            if (!string.IsNullOrWhiteSpace(transaction.Definition))
+            {
+                text += $", requestContext={{{transaction.Definition}}}";
+            }
+
+            return text;
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer/Microsoft.Health.Fhir.SqlServer.csproj
+++ b/src/Microsoft.Health.Fhir.SqlServer/Microsoft.Health.Fhir.SqlServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <!-- Properties used by sql task to generate full script -->
   <PropertyGroup>
-    <LatestSchemaVersion>113</LatestSchemaVersion>
+    <LatestSchemaVersion>114</LatestSchemaVersion>
     <GeneratedFullScriptPath>Features\Schema\Migrations\$(LatestSchemaVersion).sql</GeneratedFullScriptPath>
     <PackageTags>LatestSchemaVersion-$(LatestSchemaVersion)</PackageTags>
   </PropertyGroup>


### PR DESCRIPTION
ADO 192126.

## Why
SQL merge transaction heartbeat bookkeeping was tied to the inbound request cancellation token. If the client canceled after a transaction row was created, heartbeat updates could stop while the server-side row still needed cleanup, leaving watchdog activity harder to correlate back to the originating batch or transaction request.

## Approach
- Use a non-request cancellation token for merge transaction heartbeat updates after transaction creation.
- Store bounded request context in `dbo.Transactions.Definition` for schema V114+ and gate the SQL parameter for rolling upgrade compatibility.
- Return the stored context from timed-out transaction lookup and include it in watchdog cleanup telemetry when available.
- Add schema migration `114.diff.sql`, update base sprocs, and bump SQL latest schema version to 114.

## Notes
The stored context is intentionally bounded to the existing `varchar(2000)` column and excludes the full URI and query string. Older schemas do not receive `@Definition`, and the timeout read path tolerates missing definition columns.

## Validation
- `dotnet test src\Microsoft.Health.Fhir.SqlServer.UnitTests\Microsoft.Health.Fhir.SqlServer.UnitTests.csproj --no-restore --filter "FullyQualifiedName~SqlServerFhirDataStoreUnitTests|FullyQualifiedName~SqlStoreClientTests|FullyQualifiedName~TransactionWatchdogTests" --logger "console;verbosity=minimal"`
- `git diff --check`