### PR TITLE
Return 400 Bad Request for malformed Cosmos DB ct

### DIFF
--- a/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Queries/CosmosQueryTests.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb.UnitTests/Features/Queries/CosmosQueryTests.cs
@@ -1,0 +1,115 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Health.Fhir.Core.Exceptions;
+using Microsoft.Health.Fhir.CosmosDb.Features.Queries;
+using Microsoft.Health.Fhir.CosmosDb.Features.Storage;
+using Microsoft.Health.Fhir.Tests.Common;
+using Microsoft.Health.Test.Utilities;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.CosmosDb.UnitTests.Features.Queries
+{
+    [Trait(Traits.OwningTeam, OwningTeam.Fhir)]
+    [Trait(Traits.Category, Categories.DataSourceValidation)]
+    public class CosmosQueryTests
+    {
+        private readonly ICosmosQueryContext _queryContext;
+        private readonly FeedIterator<object> _feedIterator;
+        private readonly ICosmosResponseProcessor _processor;
+        private readonly ICosmosQueryLogger _logger;
+
+        public CosmosQueryTests()
+        {
+            _queryContext = Substitute.For<ICosmosQueryContext>();
+            _feedIterator = Substitute.For<FeedIterator<object>>();
+            _processor = Substitute.For<ICosmosResponseProcessor>();
+            _logger = Substitute.For<ICosmosQueryLogger>();
+        }
+
+        [Fact]
+        public async Task GivenAMalformedContinuationTokenException_WhenExecutingQuery_ThenRequestNotValidExceptionIsThrown()
+        {
+            // Arrange - simulate the internal SDK exception type
+            var malformedException = new MalformedContinuationTokenTestException(
+                "ParallelContinuationToken is missing field: 'token': {\"compositeToken\":{\"token\":null}}");
+
+            _feedIterator.ReadNextAsync(Arg.Any<CancellationToken>()).Throws(malformedException);
+
+            var cosmosQuery = new CosmosQuery<object>(_queryContext, _feedIterator, _processor, _logger);
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<RequestNotValidException>(
+                () => cosmosQuery.ExecuteNextAsync(CancellationToken.None));
+
+            Assert.Equal(Microsoft.Health.Fhir.Core.Resources.InvalidContinuationToken, exception.Message);
+        }
+
+        [Fact]
+        public async Task GivenACosmosException_WhenExecutingQuery_ThenProcessErrorResponseIsCalled()
+        {
+            // Arrange
+            var cosmosException = new TestCosmosException("test error", System.Net.HttpStatusCode.TooManyRequests);
+
+            _feedIterator.ReadNextAsync(Arg.Any<CancellationToken>()).Throws(cosmosException);
+
+            var cosmosQuery = new CosmosQuery<object>(_queryContext, _feedIterator, _processor, _logger);
+
+            // Act & Assert - CosmosException should still propagate after processing
+            await Assert.ThrowsAsync<TestCosmosException>(
+                () => cosmosQuery.ExecuteNextAsync(CancellationToken.None));
+
+            await _processor.Received(1).ProcessErrorResponseAsync(
+                Arg.Any<System.Net.HttpStatusCode>(),
+                Arg.Any<Headers>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task GivenAGenericException_WhenExecutingQuery_ThenExceptionIsNotCaught()
+        {
+            // Arrange - a non-MalformedContinuationToken exception should not be caught
+            var genericException = new InvalidOperationException("some other error");
+
+            _feedIterator.ReadNextAsync(Arg.Any<CancellationToken>()).Throws(genericException);
+
+            var cosmosQuery = new CosmosQuery<object>(_queryContext, _feedIterator, _processor, _logger);
+
+            // Act & Assert - generic exceptions should propagate unchanged
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => cosmosQuery.ExecuteNextAsync(CancellationToken.None));
+        }
+
+        /// <summary>
+        /// Test exception that mimics the internal Cosmos DB SDK MalformedContinuationTokenException.
+        /// The real exception is internal to the SDK, so we use a test double with a matching type name.
+        /// </summary>
+        private sealed class MalformedContinuationTokenTestException : Exception
+        {
+            public MalformedContinuationTokenTestException(string message)
+                : base(message)
+            {
+            }
+        }
+
+        /// <summary>
+        /// Test CosmosException for unit testing.
+        /// </summary>
+        private sealed class TestCosmosException : CosmosException
+        {
+            public TestCosmosException(string message, System.Net.HttpStatusCode statusCode)
+                : base(message, statusCode, 0, string.Empty, 0)
+            {
+            }
+        }
+    }
+}

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Queries/CosmosQuery.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Queries/CosmosQuery.cs
@@ -92,6 +92,13 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Queries
 
                 throw;
             }
+            catch (Exception ex) when (ex.GetType().FullName?.Contains("MalformedContinuationToken", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                // The Cosmos DB SDK may throw MalformedContinuationTokenException (an internal SDK type)
+                // during client-side continuation token parsing without wrapping it in a CosmosException.
+                // This is a client error (invalid/stale token), not a server error.
+                throw new RequestNotValidException(Microsoft.Health.Fhir.Core.Resources.InvalidContinuationToken);
+            }
         }
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Queries/CosmosQuery.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Queries/CosmosQuery.cs
@@ -97,6 +97,7 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Queries
                 // The Cosmos DB SDK may throw MalformedContinuationTokenException (an internal SDK type)
                 // during client-side continuation token parsing without wrapping it in a CosmosException.
                 // This is a client error (invalid/stale token), not a server error.
+                _logger.LogMalformedContinuationToken(ex);
                 throw new RequestNotValidException(Microsoft.Health.Fhir.Core.Resources.InvalidContinuationToken);
             }
         }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Queries/CosmosQueryLogger.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Queries/CosmosQueryLogger.cs
@@ -194,5 +194,11 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Queries
                         exception);
             }
         }
+
+        /// <inheritdoc />
+        public void LogMalformedContinuationToken(Exception exception)
+        {
+            _logger.LogWarning(exception, "Cosmos SDK threw MalformedContinuationTokenException during client-side continuation token parsing.");
+        }
     }
 }

--- a/src/Microsoft.Health.Fhir.CosmosDb/Features/Queries/ICosmosQueryLogger.cs
+++ b/src/Microsoft.Health.Fhir.CosmosDb/Features/Queries/ICosmosQueryLogger.cs
@@ -63,5 +63,11 @@ namespace Microsoft.Health.Fhir.CosmosDb.Features.Queries
             string activityId,
             string clientElapsedTime = null,
             Exception exception = null);
+
+        /// <summary>
+        /// Logs when a malformed continuation token is detected.
+        /// </summary>
+        /// <param name="exception">The exception thrown by the Cosmos DB SDK.</param>
+        void LogMalformedContinuationToken(Exception exception);
     }
 }

--- a/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/NullFhirCosmosQueryLogger.cs
+++ b/test/Microsoft.Health.Fhir.Shared.Tests.Integration/Persistence/NullFhirCosmosQueryLogger.cs
@@ -28,5 +28,9 @@ namespace Microsoft.Health.Fhir.Tests.Integration.Persistence
         public void LogQueryClientElapsedTime(string activityId, string clientElapsedTime = null, Exception exception = null)
         {
         }
+
+        public void LogMalformedContinuationToken(Exception exception)
+        {
+        }
     }
 }


### PR DESCRIPTION
## Summary

When the Cosmos DB SDK throws `MalformedContinuationTokenException` during client-side continuation token parsing, the exception was previously unhandled and resulted in **HTTP 500 Internal Server Error**.

This is a **client error** - the continuation token provided by the caller is invalid (e.g., stale, expired, or corrupted). Returning 500 incorrectly triggers ICM alerts (FHIR001 HTTP Internal Error threshold) and misrepresents the error to clients.

Addresses - https://microsofthealth.visualstudio.com/Health/_workitems/edit/192998

## Root Cause (ICM 791551287)

Clients were sending continuation tokens with `null` token fields and `resumeValues` timestamps from one year prior. The Cosmos DB SDK's internal `MalformedContinuationTokenException` escaped without being wrapped in a `CosmosException`, bypassing the existing handling in `CosmosResponseProcessor`.

## Testing

- 3 new unit tests covering:
  - MalformedContinuationToken exception -> 400 Bad Request
  - CosmosException still calls ProcessErrorResponse (existing behavior preserved)
  - Generic exceptions still propagate unchanged
