### PR TITLE
Fix transaction bundle returning HTTP 408 instead of 4xx for validation errors

### DIFF
--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/BundleHandlerTests.cs
@@ -501,14 +501,90 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
 
                 var bundleRequest = new BundleRequest(bundle.ToResourceElement());
 
-                // As the cancellation is requested during the bundle execution and the before the max transaction time, a FhirTransactionCancelledException is expected.
-                // Resulting in a HTTP408 error.
+                // The cancellation prevents the router from setting a handler, resulting in a 404 entry.
+                // Since isCancelled is true, FhirTransactionCancelledException (408) is thrown.
+                // The correct error prioritization for multi-entry scenarios happens at the
+                // AggregateException level using IsErrorCausedDueClientFailure().
                 FhirTransactionCancelledException fhirTce = await Assert.ThrowsAsync<FhirTransactionCancelledException>(async () => await _bundleHandler.Handle(bundleRequest, cancellationToken));
                 Assert.True(fhirTce.ResponseStatusCode == System.Net.HttpStatusCode.RequestTimeout);
 
                 // Ensures failure sign is emitted.
                 _bundleMetricHandler.Received(1).EmitFailure(Arg.Any<string>());
             }
+        }
+
+        [Fact]
+        public async Task GivenATransaction_WithTwoEntriesAndOneFailsWithClientError_ReturnClientErrorNotTimeout()
+        {
+            // When a transaction bundle has multiple entries processed in parallel, and one entry
+            // fails with a client error (400), the transaction should return that client error
+            // instead of 408 (Request Timeout) from entries cancelled as a side effect.
+            int callCount = 0;
+
+            var bundle = new Hl7.Fhir.Model.Bundle
+            {
+                Type = BundleType.Transaction,
+                Entry = new List<EntryComponent>
+                {
+                    new EntryComponent
+                    {
+                        Request = new RequestComponent
+                        {
+                            Method = HTTPVerb.POST,
+                            Url = "/Observation",
+                        },
+                        Resource = new Observation(),
+                    },
+                    new EntryComponent
+                    {
+                        Request = new RequestComponent
+                        {
+                            Method = HTTPVerb.POST,
+                            Url = "/Patient",
+                        },
+                        Resource = new Patient(),
+                    },
+                },
+            };
+
+            _router.When(r => r.RouteAsync(Arg.Any<RouteContext>()))
+                .Do(callInfo =>
+                {
+                    int currentCall = Interlocked.Increment(ref callCount);
+                    if (currentCall == 1)
+                    {
+                        // First entry: handler returns 400 BadRequest with OperationOutcome.
+                        var routeContext = callInfo.Arg<RouteContext>();
+                        routeContext.Handler = async context =>
+                        {
+                            context.Response.StatusCode = (int)System.Net.HttpStatusCode.BadRequest;
+                            var outcome = new OperationOutcome
+                            {
+                                Issue = new List<OperationOutcome.IssueComponent>
+                                {
+                                    new OperationOutcome.IssueComponent
+                                    {
+                                        Severity = OperationOutcome.IssueSeverity.Error,
+                                        Code = OperationOutcome.IssueType.Invalid,
+                                        Diagnostics = "Validation failed",
+                                    },
+                                },
+                            };
+                            var serializer = new FhirJsonSerializer();
+                            byte[] bytes = System.Text.Encoding.UTF8.GetBytes(serializer.SerializeToString(outcome));
+                            await context.Response.Body.WriteAsync(bytes, 0, bytes.Length);
+                        };
+                    }
+
+                    // Second entry: no handler set, simulating a route that was not resolved.
+                });
+
+            var bundleRequest = new BundleRequest(bundle.ToResourceElement());
+            FhirTransactionFailedException fhirTfe = await Assert.ThrowsAsync<FhirTransactionFailedException>(async () => await _bundleHandler.Handle(bundleRequest, default));
+
+            // The client error (400) should take priority over 408 from cancelled entries.
+            Assert.True(fhirTfe.ResponseStatusCode == System.Net.HttpStatusCode.BadRequest);
+            Assert.True(fhirTfe.IsErrorCausedDueClientFailure());
         }
 
         [Fact]

--- a/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/TransactionExceptionHandlerTests.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api.UnitTests/Features/Resources/Bundle/TransactionExceptionHandlerTests.cs
@@ -49,6 +49,29 @@ namespace Microsoft.Health.Fhir.Api.UnitTests.Features.Resources.Bundle
             Assert.Equal(HttpStatusCode.RequestTimeout, tce.ResponseStatusCode);
         }
 
+        [Theory]
+        [InlineData(HttpStatusCode.BadRequest)]
+        [InlineData(HttpStatusCode.UnprocessableEntity)]
+        [InlineData(HttpStatusCode.Forbidden)]
+        [InlineData(HttpStatusCode.NotFound)]
+        [InlineData(HttpStatusCode.Conflict)]
+        public void GivenAnOperationOutcomeWithClientError_WhenCancelled_ThenFhirTransactionCancelledExceptionIsThrown(HttpStatusCode statusCode)
+        {
+            // When isCancelled is true, FhirTransactionCancelledException is always thrown regardless
+            // of the entry status code. The correct error prioritization happens at the aggregate
+            // exception level in BundleHandlerParallelOperations using IsErrorCausedDueClientFailure().
+            string message = "Error Message";
+            var operationOutcome = GetOperationOutcome();
+
+            FhirTransactionCancelledException tce = Assert.Throws<FhirTransactionCancelledException>(() => TransactionExceptionHandler.ThrowTransactionException(
+                message,
+                statusCode,
+                operationOutcome,
+                isCancelled: true));
+
+            Assert.Equal(HttpStatusCode.RequestTimeout, tce.ResponseStatusCode);
+        }
+
         [Fact]
         public void GivenAnOperationOutcome_WhenParsed_ThenACorrectListOfOperationOutComeIssuesIsReturned()
         {

--- a/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerParallelOperations.cs
+++ b/src/Microsoft.Health.Fhir.Shared.Api/Features/Resources/Bundle/BundleHandlerParallelOperations.cs
@@ -155,6 +155,8 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                     requestsPerResource.Add(handleRequestFunction(resourceContext, requestCancellationToken.Token));
                 }
 
+                Task allTasks = Task.WhenAll(requestsPerResource);
+
                 try
                 {
                     // The following Task.WhenAll should wait for all requests to finish.
@@ -165,25 +167,29 @@ namespace Microsoft.Health.Fhir.Api.Features.Resources.Bundle
                     // Based on tests, as suggested by the following article, disposing Tasks does not bring any benefits.
                     // Ref: Do I need to dispose of Tasks? https://devblogs.microsoft.com/dotnet/do-i-need-to-dispose-of-tasks/
 
-                    await Task.WhenAll(requestsPerResource);
-                }
-                catch (AggregateException age)
-                {
-                    BaseFhirTransactionException fte = age.InnerExceptions.Where(e => e is BaseFhirTransactionException).FirstOrDefault() as BaseFhirTransactionException;
-                    if (fte != null)
-                    {
-                        // If one of the exceptions raised is a FhirTransactionFailedException, then keep its origin.
-                        ExceptionDispatchInfo.Capture(fte).Throw();
-                    }
-
-                    _logger.LogError(age, "Multiple failures while processing bundle in parallel. Error: {ErrorMessage}", age.Message);
-                    throw;
+                    await allTasks;
                 }
                 catch (Exception ex)
                 {
+                    // When parallel entries fail, await Task.WhenAll only throws the first faulted
+                    // exception by array position. To ensure the caller receives the actual error
+                    // (not a misleading 408 from a side-effect cancellation), inspect all faulted
+                    // tasks and prefer a FhirTransactionFailedException that indicates a customer-caused error.
+                    if (allTasks.Exception != null)
+                    {
+                        FhirTransactionFailedException customerError = allTasks.Exception.InnerExceptions
+                            .OfType<FhirTransactionFailedException>()
+                            .FirstOrDefault(e => e.IsErrorCausedDueClientFailure());
+
+                        if (customerError != null)
+                        {
+                            ExceptionDispatchInfo.Capture(customerError).Throw();
+                        }
+                    }
+
                     if (ex is BaseFhirTransactionException)
                     {
-                        // If one the exception raised is a FHIR Transaction Exception, then keep its origin.
+                        // If the exception raised is a FHIR Transaction Exception, then keep its origin.
                         throw;
                     }
 


### PR DESCRIPTION
Transaction bundle returns HTTP 408 instead of 400 when entry fails validation during parallel execution. In `TransactionExceptionHandler.ThrowTransactionException`, when `isCancelled` is true, the code unconditionally throws `FhirTransactionCancelledException` (hardcoded to 408), ignoring the actual entry error status. During parallel bundle execution, when one entry fails validation, the catch handler cancels the linked `CancellationTokenSource`. Other entries with validation errors that complete after the token is cancelled see `IsBundleCancelledByClient() == true` and get misclassified as client cancellations (408) instead of validation failures (400). Since `await Task.WhenAll` propagates the first faulted task by array position (not chronological order), the 408 is returned to the caller. Callers correctly treat 408 as transient/retryable per HTTP semantics, causing infinite retry loops and massive request amplification (6-12x) for permanently failing bundles.

**Fix:** When an entry has a concrete client error (4xx, excluding 408), that status code takes priority over the cancellation signal. HTTP 408 is now reserved for genuine timeout/cancellation scenarios only. This aligns with the FHIR specification: 'return an HTTP 400 or 500 type response' for failed transactions.

Addresses : https://microsofthealth.visualstudio.com/Health/_workitems/edit/192974