### PR TITLE
Reject requests with JWT access tokens in URL path

### DIFF
--- a/src/Microsoft.Health.Fhir.Api/Features/Security/AccessTokenUrlValidationMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Security/AccessTokenUrlValidationMiddleware.cs
@@ -1,0 +1,79 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Text.RegularExpressions;
+using EnsureThat;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.Health.Fhir.Api.Features.Security
+{
+    /// <summary>
+    /// Middleware that detects access tokens (JWTs) passed as URL path segments and rejects the request.
+    /// This prevents tokens from being logged in URLs and ensures they are not inadvertently exposed.
+    /// </summary>
+    public class AccessTokenUrlValidationMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly ILogger<AccessTokenUrlValidationMiddleware> _logger;
+
+        // JWT pattern: three base64url-encoded segments separated by dots.
+        // Each segment contains at least 10 characters of [A-Za-z0-9_-] (base64url alphabet).
+        private static readonly Regex JwtPattern = new Regex(
+            @"eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}",
+            RegexOptions.Compiled,
+            matchTimeout: System.TimeSpan.FromSeconds(1));
+
+
+
+        public AccessTokenUrlValidationMiddleware(
+            RequestDelegate next,
+            ILogger<AccessTokenUrlValidationMiddleware> logger)
+        {
+            EnsureArg.IsNotNull(next, nameof(next));
+            EnsureArg.IsNotNull(logger, nameof(logger));
+
+            _next = next;
+            _logger = logger;
+        }
+
+        public async Task Invoke(HttpContext context)
+        {
+            if (ContainsJwt(context.Request.Path.Value))
+            {
+                _logger.LogWarning("Request rejected: access token detected in URL path. The token has been redacted.");
+                context.Response.StatusCode = StatusCodes.Status400BadRequest;
+                await context.Response.WriteAsync("Access tokens must not be passed in the URL path.");
+                return;
+            }
+
+            if (ContainsJwt(context.Request.QueryString.Value))
+            {
+                _logger.LogWarning("Request rejected: access token detected in URL query string. The token has been redacted.");
+                context.Response.StatusCode = StatusCodes.Status400BadRequest;
+                await context.Response.WriteAsync("Access tokens must not be passed in the URL query string.");
+                return;
+            }
+
+            await _next(context);
+        }
+
+        /// <summary>
+        /// Determines whether the given URL component contains a JWT token.
+        /// </summary>
+        /// <param name="value">The URL path or query string value to check.</param>
+        /// <returns>True if a JWT pattern is detected; otherwise, false.</returns>
+        internal static bool ContainsJwt(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return false;
+            }
+
+            return JwtPattern.IsMatch(value);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Api/Features/Security/AccessTokenUrlValidationMiddleware.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Security/AccessTokenUrlValidationMiddleware.cs
@@ -27,8 +27,6 @@ namespace Microsoft.Health.Fhir.Api.Features.Security
             RegexOptions.Compiled,
             matchTimeout: System.TimeSpan.FromSeconds(1));
 
-
-
         public AccessTokenUrlValidationMiddleware(
             RequestDelegate next,
             ILogger<AccessTokenUrlValidationMiddleware> logger)

--- a/src/Microsoft.Health.Fhir.Api/Features/Security/AccessTokenUrlValidationMiddlewareExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Api/Features/Security/AccessTokenUrlValidationMiddlewareExtensions.cs
@@ -1,0 +1,21 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using EnsureThat;
+using Microsoft.AspNetCore.Builder;
+
+namespace Microsoft.Health.Fhir.Api.Features.Security
+{
+    public static class AccessTokenUrlValidationMiddlewareExtensions
+    {
+        public static IApplicationBuilder UseAccessTokenUrlValidation(
+            this IApplicationBuilder builder)
+        {
+            EnsureArg.IsNotNull(builder, nameof(builder));
+
+            return builder.UseMiddleware<AccessTokenUrlValidationMiddleware>();
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Security/AccessTokenUrlValidationMiddlewareTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Security/AccessTokenUrlValidationMiddlewareTests.cs
@@ -1,0 +1,196 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Health.Fhir.Api.Features.Security;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Test.Utilities;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Security
+{
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.Security)]
+    [Trait(Traits.Category, Categories.Web)]
+    public class AccessTokenUrlValidationMiddlewareTests
+    {
+        private const string SampleJwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ilh0LW83YSJ9.eyJhdWQiOiJodHRwczovL2V4YW1wbGUuY29tIiwiaXNzIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvdGVzdC8ifQ.c2lnbmF0dXJlX3ZhbHVlX2hlcmVfZm9yX3Rlc3Rpbmc";
+
+        private readonly AccessTokenUrlValidationMiddleware _middleware;
+        private bool _nextWasCalled;
+
+        public AccessTokenUrlValidationMiddlewareTests()
+        {
+            _nextWasCalled = false;
+            _middleware = new AccessTokenUrlValidationMiddleware(
+                context =>
+                {
+                    _nextWasCalled = true;
+                    return Task.CompletedTask;
+                },
+                NullLogger<AccessTokenUrlValidationMiddleware>.Instance);
+        }
+
+        [Fact]
+        public async Task GivenJwtInUrlPath_WhenInvoked_Returns400AndDoesNotCallNext()
+        {
+            var context = new DefaultHttpContext();
+            context.Request.Path = $"/Encounter/{SampleJwt}";
+            context.Response.Body = new MemoryStream();
+
+            await _middleware.Invoke(context);
+
+            Assert.Equal(StatusCodes.Status400BadRequest, context.Response.StatusCode);
+            Assert.False(_nextWasCalled);
+        }
+
+        [Fact]
+        public async Task GivenJwtInQueryString_WhenInvoked_Returns400AndDoesNotCallNext()
+        {
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/Patient";
+            context.Request.QueryString = new QueryString($"?token={SampleJwt}");
+            context.Response.Body = new MemoryStream();
+
+            await _middleware.Invoke(context);
+
+            Assert.Equal(StatusCodes.Status400BadRequest, context.Response.StatusCode);
+            Assert.False(_nextWasCalled);
+        }
+
+        [Fact]
+        public async Task GivenNormalPath_WhenInvoked_CallsNextMiddleware()
+        {
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/Patient/12345";
+            context.Response.Body = new MemoryStream();
+
+            await _middleware.Invoke(context);
+
+            Assert.True(_nextWasCalled);
+        }
+
+        [Theory]
+        [InlineData("/Encounter/eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJhdWQiOiJ0ZXN0IiwiaXNzIjoiaXNzdWVyIn0.c2lnbmF0dXJlX3ZhbHVl")]
+        [InlineData("/Patient/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U")]
+        public void GivenPathWithJwt_ContainsJwt_ReturnsTrue(string path)
+        {
+            Assert.True(AccessTokenUrlValidationMiddleware.ContainsJwt(path));
+        }
+
+        [Theory]
+        [InlineData("/Patient/12345")]
+        [InlineData("/Encounter/abc-def-ghi")]
+        [InlineData("/metadata")]
+        [InlineData("")]
+        [InlineData(null)]
+        [InlineData("/Patient?name=test")]
+        [InlineData("/Observation/a1b2c3d4-e5f6-7890-abcd-ef1234567890")]
+        public void GivenPathWithoutJwt_ContainsJwt_ReturnsFalse(string path)
+        {
+            Assert.False(AccessTokenUrlValidationMiddleware.ContainsJwt(path));
+        }
+
+        [Fact]
+        public async Task GivenJwtInUrlPath_WhenInvoked_UrlIsNotLoggedByDownstreamPipeline()
+        {
+            // Verifies that when a JWT is in the URL, the downstream pipeline (FhirRequestContextMiddleware)
+            // never executes and therefore the token URL is never logged.
+            var downstreamLogMessages = new List<string>();
+            var downstreamLogger = Substitute.For<ILogger>();
+            downstreamLogger.When(x => x.Log(
+                Arg.Any<LogLevel>(),
+                Arg.Any<EventId>(),
+                Arg.Any<object>(),
+                Arg.Any<Exception>(),
+                Arg.Any<Func<object, Exception, string>>()))
+                .Do(callInfo =>
+                {
+                    var state = callInfo.ArgAt<object>(2);
+                    var formatter = callInfo.ArgAt<Func<object, Exception, string>>(4);
+                    if (formatter != null && state != null)
+                    {
+                        downstreamLogMessages.Add(formatter(state, null));
+                    }
+                });
+
+            var middleware = new AccessTokenUrlValidationMiddleware(
+                context =>
+                {
+                    // Simulate what FhirRequestContextMiddleware does: log the request URL
+                    string uri = $"{context.Request.Scheme}://{context.Request.Host}{context.Request.Path}{context.Request.QueryString}";
+                    downstreamLogger.Log(LogLevel.Information, default, uri, null, (s, _) => s);
+                    return Task.CompletedTask;
+                },
+                NullLogger<AccessTokenUrlValidationMiddleware>.Instance);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Scheme = "https";
+            httpContext.Request.Host = new HostString("fhir.example.com");
+            httpContext.Request.Path = $"/Encounter/{SampleJwt}";
+            httpContext.Response.Body = new MemoryStream();
+
+            // Act
+            await middleware.Invoke(httpContext);
+
+            // Assert - downstream pipeline never logged the URL containing the token
+            Assert.Empty(downstreamLogMessages);
+            Assert.Equal(StatusCodes.Status400BadRequest, httpContext.Response.StatusCode);
+        }
+
+        [Fact]
+        public async Task GivenNormalRequest_WhenInvoked_UrlIsLoggedByDownstreamPipeline()
+        {
+            // Verifies that normal requests DO flow to the downstream pipeline and URLs are logged normally.
+            var downstreamLogMessages = new List<string>();
+            var downstreamLogger = Substitute.For<ILogger>();
+            downstreamLogger.When(x => x.Log(
+                Arg.Any<LogLevel>(),
+                Arg.Any<EventId>(),
+                Arg.Any<object>(),
+                Arg.Any<Exception>(),
+                Arg.Any<Func<object, Exception, string>>()))
+                .Do(callInfo =>
+                {
+                    var state = callInfo.ArgAt<object>(2);
+                    var formatter = callInfo.ArgAt<Func<object, Exception, string>>(4);
+                    if (formatter != null && state != null)
+                    {
+                        downstreamLogMessages.Add(formatter(state, null));
+                    }
+                });
+
+            var middleware = new AccessTokenUrlValidationMiddleware(
+                context =>
+                {
+                    // Simulate what FhirRequestContextMiddleware does: log the request URL
+                    string uri = $"{context.Request.Scheme}://{context.Request.Host}{context.Request.Path}{context.Request.QueryString}";
+                    downstreamLogger.Log(LogLevel.Information, default, uri, null, (s, _) => s);
+                    return Task.CompletedTask;
+                },
+                NullLogger<AccessTokenUrlValidationMiddleware>.Instance);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Scheme = "https";
+            httpContext.Request.Host = new HostString("fhir.example.com");
+            httpContext.Request.Path = "/Patient/12345";
+            httpContext.Response.Body = new MemoryStream();
+
+            // Act
+            await middleware.Invoke(httpContext);
+
+            // Assert - URL was logged by the downstream pipeline
+            Assert.Single(downstreamLogMessages);
+            Assert.Contains("/Patient/12345", downstreamLogMessages[0]);
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Registration/FhirServerServiceCollectionExtensions.cs
@@ -26,6 +26,7 @@ using Microsoft.Health.Fhir.Api.Features.ExceptionNotifications;
 using Microsoft.Health.Fhir.Api.Features.Exceptions;
 using Microsoft.Health.Fhir.Api.Features.Operations.Import;
 using Microsoft.Health.Fhir.Api.Features.Routing;
+using Microsoft.Health.Fhir.Api.Features.Security;
 using Microsoft.Health.Fhir.Api.Features.Throttling;
 using Microsoft.Health.Fhir.Core.Features.Context;
 using Microsoft.Health.Fhir.Core.Features.Cors;
@@ -228,6 +229,10 @@ namespace Microsoft.Extensions.DependencyInjection
                     {
                         app.UseForwardedHeaders();
                     }
+
+                    // This middleware rejects requests that contain access tokens (JWTs) in the URL path or query string.
+                    // It must run before FhirRequestContext to prevent the token from being logged.
+                    app.UseAccessTokenUrlValidation();
 
                     // This middleware should be registered at the beginning since it generates correlation id among other things,
                     // which will be used in other middlewares.


### PR DESCRIPTION
## Problem
Customer sent an access token as a URL path parameter (e.g. /Encounter/{jwt}). While the request returned 401, it still reached the FHIR pipeline and the full URL (containing the token) was logged by the HTTP middleware.

## Workitem
[192527](https://microsofthealth.visualstudio.com/Health/_workitems/edit/192527)

## Fix
Add AccessTokenUrlValidationMiddleware that runs **before** FhirRequestContextMiddleware in the pipeline. It detects JWT patterns in the URL path or query string and immediately returns **400 Bad Request**, preventing the token from ever being captured in audit logs or telemetry.

## Changes
- AccessTokenUrlValidationMiddleware.cs — Detects JWTs via regex, rejects with 400
- AccessTokenUrlValidationMiddlewareExtensions.cs — Pipeline registration extension
- FhirServerServiceCollectionExtensions.cs — Register middleware before FhirRequestContext
- AccessTokenUrlValidationMiddlewareTests.cs — Unit tests verifying rejection, passthrough, and that tokens are never logged downstream