### PR TITLE
Remove validation on TargetSearchParameterTypes

### DIFF
--- a/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Reindex/ReindexHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Core.UnitTests/Features/Operations/Reindex/ReindexHandlerTests.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
 
         private ReindexJobRecord CreateJobRecord(OperationStatus status = OperationStatus.Queued)
         {
-            return new ReindexJobRecord(new List<string>(), new List<string>(), new List<string>(), 1)
+            return new ReindexJobRecord(new List<string>(), 1)
             {
                 Status = status,
             };

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/CreateReindexRequestHandler.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/CreateReindexRequestHandler.cs
@@ -67,27 +67,8 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex
                 return new CreateReindexResponse(existingJob);
             }
 
-            // What this handles is the scenario where a user is effectively forcing a reindex to run by passing
-            // in a parameter of targetSearchParameterTypes. From those we can identify the base resource types.
-            var searchParameterResourceTypes = new HashSet<string>();
-            if (request.TargetSearchParameterTypes.Any())
-            {
-                foreach (var searchParameterUrl in request.TargetSearchParameterTypes)
-                {
-                    SearchParameterInfo searchParameterInfo = _searchParameterDefinitionManager.GetSearchParameter(searchParameterUrl);
-                    if (searchParameterInfo == null)
-                    {
-                        throw new RequestNotValidException(Core.Resources.SearchParameterByDefinitionUriNotSupported, searchParameterUrl);
-                    }
-
-                    searchParameterResourceTypes.UnionWith(searchParameterInfo.BaseResourceTypes);
-                }
-            }
-
             var jobRecord = new ReindexJobRecord(
             request.TargetResourceTypes,
-            request.TargetSearchParameterTypes,
-            searchParameterResourceTypes,
             request.MaximumResourcesPerQuery ?? _reindexJobConfiguration.MaximumNumberOfResourcesPerQuery,
             request.MaximumResourcesPerWrite ?? _reindexJobConfiguration.MaximumNumberOfResourcesPerWrite,
             request.QueryDelayIntervalInMilliseconds ?? _reindexJobConfiguration.QueryDelayIntervalInMilliseconds);

--- a/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobRecord.cs
+++ b/src/Microsoft.Health.Fhir.Core/Features/Operations/Reindex/Models/ReindexJobRecord.cs
@@ -32,8 +32,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
 
         public ReindexJobRecord(
             IReadOnlyCollection<string> targetResourceTypes,
-            IReadOnlyCollection<string> targetSearchParameterTypes,
-            IReadOnlyCollection<string> searchParameterResourceTypes,
             uint maxResourcesPerQuery = 100,
             uint maxResourcesPerWrite = 1000,
             int queryDelayIntervalInMilliseconds = 500,
@@ -41,8 +39,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
             ushort? targetDataStoreUsagePercentage = null)
         {
             TargetResourceTypes = EnsureArg.IsNotNull(targetResourceTypes, nameof(targetResourceTypes));
-            TargetSearchParameterTypes = EnsureArg.IsNotNull(targetSearchParameterTypes, nameof(targetSearchParameterTypes));
-            SearchParameterResourceTypes = EnsureArg.IsNotNull(searchParameterResourceTypes, nameof(searchParameterResourceTypes));
             TypeId = typeId;
 
             // Default values
@@ -129,18 +125,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
         [JsonProperty(JobRecordProperties.TargetResourceTypes)]
         public IReadOnlyCollection<string> TargetResourceTypes { get; private set; } = new List<string>();
 
-        /// <summary>
-        /// A user can supply a list of search params to force a reindex job even though the status is Enabled
-        /// </summary>
-        [JsonProperty(JobRecordProperties.TargetSearchParameterTypes)]
-        public IReadOnlyCollection<string> TargetSearchParameterTypes { get; private set; } = new List<string>();
-
-        /// <summary>
-        /// This will be the base resource types from the <see cref="TargetSearchParameterTypes"/>
-        /// </summary>
-        [JsonProperty(JobRecordProperties.SearchParameterResourceTypes)]
-        public IReadOnlyCollection<string> SearchParameterResourceTypes { get; private set; } = new List<string>();
-
         [JsonIgnore]
         public string ResourceList
         {
@@ -157,12 +141,6 @@ namespace Microsoft.Health.Fhir.Core.Features.Operations.Reindex.Models
         public string TargetResourceTypeList
         {
             get { return string.Join(",", TargetResourceTypes); }
-        }
-
-        [JsonIgnore]
-        public string TargetSearchParameterTypeList
-        {
-            get { return string.Join(",", TargetSearchParameterTypes); }
         }
 
         [JsonProperty(JobRecordProperties.TypeId)]

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ReindexControllerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Controllers/ReindexControllerTests.cs
@@ -186,8 +186,6 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
                         var wrapper = new ReindexJobWrapper(
                             new ReindexJobRecord(
                                 new List<string>(),
-                                new List<string>(),
-                                new List<string>(),
                                 5),
                             etag);
                         return new GetReindexResponse(HttpStatusCode.OK, wrapper);
@@ -233,8 +231,6 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
                     {
                         var wrapper = new ReindexJobWrapper(
                             new ReindexJobRecord(
-                                new List<string>(),
-                                new List<string>(),
                                 new List<string>(),
                                 5),
                             etag);
@@ -290,7 +286,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
 
         private static CreateReindexResponse GetCreateReindexResponse()
         {
-            var jobRecord = new ReindexJobRecord(new List<string>(), new List<string>(), new List<string>(), 5);
+            var jobRecord = new ReindexJobRecord(new List<string>(), 5);
             var jobWrapper = new ReindexJobWrapper(
                 jobRecord,
                 WeakETag.FromVersionId("33a64df551425fcc55e4d42a148795d9f25f89d4"));
@@ -299,7 +295,7 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Controllers
 
         private static GetReindexResponse GetReindexJobResponse()
         {
-            var jobRecord = new ReindexJobRecord(new List<string>(), new List<string>(), new List<string>(), 5);
+            var jobRecord = new ReindexJobRecord(new List<string>(), 5);
             var jobWrapper = new ReindexJobWrapper(
                 jobRecord,
                 WeakETag.FromVersionId("33a64df551425fcc55e4d42a148795d9f25f89d4"));

--- a/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexOrchestratorJobTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core.UnitTests/Features/Operations/Reindex/ReindexOrchestratorJobTests.cs
@@ -109,8 +109,6 @@ namespace Microsoft.Health.Fhir.Core.UnitTests.Features.Operations.Reindex
 
             var jobRecord = new ReindexJobRecord(
                 targetResourceTypes,
-                new List<string>(),
-                new List<string>(),
                 maxResourcePerQuery);
 
             // Enqueue the orchestrator job through the queue client

--- a/src/Microsoft.Health.Fhir.Shared.Core/Extensions/ReindexJobRecordExtensions.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Core/Extensions/ReindexJobRecordExtensions.cs
@@ -107,11 +107,6 @@ namespace Microsoft.Health.Fhir.Core.Extensions
                 parametersResource.Add(JobRecordProperties.TargetResourceTypes, new FhirString(job.TargetResourceTypeList));
             }
 
-            if (!string.IsNullOrEmpty(job.TargetSearchParameterTypeList))
-            {
-                parametersResource.Add(JobRecordProperties.TargetSearchParameterTypes, new FhirString(job.TargetSearchParameterTypeList));
-            }
-
             if (!string.IsNullOrEmpty(job.FailureDetails?.FailureReason))
             {
                 parametersResource.Add(JobRecordProperties.FailureDetails, new FhirString(job.FailureDetails.FailureReason));

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/FhirOperationDataStoreReindexTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/FhirOperationDataStoreReindexTests.cs
@@ -177,7 +177,7 @@ namespace Microsoft.Health.Fhir.Shared.Tests.Integration.Features.Operations
         public async Task GivenANonexistentReindexJob_WhenUpdatingTheReindexJob_ThenJobNotFoundExceptionShouldBeThrown()
         {
             // Create a local job record with a random ID that doesn't exist in the database or queue
-            var nonExistentJobRecord = new ReindexJobRecord(new List<string>(), new List<string>(), new List<string>())
+            var nonExistentJobRecord = new ReindexJobRecord(new List<string>())
             {
                 Id = "999999", // Use a non-existent ID
             };
@@ -247,7 +247,7 @@ namespace Microsoft.Health.Fhir.Shared.Tests.Integration.Features.Operations
 
         private async Task<ReindexJobRecord> InsertNewReindexJobRecordAsync(Action<ReindexJobRecord> jobRecordCustomizer = null)
         {
-            var jobRecord = new ReindexJobRecord(new List<string>(), new List<string>(), new List<string>());
+            var jobRecord = new ReindexJobRecord(new List<string>());
 
             jobRecordCustomizer?.Invoke(jobRecord);
 

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Features/Operations/Reindex/ReindexJobTests.cs
@@ -996,8 +996,6 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Features.Operations.Reindex
                 // Create a ReindexJobRecord for the orchestrator
                 var orchestratorRecord = new ReindexJobRecord(
                     targetResourceTypes: Array.Empty<string>(),
-                    targetSearchParameterTypes: Array.Empty<string>(),
-                    searchParameterResourceTypes: Array.Empty<string>(),
                     maxResourcesPerQuery: 3,
                     maxResourcesPerWrite: 3)
                 {


### PR DESCRIPTION
## Description
The reindex parameter TargetSearchParameterTypes isn't used anymore but is still being validated, which can cause a reindex job to be refused. This PR removes the validation on this field.

## Related issues
Addresses [Bug 192567](https://microsofthealth.visualstudio.com/Health/_workitems/edit/192567)

## Testing
Manual and existing tests

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
