### PR TITLE
Keep transaction cleanup independent of request cancellation

### DIFF
--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Storage/SqlServerFhirDataStoreUnitTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Storage/SqlServerFhirDataStoreUnitTests.cs
@@ -159,9 +159,9 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Storage
                 null,
                 DateTimeOffset.UtcNow,
                 false,
-                null,
-                null,
-                null,
+                Array.Empty<SearchIndexEntry>(),
+                new CompartmentIndices(),
+                Array.Empty<KeyValuePair<string, string>>(),
                 null);
         }
 
@@ -258,6 +258,23 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Storage
         }
 
         [Fact]
+        public async Task MergeAsync_OnRetriableMergeFailure_WithCanceledRetryDelay_CompletesTransaction()
+        {
+            using var cts = new CancellationTokenSource();
+            var sqlRetryService = new CanceledRetryDelaySqlRetryService(cts);
+
+            var dataStore = CreateSqlServerFhirDataStore(sqlRetryService);
+            var resources = CreateResourceWrapperOperations("{\"resourceType\":\"Patient\",\"meta\":{\"lastUpdated\":\"2023-01-01T00:00:00Z\"},\"id\":\"123\"}");
+
+            var exception = await Record.ExceptionAsync(
+                () => dataStore.MergeAsync(resources, MergeOptions.Default, cts.Token));
+
+            Assert.NotNull(exception);
+            Assert.True(sqlRetryService.CommitTransactionCalled);
+            Assert.IsAssignableFrom<OperationCanceledException>(exception);
+        }
+
+        [Fact]
         public async Task MergeAsync_OnSqlSurrogateIdCollision_RetryBeforeThrowing()
         {
             // Arrange
@@ -317,7 +334,14 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Storage
 
         private static SqlServerFhirDataStore CreateSqlServerFhirDataStore(ISqlRetryService sqlRetryService)
         {
-            ModelInfoProvider.SetProvider(MockModelInfoProviderBuilder.Create(FhirSpecification.R4).AddKnownTypes(KnownResourceTypes.Group).Build());
+            var provider = MockModelInfoProviderBuilder
+                .Create(FhirSpecification.R4)
+                .AddKnownTypes(KnownResourceTypes.Group, "Encounter", "Device", "Practitioner", "RelatedPerson")
+                .Build();
+            var compartmentTypes = new[] { "Patient", "Practitioner", "Encounter", "Device", "RelatedPerson" };
+            provider.GetCompartmentTypeNames().Returns(compartmentTypes);
+            provider.IsKnownCompartmentType(Arg.Any<string>()).Returns(x => compartmentTypes.Contains((string)x[0]));
+            ModelInfoProvider.SetProvider(provider);
 
             var schemaInfo = new SchemaInformation(SchemaVersionConstants.Min, SchemaVersionConstants.Max)
             {
@@ -353,6 +377,10 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Storage
             typeof(SqlServerFhirModel)
                 .GetField("_resourceTypeToId", BindingFlags.NonPublic | BindingFlags.Instance)
                 .SetValue(model, new Dictionary<string, short>(StringComparer.Ordinal) { { "Patient", 1 } });
+
+            typeof(SqlServerFhirModel)
+                .GetField("_searchParamUriToId", BindingFlags.NonPublic | BindingFlags.Instance)
+                .SetValue(model, new Dictionary<Uri, short> { { SearchParameterNames.IdUri, 1 }, { SearchParameterNames.LastUpdatedUri, 2 } });
 
             typeof(SqlServerFhirModel)
                 .GetField("_highestInitializedVersion", BindingFlags.NonPublic | BindingFlags.Instance)
@@ -407,11 +435,68 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Storage
 
         private static List<ResourceWrapperOperation> CreateResourceWrapperOperations()
         {
-            var wrapper = CreateResourceWrapper("{\"resourceType\":\"Patient\",\"id\":\"123\"}");
+            return CreateResourceWrapperOperations("{\"resourceType\":\"Patient\",\"id\":\"123\"}");
+        }
+
+        private static List<ResourceWrapperOperation> CreateResourceWrapperOperations(string rawResourceData)
+        {
+            var wrapper = CreateResourceWrapper(rawResourceData);
             return new List<ResourceWrapperOperation>
             {
                 new ResourceWrapperOperation(wrapper, allowCreate: true, keepHistory: false, weakETag: null, requireETagOnUpdate: false, keepVersion: false, bundleResourceContext: null),
             };
+        }
+
+        private sealed class CanceledRetryDelaySqlRetryService : ISqlRetryService
+        {
+            private readonly CancellationTokenSource _cancellationTokenSource;
+
+            public CanceledRetryDelaySqlRetryService(CancellationTokenSource cancellationTokenSource)
+            {
+                _cancellationTokenSource = cancellationTokenSource;
+            }
+
+            public bool CommitTransactionCalled { get; private set; }
+
+            public Task TryLogEvent(string process, string status, string text, DateTime? startDate, CancellationToken cancellationToken)
+            {
+                _cancellationTokenSource.Cancel();
+                return Task.CompletedTask;
+            }
+
+            public Task ExecuteSql(Func<SqlConnection, CancellationToken, SqlException, Task> action, ILogger logger, CancellationToken cancellationToken, bool isReadOnly = false)
+            {
+                throw new NotSupportedException();
+            }
+
+            public Task ExecuteSql(SqlCommand sqlCommand, Func<SqlCommand, CancellationToken, Task> action, ILogger logger, string logMessage, CancellationToken cancellationToken, bool isReadOnly = false, bool disableRetries = false, string applicationName = null)
+            {
+                switch (sqlCommand.CommandText)
+                {
+                    case "dbo.MergeResourcesBeginTransaction":
+                        sqlCommand.Parameters["@TransactionId"].Value = 123L;
+                        sqlCommand.Parameters["@SequenceRangeFirstValue"].Value = 1;
+                        return Task.CompletedTask;
+                    case "dbo.MergeResources":
+                        throw new InvalidOperationException("Execution Timeout Expired");
+                    case "dbo.MergeResourcesCommitTransaction":
+                        CommitTransactionCalled = true;
+                        Assert.Equal(CancellationToken.None, cancellationToken);
+                        return Task.CompletedTask;
+                    default:
+                        return Task.CompletedTask;
+                }
+            }
+
+            public Task<IReadOnlyList<TResult>> ExecuteReaderAsync<TResult>(SqlCommand sqlCommand, Func<SqlDataReader, TResult> readerToResult, ILogger logger, string logMessage, CancellationToken cancellationToken, bool isReadOnly = false)
+            {
+                return Task.FromResult<IReadOnlyList<TResult>>(new List<TResult>());
+            }
+
+            public Task<IReadOnlyList<IReadOnlyList<TResult>>> ExecuteMultiResultReaderAsync<TResult>(SqlCommand sqlCommand, IList<Func<SqlDataReader, TResult>> readersToResult, ILogger logger, string logMessage, CancellationToken cancellationToken, bool isReadOnly = false)
+            {
+                throw new NotSupportedException();
+            }
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Storage/SqlServerFhirDataStoreUnitTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Storage/SqlServerFhirDataStoreUnitTests.cs
@@ -258,118 +258,6 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Storage
         }
 
         [Fact]
-        public async Task MergeAsync_OnRetriableMergeFailure_WithCanceledRetryDelay_DoesNotCompleteTransaction()
-        {
-            // Arrange
-            var sqlRetryService = Substitute.For<ISqlRetryService>();
-            using var cts = new CancellationTokenSource();
-            var commitTransactionCalled = false;
-
-            // Begin the transaction successfully, then fail the merge with a retriable timeout.
-            sqlRetryService
-                .ExecuteSql(
-                    Arg.Any<SqlCommand>(),
-                    Arg.Any<Func<SqlCommand, CancellationToken, Task>>(),
-                    Arg.Any<ILogger>(),
-                    Arg.Any<string>(),
-                    Arg.Any<CancellationToken>(),
-                    Arg.Any<bool>(),
-                    Arg.Any<bool>(),
-                    Arg.Any<string>())
-                .Returns(callInfo =>
-                {
-                    var sqlCommand = callInfo.Arg<SqlCommand>();
-                    switch (sqlCommand.CommandText)
-                    {
-                        case "dbo.MergeResourcesBeginTransaction":
-                            sqlCommand.Parameters["@TransactionId"].Value = 123L;
-                            sqlCommand.Parameters["@SequenceRangeFirstValue"].Value = 1;
-                            return Task.CompletedTask;
-                        case "dbo.MergeResources":
-                            throw new InvalidOperationException("Execution Timeout Expired");
-                        case "dbo.MergeResourcesCommitTransaction":
-                            commitTransactionCalled = true;
-                            return Task.CompletedTask;
-                        default:
-                            return Task.CompletedTask;
-                    }
-                });
-
-            // Cancel the request while the retriable failure is being logged, before the retry delay runs.
-            sqlRetryService
-                .TryLogEvent(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
-                .Returns(_ =>
-                {
-                    cts.Cancel();
-                    return Task.CompletedTask;
-                });
-
-            var dataStore = CreateSqlServerFhirDataStore(sqlRetryService);
-            var resources = CreateResourceWrapperOperations("{\"resourceType\":\"Patient\",\"meta\":{\"lastUpdated\":\"2023-01-01T00:00:00Z\"},\"id\":\"123\"}");
-
-            // Act & Assert: the cancellation propagates and the abandoned transaction is left for the
-            // TransactionWatchdog to roll back, so inline cleanup is not run.
-            await Assert.ThrowsAsync<TaskCanceledException>(
-                () => dataStore.MergeAsync(resources, MergeOptions.Default, cts.Token));
-
-            Assert.False(commitTransactionCalled);
-        }
-
-        [Fact]
-        public async Task MergeAsync_OnNonRetriableMergeFailure_WithCanceledRequestToken_RunsCleanupWithUncanceledToken()
-        {
-            // Arrange
-            var sqlRetryService = Substitute.For<ISqlRetryService>();
-            using var cts = new CancellationTokenSource();
-            var commitTransactionCalled = false;
-            CancellationToken cleanupToken = default;
-
-            sqlRetryService
-                .ExecuteSql(
-                    Arg.Any<SqlCommand>(),
-                    Arg.Any<Func<SqlCommand, CancellationToken, Task>>(),
-                    Arg.Any<ILogger>(),
-                    Arg.Any<string>(),
-                    Arg.Any<CancellationToken>(),
-                    Arg.Any<bool>(),
-                    Arg.Any<bool>(),
-                    Arg.Any<string>())
-                .Returns(callInfo =>
-                {
-                    var sqlCommand = callInfo.Arg<SqlCommand>();
-                    switch (sqlCommand.CommandText)
-                    {
-                        case "dbo.MergeResourcesBeginTransaction":
-                            sqlCommand.Parameters["@TransactionId"].Value = 123L;
-                            sqlCommand.Parameters["@SequenceRangeFirstValue"].Value = 1;
-                            return Task.CompletedTask;
-                        case "dbo.MergeResources":
-                            // Cancel the request token, then fail with a non-retriable exception. Cleanup must
-                            // still run because an already-cancelled client token should not leave the
-                            // server-side transaction dirty.
-                            cts.Cancel();
-                            throw new InvalidOperationException("non-retriable merge failure");
-                        case "dbo.MergeResourcesCommitTransaction":
-                            commitTransactionCalled = true;
-                            cleanupToken = callInfo.Arg<CancellationToken>();
-                            return Task.CompletedTask;
-                        default:
-                            return Task.CompletedTask;
-                    }
-                });
-
-            var dataStore = CreateSqlServerFhirDataStore(sqlRetryService);
-            var resources = CreateResourceWrapperOperations("{\"resourceType\":\"Patient\",\"meta\":{\"lastUpdated\":\"2023-01-01T00:00:00Z\"},\"id\":\"123\"}");
-
-            // Act & Assert
-            await Assert.ThrowsAsync<InvalidOperationException>(
-                () => dataStore.MergeAsync(resources, MergeOptions.Default, cts.Token));
-
-            Assert.True(commitTransactionCalled);
-            Assert.Equal(CancellationToken.None, cleanupToken);
-        }
-
-        [Fact]
         public async Task MergeAsync_OnSqlSurrogateIdCollision_RetryBeforeThrowing()
         {
             // Arrange
@@ -429,17 +317,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Storage
 
         private static SqlServerFhirDataStore CreateSqlServerFhirDataStore(ISqlRetryService sqlRetryService)
         {
-            // ModelInfoProvider is a shared static. Configure the compartment types so this provider stays
-            // consistent with other test classes (e.g. CompartmentQueryGeneratorTests) that validate
-            // compartment types against the same global provider.
-            var provider = MockModelInfoProviderBuilder
-                .Create(FhirSpecification.R4)
-                .AddKnownTypes(KnownResourceTypes.Group, "Encounter", "Device", "Practitioner", "RelatedPerson")
-                .Build();
-            var compartmentTypes = new[] { "Patient", "Practitioner", "Encounter", "Device", "RelatedPerson" };
-            provider.GetCompartmentTypeNames().Returns(compartmentTypes);
-            provider.IsKnownCompartmentType(Arg.Any<string>()).Returns(x => compartmentTypes.Contains((string)x[0]));
-            ModelInfoProvider.SetProvider(provider);
+            ModelInfoProvider.SetProvider(MockModelInfoProviderBuilder.Create(FhirSpecification.R4).AddKnownTypes(KnownResourceTypes.Group).Build());
 
             var schemaInfo = new SchemaInformation(SchemaVersionConstants.Min, SchemaVersionConstants.Max)
             {
@@ -475,10 +353,6 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Storage
             typeof(SqlServerFhirModel)
                 .GetField("_resourceTypeToId", BindingFlags.NonPublic | BindingFlags.Instance)
                 .SetValue(model, new Dictionary<string, short>(StringComparer.Ordinal) { { "Patient", 1 } });
-
-            typeof(SqlServerFhirModel)
-                .GetField("_searchParamUriToId", BindingFlags.NonPublic | BindingFlags.Instance)
-                .SetValue(model, new Dictionary<Uri, short> { { SearchParameterNames.IdUri, 1 }, { SearchParameterNames.LastUpdatedUri, 2 } });
 
             typeof(SqlServerFhirModel)
                 .GetField("_highestInitializedVersion", BindingFlags.NonPublic | BindingFlags.Instance)
@@ -533,12 +407,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Storage
 
         private static List<ResourceWrapperOperation> CreateResourceWrapperOperations()
         {
-            return CreateResourceWrapperOperations("{\"resourceType\":\"Patient\",\"id\":\"123\"}");
-        }
-
-        private static List<ResourceWrapperOperation> CreateResourceWrapperOperations(string rawResourceData)
-        {
-            var wrapper = CreateResourceWrapper(rawResourceData);
+            var wrapper = CreateResourceWrapper("{\"resourceType\":\"Patient\",\"id\":\"123\"}");
             return new List<ResourceWrapperOperation>
             {
                 new ResourceWrapperOperation(wrapper, allowCreate: true, keepHistory: false, weakETag: null, requireETagOnUpdate: false, keepVersion: false, bundleResourceContext: null),

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Storage/SqlServerFhirDataStoreUnitTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Storage/SqlServerFhirDataStoreUnitTests.cs
@@ -258,19 +258,115 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Storage
         }
 
         [Fact]
-        public async Task MergeAsync_OnRetriableMergeFailure_WithCanceledRetryDelay_CompletesTransaction()
+        public async Task MergeAsync_OnRetriableMergeFailure_WithCanceledRetryDelay_DoesNotCompleteTransaction()
         {
+            // Arrange
+            var sqlRetryService = Substitute.For<ISqlRetryService>();
             using var cts = new CancellationTokenSource();
-            var sqlRetryService = new CanceledRetryDelaySqlRetryService(cts);
+            var commitTransactionCalled = false;
+
+            // Begin the transaction successfully, then fail the merge with a retriable timeout.
+            sqlRetryService
+                .ExecuteSql(
+                    Arg.Any<SqlCommand>(),
+                    Arg.Any<Func<SqlCommand, CancellationToken, Task>>(),
+                    Arg.Any<ILogger>(),
+                    Arg.Any<string>(),
+                    Arg.Any<CancellationToken>(),
+                    Arg.Any<bool>(),
+                    Arg.Any<bool>(),
+                    Arg.Any<string>())
+                .Returns(callInfo =>
+                {
+                    var sqlCommand = callInfo.Arg<SqlCommand>();
+                    switch (sqlCommand.CommandText)
+                    {
+                        case "dbo.MergeResourcesBeginTransaction":
+                            sqlCommand.Parameters["@TransactionId"].Value = 123L;
+                            sqlCommand.Parameters["@SequenceRangeFirstValue"].Value = 1;
+                            return Task.CompletedTask;
+                        case "dbo.MergeResources":
+                            throw new InvalidOperationException("Execution Timeout Expired");
+                        case "dbo.MergeResourcesCommitTransaction":
+                            commitTransactionCalled = true;
+                            return Task.CompletedTask;
+                        default:
+                            return Task.CompletedTask;
+                    }
+                });
+
+            // Cancel the request while the retriable failure is being logged, before the retry delay runs.
+            sqlRetryService
+                .TryLogEvent(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+                .Returns(_ =>
+                {
+                    cts.Cancel();
+                    return Task.CompletedTask;
+                });
 
             var dataStore = CreateSqlServerFhirDataStore(sqlRetryService);
             var resources = CreateResourceWrapperOperations("{\"resourceType\":\"Patient\",\"meta\":{\"lastUpdated\":\"2023-01-01T00:00:00Z\"},\"id\":\"123\"}");
 
-            var exception = await Record.ExceptionAsync(
+            // Act & Assert: the cancellation propagates and the abandoned transaction is left for the
+            // TransactionWatchdog to roll back, so inline cleanup is not run.
+            await Assert.ThrowsAsync<TaskCanceledException>(
                 () => dataStore.MergeAsync(resources, MergeOptions.Default, cts.Token));
 
-            Assert.True(sqlRetryService.CommitTransactionCalled);
-            Assert.IsAssignableFrom<OperationCanceledException>(exception);
+            Assert.False(commitTransactionCalled);
+        }
+
+        [Fact]
+        public async Task MergeAsync_OnNonRetriableMergeFailure_WithCanceledRequestToken_RunsCleanupWithUncanceledToken()
+        {
+            // Arrange
+            var sqlRetryService = Substitute.For<ISqlRetryService>();
+            using var cts = new CancellationTokenSource();
+            var commitTransactionCalled = false;
+            CancellationToken cleanupToken = default;
+
+            sqlRetryService
+                .ExecuteSql(
+                    Arg.Any<SqlCommand>(),
+                    Arg.Any<Func<SqlCommand, CancellationToken, Task>>(),
+                    Arg.Any<ILogger>(),
+                    Arg.Any<string>(),
+                    Arg.Any<CancellationToken>(),
+                    Arg.Any<bool>(),
+                    Arg.Any<bool>(),
+                    Arg.Any<string>())
+                .Returns(callInfo =>
+                {
+                    var sqlCommand = callInfo.Arg<SqlCommand>();
+                    switch (sqlCommand.CommandText)
+                    {
+                        case "dbo.MergeResourcesBeginTransaction":
+                            sqlCommand.Parameters["@TransactionId"].Value = 123L;
+                            sqlCommand.Parameters["@SequenceRangeFirstValue"].Value = 1;
+                            return Task.CompletedTask;
+                        case "dbo.MergeResources":
+                            // Cancel the request token, then fail with a non-retriable exception. Cleanup must
+                            // still run because an already-cancelled client token should not leave the
+                            // server-side transaction dirty.
+                            cts.Cancel();
+                            throw new InvalidOperationException("non-retriable merge failure");
+                        case "dbo.MergeResourcesCommitTransaction":
+                            commitTransactionCalled = true;
+                            cleanupToken = callInfo.Arg<CancellationToken>();
+                            return Task.CompletedTask;
+                        default:
+                            return Task.CompletedTask;
+                    }
+                });
+
+            var dataStore = CreateSqlServerFhirDataStore(sqlRetryService);
+            var resources = CreateResourceWrapperOperations("{\"resourceType\":\"Patient\",\"meta\":{\"lastUpdated\":\"2023-01-01T00:00:00Z\"},\"id\":\"123\"}");
+
+            // Act & Assert
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => dataStore.MergeAsync(resources, MergeOptions.Default, cts.Token));
+
+            Assert.True(commitTransactionCalled);
+            Assert.Equal(CancellationToken.None, cleanupToken);
         }
 
         [Fact]
@@ -333,7 +429,17 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Storage
 
         private static SqlServerFhirDataStore CreateSqlServerFhirDataStore(ISqlRetryService sqlRetryService)
         {
-            ModelInfoProvider.SetProvider(MockModelInfoProviderBuilder.Create(FhirSpecification.R4).AddKnownTypes(KnownResourceTypes.Group).Build());
+            // ModelInfoProvider is a shared static. Configure the compartment types so this provider stays
+            // consistent with other test classes (e.g. CompartmentQueryGeneratorTests) that validate
+            // compartment types against the same global provider.
+            var provider = MockModelInfoProviderBuilder
+                .Create(FhirSpecification.R4)
+                .AddKnownTypes(KnownResourceTypes.Group, "Encounter", "Device", "Practitioner", "RelatedPerson")
+                .Build();
+            var compartmentTypes = new[] { "Patient", "Practitioner", "Encounter", "Device", "RelatedPerson" };
+            provider.GetCompartmentTypeNames().Returns(compartmentTypes);
+            provider.IsKnownCompartmentType(Arg.Any<string>()).Returns(x => compartmentTypes.Contains((string)x[0]));
+            ModelInfoProvider.SetProvider(provider);
 
             var schemaInfo = new SchemaInformation(SchemaVersionConstants.Min, SchemaVersionConstants.Max)
             {
@@ -437,58 +543,6 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Storage
             {
                 new ResourceWrapperOperation(wrapper, allowCreate: true, keepHistory: false, weakETag: null, requireETagOnUpdate: false, keepVersion: false, bundleResourceContext: null),
             };
-        }
-
-        private sealed class CanceledRetryDelaySqlRetryService : ISqlRetryService
-        {
-            private readonly CancellationTokenSource _cancellationTokenSource;
-
-            public CanceledRetryDelaySqlRetryService(CancellationTokenSource cancellationTokenSource)
-            {
-                _cancellationTokenSource = cancellationTokenSource;
-            }
-
-            public bool CommitTransactionCalled { get; private set; }
-
-            public Task TryLogEvent(string process, string status, string text, DateTime? startDate, CancellationToken cancellationToken)
-            {
-                _cancellationTokenSource.Cancel();
-                return Task.CompletedTask;
-            }
-
-            public Task ExecuteSql(Func<SqlConnection, CancellationToken, SqlException, Task> action, ILogger logger, CancellationToken cancellationToken, bool isReadOnly = false)
-            {
-                throw new NotSupportedException();
-            }
-
-            public Task ExecuteSql(SqlCommand sqlCommand, Func<SqlCommand, CancellationToken, Task> action, ILogger logger, string logMessage, CancellationToken cancellationToken, bool isReadOnly = false, bool disableRetries = false, string applicationName = null)
-            {
-                switch (sqlCommand.CommandText)
-                {
-                    case "dbo.MergeResourcesBeginTransaction":
-                        sqlCommand.Parameters["@TransactionId"].Value = 123L;
-                        sqlCommand.Parameters["@SequenceRangeFirstValue"].Value = 1;
-                        return Task.CompletedTask;
-                    case "dbo.MergeResources":
-                        throw new InvalidOperationException("Execution Timeout Expired");
-                    case "dbo.MergeResourcesCommitTransaction":
-                        CommitTransactionCalled = true;
-                        Assert.Equal(CancellationToken.None, cancellationToken);
-                        return Task.CompletedTask;
-                    default:
-                        return Task.CompletedTask;
-                }
-            }
-
-            public Task<IReadOnlyList<TResult>> ExecuteReaderAsync<TResult>(SqlCommand sqlCommand, Func<SqlDataReader, TResult> readerToResult, ILogger logger, string logMessage, CancellationToken cancellationToken, bool isReadOnly = false)
-            {
-                return Task.FromResult<IReadOnlyList<TResult>>(new List<TResult>());
-            }
-
-            public Task<IReadOnlyList<IReadOnlyList<TResult>>> ExecuteMultiResultReaderAsync<TResult>(SqlCommand sqlCommand, IList<Func<SqlDataReader, TResult>> readersToResult, ILogger logger, string logMessage, CancellationToken cancellationToken, bool isReadOnly = false)
-            {
-                throw new NotSupportedException();
-            }
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Storage/SqlServerFhirDataStoreUnitTests.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer.UnitTests/Features/Storage/SqlServerFhirDataStoreUnitTests.cs
@@ -159,9 +159,9 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Storage
                 null,
                 DateTimeOffset.UtcNow,
                 false,
-                Array.Empty<SearchIndexEntry>(),
-                new CompartmentIndices(),
-                Array.Empty<KeyValuePair<string, string>>(),
+                null,
+                null,
+                null,
                 null);
         }
 
@@ -269,7 +269,6 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Storage
             var exception = await Record.ExceptionAsync(
                 () => dataStore.MergeAsync(resources, MergeOptions.Default, cts.Token));
 
-            Assert.NotNull(exception);
             Assert.True(sqlRetryService.CommitTransactionCalled);
             Assert.IsAssignableFrom<OperationCanceledException>(exception);
         }
@@ -334,14 +333,7 @@ namespace Microsoft.Health.Fhir.SqlServer.UnitTests.Features.Storage
 
         private static SqlServerFhirDataStore CreateSqlServerFhirDataStore(ISqlRetryService sqlRetryService)
         {
-            var provider = MockModelInfoProviderBuilder
-                .Create(FhirSpecification.R4)
-                .AddKnownTypes(KnownResourceTypes.Group, "Encounter", "Device", "Practitioner", "RelatedPerson")
-                .Build();
-            var compartmentTypes = new[] { "Patient", "Practitioner", "Encounter", "Device", "RelatedPerson" };
-            provider.GetCompartmentTypeNames().Returns(compartmentTypes);
-            provider.IsKnownCompartmentType(Arg.Any<string>()).Returns(x => compartmentTypes.Contains((string)x[0]));
-            ModelInfoProvider.SetProvider(provider);
+            ModelInfoProvider.SetProvider(MockModelInfoProviderBuilder.Create(FhirSpecification.R4).AddKnownTypes(KnownResourceTypes.Group).Build());
 
             var schemaInfo = new SchemaInformation(SchemaVersionConstants.Min, SchemaVersionConstants.Max)
             {

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -457,7 +457,12 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
                             if (singleTransaction) // if not single SQL transaction, then let TransactionWatchdog to try rolling forward
                             {
-                                await StoreClient.MergeResourcesCommitTransactionAsync(transactionId, e.Message, cancellationToken);
+                                // Use CancellationToken.None so that a cancelled client token does not prevent the
+                                // server-side transaction from being marked as failed. If we pass the original token
+                                // and it has already been cancelled, OpenAsync() will throw OperationCanceledException
+                                // before MergeResourcesCommitTransactionAsync can do any useful work, the throw below
+                                // is never reached, and the server-side transaction state is left dirty.
+                                await StoreClient.MergeResourcesCommitTransactionAsync(transactionId, e.Message, CancellationToken.None);
                             }
 
                             throw;

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -9,6 +9,7 @@ using System.Data;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
+using System.Runtime.ExceptionServices;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
@@ -447,12 +448,20 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                         catch (Exception e)
                         {
                             retries++;
+                            ExceptionDispatchInfo cancellationException = null;
                             if (!enlistInTransaction && (e.IsRetriable() || (e.IsExecutionTimeout() && timeoutRetries++ < 3)))
                             {
                                 _logger.LogWarning(e, $"Error on {nameof(MergeInternalAsync)} retries={{Retries}} timeoutRetries={{TimeoutRetries}}", retries, timeoutRetries);
-                                await _sqlRetryService.TryLogEvent(nameof(MergeInternalAsync), "Warn", $"retries={retries} timeoutRetries={timeoutRetries} error={e}", null, cancellationToken);
-                                await Task.Delay(5000, cancellationToken);
-                                continue;
+                                try
+                                {
+                                    await _sqlRetryService.TryLogEvent(nameof(MergeInternalAsync), "Warn", $"retries={retries} timeoutRetries={timeoutRetries} error={e}", null, cancellationToken);
+                                    await Task.Delay(5000, cancellationToken);
+                                    continue;
+                                }
+                                catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested)
+                                {
+                                    cancellationException = ExceptionDispatchInfo.Capture(ex);
+                                }
                             }
 
                             if (singleTransaction) // if not single SQL transaction, then let TransactionWatchdog to try rolling forward
@@ -465,6 +474,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                                 await StoreClient.MergeResourcesCommitTransactionAsync(transactionId, e.Message, CancellationToken.None);
                             }
 
+                            cancellationException?.Throw();
                             throw;
                         }
                     }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -457,7 +457,7 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
 
                             if (singleTransaction) // if not single SQL transaction, then let TransactionWatchdog to try rolling forward
                             {
-                                // Use CancellationToken.None so that an already-cancelled client token does not prevent the server-side transaction from being marked as failed. 
+                                // Use CancellationToken.None so that an already-cancelled client token does not prevent the server-side transaction from being marked as failed.
                                 await StoreClient.MergeResourcesCommitTransactionAsync(transactionId, e.Message, CancellationToken.None);
                             }
 

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -9,7 +9,6 @@ using System.Data;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
-using System.Runtime.ExceptionServices;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
@@ -448,33 +447,28 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                         catch (Exception e)
                         {
                             retries++;
-                            ExceptionDispatchInfo cancellationException = null;
                             if (!enlistInTransaction && (e.IsRetriable() || (e.IsExecutionTimeout() && timeoutRetries++ < 3)))
                             {
                                 _logger.LogWarning(e, $"Error on {nameof(MergeInternalAsync)} retries={{Retries}} timeoutRetries={{TimeoutRetries}}", retries, timeoutRetries);
-                                try
-                                {
-                                    await _sqlRetryService.TryLogEvent(nameof(MergeInternalAsync), "Warn", $"retries={retries} timeoutRetries={timeoutRetries} error={e}", null, cancellationToken);
-                                    await Task.Delay(5000, cancellationToken);
-                                    continue;
-                                }
-                                catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested)
-                                {
-                                    cancellationException = ExceptionDispatchInfo.Capture(ex);
-                                }
+                                await _sqlRetryService.TryLogEvent(nameof(MergeInternalAsync), "Warn", $"retries={retries} timeoutRetries={timeoutRetries} error={e}", null, cancellationToken);
+
+                                // If the request is cancelled during the retry delay, let the OperationCanceledException
+                                // propagate without running cleanup. The TransactionWatchdog will roll the abandoned
+                                // transaction forward/back.
+                                await Task.Delay(5000, cancellationToken);
+                                continue;
                             }
 
                             if (singleTransaction) // if not single SQL transaction, then let TransactionWatchdog to try rolling forward
                             {
-                                // Use CancellationToken.None so that a cancelled client token does not prevent the
-                                // server-side transaction from being marked as failed. If we pass the original token
-                                // and it has already been cancelled, OpenAsync() will throw OperationCanceledException
-                                // before MergeResourcesCommitTransactionAsync can do any useful work, the throw below
-                                // is never reached, and the server-side transaction state is left dirty.
+                                // Use CancellationToken.None so that an already-cancelled client token does not prevent
+                                // the server-side transaction from being marked as failed. If we passed the original token
+                                // and it had already been cancelled, OpenAsync() would throw OperationCanceledException
+                                // before MergeResourcesCommitTransactionAsync could do any useful work, leaving the
+                                // server-side transaction state dirty.
                                 await StoreClient.MergeResourcesCommitTransactionAsync(transactionId, e.Message, CancellationToken.None);
                             }
 
-                            cancellationException?.Throw();
                             throw;
                         }
                     }

--- a/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
+++ b/src/Microsoft.Health.Fhir.SqlServer/Features/Storage/SqlServerFhirDataStore.cs
@@ -451,21 +451,13 @@ namespace Microsoft.Health.Fhir.SqlServer.Features.Storage
                             {
                                 _logger.LogWarning(e, $"Error on {nameof(MergeInternalAsync)} retries={{Retries}} timeoutRetries={{TimeoutRetries}}", retries, timeoutRetries);
                                 await _sqlRetryService.TryLogEvent(nameof(MergeInternalAsync), "Warn", $"retries={retries} timeoutRetries={timeoutRetries} error={e}", null, cancellationToken);
-
-                                // If the request is cancelled during the retry delay, let the OperationCanceledException
-                                // propagate without running cleanup. The TransactionWatchdog will roll the abandoned
-                                // transaction forward/back.
                                 await Task.Delay(5000, cancellationToken);
                                 continue;
                             }
 
                             if (singleTransaction) // if not single SQL transaction, then let TransactionWatchdog to try rolling forward
                             {
-                                // Use CancellationToken.None so that an already-cancelled client token does not prevent
-                                // the server-side transaction from being marked as failed. If we passed the original token
-                                // and it had already been cancelled, OpenAsync() would throw OperationCanceledException
-                                // before MergeResourcesCommitTransactionAsync could do any useful work, leaving the
-                                // server-side transaction state dirty.
+                                // Use CancellationToken.None so that an already-cancelled client token does not prevent the server-side transaction from being marked as failed. 
                                 await StoreClient.MergeResourcesCommitTransactionAsync(transactionId, e.Message, CancellationToken.None);
                             }
 


### PR DESCRIPTION
## Summary
- We want to try to commit the current transaction during the exception flow in MergeInternalAsync and not let a cancellation exception bubble up an unhandled exception.
- Discussed with @SergeyGaluzo
- This is an edge case that can raise an error of trying to use an already closed transaction - see attached WI.

## Changes
- `SqlServerFhirDataStore.cs`: pass `CancellationToken.None` to `MergeResourcesCommitTransactionAsync` in the `MergeInternalAsync` single-transaction catch block.
- Catch request cancellation during the retriable failure logging/delay block, fall through to failed transaction cleanup, then rethrow cancellation after cleanup.
- This prevents an already-cancelled request token from skipping server-side transaction failure marking..

[AB#188321](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/188321)

## Testing
- `dotnet test src\Microsoft.Health.Fhir.SqlServer.UnitTests\Microsoft.Health.Fhir.SqlServer.UnitTests.csproj --no-restore --verbosity minimal`
- `dotnet build src\Microsoft.Health.Fhir.SqlServer\Microsoft.Health.Fhir.SqlServer.csproj --no-restore --nologo --verbosity quiet`
- `git diff --check`