### PR TITLE
Fix cleanup script to preserve multi-arch image child manifests

### DIFF
--- a/build/jobs/cleanup-version-images.yml
+++ b/build/jobs/cleanup-version-images.yml
@@ -38,7 +38,36 @@ jobs:
               }
           }
 
-          Write-Host "Removing untagged ${version} images"
+          Write-Host "Removing orphaned untagged ${version} images"
           $repository = "${version}_fhir-server"
-          az acr repository show-manifests --name $(azureContainerRegistryName) --repository $repository --query "[?tags[0]==null].digest" -o tsv `
-          | %{ az acr repository delete --name $(azureContainerRegistryName) --image $repository@$_ --yes }
+
+          # Step 1: Collect all digests referenced by tagged manifests (multi-arch index children)
+          $referencedDigests = @{}
+          $taggedManifests = az acr repository show-manifests --name $(azureContainerRegistryName) --repository $repository --query "[?tags[0]!=null]" -o json | ConvertFrom-Json
+          foreach ($tagged in $taggedManifests) {
+              try {
+                  $manifest = az acr manifest show --name $repository --registry $(azureContainerRegistryName) --digest $tagged.digest -o json 2>$null | ConvertFrom-Json
+                  if ($manifest.manifests) {
+                      # This is a multi-arch index; record all child digests
+                      foreach ($child in $manifest.manifests) {
+                          $referencedDigests[$child.digest] = $tagged.digest
+                          Write-Host "  Protected child manifest $($child.digest) (referenced by $($tagged.tags -join ', '))"
+                      }
+                  }
+              }
+              catch {
+                  Write-Host "  Warning: Could not inspect manifest $($tagged.digest)"
+              }
+          }
+
+          # Step 2: Delete only truly orphaned untagged manifests
+          $untaggedDigests = az acr repository show-manifests --name $(azureContainerRegistryName) --repository $repository --query "[?tags[0]==null].digest" -o tsv
+          foreach ($digest in $untaggedDigests) {
+              if ($referencedDigests.ContainsKey($digest)) {
+                  Write-Host "  Skipping $digest (referenced by tagged index $($referencedDigests[$digest]))"
+              }
+              else {
+                  Write-Host "  Deleting orphaned manifest $digest"
+                  az acr repository delete --name $(azureContainerRegistryName) --image "${repository}@${digest}" --yes
+              }
+          }


### PR DESCRIPTION
## Description
When docker buildx build --platform linux/amd64,linux/arm64 --push runs, it creates a tree of manifests in the repository:

Key point: Only the top-level OCI image index gets the tag (4.0.766). The 4 child manifests are untagged by design — they exist in the registry and are referenced by digest from the parent index. This is how the OCI spec works.
After deletion, the index 4.0.766 still exists and is tagged, but its children are gone:

## Related issues
Addresses [AB192486](https://microsofthealth.visualstudio.com/Health/_workitems/edit/192486)

## Testing
Describe how this change was tested.

## FHIR Team Checklist
- **Update the title** of the PR to be succinct and less than 65 characters
- **Add a milestone** to the PR for the sprint that it is merged (i.e. add S47)
- Tag the PR with the type of update: **Bug**, **Build**, **Dependencies**, **Enhancement**, **New-Feature** or **Documentation**
- Tag the PR with **Open source**, **Azure API for FHIR** (CosmosDB or common code) or **Azure Healthcare APIs** (SQL or common code) to specify where this change is intended to be released.
- Tag the PR with **Schema Version backward compatible** or **Schema Version backward incompatible** or **Schema Version unchanged** if this adds or updates Sql script which is/is not backward compatible with the code.
- When changing or adding behavior, if your code modifies the system design or changes design assumptions, please create and include an [ADR](https://github.com/microsoft/fhir-server/blob/main/docs/arch).
- [ ] CI is green before merge [![Build Status](https://microsofthealthoss.visualstudio.com/FhirServer/_apis/build/status/CI%20Build%20%26%20Deploy?branchName=main)](https://microsofthealthoss.visualstudio.com/FhirServer/_build/latest?definitionId=27&branchName=main) 
- Review [squash-merge requirements](https://github.com/microsoft/fhir-server/blob/main/SquashMergeRequirements.md)

### Semver Change ([docs](https://github.com/microsoft/fhir-server/blob/main/docs/Versioning.md))
Patch|Skip|Feature|Breaking (reason)
