### PR TITLE
[Bundle] Handling cancellation in case of throttling

### DIFF
--- a/src/Microsoft.Health.Fhir.Core/Features/Persistence/Orchestration/BundleOrchestratorOperation.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Persistence/Orchestration/BundleOrchestratorOperation.cs
@@ -440,6 +440,14 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence.Orchestration
                 {
                     return;
                 }
+                else if (suggestedStatus == BundleOrchestratorOperationStatus.Canceled || suggestedStatus == BundleOrchestratorOperationStatus.Failed)
+                {
+                    Status = suggestedStatus;
+                }
+                else if (Status == BundleOrchestratorOperationStatus.Failed || Status == BundleOrchestratorOperationStatus.Canceled)
+                {
+                    throw new BundleOrchestratorOperationCanceledException($"Bundle Operation {Id}. Operation is already in terminal state '{Status}'. Ignoring transition to '{suggestedStatus}'.");
+                }
                 else if (suggestedStatus == BundleOrchestratorOperationStatus.WaitingForResources && Status == BundleOrchestratorOperationStatus.Open)
                 {
                     Status = BundleOrchestratorOperationStatus.WaitingForResources;
@@ -451,14 +459,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Persistence.Orchestration
                 else if (suggestedStatus == BundleOrchestratorOperationStatus.Completed && Status == BundleOrchestratorOperationStatus.Processing)
                 {
                     Status = BundleOrchestratorOperationStatus.Completed;
-                }
-                else if (suggestedStatus == BundleOrchestratorOperationStatus.Canceled || suggestedStatus == BundleOrchestratorOperationStatus.Failed)
-                {
-                    Status = suggestedStatus;
-                }
-                else if (suggestedStatus == BundleOrchestratorOperationStatus.WaitingForResources && (Status == BundleOrchestratorOperationStatus.Failed || Status == BundleOrchestratorOperationStatus.Canceled))
-                {
-                    throw new BundleOrchestratorOperationCanceledException($"Bundle Operation {Id}. Operation is already in terminal state '{Status}'. Ignoring transition to '{suggestedStatus}'.");
                 }
                 else
                 {

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerRuntimeTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerRuntimeTests.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
             const int timeWhenCustomerCancelledTheOperation = 4;
             const int maxTransactionExecutionTimeInSeconds = 5;
 
-            var result = BundleHandlerRuntime.IsTransactionCancelledByClient(
+            var result = BundleHandlerRuntime.IsBundleCancelledByClient(
                 TimeSpan.FromSeconds(timeWhenCustomerCancelledTheOperation),
                 new BundleConfiguration { MaxExecutionTimeInSeconds = maxTransactionExecutionTimeInSeconds },
                 new CancellationToken(canceled: true));
@@ -118,7 +118,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
         [InlineData(true, 5, 5)]
         public void IsTransactionCancelledByClient_WhenFalse(bool isCancelled, int transactionElapsedTime, int maxTransactionExecutionTime)
         {
-            var result = BundleHandlerRuntime.IsTransactionCancelledByClient(
+            var result = BundleHandlerRuntime.IsBundleCancelledByClient(
                 TimeSpan.FromSeconds(transactionElapsedTime),
                 new BundleConfiguration { MaxExecutionTimeInSeconds = maxTransactionExecutionTime },
                 new CancellationToken(canceled: isCancelled));

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerTests.cs
@@ -693,8 +693,10 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
             Assert.True(bundleResponse.Info.ExecutionTime.TotalMilliseconds > 0, "ExecutionTime is not higher than zero.");
         }
 
-        [Fact]
-        public async Task GivenABundle_WhenOneRequestProducesA429_ThenCancelledTheRequestDuringDelay()
+        [Theory]
+        [InlineData(BundleType.Batch)]
+        [InlineData(BundleType.Transaction)]
+        public async Task GivenABundle_WhenOneRequestProducesA429_ThenCancelledTheRequestDuringDelay(BundleType bundleType)
         {
             const int RetryAfterSeconds = 3;
             const int CancellationAfterSeconds = 1;
@@ -704,7 +706,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
 
             var bundle = new Hl7.Fhir.Model.Bundle
             {
-                Type = BundleType.Batch,
+                Type = bundleType,
                 Entry = new List<EntryComponent>
                 {
                     new EntryComponent { Request = new RequestComponent { Method = HTTPVerb.GET, Url = "/Patient" } },
@@ -739,19 +741,33 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
             CancellationTokenSource tokenSource = new CancellationTokenSource();
             tokenSource.CancelAfter(TimeSpan.FromSeconds(CancellationAfterSeconds));
 
-            BundleResponse bundleResponse = await _bundleHandler.Handle(bundleRequest, tokenSource.Token);
+            if (bundleType == BundleType.Batch)
+            {
+                BundleResponse bundleResponse = await _bundleHandler.Handle(bundleRequest, tokenSource.Token);
 
-            Assert.Equal(2, callCount); // Two calls should be executed, as the second one is throttled and before retried it's cancelled.
-            var bundleResource = bundleResponse.Bundle.ToPoco<Hl7.Fhir.Model.Bundle>();
-            Assert.Equal(3, bundleResource.Entry.Count);
+                Assert.Equal(2, callCount); // Two calls should be executed, as the second one is throttled and before retried it's cancelled.
+                var bundleResource = bundleResponse.Bundle.ToPoco<Hl7.Fhir.Model.Bundle>();
 
-            Assert.Equal("200", bundleResource.Entry[0].Response.Status);
-            Assert.Equal("408", bundleResource.Entry[1].Response.Status); // Record marked as Request Timeout due to cancellation, before attempting to retry the throttled request.
-            Assert.Equal("408", bundleResource.Entry[2].Response.Status); // Record marked as Request Timeout due to cancellation.
+                Assert.Equal(3, bundleResource.Entry.Count);
 
-            Assert.True(bundleResponse.Info.BundleType == BundleType.Batch, "BundleType is different than the expected.");
-            Assert.True(bundleResponse.Info.ProcessingLogic == BundleProcessingLogic.Sequential, "BundleProcessingLogic is different than the expected.");
-            Assert.True(bundleResponse.Info.ExecutionTime.TotalMilliseconds > 0, "ExecutionTime is not higher than zero.");
+                Assert.Equal("200", bundleResource.Entry[0].Response.Status);
+                Assert.Equal("408", bundleResource.Entry[1].Response.Status); // Record marked as Request Timeout due to cancellation, before attempting to retry the throttled request.
+                Assert.Equal("408", bundleResource.Entry[2].Response.Status); // Record marked as Request Timeout due to cancellation.
+
+                Assert.True(bundleResponse.Info.BundleType == BundleType.Batch, "BundleType is different than the expected.");
+                Assert.True(bundleResponse.Info.ProcessingLogic == BundleProcessingLogic.Sequential, "BundleProcessingLogic is different than the expected.");
+                Assert.True(bundleResponse.Info.ExecutionTime.TotalMilliseconds > 0, "ExecutionTime is not higher than zero.");
+            }
+            else
+            {
+                FhirTransactionCancelledException fhirTce = await Assert.ThrowsAsync<FhirTransactionCancelledException>(async () => await _bundleHandler.Handle(bundleRequest, tokenSource.Token));
+                Assert.True(fhirTce.ResponseStatusCode == System.Net.HttpStatusCode.RequestTimeout);
+
+                Assert.Equal(2, callCount); // Two calls should be executed, as the second one is throttled and before retried it's cancelled.
+
+                // Ensures failure sign is emitted.
+                _bundleMetricHandler.Received(1).EmitFailure(Arg.Any<string>());
+            }
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerTests.cs
@@ -694,6 +694,67 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
         }
 
         [Fact]
+        public async Task GivenABundle_WhenOneRequestProducesA429_ThenCancelledTheRequestDuringDelay()
+        {
+            const int RetryAfterSeconds = 3;
+            const int CancellationAfterSeconds = 1;
+
+            // Set Retry-After header.
+            _fhirRequestContext.ResponseHeaders.Add("retry-after", RetryAfterSeconds.ToString());
+
+            var bundle = new Hl7.Fhir.Model.Bundle
+            {
+                Type = BundleType.Batch,
+                Entry = new List<EntryComponent>
+                {
+                    new EntryComponent { Request = new RequestComponent { Method = HTTPVerb.GET, Url = "/Patient" } },
+                    new EntryComponent { Request = new RequestComponent { Method = HTTPVerb.GET, Url = "/Patient" } },
+                    new EntryComponent { Request = new RequestComponent { Method = HTTPVerb.GET, Url = "/Patient" } },
+                },
+            };
+
+            int callCount = 0;
+
+            _router.When(r => r.RouteAsync(Arg.Any<RouteContext>()))
+                .Do(info =>
+                {
+                    info.Arg<RouteContext>().Handler = context =>
+                    {
+                        callCount++;
+                        if (callCount == 2)
+                        {
+                            context.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+                        }
+                        else
+                        {
+                            context.Response.StatusCode = StatusCodes.Status200OK;
+                        }
+
+                        return Task.CompletedTask;
+                    };
+                });
+
+            var bundleRequest = new BundleRequest(bundle.ToResourceElement());
+
+            CancellationTokenSource tokenSource = new CancellationTokenSource();
+            tokenSource.CancelAfter(TimeSpan.FromSeconds(CancellationAfterSeconds));
+
+            BundleResponse bundleResponse = await _bundleHandler.Handle(bundleRequest, tokenSource.Token);
+
+            Assert.Equal(2, callCount); // Two calls should be executed, as the second one is throttled and before retried it's cancelled.
+            var bundleResource = bundleResponse.Bundle.ToPoco<Hl7.Fhir.Model.Bundle>();
+            Assert.Equal(3, bundleResource.Entry.Count);
+
+            Assert.Equal("200", bundleResource.Entry[0].Response.Status);
+            Assert.Equal("408", bundleResource.Entry[1].Response.Status); // Record marked as Request Timeout due to cancellation, before attempting to retry the throttled request.
+            Assert.Equal("408", bundleResource.Entry[2].Response.Status); // Record marked as Request Timeout due to cancellation.
+
+            Assert.True(bundleResponse.Info.BundleType == BundleType.Batch, "BundleType is different than the expected.");
+            Assert.True(bundleResponse.Info.ProcessingLogic == BundleProcessingLogic.Sequential, "BundleProcessingLogic is different than the expected.");
+            Assert.True(bundleResponse.Info.ExecutionTime.TotalMilliseconds > 0, "ExecutionTime is not higher than zero.");
+        }
+
+        [Fact]
         public async Task GivenAConfigurationEntryLimit_WhenExceeded_ThenBundleEntryLimitExceededExceptionShouldBeThrown()
         {
             _bundleConfiguration.EntryLimit = 1;

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/TransactionExceptionHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/TransactionExceptionHandlerTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
                 message,
                 statusCode,
                 operationOutcome,
-                cancelled: false));
+                isCancelled: false));
         }
 
         [Fact]
@@ -43,7 +43,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
                 message,
                 statusCode,
                 operationOutcome,
-                cancelled: true));
+                isCancelled: true));
 
             Assert.Equal(message, tce.Message);
             Assert.Equal(HttpStatusCode.RequestTimeout, tce.ResponseStatusCode);

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
@@ -546,7 +546,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                     apiCallResults[status].Add(new BundleSubCallMetricData()
                     {
                         FhirOperation = "Bundle Sub Call",
-                        ResourceType = entry?.Resource?.TypeName,
+                        ResourceType = entry.Resource?.TypeName,
                     });
                 }
             }
@@ -779,12 +779,10 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                                     httpContext,
                                     cancellationToken);
 
-                                if (_bundleType.Equals(BundleType.Batch))
-                                {
-                                    throttledEntryComponent = entryComponent;
-                                }
+                                // For Batch bundles, we should include the 429 response for the throttled request and skip processing subsequent requests.
+                                throttledEntryComponent = entryComponent;
 
-                                return throttledEntryComponent;
+                                continue;
                             }
 
                             await resourceContext.Context.Handler.Invoke(httpContext);

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandler.cs
@@ -535,17 +535,20 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
             var apiCallResults = new Dictionary<string, List<BundleSubCallMetricData>>();
             foreach (var entry in responseBundle.Entry)
             {
-                var status = entry.Response.Status;
-                if (!apiCallResults.TryGetValue(status, out List<BundleSubCallMetricData> val))
+                if (entry != null && entry.Response != null)
                 {
-                    apiCallResults[status] = new List<BundleSubCallMetricData>();
-                }
+                    var status = entry.Response.Status;
+                    if (!apiCallResults.TryGetValue(status, out List<BundleSubCallMetricData> val))
+                    {
+                        apiCallResults[status] = new List<BundleSubCallMetricData>();
+                    }
 
-                apiCallResults[status].Add(new BundleSubCallMetricData()
-                {
-                    FhirOperation = "Bundle Sub Call",
-                    ResourceType = entry?.Resource?.TypeName,
-                });
+                    apiCallResults[status].Add(new BundleSubCallMetricData()
+                    {
+                        FhirOperation = "Bundle Sub Call",
+                        ResourceType = entry?.Resource?.TypeName,
+                    });
+                }
             }
 
             await _mediator.Publish(new BundleMetricsNotification(apiCallResults, bundleType == BundleType.Batch ? AuditEventSubType.Batch : AuditEventSubType.Transaction, _outerHttpContext.Request.Scheme), CancellationToken.None);
@@ -754,14 +757,36 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                         if (httpContext.Response.StatusCode == (int)HttpStatusCode.TooManyRequests)
                         {
                             _logger.LogWarning("BundleHandler received 429 message, attempting retry.  HttpVerb:{HttpVerb} BundleSize: {RequestCount} entryIndex:{EntryIndex}", httpVerb, _requestCount, resourceContext.Index);
-                            int retryDelay = 2;
-                            var retryAfterValues = httpContext.Response.Headers.GetCommaSeparatedValues("Retry-After");
-                            if (retryAfterValues != StringValues.Empty && int.TryParse(retryAfterValues[0], out var retryHeaderValue))
+
+                            try
                             {
-                                retryDelay = retryHeaderValue;
+                                await BundleHandlerRuntime.DelayWithRetryAfterAsync(httpContext, cancellationToken);
+                            }
+                            catch (OperationCanceledException oce)
+                            {
+                                _logger.LogWarning(oce, "BundleHandler received 429 message, client cancelled during retry delay. HttpVerb:{HttpVerb} BundleSize: {RequestCount} entryIndex:{EntryIndex}", httpVerb, _requestCount, resourceContext.Index);
+
+                                // This is an edge case scenario when the client cancels the request during the retry delay.
+                                // We should respect the cancellation and not attempt to process the request further.
+
+                                entryComponent = HandleCancelledRetryRequest(
+                                    responseBundle,
+                                    resourceContext,
+                                    _bundleType,
+                                    statistics,
+                                    _bundleConfiguration,
+                                    watch,
+                                    httpContext,
+                                    cancellationToken);
+
+                                if (_bundleType.Equals(BundleType.Batch))
+                                {
+                                    throttledEntryComponent = entryComponent;
+                                }
+
+                                return throttledEntryComponent;
                             }
 
-                            await Task.Delay(retryDelay * 1000, cancellationToken); // multiply by 1000 as retry-header specifies delay in seconds
                             await resourceContext.Context.Handler.Invoke(httpContext);
                         }
 
@@ -814,19 +839,37 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                         httpStatusCode = HttpStatusCode.BadRequest;
                     }
 
-                    var errorMessage = string.Format(Api.Resources.TransactionFailed, resourceContext.Context.HttpContext.Request.Method, resourceContext.Context.HttpContext.Request.Path);
-
-                    TransactionExceptionHandler.ThrowTransactionException(
-                        errorMessage,
-                        httpStatusCode,
-                        (OperationOutcome)entryComponent.Response.Outcome,
-                        cancelled: BundleHandlerRuntime.IsTransactionCancelledByClient(watch.Elapsed, _bundleConfiguration, cancellationToken));
+                    RaiseFhirTransactionException(resourceContext, httpStatusCode, entryComponent, isBundleCancelledByClient: BundleHandlerRuntime.IsBundleCancelledByClient(watch.Elapsed, _bundleConfiguration, cancellationToken));
                 }
 
                 responseBundle.Entry[resourceContext.Index] = entryComponent;
             }
 
             return throttledEntryComponent;
+        }
+
+        private static EntryComponent CreateEntryComponentForCancelledRequest(HttpContext httpContext)
+        {
+            httpContext.Response.Body.Seek(0, SeekOrigin.Begin);
+
+            ResponseHeaders responseHeaders = httpContext.Response.GetTypedHeaders();
+
+            var entryComponent = new EntryComponent
+            {
+                Response = new ResponseComponent
+                {
+                    Status = ((int)HttpStatusCode.RequestTimeout).ToString(),
+                    Location = responseHeaders.Location?.OriginalString,
+                    Etag = responseHeaders.ETag?.ToString(),
+                    LastModified = responseHeaders.LastModified,
+                    Outcome = CreateOperationOutcome(
+                        OperationOutcome.IssueSeverity.Warning,
+                        OperationOutcome.IssueType.TooLong,
+                        diagnostics: "Request timed out."),
+                },
+            };
+
+            return entryComponent;
         }
 
         private static EntryComponent CreateEntryComponent(FhirJsonParser fhirJsonParser, HttpContext httpContext)
@@ -865,10 +908,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
             {
                 if (httpContext.Response.StatusCode == (int)HttpStatusCode.Forbidden)
                 {
-                    entryComponent.Response.Outcome = CreateOperationOutcome(
-                        OperationOutcome.IssueSeverity.Error,
-                        OperationOutcome.IssueType.Forbidden,
-                        Api.Resources.Forbidden);
+                    entryComponent.Response.Outcome = CreateOperationOutcome(OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Forbidden, Api.Resources.Forbidden);
                 }
             }
 

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerParallelOperations.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerParallelOperations.cs
@@ -342,14 +342,29 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                             requestCount,
                             resourceExecutionContext.Index);
 
-                        int retryDelay = 2;
-                        var retryAfterValues = httpContext.Response.Headers.GetCommaSeparatedValues("Retry-After");
-                        if (retryAfterValues != StringValues.Empty && int.TryParse(retryAfterValues[0], out var retryHeaderValue))
+                        try
                         {
-                            retryDelay = retryHeaderValue;
+                            await BundleHandlerRuntime.DelayWithRetryAfterAsync(httpContext, cancellationToken);
                         }
+                        catch (OperationCanceledException oce)
+                        {
+                            logger.LogWarning(oce, "BundleHandler received 429 message, client cancelled during retry delay. HttpVerb:{HttpVerb} BundleSize: {RequestCount} entryIndex:{EntryIndex}", resourceExecutionContext.HttpVerb, requestCount, resourceExecutionContext.Index);
 
-                        await Task.Delay(retryDelay * 1000, cancellationToken); // multiply by 1000 as retry-header specifies delay in seconds
+                            // This is an edge case scenario when the client cancels the request during the retry delay.
+                            // We should respect the cancellation and not attempt to process the request further.
+
+                            entryComponent = HandleCancelledRetryRequest(
+                                responseBundle,
+                                resourceExecutionContext,
+                                bundleType,
+                                statistics,
+                                bundleConfiguration,
+                                watch,
+                                httpContext,
+                                cancellationToken);
+
+                            return entryComponent;
+                        }
 
                         // Attempt 2.
                         await resourceExecutionContext.Context.Handler.Invoke(httpContext);
@@ -404,21 +419,39 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                     httpStatusCode = HttpStatusCode.BadRequest;
                 }
 
-                var errorMessage = string.Format(
-                    Api.Resources.TransactionFailed,
-                    resourceExecutionContext.Context.HttpContext.Request.Method,
-                    resourceExecutionContext.Context.HttpContext.Request.Path);
-
-                TransactionExceptionHandler.ThrowTransactionException(
-                    errorMessage,
-                    httpStatusCode,
-                    (OperationOutcome)entryComponent.Response.Outcome,
-                    cancelled: BundleHandlerRuntime.IsTransactionCancelledByClient(watch.Elapsed, bundleConfiguration, cancellationToken));
+                RaiseFhirTransactionException(resourceExecutionContext, httpStatusCode, entryComponent, isBundleCancelledByClient: BundleHandlerRuntime.IsBundleCancelledByClient(watch.Elapsed, bundleConfiguration, cancellationToken));
             }
 
             responseBundle.Entry[resourceExecutionContext.Index] = entryComponent;
 
             return entryComponent;
+        }
+
+        private static EntryComponent HandleCancelledRetryRequest(Hl7.Fhir.Model.Bundle responseBundle, ResourceExecutionContext resourceExecutionContext, BundleType? bundleType, BundleHandlerStatistics statistics, BundleConfiguration bundleConfiguration, Stopwatch watch, HttpContext httpContext, CancellationToken cancellationToken)
+        {
+            EntryComponent entryComponent = CreateEntryComponentForCancelledRequest(httpContext);
+
+            statistics.RegisterNewEntry(resourceExecutionContext.HttpVerb, resourceExecutionContext.ResourceType, resourceExecutionContext.Index, entryComponent.Response.Status, watch.Elapsed);
+
+            if (bundleType.Equals(BundleType.Transaction))
+            {
+                RaiseFhirTransactionException(resourceExecutionContext, HttpStatusCode.RequestTimeout, entryComponent, isBundleCancelledByClient: BundleHandlerRuntime.IsBundleCancelledByClient(watch.Elapsed, bundleConfiguration, cancellationToken));
+            }
+
+            // Default path for batch bundles.
+            responseBundle.Entry[resourceExecutionContext.Index] = entryComponent;
+            return entryComponent;
+        }
+
+        private static void RaiseFhirTransactionException(
+            ResourceExecutionContext resourceContext,
+            HttpStatusCode httpStatusCode,
+            Hl7.Fhir.Model.Bundle.EntryComponent entryComponent,
+            bool isBundleCancelledByClient)
+        {
+            var errorMessage = string.Format(Api.Resources.TransactionFailed, resourceContext.Context.HttpContext.Request.Method, resourceContext.Context.HttpContext.Request.Path);
+
+            TransactionExceptionHandler.ThrowTransactionException(errorMessage, httpStatusCode, (OperationOutcome)entryComponent.Response.Outcome, isCancelled: isBundleCancelledByClient);
         }
 
         private struct ResourceExecutionContext

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerParallelOperations.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerParallelOperations.cs
@@ -363,6 +363,9 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                                 httpContext,
                                 cancellationToken);
 
+                            // This action was throttled and then cancelled. Capture the entry and reuse it for subsequent actions.
+                            throttledEntryComponent = entryComponent;
+
                             return entryComponent;
                         }
 

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerRuntime.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerRuntime.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
             var retryAfterValues = httpContext.Response.Headers.GetCommaSeparatedValues("Retry-After");
             if (retryAfterValues != StringValues.Empty && int.TryParse(retryAfterValues[0], out var retryHeaderValue))
             {
-                if (retryHeaderValue > 0 && retryHeaderValue <= 30)
+                if (retryHeaderValue > 0 && retryHeaderValue <= 15)
                 {
                     retryDelay = retryHeaderValue;
                 }

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerRuntime.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerRuntime.cs
@@ -7,10 +7,12 @@ using System;
 using System.Threading;
 using EnsureThat;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
 using Microsoft.Health.Fhir.Api.Features.Headers;
 using Microsoft.Health.Fhir.Core.Configs;
 using Microsoft.Health.Fhir.Core.Models;
 using static Hl7.Fhir.Model.Bundle;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
 {
@@ -19,6 +21,25 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
     /// </summary>
     public static class BundleHandlerRuntime
     {
+        /// <summary>
+        /// Delay logic used in case of retry operations.
+        /// </summary>
+        public static async Task DelayWithRetryAfterAsync(HttpContext httpContext, CancellationToken cancellationToken)
+        {
+            int retryDelay = 2;
+
+            var retryAfterValues = httpContext.Response.Headers.GetCommaSeparatedValues("Retry-After");
+            if (retryAfterValues != StringValues.Empty && int.TryParse(retryAfterValues[0], out var retryHeaderValue))
+            {
+                retryDelay = retryHeaderValue;
+            }
+
+            await Task.Delay(retryDelay * 1000, cancellationToken); // multiply by 1000 as retry-header specifies delay in seconds
+        }
+
+        /// <summary>
+        /// Returns the Bundle Processing Logic to be used for the current request, based on the presence of the Bundle-Processing-Logic header and the validity of its value.
+        /// </summary>
         public static BundleProcessingLogic GetBundleProcessingLogic(BundleConfiguration bundleConfiguration, HttpContext outerHttpContext, BundleType? bundleType)
         {
             EnsureArg.IsNotNull(outerHttpContext, nameof(outerHttpContext));
@@ -43,10 +64,10 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
         }
 
         /// <summary>
-        /// Determines whether a transaction has been cancelled by the client.
-        /// Íf the cancellation is requested and the elapsed time is less than the max bundle execution time, it is assumed that the client cancelled the request.
+        /// Determines whether a bundle has been cancelled by the client.
+        /// If the cancellation is requested and the elapsed time is less than the max bundle execution time, it is assumed that the client cancelled the request.
         /// </summary>
-        public static bool IsTransactionCancelledByClient(TimeSpan elapsedTime, BundleConfiguration bundleConfiguration, CancellationToken cancellationToken)
+        public static bool IsBundleCancelledByClient(TimeSpan elapsedTime, BundleConfiguration bundleConfiguration, CancellationToken cancellationToken)
         {
             EnsureArg.IsNotNull(bundleConfiguration, nameof(bundleConfiguration));
 

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerRuntime.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerRuntime.cs
@@ -31,7 +31,10 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
             var retryAfterValues = httpContext.Response.Headers.GetCommaSeparatedValues("Retry-After");
             if (retryAfterValues != StringValues.Empty && int.TryParse(retryAfterValues[0], out var retryHeaderValue))
             {
-                retryDelay = retryHeaderValue;
+                if (retryHeaderValue > 0 && retryHeaderValue <= 30)
+                {
+                    retryDelay = retryHeaderValue;
+                }
             }
 
             await Task.Delay(retryDelay * 1000, cancellationToken); // multiply by 1000 as retry-header specifies delay in seconds

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/TransactionExceptionHandler.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/TransactionExceptionHandler.cs
@@ -13,11 +13,11 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
 {
     internal static class TransactionExceptionHandler
     {
-        public static void ThrowTransactionException(string errorMessage, HttpStatusCode statusCode, OperationOutcome operationOutcome, bool cancelled)
+        public static void ThrowTransactionException(string errorMessage, HttpStatusCode statusCode, OperationOutcome operationOutcome, bool isCancelled)
         {
             List<OperationOutcomeIssue> operationOutcomeIssues = GetOperationOutcomeIssues(operationOutcome.Issue);
 
-            if (cancelled)
+            if (isCancelled)
             {
                 throw new FhirTransactionCancelledException(errorMessage, operationOutcomeIssues);
             }


### PR DESCRIPTION
## Description
In this PR I'm handling the case when a request is throttled, and during the delay before the next attempt the entire request is cancelled. 

In production this error, due the cancellation of Task.Delay method, was causing some unexpected behaviors.

With these changes, now it should proper handle the cancellation and mark return HTTP408 for the affected records. 

## Related issues
Addresses [AB#192114](https://microsofthealth.visualstudio.com/f8da5110-49b1-4e9f-9022-2f58b6124ff9/_workitems/edit/192114).

## FHIR Team Checklist
- [x] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
